### PR TITLE
Copy all JEPs to XEPs

### DIFF
--- a/content/xep-0001-1.14.html
+++ b/content/xep-0001-1.14.html
@@ -1,0 +1,701 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0001: Jabber Enhancement Proposals (JEPs)</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jabber Enhancement Proposals (JEPs)">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines the standards process followed by the Jabber Software Foundation.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0001">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0001: Jabber Enhancement Proposals (JEPs)</h1>
+<p>This JEP defines the standards process followed by the Jabber Software Foundation.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Procedural JEP defines a process or activity of the Jabber Software Foundation (JSF) that has been approved by the Jabber Council and/or the JSF Board of Directors. The JSF is currently following the process or activity defined herein and will do so until this JEP is deprecated or obsoleted.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Procedural<br>
+            Number: 0001<br>
+            Version: 1.14<br>
+            Last Updated: 2004-09-28<br>
+            JIG: None<br>
+                Approving Body: JSF Board of Directors<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Discussion by the membership of the JSF may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/members">http://mail.jabber.org/mailman/listinfo/members</a>&gt; for details).</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#objectives">Objectives</a>
+</dt>
+<dt>3.  <a href="#types">JEP Types</a>
+</dt>
+<dt>4.  <a href="#submission">Submission Process</a>
+</dt>
+<dt>5.  <a href="#publication">Publication Process</a>
+</dt>
+<dt>6.  <a href="#discussion">Discussion Process</a>
+</dt>
+<dt>7.  <a href="#proposal">Proposal Process</a>
+</dt>
+<dt>8.  <a href="#approval">Approval Process</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#approval-std">Standards Track JEPs</a>
+</dt>
+<dt>8.2.  <a href="#approval-info">Historical, Informational, and Procedural JEPs</a>
+</dt>
+</dl>
+<dt>9.  <a href="#mods">Modifications to Approved JEPs</a>
+</dt>
+<dt>10.  <a href="#expiration">Expiration Dates</a>
+</dt>
+<dt>11.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>14.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596398">1</a>] adheres to an open standards process that enables interested parties to document existing protocols used within the Jabber community and to submit proposals that define new protocols; all such protocols may be considered extensions to the Extensible Messaging and Presence Protocol (XMPP) approved by the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2601882">2</a>]. Advancement through the JSF's standards process is subject to open discussion on public discussion lists and approval by a technical steering committee elected by the members of the JSF. The focal point of the process is a series of protocol specifications called Jabber Enhancement Proposals or JEPs.  [<a href="#nt-id2601873">3</a>] The nature of JEPs and the mechanisms for managing and advancing them within the Jabber Software Foundation are canonically described in the current document, which represents the first document in the JEP series.</p>
+<h2>2.
+       <a name="objectives">Objectives</a>
+</h2>
+  <p class="" style="">The Jabber Software Foundation was founded in the year 2001 to openly document, safeguard, manage, and extend the wire protocols used within the Jabber community. The work of the Jabber Software Foundation has several objectives:</p>
+  <ol start="1" type="">
+    <li>To produce practical, technically excellent solutions to important problems of real-time communication based on the set of streaming XML technologies known as Jabber/XMPP.</li>
+    <li>To document Jabber protocols and XMPP extensions in a clear, concise manner so that the task of implementing the protocols is straightforward.</li>
+    <li>To ensure interoperability among the disparate technologies used on Jabber/XMPP networks.</li> 
+    <li>To guarantee that any person or entity may implement the protocols without encmbrance.</li>
+    <li>To work in an fair, open, objective manner.</li>
+  </ol>
+  <p class="" style="">The standards process specified herein has been developed and refined in order to meet these objectives.</p>
+<h2>3.
+       <a name="types">JEP Types</a>
+</h2>
+  <p class="" style="">There are four types of JEP:</p>
+  <ol start="1" type="">
+    <li><p class="" style="">A <span class="ref" style="">Standards Track JEP</span> defines a wire protocol intended to be used as a standard part of Jabber technologies; this is the main JEP type of interest to the JSF, and most JEPs are Standards Track.  [<a href="#nt-id2602118">7</a>]</p></li>
+    <li>
+      <p class="" style="">An <span class="ref" style="">Informational JEP</span> defines one of the following:</p>
+      <ol start="1" type="">
+        <li>Best practices for protocol development (e.g., <span class="ref">Service Discovery Extensions</span>  [<a href="#nt-id2602264">8</a>])</li>
+        <li>A usage profile for an existing protocol (e.g., <span class="ref">Invisibility</span>  [<a href="#nt-id2602189">9</a>])</li>
+      </ol>
+    </li>
+    <li><p class="" style="">An <span class="ref" style="">Historical JEP</span> documents a protocol that was developed before the JEP process was instituted, but that is still in use within the Jabber community; such a JEP may or may not be obsoleted by a Standards Track JEP, or upgraded to Standards Track.</p></li>
+    <li><p class="" style="">A <span class="ref" style="">Humorous JEP</span> attempts to be funny by defining a protocol that would never be used in the real world; such JEPs are usually published on April 1 and automatically have a status of Active.</p></li>
+    <li><p class="" style="">An <span class="ref" style="">Procedural JEP</span> defines a process or activity to be followed by the JSF, including JIG charters as specified by <span class="ref">Jabber Interest Groups</span>  [<a href="#nt-id2602382">10</a>].</p></li>
+  </ol>
+  <p class="" style="">The approving body for all Standards Track, Informational, Historical, and Humorous JEPs is the <span class="ref">Jabber Council</span>  [<a href="#nt-id2602319">11</a>]; the approving body for Procedural JEPs is usually the <span class="ref">JSF Board of Directors</span>  [<a href="#nt-id2602348">12</a>] but may be the Jabber Council.</p>
+  <p class="" style="">This document focuses primarily on Standards Track JEPs, since they are the vehicle for defining new protocols, but also discusses Historical, Informational, and Procedural JEPs.</p>
+<h2>4.
+       <a name="submission">Submission Process</a>
+</h2>
+  <p class="" style="">The JSF welcomes and encourages the submission of protocols to the JSF's standards process.  [<a href="#nt-id2602404">13</a>] Any individual or group of individuals may author a proposal and submit it to the JSF for consideration as a JEP, and there is no requirement that a JEP author shall be an elected member of the JSF. However, proposals to define official JSF protocols must be presented in the JEP format and must follow the rules defined herein.</p>
+  <p class="" style="">The submission process is defined on the JSF website. Specifically, instructions for submission, a template for creating JEPs, and a link to the JEP DTD and schema may be found at &lt;<a href="http://www.jabber.org/jeps/submit.php">http://www.jabber.org/jeps/submit.php</a>&gt;. All inquiries related to the JEP process, and all submissions, should be directed to the <span class="ref">JEP Editor</span>  [<a href="#nt-id2602550">14</a>].</p> 
+  <p class="" style="">Note well that JEP authors must transfer ownership of their protocols (but not implementations thereof) to the JSF. Refer to the <span class="ref">JSF IPR Policy</span>  [<a href="#nt-id2602485">15</a>] for details. JEP authors must make sure that they have read, understood, and agreed to the JSF IPR Policy before submitting a proposal to the JEP Editor!</p>
+  <p class="" style="">All proposals submitted to the JSF for consideration as a JEPs must contain the following information:</p>
+  <ol start="1" type="">
+    <li><p class="" style="">Legal Notice -- the legal notice must be exactly that which is specified in the JSF IPR Policy</p></li>
+    <li><p class="" style="">Author Information -- first name, last name, email address, and Jabber ID are all required and must be provided for all authors</p></li>
+  </ol>
+  <p class="" style="">Finally, Standards Track, Informational, and Historical JEPs must conform to RFC 2119 in the use of terminology regarding requirements levels.</p>
+<h2>5.
+       <a name="publication">Publication Process</a>
+</h2>
+  <p class="" style="">The approving body for almost all JEPs is the Jabber Council; therefore, in order to be published as a JEP, a proposal must first be accepted by the Jabber Council (the only exceptions are certain kinds of Procedural JEPs, for which the approving body may be the JSF Board of Directors and which may be accepted for publication by the JEP Editor in consultation with the Board). Upon receiving a proposal, the JEP Editor shall do the following:</p>
+  <ul>
+    <li>ensure that its format is correct</li>
+    <li>publish it to &lt;<a href="http://www.jabber.org/jeps/inbox/">http://www.jabber.org/jeps/inbox/</a>&gt;</li>
+    <li>publicly announce its existence by sending a message to the discussion list of the <span class="ref">Standards JIG</span>  [<a href="#nt-id2602730">16</a>]</li>
+    <li>request acceptance of the proposal as a JEP by the Jabber Council</li>
+  </ul>
+  <p class="" style="">If no member of the Jabber Council objects to publication of the proposal within seven (7) days, the JEP Editor shall accept it as a JEP. If objections are raised by the Council on the Standards-JIG list, the JEP author(s) is encouraged to address the feedback of the Council and to submit a revised version of the proposal and/or confer with the JEP Editor or objecting Council member(s) regarding how to proceed.</p>
+  <p class="" style="">If the proposal is accepted as a JEP, the JEP Editor shall do the following:</p>
+  <ul>
+    <li>assign it a number</li>
+    <li>specify an appropriate type</li>
+    <li>specify a status of Experimental</li>
+    <li>add it to source control  [<a href="#nt-id2602680">17</a>]</li>
+    <li>add tracking information to the JEPs database</li>
+    <li>publish version 0.1 of the JEP to the JSF website  [<a href="#nt-id2602754">18</a>]</li>
+    <li>publicly announce the existence of the JEP by sending a message to the Standards-JIG list</li>
+  </ul>
+  <p class="" style="">Note well that no special criteria (other than acceptance by the Jabber Council and minimal formatting compliance) need to be met in order for a JEP to be granted a status of Experimental. The granting of Experimental status must not be construed as indicating any level of approval by the JSF, the Jabber Council, or the Jabber community. Implementation of Experimental JEPs is encouraged in an exploratory fashion (e.g., in a proof of concept), but such implementations may not be appropriate for deployment in production systems.</p>
+<h2>6.
+       <a name="discussion">Discussion Process</a>
+</h2>
+  <p class="" style="">Once a JEP is published, it becomes available for public discussion within the Standards JIG and the broader Jabber community. The JEP author(s) is responsible for collecting feedback from the Jabber community during the life of the JEP and for incorporating such feedback into the proposal. In order to fully participate in discussion of the proposal, the JEP author(s) should be subscribed to the Standards-JIG list, which is the primary venue for discussion of JEPs. Changes made based on feedback received by the JEP author(s) must be captured in updated versions of the JEP (e.g., 0.2 after 0.1), each of which must be put under source control and subsequently tracked and announced by the JEP Editor.</p>
+  <p class="" style="">If an Experimental JEP is inactive (i.e., no updated versions are published) for a period of six months, the JEP Editor shall automatically change the status of the JEP to Deferred unless it is in the queue of JEPs under active consideration for advancement by the Jabber Council; upon submission of an updated version, the JEP Editor shall change the status back to Experimental.</p>
+<h2>7.
+       <a name="proposal">Proposal Process</a>
+</h2>
+  <p class="" style="">Before an experimental JEP may be proposed to the Jabber Council for advancement to Draft (Standards Track JEPs) or Active (Historical, Informational, and Procedural JEPs), the Jabber Council must agree that the JEP is ready to be considered for advancement. Once the Council so agrees, it shall instruct the JEP Editor to (1) change the status of the JEP from Experimental to Proposed and (2) issue a Last Call for open discussion on the Standards JIG list. The Last Call shall expire not less than 10 days after the date of issue.</p>
+  <p class="" style="">Once the consensus of the Standards JIG has been incorporated into the JEP and all issues of substance raised during the Last Call have been addressed by the JEP author(s), the JEP Editor shall formally propose a specific revision of the JEP to the Jabber Council for its vote. If necessary, the JEP Editor may, at his discretion and in consultation with the Jabber Council, extend the Last Call or issue a new Last Call if the JEP requires further discussion.</p>
+  <p class="" style="">Last Calls regarding Procedural JEPs for which the approving body is the JSF Board of Directors may be issued directly by the JEP Editor once instructed by the Board.</p>
+<h2>8.
+       <a name="approval">Approval Process</a>
+</h2>
+  <p class="" style="">After a JEP has been proposed to the Jabber Council, any change in its status shall be determined by a vote of the Jabber Council. All members of the Council must vote, with the possible values being +1 (approve), 0 (neutral), or -1 (disapprove, with reasons). A JEP shall not be advanced to the next stage in the approval process so long as any Council Member continues to vote -1; that Council Member's written concerns must be addressed in order for the JEP to advance. A majority of Council members must vote +1 in order for a JEP to advance. (Additional voting policies, such as voting periods and defaults if a member does not vote, may be set by the Jabber Council.) A vote of the Jabber Council is final and binding, although an JEP author(s) is free to address the concerns of the Council and to resubmit the JEP for future consideration.</p>
+  <p class="" style="">If the Jabber Council does not complete voting on a JEP before the end of its term, the JEP Editor shall issue a new Last Call on the Standards JIG list and the newly-elected Council shall vote anew on the JEP after completion of the Last Call. This provides an opportunity for any member of the previous Council who had voted -1 to voice his or her concerns in a public forum before the new Council votes on the JEP.</p>
+  <p class="" style="">A vote of the Jabber Council applies only to the specific revision of the JEP that has been presented to it. Further revisions may need to be re-submitted for approval.</p>
+  <p class="" style="">Any change in the status of a JEP must be announced on the Standards-JIG list by the JEP Editor. If a JEP advances to a status of Final, it shall be so announced and also published as one of the official JSF protocols  [<a href="#nt-id2602991">19</a>] on the website of the Jabber Software Foundation.</p>
+  <p class="" style="">Approval of Procedural JEPs for which the approving body is the JSF Board of Directors shall occur upon approval by the Board in accordance with the rules defined in the <span class="ref">JSF Bylaws</span>  [<a href="#nt-id2603113">20</a>].</p>
+  <p class="" style="">More detailed information about the approval process is provided below, including criteria for Standards Track JEPs and for Historical, Informational, and Procedural JEPs.</p>
+  <div class="indent">
+<h3>8.1 <a name="approval-std">Standards Track JEPs</a>
+</h3>
+    <p class="" style="">The possible states for a Standards Track JEP are as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+                       +------&gt; Rejected
+                       |           +
+                       |           |
+Experimental ---&gt; Proposed ---&gt; Draft ----&gt; Final
+     |                 |           |          |
+     |                 |           +          +
+ Retracted             +------&gt; Deferred  Deprecated ---&gt; Obsolete
+      </pre></div>
+    <p class="" style="">The ideal path is for a Standards Track JEP to be advanced by the Jabber Council from Proposed to Draft to Final (the criteria for this approval are described in the following paragraphs). However, rather than being advanced from Proposed to Draft or from Draft to Final, a Standards Track JEP may, at the discretion of the Jabber Council, be either Deferred or Rejected, and thus not be advanced along the ideal path. Specifically, a JEP may be assigned a status of Deferred if no progress is being made on the JEP or if it is dependent on other protocol enhancements that are yet to be completed. Similarly, a JEP may be assigned a status of Rejected if it is deemed unacceptable by the Jabber Council. (Note that if a JEP is Deferred, the JEP Editor may at some point re-assign it to Experimental status, and that, even if a JEP is Rejected, it is retained in source control and on the Jabber Software Foundation website for future reference.) Finally, a JEP author(s) may retract an Experimental JEP from further consideration, resulting in a status of Retracted.</p>
+    <p class="" style="">In order for a JEP to advance from Proposed to Draft, it must:</p>
+    <ol start="" type="">
+      <li>fill known gaps in Jabber technologies or deficiencies with existing protocols</li>
+      <li>be clearly described and accurately documented so that it can be understood and implemented by interested and knowledgeable members of the Jabber community</li>
+      <li>document any known security considerations with the proposed technology</li>
+      <li>be generally stable and appropriate for further field experience</li>
+      <li>have achieved rough consensus (though not necessarily unanimity) within the Standards JIG</li>
+      <li>be formally defined by an XML schema</li>
+      <li>receive the requisite votes from the Jabber Council</li>
+    </ol>
+    <p class="" style="">Elevation to Draft status is a major advancement for the JEP, indicating a strong belief on the part of the Jabber Council and Jabber community that the specification will be of lasting value. Since a Draft standard must be well-understood and must be known to be reasonably stable, it is relatively safe to use it as the basis for implementations and production deployments. However, note that because a Draft standard may still require additional field experience and may be subject to change based on such experience, mission-critical or large-scale implementations of the Draft standard may not be advisable.</p>
+    <p class="" style="">In order for a JEP to advance from Draft to Final, it must be shown to be stable and well-received by the Jabber community. Before presenting a Draft standard to the Jabber Council for consideration as a Final standard, the JEP Editor shall issue a Call for Experience on the Standards-JIG list so that feedback can be gathered from those who have implemented the Draft standard (the Call for Experience shall expire not less than 14 days after the date of issue, and shall not be issued until at least 60 days have passed since advancement to Draft). In addition, at least two implementations of the JEP must exist, at least one of which must be free software (in accordance with the <span class="ref">The General Public License</span>  [<a href="#nt-id2603242">21</a>] or <span class="ref">The Lesser General Public License</span>  [<a href="#nt-id2603267">22</a>]) or open-source software (in accordance with the definition provided by <span class="ref">The Open Source Initiative</span>  [<a href="#nt-id2595883">23</a>]). Until two implementations are produced, a Standards Track JEP shall retain a status of Draft. Once (1) two implementations have been presented to the Jabber Council, (2) feedback provided during the Call for Experience has been incorporated into the JEP, and (3) the JEP has been fully checked for accuracy, the status of the JEP may be changed to Final upon a vote of the Council.</p> 
+    <p class="" style="">Finally, a Standards Track JEP that has been granted a status of Final may be superseded by a future JEP approved by the Jabber Council. In such cases, the status of the earlier JEP shall be changed to Deprecated, possibly with an expiration date assigned by the Jabber Council (see the <a href="#expiration">Expiration Dates</a> section below). After a reasonable period of time or upon the passing of the expiration date, the status of the JEP shall be changed to Obsolete.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="approval-info">Historical, Informational, and Procedural JEPs</a>
+</h3>
+    <p class="" style="">The possible states for a Historical, Informational, or Procedural JEP are as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+
+                      +-------&gt; Rejected
+                      |
+                      |
+Experimental ---&gt; Proposed ---&gt; Active ---------&gt; Obsolete
+     |                |                      |
+     |                |                      |
+ Retracted            +-------&gt; Deprecated --+
+    </pre></div>
+    <p class="" style="">Because such JEPs do not seek to define standard protocols, in general they are less controversial and tend to proceed from Proposed to Active without controversy on a vote of the Jabber Council. However, some of these JEPs may be remanded from the Council to the JEP author(s) and/or JEP Editor for revision in order to be suitable for advancement from Proposed to Active (e.g., documentation of protocols in use must be accurate and describe any existing security concerns). As with Standards Track JEPs, the JEP author(s) may retract such a JEP when it is Experimental, and the Council may reject such a JEP when it is Proposed.</p> 
+    <p class="" style="">Once approved, most Historical, Informational, and Procedural JEPs will have a status of Active. Naturally, such a JEP may also be assigned a status of Rejected or Deprecated (instead of Active) by the Jabber Council. Furthermore, such a JEP may be replaced by a new JEP on the same or a similar topic, thus rendering the earlier JEP obsolete; in such cases, the earlier JEP shall be assigned a status of Obsolete with a note specifying the superseding JEP. 
+    </p> 
+    <p class="" style="">The Jabber Council may, at its discretion, decide to convert an Historical JEP into a Standards Track JEP if the protocol defined in the JEP has been in long use, is deemed stable and uncontroversial, and is unlikely to be superseded by a newer protocol. The Historical JEP shall be treated in the same way as a Standards Track JEP that has a status of Experimental, beginning with the <a href="#proposal">Proposal Process</a>. If after the Last Call and voting by the Jabber Council the JEP is approved for advancement on the standards track, its type shall be changed to Standards Track and its status shall be changed to Draft.</p>
+  </div>
+<h2>9.
+       <a name="mods">Modifications to Approved JEPs</a>
+</h2>
+  <p class="" style="">Sometimes it is necessary to modify JEPs that have received final approval by the Jabber Council or JSF Board of Directors (e.g., to correct errors, incorporate the lessons of experience, or document new security concerns). This section describes the process for doing so with regard to Standards Track JEPs that have achieved a status of Final and Historical, Informational, and Procedural JEPs that have achieved a status of Active.</p>
+  <p class="" style="">With regard to Standards Track JEPs, the Jabber Software Foundation (in particular, the Jabber Council) strives to ensure that such JEPs are accurate, complete, and stable before advancing them to a status of Final (corresponding to document version 2.0 of the JEP). The Call for Experience and discussion within the Standards JIG help to ensure this result, but final responsibility rests with the Jabber Council. Despite the best efforts of all concerned, errors are sometimes discovered in Final JEPs (the individual who discovers such an error should inform the Council via the Standards-JIG mailing list or communicate directly with the JEP Editor). Whereas other standards development organizations may issue errata while leaving the specification itself unchanged, the JSF makes changes to the Final JEP and publishes a revised document version (e.g., version 2.1). In general the changes are made by the JEP Editor or JEP author(s) in consultation with the Jabber Council, discussed within the Standards JIG if appropriate, and agreed upon by the full Jabber Council. Upon agreement regarding the exact changes, the Jabber Council instructs the JEP Editor to publish a revised version of the JEP and announce the existence of the revised version through the normal channels (e.g., on the JSF website and to the Standards-JIG list). Naturally, if members of the Jabber community have concerns regarding the changes made, they are free to discuss the matter in the relevant forum (usually the Standards-JIG list) before or after the revised version has been published.</p>
+  <p class="" style="">The process is similar with regard to Historical and Informational JEPs that have achieved a status of Active (corresponding to document version 1.0 of the JEP): the Jabber Council agrees on the exact changes to be made and instructs the JEP Editor to publish and announce a revised version (e.g., version 1.1). Here again the Jabber Council bears responsibility for any changes and public discussion is welcome.</p>
+  <p class="" style="">Procedural JEPs may be modified more frequently as the Jabber Software Foundation gains experience with the processes defined therein. For example, JEP-0001 is modified periodically in order to document processes previously not made explicit or to modify existing processes based on experience with the JEP process; similar changes are sometimes made to the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603787">24</a>] JEP and to various JIG-related JEPs. Changes to these JEPs are discussed by the Jabber Council, JSF Board of Directors, JSF membership, and Standards JIG as appropriate, and exact changes are agreed to by the relevant approving body (Jabber Council or JSF Board of Directors). The approving body then instructs the JEP Editor to publish and announce the revised version as described above.</p>
+<h2>10.
+       <a name="expiration">Expiration Dates</a>
+</h2>
+  <p class="" style="">In rare cases, a protocol enhancement may be accepted as an interim solution, especially when it is recognized that expected future improvements in technology or the underlying Jabber/XMPP protocols will make possible a much better solution to the problem at hand (e.g., a better protocol for user avatars may be contingent upon the development of a robust protocol for publish/subscribe functionality). In such cases, a JEP may be approved provisionally and be assigned an expiration date.</p>
+  <p class="" style="">The exact form of such an expiration date shall be left up to the discretion of the Jabber Council. However, the preferred form is to assign an expiration date of six months in the future, at which time the Jabber Council must re-affirm the status of the JEP and, if desired, extend the expiration date for another six months. While this process may continue indefinitely (although that is unlikely), it has the virtue of forcing the Jabber Council and Jabber community to re-examine the provisional protocol on a fairly regular basis in the light of technological changes. Alternatively, a JEP may be assigned a &quot;soft&quot; expiration date: that is, the JEP will expire when an expected future protocol comes into existence, whenever that may be. In either case, the status of the JEP shall be changed to Deprecated when it expires.</p>
+  <p class="" style="">In addition, an expiration date may be assigned when the status of a JEP is changed from Final (or, potentially, Draft) to Deprecated. In this case, the expiration date applies to the date when the JEP is expected to change from Deprecated to Obsolete. These dates may be flexible; however it is expected that they will follow the same six-month rule as provisional protocol enhancements.</p>
+<h2>11.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Every JEP must contain a section entitled &quot;Security Considerations&quot;, detailing security concerns or features related to the proposal; in particular, a Standards Track JEP should list the security threats that the protocol addresses and does not address, as well as security issues related to implementation of the protocol. JEP authors should refer to <span class="ref">RFC 3552</span>  [<a href="#nt-id2603926">25</a>] for helpful information about documenting security considerations and should also confer with the JEP Editor and/or Jabber Council regarding this important task.</p>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">Some JEPs may require interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603872">26</a>]. The IANA acts as a clearinghouse to assign and coordinate the use of numerous Internet protocol parameters, such as MIME types and port numbers (e.g., the TCP ports 5222 and 5269 used by the Jabber community are registered with the IANA). Whether or not a JEP requires registration of parameters with the IANA, that fact must be noted and explained in a distinct section of the JEP entitled &quot;IANA Considerations&quot;. Registration with the IANA should not occur until a JEP advances to a status of Draft (Standards Track JEPs) or Active (Informational and Historical JEPs), and should be initiated by the Jabber Registrar in consultation with the JEP author, not by the JEP author(s) directly with the IANA.</p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2604033">27</a>] performs a function similar to the IANA, although limited to the Jabber community. It does so by reserving protocol namespaces and by uniquely assigning parameters for use in the context of Jabber/XMPP protocols (for example, the categories and types used in <span class="ref">Service Discovery</span>  [<a href="#nt-id2603959">28</a>]).</p>
+  <p class="" style="">Whether or not a JEP requires registration of protocol namespaces or parameters with the Jabber Registrar, that fact must be noted and explained in a distinct section of the JEP entitled &quot;Jabber Registrar Considerations&quot;. Such registration should not occur until a JEP advances to a status of Draft (Standards Track JEPs) or Active (Informational and Historical JEPs). Registration of protocol namespaces is initiated by the JEP Editor when a JEP advances to Draft or Active. Registration of particular parameters used within a specification may be initiated by a JEP author(s) within the text of the JEP, or by an implementor of the JEP after it has advanced to Draft or Active. For details regarding the Jabber Registrar and its processes, refer to JEP-0053.</p>
+  <p class="" style="">A JEP may also request that a new registry is to be created by the Jabber Registrar. The JEP author(s) must clearly define the nature of the new registry as well as the process for submitting data to the registry, and must do so in collaboration with the Registrar.</p>
+<h2>14.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">JEPs that define official JSF protocols must include a schema that conforms to <span class="ref">XML Schema Part 1</span>  [<a href="#nt-id2604142">29</a>] and <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2604162">30</a>].</p>
+  <p class="" style="">The schema for the JEP format itself is as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://www.jabber.org/jeps'
+    xmlns='http://www.jabber.org/jeps'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jep'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;
+
+        This schema defines the document format for Jabber Enhancement 
+        Proposals (JEPs). For further information about JEPs, visit:
+
+           http://www.jabber.org/jeps/ 
+        
+        The canonical URL for this schema is:
+        
+           http://www.jabber.org/jeps/jep.xsd
+
+      &lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='header'/&gt;
+        &lt;xs:element ref='section1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='header'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='title' type='xs:string'/&gt;
+        &lt;xs:element name='abstract' type='xs:string'/&gt;
+        &lt;xs:element name='legal' type='xs:string'/&gt;
+        &lt;xs:element name='number' type='xs:byte'/&gt;
+        &lt;xs:element ref='status'/&gt;
+        &lt;xs:element ref='type'/&gt; 
+        &lt;xs:element name='jig' type='xs:string'/&gt;
+        &lt;xs:element name='approver' type='xs:string'/&gt;
+        &lt;xs:element name='dependencies' type='xs:string'/&gt;
+        &lt;xs:element name='supersedes' type='xs:string'/&gt;
+        &lt;xs:element name='supersededby' type='xs:string'/&gt;
+        &lt;xs:element name='shortname' type='xs:NCNAME'/&gt;
+        &lt;xs:element ref='schemaloc' minOccurs='0' maxOccurs='unbounded'/&gt; 
+        &lt;xs:element name='registry' type='empty' minOccurs='0'/&gt; 
+        &lt;xs:element name='expires' type='xs:string' minOccurs='0'/&gt; 
+        &lt;xs:element ref='author' minOccurs='0' maxOccurs='unbounded'/&gt; 
+        &lt;xs:element ref='revision' minOccurs='0' maxOccurs='unbounded'/&gt; 
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:NCNAME'&gt;
+        &lt;xs:enumeration value='Active'/&gt;
+        &lt;xs:enumeration value='Deferred'/&gt;
+        &lt;xs:enumeration value='Deprecated'/&gt;
+        &lt;xs:enumeration value='Draft'/&gt;
+        &lt;xs:enumeration value='Experimental'/&gt;
+        &lt;xs:enumeration value='Final'/&gt;
+        &lt;xs:enumeration value='Obsolete'/&gt;
+        &lt;xs:enumeration value='Proposed'/&gt;
+        &lt;xs:enumeration value='Rejected'/&gt;
+        &lt;xs:enumeration value='Retracted'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='type'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:string'&gt;
+        &lt;xs:enumeration value='Historical'/&gt;
+        &lt;xs:enumeration value='Humorous'/&gt;
+        &lt;xs:enumeration value='Informational'/&gt;
+        &lt;xs:enumeration value='Procedural'/&gt;
+        &lt;xs:enumeration value='Standards Track'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='schemaloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='ns' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='url' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='author'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='firstname' type='xs:string'/&gt;
+        &lt;xs:element name='surname' type='xs:string'/&gt;
+        &lt;xs:element name='org' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='email' type='xs:string'/&gt;
+        &lt;xs:element name='jid' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='revision'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='version' type='xs:string'/&gt;
+        &lt;xs:element name='date' type='xs:dateTime'/&gt;
+        &lt;xs:element name='initials' type='xs:NCName'/&gt;
+        &lt;xs:element name='remark' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='section1'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section2' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='topic' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='anchor' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='section2'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section3' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='topic' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='anchor' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='section3'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section4' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element name='code' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='topic' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='anchor' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='section4'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='topic' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='anchor' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='div'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='class' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='style' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='p' type='markup'/&gt;
+
+  &lt;xs:element name='ul'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='li' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='ol'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='li' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='start' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:NCName' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='li' type='markup'/&gt;
+
+  &lt;xs:element name='img'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='source' use='required'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='link'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='url' use='required'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='note' type='markup'/&gt;
+
+  &lt;xs:element name='example'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='caption' use='optional'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='code'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='caption' use='optional'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='table'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='tr' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='caption' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='tr'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='th' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='td' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='th'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='colspan' use='optional'/&gt; 
+          &lt;xs:attribute name='rowspan' use='optional'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='td'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='colspan' use='optional'/&gt; 
+          &lt;xs:attribute name='rowspan' use='optional'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:complexType name='markup' type='mixed'&gt;
+    &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+      &lt;xs:element name='cite' type='xs:token'/&gt;
+      &lt;xs:element name='em' type='xs:token'/&gt;
+      &lt;xs:element ref='img'/&gt;
+      &lt;xs:element ref='link'/&gt;
+      &lt;xs:element ref='note'/&gt;
+      &lt;xs:element name='span' type='xs:token'/&gt;
+      &lt;xs:element name='strong' type='xs:token'/&gt;
+      &lt;xs:element name='tt' type='xs:token'/&gt;
+    &lt;/xs:choice&gt;
+    &lt;xs:attribute name='class' type='xs:string' use='optional'/&gt;
+    &lt;xs:attribute name='style' type='xs:string' use='optional'/&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596398">1</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2601882">2</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601873">3</a>. The JEP concept as exemplified in version 1.0 of this document (approved in July of 2001) was borrowed from the Python community (see <a href="http://python.sourceforge.net/peps/pep-0001.html">PEP-1</a>). Subsequent revisions have been based on the Jabber community's experience with the JEP process, as well as insights gleaned from the standards processes followed by the IETF (<span class="ref">RFC 2026</span>  [<a href="#nt-id2601930">4</a>]), the <span class="ref">World Wide Web Consortium (W3C)</span>  [<a href="#nt-id2602040">5</a>] (<span class="ref">W3C Process Document</span>  [<a href="#nt-id2602064">6</a>]), and other standards development organizations.</p>
+<p>
+<a name="nt-id2601930">4</a>. RFC 2026: The Internet Standards Process &lt;<a href="http://www.ietf.org/rfc/rfc2026.txt">http://www.ietf.org/rfc/rfc2026.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602040">5</a>. The World Wide Web Consortium defines data formats and markup languages (such as HTML and XML) for use over the Internet. For further information, see &lt;<a href="http://www.w3.org/">http://www.w3.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602064">6</a>. W3C Process Document &lt;<a href="http://www.w3.org/Consortium/Process-20010719/process.html">http://www.w3.org/Consortium/Process-20010719/process.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602118">7</a>. Note well that a Standards Track JEP is not considered a full standard of the Jabber Software Foundation until it achieves a status of Final within the standards process defined herein (a Standards Track JEP that has achieved a status of Draft may be referred to as a Draft Standard; a Standards Track JEP that has a status of Experimental must not be referred to as a standard, but instead should be referred to as a work in progress).</p>
+<p>
+<a name="nt-id2602264">8</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602189">9</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602382">10</a>. JEP-0002: Jabber Interest Groups &lt;<a href="http://www.jabber.org/jeps/jep-0002.html">http://www.jabber.org/jeps/jep-0002.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602319">11</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p>
+<a name="nt-id2602348">12</a>. The JSF Board of Directors is an elected body that possesses overall responsibility for the affairs of the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/board/">http://www.jabber.org/board/</a>&gt;.</p>
+<p>
+<a name="nt-id2602404">13</a>. It is important to understand that private extensions to XMPP are also allowed. The JSF does not, and cannot, require such private extensions to be added to the public, official set of protocols recognized by the JSF. The processes and procedures in this document apply only to protocols that are submitted to the JSF, not to private protocol extensions used for custom functionality in particular applications. However, such private extensions must not be considered part of the protocols recognized by the JSF.</p>
+<p>
+<a name="nt-id2602550">14</a>. The JEP Editor is the individual appointed by the JSF Board of Directors to handle protocol submissions and provide day-to-day management of the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/jeps/editor.php">http://www.jabber.org/jeps/editor.php</a>&gt;.</p>
+<p>
+<a name="nt-id2602485">15</a>. The JSF IPR Policy defines the Jabber Software Foundation's official policy regarding intellectual property rights (IPR) as they pertain to Jabber Enhancement Proposals (JEPs). For further information, see &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;.</p>
+<p>
+<a name="nt-id2602730">16</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p>
+<a name="nt-id2602680">17</a>. JEPs are kept under source control in the 'jeps' module of the CVS repository maintained at the jabberstudio.org service. Instructions for accessing these files can be found at &lt;<a href="http://www.jabberstudio.org/cvs.php">http://www.jabberstudio.org/cvs.php</a>&gt;, and a web interface to these files is available at &lt;<a href="http://www.jabberstudio.org/cgi-bin/viewcvs.cgi/jeps/">http://www.jabberstudio.org/cgi-bin/viewcvs.cgi/jeps/</a>&gt;.</p>
+<p>
+<a name="nt-id2602754">18</a>. The canonical URL for accessing JEPs is &lt;<a href="http://www.jabber.org/jeps/jeplist.php">http://www.jabber.org/jeps/jeplist.php</a>&gt;.</p>
+<p>
+<a name="nt-id2602991">19</a>. A list of official JSF protocols is maintained at &lt;<a href="http://www.jabber.org/protocol/">http://www.jabber.org/protocol</a>&gt;.</p>
+<p>
+<a name="nt-id2603113">20</a>. The Bylaws of the Jabber Software Foundation (JSF) define the legal basis and operating procedures of the JSF. For further information, see &lt;<a href="http://www.jabber.org/jsf/bylaws.php">http://www.jabber.org/jsf/bylaws.php</a>&gt;.</p>
+<p>
+<a name="nt-id2603242">21</a>. The General Public License is the primary code license for free software as defined by the Free Software Foundation. For further information, see &lt;<a href="http://www.gnu.org/licenses/gpl.txt">http://www.gnu.org/licenses/gpl.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603267">22</a>. The Lesser General Public License is a secondary code license for free software as defined by the Free Software Foundation. For further information, see &lt;<a href="http://www.gnu.org/licenses/lgpl.txt">http://www.gnu.org/licenses/lgpl.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595883">23</a>. The Open Source Initiative defines the term 'open source' and maintains a list of a open-source code licenses. For further information, see &lt;<a href="http://www.opensource.org/">http://www.opensource.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603787">24</a>. JEP-0053: Jabber Registrar &lt;<a href="http://www.jabber.org/jeps/jep-0053.html">http://www.jabber.org/jeps/jep-0053.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603926">25</a>. RFC 3552: Guidelines for Writing RFC Text on Security Considerations &lt;<a href="http://www.ietf.org/rfc/rfc3552.txt">http://www.ietf.org/rfc/rfc3552.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603872">26</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2604033">27</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2603959">28</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604142">29</a>. XML Schema Part 1: Structures &lt;<a href="http://www.w3.org/TR/xmlschema-1/">http://www.w3.org/TR/xmlschema-1/</a>&gt;.</p>
+<p>
+<a name="nt-id2604162">30</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.14 (2004-09-28)</h4>
+<div class="indent">Defined Procedural JEP type as the union of JIG Formation JEPs and certain Informational JEPs in order to clarify the JEP categories; added Modifications to Approved JEPs section in order to make explicit existing Council practices regarding Active and Final JEPs; specified that JEPs on which voting was not complete at the end of a Council term shall undergo a second Last Call and subsequent vote by the new Council; modified Proposal Process to specify that the Jabber Council shall issue Last Calls on JEPs for which it is the approving body, with all discussion to occur on the Standards-JIG list; updated the schema. (psa)
+    </div>
+<h4>Version 1.13 (2004-08-24)</h4>
+<div class="indent">Further specified the goals of the JEP process; mentioned Board-approved JEPs. (psa)
+    </div>
+<h4>Version 1.11 (2004-07-14)</h4>
+<div class="indent">Specified the procedure for changing a JEP from Historical to Standards Track. (psa)
+    </div>
+<h4>Version 1.10 (2004-03-24)</h4>
+<div class="indent">Specified the procedure for acceptance of a proposal as a JEP; clarified the JEP types; completed editorial review. (psa)
+    </div>
+<h4>Version 1.9 (2003-12-22)</h4>
+<div class="indent">Added rule about automatic deferral of inactive JEPs. (psa)
+    </div>
+<h4>Version 1.8 (2003-10-06)</h4>
+<div class="indent">Clarified the definition of informational JEP. (psa)
+    </div>
+<h4>Version 1.7 (2003-04-11)</h4>
+<div class="indent">Added status of Retracted; corrected several errors related to the Jabber Registrar. (psa)
+    </div>
+<h4>Version 1.6 (2003-01-08)</h4>
+<div class="indent">Further clarified the proposal process per discussion on the JSF members list. (psa)
+    </div>
+<h4>Version 1.5 (2002-10-29)</h4>
+<div class="indent">Major revision based on experience. In addition to a reorganization of the content to improve the clarity of the presentation, changes include: (1) no anonymous authors; (2) proposal must be seconded by at least 5% of JSF members before being proposed for a Council vote; (3) clarification that the Council votes only on a particular revision of a JEP (e.g., version 1.3 when proceeding from Draft to Final); (4) added information about the &quot;Call for Experience&quot; phase before proceeding from Draft to Final; (5) added reference to RFC 2119; (6) added sections for security considerations, IANA considerations, and Jabber Registrar considerations. Approved by the JSF Board and Jabber Council on 2002-11-20. (psa)
+    </div>
+<h4>Version 1.4 (2002-01-16)</h4>
+<div class="indent">Added information about the new &quot;Experimental&quot; state for Standards Track JEPs and made appropriate changes to the JEP process. (psa)
+    </div>
+<h4>Version 1.3.1 (2002-01-11)</h4>
+<div class="indent">Added link to DTD. (psa)
+    </div>
+<h4>Version 1.3 (2001-10-23)</h4>
+<div class="indent">(1) Added information about the &quot;cooling off&quot; period before a Standards Track JEP may be advanced from Draft to Final; (2) Added a link to the JEP template file; (3) Performed several minor fixes. (psa)
+    </div>
+<h4>Version 1.2 (2001-09-27)</h4>
+<div class="indent">(1) Added information about expiration dates; (2) Added a status of Deprecated to Standards Track JEPs. (psa)
+    </div>
+<h4>Version 1.1 (2001-09-09)</h4>
+<div class="indent">(1) Changed &quot;Jabber Foundation&quot; to &quot;Jabber Software Foundation&quot;; (2) Changed &quot;JIG Proposal JEP&quot; to &quot;JIG Formation JEP&quot;; (3) Removed reference to the Secretary of the Jabber Software Foundation in connection with the role of JEP Editor; (4) Clarified the possible states of acceptance of each kind of JEP and described in greater detail the criteria for advancement from one state to another. (psa)
+    </div>
+<h4>Version 1.0 (2001-07-09)</h4>
+<div class="indent">Changed status to Active. (psa)
+    </div>
+<h4>Version 0.1 (2001-06-28)</h4>
+<div class="indent">Initial release -- a simplified and updated version of Rahul Dave's Jabberization of the process and format for Python Enhancement Proposals (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0001-1.15.html
+++ b/content/xep-0001-1.15.html
@@ -1,0 +1,693 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0001: Jabber Enhancement Proposals (JEPs)</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jabber Enhancement Proposals (JEPs)">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines the standards process followed by the Jabber Software Foundation.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0001">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0001: Jabber Enhancement Proposals (JEPs)</h1>
+<p>This JEP defines the standards process followed by the Jabber Software Foundation.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Procedural JEP defines a process or activity of the Jabber Software Foundation (JSF) that has been approved by the Jabber Council and/or the JSF Board of Directors. The JSF is currently following the process or activity defined herein and will do so until this JEP is deprecated or obsoleted.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Procedural<br>
+            Number: 0001<br>
+            Version: 1.15<br>
+            Last Updated: 2004-11-02<br>
+            JIG: None<br>
+                Approving Body: JSF Board of Directors<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jabber%20Enhancement%20Proposals%20(JEPs)%20(JEP-0001)">http://wiki.jabber.org/index.php/Jabber Enhancement Proposals (JEPs) (JEP-0001)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Discussion by the membership of the JSF may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/members">http://mail.jabber.org/mailman/listinfo/members</a>&gt; for details).</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#objectives">Objectives</a>
+</dt>
+<dt>3.  <a href="#types">JEP Types</a>
+</dt>
+<dt>4.  <a href="#submission">Submission Process</a>
+</dt>
+<dt>5.  <a href="#publication">Publication Process</a>
+</dt>
+<dt>6.  <a href="#discussion">Discussion Process</a>
+</dt>
+<dt>7.  <a href="#proposal">Proposal Process</a>
+</dt>
+<dt>8.  <a href="#approval">Approval Process</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#approval-std">Standards Track JEPs</a>
+</dt>
+<dt>8.2.  <a href="#approval-info">Historical, Informational, and Procedural JEPs</a>
+</dt>
+</dl>
+<dt>9.  <a href="#mods">Modifications to Approved JEPs</a>
+</dt>
+<dt>10.  <a href="#expiration">Expiration Dates</a>
+</dt>
+<dt>11.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>14.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2250797">1</a>] adheres to an open standards process that enables interested parties to document existing protocols used within the Jabber community and to submit proposals that define new protocols; all such protocols may be considered extensions to the Extensible Messaging and Presence Protocol (XMPP) approved by the <span class="ref" style="">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2250838">2</a>] in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250862">3</a>] and <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250884">4</a>]. Advancement through the JSF's standards process is subject to open discussion on public discussion lists and approval by a technical steering committee elected by the members of the JSF. The focal point of the process is a series of protocol specifications called Jabber Enhancement Proposals or JEPs.  [<a href="#nt-id2250851">5</a>] The nature of JEPs and the mechanisms for managing and advancing them within the Jabber Software Foundation are canonically described in the current document, which represents the first document in the JEP series.</p>
+<h2>2.
+       <a name="objectives">Objectives</a>
+</h2>
+  <p class="" style="">The Jabber Software Foundation was founded in the year 2001 to openly document, safeguard, manage, and extend the wire protocols used within the Jabber community. The work of the Jabber Software Foundation has several objectives:</p>
+  <ol start="1" type="">
+    <li>To produce practical, technically excellent solutions to important problems of real-time communication based on the set of streaming XML technologies known as Jabber/XMPP.</li>
+    <li>To document Jabber protocols and XMPP extensions in a clear, concise manner so that the task of implementing the protocols is straightforward.</li>
+    <li>To ensure interoperability among the disparate technologies used on Jabber/XMPP networks.</li> 
+    <li>To guarantee that any person or entity may implement the protocols without encmbrance.</li>
+    <li>To work in an fair, open, objective manner.</li>
+  </ol>
+  <p class="" style="">The standards process specified herein has been developed and refined in order to meet these objectives.</p>
+<h2>3.
+       <a name="types">JEP Types</a>
+</h2>
+  <p class="" style="">There are five types of JEP:</p>
+  <ol start="1" type="">
+    <li>
+      <p class="" style="">A <span class="ref" style="">Standards Track JEP</span> defines one of the following:</p>
+      <ol start="" type="">
+        <li>A wire protocol intended to be used as a standard part of Jabber technologies.
+	   [<a href="#nt-id2256915">9</a>]
+	</li>
+        <li>A protocol suite that determines conformance requirements (e.g., <span class="ref" style="">Basic IM Protocol Suite</span>  [<a href="#nt-id2256952">10</a>]).</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">An <span class="ref" style="">Informational JEP</span> defines one of the following:</p>
+      <ol start="1" type="">
+        <li>Best practices for protocol development (e.g., <span class="ref" style="">Service Discovery Extensions</span>  [<a href="#nt-id2257003">11</a>]).</li>
+        <li>A usage profile for an existing protocol (e.g., <span class="ref" style="">Invisibility</span>  [<a href="#nt-id2257031">12</a>]).</li>
+      </ol>
+    </li>
+    <li><p class="" style="">An <span class="ref" style="">Historical JEP</span> documents a protocol that was developed before the JEP process was instituted, but that is still in use within the Jabber community; such a JEP may or may not be obsoleted by a Standards Track JEP, or upgraded to Standards Track.</p></li>
+    <li><p class="" style="">A <span class="ref" style="">Humorous JEP</span> attempts to be funny by defining a protocol that would never be used in the real world; such JEPs are usually published on April 1 and automatically have a status of Active.</p></li>
+    <li><p class="" style="">A <span class="ref" style="">Procedural JEP</span> defines a process or activity to be followed by the JSF, including JIG charters as specified by <span class="ref" style="">Jabber Interest Groups</span>  [<a href="#nt-id2257111">13</a>].</p></li>
+  </ol>
+  <p class="" style="">The approving body for all Standards Track, Informational, Historical, and Humorous JEPs is the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2257143">14</a>]; the approving body for Procedural JEPs is usually the <span class="ref" style="">JSF Board of Directors</span>  [<a href="#nt-id2257169">15</a>] but may be the Jabber Council.</p>
+  <p class="" style="">This document focuses primarily on Standards Track JEPs, since they are the vehicle for defining new protocols, but also discusses Historical, Informational, and Procedural JEPs.</p>
+<h2>4.
+       <a name="submission">Submission Process</a>
+</h2>
+  <p class="" style="">The JSF welcomes and encourages the submission of protocols to the JSF's standards process.  [<a href="#nt-id2257196">16</a>] Any individual or group of individuals may author a proposal and submit it to the JSF for consideration as a JEP, and there is no requirement that a JEP author shall be an elected member of the JSF. However, proposals to define official JSF protocols must be presented in the JEP format and must follow the rules defined herein. The JEP authoring and submission process is defined in <span class="ref" style="">Guidelines for JEP Authors</span>  [<a href="#nt-id2257234">17</a>] (see also &lt;<a href="http://www.jabber.org/jeps/submit.shtml">http://www.jabber.org/jeps/submit.shtml</a>&gt;). All inquiries related to the JEP process, and all submissions, should be directed to the <span class="ref" style="">JEP Editor</span>  [<a href="#nt-id2257266">18</a>].</p> 
+  <p class="" style="">Note well that JEP authors must transfer ownership of their protocols (but not implementations thereof) to the JSF. Refer to the <span class="ref" style="">JSF IPR Policy</span>  [<a href="#nt-id2257303">19</a>] for details. JEP authors must make sure that they have read, understood, and agreed to the JSF IPR Policy before submitting a proposal to the JEP Editor!</p>
+  <p class="" style="">All proposals submitted to the JSF for consideration as a JEPs must contain the following information:</p>
+  <ol start="1" type="">
+    <li><p class="" style="">Legal Notice -- the legal notice must be exactly that which is specified in the JSF IPR Policy</p></li>
+    <li><p class="" style="">Author Information -- first name, last name, email address, and Jabber ID are all required and must be provided for all authors</p></li>
+  </ol>
+  <p class="" style="">Finally, Standards Track, Informational, and Historical JEPs must conform to <span class="ref" style="">RFC 2119</span>  [<a href="#nt-id2257380">20</a>] in the use of terminology regarding requirements levels.</p>
+<h2>5.
+       <a name="publication">Publication Process</a>
+</h2>
+  <p class="" style="">The approving body for almost all JEPs is the Jabber Council; therefore, in order to be published as a JEP, a proposal must first be accepted by the Jabber Council (the only exceptions are certain kinds of Procedural JEPs, for which the approving body may be the JSF Board of Directors and which may be accepted for publication by the JEP Editor in consultation with the Board). Upon receiving a proposal, the JEP Editor shall do the following:</p>
+  <ul>
+    <li>ensure that its format is correct</li>
+    <li>publish it to &lt;<a href="http://www.jabber.org/jeps/inbox/">http://www.jabber.org/jeps/inbox/</a>&gt;</li>
+    <li>publicly announce its existence by sending a message to the discussion list of the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2257444">21</a>]</li>
+    <li>request acceptance of the proposal as a JEP by the Jabber Council</li>
+  </ul>
+  <p class="" style="">If no member of the Jabber Council objects to publication of the proposal within seven (7) days, the JEP Editor shall accept it as a JEP. If objections are raised by the Council on the Standards-JIG list, the JEP author(s) is encouraged to address the feedback of the Council and to submit a revised version of the proposal and/or confer with the JEP Editor or objecting Council member(s) regarding how to proceed.</p>
+  <p class="" style="">If the proposal is accepted as a JEP, the JEP Editor shall do the following:</p>
+  <ul>
+    <li>assign it a number</li>
+    <li>specify an appropriate type</li>
+    <li>specify a status of Experimental</li>
+    <li>add it to source control  [<a href="#nt-id2257496">22</a>]</li>
+    <li>add tracking information to the JEPs database</li>
+    <li>publish version 0.1 of the JEP to the JSF website  [<a href="#nt-id2257529">23</a>]</li>
+    <li>publicly announce the existence of the JEP by sending a message to the Standards-JIG list</li>
+  </ul>
+  <p class="" style="">Note well that no special criteria (other than acceptance by the Jabber Council and minimal formatting compliance) need to be met in order for a JEP to be granted a status of Experimental. The granting of Experimental status must not be construed as indicating any level of approval by the JSF, the Jabber Council, or the Jabber community. Implementation of Experimental JEPs is encouraged in an exploratory fashion (e.g., in a proof of concept), but such implementations may not be appropriate for deployment in production systems.</p>
+<h2>6.
+       <a name="discussion">Discussion Process</a>
+</h2>
+  <p class="" style="">Once a JEP is published, it becomes available for public discussion within the Standards JIG and the broader Jabber community. The JEP author(s) is responsible for collecting feedback from the Jabber community during the life of the JEP and for incorporating such feedback into the proposal. In order to fully participate in discussion of the proposal, the JEP author(s) should be subscribed to the Standards-JIG list, which is the primary venue for discussion of JEPs. Changes made based on feedback received by the JEP author(s) must be captured in updated versions of the JEP (e.g., 0.2 after 0.1), each of which must be put under source control and subsequently tracked and announced by the JEP Editor.</p>
+  <p class="" style="">If an Experimental JEP is inactive (i.e., no updated versions are published) for a period of six months, the JEP Editor shall automatically change the status of the JEP to Deferred unless it is in the queue of JEPs under active consideration for advancement by the Jabber Council; upon submission of an updated version, the JEP Editor shall change the status back to Experimental.</p>
+<h2>7.
+       <a name="proposal">Proposal Process</a>
+</h2>
+  <p class="" style="">Before an experimental JEP may be proposed to the Jabber Council for advancement to Draft (Standards Track JEPs) or Active (Historical, Informational, and Procedural JEPs), the Jabber Council must agree that the JEP is ready to be considered for advancement. Once the Council so agrees, it shall instruct the JEP Editor to (1) change the status of the JEP from Experimental to Proposed and (2) issue a Last Call for open discussion on the Standards JIG list. The Last Call shall expire not less than 10 days after the date of issue.</p>
+  <p class="" style="">Once the consensus of the Standards JIG has been incorporated into the JEP and all issues of substance raised during the Last Call have been addressed by the JEP author(s), the JEP Editor shall formally propose a specific revision of the JEP to the Jabber Council for its vote. If necessary, the JEP Editor may, at his discretion and in consultation with the Jabber Council, extend the Last Call or issue a new Last Call if the JEP requires further discussion.</p>
+  <p class="" style="">Last Calls regarding Procedural JEPs for which the approving body is the JSF Board of Directors may be issued directly by the JEP Editor once instructed by the Board.</p>
+<h2>8.
+       <a name="approval">Approval Process</a>
+</h2>
+  <p class="" style="">After a JEP has been proposed to the Jabber Council, any change in its status shall be determined by a vote of the Jabber Council. All members of the Council must vote, with the possible values being +1 (approve), 0 (neutral), or -1 (disapprove, with reasons). A JEP shall not be advanced to the next stage in the approval process so long as any Council Member continues to vote -1; that Council Member's written concerns must be addressed in order for the JEP to advance. A majority of Council members must vote +1 in order for a JEP to advance. (Additional voting policies, such as voting periods and defaults if a member does not vote, may be set by the Jabber Council.) A vote of the Jabber Council is final and binding, although a JEP author(s) is free to address the concerns of the Council and to resubmit the JEP for future consideration.</p>
+  <p class="" style="">If the Jabber Council does not complete voting on a JEP before the end of its term, the JEP Editor shall issue a new Last Call on the Standards JIG list and the newly-elected Council shall vote anew on the JEP after completion of the Last Call. This provides an opportunity for any member of the previous Council who had voted -1 to voice his or her concerns in a public forum before the new Council votes on the JEP.</p>
+  <p class="" style="">A vote of the Jabber Council applies only to the specific revision of the JEP that has been presented to it. Further revisions may need to be re-submitted for approval.</p>
+  <p class="" style="">Any change in the status of a JEP must be announced on the Standards-JIG list by the JEP Editor. If a JEP advances to a status of Final, it shall be so announced and also published as one of the official JSF protocols  [<a href="#nt-id2257719">24</a>] on the website of the Jabber Software Foundation.</p>
+  <p class="" style="">Approval of Procedural JEPs for which the approving body is the JSF Board of Directors shall occur upon approval by the Board in accordance with the rules defined in the <span class="ref" style="">JSF Bylaws</span>  [<a href="#nt-id2257764">25</a>].</p>
+  <p class="" style="">More detailed information about the approval process is provided below, including criteria for Standards Track JEPs and for Historical, Informational, and Procedural JEPs.</p>
+  <div class="indent">
+<h3>8.1 <a name="approval-std">Standards Track JEPs</a>
+</h3>
+    <p class="" style="">The possible states for a Standards Track JEP are as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+                       +------&gt; Rejected
+                       |           +
+                       |           |
+Experimental ---&gt; Proposed ---&gt; Draft ----&gt; Final
+     |                 |           |          |
+     |                 |           +          +
+ Retracted             +------&gt; Deferred  Deprecated ---&gt; Obsolete
+      </pre></div>
+    <p class="" style="">The ideal path is for a Standards Track JEP to be advanced by the Jabber Council from Proposed to Draft to Final (the criteria for this approval are described in the following paragraphs). However, rather than being advanced from Proposed to Draft or from Draft to Final, a Standards Track JEP may, at the discretion of the Jabber Council, be either Deferred or Rejected, and thus not be advanced along the ideal path. Specifically, a JEP may be assigned a status of Deferred if no progress is being made on the JEP or if it is dependent on other protocol enhancements that are yet to be completed. Similarly, a JEP may be assigned a status of Rejected if it is deemed unacceptable by the Jabber Council. (Note that if a JEP is Deferred, the JEP Editor may at some point re-assign it to Experimental status, and that, even if a JEP is Rejected, it is retained in source control and on the Jabber Software Foundation website for future reference.) Finally, a JEP author(s) may retract an Experimental JEP from further consideration, resulting in a status of Retracted.</p>
+    <p class="" style="">In order for a JEP to advance from Proposed to Draft, it must:</p>
+    <ol start="" type="">
+      <li>fill known gaps in Jabber technologies or deficiencies with existing protocols</li>
+      <li>be clearly described and accurately documented so that it can be understood and implemented by interested and knowledgeable members of the Jabber community</li>
+      <li>document any known security considerations with the proposed technology</li>
+      <li>be generally stable and appropriate for further field experience</li>
+      <li>have achieved rough consensus (though not necessarily unanimity) within the Standards JIG</li>
+      <li>be formally defined by an XML schema</li>
+      <li>receive the requisite votes from the Jabber Council</li>
+    </ol>
+    <p class="" style="">Elevation to Draft status is a major advancement for the JEP, indicating a strong belief on the part of the Jabber Council and Jabber community that the specification will be of lasting value. Since a Draft standard must be well-understood and must be known to be reasonably stable, it is relatively safe to use it as the basis for implementations and production deployments. However, note that because a Draft standard may still require additional field experience and may be subject to change based on such experience, mission-critical or large-scale implementations of the Draft standard may not be advisable.</p>
+    <p class="" style="">In order for a JEP to advance from Draft to Final, it must be shown to be stable and well-received by the Jabber community. Before presenting a Draft standard to the Jabber Council for consideration as a Final standard, the JEP Editor shall issue a Call for Experience on the Standards-JIG list so that feedback can be gathered from those who have implemented the Draft standard (the Call for Experience shall expire not less than 14 days after the date of issue, and shall not be issued until at least 60 days have passed since advancement to Draft). In addition, at least two implementations of the JEP must exist, at least one of which must be free software (in accordance with the <span class="ref" style="">The General Public License</span>  [<a href="#nt-id2257949">26</a>] or <span class="ref" style="">The Lesser General Public License</span>  [<a href="#nt-id2257976">27</a>]) or open-source software (in accordance with the definition provided by <span class="ref" style="">The Open Source Initiative</span>  [<a href="#nt-id2258002">28</a>]). Until two implementations are produced, a Standards Track JEP shall retain a status of Draft. Once (1) two implementations have been presented to the Jabber Council, (2) feedback provided during the Call for Experience has been incorporated into the JEP, and (3) the JEP has been fully checked for accuracy, the status of the JEP may be changed to Final upon a vote of the Council.</p> 
+    <p class="" style="">Finally, a Standards Track JEP that has been granted a status of Final may be superseded by a future JEP approved by the Jabber Council. In such cases, the status of the earlier JEP shall be changed to Deprecated, possibly with an expiration date assigned by the Jabber Council (see the <a href="#expiration">Expiration Dates</a> section below). After a reasonable period of time or upon the passing of the expiration date, the status of the JEP shall be changed to Obsolete.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="approval-info">Historical, Informational, and Procedural JEPs</a>
+</h3>
+    <p class="" style="">The possible states for a Historical, Informational, or Procedural JEP are as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+
+                      +-------&gt; Rejected
+                      |
+                      |
+Experimental ---&gt; Proposed ---&gt; Active ---------&gt; Obsolete
+     |                |                      |
+     |                |                      |
+ Retracted            +-------&gt; Deprecated --+
+    </pre></div>
+    <p class="" style="">Because such JEPs do not seek to define standard protocols, in general they are less controversial and tend to proceed from Proposed to Active without controversy on a vote of the Jabber Council. However, some of these JEPs may be remanded from the Council to the JEP author(s) and/or JEP Editor for revision in order to be suitable for advancement from Proposed to Active (e.g., documentation of protocols in use must be accurate and describe any existing security concerns). As with Standards Track JEPs, the JEP author(s) may retract such a JEP when it is Experimental, and the Council may reject such a JEP when it is Proposed.</p> 
+    <p class="" style="">Once approved, most Historical, Informational, and Procedural JEPs will have a status of Active. Naturally, such a JEP may also be assigned a status of Rejected or Deprecated (instead of Active) by the Jabber Council. Furthermore, such a JEP may be replaced by a new JEP on the same or a similar topic, thus rendering the earlier JEP obsolete; in such cases, the earlier JEP shall be assigned a status of Obsolete with a note specifying the superseding JEP. 
+    </p> 
+    <p class="" style="">The Jabber Council may, at its discretion, decide to convert an Historical JEP into a Standards Track JEP if the protocol defined in the JEP has been in long use, is deemed stable and uncontroversial, and is unlikely to be superseded by a newer protocol. The Historical JEP shall be treated in the same way as a Standards Track JEP that has a status of Experimental, beginning with the <a href="#proposal">Proposal Process</a>. If after the Last Call and voting by the Jabber Council the JEP is approved for advancement on the standards track, its type shall be changed to Standards Track and its status shall be changed to Draft.</p>
+  </div>
+<h2>9.
+       <a name="mods">Modifications to Approved JEPs</a>
+</h2>
+  <p class="" style="">Sometimes it is necessary to modify JEPs that have received final approval by the Jabber Council or JSF Board of Directors (e.g., to correct errors, incorporate the lessons of experience, or document new security concerns). This section describes the process for doing so with regard to Standards Track JEPs that have achieved a status of Final and Historical, Informational, and Procedural JEPs that have achieved a status of Active.</p>
+  <p class="" style="">With regard to Standards Track JEPs, the Jabber Software Foundation (in particular, the Jabber Council) strives to ensure that such JEPs are accurate, complete, and stable before advancing them to a status of Final (corresponding to document version 2.0 of the JEP). The Call for Experience and discussion within the Standards JIG help to ensure this result, but final responsibility rests with the Jabber Council. Despite the best efforts of all concerned, errors are sometimes discovered in Final JEPs (the individual who discovers such an error should inform the Council via the Standards-JIG mailing list or communicate directly with the JEP Editor). Whereas other standards development organizations may issue errata while leaving the specification itself unchanged, the JSF makes changes to the Final JEP and publishes a revised document version (e.g., version 2.1). In general the changes are made by the JEP Editor or JEP author(s) in consultation with the Jabber Council, discussed within the Standards JIG if appropriate, and agreed upon by the full Jabber Council. Upon agreement regarding the exact changes, the Jabber Council instructs the JEP Editor to publish a revised version of the JEP and announce the existence of the revised version through the normal channels (e.g., on the JSF website and to the Standards-JIG list). Naturally, if members of the Jabber community have concerns regarding the changes made, they are free to discuss the matter in the relevant forum (usually the Standards-JIG list) before or after the revised version has been published.</p>
+  <p class="" style="">The process is similar with regard to Historical and Informational JEPs that have achieved a status of Active (corresponding to document version 1.0 of the JEP): the Jabber Council agrees on the exact changes to be made and instructs the JEP Editor to publish and announce a revised version (e.g., version 1.1). Here again the Jabber Council bears responsibility for any changes and public discussion is welcome.</p>
+  <p class="" style="">Procedural JEPs may be modified more frequently as the Jabber Software Foundation gains experience with the processes defined therein. For example, JEP-0001 is modified periodically in order to document processes previously not made explicit or to modify existing processes based on experience with the JEP process; similar changes are sometimes made to the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258216">29</a>] JEP and to various JIG-related JEPs. Changes to these JEPs are discussed by the Jabber Council, JSF Board of Directors, JSF membership, and Standards JIG as appropriate, and exact changes are agreed to by the relevant approving body (Jabber Council or JSF Board of Directors). The approving body then instructs the JEP Editor to publish and announce the revised version as described above.</p>
+<h2>10.
+       <a name="expiration">Expiration Dates</a>
+</h2>
+  <p class="" style="">In rare cases, a protocol enhancement may be accepted as an interim solution, especially when it is recognized that expected future improvements in technology or the underlying Jabber/XMPP protocols will make possible a much better solution to the problem at hand (e.g., a better protocol for user avatars may be contingent upon the development of a robust protocol for publish/subscribe functionality). In such cases, a JEP may be approved provisionally and be assigned an expiration date.</p>
+  <p class="" style="">The exact form of such an expiration date shall be left up to the discretion of the Jabber Council. However, the preferred form is to assign an expiration date of six months in the future, at which time the Jabber Council must re-affirm the status of the JEP and, if desired, extend the expiration date for another six months. While this process may continue indefinitely (although that is unlikely), it has the virtue of forcing the Jabber Council and Jabber community to re-examine the provisional protocol on a fairly regular basis in the light of technological changes. Alternatively, a JEP may be assigned a "soft" expiration date: that is, the JEP will expire when an expected future protocol comes into existence, whenever that may be. In either case, the status of the JEP shall be changed to Deprecated when it expires.</p>
+  <p class="" style="">In addition, an expiration date may be assigned when the status of a JEP is changed from Final (or, potentially, Draft) to Deprecated. In this case, the expiration date applies to the date when the JEP is expected to change from Deprecated to Obsolete. These dates may be flexible; however it is expected that they will follow the same six-month rule as provisional protocol enhancements.</p>
+<h2>11.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Every JEP must contain a section entitled "Security Considerations", detailing security concerns or features related to the proposal; in particular, a Standards Track JEP should list the security threats that the protocol addresses and does not address, as well as security issues related to implementation of the protocol. JEP authors should refer to <span class="ref" style="">RFC 3552</span>  [<a href="#nt-id2258377">30</a>] for helpful information about documenting security considerations and should also confer with the JEP Editor and/or Jabber Council regarding this important task.</p>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">Some JEPs may require interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258385">31</a>]. The IANA acts as a clearinghouse to assign and coordinate the use of numerous Internet protocol parameters, such as MIME types and port numbers (e.g., the TCP ports 5222 and 5269 used by the Jabber community are registered with the IANA). Whether or not a JEP requires registration of parameters with the IANA, that fact must be noted and explained in a distinct section of the JEP entitled "IANA Considerations". Registration with the IANA should not occur until a JEP advances to a status of Draft (Standards Track JEPs) or Active (Informational and Historical JEPs), and should be initiated by the Jabber Registrar in consultation with the JEP author, not by the JEP author(s) directly with the IANA.</p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258433">32</a>] performs a function similar to the IANA, although limited to the Jabber community. It does so by reserving protocol namespaces and by uniquely assigning parameters for use in the context of Jabber/XMPP protocols (for example, the categories and types used in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2258467">33</a>]).</p>
+  <p class="" style="">Whether or not a JEP requires registration of protocol namespaces or parameters with the Jabber Registrar, that fact must be noted and explained in a distinct section of the JEP entitled "Jabber Registrar Considerations". Such registration should not occur until a JEP advances to a status of Draft (Standards Track JEPs) or Active (Informational and Historical JEPs). Registration of protocol namespaces is initiated by the JEP Editor when a JEP advances to Draft or Active. Registration of particular parameters used within a specification may be initiated by a JEP author(s) within the text of the JEP, or by an implementor of the JEP after it has advanced to Draft or Active. For details regarding the Jabber Registrar and its processes, refer to JEP-0053.</p>
+  <p class="" style="">A JEP may also request that a new registry is to be created by the Jabber Registrar. The JEP author(s) must clearly define the nature of the new registry as well as the process for submitting data to the registry, and must do so in collaboration with the Registrar.</p>
+<h2>14.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">JEPs that define official JSF protocols must include a schema that conforms to <span class="ref" style="">XML Schema Part 1</span>  [<a href="#nt-id2258533">34</a>] and <span class="ref" style="">XML Schema Part 2</span>  [<a href="#nt-id2258520">35</a>].</p>
+  <p class="" style="">The schema for the JEP format itself is as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://www.jabber.org/jeps'
+    xmlns='http://www.jabber.org/jeps'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jep'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;
+
+        This schema defines the document format for Jabber Enhancement 
+        Proposals (JEPs). For further information about JEPs, visit:
+
+           http://www.jabber.org/jeps/ 
+        
+        The canonical URL for this schema is:
+        
+           http://www.jabber.org/jeps/jep.xsd
+
+      &lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='header'/&gt;
+        &lt;xs:element ref='section1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='header'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='title' type='xs:string'/&gt;
+        &lt;xs:element name='abstract' type='xs:string'/&gt;
+        &lt;xs:element name='legal' type='xs:string'/&gt;
+        &lt;xs:element name='number' type='xs:byte'/&gt;
+        &lt;xs:element ref='status'/&gt;
+        &lt;xs:element ref='type'/&gt; 
+        &lt;xs:element name='jig' type='xs:string'/&gt;
+        &lt;xs:element name='approver' type='xs:string'/&gt;
+        &lt;xs:element name='dependencies' type='xs:string'/&gt;
+        &lt;xs:element name='supersedes' type='xs:string'/&gt;
+        &lt;xs:element name='supersededby' type='xs:string'/&gt;
+        &lt;xs:element name='shortname' type='xs:NCNAME'/&gt;
+        &lt;xs:element ref='schemaloc' minOccurs='0' maxOccurs='unbounded'/&gt; 
+        &lt;xs:element name='registry' type='empty' minOccurs='0'/&gt; 
+        &lt;xs:element name='expires' type='xs:string' minOccurs='0'/&gt; 
+        &lt;xs:element ref='author' minOccurs='0' maxOccurs='unbounded'/&gt; 
+        &lt;xs:element ref='revision' minOccurs='0' maxOccurs='unbounded'/&gt; 
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:NCNAME'&gt;
+        &lt;xs:enumeration value='Active'/&gt;
+        &lt;xs:enumeration value='Deferred'/&gt;
+        &lt;xs:enumeration value='Deprecated'/&gt;
+        &lt;xs:enumeration value='Draft'/&gt;
+        &lt;xs:enumeration value='Experimental'/&gt;
+        &lt;xs:enumeration value='Final'/&gt;
+        &lt;xs:enumeration value='Obsolete'/&gt;
+        &lt;xs:enumeration value='Proposed'/&gt;
+        &lt;xs:enumeration value='Rejected'/&gt;
+        &lt;xs:enumeration value='Retracted'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='type'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:string'&gt;
+        &lt;xs:enumeration value='Historical'/&gt;
+        &lt;xs:enumeration value='Humorous'/&gt;
+        &lt;xs:enumeration value='Informational'/&gt;
+        &lt;xs:enumeration value='Procedural'/&gt;
+        &lt;xs:enumeration value='Standards Track'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='schemaloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='ns' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='url' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='author'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='firstname' type='xs:string'/&gt;
+        &lt;xs:element name='surname' type='xs:string'/&gt;
+        &lt;xs:element name='org' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='email' type='xs:string'/&gt;
+        &lt;xs:element name='jid' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='revision'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='version' type='xs:string'/&gt;
+        &lt;xs:element name='date' type='xs:dateTime'/&gt;
+        &lt;xs:element name='initials' type='xs:NCName'/&gt;
+        &lt;xs:element name='remark' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='section1'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section2' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='topic' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='anchor' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='section2'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section3' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='topic' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='anchor' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='section3'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section4' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element name='code' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='topic' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='anchor' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='section4'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='topic' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='anchor' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='div'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='div' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='p' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='example' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='code' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ul' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='ol' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='class' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='style' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='p' type='markup'/&gt;
+
+  &lt;xs:element name='ul'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='li' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='ol'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='li' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='start' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:NCName' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='li' type='markup'/&gt;
+
+  &lt;xs:element name='img'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='source' use='required'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='link'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='url' use='required'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='note' type='markup'/&gt;
+
+  &lt;xs:element name='example'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='caption' use='optional'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='code'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='caption' use='optional'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='table'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='tr' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='caption' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='tr'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='th' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='td' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='th'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='colspan' use='optional'/&gt; 
+          &lt;xs:attribute name='rowspan' use='optional'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='td'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='colspan' use='optional'/&gt; 
+          &lt;xs:attribute name='rowspan' use='optional'/&gt; 
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:complexType name='markup' type='mixed'&gt;
+    &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+      &lt;xs:element name='cite' type='xs:token'/&gt;
+      &lt;xs:element name='em' type='xs:token'/&gt;
+      &lt;xs:element ref='img'/&gt;
+      &lt;xs:element ref='link'/&gt;
+      &lt;xs:element ref='note'/&gt;
+      &lt;xs:element name='span' type='xs:token'/&gt;
+      &lt;xs:element name='strong' type='xs:token'/&gt;
+      &lt;xs:element name='tt' type='xs:token'/&gt;
+    &lt;/xs:choice&gt;
+    &lt;xs:attribute name='class' type='xs:string' use='optional'/&gt;
+    &lt;xs:attribute name='style' type='xs:string' use='optional'/&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250797">1</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2250838">2</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p><a name="nt-id2250862">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250884">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250851">5</a>. The JEP concept as exemplified in version 1.0 of this document (approved in July of 2001) was borrowed from the Python community (see <a href="http://python.sourceforge.net/peps/pep-0001.html">PEP-1</a>). Subsequent revisions have been based on the Jabber community's experience with the JEP process, as well as insights gleaned from the standards processes followed by the IETF (<span class="ref" style="">RFC 2026</span>  [<a href="#nt-id2256762">6</a>]), the <span class="ref" style="">World Wide Web Consortium (W3C)</span>  [<a href="#nt-id2256781">7</a>] (<span class="ref" style="">W3C Process Document</span>  [<a href="#nt-id2256804">8</a>]), and other standards development organizations.</p>
+<p><a name="nt-id2256762">6</a>. RFC 2026: The Internet Standards Process &lt;<a href="http://www.ietf.org/rfc/rfc2026.txt">http://www.ietf.org/rfc/rfc2026.txt</a>&gt;.</p>
+<p><a name="nt-id2256781">7</a>. The World Wide Web Consortium defines data formats and markup languages (such as HTML and XML) for use over the Internet. For further information, see &lt;<a href="http://www.w3.org/">http://www.w3.org/</a>&gt;.</p>
+<p><a name="nt-id2256804">8</a>. W3C Process Document &lt;<a href="http://www.w3.org/Consortium/Process-20010719/process.html">http://www.w3.org/Consortium/Process-20010719/process.html</a>&gt;.</p>
+<p><a name="nt-id2256915">9</a>. Note well that a protocol defined in a Standards Track JEP is not considered a full standard of the Jabber Software Foundation until it achieves a status of Final within the standards process defined herein (a Standards Track JEP that has achieved a status of Draft may be referred to as a Draft Standard; a Standards Track JEP that has a status of Experimental must not be referred to as a standard, but instead should be referred to as a work in progress).</p>
+<p><a name="nt-id2256952">10</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p><a name="nt-id2257003">11</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p><a name="nt-id2257031">12</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p><a name="nt-id2257111">13</a>. JEP-0002: Jabber Interest Groups &lt;<a href="http://www.jabber.org/jeps/jep-0002.html">http://www.jabber.org/jeps/jep-0002.html</a>&gt;.</p>
+<p><a name="nt-id2257143">14</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2257169">15</a>. The JSF Board of Directors is an elected body that possesses overall responsibility for the affairs of the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/board/">http://www.jabber.org/board/</a>&gt;.</p>
+<p><a name="nt-id2257196">16</a>. It is important to understand that private extensions to XMPP are also allowed. The JSF does not, and cannot, require such private extensions to be added to the public, official set of protocols recognized by the JSF. The processes and procedures in this document apply only to protocols that are submitted to the JSF, not to private protocol extensions used for custom functionality in particular applications. However, such private extensions must not be considered part of the protocols recognized by the JSF.</p>
+<p><a name="nt-id2257234">17</a>. JEP-0143: Guidelines for JEP Authors &lt;<a href="http://www.jabber.org/jeps/jep-0143.html">http://www.jabber.org/jeps/jep-0143.html</a>&gt;.</p>
+<p><a name="nt-id2257266">18</a>. The JEP Editor is the individual appointed by the JSF Board of Directors to handle protocol submissions and provide day-to-day management of the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/jeps/editor.shtml">http://www.jabber.org/jeps/editor.shtml</a>&gt;.</p>
+<p><a name="nt-id2257303">19</a>. The JSF IPR Policy defines the Jabber Software Foundation's official policy regarding intellectual property rights (IPR) as they pertain to Jabber Enhancement Proposals (JEPs). For further information, see &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;.</p>
+<p><a name="nt-id2257380">20</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p><a name="nt-id2257444">21</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2257496">22</a>. JEPs are kept under source control in the 'jeps' module of the CVS repository maintained at the jabberstudio.org service. Instructions for accessing these files can be found at &lt;<a href="http://www.jabberstudio.org/cvs.php">http://www.jabberstudio.org/cvs.php</a>&gt;, and a web interface to these files is available at &lt;<a href="http://www.jabberstudio.org/cgi-bin/viewcvs.cgi/jeps/">http://www.jabberstudio.org/cgi-bin/viewcvs.cgi/jeps/</a>&gt;.</p>
+<p><a name="nt-id2257529">23</a>. The canonical URL for accessing JEPs is &lt;<a href="http://www.jabber.org/jeps/">http://www.jabber.org/jeps/</a>&gt;.</p>
+<p><a name="nt-id2257719">24</a>. A list of official JSF protocols is maintained at &lt;<a href="http://www.jabber.org/protocol/">http://www.jabber.org/protocol</a>&gt;.</p>
+<p><a name="nt-id2257764">25</a>. The Bylaws of the Jabber Software Foundation (JSF) define the legal basis and operating procedures of the JSF. For further information, see &lt;<a href="http://www.jabber.org/jsf/bylaws.shtml">http://www.jabber.org/jsf/bylaws.shtml</a>&gt;.</p>
+<p><a name="nt-id2257949">26</a>. The General Public License is the primary code license for free software as defined by the Free Software Foundation. For further information, see &lt;<a href="http://www.gnu.org/licenses/gpl.txt">http://www.gnu.org/licenses/gpl.txt</a>&gt;.</p>
+<p><a name="nt-id2257976">27</a>. The Lesser General Public License is a secondary code license for free software as defined by the Free Software Foundation. For further information, see &lt;<a href="http://www.gnu.org/licenses/lgpl.txt">http://www.gnu.org/licenses/lgpl.txt</a>&gt;.</p>
+<p><a name="nt-id2258002">28</a>. The Open Source Initiative defines the term 'open source' and maintains a list of a open-source code licenses. For further information, see &lt;<a href="http://www.opensource.org/">http://www.opensource.org/</a>&gt;.</p>
+<p><a name="nt-id2258216">29</a>. JEP-0053: Jabber Registrar &lt;<a href="http://www.jabber.org/jeps/jep-0053.html">http://www.jabber.org/jeps/jep-0053.html</a>&gt;.</p>
+<p><a name="nt-id2258377">30</a>. RFC 3552: Guidelines for Writing RFC Text on Security Considerations &lt;<a href="http://www.ietf.org/rfc/rfc3552.txt">http://www.ietf.org/rfc/rfc3552.txt</a>&gt;.</p>
+<p><a name="nt-id2258385">31</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258433">32</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2258467">33</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2258533">34</a>. XML Schema Part 1: Structures &lt;<a href="http://www.w3.org/TR/xmlschema-1/">http://www.w3.org/TR/xmlschema-1/</a>&gt;.</p>
+<p><a name="nt-id2258520">35</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.15 (2004-11-02)</h4>
+<div class="indent">Specified that a Standards Track JEP defines either (1) a wire protocol or (2) a protocol suite. (psa)
+    </div>
+<h4>Version 1.14 (2004-09-28)</h4>
+<div class="indent">Defined Procedural JEP type as the union of JIG Formation JEPs and certain Informational JEPs in order to clarify the JEP categories; added Modifications to Approved JEPs section in order to make explicit existing Council practices regarding Active and Final JEPs; specified that JEPs on which voting was not complete at the end of a Council term shall undergo a second Last Call and subsequent vote by the new Council; modified Proposal Process to specify that the Jabber Council shall issue Last Calls on JEPs for which it is the approving body, with all discussion to occur on the Standards-JIG list; updated the schema. (psa)
+    </div>
+<h4>Version 1.13 (2004-08-24)</h4>
+<div class="indent">Further specified the goals of the JEP process; mentioned Board-approved JEPs. (psa)
+    </div>
+<h4>Version 1.11 (2004-07-14)</h4>
+<div class="indent">Specified the procedure for changing a JEP from Historical to Standards Track. (psa)
+    </div>
+<h4>Version 1.10 (2004-03-24)</h4>
+<div class="indent">Specified the procedure for acceptance of a proposal as a JEP; clarified the JEP types; completed editorial review. (psa)
+    </div>
+<h4>Version 1.9 (2003-12-22)</h4>
+<div class="indent">Added rule about automatic deferral of inactive JEPs. (psa)
+    </div>
+<h4>Version 1.8 (2003-10-06)</h4>
+<div class="indent">Clarified the definition of informational JEP. (psa)
+    </div>
+<h4>Version 1.7 (2003-04-11)</h4>
+<div class="indent">Added status of Retracted; corrected several errors related to the Jabber Registrar. (psa)
+    </div>
+<h4>Version 1.6 (2003-01-08)</h4>
+<div class="indent">Further clarified the proposal process per discussion on the JSF members list. (psa)
+    </div>
+<h4>Version 1.5 (2002-10-29)</h4>
+<div class="indent">Major revision based on experience. In addition to a reorganization of the content to improve the clarity of the presentation, changes include: (1) no anonymous authors; (2) proposal must be seconded by at least 5% of JSF members before being proposed for a Council vote; (3) clarification that the Council votes only on a particular revision of a JEP (e.g., version 1.3 when proceeding from Draft to Final); (4) added information about the "Call for Experience" phase before proceeding from Draft to Final; (5) added reference to RFC 2119; (6) added sections for security considerations, IANA considerations, and Jabber Registrar considerations. Approved by the JSF Board and Jabber Council on 2002-11-20. (psa)
+    </div>
+<h4>Version 1.4 (2002-01-16)</h4>
+<div class="indent">Added information about the new "Experimental" state for Standards Track JEPs and made appropriate changes to the JEP process. (psa)
+    </div>
+<h4>Version 1.3.1 (2002-01-11)</h4>
+<div class="indent">Added link to DTD. (psa)
+    </div>
+<h4>Version 1.3 (2001-10-23)</h4>
+<div class="indent">(1) Added information about the "cooling off" period before a Standards Track JEP may be advanced from Draft to Final; (2) Added a link to the JEP template file; (3) Performed several minor fixes. (psa)
+    </div>
+<h4>Version 1.2 (2001-09-27)</h4>
+<div class="indent">(1) Added information about expiration dates; (2) Added a status of Deprecated to Standards Track JEPs. (psa)
+    </div>
+<h4>Version 1.1 (2001-09-09)</h4>
+<div class="indent">(1) Changed "Jabber Foundation" to "Jabber Software Foundation"; (2) Changed "JIG Proposal JEP" to "JIG Formation JEP"; (3) Removed reference to the Secretary of the Jabber Software Foundation in connection with the role of JEP Editor; (4) Clarified the possible states of acceptance of each kind of JEP and described in greater detail the criteria for advancement from one state to another. (psa)
+    </div>
+<h4>Version 1.0 (2001-07-09)</h4>
+<div class="indent">Changed status to Active. (psa)
+    </div>
+<h4>Version 0.1 (2001-06-28)</h4>
+<div class="indent">Initial release -- a simplified and updated version of Rahul Dave's Jabberization of the process and format for Python Enhancement Proposals (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0004-2.5.html
+++ b/content/xep-0004-2.5.html
@@ -1,0 +1,827 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0004: Data Forms</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Data Forms">
+<meta name="DC.Creator" content="Ryan Eatmon">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Jeremie Miller">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for data forms and generic data description in Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-05-07">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0004">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0004: Data Forms</h1>
+<p>This JEP defines a protocol for data forms and generic data description in Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Final Standard of the Jabber Software Foundation and may be considered a stable technology for implementation and deployment.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Final<br>
+            Type: Standards Track<br>
+            Number: 0004<br>
+            Version: 2.5<br>
+            Last Updated: 2004-05-07<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: x-data<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/x-data/x-data.xsd">http://jabber.org/protocol/x-data/x-data.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Ryan Eatmon</h3>
+<p class="indent">
+        Email: reatmon@jabber.org<br>
+        JID: reatmon@jabber.org</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Jeremie Miller</h3>
+<p class="indent">
+        Email: jer@jabber.org<br>
+        JID: jer@jabber.org</p>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#protocol-formtypes">Form Types</a>
+</dt>
+<dt>3.2.  <a href="#protocol-field">The Field Element</a>
+</dt>
+<dt>3.3.  <a href="#protocol-fieldtypes">Field Types</a>
+</dt>
+<dt>3.4.  <a href="#protocol-results">Multiple Items in Form Results</a>
+</dt>
+</dl>
+<dt>4.  <a href="#validation">Data Validation</a>
+</dt>
+<dt>5.  <a href="#examples">Examples</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#examples-config">Configuration</a>
+</dt>
+<dt>5.2.  <a href="#examples-search">Search</a>
+</dt>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-namespaces">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-parameters">Parameter Values</a>
+</dt>
+</dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>10.  <a href="#draft-to-final">Changes Between Draft and Final</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Several existing Jabber/XMPP protocols involve the exchange of structured data between users and applications for common tasks such as registration (<span class="ref">In-Band Registration</span>  [<a href="#nt-id2601883">1</a>]) and searching (<span class="ref">Jabber Search</span>  [<a href="#nt-id2601904">2</a>]). Unfortunately, these early protocols were &quot;hard coded&quot; and thus place significant restrictions on the range of information that can be exchanged. Furthermore, other protocols (e.g., <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2601809">3</a>]) may need to exchange data for purposes such as configuration, but the configuration options may differ depending on the specific implementation or deployment. Finally, developers may want to extend other protocols (e.g., <span class="ref">Service Discovery</span>  [<a href="#nt-id2601834">4</a>]) in a flexible manner in order to provide information that is not defined in the base protocol. In all of these cases, it would be helpful to use a generic data description format that can be used for dynamic forms generation and data &quot;modelling&quot; in a variety of circumstances.</p>
+  <p class="" style="">An example may be helpful. Let us imagine that when a user creates a multi-user chatroom on a text conferencing service, the service allows the user to configure the room in various ways. While most implementations will probably provide a somewhat common set of configurable features (discussion logging, maximum number of room occupants, etc.), there will be some divergence: perhaps one implementation will enable archiving of the room log in a variety of file types (XML, HTML, PDF, etc.) and for a variety of time periods (hourly, daily, weekly, etc.), whereas another implementation may present a boolean on/off choice of logging in only one format (e.g., daily logs saved in HTML). Obviously, the first implementation will have more configuration options than the second implementation. Rather than &quot;hard-coding&quot; every option via distinct XML elements (e.g., &lt;room_logging_period/&gt;), a better design would involve a more flexible format.</p>
+  <p class="" style="">The 'jabber:x:data' protocol described herein defines such a flexible format for use by Jabber/XMPP entities, steering a middle course between the simplicity of &quot;name-value&quot; pairs and the complexity of <span class="ref">XForms 1.0</span>  [<a href="#nt-id2602033">5</a>] (on which development had just begun when this protocol was designed). In many ways, 'jabber:x:data' is similar to the Forms Module of <span class="ref">XHTML 1.0</span>  [<a href="#nt-id2601867">6</a>]; however, it provides several Jabber-specific data types, enables applications to require data fields, integrates more naturally into the &quot;workflow&quot; semantics of IQ stanzas, and can be included as an extension of existing Jabber/XMPP protocols in ways that the XHTML Forms Module could not when this protocol was developed (especially because <span class="ref">Modularization of XHTML</span>  [<a href="#nt-id2601986">7</a>] did not exist at that time).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>
+<span style="font-weight: bold">Data Gathering</span> -- the protocol should enable a forms-processing entity (commonly a server, service, or bot) to gather data from a forms-submitting entity (commonly a client controlled by a human user); this should be done via distinct data fields (e.g., items in a questionnaire or configuration form), each of which can be a different data &quot;type&quot; and enable free-form input or a choice between multiple options (as is familiar from HTML forms).</li>
+    <li>
+<span style="font-weight: bold">Data Reporting</span> -- the protocol should enable a forms-processing entity to report data (e.g., search results) to a forms-submitting entity, again via distinct data fields.</li>
+    <li>
+<span style="font-weight: bold">Portability</span> -- the protocol should as much as possible define generic data formats and basic datatypes only; hints may be provided regarding the user interface, but they should be hints only and not hard-and-fast requirements.</li>
+    <li>
+<span style="font-weight: bold">Simplicity</span> -- the protocol should be simple for clients to implement, and most of the complexity (e.g., data validation and processing) should be the responsibility of servers and components rather than clients.</li>
+    <li>
+<span style="font-weight: bold">Flexibility</span> -- the protocol should be flexible and extensible rather than &quot;hard-coded&quot;.</li>
+    <li>
+<span style="font-weight: bold">Compatibility</span> -- the protocol should define an extension to existing Jabber/XMPP protocols and not break existing implementations unless absolutely necessary.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">The base syntax for the 'jabber:x:data' namespace is as follows (a formal description can be found in the <a href="#schema">XML Schema</a> section below):</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data'
+   type='{form-type}'&gt;
+  &lt;title/&gt;
+  &lt;instructions/&gt;
+  &lt;field var='field-name'
+         type='{field-type}'
+         label='description'&gt;
+    &lt;desc/&gt;
+    &lt;required/&gt;
+    &lt;value&gt;field-value&lt;/value&gt;
+    &lt;option label='option-label'&gt;&lt;value&gt;option-value&lt;/value&gt;&lt;/option&gt;
+    &lt;option label='option-label'&gt;&lt;value&gt;option-value&lt;/value&gt;&lt;/option&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+  </pre></div>
+  <p class="" style="">The &lt;x/&gt; element qualified by the 'jabber:x:data' namespace SHOULD be included as a first-level child of an XML stanza; the stanza MAY be of any kind (&lt;iq/&gt;, &lt;message/&gt;, or &lt;presence/&gt;), although it is RECOMMENDED to use &lt;iq/&gt; or &lt;message/&gt; (see also the restrictions enumerated below).</p>
+  <p class="" style="">The OPTIONAL &lt;title/&gt; and &lt;instructions/&gt; elements enable the forms-processing entity to label the form as a whole and specify natural-language instructions to be followed by the forms-submitting entity. The XML character data for these elements SHOULD NOT contain newlines (the \n and \r characters), and any handling of newlines (e.g., presentation in a user interface) is unspecified herein; however, multiple instances of the &lt;instructions/&gt; element MAY be included.</p>
+  <div class="indent">
+<h3>3.1 <a name="protocol-formtypes">Form Types</a>
+</h3>
+    <p class="" style="">The data gathered or provided in a 'jabber:x:data' form can be situated in a number of different contexts. Examples include an empty form that needs to be filled out, a completed form, the results of a submission, a search result, or simply a set of data that is encapsulated using the 'jabber:x:data' namespace. The full context for the data is provided by three things:</p>
+    <ol start="" type="">
+      <li>the &quot;wrapper&quot; protocol (i.e., the namespace whose root element is the direct child of the &lt;iq/&gt; stanza and the parent of the &lt;x/&gt; element qualified by the 'jabber:x:data' namespace)</li>
+      <li>the place of the form within a transaction (e.g., an IQ &quot;set&quot; or &quot;result&quot;) or structured conversation (e.g., a message &lt;thread/&gt;)</li>
+      <li>the 'type' attribute on the form's root &lt;x/&gt; element</li>
+    </ol>
+    <p class="" style="">The first two pieces of contextual information are provided by other protocols, whereas the form types are described in the following table.</p>
+    <p class="caption">Table 1: Form Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Type</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">form</td>
+        <td align="" colspan="" rowspan="">The forms-processing entity is asking the forms-submitting entity to complete a form.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">submit</td>
+        <td align="" colspan="" rowspan="">The forms-submitting entity is submitting data to the forms-processing entity.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">cancel</td>
+        <td align="" colspan="" rowspan="">The forms-submitting entity has cancelled submission of data to the forms-processing entity.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">result</td>
+        <td align="" colspan="" rowspan="">The forms-processing entity is returning data (e.g., search results) to the forms-submitting entity, or the data is a generic data set.</td>
+      </tr>
+    </table>
+    <p class="" style="">In order to maintain the context of the data as captured in the form type, the following rules MUST be observed:</p>
+    <ul>
+      <li><p class="" style="">For &lt;iq/&gt; stanzas, the root element qualified by the &quot;wrapper&quot; namespace in a form of type &quot;form&quot; or &quot;submit&quot; MUST be returned in a form of type &quot;result&quot;. The &lt;x/&gt; element qualified by the 'jabber:x:data' namespace MUST be a child of the &quot;wrapper&quot; namespace's root element. As defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2602510">8</a>], the 'id' attribute MUST be copied in the IQ result. For data forms of type &quot;form&quot; or &quot;result&quot;, the &lt;iq/&gt; stanza SHOULD be of type &quot;result&quot;.  For data forms of type &quot;submit&quot; or &quot;cancel&quot;, the &lt;iq/&gt; stanza SHOULD be of type &quot;set&quot;.</p></li>
+      <li><p class="" style="">For &lt;message/&gt; stanzas, the &lt;thread/&gt; SHOULD be copied in the reply if provided. The &lt;x/&gt; element qualified by the 'jabber:x:data' namespace MUST be a child of the &lt;message/&gt; stanza.</p></li>
+      <li><p class="" style="">The only data form type allowed for &lt;presence/&gt; stanzas is &quot;result&quot;. The &lt;x/&gt; element qualified by the 'jabber:x:data' namespace MUST be a child of the &lt;presence/&gt; stanza. In accordance with <span style="font-weight: bold">XMPP Core</span>, use of data forms is not recommended unless necessary to provide information that is directly related to an entity's network availability.</p></li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="protocol-field">The Field Element</a>
+</h3>
+    <p class="" style="">A data form of type &quot;form&quot;, &quot;submit&quot;, or &quot;result&quot; SHOULD contain at least one &lt;field/&gt; element; a data form of type &quot;cancel&quot; SHOULD NOT contain any &lt;field/&gt; elements.</p>
+    <p class="" style="">The &lt;field/&gt; element MAY contain any of the following child elements:</p>
+    <ul>
+      <li>
+<span style="font-weight: bold">&lt;desc/&gt;</span> -- The XML character data of this element provides a natural-language description of the field, intended for presentation in a user-agent (e.g., as a &quot;tool-tip&quot;, help button, or explanatory text provided near the field). The &lt;desc/&gt; element SHOULD NOT contain newlines (the \n and \r characters), since layout is the responsibility of a user agent, and any handling of newlines (e.g., presentation in a user interface) is unspecified herein. (Note: To provide a description of a field, it is RECOMMENDED to use a &lt;desc/&gt; element SHOULD rather than a separate &lt;field/&gt; element of type &quot;fixed&quot;.)</li>
+      <li>
+<span style="font-weight: bold">&lt;required/&gt;</span> -- This element, which MUST be empty, flags the field as required in order for the form to be considered valid.</li>
+      <li>
+<span style="font-weight: bold">&lt;value/&gt;</span> -- The XML character data of this element defines the default value for the field, the data provided by an entity that has completed the form, or a data result. In data forms of type &quot;form&quot;, an entity SHOULD NOT attempt to enforce a default value if it is not provided via the &lt;value/&gt; element.</li>
+      <li>
+<span style="font-weight: bold">&lt;option/&gt;</span> -- One of the options in a field of type &quot;list-single&quot; or &quot;list-multi&quot;. The XML character of the &lt;value/&gt; child defines the option value, and the 'label' attribute defines a human-readable name for the option. The &lt;option/&gt; element MAY contain more than one &lt;value/&gt; child if the field type is &quot;list-multi&quot;.</li>
+    </ul>
+    <p class="" style="">If the &lt;field/&gt; element type is anything other than &quot;fixed&quot; (see below), it MUST possess a 'var' attribute that uniquely identifies the field in the context of the form (if it is &quot;fixed&quot;, it MAY possess a 'var' attribute). The &lt;field/&gt; element MAY possess a 'label' attribute that defines a human-readable name for the field. For data forms of type &quot;form&quot;, each &lt;field/&gt; element SHOULD possess a 'type' attribute that defines the data &quot;type&quot; of the field data (if no 'type' is specified, the default is &quot;text-single&quot;); fields provided in the context of other forms types MAY possess a 'type' attribute as well.</p>
+    <p class="" style="">If fields are presented in a user interface (e.g., as items in a questionnaire or form result), the order of the field elements in the XML SHOULD determine the order of items presented to the user.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="protocol-fieldtypes">Field Types</a>
+</h3>
+    <p class="" style="">The following field types represent data &quot;types&quot; that are commonly exchanged between Jabber/XMPP entities. These field types are not intended to be as comprehensive as the datatypes defined in, for example, <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602766">9</a>], nor do they define user interface elements.</p>
+    <p class="caption">Table 2: Field Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Type</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">boolean</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide an either-or choice between two options. The allowable values are 1 for yes/true/assent and 0 for no/false/decline. The default value is 0.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">fixed</td>
+        <td align="" colspan="" rowspan="">The field is intended for data description (e.g., human-readable text such as &quot;section&quot; headers) rather than data gathering or provision. The &lt;value/&gt; child SHOULD NOT contain newlines (the \n and \r characters); instead an application SHOULD generate multiple fixed fields, each with one &lt;value/&gt; child.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">hidden</td>
+        <td align="" colspan="" rowspan="">The field is not shown to the entity providing information, but instead is returned with the form.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">jid-multi *</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide multiple Jabber IDs.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">jid-single *</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide a single Jabber ID.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">list-multi</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide one or more options from among many.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">list-single</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide one option from among many.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">text-multi **</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide multiple lines of text.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">text-private</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide a single line or word of text, which shall be obscured in an interface (e.g., *****).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">text-single</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide a single line or word of text, which may be shown in an interface. This field type is the default and MUST be assumed if an entity receives a field type it does not understand.</td>
+      </tr>
+    </table>
+    <p class="" style="">* Note: Data provided for fields of type &quot;jid-single&quot; or &quot;jid-multi&quot; MUST contain one or more valid Jabber IDs, where validity is determined by the addressing rules defined in <span style="font-weight: bold">XMPP Core</span> (see the <a href="#validation">Data Validation</a> section below).</p>
+    <p class="" style="">** Note: Data provided for fields of type &quot;text-multi&quot; SHOULD NOT contain any newlines (the \n and \r characters). Instead, the application SHOULD split the data into multiple strings (based on the newlines inserted by the platform), then specify each string as the XML character data of a distinct &lt;value/&gt; element. Similarly, an application that receives multiple &lt;value/&gt; elements for a field of type &quot;text-multi&quot; SHOULD merge the XML character data of the value elements into one text block for presentation to a user, with each string separated by a newline character as appropriate for that platform.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="protocol-results">Multiple Items in Form Results</a>
+</h3>
+    <p class="" style="">In some contexts (e.g., the results of a search request), it may be necessary to communicate multiple items. Therefore, a data form of type &quot;result&quot; MAY contain two child elements not described in the basic syntax above: one &lt;reported/&gt; element followed by zero or more &lt;item/&gt; elements. The syntax is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data'
+   type='result'&gt;
+  &lt;reported&gt;
+    &lt;field var='field-name' label='description' type='{field-type}'&gt;
+      &lt;value&gt;field-value&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/reported&gt;
+  &lt;item&gt;
+    &lt;field var='field-name'&gt;
+      &lt;value&gt;field-value&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/item&gt;
+  &lt;item&gt;
+    &lt;field var='field-name'&gt;
+      &lt;value&gt;field-value&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/item&gt;
+  .
+  .
+  .
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">Each of these elements MUST contain one or more &lt;field/&gt; children. The &lt;reported/&gt; element defines the data format for the result items by specifying the fields to be expected for each item; for this reason, the &lt;field/&gt; elements SHOULD possess a 'type' attribute and 'label' attribute in addition to the 'var' attribute. Each &lt;item/&gt; element defines one item in the result set, and MUST contain each field specified in the &lt;reported/&gt; element (although the XML character data of the &lt;value/&gt; element MAY be null).</p>
+  </div>
+<h2>4.
+       <a name="validation">Data Validation</a>
+</h2>
+  <p class="" style="">Data validation is the responsibility of the forms-processing entity (commonly a server, service, or bot) rather than the forms-submitting entity (commonly a client controlled by a human user). This helps to meet the requirement for keeping client implementations simple. If the forms-processing entity determines that the data provided is not valid, it SHOULD return a &quot;Not Acceptable&quot; error, optionally providing a textual explanation in the XMPP &lt;text/&gt; element or an application-specific child element that identifies the problem (see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2603252">10</a>] for information about mappings and formats).</p>
+<h2>5.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">For the sake of the following examples, let us suppose that there exists a bot hosting service on the Jabber network, located at &lt;botster.shakespeare.lit&gt;. This service enables registered users to create and configure new bots, find and interact with existing bots, and so on. We will assume that these interactions occur using the <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2603210">11</a>] protocol, which is used as a &quot;wrapper&quot; protocol for data forms qualified by the 'jabber:x:data' namespace. The examples in the sections that follow show most of the features of the data forms protocol described above.</p>
+  <p class="" style="">Note: Additional examples can be found in the specifications for various using protocols, such as <span style="font-weight: bold">JEP-0045: Multi-User Chat</span> and <span style="font-weight: bold">JEP-0055: Jabber Search</span>.</p>
+  <div class="indent">
+<h3>5.1 <a name="examples-config">Configuration</a>
+</h3>
+    <p class="" style="">The first step is for a user to create a new bot on the hosting service. We will assume that this is done by sending a &quot;create&quot; command to the desired bot:</p>
+    <p class="caption">Example 1. User Requests Bot Creation</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/home'
+    to='joogle@botster.shakespeare.lit'
+    type='get'
+    xml:lang='en'
+    id='create1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='create'
+           action='execute'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The hosting service then returns a data form to the user:</p>
+    <p class="caption">Example 2. Service Returns Bot Creation Form</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='romeo@montague.net/home'
+    type='result'
+    xml:lang='en'
+    id='create1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='create'
+           sessionid='create:20040408T0128Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Bot Configuration&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to configure your new bot!&lt;/instructions&gt;
+      &lt;field type='hidden'
+             var='FORM_TYPE'&gt;
+        &lt;value&gt;jabber:bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;&lt;value&gt;Section 1: Bot Info&lt;/value&gt;&lt;/fixed&gt;
+      &lt;field type='text-single'
+             label='The name of your bot'
+             var='botname'/&gt;
+      &lt;field type='text-multi'
+             label='Helpful description of your bot'
+             var='description'/&gt;
+      &lt;field type='boolean'
+             label='Public bot?'
+             var='public'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field type='text-private'
+             label='Password for special access'
+             var='password'/&gt;
+      &lt;field type='fixed'&gt;&lt;value&gt;Section 2: Features&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='list-multi'
+             label='What features will the bot support?'
+             var='features'&gt;
+        &lt;option label='Contests'&gt;&lt;value&gt;contests&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='News'&gt;&lt;value&gt;news&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Polls'&gt;&lt;value&gt;polls&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Reminders'&gt;&lt;value&gt;reminders&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Search'&gt;&lt;value&gt;search&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;&lt;value&gt;Section 3: Subscriber List&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='list-single'
+             label='Maximum number of subscribers'
+             var='maxsubs'&gt;
+        &lt;value&gt;20&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;&lt;value&gt;Section 4: Invitations&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='jid-multi'
+             label='People to invite'
+             var='invitelist'&gt;
+        &lt;desc&gt;Tell all your friends about your new bot!&lt;/desc&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The user then submits the configuration form:</p>
+    <p class="caption">Example 3. User Submits Bot Creation Form</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='romeo@montague.net/home'
+    type='submit'
+    xml:lang='en'
+    id='create2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='create'
+           sessionid='create:20040408T0128Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;jabber:bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='botname'&gt;
+        &lt;value&gt;The Jabber Google Bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-multi' var='description'&gt;
+        &lt;value&gt;This bot enables you to send requests to&lt;/value&gt;
+        &lt;value&gt;Google and receive the search results right&lt;/value&gt;
+        &lt;value&gt;in your Jabber client. It&amp;apos; really cool!&lt;/value&gt;
+        &lt;value&gt;It even supports Google News!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='public'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-private' var='password'&gt;
+        &lt;value&gt;v3r0na&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='features'&gt;
+        &lt;value&gt;news&lt;/value&gt;
+        &lt;value&gt;search&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='maxsubs'&gt;
+        &lt;value&gt;50&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='jid-multi' var='invitelist'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+        &lt;value&gt;benvolio@montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service then returns the results to the user:</p>
+    <p class="caption">Example 4. Service Returns Bot Creation Result</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='romeo@montague.net/home'
+    type='result'
+    xml:lang='en'
+    id='create2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='create'
+           sessionid='create:20040408T0128Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;jabber:bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='botname'&gt;
+        &lt;value&gt;The Jabber Google Bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='public'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-private' var='password'&gt;
+        &lt;value&gt;v3r0na&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='features'&gt;
+        &lt;value&gt;news&lt;/value&gt;
+        &lt;value&gt;search&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='maxsubs'&gt;
+        &lt;value&gt;50&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='jid-multi' var='invitelist'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+        &lt;value&gt;benvolio@montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="examples-search">Search</a>
+</h3>
+    <p class="" style="">Now that the user has created this search bot, let us suppose that one of the friends he has invited decides to try it out by sending a search request:</p>
+    <p class="caption">Example 5. User Requests Search Form</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/chamber'
+    to='joogle@botster.shakespeare.lit'
+    type='get'
+    xml:lang='en'
+    id='search1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='search'
+           action='execute'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Service Returns Search Form</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    type='result'
+    xml:lang='en'
+    id='search1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='search'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Joogle Search&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to search for information!&lt;/instructions&gt;
+      &lt;field type='text-single'
+             var='search_request'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 7. User Submits Search Form</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/chamber'
+    to='joogle@botster.shakespeare.lit'
+    type='get'
+    xml:lang='en'
+    id='search2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='search'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='text-single' var='search_request'&gt;
+        &lt;value&gt;verona&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Returns Search Results</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    type='result'
+    xml:lang='en'
+    id='search2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='search'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;title&gt;Joogle Search: verona&lt;/title&gt;
+      &lt;reported&gt;
+        &lt;field var='name'/&gt;
+        &lt;field var='description'/&gt;
+        &lt;field var='category'/&gt;
+        &lt;field var='url'/&gt;
+      &lt;/reported&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;Comune di Verona - Benvenuti nel sito ufficiale&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.comune.verona.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;benvenuto!&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.hellasverona.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;Universita degli Studi di Verona - Home Page&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.univr.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;Aeroporti del Garda&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.aeroportoverona.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;Veronafiere - fiera di Verona&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.veronafiere.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security concerns related to this specification above and beyond those described in the relevant section of <span style="font-weight: bold">XMPP Core</span>.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603838">12</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-namespaces">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603786">13</a>] includes the 'jabber:x:data' namespace in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-parameters">Parameter Values</a>
+</h3>
+    <p class="" style="">The Jabber Registrar maintains a registry of parameter values related to the 'jabber:x:data' namespace, specifically as defined in <span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2603942">14</a>]; the registry is located at &lt;<a href="http://www.jabber.org/registrar/formtypes.html">http://www.jabber.org/registrar/formtypes.html</a>&gt;.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This schema is descriptive, not normative.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:x:data'
+    xmlns='jabber:x:data'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0004: http://www.jabber.org/jeps/jep-0004.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='instructions' 
+                    minOccurs='0' 
+                    maxOccurs='unbounded' 
+                    type='xs:string'/&gt;
+        &lt;xs:element name='title' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element ref='field' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='reported' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='cancel'/&gt;
+            &lt;xs:enumeration value='form'/&gt;
+            &lt;xs:enumeration value='result'/&gt;
+            &lt;xs:enumeration value='submit'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='field'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='desc' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='required' minOccurs='0' type='empty'/&gt;
+        &lt;xs:element ref='value' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='option' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' use='optional' default='text-single'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='boolean'/&gt;
+            &lt;xs:enumeration value='fixed'/&gt;
+            &lt;xs:enumeration value='hidden'/&gt;
+            &lt;xs:enumeration value='jid-multi'/&gt;
+            &lt;xs:enumeration value='jid-single'/&gt;
+            &lt;xs:enumeration value='list-multi'/&gt;
+            &lt;xs:enumeration value='list-single'/&gt;
+            &lt;xs:enumeration value='text-multi'/&gt;
+            &lt;xs:enumeration value='text-private'/&gt;
+            &lt;xs:enumeration value='text-single'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='var' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='option'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='value'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='value' type='xs:string'/&gt;
+
+  &lt;xs:element name='reported'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='field' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='field' maxOccurs='unbounded'/&gt;
+      &lt;xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>10.
+       <a name="draft-to-final">Changes Between Draft and Final</a>
+</h2>
+  <p class="" style="">The following protocol changes were incorporated in the Final specification as a result of experience with the Draft specification (described in version 1.0 of this document):</p>
+  <ul>
+    <li>The &lt;x/&gt; element MAY be included in &lt;message/&gt; and &lt;presence/&gt; elements.</li>
+    <li>The &lt;x/&gt; element MAY contain a &lt;title/&gt; child for forms and results.</li>
+    <li>The &lt;x/&gt; element MUST possess a 'type' attribute.</li>
+    <li>A &lt;field/&gt; element MAY be of type='jid-single'.</li>
+    <li>Results MAY be reported back in &lt;item/&gt; tags.</li>
+    <li>Results MAY contain a &lt;reported/&gt; element with result set.</li>
+    <li>The &lt;reported/&gt; fields MAY possess a 'type' attribute to provide hints about how to interact with the data (type='jid-single' being the most useful).</li>
+  </ul>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2601883">1</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601904">2</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601809">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601834">4</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602033">5</a>. XForms 1.0 &lt;<a href="http://www.w3.org/TR/xforms">http://www.w3.org/TR/xforms</a>&gt;.</p>
+<p>
+<a name="nt-id2601867">6</a>. XHTML 1.0 &lt;<a href="http://www.w3.org/TR/xhtml1">http://www.w3.org/TR/xhtml1</a>&gt;.</p>
+<p>
+<a name="nt-id2601986">7</a>. Modularization of XHTML &lt;<a href="http://www.w3.org/TR/2004/WD-xhtml-modularization-20040218/">http://www.w3.org/TR/2004/WD-xhtml-modularization-20040218/</a>&gt;.</p>
+<p>
+<a name="nt-id2602510">8</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602766">9</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2603252">10</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603210">11</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603838">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603786">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2603942">14</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 2.5 (2004-05-07)</h4>
+<div class="indent">Clarified terminology regarding form-processing entities and forms-submitting entities; corrected several small errors in the schema. (psa)
+    </div>
+<h4>Version 2.4 (2004-05-04)</h4>
+<div class="indent">Per discussion by the JEP authors and Jabber Council, specified that the 'var' attribute is required for all field types except &quot;fixed&quot;, for which the 'var' attribute is optional. (psa)
+    </div>
+<h4>Version 2.3 (2004-03-31)</h4>
+<div class="indent">Formalization and further editorial revisions. (psa)
+    </div>
+<h4>Version 2.2 (2004-01-22)</h4>
+<div class="indent">Editorial revisions. (psa)
+    </div>
+<h4>Version 2.1 (2003-02-16)</h4>
+<div class="indent">Added schema. (psa)
+    </div>
+<h4>Version 2.0 (2002-12-09)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Final. (psa)
+    </div>
+<h4>Version 1.1 (2002-10-15)</h4>
+<div class="indent">Call for Experience changes (see <a href="#draft-to-final">Changes Between Draft and Final</a> section). This version voted to Final on 2002-12-09. (rwe)
+    </div>
+<h4>Version 1.0 (2002-04-24)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Draft. (psa)
+    </div>
+<h4>Version 0.6 (2002-03-15)</h4>
+<div class="indent">Protocol tweaks based on standards-jig discussion. (rwe)
+    </div>
+<h4>Version 0.5 (2002-02-06)</h4>
+<div class="indent">Protocol tweaks based on implementation and discussion. (rwe)
+    </div>
+<h4>Version 0.4 (2001-11-16)</h4>
+<div class="indent">Major redesign to attempt to clarify the scope of this JEP and limit what it is trying to solve. (rwe)
+    </div>
+<h4>Version 0.3 (2001-07-23)</h4>
+<div class="indent">Protocol update (rwe)
+    </div>
+<h4>Version 0.2 (2001-06-29)</h4>
+<div class="indent">Protocol update and DocBook version (rwe)
+    </div>
+<h4>Version 0.1 (2001-01-25)</h4>
+<div class="indent">Initial release (rwe)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0004-2.6.html
+++ b/content/xep-0004-2.6.html
@@ -1,0 +1,824 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0004: Data Forms</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Data Forms">
+<meta name="DC.Creator" content="Ryan Eatmon">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Jeremie Miller">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for data forms and generic data description in Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-13">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0004">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0004: Data Forms</h1>
+<p>This JEP defines a protocol for data forms and generic data description in Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Final Standard of the Jabber Software Foundation and may be considered a stable technology for implementation and deployment.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Final<br>
+            Type: Standards Track<br>
+            Number: 0004<br>
+            Version: 2.6<br>
+            Last Updated: 2004-10-13<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: x-data<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/x-data/x-data.xsd">http://jabber.org/protocol/x-data/x-data.xsd</a>&gt;<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Data%20Forms%20(JEP-0004)">http://wiki.jabber.org/index.php/Data Forms (JEP-0004)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ryan Eatmon</h3>
+<p class="indent">
+        Email: reatmon@jabber.org<br>
+        JID: reatmon@jabber.org</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Jeremie Miller</h3>
+<p class="indent">
+        Email: jer@jabber.org<br>
+        JID: jer@jabber.org</p>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#protocol-formtypes">Form Types</a>
+</dt>
+<dt>3.2.  <a href="#protocol-field">The Field Element</a>
+</dt>
+<dt>3.3.  <a href="#protocol-fieldtypes">Field Types</a>
+</dt>
+<dt>3.4.  <a href="#protocol-results">Multiple Items in Form Results</a>
+</dt>
+</dl>
+<dt>4.  <a href="#validation">Data Validation</a>
+</dt>
+<dt>5.  <a href="#examples">Examples</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#examples-config">Configuration</a>
+</dt>
+<dt>5.2.  <a href="#examples-search">Search</a>
+</dt>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-namespaces">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-parameters">Parameter Values</a>
+</dt>
+</dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>10.  <a href="#draft-to-final">Changes Between Draft and Final</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Several existing Jabber/XMPP protocols involve the exchange of structured data between users and applications for common tasks such as registration (<span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2250732">1</a>]) and searching (<span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250758">2</a>]). Unfortunately, these early protocols were "hard coded" and thus place significant restrictions on the range of information that can be exchanged. Furthermore, other protocols (e.g., <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250780">3</a>]) may need to exchange data for purposes such as configuration, but the configuration options may differ depending on the specific implementation or deployment. Finally, developers may want to extend other protocols (e.g., <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250802">4</a>]) in a flexible manner in order to provide information that is not defined in the base protocol. In all of these cases, it would be helpful to use a generic data description format that can be used for dynamic forms generation and data "modelling" in a variety of circumstances.</p>
+  <p class="" style="">An example may be helpful. Let us imagine that when a user creates a multi-user chatroom on a text conferencing service, the service allows the user to configure the room in various ways. While most implementations will probably provide a somewhat common set of configurable features (discussion logging, maximum number of room occupants, etc.), there will be some divergence: perhaps one implementation will enable archiving of the room log in a variety of file types (XML, HTML, PDF, etc.) and for a variety of time periods (hourly, daily, weekly, etc.), whereas another implementation may present a boolean on/off choice of logging in only one format (e.g., daily logs saved in HTML). Obviously, the first implementation will have more configuration options than the second implementation. Rather than "hard-coding" every option via distinct XML elements (e.g., &lt;room_logging_period/&gt;), a better design would involve a more flexible format.</p>
+  <p class="" style="">The 'jabber:x:data' protocol described herein defines such a flexible format for use by Jabber/XMPP entities, steering a middle course between the simplicity of "name-value" pairs and the complexity of <span class="ref" style="">XForms 1.0</span>  [<a href="#nt-id2256283">5</a>] (on which development had just begun when this protocol was designed). In many ways, 'jabber:x:data' is similar to the Forms Module of <span class="ref" style="">XHTML 1.0</span>  [<a href="#nt-id2256303">6</a>]; however, it provides several Jabber-specific data types, enables applications to require data fields, integrates more naturally into the "workflow" semantics of IQ stanzas, and can be included as an extension of existing Jabber/XMPP protocols in ways that the XHTML Forms Module could not when this protocol was developed (especially because <span class="ref" style="">Modularization of XHTML</span>  [<a href="#nt-id2256330">7</a>] did not exist at that time).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>
+<span style="font-weight: bold">Data Gathering</span> -- the protocol should enable a forms-processing entity (commonly a server, service, or bot) to gather data from a forms-submitting entity (commonly a client controlled by a human user); this should be done via distinct data fields (e.g., items in a questionnaire or configuration form), each of which can be a different data "type" and enable free-form input or a choice between multiple options (as is familiar from HTML forms).</li>
+    <li>
+<span style="font-weight: bold">Data Reporting</span> -- the protocol should enable a forms-processing entity to report data (e.g., search results) to a forms-submitting entity, again via distinct data fields.</li>
+    <li>
+<span style="font-weight: bold">Portability</span> -- the protocol should as much as possible define generic data formats and basic datatypes only; hints may be provided regarding the user interface, but they should be hints only and not hard-and-fast requirements.</li>
+    <li>
+<span style="font-weight: bold">Simplicity</span> -- the protocol should be simple for clients to implement, and most of the complexity (e.g., data validation and processing) should be the responsibility of servers and components rather than clients.</li>
+    <li>
+<span style="font-weight: bold">Flexibility</span> -- the protocol should be flexible and extensible rather than "hard-coded".</li>
+    <li>
+<span style="font-weight: bold">Compatibility</span> -- the protocol should define an extension to existing Jabber/XMPP protocols and not break existing implementations unless absolutely necessary.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">The base syntax for the 'jabber:x:data' namespace is as follows (a formal description can be found in the <a href="#schema">XML Schema</a> section below):</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data'
+   type='{form-type}'&gt;
+  &lt;title/&gt;
+  &lt;instructions/&gt;
+  &lt;field var='field-name'
+         type='{field-type}'
+         label='description'&gt;
+    &lt;desc/&gt;
+    &lt;required/&gt;
+    &lt;value&gt;field-value&lt;/value&gt;
+    &lt;option label='option-label'&gt;&lt;value&gt;option-value&lt;/value&gt;&lt;/option&gt;
+    &lt;option label='option-label'&gt;&lt;value&gt;option-value&lt;/value&gt;&lt;/option&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+  </pre></div>
+  <p class="" style="">The &lt;x/&gt; element qualified by the 'jabber:x:data' namespace SHOULD be included as a first-level child of an XML stanza; the stanza MAY be of any kind (&lt;iq/&gt;, &lt;message/&gt;, or &lt;presence/&gt;), although it is RECOMMENDED to use &lt;iq/&gt; or &lt;message/&gt; (see also the restrictions enumerated below).</p>
+  <p class="" style="">The OPTIONAL &lt;title/&gt; and &lt;instructions/&gt; elements enable the forms-processing entity to label the form as a whole and specify natural-language instructions to be followed by the forms-submitting entity. The XML character data for these elements SHOULD NOT contain newlines (the \n and \r characters), and any handling of newlines (e.g., presentation in a user interface) is unspecified herein; however, multiple instances of the &lt;instructions/&gt; element MAY be included.</p>
+  <div class="indent">
+<h3>3.1 <a name="protocol-formtypes">Form Types</a>
+</h3>
+    <p class="" style="">The data gathered or provided in a 'jabber:x:data' form can be situated in a number of different contexts. Examples include an empty form that needs to be filled out, a completed form, the results of a submission, a search result, or simply a set of data that is encapsulated using the 'jabber:x:data' namespace. The full context for the data is provided by three things:</p>
+    <ol start="" type="">
+      <li>the "wrapper" protocol (i.e., the namespace whose root element is the direct child of the &lt;iq/&gt; stanza and the parent of the &lt;x/&gt; element qualified by the 'jabber:x:data' namespace)</li>
+      <li>the place of the form within a transaction (e.g., an IQ "set" or "result") or structured conversation (e.g., a message &lt;thread/&gt;)</li>
+      <li>the 'type' attribute on the form's root &lt;x/&gt; element</li>
+    </ol>
+    <p class="" style="">The first two pieces of contextual information are provided by other protocols, whereas the form types are described in the following table.</p>
+    <p class="caption">Table 1: Form Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Type</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">form</td>
+        <td align="" colspan="" rowspan="">The forms-processing entity is asking the forms-submitting entity to complete a form.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">submit</td>
+        <td align="" colspan="" rowspan="">The forms-submitting entity is submitting data to the forms-processing entity.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">cancel</td>
+        <td align="" colspan="" rowspan="">The forms-submitting entity has cancelled submission of data to the forms-processing entity.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">result</td>
+        <td align="" colspan="" rowspan="">The forms-processing entity is returning data (e.g., search results) to the forms-submitting entity, or the data is a generic data set.</td>
+      </tr>
+    </table>
+    <p class="" style="">In order to maintain the context of the data as captured in the form type, the following rules MUST be observed:</p>
+    <ul>
+      <li><p class="" style="">For &lt;iq/&gt; stanzas, the root element qualified by the "wrapper" namespace in a form of type "form" or "submit" MUST be returned in a form of type "result". The &lt;x/&gt; element qualified by the 'jabber:x:data' namespace MUST be a child of the "wrapper" namespace's root element. As defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2256692">8</a>], the 'id' attribute MUST be copied in the IQ result. For data forms of type "form" or "result", the &lt;iq/&gt; stanza SHOULD be of type "result".  For data forms of type "submit" or "cancel", the &lt;iq/&gt; stanza SHOULD be of type "set".</p></li>
+      <li><p class="" style="">For &lt;message/&gt; stanzas, the &lt;thread/&gt; SHOULD be copied in the reply if provided. The &lt;x/&gt; element qualified by the 'jabber:x:data' namespace MUST be a child of the &lt;message/&gt; stanza.</p></li>
+      <li><p class="" style="">The only data form type allowed for &lt;presence/&gt; stanzas is "result". The &lt;x/&gt; element qualified by the 'jabber:x:data' namespace MUST be a child of the &lt;presence/&gt; stanza. In accordance with <span style="font-weight: bold">XMPP Core</span>, use of data forms is not recommended unless necessary to provide information that is directly related to an entity's network availability.</p></li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="protocol-field">The Field Element</a>
+</h3>
+    <p class="" style="">A data form of type "form", "submit", or "result" SHOULD contain at least one &lt;field/&gt; element; a data form of type "cancel" SHOULD NOT contain any &lt;field/&gt; elements.</p>
+    <p class="" style="">The &lt;field/&gt; element MAY contain any of the following child elements:</p>
+    <ul>
+      <li>
+<span style="font-weight: bold">&lt;desc/&gt;</span> -- The XML character data of this element provides a natural-language description of the field, intended for presentation in a user-agent (e.g., as a "tool-tip", help button, or explanatory text provided near the field). The &lt;desc/&gt; element SHOULD NOT contain newlines (the \n and \r characters), since layout is the responsibility of a user agent, and any handling of newlines (e.g., presentation in a user interface) is unspecified herein. (Note: To provide a description of a field, it is RECOMMENDED to use a &lt;desc/&gt; element rather than a separate &lt;field/&gt; element of type "fixed".)</li>
+      <li>
+<span style="font-weight: bold">&lt;required/&gt;</span> -- This element, which MUST be empty, flags the field as required in order for the form to be considered valid.</li>
+      <li>
+<span style="font-weight: bold">&lt;value/&gt;</span> -- The XML character data of this element defines the default value for the field, the data provided by an entity that has completed the form, or a data result. In data forms of type "form", an entity SHOULD NOT attempt to enforce a default value if it is not provided via the &lt;value/&gt; element.</li>
+      <li>
+<span style="font-weight: bold">&lt;option/&gt;</span> -- One of the options in a field of type "list-single" or "list-multi". The XML character of the &lt;value/&gt; child defines the option value, and the 'label' attribute defines a human-readable name for the option. The &lt;option/&gt; element MAY contain more than one &lt;value/&gt; child if the field type is "list-multi".</li>
+    </ul>
+    <p class="" style="">If the &lt;field/&gt; element type is anything other than "fixed" (see below), it MUST possess a 'var' attribute that uniquely identifies the field in the context of the form (if it is "fixed", it MAY possess a 'var' attribute). The &lt;field/&gt; element MAY possess a 'label' attribute that defines a human-readable name for the field. For data forms of type "form", each &lt;field/&gt; element SHOULD possess a 'type' attribute that defines the data "type" of the field data (if no 'type' is specified, the default is "text-single"); fields provided in the context of other forms types MAY possess a 'type' attribute as well.</p>
+    <p class="" style="">If fields are presented in a user interface (e.g., as items in a questionnaire or form result), the order of the field elements in the XML SHOULD determine the order of items presented to the user.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="protocol-fieldtypes">Field Types</a>
+</h3>
+    <p class="" style="">The following field types represent data "types" that are commonly exchanged between Jabber/XMPP entities. These field types are not intended to be as comprehensive as the datatypes defined in, for example, <span class="ref" style="">XML Schema Part 2</span>  [<a href="#nt-id2256914">9</a>], nor do they define user interface elements.</p>
+    <p class="caption">Table 2: Field Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Type</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">boolean</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide an either-or choice between two options. The default value is "false".  [<a href="#nt-id2256966">10</a>]</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">fixed</td>
+        <td align="" colspan="" rowspan="">The field is intended for data description (e.g., human-readable text such as "section" headers) rather than data gathering or provision. The &lt;value/&gt; child SHOULD NOT contain newlines (the \n and \r characters); instead an application SHOULD generate multiple fixed fields, each with one &lt;value/&gt; child.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">hidden</td>
+        <td align="" colspan="" rowspan="">The field is not shown to the entity providing information, but instead is returned with the form.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">jid-multi *</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide multiple Jabber IDs.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">jid-single *</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide a single Jabber ID.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">list-multi</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide one or more options from among many.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">list-single</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide one option from among many.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">text-multi **</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide multiple lines of text.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">text-private</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide a single line or word of text, which shall be obscured in an interface (e.g., *****).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">text-single</td>
+        <td align="" colspan="" rowspan="">The field enables an entity to gather or provide a single line or word of text, which may be shown in an interface. This field type is the default and MUST be assumed if an entity receives a field type it does not understand.</td>
+      </tr>
+    </table>
+    <p class="" style="">* Note: Data provided for fields of type "jid-single" or "jid-multi" MUST contain one or more valid Jabber IDs, where validity is determined by the addressing rules defined in <span style="font-weight: bold">XMPP Core</span> (see the <a href="#validation">Data Validation</a> section below).</p>
+    <p class="" style="">** Note: Data provided for fields of type "text-multi" SHOULD NOT contain any newlines (the \n and \r characters). Instead, the application SHOULD split the data into multiple strings (based on the newlines inserted by the platform), then specify each string as the XML character data of a distinct &lt;value/&gt; element. Similarly, an application that receives multiple &lt;value/&gt; elements for a field of type "text-multi" SHOULD merge the XML character data of the value elements into one text block for presentation to a user, with each string separated by a newline character as appropriate for that platform.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="protocol-results">Multiple Items in Form Results</a>
+</h3>
+    <p class="" style="">In some contexts (e.g., the results of a search request), it may be necessary to communicate multiple items. Therefore, a data form of type "result" MAY contain two child elements not described in the basic syntax above: one &lt;reported/&gt; element followed by zero or more &lt;item/&gt; elements. The syntax is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data'
+   type='result'&gt;
+  &lt;reported&gt;
+    &lt;field var='field-name' label='description' type='{field-type}'/&gt;
+  &lt;/reported&gt;
+  &lt;item&gt;
+    &lt;field var='field-name'&gt;
+      &lt;value&gt;field-value&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/item&gt;
+  &lt;item&gt;
+    &lt;field var='field-name'&gt;
+      &lt;value&gt;field-value&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/item&gt;
+  .
+  .
+  .
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">Each of these elements MUST contain one or more &lt;field/&gt; children. The &lt;reported/&gt; element defines the data format for the result items by specifying the fields to be expected for each item; for this reason, the &lt;field/&gt; elements SHOULD possess a 'type' attribute and 'label' attribute in addition to the 'var' attribute, and SHOULD NOT contain a &lt;value/&gt; element. Each &lt;item/&gt; element defines one item in the result set, and MUST contain each field specified in the &lt;reported/&gt; element (although the XML character data of the &lt;value/&gt; element MAY be null).</p>
+  </div>
+<h2>4.
+       <a name="validation">Data Validation</a>
+</h2>
+  <p class="" style="">Data validation is the responsibility of the forms-processing entity (commonly a server, service, or bot) rather than the forms-submitting entity (commonly a client controlled by a human user). This helps to meet the requirement for keeping client implementations simple. If the forms-processing entity determines that the data provided is not valid, it SHOULD return a "Not Acceptable" error, optionally providing a textual explanation in the XMPP &lt;text/&gt; element or an application-specific child element that identifies the problem (see <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257340">11</a>] for information about mappings and formats).</p>
+<h2>5.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">For the sake of the following examples, let us suppose that there exists a bot hosting service on the Jabber network, located at &lt;botster.shakespeare.lit&gt;. This service enables registered users to create and configure new bots, find and interact with existing bots, and so on. We will assume that these interactions occur using the <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2257392">12</a>] protocol, which is used as a "wrapper" protocol for data forms qualified by the 'jabber:x:data' namespace. The examples in the sections that follow show most of the features of the data forms protocol described above.</p>
+  <p class="" style="">Note: Additional examples can be found in the specifications for various using protocols, such as <span style="font-weight: bold">JEP-0045: Multi-User Chat</span> and <span style="font-weight: bold">JEP-0055: Jabber Search</span>.</p>
+  <div class="indent">
+<h3>5.1 <a name="examples-config">Configuration</a>
+</h3>
+    <p class="" style="">The first step is for a user to create a new bot on the hosting service. We will assume that this is done by sending a "create" command to the desired bot:</p>
+    <p class="caption">Example 1. User Requests Bot Creation</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/home'
+    to='joogle@botster.shakespeare.lit'
+    type='get'
+    xml:lang='en'
+    id='create1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='create'
+           action='execute'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The hosting service then returns a data form to the user:</p>
+    <p class="caption">Example 2. Service Returns Bot Creation Form</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='romeo@montague.net/home'
+    type='result'
+    xml:lang='en'
+    id='create1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='create'
+           sessionid='create:20040408T0128Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Bot Configuration&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to configure your new bot!&lt;/instructions&gt;
+      &lt;field type='hidden'
+             var='FORM_TYPE'&gt;
+        &lt;value&gt;jabber:bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;&lt;value&gt;Section 1: Bot Info&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='text-single'
+             label='The name of your bot'
+             var='botname'/&gt;
+      &lt;field type='text-multi'
+             label='Helpful description of your bot'
+             var='description'/&gt;
+      &lt;field type='boolean'
+             label='Public bot?'
+             var='public'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field type='text-private'
+             label='Password for special access'
+             var='password'/&gt;
+      &lt;field type='fixed'&gt;&lt;value&gt;Section 2: Features&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='list-multi'
+             label='What features will the bot support?'
+             var='features'&gt;
+        &lt;option label='Contests'&gt;&lt;value&gt;contests&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='News'&gt;&lt;value&gt;news&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Polls'&gt;&lt;value&gt;polls&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Reminders'&gt;&lt;value&gt;reminders&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Search'&gt;&lt;value&gt;search&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;&lt;value&gt;Section 3: Subscriber List&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='list-single'
+             label='Maximum number of subscribers'
+             var='maxsubs'&gt;
+        &lt;value&gt;20&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;&lt;value&gt;Section 4: Invitations&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='jid-multi'
+             label='People to invite'
+             var='invitelist'&gt;
+        &lt;desc&gt;Tell all your friends about your new bot!&lt;/desc&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The user then submits the configuration form:</p>
+    <p class="caption">Example 3. User Submits Bot Creation Form</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='romeo@montague.net/home'
+    type='set'
+    xml:lang='en'
+    id='create2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='create'
+           sessionid='create:20040408T0128Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;jabber:bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='botname'&gt;
+        &lt;value&gt;The Jabber Google Bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-multi' var='description'&gt;
+        &lt;value&gt;This bot enables you to send requests to&lt;/value&gt;
+        &lt;value&gt;Google and receive the search results right&lt;/value&gt;
+        &lt;value&gt;in your Jabber client. It&amp;apos; really cool!&lt;/value&gt;
+        &lt;value&gt;It even supports Google News!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='public'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-private' var='password'&gt;
+        &lt;value&gt;v3r0na&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='features'&gt;
+        &lt;value&gt;news&lt;/value&gt;
+        &lt;value&gt;search&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='maxsubs'&gt;
+        &lt;value&gt;50&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='jid-multi' var='invitelist'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+        &lt;value&gt;benvolio@montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service then returns the results to the user:</p>
+    <p class="caption">Example 4. Service Returns Bot Creation Result</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='romeo@montague.net/home'
+    type='result'
+    xml:lang='en'
+    id='create2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='create'
+           sessionid='create:20040408T0128Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;jabber:bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='botname'&gt;
+        &lt;value&gt;The Jabber Google Bot&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='public'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-private' var='password'&gt;
+        &lt;value&gt;v3r0na&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='features'&gt;
+        &lt;value&gt;news&lt;/value&gt;
+        &lt;value&gt;search&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='maxsubs'&gt;
+        &lt;value&gt;50&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='jid-multi' var='invitelist'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+        &lt;value&gt;benvolio@montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="examples-search">Search</a>
+</h3>
+    <p class="" style="">Now that the user has created this search bot, let us suppose that one of the friends he has invited decides to try it out by sending a search request:</p>
+    <p class="caption">Example 5. User Requests Search Form</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/chamber'
+    to='joogle@botster.shakespeare.lit'
+    type='get'
+    xml:lang='en'
+    id='search1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='search'
+           action='execute'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Service Returns Search Form</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    type='result'
+    xml:lang='en'
+    id='search1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='search'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Joogle Search&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to search for information!&lt;/instructions&gt;
+      &lt;field type='text-single'
+             var='search_request'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 7. User Submits Search Form</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/chamber'
+    to='joogle@botster.shakespeare.lit'
+    type='get'
+    xml:lang='en'
+    id='search2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='search'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='text-single' var='search_request'&gt;
+        &lt;value&gt;verona&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Returns Search Results</p>
+<div class="indent"><pre>
+&lt;iq from='joogle@botster.shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    type='result'
+    xml:lang='en'
+    id='search2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='search'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;title&gt;Joogle Search: verona&lt;/title&gt;
+      &lt;reported&gt;
+        &lt;field var='name'/&gt;
+        &lt;field var='url'/&gt;
+      &lt;/reported&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;Comune di Verona - Benvenuti nel sito ufficiale&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.comune.verona.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;benvenuto!&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.hellasverona.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;Universita degli Studi di Verona - Home Page&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.univr.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;Aeroporti del Garda&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.aeroportoverona.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+      &lt;item&gt;
+        &lt;field var='name'&gt;
+          &lt;value&gt;Veronafiere - fiera di Verona&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='url'&gt;
+          &lt;value&gt;http://www.veronafiere.it/&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/item&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security concerns related to this specification above and beyond those described in the relevant section of <span style="font-weight: bold">XMPP Core</span>.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257854">13</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-namespaces">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257900">14</a>] includes the 'jabber:x:data' namespace in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-parameters">Parameter Values</a>
+</h3>
+    <p class="" style="">The Jabber Registrar maintains a registry of parameter values related to the 'jabber:x:data' namespace, specifically as defined in <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2257947">15</a>]; the registry is located at &lt;<a href="http://www.jabber.org/registrar/formtypes.html">http://www.jabber.org/registrar/formtypes.html</a>&gt;.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This schema is descriptive, not normative.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:x:data'
+    xmlns='jabber:x:data'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0004: http://www.jabber.org/jeps/jep-0004.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='instructions' 
+                    minOccurs='0' 
+                    maxOccurs='unbounded' 
+                    type='xs:string'/&gt;
+        &lt;xs:element name='title' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element ref='field' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='reported' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='cancel'/&gt;
+            &lt;xs:enumeration value='form'/&gt;
+            &lt;xs:enumeration value='result'/&gt;
+            &lt;xs:enumeration value='submit'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='field'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='desc' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='required' minOccurs='0' type='empty'/&gt;
+        &lt;xs:element ref='value' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='option' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' use='optional' default='text-single'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='boolean'/&gt;
+            &lt;xs:enumeration value='fixed'/&gt;
+            &lt;xs:enumeration value='hidden'/&gt;
+            &lt;xs:enumeration value='jid-multi'/&gt;
+            &lt;xs:enumeration value='jid-single'/&gt;
+            &lt;xs:enumeration value='list-multi'/&gt;
+            &lt;xs:enumeration value='list-single'/&gt;
+            &lt;xs:enumeration value='text-multi'/&gt;
+            &lt;xs:enumeration value='text-private'/&gt;
+            &lt;xs:enumeration value='text-single'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='var' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='option'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='value'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='value' type='xs:string'/&gt;
+
+  &lt;xs:element name='reported'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='field' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;
+        When contained in a "reported" element, the "field" element
+        SHOULD NOT contain a "value" child.
+      &lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='field' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>10.
+       <a name="draft-to-final">Changes Between Draft and Final</a>
+</h2>
+  <p class="" style="">The following protocol changes were incorporated in the Final specification as a result of experience with the Draft specification (described in version 1.0 of this document):</p>
+  <ul>
+    <li>The &lt;x/&gt; element MAY be included in &lt;message/&gt; and &lt;presence/&gt; elements.</li>
+    <li>The &lt;x/&gt; element MAY contain a &lt;title/&gt; child for forms and results.</li>
+    <li>The &lt;x/&gt; element MUST possess a 'type' attribute.</li>
+    <li>A &lt;field/&gt; element MAY be of type='jid-single'.</li>
+    <li>Results MAY be reported back in &lt;item/&gt; tags.</li>
+    <li>Results MAY contain a &lt;reported/&gt; element with result set.</li>
+    <li>The &lt;reported/&gt; fields MAY possess a 'type' attribute to provide hints about how to interact with the data (type='jid-single' being the most useful).</li>
+  </ul>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250732">1</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2250758">2</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2250780">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2250802">4</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256283">5</a>. XForms 1.0 &lt;<a href="http://www.w3.org/TR/xforms">http://www.w3.org/TR/xforms</a>&gt;.</p>
+<p><a name="nt-id2256303">6</a>. XHTML 1.0 &lt;<a href="http://www.w3.org/TR/xhtml1">http://www.w3.org/TR/xhtml1</a>&gt;.</p>
+<p><a name="nt-id2256330">7</a>. Modularization of XHTML &lt;<a href="http://www.w3.org/TR/2004/WD-xhtml-modularization-20040218/">http://www.w3.org/TR/2004/WD-xhtml-modularization-20040218/</a>&gt;.</p>
+<p><a name="nt-id2256692">8</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256914">9</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p><a name="nt-id2256966">10</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2257340">11</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257392">12</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2257854">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257900">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2257947">15</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 2.6 (2004-10-13)</h4>
+<div class="indent">Incorporated errata: (1) corrected syntax of &lt;reported/&gt; element (&lt;field/&gt; element should not contain a &lt;value/&gt; child); (2) corrected Example 8. (psa)
+    </div>
+<h4>Version 2.5 (2004-05-07)</h4>
+<div class="indent">Clarified terminology regarding form-processing entities and forms-submitting entities; corrected several small errors in the schema. (psa)
+    </div>
+<h4>Version 2.4 (2004-05-04)</h4>
+<div class="indent">Per discussion by the JEP authors and Jabber Council, specified that the 'var' attribute is required for all field types except "fixed", for which the 'var' attribute is optional. (psa)
+    </div>
+<h4>Version 2.3 (2004-03-31)</h4>
+<div class="indent">Formalization and further editorial revisions. (psa)
+    </div>
+<h4>Version 2.2 (2004-01-22)</h4>
+<div class="indent">Editorial revisions. (psa)
+    </div>
+<h4>Version 2.1 (2003-02-16)</h4>
+<div class="indent">Added schema. (psa)
+    </div>
+<h4>Version 2.0 (2002-12-09)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Final. (psa)
+    </div>
+<h4>Version 1.1 (2002-10-15)</h4>
+<div class="indent">Call for Experience changes (see <a href="#draft-to-final">Changes Between Draft and Final</a> section). This version voted to Final on 2002-12-09. (rwe)
+    </div>
+<h4>Version 1.0 (2002-04-24)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Draft. (psa)
+    </div>
+<h4>Version 0.6 (2002-03-15)</h4>
+<div class="indent">Protocol tweaks based on standards-jig discussion. (rwe)
+    </div>
+<h4>Version 0.5 (2002-02-06)</h4>
+<div class="indent">Protocol tweaks based on implementation and discussion. (rwe)
+    </div>
+<h4>Version 0.4 (2001-11-16)</h4>
+<div class="indent">Major redesign to attempt to clarify the scope of this JEP and limit what it is trying to solve. (rwe)
+    </div>
+<h4>Version 0.3 (2001-07-23)</h4>
+<div class="indent">Protocol update (rwe)
+    </div>
+<h4>Version 0.2 (2001-06-29)</h4>
+<div class="indent">Protocol update and DocBook version (rwe)
+    </div>
+<h4>Version 0.1 (2001-01-25)</h4>
+<div class="indent">Initial release (rwe)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0008-0.2.html
+++ b/content/xep-0008-0.2.html
@@ -1,0 +1,202 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0008: User Avatars in Jabber</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Avatars in Jabber">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Creator" content="Julian Missig">
+<meta name="DC.Creator" content="Jens Alfke">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Description" content="A proposal for avatars in Jabber.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2003-05-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0008">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0008: User Avatars in Jabber</h1>
+<p>A proposal for avatars in Jabber.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This JEP has been retracted by the author(s). Implementation of the protocol described herein is not recommended. Developers desiring similar functionality should implement the protocol that supersedes this one (if any).</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Retracted<br>
+            Type: Standards Track<br>
+            Number: 0008<br>
+            Version: 0.2<br>
+            Last Updated: 2003-05-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: None<br>
+</p>
+<h2>Author Information</h2>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h3>Julian Missig</h3>
+<p class="indent">
+        Email: julian@jabber.org<br>
+        JID: julian@jabber.org</p>
+<h3>Jens Alfke</h3>
+<p class="indent">
+        Email: jens@mac.com<br>
+</p>
+<h3>Peter Millard</h3>
+<p class="indent">
+        Email: me@pgmillard.com<br>
+        JID: pgmillard@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2595994">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596017">Image Requirements</a>
+</dt>
+<dt>3.  <a href="#sect-id2596050">Avatar Availability</a>
+</dt>
+<dt>4.  <a href="#sect-id2596236">Avatar Retrieval</a>
+</dt>
+<dt>5.  <a href="#sect-id2601855">Future Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2595994">Introduction</a>
+</h2>
+  <p class="" style="">Many communication applications now allow for the association of a small image or buddy icon (avatar) with a user of that application. The avatar is not intended to be a defining portrait of the user, but rather a simple expression of the user's appearance, mood, status, and the like. This proposal outlines a way to incorporate avatars into the current Jabber platform.</p>
+<h2>2.
+       <a name="sect-id2596017">Image Requirements</a>
+</h2>
+  <p class="" style="">Certain restrictions are placed upon the image. First, the image height and width must be between thirty-two (32) and sixty-four (64) pixels. The suggested size is sixty-four (64) pixels high and sixty-four (64) pixels wide  [<a href="#nt-id2596035">1</a>]. Images should be square, but this is not required. Images should be in GIF, JPEG, or PNG format, although it is possible that in future revisions of this spec more formats will be allowed. Finally, images must use less than eight (8) kilobytes of data.</p>
+<h2>3.
+       <a name="sect-id2596050">Avatar Availability</a>
+</h2>
+  <p class="" style="">There are two methods of showing that a client has an avatar available:</p>
+  <ol start="" type="">
+    <li>Embedding the jabber:x:avatar namespace within &lt;presence/&gt; packets using Jabber's &lt;x/&gt; element</li>
+    <li>Displaying the jabber:iq:avatar namespace in browse requests</li>
+  </ol>
+  <p class="" style="">Partly because Jabber browsing is relatively undeveloped, this proposal focuses on the first option.</p>
+  <p class="" style="">The &lt;x/&gt; element in the jabber:x:avatar namespace contains a SHA1 hash (hexadecimal, not base64) of the image data in a &lt;hash/&gt; element. (Because the odds of creating an identical hash are small, the hash is considered unique to the image and can be used to cache images between client sessions, resulting in fewer requests for the image.) The initial announcement of the availability of an avatar is done by sending a presence packet with the jabber:x:avatar information, as follows:</p>
+  <p class="caption">Example 1. </p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='jabber:x:avatar'&gt;
+    &lt;hash&gt;SHA1 of image data&lt;/hash&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">If the avatar-generating user changes the avatar, a new presence packet is sent out with the updated information:</p>
+  <p class="caption">Example 2. </p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='jabber:x:avatar'&gt;
+    &lt;hash&gt;SHA1 of new image data&lt;/hash&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">To disable the avatar, the avatar-generating user's client will send a presence packet with the jabber:x:avatar namespace but with no hash information:</p>
+  <p class="caption">Example 3. </p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='jabber:x:avatar'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">Clients should send the current avatar hash in every &lt;presence/&gt; packet even if the avatar has not changed. Remember that other clients logging in will receive a copy of the most recent &lt;presence/&gt; element, which should therefore always contain the most recent avatar hash. However, if the client's connection is lost unexpectedly or the client disconnects without sending an unavailable presence, the server will send other clients a &lt;presence/&gt; element containing no jabber:x:avatar extension. Therefore if, after receiving one or more presence packets containing jabber:x:avatar information, an avatar-receiving client receives a presence packet that does not include the jabber:x:avatar namespace, it is recommended that the client save the avatar image until the next set of information is received. In this case the avatar-generating client might send something as simple as the following:</p>
+  <p class="caption">Example 4. </p>
+<div class="indent"><pre>
+&lt;presence/&gt;
+  </pre></div>
+<h2>4.
+       <a name="sect-id2596236">Avatar Retrieval</a>
+</h2>
+  <p class="" style="">There are two methods for retrieving the actual avatar data:</p>
+  <ol start="" type="">
+    <li>An exchange between clients of &lt;iq/&gt; elements in the jabber:iq:avatar namespace</li>
+    <li>Public XML storage from the avatar-generating client to the server and public XML retrieval from the server to the avatar-requesting client  [<a href="#nt-id2596274">2</a>]</li>
+  </ol>
+  <p class="" style="">The first of these methods is preferred. On this model, a query is sent directly to the avatar-generating client using an &lt;iq/&gt; element of type &quot;get&quot; in the jabber:iq:avatar namespace  [<a href="#nt-id2596300">3</a>]  [<a href="#nt-id2596307">4</a>]:</p>
+  <p class="caption">Example 5. </p>
+<div class="indent"><pre>
+&lt;iq id='2' type='get' to='user@server/resource'&gt;
+  &lt;query xmlns='jabber:iq:avatar'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The avatar-generating client will reply with an &lt;iq/&gt; element of type &quot;result&quot; in the jabber:iq:avatar namespace; this reply will contain a query element that in turn contains a &lt;data/&gt; element with the MIME type in the 'mimetype' attribute and the data base64-encoded in the body of the &lt;data/&gt; element:</p>
+  <p class="caption">Example 6. </p>
+<div class="indent"><pre>
+&lt;iq id='2' type='result' to='user@server/resource'&gt;
+  &lt;query xmlns='jabber:iq:avatar'&gt;
+    &lt;data mimetype='image/jpeg'&gt;
+      Base64-Encoded Data
+    &lt;/data&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the first method fails, the second method that should be attempted by sending a request to the server for the avatar-generating user's public XML containing the avatar data. This data is to be stored in the storage:client:avatar namespace. This method presumes that the avatar-generating client has already stored its avatar data on the server:</p>
+  <p class="caption">Example 7. </p>
+<div class="indent"><pre>
+&lt;iq id='0' type='set' to='user@server'&gt;
+  &lt;query xmlns='storage:client:avatar'&gt;
+    &lt;data mimetype='image/jpeg'&gt;
+      Base64 Encoded Data
+    &lt;/data&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Once such data has been set, the avatar can be retrieved by any requesting client from the avatar-generating client's public XML storage:</p>
+  <p class="caption">Example 8. </p>
+<div class="indent"><pre>
+&lt;iq id='1' type='get' to='user@server'&gt;
+  &lt;query xmlns='storage:client:avatar'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="sect-id2601855">Future Considerations</a>
+</h2>
+  <p class="" style="">It is acknowledged that sending avatar information within presence packets is less than desirable in many respects (e.g., in network traffic generated); however, there currently exists in Jabber no generic framework for addressing these shortcomings. Possible solutions on the horizon include live browsing and a pub/sub model, but these are still embryonic and experimental. Once something of that nature is accepted by the Council, the avatar spec will be modified to work within that framework rather than by attaching to presence.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596035">1</a>. It is highly recommended that clients never scale up images when displaying them.</p>
+<p>
+<a name="nt-id2596274">2</a>. Refer to the <a href="http://docs.jabber.org/draft-proto/html/xml.html">Generic XML Namespace Storage</a> draft protocol.</p>
+<p>
+<a name="nt-id2596300">3</a>. Whenever possible, the avatar-requesting client should attempt to determine if the avatar-generating client has an avatar available before requesting it.</p>
+<p>
+<a name="nt-id2596307">4</a>. It is suggested that no request be made if it is known (such as through a browse reply) that a client does not support the jabber:iq:avatar namespace.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2003-05-06)</h4>
+<div class="indent">At the request of the authors, the status of this JEP has been changed to Retracted, to be superseded by a forthcoming JEP. This JEP will not be considered further by the Jabber Software Foundation and should not be used as a basis for implementations. (psa)
+    </div>
+<h4>Version 0.1 (2001-09-14)</h4>
+<div class="indent">Initial release (tm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0009-2.0.html
+++ b/content/xep-0009-2.0.html
@@ -1,0 +1,302 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0009: Jabber-RPC</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jabber-RPC">
+<meta name="DC.Creator" content="DJ Adams">
+<meta name="DC.Description" content="This JEP defines a method for transporting XML-RPC encoded requests and responses over Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2002-12-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0009">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0009: Jabber-RPC</h1>
+<p>This JEP defines a method for transporting XML-RPC encoded requests and responses over Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Final Standard of the Jabber Software Foundation and may be considered a stable technology for implementation and deployment.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Final<br>
+            Type: Standards Track<br>
+            Number: 0009<br>
+            Version: 2.0<br>
+            Last Updated: 2002-12-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XML-RPC<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jabber-rpc<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/jabber-rpc/jabber-rpc.xsd">http://jabber.org/protocol/jabber-rpc/jabber-rpc.xsd</a>&gt;<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jabber-RPC%20(JEP-0009)">http://wiki.jabber.org/index.php/Jabber-RPC (JEP-0009)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>DJ Adams</h3>
+<p class="indent">
+        Email: dj.adams@pobox.com<br>
+        JID: dj@gnu.mine.nu</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#sect-id2251594">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2251682">Jabber-RPC</a>
+</dt>
+<dt>3.  <a href="#sect-id2250561">Examples</a>
+</dt>
+<dt>4.  <a href="#sect-id2250594">Formal Description</a>
+</dt>
+<dl><dt>4.1.  <a href="#sect-id2250600">Schema</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2251594">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XML-RPC</span>  [<a href="#nt-id2251627">1</a>] is a method of encoding RPC requests and responses in XML. The original specification defines HTTP (see <span class="ref" style="">RFC 2068</span>  [<a href="#nt-id2251651">2</a>]) as the only valid transport for XML-RPC payloads.</p>
+  <p class="" style="">Various initiatives exist already to transport XML-RPC payloads over Jabber. These initiatives were independent of each other and used slightly differing methods (e.g. carrying the payload in a &lt;message/&gt; element as opposed to an &lt;iq/&gt; element), resulting in potential interoperability problems.</p>
+  <p class="" style="">A working session during JabberCon 2001 resulted in a <a href="http://www.pipetree.com/jabber/jrpc.html">formalisation</a> of a single method. This JEP describes that method, which is labelled as Jabber-RPC to differentiate it from XML-RPC itself.</p>
+<h2>2.
+       <a name="sect-id2251682">Jabber-RPC</a>
+</h2>
+  <p class="" style="">The &lt;iq/&gt; element is used to transport XML-RPC payloads. XML-RPC requests are transported using an &lt;iq/&gt; packet of type "set", and XML-RPC responses are transported using an &lt;iq/&gt; packet of type "result". An &lt;iq/&gt; element MUST NOT contain more than one request or response.</p>
+  <p class="" style="">The &lt;iq/&gt; element contains a single &lt;query/&gt; sub-element in the jabber:iq:rpc namespace. The direct child of the &lt;query/&gt; element will be either a single &lt;methodCall/&gt; element (in the case of a request) or a single &lt;methodResponse/&gt; element (in the case of a response). This child element will contain the XML-RPC payload. Note that the XML declaration that normally appears at the head of an XML-RPC request or response when transported as the payload of an HTTP POST request MUST BE omitted when it is transported via a Jabber &lt;iq/&gt; element.</p>
+  <p class="" style="">The encoding of the Jabber XML stream is UTF-8. It is assumed that the encoding of the XML-RPC payload is also UTF-8.</p>
+  <p class="" style="">Application-level errors will be indicated within the XML-RPC payload (as is the case with the traditional HTTP-based XML-RPC mechanism). Transport level errors will be indicated in the normal way for &lt;iq/&gt; elements -- namely, by an &lt;iq/&gt; element of type "error" and the addition of an &lt;error/&gt; tag as a direct child of the &lt;iq/&gt; element. There are no specific XML-RPC-related, transport-level errors.</p>
+<h2>3.
+       <a name="sect-id2250561">Examples</a>
+</h2>
+<p class="caption">Example 1. A typical request</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='responder@company-a.com/jrpc-server' id='1'&gt;
+  &lt;query xmlns='jabber:iq:rpc'&gt;
+    &lt;methodCall&gt;
+      &lt;methodName&gt;examples.getStateName&lt;/methodName&gt;
+      &lt;params&gt;
+        &lt;param&gt;
+          &lt;value&gt;&lt;i4&gt;6&lt;/i4&gt;&lt;/value&gt;
+        &lt;/param&gt;
+      &lt;/params&gt;
+    &lt;/methodCall&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<p class="caption">Example 2. A typical response</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@company-b.com/jrpc-client' 
+            from='responder@company-a.com/jrpc-server' id='1'&gt;
+  &lt;query xmlns='jabber:iq:rpc'&gt;
+    &lt;methodResponse&gt;
+      &lt;params&gt;
+        &lt;param&gt;
+          &lt;value&gt;&lt;string&gt;Colorado&lt;/string&gt;&lt;/value&gt;
+        &lt;/param&gt;
+      &lt;/params&gt;
+    &lt;/methodResponse&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>4.
+       <a name="sect-id2250594">Formal Description</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="sect-id2250600">Schema</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:rpc'
+    xmlns='jabber:iq:rpc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0009: http://www.jabber.org/jeps/jep-0009.html
+
+      There is no official XML schema for XML-RPC. The main body 
+      of this schema has been borrowed from an unofficial schema 
+      representation contained in the book "Processing XML With 
+      Java" by Elliotte Rusty Harold, as located at:
+
+      http://www.ibiblio.org/xml/books/xmljava/chapters/ch02s05.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='1'&gt;
+        &lt;xs:element ref='methodCall'/&gt;
+        &lt;xs:element ref='methodResponse'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name="methodCall"&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:all&gt;
+        &lt;xs:element name="methodName"&gt;
+          &lt;xs:simpleType&gt;
+            &lt;xs:restriction base="ASCIIString"&gt;
+              &lt;xs:pattern value="([A-Za-z0-9]|/|\.|:|_)*" /&gt;
+            &lt;/xs:restriction&gt;
+          &lt;/xs:simpleType&gt;
+        &lt;/xs:element&gt;
+        &lt;xs:element name="params" minOccurs="0" maxOccurs="1"&gt;
+          &lt;xs:complexType&gt;
+            &lt;xs:sequence&gt;
+              &lt;xs:element name="param"  type="ParamType" 
+                           minOccurs="0" maxOccurs="unbounded"/&gt;
+            &lt;/xs:sequence&gt;
+          &lt;/xs:complexType&gt;
+         &lt;/xs:element&gt;
+      &lt;/xs:all&gt;
+    &lt;/xs:complexType&gt;  
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name="methodResponse"&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element name="params"&gt;
+          &lt;xs:complexType&gt;
+            &lt;xs:sequence&gt;
+              &lt;xs:element name="param" type="ParamType"/&gt;
+            &lt;/xs:sequence&gt;
+          &lt;/xs:complexType&gt;
+        &lt;/xs:element&gt;
+        &lt;xs:element name="fault"&gt;
+          &lt;!-- What can appear inside a fault is very restricted --&gt;
+          &lt;xs:complexType&gt;
+            &lt;xs:sequence&gt;
+              &lt;xs:element name="value"&gt;
+                &lt;xs:complexType&gt;
+                  &lt;xs:sequence&gt;
+                    &lt;xs:element name="struct"&gt; 
+                      &lt;xs:complexType&gt; 
+                        &lt;xs:sequence&gt; 
+                          &lt;xs:element name="member" 
+                                       type="MemberType"&gt;
+                          &lt;/xs:element&gt;
+                          &lt;xs:element name="member" 
+                                       type="MemberType"&gt;
+                          &lt;/xs:element&gt;
+                        &lt;/xs:sequence&gt;
+                      &lt;/xs:complexType&gt;
+                    &lt;/xs:element&gt;
+                  &lt;/xs:sequence&gt;
+                &lt;/xs:complexType&gt;
+              &lt;/xs:element&gt;
+            &lt;/xs:sequence&gt;
+          &lt;/xs:complexType&gt;
+         &lt;/xs:element&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;  
+  &lt;/xs:element&gt;
+
+  &lt;xs:complexType name="ParamType"&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element name="value" type="ValueType"/&gt;
+    &lt;/xs:sequence&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:complexType name="ValueType" mixed="true"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:element name="i4"            type="xs:int"/&gt;
+      &lt;xs:element name="int"           type="xs:int"/&gt;
+      &lt;xs:element name="string"        type="ASCIIString"/&gt;
+      &lt;xs:element name="double"        type="xs:decimal"/&gt;
+      &lt;xs:element name="Base64"        type="xs:base64Binary"/&gt;
+      &lt;xs:element name="boolean"       type="NumericBoolean"/&gt;
+      &lt;xs:element name="dateTime.iso8601" type="xs:dateTime"/&gt;
+      &lt;xs:element name="array"         type="ArrayType"/&gt;
+      &lt;xs:element name="struct"        type="StructType"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:complexType name="StructType"&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element name="member" type="MemberType" 
+                   maxOccurs="unbounded"/&gt;
+    &lt;/xs:sequence&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:complexType name="MemberType"&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element name="name"  type="xs:string" /&gt;
+      &lt;xs:element name="value" type="ValueType"/&gt;
+    &lt;/xs:sequence&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:complexType name="ArrayType"&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element name="data"&gt;
+        &lt;xs:complexType&gt;
+          &lt;xs:sequence&gt;
+            &lt;xs:element name="value"  type="ValueType" 
+                         minOccurs="0" maxOccurs="unbounded"/&gt;
+          &lt;/xs:sequence&gt;
+        &lt;/xs:complexType&gt;
+      &lt;/xs:element&gt;
+    &lt;/xs:sequence&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:simpleType name="ASCIIString"&gt;
+    &lt;xs:restriction base="xs:string"&gt;
+      &lt;xs:pattern value="([ -~]|\n|\r|\t)*" /&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name="NumericBoolean"&gt;
+    &lt;xs:restriction base="xs:boolean"&gt;
+      &lt;xs:pattern value="0|1" /&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251627">1</a>. XML-RPC &lt;<a href="http://www.xmlrpc.com/spec">http://www.xmlrpc.com/spec</a>&gt;.</p>
+<p><a name="nt-id2251651">2</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 2.0 (2002-12-09)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Final. (psa)
+    </div>
+<h4>Version 1.0 (2001-09-27)</h4>
+<div class="indent">Changed status to Draft (psa)
+    </div>
+<h4>Version 0.1 (2001-09-14)</h4>
+<div class="indent">Initial version (dja)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0011-1.1.html
+++ b/content/xep-0011-1.1.html
@@ -1,0 +1,569 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0011: Jabber Browsing</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jabber Browsing">
+<meta name="DC.Creator" content="Jeremie Miller">
+<meta name="DC.Creator" content="Julian Missig">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Description" content="This JEP defines a way to describe information about Jabber entities and the relationships between entities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-01-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0011">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0011: Jabber Browsing</h1>
+<p>This JEP defines a way to describe information about Jabber entities and the relationships between entities.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in wide use within the Jabber community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; therefore it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0011<br>
+            Version: 1.1<br>
+            Last Updated: 2004-01-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>Superseded By: JEP-0030<br>
+            Short Name: iq-browse<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/iq-browse/iq-browse.xsd">http://jabber.org/protocol/iq-browse/iq-browse.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Jeremie Miller</h3>
+<p class="indent">
+        Email: jer@jabber.org<br>
+        JID: jer@jabber.org</p>
+<h3>Julian Missig</h3>
+<p class="indent">
+        Email: julian@jabber.org<br>
+        JID: julian@jabber.org</p>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2596090">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596124">JID-Types</a>
+</dt>
+<dt>3.  <a href="#sect-id2603010">The jabber:iq:browse Namespace</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2603032">Browsing to a JabberID</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2603062">Generic Attributes for Browse Results</a>
+</dt>
+<dt>3.3.  <a href="#sect-id2603118">Expressing Relationships</a>
+</dt>
+<dt>3.4.  <a href="#sect-id2595716">Namespace Advertising</a>
+</dt>
+<dt>3.5.  <a href="#sect-id2595805">Empty Results</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2595834">Supplanting jabber:iq:agents</a>
+</dt>
+<dt>5.  <a href="#sect-id2603554">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#sect-id2603577">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2603598">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2603616">Jabber Registrar Considerations</a>
+</dt>
+<dt>9.  <a href="#sect-id2603638">XML Schema</a>
+</dt>
+<dt>10.  <a href="#sect-id2603680">Future Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2596090">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber world is a diverse place, with lots of services, transports, software agents, users, groupchat rooms, translators, headline tickers, and just about anything that might interact on a real-time basis using conversational messages or presence. Every JabberID (JID) is a node that can be interacted with via messages, presence, and special purpose IQ namespaces. Some JIDs are parents (such as transports), and often many JIDs have relationships with other JIDs (such as a user to their resources, a server to its services, etc.). We need a better way to structure and manage this culture of multi-namespace JID stew. The answer: Jabber Browsing.</p>
+  <p class="" style=""><span style="font-style: italic">Note well that implementors are encouraged to implement <span class="ref">Service Discovery</span>  [<a href="#nt-id2596227">1</a>] instead of Jabber Browsing.</span></p>
+<h2>2.
+       <a name="sect-id2596124">JID-Types</a>
+</h2>
+  <p class="" style="">One of the concepts in browsing which helps to extend the interaction between JIDs is a &quot;JID-Type&quot;, a simple heirarchy for identifying the role of any JabberID that is similar to the mime-type format. Many programmers are comfortable with the concept of identifying file types by mime-types, which use the format &quot;category/type&quot;. A JID-Type, once discovered, is to be used in the same way that a mime-type would be for a file, to alter the user interface representing that JID or provide alternative functionality for interacting with it (either automatically or driven by user interaction). The following categories and types are proposed as the canonical list for the purpose of JID-Types:</p>
+  <p class="caption">Table 1: Official List of JID-Type Categories and Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Category</th>
+      <th colspan="" rowspan="">Type</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="7">application/</td>
+      <td align="" colspan="" rowspan=""> </td>
+      <td align="" colspan="" rowspan="">Specific applications running as a resource on a user@host</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">bot</td>
+      <td align="" colspan="" rowspan="">Automated conversations</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">calendar</td>
+      <td align="" colspan="" rowspan="">Calendaring and scheduling service</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">editor</td>
+      <td align="" colspan="" rowspan="">Collaborative editor</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">fileserver</td>
+      <td align="" colspan="" rowspan="">Available files</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">game</td>
+      <td align="" colspan="" rowspan="">Multi-player game</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">whiteboard</td>
+      <td align="" colspan="" rowspan="">Whiteboard tool</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="7">conference/</td>
+      <td align="" colspan="" rowspan=""> </td>
+      <td align="" colspan="" rowspan="">Nodes of this category provide multi-user chat facilities (a.k.a. conference rooms).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">irc</td>
+      <td align="" colspan="" rowspan="">IRC rooms (note: this enables Jabber users to connect to Internet Relay Chat rooms)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">list</td>
+      <td align="" colspan="" rowspan="">Mailing-list-style conferences</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">private</td>
+      <td align="" colspan="" rowspan="">Private, dynamically-generated conference rooms</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">public</td>
+      <td align="" colspan="" rowspan="">Public, permanent conference rooms</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">topic</td>
+      <td align="" colspan="" rowspan="">Topic-based conferences</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">url</td>
+      <td align="" colspan="" rowspan="">Website-hosted conferences</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="5">headline/</td>
+      <td align="" colspan="" rowspan=""> </td>
+      <td align="" colspan="" rowspan="">Recognize different sources of headlines, GUI hints</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">logger</td>
+      <td align="" colspan="" rowspan="">Log messages (usually presented in a scrolling GUI)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">notice</td>
+      <td align="" colspan="" rowspan="">Alerts and warnings (usually presented as popup messages)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">rss</td>
+      <td align="" colspan="" rowspan="">Rich Site Summary syndication</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">stock</td>
+      <td align="" colspan="" rowspan="">Stock market information by symbol (ticker)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="7">keyword/</td>
+      <td align="" colspan="" rowspan=""> </td>
+      <td align="" colspan="" rowspan="">Keyword-based lookup services (search engines, etc.)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">dictionary</td>
+      <td align="" colspan="" rowspan="">Dictionary lookup service</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">dns</td>
+      <td align="" colspan="" rowspan="">DNS resolver</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">software</td>
+      <td align="" colspan="" rowspan="">Software search</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">thesaurus</td>
+      <td align="" colspan="" rowspan="">Thesaurus lookup service</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">web</td>
+      <td align="" colspan="" rowspan="">Web search</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">whois</td>
+      <td align="" colspan="" rowspan="">Whois query service</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="4">render/</td>
+      <td align="" colspan="" rowspan=""> </td>
+      <td align="" colspan="" rowspan="">Automated translation services</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">en2fr</td>
+      <td align="" colspan="" rowspan="">English to French</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">*2*</td>
+      <td align="" colspan="" rowspan="">Other language to language (using standard language codes)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">tts</td>
+      <td align="" colspan="" rowspan="">Text to Speech</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="12">service/</td>
+      <td align="" colspan="" rowspan=""> </td>
+      <td align="" colspan="" rowspan="">Nodes of this category provide a link to another Instant Messaging network or messaging gateway. The 'jabber:iq:register' namespace can be used to gain access to such networks, and the 'jabber:iq:search' namespace may also be available.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">aim</td>
+      <td align="" colspan="" rowspan="">AIM transport</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">icq</td>
+      <td align="" colspan="" rowspan="">ICQ transport</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">irc</td>
+      <td align="" colspan="" rowspan="">IRC gateway (note: this enables IRC users to connect to Jabber)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jabber</td>
+      <td align="" colspan="" rowspan="">A Jabber server which conforms to the specification for the 'jabber:client' namespace</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jud</td>
+      <td align="" colspan="" rowspan="">Jabber User Directory</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">msn</td>
+      <td align="" colspan="" rowspan="">MSN transport</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">pager</td>
+      <td align="" colspan="" rowspan="">Pager gateway</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">serverlist</td>
+      <td align="" colspan="" rowspan="">A list of servers. It is assumed that this node has service/* children</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">sms</td>
+      <td align="" colspan="" rowspan="">SMS gateway</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">smtp</td>
+      <td align="" colspan="" rowspan="">SMTP gateway</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">yahoo</td>
+      <td align="" colspan="" rowspan="">Yahoo! transport</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="6">user/</td>
+      <td align="" colspan="" rowspan=""> </td>
+      <td align="" colspan="" rowspan="">Nodes of this category are Jabber users, typically implementing enough of the 'jabber:client' namespace to be compliant.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">client</td>
+      <td align="" colspan="" rowspan="">A standard or fully-featured Jabber client compliant with the 'jabber:client' namespace</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">forward</td>
+      <td align="" colspan="" rowspan="">A forward alias</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">inbox</td>
+      <td align="" colspan="" rowspan="">An alternate inbox</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">portable</td>
+      <td align="" colspan="" rowspan="">A portable device implementing some of the 'jabber:client' namespace</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">voice</td>
+      <td align="" colspan="" rowspan="">A node providing phone or voice access</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="4">validate/</td>
+      <td align="" colspan="" rowspan=""> </td>
+      <td align="" colspan="" rowspan="">Validation services</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">grammar</td>
+      <td align="" colspan="" rowspan="">Grammar-checking tool</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">spell</td>
+      <td align="" colspan="" rowspan="">Spell-checking tool</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">xml</td>
+      <td align="" colspan="" rowspan="">XML validator</td>
+    </tr>
+  </table>
+  <p class="" style="">Historically each category was used as the name of an element, and the type was an attribute, such as &lt;service type=&quot;aim&quot;/&gt;. The proper expression for all new implementations supporting this specification is to express the type information as attributes on a generic item element: &lt;item category=&quot;service&quot; type=&quot;aim&quot;/&gt;. When processing returned browse information this new syntax should always be handled first, and the old syntax only used if it is important to be able to access older implementations.</p>
+  <p class="" style="">Additional unofficial categories or types may be specified by prefixing their name with an &quot;x-&quot;, such as &quot;service/x-virgeim&quot; or &quot;x-location/gps&quot;. Changes to the official categories and subtypes may be defined either by revising this JEP or by activating another JEP. Removal of a category or subtype must be noted in this document.</p>
+<h2>3.
+       <a name="sect-id2603010">The jabber:iq:browse Namespace</a>
+</h2>
+  <p class="" style="">The namespace containing the Jabber Browsing data is jabber:iq:browse. The primary element within this namespace is 'item' (again, historically every category listed above would also be an element).</p>
+  <div class="indent">
+<h3>3.1 <a name="sect-id2603032">Browsing to a JabberID</a>
+</h3>
+    <p class="" style="">The common way to browse to a JabberID using IQ is:</p>
+    <p class="caption">Example 1. Browsing to a JabberID</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot; to=&quot;jer@jabber.org&quot; id=&quot;browse1&quot;/&gt;
+  &lt;query xmlns=&quot;jabber:iq:browse&quot;/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sect-id2603062">Generic Attributes for Browse Results</a>
+</h3>
+    <p class="" style="">The item element has these attributes in a browse result:</p>
+    <ul>
+      <li>jid [required] -- The full JabberID of the entity described.</li>
+      <li>category [optional] -- One of the categories from the list above, or a non-standard category prefixed with the string &quot;x-&quot;.</li>
+      <li>type [optional] -- One of the official types from the specified category, or a non-standard type prefixed with the string &quot;x-&quot;.</li>
+      <li>name [optional] -- A friendly name that may be used in a user interface.</li>
+      <li>version [optional] -- A string containing the version of the node, equivalent to the response provided to a query in the 'jabber:iq:version' namespace. This is useful for servers, especially for lists of services (see the 'service/serverlist' category/type above).</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="sect-id2603118">Expressing Relationships</a>
+</h3>
+    <p class="" style="">Any item may contain any number of additional items as a child, which describes the hierarchical relationship between the parent and the child items. This relationship could be represented as a &quot;link&quot; in a wizard or page-based user interface, or as a branch in a tree as it is expanded. Browse results usually only contain the direct children of a node, not the grandchildren. Browsing to a user, but not a resource, will return results from the server (still with the user's JID) containing the list of resources.</p>
+    <p class="" style="">For example, this could be the result of browsing to jer@jabber.org:</p>
+    <p class="caption">Example 2. Result of Browsing to a User</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot; from=&quot;jer@jabber.org&quot; id=&quot;browse1&quot;&gt;
+  &lt;query
+      xmlns=&quot;jabber:iq:browse&quot;
+      category=&quot;user&quot;
+      jid=&quot;jer@jabber.org&quot;
+      name=&quot;jer&quot;&gt;
+    &lt;item
+        category=&quot;user&quot;
+        jid=&quot;jer@jabber.org/foxy&quot;
+        type=&quot;client&quot;/&gt;
+    &lt;item
+        category=&quot;application&quot;
+        jid=&quot;jer@jabber.org/chess&quot;
+        name=&quot;XChess&quot;/
+        type=&quot;game&quot;&gt;
+    &lt;item
+        category=&quot;user&quot;
+        jid=&quot;jer@jabber.org/palm&quot;
+        type=&quot;client&quot;/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">More definitively, throughout all of browsing, a parent describes the children, and the children when browsed to fully describe themselves. The browse data received from the child takes precedence.</p>
+    <p class="" style="">Parents should list children only if they are available. This means that if for a user a child client goes offline, the parent should remove it from its browse result.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="sect-id2595716">Namespace Advertising</a>
+</h3>
+    <p class="" style="">On top of the browsing framework, a simple form of &quot;feature advertisement&quot; can be built. This enables any entity to advertise which features it supports, based on the namespaces associated with those features. The &lt;ns/&gt; element is allowed as a subelement of the item. This element contains a single namespace that the entity supports, and multiple &lt;ns/&gt; elements can be included in any item. For a connected client this might be &lt;ns&gt;jabber:iq:oob&lt;/ns&gt;, or for a service &lt;ns&gt;jabber:iq:search&lt;/ns&gt;. This list of namespaces should be used to present available options for a user or to automatically locate functionality for an application.</p>
+    <p class="" style="">The children of a browse result may proactively contain a few &lt;ns/&gt; elements (such as the result of the service request to the home server), which advertises the features that the particular service supports. This list may not be complete (it is only for first-pass filtering by simpler clients), and the JID should be browsed if a complete list is required.</p>
+    <p class="" style="">Clients should answer incoming browsing requests to advertise the namespaces they support.</p>
+    <p class="caption">Example 3. Result of Browsing to a Resource</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot; from=&quot;jer@jabber.org/foxy&quot; id=&quot;browse2&quot;&gt;
+  &lt;query
+      xmlns=&quot;jabber:iq:browse&quot;
+      category=&quot;user&quot;
+      jid=&quot;jer@jabber.org/foxy&quot;
+      name=&quot;laptop&quot;
+      type=&quot;client&quot;&gt;
+    &lt;ns&gt;jabber:client&lt;/ns&gt;
+    &lt;ns&gt;jabber:iq:browse&lt;/ns&gt;
+    &lt;ns&gt;jabber:iq:conference&lt;/ns&gt;
+    &lt;ns&gt;jabber:iq:time&lt;/ns&gt;
+    &lt;ns&gt;jabber:iq:version&lt;/ns&gt;
+    &lt;ns&gt;jabber:x:roster&lt;/ns&gt;
+    &lt;ns&gt;jabber:x:signed&lt;/ns&gt;
+    &lt;ns&gt;jabber:x:encrypted&lt;/ns&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="sect-id2595805">Empty Results</a>
+</h3>
+    <p class="" style="">When a JabberID is browsed, the result may contain children or it may be empty. An empty result means there are no further relationships or links under that JID, which could be represented as a page containing a list of functions available for the JID, such as vCard, message, register, etc. When the result contains children, they may also be empty (as in the first result from jer@jabber.org above). An empty child does not mean anything, and to determine the namespaces supported or if there are more children, it must be browsed to directly.</p>
+  </div>
+<h2>4.
+       <a name="sect-id2595834">Supplanting jabber:iq:agents</a>
+</h2>
+  <p class="" style="">The first important use of jabber:iq:browse is to replace the jabber:iq:agents namespace. When a client connects, it may optionally browse to the server to which it connected in order to retrieve a list of available services. The resulting iq might look like the following example:</p>
+    <p class="caption">Example 4. Result of Browsing to a Server</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot; from=&quot;jabber.org&quot; id=&quot;browse3&quot;&gt;
+  &lt;query
+      xmlns=&quot;jabber:iq:browse&quot;
+      category=&quot;service&quot;
+      type=&quot;jabber&quot;
+      jid=&quot;jabber.org&quot;
+      name=&quot;Jabber.org Public Server&quot;&gt;
+    &lt;ns&gt;jabber:client&lt;/ns&gt;
+    &lt;ns&gt;jabber:iq:browse&lt;/ns&gt;
+    &lt;ns&gt;jabber:iq:conference&lt;/ns&gt;
+    &lt;ns&gt;jabber:iq:time&lt;/ns&gt;
+    &lt;ns&gt;jabber:iq:version&lt;/ns&gt;
+    &lt;item
+        category=&quot;service&quot;
+        jid=&quot;icq.jabber.org&quot;
+        name=&quot;ICQ Transport&quot;
+        type=&quot;icq&quot;&gt;
+      &lt;ns&gt;jabber:iq:register&lt;/ns&gt;
+      &lt;ns&gt;jabber:iq:search&lt;/ns&gt;
+      &lt;ns&gt;jabber:iq:gateway&lt;/ns&gt;
+    &lt;/item&gt;
+    &lt;item
+      category=&quot;conference&quot;
+      type=&quot;private&quot;
+      jid=&quot;conference.jabber.org&quot;
+      name=&quot;Private Chatrooms&quot;/&gt;
+    &lt;item
+        category=&quot;application&quot;
+        jid=&quot;jabber.org/help&quot;
+        name=&quot;Assistance Agent&quot;
+        type=&quot;bot&quot;/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">To determine any further details from this list, each child would have to be browsed. The elements within the icq service are only hints to a client for building user interface elements. The icq.jabber.org service would still need to be browsed in order to determine any relationships or additional namespaces. This top-level list is the master &quot;services&quot; list available from the server, and should be used for any default functionality when available. This list could also serve as the &quot;home page&quot; for a page-based browsing user interface.</p>
+<h2>5.
+       <a name="sect-id2603554">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client should not just blindly request browse information every time the user requests it, rather, a client should cache the browse results based on JabberID. Any display or use of the browse data should then be returned from the cache. This model is similiar to that of presence.</p>
+<h2>6.
+       <a name="sect-id2603577">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>7.
+       <a name="sect-id2603598">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603716">2</a>].</p>
+<h2>8.
+       <a name="sect-id2603616">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No action on the part of the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603656">3</a>] is necessary as a result of this JEP, since 'jabber:iq:browse' is already a registered protocol namespace.</p>
+<h2>9.
+       <a name="sect-id2603638">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:browse'
+    xmlns='jabber:iq:browse'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0011: http://www.jabber.org/jeps/jep-0011.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='item'/&gt;
+        &lt;xs:element ref='ns'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='category' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='ns' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='category' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='ns' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+<h2>10.
+       <a name="sect-id2603680">Future Considerations</a>
+</h2>
+  <p class="" style="">The 'jabber:iq:browse' namespace has been in use for quite some time. However, live browsing still needs to be better defined by a generic publication/subscription system. It is assumed that when such a system is defined, updates to this JEP will be made. It is, however, possible that no futher changes to jabber:iq:browse itself may be needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596227">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603716">2</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603656">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2004-01-06)</h4>
+<div class="indent">Added schema. (psa)
+    </div>
+<h4>Version 1.0 (2002-05-08)</h4>
+<div class="indent">Changed status to Active. (psa)
+    </div>
+<h4>Version 0.4 (2002-04-15)</h4>
+<div class="indent">Changed the suggested use of category to an attribute of item instead of the element names. (jer)
+    </div>
+<h4>Version 0.3 (2002-01-16)</h4>
+<div class="indent">Added additional category/type combinations from the protocol draft (also created new category 'validate' as a bucket for the grammar and spelling checkers, which formerly were under the 'render' category). (psa)
+    </div>
+<h4>Version 0.2 (2002-01-04)</h4>
+<div class="indent">Updated to JEP format and revised description. (jkm)
+    </div>
+<h4>Version 0.1 (2001-01-25)</h4>
+<div class="indent">Initial draft version. (jm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0013-1.0.html
+++ b/content/xep-0013-1.0.html
@@ -1,0 +1,431 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0013: Flexible Offline Message Retrieval</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Flexible Offline Message Retrieval">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Craig Kaes">
+<meta name="DC.Description" content="A protocol for flexible, POP3-like handling of offline messages in Jabber.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2003-09-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0013">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0013: Flexible Offline Message Retrieval</h1>
+<p>A protocol for flexible, POP3-like handling of offline messages in Jabber.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0013<br>
+            Version: 1.0<br>
+            Last Updated: 2003-09-09<br>
+            JIG: Standards JID<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: offline<br>
+        Schema for http://jabber.org/protocol/offline: &lt;<a href="http://jabber.org/protocol/offline/offline.xsd">http://jabber.org/protocol/offline/offline.xsd</a>&gt;<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Craig Kaes</h3>
+<p class="indent">
+        Email: ckaes@jabber.com<br>
+        JID: ckaes@corp.jabber.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#sect-id2244183">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2244298">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#sect-id2244305">Determining Server Support</a>
+</dt>
+<dt>2.2.  <a href="#sect-id2244378">Requesting Message Header Information</a>
+</dt>
+<dt>2.3.  <a href="#sect-id2248494">Retrieving Specific Messages</a>
+</dt>
+<dt>2.4.  <a href="#sect-id2248585">Removing Specific Messages</a>
+</dt>
+<dt>2.5.  <a href="#sect-id2248675">Retrieving All Messages</a>
+</dt>
+<dt>2.6.  <a href="#sect-id2248752">Removing All Messages</a>
+</dt>
+</dl>
+<dt>3.  <a href="#sect-id2248815">Protocol Flow</a>
+</dt>
+<dt>4.  <a href="#sect-id2248858">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2248885">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2248910">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2248985">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2244183">Introduction</a>
+</h2>
+  <p class="" style="">The current means for retrieving one's offline messages is simple: one sends available presence to the server and, as a consequence, the server sends a one-time "flood" of all the messages that have been stored while one was offline. This simplification has the following deficiencies:</p>
+  <ol start="" type="">
+    <li>It can be overwhelming, which is undesirable for the vacationer or heavy user. Many individuals upon returning to work from a weeklong vacation spend the first few hours wading through the dozens, even hundreds, of emails that they received during their absence. Unlucky, however, is this user who then logs onto their Jabber server and is bombarded by hundreds of instant messages, possibly in scores of popup dialogs, simultaneously. Should their client crash, they have lost all communication that occurred while they were away.</li>
+    <li>It can be difficult to integrate with web-based email clients, which is undesirable for some portals. Several large portals are currently trying to blur the distinction between IM and email -- providing both through one web interface. With offline retrieval semantics so vastly different between the two, this is quite difficult.</li>
+  </ol>
+  <p class="" style="">What is needed is a flexible semantic for offline message handling, similar to POP3 in the email world. This would enable the wireless user to view header information for all offline messages and select only those from their boss and important clients for viewing. It would enable the vacationer to read and delete their messages one at a time, minimizing the possibility of losing all correspondence. And it would provide for seamless integration with existing web-based email clients.</p>
+  <p class="" style="">In particular, such a protocol must support the following use cases:</p>
+    <ol start="" type="">
+      <li>Client determines server support for this protocol.</li>
+      <li>Client requests message "header" information (thereby choosing flexible offline message retrieval as opposed to old-fashioned "flood" mode).</li>
+      <li>Client retrieves specific messages.</li>
+      <li>Client removes specific messages.</li>
+      <li>Client retrieves all messages.</li>
+      <li>Client removes all messages.</li>
+    </ol>
+<h2>2.
+       <a name="sect-id2244298">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="sect-id2244305">Determining Server Support</a>
+</h3>
+    <p class="" style="">In order to discover whether one's server supports this protocol, one uses <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2244341">1</a>].</p>
+    <p class="caption">Example 1. User Requests Service Discovery Information</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt; 
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Server Reply to Discovery Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='montague.net' to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/offline'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server supports this protocol, it MUST return a &lt;feature/&gt; element in the disco result with the 'var' attribute set to the namespace name for this protocol: 'http://jabber.org/protocol/offline'.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="sect-id2244378">Requesting Message Header Information</a>
+</h3>
+    <p class="" style="">In order to determine whether to view a full message, a user must be able to inspect the full Jabber ID (JID) of the sender and a timestamp specifying the date and time of the message. In addition, the header information must include a unique identifier for the message within the user's "inbox" so that the user may appropriately manage (view or remove) the message.</p>
+    <p class="" style="">In order to retrieve meta-information about the message, the user sends a disco#items request without a 'to' address (i.e., implicitly to the user himself) and with the disco node specified as 'http://jabber.org/protocol/offline'.</p>
+    <p class="caption">Example 3. User Requests Offline Message Headers</p>
+<div class="indent"><pre>
+&lt;iq type='get'&gt;
+  &lt;query 
+      xmlns='http://jabber.org/protocol/disco#items' 
+      node='http://jabber.org/protocol/offline'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Upon receiving this request, the server MUST return headers for all of the user's offline messages. The server also MUST NOT send a flood of offline messages if the user subsequently sends initial presence to the server during this session. Thus the user is now free to send initial presence (if desired) and to engage in normal IM activities while continuing to read through offline messages. Note well: once the user sends presence, the user's server MUST deliver in-session messages as usual; this JEP applies to offline messages only! In addition, if the user authenticates and provides presence for another resource while the first (non-flood) resource still has an active session, the server MUST NOT flood the second resource with the offline message queue.</p>
+    <p class="caption">Example 4. Server Provides Offline Message Headers</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard'&gt;
+  &lt;query 
+      xmlns='http://jabber.org/protocol/disco#items' 
+      node='http://jabber.org/protocol/offline'&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:49:17.008Z'
+        name='mercutio@shakespeare.lit/pda'/&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:52:37.225Z'
+        name='juliet@capulet.com/balcony'/&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:52:51.270Z'
+        name='juliet@capulet.com/balcony'/&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:53:03.421Z'
+        name='juliet@capulet.com/balcony'/&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:53:13.925Z'
+        name='juliet@capulet.com/balcony'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a 403 (Forbidden) error.</p>
+    <p class="" style="">If the requestor is authorized but the node does not exist, the server MUST return a 404 (Not Found) error.</p>
+    <p class="" style="">If there are no offline messages for this user, the server MUST return an empty query as defined in JEP-0030.</p>
+    <p class="" style="">The syntax and semantics of the attributes are as follows:</p>
+    <ul>
+      <li>The 'jid' attribute is the Jabber ID with which the item nodes are associated, i.e., the user himself.</li>
+      <li>The 'name' attribute is the full JID of the sender as received in the 'from' address of the message itself.</li>
+      <li>The 'node' attribute is a unique identifier for the message. The value SHOULD be considered opaque, but applications MAY perform character-by-character dictionary ordering on the values. This enables applications to implement ordering on messages, such as that shown above, wherein the node values are UTC timestamps (if timestamps are used, they MUST conform to the 'Datetime' profile defined in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2248503">2</a>]).</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="sect-id2248494">Retrieving Specific Messages</a>
+</h3>
+    <p class="" style="">Messages are viewed based on the value of the 'node' attribute as provided for each item returned by the server in the header information. A user may request one or more messages in the same IQ get.</p>
+    <p class="caption">Example 5. User Requests Offline Messages</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='view1'&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;item action='view'
+          node='2003-02-27T22:52:37.225Z'/&gt;
+  &lt;/offline&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a 403 (Forbidden) error.</p>
+    <p class="" style="">If the requestor is authorized but the node does not exist, the server MUST return a 404 (Not Found) error.</p>
+    <p class="" style="">Otherwise, the server MUST send the requested message(s) plus an IQ result:</p>
+    <p class="caption">Example 6. Server Provides Offline Messages</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='juliet@capulet.com/balcony'&gt;
+  &lt;body&gt;O Romeo, Romeo! wherefore art thou Romeo?&lt;/body&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;item node='2003-02-27T22:52:37.225Z'/&gt;
+  &lt;/offline&gt;
+&lt;/message&gt;
+
+&lt;iq type='result' to='user@domain/resource' id='view1'/&gt;
+    </pre></div>
+    <p class="" style="">In order to distinguish incoming messages, each message MUST contain the node value.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="sect-id2248585">Removing Specific Messages</a>
+</h3>
+    <p class="" style="">A server MUST NOT remove a message simply because it has been requested by and delivered to the user; instead, the user must specifically request to remove a message. This further implies that the user's offline message queue SHOULD NOT be automatically cleared out by the server if there are offline messages remaining when the user's session ends. However, a server or deployment MAY remove messages according to its own algorithms (e.g., storage timeouts based on a "first in first out" rule) or policies (message size limits) if desired.</p>
+    <p class="" style="">As with viewing, messages are removed based on the value of the 'node' attribute as provided for each item returned by the server in the header information. The user may request the removal of one or more messages in the same IQ set.</p>
+    <p class="caption">Example 7. User Requests Removal of Offline Messages</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='remove1'&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;item action='remove'
+          node='2003-02-27T22:49:17.008Z'
+    &lt;item action='remove'
+          node='2003-02-27T22:52:37.225Z'/&gt;
+  &lt;/offline&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a 403 (Forbidden) error.</p>
+    <p class="" style="">If the requestor is authorized but the node does not exist, the server MUST return a 404 (Not Found) error.</p>
+    <p class="" style="">Otherwise, the server MUST remove the messages and inform the user:</p>
+    <p class="caption">Example 8. Server Informs User of Removal</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' id='remove1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="sect-id2248675">Retrieving All Messages</a>
+</h3>
+    <p class="" style="">The user may retrieve all message by sending the "fetch" command:</p>
+    <p class="caption">Example 9. User Retrieval of All Offline Messages</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='fetch1'&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;fetch/&gt;
+  &lt;/offline&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a 403 (Forbidden) error.</p>
+    <p class="" style="">If the requestor is authorized but the node does not exist, the server MUST return a 404 (Not Found) error.</p>
+    <p class="" style="">Otherwise, the server MUST retrieve all messages and inform the user:</p>
+    <p class="caption">Example 10. Server Sends All Messages and Informs User of Successful Fetch</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='juliet@capulet.com/balcony'&gt;
+  &lt;body&gt;O Romeo, Romeo! wherefore art thou Romeo?&lt;/body&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;item node='2003-02-27T22:52:37.225Z'/&gt;
+  &lt;/offline&gt;
+&lt;/message&gt;
+
+...
+
+&lt;iq type='result' to='romeo@montague.net/orchard' id='fetch1'/&gt;
+    </pre></div>
+    <p class="" style="">A client MAY retrieve all messages without first requesting message headers. In this case, the server MUST return all of the user's offline messages and also MUST NOT send a flood of offline messages if the user subsequently sends initial presence to the server during this session. That is, the semantics here are the same as for requesting message headers.</p>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="sect-id2248752">Removing All Messages</a>
+</h3>
+    <p class="" style="">The user may remove all message by sending the "purge" command:</p>
+    <p class="caption">Example 11. User Requests Removal of Offline Messages</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='purge1'&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;purge/&gt;
+  &lt;/offline&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a 403 (Forbidden) error.</p>
+    <p class="" style="">If the requestor is authorized but the node does not exist, the server MUST return a 404 (Not Found) error.</p>
+    <p class="" style="">Otherwise, the server MUST remove all messages and inform the user:</p>
+    <p class="caption">Example 12. Server Informs User of Successful Purge</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' id='purge1'/&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="sect-id2248815">Protocol Flow</a>
+</h2>
+  <p class="" style="">This section shows the flow of protocol between client (C:) and server (S:) for the existing (flood) scenario and the improved (POP3-like) scenario.</p>
+    <p class="caption">Example 13. Existing Protocol Flow (Flood)</p>
+<div class="indent"><pre>
+C: &lt;stream:stream ...&gt;
+
+S: &lt;stream:stream ...&gt;
+
+C: authentication (SASL in XMPP, non-SASL in older systems)
+
+S: acknowledge successful authentication 
+
+C: &lt;presence/&gt;
+
+S: send message flood to Client
+
+C: receive flood, send and receive messages, etc.
+
+... and so on</pre></div>
+    <p class="" style="">The semantics change with POP-like offline message handling, and server behavior changes as well...</p>
+    <p class="caption">Example 14. Improved Protocol Flow (POP3-Like)</p>
+<div class="indent"><pre>
+C: &lt;stream:stream ...&gt;
+
+S: &lt;stream:stream ...&gt;
+
+C: authentication (SASL in XMPP, non-SASL in older systems)
+
+S: acknowledge successful authentication 
+
+C: request message headers
+
+S: send message headers to Client
+
+NOTE: Server now MUST NOT flood Client with offline messages.
+
+C: &lt;presence/&gt;
+
+NOTE: Server does not flood Client with offline messages, but 
+      sends in-session messages as usual.
+
+C: request and remove offline messages, send and receive messages, etc.
+
+... and so on</pre></div>
+<h2>4.
+       <a name="sect-id2248858">Security Considerations</a>
+</h2>
+  <p class="" style="">A server MUST NOT deliver a user's offline messages to any JID except one of the user's authorized resources.</p>
+<h2>5.
+       <a name="sect-id2248885">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2248922">3</a>].</p>
+<h2>6.
+       <a name="sect-id2248910">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'http://jabber.org/protocol/offline' namespace shall be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2248968">4</a>] as a result of this JEP.</p> 
+<h2>7.
+       <a name="sect-id2248985">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/offline'
+    xmlns='http://jabber.org/protocol/offline'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='offline'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='action' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='remove'/&gt;
+            &lt;xs:enumeration value='view'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2244341">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2248503">2</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2248922">3</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2248968">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2003-09-09)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.8 (2003-08-25)</h4>
+<div class="indent">More changes to address Council feedback: removed bandwidth rationale in requirements; added protocol flow section; adjusted semantics for node values (opaque, but dictionary ordering allowed). Also added &lt;fetch/&gt; and &lt;purge/&gt; elements. (psa)
+    </div>
+<h4>Version 0.7 (2003-08-21)</h4>
+<div class="indent">Changes to address Council feedback: added error codes; enhanced the security considerations; clarified the nature of the node IDs and removed the protocol URI string (leaving only the timestamp). (psa)
+    </div>
+<h4>Version 0.6 (2003-06-10)</h4>
+<div class="indent">Slight fixes to JEP-0082 reference and XML schema. (psa)
+    </div>
+<h4>Version 0.5 (2003-04-28)</h4>
+<div class="indent">Added reference to JEP-0082; changed timestamp format to use milliseconds rather than ten-thousandths of a second; made several small editorial changes throughout. (psa)
+    </div>
+<h4>Version 0.4 (2003-02-27)</h4>
+<div class="indent">Major overhaul: clarified requirements, incorporated disco, simplified and updated the protocol, specified syntax and semantics for nodes, defined business rules, and added XML schema. (psa)
+    </div>
+<h4>Version 0.3 (2002-10-02)</h4>
+<div class="indent">Reworked to exclude XDBID performace hack, thereby maximizing palatability.  Removed all changes made by psa. (cak)
+    </div>
+<h4>Version 0.2 (2002-10-02)</h4>
+<div class="indent">Changed type and added information about scope. (psa)
+    </div>
+<h4>Version 0.1 (2002-01-11)</h4>
+<div class="indent">Initial version (cak)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0013-1.1.html
+++ b/content/xep-0013-1.1.html
@@ -1,0 +1,434 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0013: Flexible Offline Message Retrieval</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Flexible Offline Message Retrieval">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Craig Kaes">
+<meta name="DC.Description" content="This JEP defines a protocol for flexible, POP3-like handling of offline messages in Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-01-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0013">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0013: Flexible Offline Message Retrieval</h1>
+<p>This JEP defines a protocol for flexible, POP3-like handling of offline messages in Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0013<br>
+            Version: 1.1<br>
+            Last Updated: 2004-01-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: offline<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/offline/offline.xsd">http://jabber.org/protocol/offline/offline.xsd</a>&gt;<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Craig Kaes</h3>
+<p class="indent">
+        Email: ckaes@jabber.com<br>
+        JID: ckaes@corp.jabber.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#sect-id2244210">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2243267">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#sect-id2243273">Determining Server Support</a>
+</dt>
+<dt>2.2.  <a href="#sect-id2243327">Requesting Message Header Information</a>
+</dt>
+<dt>2.3.  <a href="#sect-id2248554">Retrieving Specific Messages</a>
+</dt>
+<dt>2.4.  <a href="#sect-id2248630">Removing Specific Messages</a>
+</dt>
+<dt>2.5.  <a href="#sect-id2248706">Retrieving All Messages</a>
+</dt>
+<dt>2.6.  <a href="#sect-id2248770">Removing All Messages</a>
+</dt>
+</dl>
+<dt>3.  <a href="#sect-id2248814">Protocol Flow</a>
+</dt>
+<dt>4.  <a href="#sect-id2248855">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2248882">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2248908">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2248982">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2244210">Introduction</a>
+</h2>
+  <p class="" style="">The current means for retrieving one's offline messages is simple: one sends available presence to the server and, as a consequence, the server sends a one-time "flood" of all the messages that have been stored while one was offline. This simplification has the following deficiencies:</p>
+  <ol start="" type="">
+    <li><p class="" style="">It can be overwhelming, which is undesirable for the vacationer or heavy user. Many individuals upon returning to work from a weeklong vacation spend the first few hours wading through the dozens, even hundreds, of emails that they received during their absence. Unlucky, however, is this user who then logs onto their Jabber server and is bombarded by hundreds of instant messages, possibly in scores of popup dialogs, simultaneously. Should their client crash, they have lost all communication that occurred while they were away.</p></li>
+    <li><p class="" style="">It can be difficult to integrate with web-based email clients, which is undesirable for some portals. Several large portals are currently trying to blur the distinction between IM and email -- providing both through one web interface. With offline retrieval semantics so vastly different between the two, this is quite difficult.</p></li>
+  </ol>
+  <p class="" style="">What is needed is a flexible semantic for offline message handling, similar to POP3 in the email world (see <span class="ref" style="">RFC 1939</span>  [<a href="#nt-id2243216">1</a>]). This would enable the wireless user to view header information for all offline messages and select only those from their boss and important clients for viewing. It would enable the vacationer to read and delete their messages one at a time, minimizing the possibility of losing all correspondence. And it would provide for seamless integration with existing web-based email clients.</p>
+  <p class="" style="">In particular, such a protocol must support the following use cases:</p>
+    <ol start="" type="">
+      <li>Client determines server support for this protocol.</li>
+      <li>Client requests message "header" information (thereby choosing flexible offline message retrieval as opposed to old-fashioned "flood" mode).</li>
+      <li>Client retrieves specific messages.</li>
+      <li>Client removes specific messages.</li>
+      <li>Client retrieves all messages.</li>
+      <li>Client removes all messages.</li>
+    </ol>
+<h2>2.
+       <a name="sect-id2243267">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="sect-id2243273">Determining Server Support</a>
+</h3>
+    <p class="" style="">In order to discover whether one's server supports this protocol, one uses <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2243309">2</a>].</p>
+    <p class="caption">Example 1. User Requests Service Discovery Information</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt; 
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Server Reply to Discovery Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='montague.net' 
+    to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/offline'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server supports this protocol, it MUST return a &lt;feature/&gt; element in the disco result with the 'var' attribute set to the namespace name for this protocol: 'http://jabber.org/protocol/offline'.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="sect-id2243327">Requesting Message Header Information</a>
+</h3>
+    <p class="" style="">So that the user may determine whether to view a full message, the header infromation provided MUST include the full Jabber ID of the sender (encoded in the 'name' attribute) and a unique identifier for the message within the user's "inbox" (encoded in the 'node' attribute), so that the user may appropriately manage (view or remove) the message.</p>
+    <p class="" style="">In order to retrieve meta-information about the message, the user sends a disco#items request without a 'to' address (i.e., implicitly to the user himself) and with the disco node specified as 'http://jabber.org/protocol/offline'.</p>
+    <p class="caption">Example 3. User Requests Offline Message Headers</p>
+<div class="indent"><pre>
+&lt;iq type='get'&gt;
+  &lt;query 
+      xmlns='http://jabber.org/protocol/disco#items' 
+      node='http://jabber.org/protocol/offline'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Upon receiving this request, the server MUST return headers for all of the user's offline messages. The server also MUST NOT send a flood of offline messages if the user subsequently sends initial presence to the server during this session. Thus the user is now free to send initial presence (if desired) and to engage in normal IM activities while continuing to read through offline messages. Note well: once the user sends presence, the user's server MUST deliver in-session messages as usual; this JEP applies to offline messages only! In addition, if the user authenticates and provides presence for another resource while the first (non-flood) resource still has an active session, the server MUST NOT flood the second resource with the offline message queue.</p>
+    <p class="caption">Example 4. Server Provides Offline Message Headers</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard'&gt;
+  &lt;query 
+      xmlns='http://jabber.org/protocol/disco#items' 
+      node='http://jabber.org/protocol/offline'&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:49:17.008Z'
+        name='mercutio@shakespeare.lit/pda'/&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:52:37.225Z'
+        name='juliet@capulet.com/balcony'/&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:52:51.270Z'
+        name='juliet@capulet.com/balcony'/&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:53:03.421Z'
+        name='juliet@capulet.com/balcony'/&gt;
+    &lt;item 
+        jid='romeo@montague.net'
+        node='2003-02-27T22:53:13.925Z'
+        name='juliet@capulet.com/balcony'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a "Forbidden" error. If the requestor is authorized but the node does not exist, the server MUST return an "Item Not Found" error. If there are no offline messages for this user, the server MUST return an empty query as defined in JEP-0030. (For information about the syntax of error conditions, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2248518">3</a>].)</p>
+    <p class="" style="">The syntax and semantics of the attributes are as follows:</p>
+    <ul>
+      <li>The 'jid' attribute is the Jabber ID with which the item nodes are associated, i.e., the user himself.</li>
+      <li>The 'name' attribute is the full JID of the sender as received in the 'from' address of the message itself.</li>
+      <li>The 'node' attribute is a unique identifier for the message. The value SHOULD be considered opaque, but applications MAY perform character-by-character dictionary ordering on the values. This enables applications to implement ordering on messages, such as that shown above, wherein the node values are UTC timestamps (if timestamps are used, they MUST conform to the 'Datetime' profile defined in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2248567">4</a>]).</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="sect-id2248554">Retrieving Specific Messages</a>
+</h3>
+    <p class="" style="">Messages are viewed based on the value of the 'node' attribute as provided for each item returned by the server in the header information. A user MAY request one or more messages in the same IQ get.</p>
+    <p class="caption">Example 5. User Requests Offline Messages</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='view1'&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;item action='view'
+          node='2003-02-27T22:52:37.225Z'/&gt;
+  &lt;/offline&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a "Forbidden" error. If the requestor is authorized but the node does not exist, the server MUST return an "Item Not Found" error. Otherwise, the server MUST send the requested message(s) plus an IQ result:</p>
+    <p class="caption">Example 6. Server Provides Offline Messages</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='juliet@capulet.com/balcony'&gt;
+  &lt;body&gt;O Romeo, Romeo! wherefore art thou Romeo?&lt;/body&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;item node='2003-02-27T22:52:37.225Z'/&gt;
+  &lt;/offline&gt;
+&lt;/message&gt;
+
+&lt;iq type='result' to='user@domain/resource' id='view1'/&gt;
+    </pre></div>
+    <p class="" style="">In order to distinguish incoming messages, each message MUST contain the node value.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="sect-id2248630">Removing Specific Messages</a>
+</h3>
+    <p class="" style="">A server MUST NOT remove a message simply because it has been requested by and delivered to the user; instead, the user must specifically request to remove a message. This further implies that the user's offline message queue SHOULD NOT be automatically cleared out by the server if there are offline messages remaining when the user's session ends. However, a server or deployment MAY remove messages according to its own algorithms (e.g., storage timeouts based on a "first in first out" rule) or policies (e.g., message queue size limits) if desired.</p>
+    <p class="" style="">As with viewing, messages are removed based on the value of the 'node' attribute as provided for each item returned by the server in the header information. The user MAY request the removal of one or more messages in the same IQ set.</p>
+    <p class="caption">Example 7. User Requests Removal of Offline Messages</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='remove1'&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;item action='remove'
+          node='2003-02-27T22:49:17.008Z'
+    &lt;item action='remove'
+          node='2003-02-27T22:52:37.225Z'/&gt;
+  &lt;/offline&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a "Forbidden" error. If the requestor is authorized but the node does not exist, the server MUST return a "Item Not Found" error. Otherwise, the server MUST remove the messages and inform the user:</p>
+    <p class="caption">Example 8. Server Informs User of Removal</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' id='remove1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="sect-id2248706">Retrieving All Messages</a>
+</h3>
+    <p class="" style="">The user retrieves all message by sending the "fetch" command:</p>
+    <p class="caption">Example 9. User Retrieval of All Offline Messages</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='fetch1'&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;fetch/&gt;
+  &lt;/offline&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a "Forbidden" error. If the requestor is authorized but the node does not exist, the server MUST return a "Item Not Found" error. Otherwise, the server MUST retrieve all messages and inform the user:</p>
+    <p class="caption">Example 10. Server Sends All Messages and Informs User of Successful Fetch</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='juliet@capulet.com/balcony'&gt;
+  &lt;body&gt;O Romeo, Romeo! wherefore art thou Romeo?&lt;/body&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;item node='2003-02-27T22:52:37.225Z'/&gt;
+  &lt;/offline&gt;
+&lt;/message&gt;
+
+...
+
+&lt;iq type='result' to='romeo@montague.net/orchard' id='fetch1'/&gt;
+    </pre></div>
+    <p class="" style="">A client MAY retrieve all messages without first requesting message headers. In this case, the server MUST return all of the user's offline messages and also MUST NOT send a flood of offline messages if the user subsequently sends initial presence to the server during this session. That is, the semantics here are the same as for requesting message headers.</p>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="sect-id2248770">Removing All Messages</a>
+</h3>
+    <p class="" style="">The user removes all message by sending the "purge" command:</p>
+    <p class="caption">Example 11. User Requests Removal of Offline Messages</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='purge1'&gt;
+  &lt;offline xmlns='http://jabber.org/protocol/offline'&gt;
+    &lt;purge/&gt;
+  &lt;/offline&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requestor is a JID other than an authorized resource of the user, the server MUST return a "Forbidden" error. If the requestor is authorized but the node does not exist, the server MUST return a "Item Not Found" error. Otherwise, the server MUST remove all messages and inform the user:</p>
+    <p class="caption">Example 12. Server Informs User of Successful Purge</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' id='purge1'/&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="sect-id2248814">Protocol Flow</a>
+</h2>
+  <p class="" style="">This section shows the flow of protocol between client (C:) and server (S:) for the existing (flood) scenario and the improved (POP3-like) scenario.</p>
+    <p class="caption">Example 13. Existing Protocol Flow (Flood)</p>
+<div class="indent"><pre>
+C: &lt;stream:stream ...&gt;
+
+S: &lt;stream:stream ...&gt;
+
+C: authentication (SASL in XMPP, non-SASL in older systems)
+
+S: acknowledge successful authentication 
+
+C: &lt;presence/&gt;
+
+S: send message flood to Client
+
+C: receive flood, send and receive messages, etc.
+
+... and so on</pre></div>
+    <p class="" style="">The semantics change with POP-like offline message handling, and server behavior changes as well...</p>
+    <p class="caption">Example 14. Improved Protocol Flow (POP3-Like)</p>
+<div class="indent"><pre>
+C: &lt;stream:stream ...&gt;
+
+S: &lt;stream:stream ...&gt;
+
+C: authentication (SASL in XMPP, non-SASL in older systems)
+
+S: acknowledge successful authentication 
+
+C: request message headers
+
+S: send message headers to Client
+
+NOTE: Server now MUST NOT flood Client with offline messages.
+
+C: &lt;presence/&gt;
+
+NOTE: Server does not flood Client with offline messages, but 
+      sends in-session messages as usual.
+
+C: request and remove offline messages, send and receive messages, etc.
+
+... and so on</pre></div>
+<h2>4.
+       <a name="sect-id2248855">Security Considerations</a>
+</h2>
+  <p class="" style="">A server MUST NOT deliver a user's offline messages to any JID except one of the user's authorized resources.</p>
+<h2>5.
+       <a name="sect-id2248882">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2248920">5</a>].</p>
+<h2>6.
+       <a name="sect-id2248908">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'http://jabber.org/protocol/offline' protocol namespace shall be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2248965">6</a>] as a result of this JEP.</p> 
+<h2>7.
+       <a name="sect-id2248982">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/offline'
+    xmlns='http://jabber.org/protocol/offline'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0013: http://www.jabber.org/jeps/jep-0013.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='offline'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='action' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='remove'/&gt;
+            &lt;xs:enumeration value='view'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2243216">1</a>. RFC 1939: Post Office Protocol - Version 3 &lt;<a href="http://www.ietf.org/rfc/rfc1939.txt">http://www.ietf.org/rfc/rfc1939.txt</a>&gt;.</p>
+<p><a name="nt-id2243309">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2248518">3</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2248567">4</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2248920">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2248965">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2004-01-22)</h4>
+<div class="indent">Editorial revisions. (psa)
+    </div>
+<h4>Version 1.0 (2003-09-09)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.8 (2003-08-25)</h4>
+<div class="indent">More changes to address Council feedback: removed bandwidth rationale in requirements; added protocol flow section; adjusted semantics for node values (opaque, but dictionary ordering allowed). Also added &lt;fetch/&gt; and &lt;purge/&gt; elements. (psa)
+    </div>
+<h4>Version 0.7 (2003-08-21)</h4>
+<div class="indent">Changes to address Council feedback: added error codes; enhanced the security considerations; clarified the nature of the node IDs and removed the protocol URI string (leaving only the timestamp). (psa)
+    </div>
+<h4>Version 0.6 (2003-06-10)</h4>
+<div class="indent">Slight fixes to JEP-0082 reference and XML schema. (psa)
+    </div>
+<h4>Version 0.5 (2003-04-28)</h4>
+<div class="indent">Added reference to JEP-0082; changed timestamp format to use milliseconds rather than ten-thousandths of a second; made several small editorial changes throughout. (psa)
+    </div>
+<h4>Version 0.4 (2003-02-27)</h4>
+<div class="indent">Major overhaul: clarified requirements, incorporated disco, simplified and updated the protocol, specified syntax and semantics for nodes, defined business rules, and added XML schema. (psa)
+    </div>
+<h4>Version 0.3 (2002-10-02)</h4>
+<div class="indent">Reworked to exclude XDBID performace hack, thereby maximizing palatability.  Removed all changes made by psa. (cak)
+    </div>
+<h4>Version 0.2 (2002-10-02)</h4>
+<div class="indent">Changed type and added information about scope. (psa)
+    </div>
+<h4>Version 0.1 (2002-01-11)</h4>
+<div class="indent">Initial version (cak)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0023-1.1.html
+++ b/content/xep-0023-1.1.html
@@ -1,0 +1,227 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0023: Message Expiration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Expiration">
+<meta name="DC.Creator" content="Jeremie Miller">
+<meta name="DC.Creator" content="DJ Adams">
+<meta name="DC.Creator" content="Harold Gottschalk">
+<meta name="DC.Description" content="This JEP documents a protocol that can be used to specify expiration dates for messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-01-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0023">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0023: Message Expiration</h1>
+<p>This JEP documents a protocol that can be used to specify expiration dates for messages.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in wide use within the Jabber community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; therefore it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0023<br>
+            Version: 1.1<br>
+            Last Updated: 2004-01-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>Superseded By: JEP-0079<br>
+            Short Name: x-expire<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/x-expire/x-expire.xsd">http://jabber.org/protocol/x-expire/x-expire.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Jeremie Miller</h3>
+<p class="indent">
+        Email: jer@jabber.org<br>
+        JID: jer@jabber.org</p>
+<h3>DJ Adams</h3>
+<p class="indent">
+        Email: dj.adams@pobox.com<br>
+        JID: dj@gnu.mine.nu</p>
+<h3>Harold Gottschalk</h3>
+<p class="indent">
+        Email: heg@imissary.com<br>
+        JID: heg@imissary.com</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2596054">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596129">Specifying a TTL</a>
+</dt>
+<dt>3.  <a href="#sect-id2596231">Handling XML Stanzas with a TTL</a>
+</dt>
+<dl><dt>3.1.  <a href="#sect-id2596328">Usage in client space</a>
+</dt></dl>
+<dt>4.  <a href="#sect-id2601822">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2601842">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2601860">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2601882">XML Schema</a>
+</dt>
+<dt>8.  <a href="#sect-id2601942">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2596054">Introduction</a>
+</h2>
+  <p class="" style="">It is sometimes helpful to indicate that a piece of information has a finite useful life or time-to-live (TTL). In the context of instant messaging, the main use of a TTL is to indicate that a message must or should be used by or read by a certain time, usually because the message has meaning or purpose only within a finite amount of time. In normal usage, such a message should be discarded after the specified time has passed if it has not been used or read by that time.</p>
+  <p class="" style="">In Jabber, TTL functionality has been implemented informally using the jabber:x:expire namespace. Support for this namespace was added to the <span class="ref">jabberd</span>  [<a href="#nt-id2596187">1</a>] server as well as some clients and components in early 2001. Specifically, that support has involved the following two areas of responsibility:</p>
+  <ul>
+    <li>The sender of the message is responsible for attaching a jabber:x:expire extension to the XML stanza (usually a message).</li>
+    <li>Mechanisms involved in the store-and-forward of such a stanza
+ [<a href="#nt-id2596102">2</a>]
+en route to its intended recipient are responsible for checking the remaining time to live and expiring (discarding) the XML stanza if necessary.</li>
+  </ul>
+  <p class="" style=""><span style="font-style: italic">Note: the recommended protocol for implementing the kind of functionality described herein is now <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2596141">3</a>].</span></p>
+<h2>2.
+       <a name="sect-id2596129">Specifying a TTL</a>
+</h2>
+  <p class="" style="">An Endpoint can specify a TTL for an XML stanza that it wishes to send by attaching an &lt;x/&gt; extension qualified by the jabber:x:expire namespace. The extension contains no children, only a 'seconds' attribute that contains a value representing the stanza's TTL, in seconds.</p>
+
+  <p class="caption">Example 1. Specifying a 30-minute TTL for a message</p>
+<div class="indent"><pre>
+SEND: &lt;message to='sabine@gnu.mine.nu' id='msg811'&gt;
+        &lt;subject&gt;Eccles cakes!&lt;/subject&gt;
+        &lt;body&gt;
+          I've got some freshly made Eccles cakes here, come
+          round for one before they all disappear!
+        &lt;/body&gt;
+        &lt;x xmlns='jabber:x:expire' seconds='1800'/&gt;
+      &lt;/message&gt;
+  </pre></div>
+<h2>3.
+       <a name="sect-id2596231">Handling XML Stanzas with a TTL</a>
+</h2>
+  <p class="" style="">Any mechanism that is involved in the storage, forwarding, and general handling of XML stanzas must check for the presence of such an extension and act accordingly, expiring (discarding) any stanzas that have exceeded their TTL lifetime.  The jabber:x:expire namespace allows for a further attribute inside the &lt;x/&gt; extension: 'stored'. Here, the mechanism can record a value representing when the stanza was committed to storage, so that when the stanza is eventually retrieved for forwarding to the intended recipient, the elapsed time of storage can be calculated. This is to prevent the stanza from being held in 'suspended animation'.</p>
+  <p class="" style="">Here we see what the original message looks like after the stanza has been committed to storage and the time of storage recorded:</p>
+  <p class="caption">Example 2. Recording a storage-time in the extension</p>
+<div class="indent"><pre>
+SEND: &lt;message to='sabine@gnu.mine.nu' id='msg811'&gt;
+        &lt;subject&gt;Eccles cakes!&lt;/subject&gt;
+        &lt;body&gt;
+          I've got some freshly made Eccles cakes here, come
+          round for one before they all disappear!
+        &lt;/body&gt;
+        &lt;x xmlns='jabber:x:expire'
+           seconds='1800'
+           stored='912830221'/&gt;
+      &lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Sabine attempts to retrieve her offline messages, the store-and-forward mechanism (e.g., mod_offline) compares the current time against the stored attribute. If the 1800 seconds have passed, the mechanism should simply drop the message, without notifying either the sender or the intended recipient. No Eccles cakes for Sabine!</p>
+<div class="indent">
+<h3>3.1 <a name="sect-id2596328">Usage in client space</a>
+</h3>
+  <p class="" style="">Although current usage of jabber:x:expire is most commonly seen in server implementations to address any TTL requirements of stored messages, Jabber clients can also be seen as handlers of messages that may contain expiration extension information. If a message is received by a Jabber client, and not immediately displayed to the user, the client must check for TTL information and expire the message (rather than display it to the user) if appropriate.</p>
+</div>
+<h2>4.
+       <a name="sect-id2601822">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>5.
+       <a name="sect-id2601842">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2601960">4</a>].</p>
+<h2>6.
+       <a name="sect-id2601860">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No action on the part of the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2601900">5</a>] is necessary as a result of this JEP, since 'jabber:x:expire' is already a registered protocol namespace.</p>
+<h2>7.
+       <a name="sect-id2601882">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:x:expire'
+    xmlns='jabber:x:expire'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0023: http://www.jabber.org/jeps/jep-0023.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='seconds' type='xs:unsignedLong' use='required'/&gt;
+          &lt;xs:attribute name='stored' type='xs:unsignedLong' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+<h2>8.
+       <a name="sect-id2601942">Open Issues</a>
+</h2>
+  <ol start="" type="">
+    <li>The jabber:x:expire namespace is processed only for delayed messages and only by servers and subsystems which support this informational draft. Therefore it is possible or even likely that a TTL will not be properly handled from the user perspective.</li>
+    <li>A physical, time-based TTL is not implemented by this JEP, and would not be possible across systems without synchronized time.</li>
+  </ol>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596187">1</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596102">2</a>. The best-known example of a mechanism that handles storing and forwarding of XML stanzas is the Jabber Session Manager (JSM) within current Jabber server implementations, specifically the mod_offline module. However, expiration of an XML stanza could also be handled by a Jabber client.</p>
+<p>
+<a name="nt-id2596141">3</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601960">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601900">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2004-01-06)</h4>
+<div class="indent">Added XML schema; added security, IANA, and Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 1.0 (2002-07-15)</h4>
+<div class="indent">Changed status to Active. (psa)
+    </div>
+<h4>Version 0.9 (2002-03-19)</h4>
+<div class="indent">Added remarks about client-end expiry. (dja)
+    </div>
+<h4>Version 0.1 (2002-03-07)</h4>
+<div class="indent">Initial draft. (dja)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0025-1.0.html
+++ b/content/xep-0025-1.0.html
@@ -1,0 +1,464 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0025: Jabber HTTP Polling</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jabber HTTP Polling">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Craig Kaes">
+<meta name="DC.Creator" content="David Waite">
+<meta name="DC.Description" content="This JEP defines a protocol that enables access to a Jabber server from behind firewalls which do not allow outgoing sockets on port 5222, via HTTP requests.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2002-10-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0025">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0025: Jabber HTTP Polling</h1>
+<p>This JEP defines a protocol that enables access to a Jabber server from behind firewalls which do not allow outgoing sockets on port 5222, via HTTP requests.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in use within the Jabber/XMPP community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; however, it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0025<br>
+            Version: 1.0<br>
+            Last Updated: 2002-10-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: httppoll<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jabber%20HTTP%20Polling%20(JEP-0025)">http://wiki.jabber.org/index.php/Jabber HTTP Polling (JEP-0025)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Craig Kaes</h3>
+<p class="indent">
+        Email: ckaes@jabber.com<br>
+        JID: ckaes@corp.jabber.com</p>
+<h3>David Waite</h3>
+<p class="indent">
+        Email: mass@akuma.org<br>
+        JID: mass@akuma.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#sect-id2251622">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2251643">Background</a>
+</dt>
+<dt>3.  <a href="#sect-id2250560">Normal data transfer</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2250773">Error conditions</a>
+</dt>
+<dl>
+<dt>3.1.1.  <a href="#sect-id2250790">Unknown Error</a>
+</dt>
+<dt>3.1.2.  <a href="#sect-id2250807">Server Error</a>
+</dt>
+<dt>3.1.3.  <a href="#sect-id2256235">Bad Request</a>
+</dt>
+<dt>3.1.4.  <a href="#sect-id2256250">Key Sequence Error</a>
+</dt>
+</dl>
+</dl>
+<dt>4.  <a href="#sect-id2256415">Usage</a>
+</dt>
+<dt>5.  <a href="#sect-id2256575">Known issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2251622">Introduction</a>
+</h2>
+    <p class="" style="">
+      This JEP documents a method to allow Jabber clients to access Jabber
+      servers from behind existing firewalls. Although several similar methods
+      have been proposed, this approach should work through all known firewall
+      configurations which allow outbound HTTP access.
+    </p>
+  <h2>2.
+       <a name="sect-id2251643">Background</a>
+</h2>
+    <p class="" style="">
+      In general, a firewall is a box that protects a network from outsiders,
+      by controlling the IP connections that are allowed to pass through the
+      box. Often, a firewall will also allow access outside only by proxy,
+      either explicit proxy support or implicit through Network Address
+      Translation (NAT).
+    </p>
+    <p class="" style="">
+      In the interest of security, many firewall administrators do not allow
+      outbound connections to unknown and unused ports. Until Jabber becomes
+      more widely deployed, port 5222/tcp (for Jabber client connections) will
+      often be blocked.
+    </p>
+    <p class="" style="">
+      The best solution for sites that are concerned about security is to run
+      their own Jabber server, either inside the firewall, or in a DMZ
+       [<a href="#nt-id2251685">1</a>]
+      network. However, there are network configuration where an external
+      Jabber server must still be used and port 5222/tcp outbound cannot be
+      allowed. In these situations, different methods for connecting to a
+      Jabber server are required. Several methods exist today for doing this
+      traversal. Most rely on the fact that a most firewalls are configured to
+      allow access through port 80/tcp. Although some less-complicated
+      firewalls will allow any protocol to traverse this port, many will proxy,
+      filter, and verify requests on this port as HTTP. Because of this, a
+      normal Jabber connection on port 80/tcp will not suffice.
+    </p>
+    <p class="" style="">
+      In addition, many firewalls/proxy servers will also not allow or not
+      honor HTTP Keep-alives (as defined in section 19.7.1.1 of <span class="ref" style="">RFC 2068</span>  [<a href="#nt-id2250541">2</a>])
+      and will consider long-lived socket connections as security issues.
+      Because of this the traditional Jabber connection model, where one
+      socket is one stream is one session, will not work reliably.
+    </p>
+    <p class="" style="">
+      In light of all of the ways that default firewall rules can interfere
+      with Jabber connectivity, a lowest-common denominator approach was
+      selected. HTTP is used to send XML as POST requests and receieve pending
+      XML within the responses. Additional information is prepended in the
+      request body to ensure an equivalent level of security to TCP/IP sockets.
+    </p>
+  <h2>3.
+       <a name="sect-id2250560">Normal data transfer</a>
+</h2>
+    <p class="" style="">
+      The client makes HTTP requests periodically to the server. Whenever the
+      client has something to send, that XML is included in the body of the
+      request. When the server has something to send to the client, it must be
+      contained in the body of the response.
+    </p>
+    <p class="" style="">
+      In some browser/platform combinations, sending cookies from the client is
+      not possible due to design choices and limitations in the
+      browser. Therefore, a work-around was needed to support clients based on
+      these application platforms.
+    </p>
+    <p class="" style="">
+      All requests to the server are HTTP POST requests, with Content-Type:
+      application/x-www-form-urlencoded. Responses from the server have
+      Content-Type: text/xml. Both the request and response bodies are UTF-8
+      encoded text, even if an HTTP header to the contrary exists. All
+      responses contain a Set-Cookie header with an identifier, which is sent
+      along with future requests as described below. This identifier cookie
+      must have a name of 'ID'. The first request to a server always uses 0 as
+      the identifier. The server must always return a 200 response code,
+      sending any session errors as specially-formatted identifiers.
+    </p>
+    <p class="" style="">
+      The client sends requests with bodies in the following format:
+      <p class="caption">Example 1. Request Format</p><div class="indent"><pre>
+          identifier ; key [ ; new_key] , [xml_body]
+      </pre></div>
+      If the identifier is zero, key indicates an initial key. In this case,
+      new_key should not be specified, and must be ignored.
+      <p class="caption">Table 1: Request Values</p><table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Identifier</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">identifier</td>
+          <td align="" colspan="" rowspan="">
+            To uniquely identify the session server-side. This field is only
+            used to identify the session, and provides no security.
+          </td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">key</td>
+          <td align="" colspan="" rowspan="">
+            To verify this request is from the originator of the session. The
+            client generates a new key in the manner described below for each
+            request, which the server then verifies before processing the
+            request.
+          </td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">new_key</td>
+          <td align="" colspan="" rowspan="">
+            The key algorithm can exhaust valid keys in a sequence, which
+            requires a new key sequence to be used in order to continue the
+            session. The new key is sent along with the last used key in the
+            old sequence.
+          </td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">xml_body</td>
+          <td align="" colspan="" rowspan="">
+            The body of text to send. Since a POST must be sent in order for
+            the server to respond with recent messages, a client may send
+            a request without an xml_body in order to just retrieve new
+            incoming packets. This is not required to be a full XML document or
+            XML fragment, it does not need to start or end on element boundaries.
+          </td>
+        </tr>
+      </table>
+    </p>
+    <p class="" style="">
+      The identifier is everything before the first semicolon, and must consist
+      of the characters [A-Za-z0-9:-]. The identifier returned from the first
+      request is the identifier for the session. Any new identifier that ends
+      in ':0' indicates an error, with the entire identifier indicating the
+      specific error condition. Any new identifier that does not end in ':0' is
+      a server programming error, the client should discontinue the
+      session. For new sessions, the client identifier is considered to be 0.
+    </p>
+    <div class="indent">
+<h3>3.1 <a name="sect-id2250773">Error conditions</a>
+</h3>
+      <p class="" style="">
+        Any identifier that ends in ':0' indicates an error. Any previous
+        identifier associated with this session is no longer valid.
+      </p>
+      <div class="indent">
+<h3>3.1.1 <a name="sect-id2250790">Unknown Error</a>
+</h3>
+        <p class="" style="">
+          Server returns ID=0:0. The response body can contain a textual error
+          message.
+        </p>
+      </div>
+      <div class="indent">
+<h3>3.1.2 <a name="sect-id2250807">Server Error</a>
+</h3>
+        <p class="" style="">Server returns ID=-1:0</p>
+      </div>
+      <div class="indent">
+<h3>3.1.3 <a name="sect-id2256235">Bad Request</a>
+</h3>
+        <p class="" style="">Server returns ID=-2:0</p>
+      </div>
+      <div class="indent">
+<h3>3.1.4 <a name="sect-id2256250">Key Sequence Error</a>
+</h3>
+        <p class="" style="">Server returns ID=-3:0</p>
+      </div>
+    </div>
+    <p class="" style="">
+      The key is a client security feature to allow TCP/IP socket equivalent
+      security. It does not protect against intermediary attacks, but does
+      prevent a person who is capable of listening to the HTTP traffic from
+      sending messages and receiving incoming traffic from another machine.
+    </p>
+    <p class="" style="">The key algorithm should be familiar with those with knowledge of Jabber zero-knowledge authentication.</p>
+    <p class="caption">Example 2. Key Algorithm</p>
+<div class="indent"><pre>
+        K(n, seed) = Base64Encode(SHA1(K(n - 1, seed))), for n &gt; 0
+        K(0, seed) = seed, which is client-determined
+    </pre></div>
+    <p class="" style="">Note: Base64 encoding is defined in <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256327">3</a>]. SHA1 is defined in <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2256351">4</a>].</p>
+    <p class="" style="">
+      No framing is implied by a single request or reply. A single request can
+      have no content sent, in which case the body contains only the identifier
+      followed by a comma. A reply may have no content to send, in which case
+      the body is empty. Zero or more XMPP packets may be sent in a single
+      request or reply, including partial XMPP packets.
+    </p>
+    <p class="" style="">
+      The absense of a long-lived connection requires the server to consider
+      client traffic as a heartbeat to keep the session alive. If a
+      server-configurable period of time passes without a successful POST
+      request sent by the client, the server must end the client session. Any
+      client requests using the identifier associated with that now dead
+      session must return an error of '0:0'.
+    </p>
+    <p class="" style="">
+      The maximum period of time to keep a client session active without an
+      incoming POST request is not defined, but five minutes is the recommended
+      minimum. The maximum period of time recommended for clients between
+      requests is two minutes; if the client has not sent any XML out for two
+      minutes, a request without an XML body should be sent. If a client is
+      disconnecting from the server, a closing &lt;stream:stream&gt; must be
+      sent to end the session. Failure to do this may have the client continue
+      to be represented to other users as available.
+    </p>
+    <p class="" style="">
+      If the server disconnects the user do to a session timeout, the server
+      MUST bounce pending IQ requests and either bounce or store offline
+      incoming messages.
+    </p>
+  <h2>4.
+       <a name="sect-id2256415">Usage</a>
+</h2>
+    <p class="" style="">
+      The following is the sequence used for client communication
+      <ol start="" type="">
+        <li>
+          The client generates some initial K(0, seed) and runs the algorithm
+          above 'n' times to determine the initial key sent to the server,
+          K(n, seed)
+        </li>
+        <li>
+          The client sends the request to the server to start the stream,
+          including an identifier with a value of zero and K(n, seed)
+        </li>
+        <li>
+          The server responds with the session identifier in the headers
+          (within the Set-Cookie field).
+        </li>
+        <li>
+          For each further request done by the client, the identifier from the
+          server and K(n - 1, seed) are sent along.
+        </li>
+        <li>
+          The server verifies the incoming value by generating
+          K(1, incoming_value), and verifying that value against the value sent
+          along with the last client request. If the values do not match, the
+          request should be ignored or logged, with an error code being
+          returned of -3:0. The request must not be processed, and must not
+          extend the session keepalive. 
+        </li>
+        <li>
+          The client may send a new key K(m, seed') at any point, but should
+          do this for n &gt; 0 and must do this for n = 0. If K(0, seed) is
+          sent without a new key, the client will not be able to continue the
+          session.
+        </li>
+      </ol>
+    </p>
+    <p class="caption">Example 3. Initial request (without keys)</p>
+<div class="indent"><pre>
+
+POST /wc12/webclient HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+Host: webim.jabber.com
+
+0,&lt;stream:stream to="jabber.com"
+  xmlns="jabber:client"
+  xmlns:stream="http://etherx.jabber.org/streams"&gt;
+ 
+    </pre></div>
+    <p class="caption">Example 4. Initial response</p>
+<div class="indent"><pre>
+
+Date: Fri, 15 Mar 2002 20:30:30 GMT
+Server: Apache/1.3.20
+Set-Cookie: ID=7776:2054; path=/webclient/; expires=-1
+Content-Type: text/xml
+
+&lt;?xml version='1.0'?&gt;
+&lt;stream:stream xmlns:stream='http://etherx.jabber.org/streams'
+  id='3C9258BB'
+  xmlns='jabber:client' from='jabber.com'&gt;
+
+    </pre></div>
+    <p class="caption">Example 5. Next request (without keys)</p>
+<div class="indent"><pre>
+
+POST /wc12/webclient HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+Host: webim.jabber.com
+
+7776:2054,&lt;iq type="get" id="WEBCLIENT3"&gt;
+  &lt;query xmlns="jabber:iq:auth"&gt;
+    &lt;username&gt;hildjj&lt;/username&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+    </pre></div>
+    <p class="caption">Example 6. key sequence</p>
+<div class="indent"><pre>
+      K(0, "foo") = "foo"
+      K(1, "foo") = "C+7Hteo/D9vJXQ3UfzxbwnXaijM="
+      K(2, "foo") = "6UU8CDmH3O4aHFmCqSORCn721+M="
+      K(3, "foo") = "vFFYSOhGyaGUgLrldtMBX7x91Wc="
+      K(4, "foo") = "ZaDxCilBVTHS9dJfbBo1NsC2b+8="
+      K(5, "foo") = "moPFsvHytDGiJQOjp186AMXAeP0="
+      K(6, "foo") = "VvxEk07IFy6hUmG/PPBlTLE2fiA="
+    </pre></div>
+      <p class="caption">Example 7. Initial request (with keys)</p>
+<div class="indent"><pre>
+
+POST /wc12/webclient HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+Host: webim.jabber.com
+
+0;VvxEk07IFy6hUmG/PPBlTLE2fiA=,&lt;stream:stream to="jabber.com"
+  xmlns="jabber:client"
+  xmlns:stream="http://etherx.jabber.org/streams"&gt;
+ 
+      </pre></div>
+      <p class="caption">Example 8. Next request (with keys)</p>
+<div class="indent"><pre>
+
+POST /wc12/webclient HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+Host: webim.jabber.com
+
+7776:2054;moPFsvHytDGiJQOjp186AMXAeP0=,&lt;iq type="get" id="WEBCLIENT3"&gt;
+  &lt;query xmlns="jabber:iq:auth"&gt;
+    &lt;username&gt;hildjj&lt;/username&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+    </pre></div>
+    <p class="caption">Example 9. Changing key</p>
+<div class="indent"><pre>
+POST /wc12/webclient HTTP/1.1
+Content-Type: application/x-www-form-urlencoded
+Host: webim.jabber.com
+
+7776:2054;C+7Hteo/D9vJXQ3UfzxbwnXaijM=;Tr697Eff02+32FZp38Xaq2+3Bv4=,&lt;presence/&gt;
+    </pre></div>
+  <h2>5.
+       <a name="sect-id2256575">Known issues</a>
+</h2>
+    <ul>
+      <li>This method works over HTTPS, which is good from the standpoint of functionality, but bad in the sense that a massive amount of hardware would be needed to support reasonable polling intervals for non-trivial numbers of clients.</li>
+    </ul>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251685">1</a>. 
+        DMZ definition at
+        <a href="http://searchwebmanagement.techtarget.com/sDefinition/0,,sid27_gci213891,00.html">
+          searchwebmanagement.com
+        </a>
+      </p>
+<p><a name="nt-id2250541">2</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+<p><a name="nt-id2256327">3</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256351">4</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2002-10-11)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Active. (psa)
+    </div>
+<h4>Version 0.2 (2002-09-23)</h4>
+<div class="indent">Changed format to allow socket-equivalent security. (dew)
+    </div>
+<h4>Version 0.1 (2002-03-14)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0030-2.1.html
+++ b/content/xep-0030-2.1.html
@@ -1,0 +1,1026 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0030: Service Discovery</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Discovery">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Creator" content="Ryan Eatmon">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for discovering (1) information about Jabber entities and (2) the items associated with such entities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-03">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0030">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0030: Service Discovery</h1>
+<p>This JEP defines a protocol for discovering (1) information about Jabber entities and (2) the items associated with such entities.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Final Standard of the Jabber Software Foundation and may be considered a stable technology for implementation and deployment.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Final<br>
+            Type: Standards Track<br>
+            Number: 0030<br>
+            Version: 2.1<br>
+            Last Updated: 2005-03-03<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>Supersedes: JEP-0011, JEP-0094<br>
+                Superseded By: None<br>
+            Short Name: disco<br>
+        Schema for disco#info: &lt;<a href="http://jabber.org/protocol/disco/info.xsd">http://jabber.org/protocol/disco/info.xsd</a>&gt;<br>
+        Schema for disco#items: &lt;<a href="http://jabber.org/protocol/disco/items.xsd">http://jabber.org/protocol/disco/items.xsd</a>&gt;<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/disco.html">http://www.jabber.org/registrar/disco.html</a>&gt;
+              <br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Service%20Discovery%20(JEP-0030)">http://wiki.jabber.org/index.php/Service Discovery (JEP-0030)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Millard</h3>
+<p class="indent">
+        Email: pgmillard@jabber.org<br>
+        JID: pgmillard@jabber.org</p>
+<h3>Ryan Eatmon</h3>
+<p class="indent">
+        Email: reatmon@jabber.org<br>
+        JID: reatmon@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#info">Discovering Information About a Jabber Entity</a>
+</dt>
+<dt>4.  <a href="#items">Discovering the Items Associated with a Jabber Entity</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#items-basic">Basic Protocol</a>
+</dt>
+<dt>4.2.  <a href="#items-nodes">Nodes</a>
+</dt>
+<dt>4.3.  <a href="#items-hierarchy">Node Hierarchies</a>
+</dt>
+<dt>4.4.  <a href="#items-relationship">Relationship Between an Entity and its Items</a>
+</dt>
+</dl>
+<dt>5.  <a href="#publish">Publishing Available Items</a>
+</dt>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#errors">Error Conditions</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-reg">Registries</a>
+</dt>
+<dl>
+<dt>10.2.1.  <a href="#registrar-reg-identity">Identity Categories and Types Registry</a>
+</dt>
+<dl>
+<dt>10.2.1.1.  <a href="#registrar-identity">Process</a>
+</dt>
+<dt>10.2.1.2.  <a href="#registrar-reg-identity-init">Initial Submission</a>
+</dt>
+</dl>
+<dt>10.2.2.  <a href="#registrar-reg-features">Features Registry</a>
+</dt>
+<dl>
+<dt>10.2.2.1.  <a href="#registrar-reg-features-process">Process</a>
+</dt>
+<dt>10.2.2.2.  <a href="#registrar-reg-features-init">Initial Submission</a>
+</dt>
+</dl>
+<dt>10.2.3.  <a href="#registrar-reg-nodes">Well-Known Nodes</a>
+</dt>
+<dl><dt>10.2.3.1.  <a href="#registrar-reg-nodes-process">Process</a>
+</dt></dl>
+</dl>
+</dl>
+<dt>11.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schemas-info">disco#info</a>
+</dt>
+<dt>11.2.  <a href="#schemas-items">disco#items</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">The ability to discover information about entities on the Jabber network is extremely valuable. Such information might include features offered or protocols supported by the entity, the entity's type or identity, and additional entities that are associated with the original entity in some way (often thought of as "children" of the "parent" entity). While mechanisms for doing so are not defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250282">1</a>], several protocols have been used in the past within the Jabber community for service discovery, specifically <span class="ref" style="">Jabber Browsing</span>  [<a href="#nt-id2250310">2</a>] and <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2250333">3</a>]. However, those protocols are perceived to be inadequate for several reasons:</p>
+    <ol start="" type="">
+      <li><p class="" style="">Neither Jabber Browsing nor Agent Information is easily extensible. For example, the categories and subcategories listed for JID-Types in JEP-0011 are explicitly defined as the only official categories, and any additions to the list of JID-Types would require a modification to JEP-0011. While the Jabber Browsing specification does allow for the use of unofficial categories and types prefixed with the string 'x-', this introduces migration issues. This lack of flexibility violates one of the Jabber community's core <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2250375">4</a>].</p></li>
+      <li><p class="" style="">In Agent Information, there is no way to advertise supported features. While Jabber Browsing includes such a mechanism, the only way to express the availability of a feature is to advertise a supported protocol namespace. Yet some features may not be uniquely associated with a protocol namespace, which are one implementation of features but not the only one.</p></li>
+      <li><p class="" style="">A Jabber Browsing result returns a combination of (1) namespaces supported by a Jabber Entity, (2) items associated with a Jabber Entity, and (3) namespaces supported by the associated items. This approach mixes information levels and requires parents to know everything about child nodes, thereby introducing significant confusion.</p></li>
+      <li><p class="" style="">In both Jabber Browsing and Agent Information, items must be addressable as JIDs; however, this may not be possible in some applications.</p></li>
+    </ol>
+    <p class="" style="">This JEP addresses the perceived weaknesses of both the Jabber Browsing and Agent Information protocols. The result is a standards-track protocol for service discovery (often abbreviated to "disco", as is familiar in protocols such as <span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2256660">5</a>]).</p>
+  <h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">The authors have designed the service discovery protocol with the following requirements in mind:</p>
+    <ul>
+      <li><p class="" style="">The protocol MUST support all functionality supported by the protocols it supersedes (Jabber Browsing and Agent Information).</p></li>
+      <li>
+        <p class="" style="">There are three kinds of information that need to be discovered about an entity:</p>
+        <ol start="" type="">
+          <li>its basic identity (type and/or category)</li>
+          <li>the features it offers and protocols it supports</li>
+          <li>any additional items associated with the entity, whether or not they are addressable as JIDs</li>
+        </ol>
+        <p class="" style="">All three MUST be supported, but the first two kinds of information relate to the entity itself whereas the third kind of information relates to items associated with the entity itself; therefore two different query types are needed.</p>
+      </li>
+      <li><p class="" style="">Discovering information about a child item MUST be accomplished by sending a separate discovery request to that item, not to the parent entity. (One result of this is that discovering complete information about an entire tree will require multiple request/response pairs in order to "walk the tree".)</p></li>
+      <li><p class="" style="">The lists of identities and features MUST be flexible.</p></li>
+      <li><p class="" style="">The protocol itself MUST be extensible.</p></li>
+    </ul>
+  <h2>3.
+       <a name="info">Discovering Information About a Jabber Entity</a>
+</h2>
+    <p class="" style="">A requesting entity may want to discover information about another entity on the network. The information desired generally is of two kinds:</p>
+    <ol start="" type="">
+      <li>
+<p class="" style=""><span style="font-weight: bold">The target entity's identity.</span> In disco, an entity's identity is broken down into its category (server, client, gateway, directory, etc.) and its particular type within that category (IM server, phone vs. handheld client, MSN gateway vs. AIM gateway, user directory vs. chatroom directory, etc.). This information helps requesting entities to determine the group or "bucket" of services into which the entity is most appropriately placed (e.g., perhaps the entity is shown in a GUI with an appropriate icon). An entity MAY have multiple identities. When multiple identity elements are provided, the name attributes for each identity element SHOULD have the same value.</p>
+      </li>
+      <li><p class="" style=""><span style="font-weight: bold">The features offered and protocols supported by the target entity.</span> This information helps requesting entities determine what actions are possible with regard to this entity (registration, search, join, etc.), what protocols the entity supports, and specific feature types of interest, if any (e.g., for the purpose of feature negotiation).</p></li>
+    </ol>
+    <p class="" style="">In order to discover such information, the requesting entity MUST send an IQ stanza of type "get", containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/disco#info' namespace, to the JID of the target entity (the 'to' address is REQUIRED and MUST contain a valid JID; a 'node' attribute on the &lt;query/&gt; element is OPTIONAL as described in the <a href="#items-nodes">Nodes</a> section of this document):</p>
+    <p class="caption">Example 1. Querying for further information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='plays.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The target entity then MUST either return an IQ result, or return an error (see the <a href="#errors">Error Conditions</a> section of this document). The result MUST contain a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/disco#info' namespace, which in turn contains one or more &lt;identity/&gt; elements and one or more &lt;feature/&gt; elements. (Note: Every entity MUST have at least one identity, and every entity MUST support at least the 'http://jabber.org/protocol/disco#info' feature; however, an entity is not required to return a result and MAY return an error, most likely &lt;feature-not-implemented/&gt; or &lt;service-unavailable/&gt;, although other error conditions may be appropriate.) Each &lt;identity/&gt; element MUST possess 'category' and 'type' attributes specifying the category and type for the entity, and MAY possess a 'name' attribute specifying a natural-language name for the entity. Each &lt;feature/&gt; element MUST possess a 'var' attribute whose value is a protocol namespace or other feature offered by the entity. Preferably, both the category/type values and the feature values will be registered in a public registry, as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.</p>
+    <p class="caption">Example 2. Result-set for information request</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='plays.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        type='text'
+        name='Play-Specific Chatrooms'/&gt;
+    &lt;identity
+        category='directory'
+        type='chatroom'
+        name='Play-Specific Chatrooms'/&gt;
+    &lt;feature var='http://jabber.org/protocol/disco#info'/&gt;
+    &lt;feature var='http://jabber.org/protocol/disco#items'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='jabber:iq:register'/&gt;
+    &lt;feature var='jabber:iq:search'/&gt;
+    &lt;feature var='jabber:iq:time'/&gt;
+    &lt;feature var='jabber:iq:version'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the JID or JID+Node of the specified target entity does not exist, the server or other authoritative entity SHOULD return an &lt;item-not-found/&gt; error, unless doing so would violate the privacy and security considerations specified in <span style="font-weight: bold">XMPP Core</span> and <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2257041">6</a>], or local privacy and security policies:</p>
+    <p class="caption">Example 3. Target entity does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='plays.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:xml:params:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If privacy and security considerations or policies prevent the server or other authoritative entity from returning an &lt;item-not-found/&gt; error, it SHOULD return a &lt;service-unavailable/&gt; error instead:</p>
+    <p class="caption">Example 4. Service unavailable</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='plays.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:xml:params:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A query sent to a more specific entity may result in different or more detailed information. One example is sending a query to a particular conference room rather than the parent conference service:</p>
+    <p class="caption">Example 5. Querying a specific conference room</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='juliet@capulet.com/balcony'
+    to='balconyscene@plays.shakespeare.lit'
+    id='info2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='balconyscene@plays.shakespeare.lit'
+    to='juliet@capulet.com/balcony'
+    id='info2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        type='text'
+        name='Romeo and Juliet, Act II, Scene II'/&gt;
+    &lt;feature var='http://jabber.org/protocol/disco#info'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/feature-neg'/&gt;
+    &lt;feature var='muc-password'/&gt;
+    &lt;feature var='muc-hidden'/&gt;
+    &lt;feature var='muc-temporary'/&gt;
+    &lt;feature var='muc-open'/&gt;
+    &lt;feature var='muc-unmoderated'/&gt;
+    &lt;feature var='muc-nonanonymous'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+    <p class="" style="">Another example of this is sending a query to a specific connected resource for an IM user:</p>
+    <p class="caption">Example 6. Querying a connected resource for further information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/orchard'
+    id='info3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'
+    id='info3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='client'
+        type='pc'
+        name='Gabber'/&gt;
+    &lt;feature var='jabber:iq:time'/&gt;
+    &lt;feature var='jabber:iq:version'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A query MAY also be directed to a specific node identifier associated with a JID:</p>
+    <p class="caption">Example 7. Querying a specific JID and node combination</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='mim.shakespeare.lit'
+    id='info3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info' 
+         node='http://jabber.org/protocol/commands'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. JID+node result</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='mim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='info3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info' 
+         node='http://jabber.org/protocol/commands'&gt;
+    &lt;identity
+        category='automation'
+        type='command-list'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a specific entity (JID or JID+node) does not support the disco#info namespace, does not have a defined identity, or refuses to return disco#info results to the specific requesting entity or to any requesting entity, it SHOULD return an appropriate error message (such as &lt;service-unavailable/&gt;, &lt;feature-not-implemented/&gt;, &lt;forbidden/&gt;, or &lt;not-allowed/&gt;, respectively). One example is shown below.</p>
+    <p class="caption">Example 9. JID+node error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='mim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='info3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info' 
+         node='http://jabber.org/protocol/commands'/&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Other error conditions may be appropriate depending on the application; refer to the <a href="#errors">Error Conditions</a> section of this document.</p>
+  <h2>4.
+       <a name="items">Discovering the Items Associated with a Jabber Entity</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="items-basic">Basic Protocol</a>
+</h3>
+      <p class="" style="">In order for the requesting entity to discover the items associated with a Jabber Entity, it MUST send an IQ stanza of type "get" to the target entity, containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/disco#items' namespace:</p>
+      <p class="caption">Example 10. Requesting all items</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='shakespeare.lit'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The target entity then MUST either return its list of publicly-available items, or return an error. The list of items MUST be provided in an IQ stanza of type "result", with each item specified by means of an &lt;item/&gt; child of a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/disco#items' namespace (the &lt;item/&gt; child MUST possess a 'jid' attribute specifying the JID of the item and MAY possess a 'name' attribute specifying a natural-language name for the item):</p>
+      <p class="caption">Example 11. Result-set for all items</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='people.shakespeare.lit'
+          name='Directory of Characters'/&gt;
+    &lt;item jid='plays.shakespeare.lit'
+          name='Play-Specific Chatrooms'/&gt;
+    &lt;item jid='mim.shakespeare.lit'
+          name='Gateway to Marlowe IM'/&gt;
+    &lt;item jid='words.shakespeare.lit'
+          name='Shakespearean Lexicon'/&gt;
+    &lt;item jid='globe.shakespeare.lit'
+          name='Calendar of Performances'/&gt;
+    &lt;item jid='headlines.shakespeare.lit'
+          name='Latest Shakespearean News'/&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          name='Buy Shakespeare Stuff!'/&gt;
+    &lt;item jid='en2fr.shakespeare.lit'
+          name='French Translation Service'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The &lt;item/&gt; element MUST NOT contain XML character data and SHOULD be empty; while it MAY contain XML data in another namespace, such data MUST be ignored if an implementation does not understand it.</p>
+      <p class="" style="">If there are no items associated with an entity (or if those items are not publicly available), the target entity MUST return an empty query element to the requesting entity:</p>
+      <p class="caption">Example 12. Empty result set</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="items-nodes">Nodes</a>
+</h3>
+      <p class="" style="">It is possible that an item associated with an entity will not be addressable as a JID; examples might include offline messages stored in an inbox (see <span class="ref" style="">Flexible Offline Message Retrieval</span>  [<a href="#nt-id2257296">7</a>]), entries in a Jabber-enabled weblog, XML-RPC services associated with a client or component, items available in an online trading system (e.g., a catalog or auction), news postings located at an NNTP gateway, and topics hosted by a <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257327">8</a>] component. In order to handle such items, the &lt;item/&gt; element MAY possess an OPTIONAL 'node' attribute that supplements the REQUIRED 'jid' attribute.</p>
+      <p class="" style="">The value of the node attribute may or may not have semantic meaning; from the perspective of Service Discovery, a node is merely something that is associated with an entity. In order to discover more about the node, the requesting entity MUST query the entity's JID while specifying the node. If the value of the 'node' attribute has semantic meaning, that meaning is provided by the using protocol or application, not by the Service Discovery protocol. A node attribute SHOULD NOT be included unless it is necessary to provide or discover information about an entity that cannot be directly addressed as a JID (i.e., if the associated item can be addressed as a JID, do not include a node). The value of the 'node' attribute MUST NOT be null.</p>
+      <p class="" style="">In the following example, a user requests all available items from an online catalog service:</p>
+      <p class="caption">Example 13. Requesting nodes</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='catalog.shakespeare.lit'
+    id='items2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If there are items associated with the target entity but they are not addressable as JIDs, the service SHOULD then return a list of nodes (where each &lt;item/&gt; element MUST possess a 'jid' attribute, SHOULD possess a 'node' attribute, and MAY possess a 'name' attribute):</p>
+        <p class="caption">Example 14. Service returns nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='catalog.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='items2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='books'
+          name='Books by and about Shakespeare'/&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='clothing'
+          name='Wear your literary taste with pride'/&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='music'
+          name='Music from the time of Shakespeare'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">There may be futher nodes associated with the "first-level" nodes returned in the above query (e.g., the nodes may be categories that have associated items). The requesting entity can query a node further by sending a request to the JID and specifying the node of interest in the query.</p>
+      <p class="caption">Example 15. Requesting further nodes</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='catalog.shakespeare.lit'
+    id='items3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items' 
+         node='music'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The service then returns the further nodes associated with the "parent" node. In the following example, the service itself enforces an alphabetically-ordered hierarchical structure on the nodes that are returned, but such a structure is a matter of implementation rather than protocol.</p>
+      <p class="caption">Example 16. Service returns further nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='catalog.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='items3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items' 
+         node='music'&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='music/A'/&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='music/B'/&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='music/C'/&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='music/D'/&gt;
+    .
+    .
+    .
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The requesting entity can then query further if desired:</p>
+      <p class="caption">Example 17. Requesting even more nodes</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='catalog.shakespeare.lit'
+    id='items4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items' 
+         node='music/D'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 18. Service returns even more nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='catalog.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='items4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items' 
+         node='music/D'&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='music/D/dowland-firstbooke'
+          name='John Dowland - First Booke of Songes or Ayres'/&gt;
+    &lt;item jid='catalog.shakespeare.lit'
+          node='music/D/dowland-solace'
+          name='John Dowland - A Pilgrimes Solace'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3 <a name="items-hierarchy">Node Hierarchies</a>
+</h3>
+      <p class="" style="">The foregoing examples show a hierarchy of nodes, in which some nodes are branches (i.e., contain further nodes) and some nodes are leaves (i.e., do not contain further nodes). The "hierarchy" category SHOULD be used to identify such nodes, where the "branch" and "leaf" types are exhaustive of the types within this category.</p>
+      <p class="" style="">If the hierarchy category is used, every node in the hierarchy MUST be identified as either a branch or a leaf; however, since a node MAY have multiple identities, any given node MAY also possess an identity other than "hierarchy/branch" or "hierarchy/leaf".</p>
+      <p class="" style="">Therefore, a disco#info request to the "music/D" node shown above would yield &lt;identity category='hierarchy' type='branch'/&gt; while a disco#info request to the "music/D/dowland-firstbooke" node would yield &lt;identity category='hierarchy' type='leaf'/&gt; (and each node could yield additional identities as appropriate).</p>
+    </div>
+    <div class="indent">
+<h3>4.4 <a name="items-relationship">Relationship Between an Entity and its Items</a>
+</h3>
+      <p class="" style="">This section explains in greater detail the relationship between an entity and its associated items.</p>
+      <p class="" style="">In general, the items returned by an entity in a disco#items result MUST be items over which the entity has some relationship of ownership -- either direct control over the item itself (e.g., <span style="font-weight: bold">Publish-Subscribe</span> nodes owned by the entity) or at least the ability to provide or vouch for the item in a canonical way on the Jabber network (e.g., groupchat rooms directly hosted by a multi-user chat service or IRC channels to which a gateway provides access).</p>
+      <p class="" style="">Such a relationship does not constrain the relationship between the owning entity's address and the address of the associated entity. In particular, any of the following scenarios is perfectly acceptable:</p>
+      <ol start="" type="">
+        <li><p class="" style="">Upon querying an entity (JID1) for items, one receives a list of items that can be addressed as JIDs; each associated item has its own JID, but no such JID equals JID1.</p></li>
+        <li><p class="" style="">Upon querying an entity (JID1) for items, one receives a list of items that cannot be addressed as JIDs; each associated item has its own JID+node, where each JID equals JID1 and each NodeID is unique.</p></li>
+        <li><p class="" style="">Upon querying an entity (JID1+NodeID1) for items, one receives a list of items that can be addressed as JIDs; each associated item has its own JID, but no such JID equals JID1.</p></li>
+        <li><p class="" style="">Upon querying an entity (JID1+NodeID1) for items, one receives a list of items that cannot be addressed as JIDs; each associated item has its own JID+node, but no such JID+node equals JID1+NodeID1 and each NodeID is unique in the context of the associated JID.</p></li>
+      </ol>
+      <p class="" style="">In addition, the results MAY also be mixed, so that a query to a JID or a JID+node could yield both (1) items that are addressed as JIDs and (2) items that are addressed as JID+node combinations.</p>
+      <p class="" style="">Consider the case of an entity that owns multiple publish-subscribe nodes -- for example, a person who owns one such node for each of his music players. The following examples show what the disco#items query and result might look like (using the protocol defined in <span class="ref" style="">User Tune</span>  [<a href="#nt-id2257682">9</a>]):</p>
+      <p class="caption">Example 19. User queries entity regarding tunes</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/chamber'
+    id='items4'
+    to='romeo@montague.net'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items' 
+         node='http://jabber.org/protocol/tune'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The queried entity now returns a list of publish-subscribe nodes over which it has control, each of which is hosted on a different pubsub service:</p> 
+      <p class="caption">Example 20. Entity returns multiple items</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net'
+    id='items4'
+    to='juliet@capulet.com/chamber'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items' 
+         node='http://jabber.org/protocol/tune'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Romeo&amp;apos;s CD player'
+          node='s623nms9s3bfh8js'/&gt;
+    &lt;item jid='pubsub.montague.net'
+          node='music/R/Romeo/iPod'/&gt;
+    &lt;item jid='tunes.characters.lit'
+          node='g8k4kds9sd89djf3'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+  <h2>5.
+       <a name="publish">Publishing Available Items</a>
+</h2>
+    <p class="" style="">The server handling rules defined in <span style="font-weight: bold">XMPP IM</span> require that the server itself reply on behalf of the user if the 'to' attribute of an IQ get or set is of the form &lt;user@host&gt;. This functionality is currently employed so that the user can "publish" information (e.g., vCard information as specified in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257772">10</a>]) in a way that makes it possible for other entities to retrieve that information even if the user is unavailable. The service discovery specification defined herein builds on that notion by enabling a user to publish some of its service discovery information to the server, which shall store that information in persistent storage and return that information when other entities request it from the user's "bare JID" (user@host), either alone or in combination with a particular node.</p>
+    <p class="" style="">Implementations of service discovery that are built into instant messaging servers SHOULD allow user to publish items in this fashion, although they are not required to do so in order to conform to the service discovery specification. In order to discover whether his or her server supports this publish functionality, the user SHOULD send a disco#info request to his or her server:</p>
+    <p class="caption">Example 21. User sends disco#info request to server</p>
+<div class="indent"><pre>
+&lt;iq from='kinglear@shakespeare.lit'
+    id='pubinfo'
+    to='shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server supports service discovery publishing and the server wishes to disclose that fact to the user, it MUST include a feature of 'http://jabber.org/protocol/disco#publish' in its response.</p>
+    <p class="caption">Example 22. Server responds with identity and feature information</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='pubinfo'
+    to='kinglear@shakespeare.lit'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='server' type='im'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/disco#publish'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="" style="">In order to publish items, an entity uses an IQ-set transaction to its server, which is responsible for responding to requests on behalf of that entity. Each &lt;item/&gt; child element of the parent query MUST possess the following attributes:</p>
+    <ul>
+      <li>
+<span style="font-weight: bold">action</span> -- specifies the action to be taken for the item</li>
+      <li>
+<span style="font-weight: bold">jid</span> -- specifies the Jabber ID of the item "owner" or location</li>
+    </ul>
+    <p class="" style="">The &lt;item/&gt; element MAY also possess the following attributes:</p>
+    <ul>
+      <li>
+<span style="font-weight: bold">name</span> -- specifies a natural-language name for the item.</li>
+      <li>
+<span style="font-weight: bold">node</span> -- specifies the particular node associated with the JID of the item "owner" or location</li>
+    </ul>
+    <p class="" style="">The allowable values for the 'action' attribute are "update" and "remove"). If the action is "update", the server MUST either create a new entry (if the node and jid combination does not already exist) or overwrite an existing entry. If the action is "remove", the item MUST be removed from persistent storage.</p>
+    <p class="" style="">The following example shows a user publishing a list of his biological children to a well-known (but fictitious) service discovery node.</p>
+    <p class="caption">Example 23. Publishing items</p>
+<div class="indent"><pre>
+&lt;iq from='kinglear@shakespeare.lit'
+    id='publish1'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='jabber:iq:kids'&gt;
+    &lt;item action='update'
+          jid='cordelia@shakespeare.lit'
+          name='Cordelia'/&gt;
+    &lt;item action='update'
+          jid='goneril@shakespeare.lit'
+          name='Goneril'/&gt;
+    &lt;item action='update'
+          jid='regan@shakespeare.lit'
+          name='Regan'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="caption">Example 24. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq id='publish1'
+    to='kinglear@shakespeare.lit'
+    type='result'/&gt;
+    </pre></div>
+
+    <p class="" style="">Subsequent queries to "jid='kinglear@shakespeare.lit'" and "node='jabber:iq:kids'" will yield the list shown above (absent the 'action' attributes).</p>
+
+    <p class="" style="">If the server or service does not support persistent storage, it MUST respond to IQ-set requests with a &lt;feature-not-implemented/&gt; error.</p>
+
+    <p class="caption">Example 25. Persistent storage is not available</p>
+<div class="indent"><pre>
+&lt;iq id='publish1'
+    to='kinglear@shakespeare.lit'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='jabber:iq:kids'&gt;
+    &lt;item action='update'
+          jid='cordelia@shakespeare.lit'
+          name='Cordelia'/&gt;
+    &lt;item action='update'
+          jid='goneril@shakespeare.lit'
+          name='Goneril'/&gt;
+    &lt;item action='update'
+          jid='regan@shakespeare.lit'
+          name='Regan'/&gt;
+  &lt;/query&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:xml:params:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <p class="" style="">In order to retrieve full information about an entity and its associated items, the requesting application needs to "walk the tree" of items. Naturally, this can result in a large number of requests and responses. The requesting application SHOULD NOT send follow-up requests to all items associated with an entity if the list of such items is long (e.g., more than twenty items). Entities that will routinely host a large number of items (e.g., IRC gateways or NNTP services) SHOULD structure nodes into hierarchies and/or provide more robust searching capabilities, for example via <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2258004">11</a>]; they SHOULD NOT return extremely large result sets via Service Discovery.</p>
+    <p class="" style="">This JEP does not require that a responding entity must return the same results in response to the same request from different requesting entities (e.g., an entity could return a different list of items or features based on the degree to which it trusts the requesting entity, or based on the known capabilities of the requesting entity). However, the responding entity SHOULD return the same &lt;identity/&gt; element (category+type) to all disco#info requests sent to the same JID+node combination.</p>
+    <p class="" style="">As mentioned above, when an entity sends a request to a bare JID (account@domain) hosted by a server, the server itself shall reply on behalf of the hosted account. The primary identity returned in the server's response to a disco#info query SHOULD have a category of "account", with an appropriate type as specified in the Service Discovery Identities registry (most likely, a type of "registered"). In response to a disco#items query, if the requesting entity is subscribed to the account's presence, then the server SHOULD include one &lt;item/&gt; for each of the account's "available resources" (as that term is defined in <span style="font-weight: bold">RFC 3921</span>); if the requesting entity is not subscribed to the account's presence, then the server MUST NOT return items for the account's available resources.</p>
+  <h2>7.
+       <a name="errors">Error Conditions</a>
+</h2>
+    <p class="" style="">The following table summarizes the common error conditions that can have special meaning in the context of Service Discovery (for information regarding error condition syntax and semantics, see <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2258096">12</a>]).</p>
+    <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Condition</th>
+        <th colspan="" rowspan="">Cause</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+        <td align="" colspan="" rowspan="">The sender has attempted to publish items but the server does not support the <a href="#publish">Publishing Available Items</a> feature.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;item-not-found/&gt;</td>
+        <td align="" colspan="" rowspan="">The JID or JID+NodeID of the specified target entity does not exist and that fact can be divulged in accordance with privacy and security considerations and policies.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+        <td align="" colspan="" rowspan="">The target entity does not support this protocol, or the specified target entity does not exist but that fact cannot be divulged because of pricacy and security considerations.</td>
+      </tr>
+    </table>
+    <p class="" style="">The other error conditions specified in <span style="font-weight: bold">XMPP Core</span> MAY be returned as well (&lt;forbidden/&gt;, &lt;not-allowed/&gt;, &lt;not-authorized/&gt;, etc.), including application-specific conditions.</p>
+    <p class="" style="">As noted above, if an entity has no associated items, it MUST return an empty &lt;query/&gt; element (rather than an error) in response to a disco#items request.</p>
+  <h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Certain attacks may be made easier when an entity discloses (via disco#info responses) that it supports particular protocols or features; however, in general, service discovery introduces no new vulnerabilities, since a malicious entity could discover that the responding entity supports such protocols and features by sending requests specific to those protocols rather than by sending service discovery requests.</p>
+    <p class="" style="">A responding entity is under no obligation to return the identical service discovery response when replying to service discovery requests received from different requesting entities, and MAY perform authorization checks before responding in order to determine how (or whether) to respond.</p>
+  <h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258296">13</a>].</p>
+  <h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>10.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258380">14</a>] includes the 'http://jabber.org/protocol/disco#info' and 'http://jabber.org/protocol/disco#items' namespaces in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>10.2 <a name="registrar-reg">Registries</a>
+</h3>
+      <div class="indent">
+<h3>10.2.1 <a name="registrar-reg-identity">Identity Categories and Types Registry</a>
+</h3>
+        <p class="" style="">The Jabber Registrar shall maintain a registry of values for the 'category' and 'type' attributes of the &lt;identity/&gt; element in the 'http://jabber.org/protocol/disco#info' namespace; see &lt;<a href="http://www.jabber.org/registrar/disco-categories.html">http://www.jabber.org/registrar/disco-categories.html</a>&gt;.</p>
+        <div class="indent">
+<h3>10.2.1.1 <a name="registrar-identity">Process</a>
+</h3>
+          <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;the name of the category (all lower-case)&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the category&lt;/desc&gt;
+  &lt;type&gt;
+    &lt;name&gt;the name of the specific type (all lower-case)&lt;/name&gt;
+    &lt;desc&gt;a natural-language description of the type&lt;/desc&gt;
+    &lt;doc&gt;the document (e.g., JEP) in which this type is specified&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+          </pre></div>
+          <p class="" style="">The registrant may register more than one category at a time, each contained in a separate &lt;category/&gt; element. The registrant may also register more than one type at a time, each contained in a separate &lt;type/&gt; child element. Registrations of new types within an existing category must include the full XML snippet but should not include the category description (only the name).</p>
+        </div>
+        <div class="indent">
+<h3>10.2.1.2 <a name="registrar-reg-identity-init">Initial Submission</a>
+</h3>
+          <p class="" style="">This JEP defines a "hierarchy" category that contains two and only two types: "branch" and "leaf"; the associated registry submission is as follows:</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;hierarchy&lt;/name&gt;
+  &lt;desc&gt;
+    An entity that exists in the context of a 
+    service discovery node hierarchy.
+  &lt;/desc&gt;
+  &lt;type&gt;
+    &lt;name&gt;branch&lt;/name&gt;
+    &lt;desc&gt;
+      A "container node" for other entities in a 
+      service discovery node hierarchy.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0030&lt;/doc&gt;
+  &lt;/type&gt;
+  &lt;type&gt;
+    &lt;name&gt;leaf&lt;/name&gt;
+    &lt;desc&gt;
+      A "terminal node" in a service discovery 
+      node hierarchy.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0030&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+          </pre></div>
+        </div>
+      </div>
+      <div class="indent">
+<h3>10.2.2 <a name="registrar-reg-features">Features Registry</a>
+</h3>
+        <p class="" style="">The Jabber Registrar shall maintain a registry of features for use as values of the 'var' attribute of the &lt;feature/&gt; element in the 'http://jabber.org/protocol/disco#info' namespace; see &lt;<a href="http://www.jabber.org/registrar/disco-vars.html">http://www.jabber.org/registrar/disco-vars.html</a>&gt;.</p>
+        <div class="indent">
+<h3>10.2.2.1 <a name="registrar-reg-features-process">Process</a>
+</h3>
+          <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;feature var='name of feature or namespace'&gt;
+  &lt;desc&gt;a natural-language description of the feature&lt;/desc&gt;
+  &lt;doc&gt;the document (e.g., JEP) in which this feature is specified&lt;/doc&gt;
+&lt;/feature&gt;</pre></div>
+          <p class="" style="">The registrant may register more than one feature at a time, each contained in a separate &lt;feature/&gt; element.</p>
+        </div>
+        <div class="indent">
+<h3>10.2.2.2 <a name="registrar-reg-features-init">Initial Submission</a>
+</h3>
+          <p class="" style="">This JEP defines a "publish" feature that is not associated with either of the protocol namespaces listed above; the registry submission for this feature is as follows:</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;feature var='http://jabber.org/protocol/disco#publish'&gt;
+  &lt;desc&gt;the service discovery "publish" feature&lt;/desc&gt;
+  &lt;doc&gt;JEP-0030&lt;/doc&gt;
+&lt;/feature&gt;
+          </pre></div>
+        </div>
+      </div>
+      <div class="indent">
+<h3>10.2.3 <a name="registrar-reg-nodes">Well-Known Nodes</a>
+</h3>
+        <p class="" style="">A using protocol may specify one or more service discovery nodes that have a special and well-defined meaning in the context of that protocol. For the purpose of reserving these node names globally across all Jabber protocols, the Jabber Registrar shall maintain a registry of well-known service discovery nodes; see &lt;<a href="http://www.jabber.org/registrar/disco-nodes.html">http://www.jabber.org/registrar/disco-nodes.html</a>&gt;.</p>
+        <div class="indent">
+<h3>10.2.3.1 <a name="registrar-reg-nodes-process">Process</a>
+</h3>
+          <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;node&gt;
+  &lt;name&gt;the name of the node&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the node&lt;/desc&gt;
+  &lt;doc&gt;the document (e.g., JEP) in which this node is specified&lt;/doc&gt;
+&lt;/node&gt;
+          </pre></div>
+          <p class="" style="">The registrant may register more than one node at a time, each contained in a separate &lt;node/&gt; element.</p>
+        </div>
+      </div>
+    </div>
+  <h2>11.
+       <a name="schemas">XML Schemas</a>
+</h2>
+    <div class="indent">
+<h3>11.1 <a name="schemas-info">disco#info</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8' ?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/disco#info'
+    xmlns='http://jabber.org/protocol/disco#info'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0030: http://www.jabber.org/jeps/jep-0030.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:element ref='identity' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='feature' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='identity'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='category' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='type' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='feature'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='var' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>11.2 <a name="schemas-items">disco#items</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8' ?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/disco#items'
+    xmlns='http://jabber.org/protocol/disco#items'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0030: http://www.jabber.org/jeps/jep-0030.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='action' use='optional'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='remove'/&gt;
+                &lt;xs:enumeration value='update'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250282">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250310">2</a>. JEP-0011: Jabber Browsing &lt;<a href="http://www.jabber.org/jeps/jep-0011.html">http://www.jabber.org/jeps/jep-0011.html</a>&gt;.</p>
+<p><a name="nt-id2250333">3</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2250375">4</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2256660">5</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2257041">6</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257296">7</a>. JEP-0013: Flexible Offline Message Retrieval &lt;<a href="http://www.jabber.org/jeps/jep-0013.html">http://www.jabber.org/jeps/jep-0013.html</a>&gt;.</p>
+<p><a name="nt-id2257327">8</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257682">9</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2257772">10</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2258004">11</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2258096">12</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2258296">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258380">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 2.1 (2005-03-03)</h4>
+<div class="indent">Added paragraph to implementation notes about server handling of requests sent to bare JIDs. (psa)
+    </div>
+<h4>Version 2.0 (2004-07-20)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Final. (psa)
+    </div>
+<h4>Version 1.10 (2004-06-29)</h4>
+<div class="indent">Defined security considerations; changed extended presence example to use a fictitious protocol; further specified publish feature; defined registry submissions. (psa/jjh)
+    </div>
+<h4>Version 1.9 (2004-05-27)</h4>
+<div class="indent">Clarified error conditions. (psa)
+    </div>
+<h4>Version 1.8 (2004-05-21)</h4>
+<div class="indent">Moved remaining feature negotiation text to JEP-0020. (psa)
+    </div>
+<h4>Version 1.7 (2004-05-13)</h4>
+<div class="indent">Added implementation note regarding flexibility of feature and item results; final editorial cleanup. (psa)
+    </div>
+<h4>Version 1.6 (2004-05-11)</h4>
+<div class="indent">Corrected examples of publishing available items; further clarified nature of node hierarchies. (psa)
+    </div>
+<h4>Version 1.5 (2004-05-10)</h4>
+<div class="indent">Added clarifying note about node hierarchies. (psa)
+    </div>
+<h4>Version 1.4 (2004-05-07)</h4>
+<div class="indent">Clarified usage of "directory"; added section defining the relationship between an entity and its associated items. (psa)
+    </div>
+<h4>Version 1.3 (2004-04-23)</h4>
+<div class="indent">Further clarified item-publication protocol; moved some feature negotiation text to JEP-0020; added information about registry of well-known service discovery nodes; added implementation notes regarding tree-walking and large result sets; incorporated additional Call for Experience suggestions. (psa)
+    </div>
+<h4>Version 1.2 (2004-04-20)</h4>
+<div class="indent">Editorial cleanup; incorporated some Call for Experience suggestions. (psa)
+    </div>
+<h4>Version 1.1 (2004-03-15)</h4>
+<div class="indent">Described requirements, syntax, and use cases in a more formal manner; corrected several errors in the examples and schemas; defined Jabber Registrar procedures; added a number of references; specified XMPP error handling. (psa)
+    </div>
+<h4>Version 1.0 (2003-04-21)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft; also added XML schemas. (psa)
+    </div>
+<h4>Version 0.13 (2003-02-25)</h4>
+<div class="indent">Added remarks about empty node attributes; described semantics regarding multiple identity elements. (pgm)
+    </div>
+<h4>Version 0.12 (2003-02-06)</h4>
+<div class="indent">Added support for IQ-set; added example for disco#info to a specific node. (pgm)
+    </div>
+<h4>Version 0.11 (2002-12-17)</h4>
+<div class="indent">Added support for the 'node' attribute per discussion on the Standards-JIG list in order to support items that are not JID-addressable. (psa)
+    </div>
+<h4>Version 0.10 (2002-11-21)</h4>
+<div class="indent">Changed &lt;feature type='foo'/&gt; to &lt;feature var='foo'/&gt; to track changes in feature negotiation (JEP-0020); added initial registry parameters. (psa)
+    </div>
+<h4>Version 0.9 (2002-11-07)</h4>
+<div class="indent">Added support for empty result sets in disco#item. (psa)
+    </div>
+<h4>Version 0.8 (2002-11-01)</h4>
+<div class="indent">Removed the max, start, and total attributes for item queries (this will be handled by a generic paging JEP); added "http://jabber.org/protocol/feature-neg" namespace as a feature to signal negotiability regarding one or more features. (psa)
+    </div>
+<h4>Version 0.7 (2002-10-28)</h4>
+<div class="indent">Cleaned up the feature text and examples. (psa)
+    </div>
+<h4>Version 0.6 (2002-10-27)</h4>
+<div class="indent">Added the 'category' attribute to the &lt;feature/&gt; element; added security, IANA, and Jabber Registrar considerations; added a number of examples. (psa)
+    </div>
+<h4>Version 0.5 (2002-10-15)</h4>
+<div class="indent">Total overhaul and simplification. (psa)
+    </div>
+<h4>Version 0.4 (2002-07-16)</h4>
+<div class="indent">Major additions and fixes, many more examples. (psa)
+    </div>
+<h4>Version 0.3 (2002-05-30)</h4>
+<div class="indent">Re-organized around use cases, made some minor fixes. (psa)
+    </div>
+<h4>Version 0.2 (2002-05-05)</h4>
+<div class="indent">Incorporated comments from co-authors and added notes. (psa)
+    </div>
+<h4>Version 0.1 (2002-05-03)</h4>
+<div class="indent">Initial draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0045-1.16.html
+++ b/content/xep-0045-1.16.html
@@ -1,0 +1,4907 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0045: Multi-User Chat</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Multi-User Chat">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a robust protocol for XMPP-based text conferencing.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-06-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0045">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0045: Multi-User Chat</h1>
+<p>This JEP defines a robust protocol for XMPP-based text conferencing.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0045<br>
+            Version: 1.16<br>
+            Last Updated: 2004-06-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0004, JEP-0030, JEP-0068, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: muc<br>
+        Schema for muc: &lt;<a href="http://jabber.org/protocol/muc/muc.xsd">http://jabber.org/protocol/muc/muc.xsd</a>&gt;<br>
+        Schema for muc#admin: &lt;<a href="http://jabber.org/protocol/muc/admin.xsd">http://jabber.org/protocol/muc/admin.xsd</a>&gt;<br>
+        Schema for muc#owner: &lt;<a href="http://jabber.org/protocol/muc/owner.xsd">http://jabber.org/protocol/muc/owner.xsd</a>&gt;<br>
+        Schema for muc#user: &lt;<a href="http://jabber.org/protocol/muc/user.xsd">http://jabber.org/protocol/muc/user.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#scope">Scope</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#terms-general">General Terms</a>
+</dt>
+<dt>4.2.  <a href="#terms-rooms">Room Types</a>
+</dt>
+</dl>
+<dt>5.  <a href="#connections">Roles and Affiliations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#roles">Roles</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#roles-priv">Privileges</a>
+</dt>
+<dt>5.1.2.  <a href="#roles-change">Changing Roles</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#affil">Affiliations</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#affil-priv">Privileges</a>
+</dt>
+<dt>5.2.2.  <a href="#affil-change">Changing Affiliations</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#user">Occupant Use Cases</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#discovery">Discovering Component Support for MUC</a>
+</dt>
+<dt>6.2.  <a href="#discovery-client">Discovering Client Support for MUC</a>
+</dt>
+<dt>6.3.  <a href="#enter">Entering a Room</a>
+</dt>
+<dl>
+<dt>6.3.1.  <a href="#enter-gc">Groupchat 1.0 Protocol</a>
+</dt>
+<dt>6.3.2.  <a href="#enter-muc">Basic MUC Protocol</a>
+</dt>
+<dt>6.3.3.  <a href="#enter-pres">Presence Broadcast</a>
+</dt>
+<dt>6.3.4.  <a href="#enter-roles">Default Roles</a>
+</dt>
+<dt>6.3.5.  <a href="#enter-nonanon">Non-Anonymous Rooms</a>
+</dt>
+<dt>6.3.6.  <a href="#enter-semianon">Semi-Anonymous Rooms</a>
+</dt>
+<dt>6.3.7.  <a href="#enter-pw">Password-Protected Rooms</a>
+</dt>
+<dt>6.3.8.  <a href="#enter-members">Members-Only Rooms</a>
+</dt>
+<dt>6.3.9.  <a href="#enter-banned">Banned Users</a>
+</dt>
+<dt>6.3.10.  <a href="#enter-conflict">Nickname Conflict</a>
+</dt>
+<dt>6.3.11.  <a href="#enter-history">Discussion History</a>
+</dt>
+<dt>6.3.12.  <a href="#enter-managehistory">Managing Discussion History</a>
+</dt>
+<dt>6.3.13.  <a href="#enter-create">Room Creation</a>
+</dt>
+</dl>
+<dt>6.4.  <a href="#exit">Exiting a Room</a>
+</dt>
+<dt>6.5.  <a href="#changenick">Changing Nickname</a>
+</dt>
+<dt>6.6.  <a href="#changepres">Changing Availability Status</a>
+</dt>
+<dt>6.7.  <a href="#invite">Inviting Another User to a Room</a>
+</dt>
+<dt>6.8.  <a href="#subject-occupant">Occupant Modification of the Room Subject</a>
+</dt>
+<dt>6.9.  <a href="#privatemessage">Sending a Private Message</a>
+</dt>
+<dt>6.10.  <a href="#message">Sending a Message to All Occupants</a>
+</dt>
+<dt>6.11.  <a href="#register">Registering with a Room</a>
+</dt>
+<dt>6.12.  <a href="#reservednick">Discovering Reserved Room Nickname</a>
+</dt>
+</dl>
+<dt>7.  <a href="#moderator">Moderator Use Cases</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#subject-mod">Modifying the Room Subject</a>
+</dt>
+<dt>7.2.  <a href="#kick">Kicking a Visitor or Participant from a Room</a>
+</dt>
+<dt>7.3.  <a href="#grantvoice">Granting Voice to a Visitor</a>
+</dt>
+<dt>7.4.  <a href="#revokevoice">Revoking Voice from a Participant</a>
+</dt>
+<dt>7.5.  <a href="#modifyvoice">Modifying the Voice List</a>
+</dt>
+</dl>
+<dt>8.  <a href="#admin">Admin Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#ban">Banning a User</a>
+</dt>
+<dt>8.2.  <a href="#modifyban">Modifying the Ban List</a>
+</dt>
+<dt>8.3.  <a href="#grantmember">Granting Membership</a>
+</dt>
+<dt>8.4.  <a href="#revokemember">Revoking Membership</a>
+</dt>
+<dt>8.5.  <a href="#modifymember">Modifying the Member List</a>
+</dt>
+<dt>8.6.  <a href="#grantmod">Granting Moderator Privileges</a>
+</dt>
+<dt>8.7.  <a href="#revokemod">Revoking Moderator Privileges</a>
+</dt>
+<dt>8.8.  <a href="#modifymod">Modifying the Moderator List</a>
+</dt>
+</dl>
+<dt>9.  <a href="#owner">Owner Use Cases</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#createroom">Creating a Room</a>
+</dt>
+<dt>9.2.  <a href="#roomconfig">Subsequent Room Configuration</a>
+</dt>
+<dt>9.3.  <a href="#grantowner">Granting Ownership Privileges</a>
+</dt>
+<dt>9.4.  <a href="#revokeowner">Revoking Ownership Privileges</a>
+</dt>
+<dt>9.5.  <a href="#modifyowner">Modifying the Owner List</a>
+</dt>
+<dt>9.6.  <a href="#grantadmin">Granting Administrative Privileges</a>
+</dt>
+<dt>9.7.  <a href="#revokeadmin">Revoking Administrative Privileges</a>
+</dt>
+<dt>9.8.  <a href="#modifyadmin">Modifying the Admin List</a>
+</dt>
+<dt>9.9.  <a href="#destroyroom">Destroying a Room</a>
+</dt>
+</dl>
+<dt>10.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dt>11.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>13.2.  <a href="#registrar-discocat">Service Discovery Category/Type</a>
+</dt>
+<dt>13.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>13.4.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+<dl>
+<dt>13.4.1.  <a href="#registrar-formtype-user">muc#user FORM_TYPE</a>
+</dt>
+<dt>13.4.2.  <a href="#registrar-formtype-owner">muc#owner FORM_TYPE</a>
+</dt>
+<dt>13.4.3.  <a href="#registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</dt>
+</dl>
+</dl>
+<dt>14.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#bizrules-jids">Room JIDs</a>
+</dt>
+<dt>14.2.  <a href="#bizrules-message">Message</a>
+</dt>
+<dt>14.3.  <a href="#bizrules-presence">Presence</a>
+</dt>
+<dt>14.4.  <a href="#bizrules-iq">IQ</a>
+</dt>
+</dl>
+<dt>15.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#impl-service">Services</a>
+</dt>
+<dt>15.2.  <a href="#impl-client">Clients</a>
+</dt>
+<dl><dt>15.2.1.  <a href="#impl-client-irc">IRC Command Mapping</a>
+</dt></dl>
+</dl>
+<dt>16.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#schemas-muc">http://jabber.org/protocol/muc</a>
+</dt>
+<dt>16.2.  <a href="#schemas-user">http://jabber.org/protocol/muc#user</a>
+</dt>
+<dt>16.3.  <a href="#schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</dt>
+<dt>16.4.  <a href="#schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</dt>
+</dl>
+<dt>17.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">It has long been recognized that the Jabber community needs a more robust protocol for text-based conferencing. This JEP defines extensions that enable Jabber systems to offer a much wider range of functionality, while still enabling older Jabber clients to access the minimal feature-set provided by the existing &quot;groupchat 1.0&quot; protocol. The extensions are implemented using protocol elements that fall into the 'http://jabber.org/protocol/muc' namespace and associated functionality areas (denoted by #owner, #admin, and #user fragments on the main namespace URI where appropriate).</p>
+<h2>2.
+       <a name="scope">Scope</a>
+</h2>
+  <p class="" style="">This JEP addresses common requirements related to configuration of, participation in, and administration of individual text-based conference rooms. All of the requirements addressed herein apply at the level of the individual room and are &quot;common&quot; in the sense that they have been widely discussed within the Jabber community or are familiar from existing text-based conference environments outside of Jabber (e.g., Internet Relay Chat as defined in <span class="ref">RFC 1459</span>  [<a href="#nt-id2602338">1</a>]). This JEP explicitly does <span style="font-style: italic">not</span> address the following: relationships between rooms (e.g., hierarchies of rooms); management of multi-user chat services (e.g., managing permissions across an entire service or registering a global room nickname); moderation of individual messages; security and encryption at the level of a room or service; advanced features such as attaching files to a room, integrating whiteboards, and interfacing with audio chat services; or interaction between Jabber and foreign chat systems (e.g., gateways to IRC or to legacy IM systems). This limited scope is not meant to disparage such topics, which are of inherent interest; however, it is meant to focus the discussion in this JEP and to present a comprehensible proposal that can be implemented by Jabber client and component developers alike. Future JEPs may of course address the topics mentioned above.</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP must address the minimal functionality provided by existing multi-user chat services in Jabber. For the sake of backward-compatibility, this JEP uses the original &quot;groupchat 1.0&quot; protocol for this baseline functionality, with the result that:</p>
+  <ul>
+    <li>Messages sent within multi-user chat rooms are of a special type &quot;groupchat&quot;.</li>
+    <li>Each room is identified as room@service (e.g., jdev@conference.jabber.org), where &quot;room&quot; is the name of the room and &quot;service&quot; is the hostname at which the multi-user chat service is running.</li>
+    <li>Each occupant in a room is identified as room@service/nick, where &quot;nick&quot; is the room nickname of the occupant as specified on entering the room or subsequently changed during the occupant's visit.</li>
+    <li>A user enters a room (i.e., becomes an occupant) by sending presence to it.</li>
+    <li>An occupant exits a room by sending presence of type &quot;unavailable&quot; to it.</li>
+    <li>An occupant can change his or her room nickname and availability status within the room by sending updated presence information.</li>
+  </ul>
+  <p class="" style="">The additional features and functionality addressed in this JEP include the following:</p>
+  <ol start="" type="">
+    <li>&quot;native&quot; conversation logging (no bot required)</li>
+    <li>enabling users to request membership in a room</li>
+    <li>enabling occupants to view an occupant's full JID in a non-anonymous room</li>
+    <li>enabling moderators to view an occupant's full JID in a semi-anonymous room</li>
+    <li>allowing only moderators to change the room subject</li>
+    <li>enabling moderators to kick participants and visitors from the room</li>
+    <li>enabling moderators to grant and revoke voice (i.e., the privilege to speak) in a moderated room, and to manage the voice list</li>
+    <li>enabling admins to grant and revoke moderator privileges, and to manage the moderator list</li>
+    <li>enabling admins to ban users from the room, and to manage the ban list</li>
+    <li>enabling admins to grant and revoke membership privileges, and to manage the member list for a members-only room</li>
+    <li>enabling owners to limit the number of occupants</li>
+    <li>enabling owners to specify other owners</li>
+    <li>enabling owners to grant and revoke administrative privileges, and to manage the admin list</li>
+    <li>enabling owners to destroy the room</li>
+  </ol>
+  <p class="" style="">In addition, this JEP provides protocol elements for supporting the following room types:</p>
+  <ol start="" type="">
+    <li>public or hidden</li>
+    <li>persistent or temporary</li>
+    <li>password-protected or unsecured</li>
+    <li>members-only or open</li>
+    <li>moderated or unmoderated</li>
+    <li>non-anonymous or semi-anonymous</li>
+  </ol>
+<h2>4.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="terms-general">General Terms</a>
+</h3>
+    <p class="" style="">Affiliation -- a long-lived association or connection with a room; the possible affiliations are &quot;owner&quot;, &quot;admin&quot;, &quot;member&quot;, and &quot;outcast&quot; (naturally it is also possible to have no affiliation); affiliation is orthogonal to role. An affiliation lasts across a user's visits to a room.</p>
+    <p class="" style="">Ban -- to remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). A banned user has an affiliation of &quot;outcast&quot;.</p>
+    <p class="" style="">Bare JID -- the user@host by which a user is identified outside the context of any existing session or resource; contrast with Full JID and Room JID.</p>
+    <p class="" style="">Full JID -- the user@host/resource by which an online user is identified outside the context of a room; contrast with Bare JID and Room JID.</p>
+    <p class="" style="">GC -- the minimal &quot;groupchat 1.0&quot; protocol  [<a href="#nt-id2602565">2</a>] currently in use for text-based conferencing in Jabber.</p>
+    <p class="" style="">History -- a limited number of message stanzas sent to a new occupant to provide the context of current discussion.</p>
+    <p class="" style="">Invitation -- a special message sent from one user to another asking the recipient to join a room.</p>
+    <p class="" style="">IRC -- Internet Relay Chat.</p>
+    <p class="" style="">Kick -- to temporarily remove a participant or visitor from a room; the user is allowed to re-enter the room at any time. A kicked user has a role of &quot;none&quot;.</p>
+    <p class="" style="">Logging -- storage of discussions that occur within a room for future retrieval inside or outside the context of the room.</p>
+    <p class="" style="">Member -- a user who is on the &quot;whitelist&quot; for a members-only room or who is registered with an open room. A member has an affiliation of &quot;member&quot;.</p>
+    <p class="" style="">Moderator -- a room role that is usually associated with room admins but that may be granted to non-admins; is allowed to kick users, grant and revoke voice, etc. A moderator has an affiliation of &quot;moderator&quot;.</p>
+    <p class="" style="">MUC -- the multi-user chat protocol for text-based conferencing documented in this JEP.</p>
+    <p class="" style="">Occupant -- any Jabber user who is in a room (this is an &quot;abstract class&quot; and does not correspond to any specific role).</p>
+    <p class="" style="">Outcast -- a user who has been banned from a room. An outcast has an affiliation of &quot;outcast&quot;.</p>
+    <p class="" style="">Participant -- an occupant who does not have administrative privileges; in a moderated room, a participant is further defined as having voice (in contrast to a visitor). A participant has a role of &quot;participant&quot;.</p>
+    <p class="" style="">Private Message -- a message sent from one occupant directly to another's room JID (not to the room itself for broadcasting to all occupants).</p>
+    <p class="" style="">Role -- a temporary position or privilege level within a room, orthogonal to a user's long-lived affiliation with the room; the possible roles are &quot;moderator&quot;, &quot;participant&quot;, and &quot;visitor&quot; (it is also possible to have no defined role). A role lasts only for the duration of an occupant's visit to a room.</p>
+    <p class="" style="">Room -- a virtual space that Jabber users figuratively enter in order to participate in real-time, text-based conferencing with more than one other user.</p>
+    <p class="" style="">Room Administrator -- a user empowered by the room owner to perform administrative functions such as banning users; however, is not allowed to change defining room features. An admin has an affiliation of &quot;admin&quot;.</p>
+    <p class="" style="">Room ID -- the node identifier portion of a Room JID, which may be opaque and thus lack meaning for human users (see Business Rules for syntax); contrast with Room Name.</p>
+    <p class="" style="">Room JID -- the &lt;room@service/nick&gt; by which an occupant is identified within the context of a room; contrast with Bare JID and Full JID.</p>
+    <p class="" style="">Room Name -- a user-friendly, natural-language name for a room, configured by the room owner and presented in Service Discovery queries; contrast with Room ID.</p>
+    <p class="" style="">Room Nickname -- the resource identifier portion of a Room JID (see Business Rules for syntax).</p>
+    <p class="" style="">Room Owner -- the Jabber user who created the room, or a Jabber user who has been designated by the room creator as someone with owner privileges (if allowed); is allowed to change defining room features as well as perform all administrative functions. An owner has an affiliation of &quot;owner&quot;.</p>
+    <p class="" style="">Room Roster -- a Jabber client's representation of the occupants in a room.</p>
+    <p class="" style="">Server -- a Jabber server that may or may not have associated with it a text-based conferencing service.</p>
+    <p class="" style="">Service -- a host that offers text-based conferencing capabilities; often but not necessarily a sub-domain of a Jabber server (e.g., conference.jabber.org).</p>
+    <p class="" style="">Subject -- a temporary discussion topic within a room.</p>
+    <p class="" style="">Visit -- a user's &quot;session&quot; in a room, beginning when the user enters the room (i.e., becomes an occupant) and ending when the user exits the room.</p>
+    <p class="" style="">Visitor -- in a moderated room, an occupant who does not have voice (in contrast to a participant). A visitor has a role of &quot;visitor&quot;.</p>
+    <p class="" style="">Voice -- in a moderated room, the privilege to send messages to all occupants.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="terms-rooms">Room Types</a>
+</h3>
+    <p class="" style="">Fully-Anonymous Room -- a room in which the full JIDs or bare JIDs of occupants cannot be discovered by anyone, including room admins and room owners; such rooms are NOT RECOMMENDED or explicitly supported by MUC, but are possible using this protocol; contrast with Non-Anonymous Room and Semi-Anonymous Room.</p>
+    <p class="" style="">Hidden Room -- a room that cannot be found through searching, browsing, etc.; antonym: Public Room.</p>
+    <p class="" style="">Members-Only Room -- a room that a user cannot enter without being on the member list; antonym: Open Room.</p>
+    <p class="" style="">Moderated Room -- a room in which only those with &quot;voice&quot; may send messages to all occupants; antonym: Unmoderated Room.</p>
+    <p class="" style="">Non-Anonymous Room -- a room in which occupants' full JIDs are exposed to all occupants, although they may choose any desired room nickname; contrast with Semi-Anonymous Room and Fully-Anonymous Room.</p>
+    <p class="" style="">Open Room -- a room that anyone may enter without being on the member list; antonym: Members-Only Room.</p>
+    <p class="" style="">Password-Protected Room -- a room that a user cannot enter without first providing the correct password; antonym: Unsecured Room.</p>
+    <p class="" style="">Persistent Room -- a room that is not destroyed if the last occupant exits; antonym: Temporary Room.</p>
+    <p class="" style="">Public Room -- a room that can be found through searching, browsing, etc.); antonym: Hidden Room.</p>
+    <p class="" style="">Semi-Anonymous Room -- a room in which occupants' full JIDs can be discovered by room admins only; contrast with Fully-Anonymous Room and Non-Anonymous Room.</p>
+    <p class="" style="">Temporary Room -- a room that is destroyed if the last occupant exits; antonym: Persistent Room.</p>
+    <p class="" style="">Unmoderated Room -- a room in which any occupant is allowed to send messages to all occupants; antonym: Moderated Room.</p>
+    <p class="" style="">Unsecured Room -- a room that anyone is allowed to enter without first providing the correct password; antonym: Password-Protected Room.</p>
+  </div>
+<h2>5.
+       <a name="connections">Roles and Affiliations</a>
+</h2>
+  <p class="" style="">There are two dimensions along which we can measure a user's connection with or position in a room. One is the user's long-lived affiliation with a room -- e.g., a user's status as an owner or an outcast. The other is a user's role while an occupant of a room -- e.g., an occupant's position as a moderator with the ability to kick visitors and participants. These two dimensions are orthogonal to each other, since an affiliation lasts across visits, while a role lasts only for the duration of a visit. In addition, there is no one-to-one correspondence between roles and affiliations; for example, someone who is not affiliated with a room may be a (temporary) moderator, and a member may be a participant or a visitor in a moderated room. These concepts are explained more fully below.</p>
+  <div class="indent">
+<h3>5.1 <a name="roles">Roles</a>
+</h3>
+    <p class="" style="">There are four defined roles that an occupant can have:</p>
+    <ol start="" type="">
+      <li>Moderator</li>
+      <li>Participant</li>
+      <li>Visitor</li>
+      <li>None (the absence of a role)</li>
+    </ol>
+    <p class="" style="">These roles are temporary in that they do not persist across a user's visits to the room and can change during the course of an occupant's visit to the room. In addition, there is no one-to-one mapping between these roles and a user's affiliation with the room (e.g., a member could be a participant or a visitor).</p>
+    <p class="" style="">A moderator is the most powerful occupant within the context of the room, and can to some extent manage other occupants' roles in the room. A participant has fewer privileges than a moderator, although he or she always has the right to speak. A visitor is a more restricted role within the context of a moderated room, since visitors are not allowed to send messages to all occupants.</p>
+    <p class="" style="">Roles are granted, revoked, and maintained based on the occupant's room nickname or full JID rather than bare JID. The privileges associated with these roles, as well as the actions that trigger changes in roles, are defined below.</p>
+    <p class="" style="">Information about roles MUST be sent in all presence stanzas generated or reflected by the room and thus sent to occupants.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="roles-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, roles exist in a hierarchy. For instance, a participant can do anything a visitor can do, and a moderator can do anything a participant can do. Each role has privileges not possessed by the next-lowest role; these privileges are specified in the following table as defaults (naturally an implementation MAY provide configuration options that override these defaults).</p>
+      <p class="caption">Table 1: Privileges Associated With Roles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Present in Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Receive Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Availability Status</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Nickname</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Private Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Invite Other Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Messages to All</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No**</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Modify Subject</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Kick Participants and Visitors</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Grant Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Revoke Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes***</td>
+        </tr>
+      </table>
+      <p class="" style="">* Default; configuration settings MAY further restrict this privilege.</p>
+      <p class="" style="">** An implementation MAY grant voice by default to visitors in unmoderated rooms.</p>
+      <p class="" style="">*** A moderator MUST NOT be able to revoke voice privileges from an admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="roles-change">Changing Roles</a>
+</h3>
+      <p class="" style="">The ways in which an occupant's role changes are well-defined. Sometimes the change results from the occupant's own action (e.g., entering or exiting the room), whereas sometimes the change results from an action taken by a moderator, admin, or owner. If an occupant's role changes, a compliant component implementation MUST change the occupant's role to reflect the change and communicate that to all occupants. Role changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 2: Role State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">--&gt;</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Enter moderated room</td>
+          <td align="" colspan="" rowspan="">Enter unmoderated room</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Moderator grants voice</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">Moderator revokes voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Exit room</td>
+          <td align="" colspan="" rowspan="">n/a *</td>
+          <td align="" colspan="" rowspan="">Admin revokes moderator privileges **</td>
+          <td align="" colspan="" rowspan="">No</td>
+        </tr>
+      </table>
+      <p class="" style="">* A moderator cannot be directly changed to a role of visitor; he or she MUST first be changed to a role of participant and then have voice revoked.</p>
+      <p class="" style="">** A moderator MUST NOT be able to revoke moderator privileges from an occupant who is equal to or above the moderator in the hierarchy of affiliations.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="affil">Affiliations</a>
+</h3>
+    <p class="" style="">There are five defined affiliations that a user can have in relation to a room:</p>
+    <ol start="" type="">
+      <li>Owner</li>
+      <li>Admin</li>
+      <li>Member</li>
+      <li>Outcast</li>
+      <li>None (the absence of an affiliation)</li>
+    </ol>
+    <p class="" style="">These affiliations are long-lived in that they persist across a user's visits to the room and are not affected by happenings in the room. In addition, there is no one-to-one mapping between these affiliations and an occupant's role within the room. Affiliations are granted, revoked, and maintained based on the user's bare JID.</p>
+    <p class="" style="">If a user without a defined affiliation enters a room, the user's affiliation is defined as &quot;none&quot;; however, this affiliation does not persist across visits.</p>
+    <p class="" style="">Owners and admins are by definition immune from certain actions. Specifically, an owner or admin cannot be kicked from a room and cannot be banned from a room. An admin MUST first lose his or her affiliation (i.e., have an affiliation of &quot;none&quot; or &quot;member&quot;) before such actions could be performed on them.</p>
+    <p class="" style="">The member affiliation provides a way for a room owner or admin to specify a &quot;whitelist&quot; of users who are allowed to enter a members-only room. When a member enters a members-only room, his or her affiliation does not change, no matter what his or her role is. The member affiliation also provides a way for users to effectively register with an open room and thus be lastingly associated with that room in some way (one result may be that the user's nickname is reserved in the room).</p>
+    <p class="" style="">An outcast is a user who has been banned from a room and who is not allowed to enter the room.</p>
+    <p class="" style="">Information about affiliations MUST be sent in all presence stanzas generated or reflected by the room and sent to occupants.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="affil-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, affiliations exist in a hierarchy. For instance, an owner can do anything an admin can do, and an admin can do anything a member can do. Each affiliation has privileges not possessed by the next-lowest affiliation; these privileges are specified in the following table.</p>
+      <p class="caption">Table 3: Privileges Associated With Affiliations</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Register with an Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Members-Only Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Ban Members and Unaffiliated Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Member List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Moderator List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Admin List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Owner List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Definition</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Destroy Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+      </table>
+      <p class="" style="">* As a default, an unaffiliated user enters a moderated room as a visitor, and enters an open room as a participant. A member enters a room as a participant. An admin or owner enters a room as a moderator.</p>
+      <p class="" style="">** An admin or owner MUST NOT be able to revoke moderation privileges from another admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="affil-change">Changing Affiliations</a>
+</h3>
+      <p class="" style="">The ways in which a user's affiliation changes are well-defined. Sometimes the change results from the user's own action (e.g., registering as a member of the room), whereas sometimes the change results from an action taken by an admin or owner. If a user's affiliation changes, a compliant component implementation MUST change the user's affiliation to reflect the change and communicate that to all occupants. Affiliation changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 4: Affiliation State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">--&gt;</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Outcast</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Admin or owner removes ban</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Admin adds user to member list, or user registers as member (if allowed)</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Member</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner removes from member list</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Admin</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">Owner removes user from admin list</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Owner</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">Owner removes user from owner list</td>
+          <td align="" colspan="" rowspan="">No</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+<h2>6.
+       <a name="user">Occupant Use Cases</a>
+</h2>
+  <p class="" style="">The main actor in a multi-user chat environment is the occupant, who can be said to be located &quot;in&quot; a multi-user chat room and to participate in the discussions held in that room (for the purposes of this JEP, participants and visitors are considered to be &quot;mere&quot; occupants, since they possess no administrative privileges). As will become clear, the protocol elements proposed in this JEP to fulfill the occupant use cases fall into three categories:</p>
+  <ol start="" type="">
+    <li><p class="" style="">existing &quot;groupchat 1.0&quot; protocol for minimal functionality</p></li>
+    <li><p class="" style="">straightforward applications of the &quot;groupchat 1.0&quot; protocol, for example to handle some of the errors related to new room types</p></li>
+    <li><p class="" style="">new protocol elements to handle functionality not covered by &quot;groupchat 1.0&quot; (room invites, room passwords, extended presence related to room roles and affiliations); these are contained in the new 'http://jabber.org/protocol/muc#user' namespace</p></li>
+  </ol>
+  <p class="" style="">Note: All client-generated examples herein are presented from the perspective of the service, with the result that all stanzas received by a service contain a 'from' attribute corresponding to the sender's full JID as added by a normal Jabber router or session manager. In addition, normal IQ result stanzas sent upon successful completion of a request are not shown. Most of the examples in this document use the scenario of the witches' meeting held in a dark cave at the beginning of Act IV, Scene I of Shakespeare's <span style="font-style: italic">Macbeth</span>. The characters are as follows:</p>
+  <p class="caption">Table 5: Dramatis Personae</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Room Nickname</th>
+      <th colspan="" rowspan="">Full JID</th>
+      <th colspan="" rowspan="">Affiliation</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">firstwitch</td>
+      <td align="" colspan="" rowspan="">crone1@shakespeare.lit/desktop</td>
+      <td align="" colspan="" rowspan="">Owner</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">secondwitch</td>
+      <td align="" colspan="" rowspan="">wiccarocks@shakespeare.lit/laptop</td>
+      <td align="" colspan="" rowspan="">Admin</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">thirdwitch</td>
+      <td align="" colspan="" rowspan="">hag66@shakespeare.lit/pda</td>
+      <td align="" colspan="" rowspan="">None</td>
+    </tr>
+  </table>
+  <div class="indent">
+<h3>6.1 <a name="discovery">Discovering Component Support for MUC</a>
+</h3>
+    <p class="" style="">Before entering a room, a Jabber user may want to discover if the room complies with the Multi-User Chat protocol.</p>
+    <p class="" style="">A compliant implementation MUST support <span class="ref">Service Discovery</span>  [<a href="#nt-id2605990">3</a>].</p>
+    <p class="caption">Example 1. User Queries Chat Service for MUC Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco1'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST return its identity and the features it supports:</p>
+    <p class="caption">Example 2. Service Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='Macbeth Chat Service'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: because MUC is a superset of the old &quot;Groupchat 1.0&quot; protocol, a MUC service SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result.</p>
+    <p class="" style="">The disco protocol also enables a user to query a service for a list of associated items, which in the case of a chat service would mainly consist of the specific chat rooms hosted by the service.</p>
+    <p class="caption">Example 3. User Queries Chat Service for Associated Items</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco2'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Returns Disco Item Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='heath@macbeth.shakespeare.lit'
+          name='A Lonely Heath'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='A Dark Cave'/&gt;
+    &lt;item jid='forres@macbeth.shakespeare.lit'
+          name='The Palace'/&gt;
+    &lt;item jid='inverness@macbeth.shakespeare.lit'
+          name='Macbeth&amp;apos;s Castle'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Using disco, a user may also query a specific chat room for more detailed information:</p>
+    <p class="caption">Example 5. User Queries for Information about a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The room MUST return its identity and SHOULD return the features it supports:</p>
+    <p class="caption">Example 6. Room Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: because MUC is a superset of the old &quot;Groupchat 1.0&quot; protocol, a MUC room SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result. The room SHOULD return the materially-relevant features it supports, such as password protection and room moderation (these are listed fully in the feature var registry maintained by the Jabber Registrar; see also the registry submission in this document).</p>
+    <p class="" style="">A chatroom MAY return more detailed information in its disco#info response using <span class="ref">Service Discovery Extensions</span>  [<a href="#nt-id2606189">4</a>]. Such information might include a more verbose description of the room, the current room subject, and the current number of occupants in the room:</p>
+    <p class="caption">Example 7. Room Returns Extended Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3a'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roominfo&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_description' label='Description'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_subject' label='Subject'&gt;
+        &lt;value&gt;Spells&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_occupants' label='Number of occupants'&gt;
+        &lt;value&gt;3&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_lang' label='Language of discussion'&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The foregoing extended service discovery fields for the 'http://jabber.org/protocol/muc#roominfo' FORM_TYPE may be supplemented in the future via the mechanisms described in the <a href="#registrar-formtype">Field Standardization</a> section of this document.</p>
+    <p class="" style="">Finally, a user may also query a specific chat room for its associated items:</p>
+    <p class="caption">Example 8. User Queries for Items Associated with a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">An implementation MAY return a list of existing occupants if that information is publicly available, or return no list at all if this information is kept private.</p>
+    <p class="caption">Example 9. Room Returns Disco Item Results (Items are Public)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/firstwitch'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note that these &lt;item/&gt; elements are in the disco#items namespace, not the muc namespace. This means that they cannot possess 'affiliation' or 'role' attributes, for example.</p>
+    <p class="caption">Example 10. Room Returns Empty Disco Item Results (Items are Private)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If an entity attempts to send a disco request to an address of the form &lt;room@service/nick&gt;, a compliant component SHOULD return the request to the entity and specify a &quot;Bad Request&quot; error condition.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="discovery-client">Discovering Client Support for MUC</a>
+</h3>
+    <p class="" style="">A Jabber user may want to discover if one of the user's contacts supports the Multi-User Chat protocol. This is done using Service Discovery.</p>
+    <p class="caption">Example 11. User Queries Contact regarding MUC Support</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco5'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client SHOULD return its identity and the features it supports:</p>
+    <p class="caption">Example 12. Contact Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='disco5'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='client'
+        type='pc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A user may also query a contact regarding which rooms the contact is in. This is done by querying the contact's full JID while specifying a node of 'http://jabber.org/protocol/muc#rooms':</p>
+    <p class="caption">Example 13. User Queries Contact for Current Rooms</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='rooms1'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Contact Returns Room Query Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='rooms1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'/&gt;
+    &lt;item jid='characters@conference.shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Optionally, the contact MAY include its roomnick as the value of the 'name' attribute:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+    ...
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='secondwitch'/&gt;
+    ...
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="enter">Entering a Room</a>
+</h3>
+    <div class="indent">
+<h3>6.3.1 <a name="enter-gc">Groupchat 1.0 Protocol</a>
+</h3>
+      <p class="" style="">In order to participate in the discussions held in a multi-user chat room, a Jabber user MUST first become an occupant by entering the room. In the old &quot;groupchat 1.0&quot; protocol, this is done by sending presence to room@service/nick, where &quot;room&quot; is the room ID, &quot;service&quot; is the hostname of the chat service, and &quot;nick&quot; is the user's desired nickname within the room:</p>
+      <p class="caption">Example 15. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'/&gt;
+      </pre></div>
+      <p class="" style="">In this example, a user with a full JID of &quot;hag66@shakespeare.lit/pda&quot; has requested to enter the room &quot;darkcave&quot; on the &quot;macbeth.shakespeare.lit&quot; chat service with a room nickname of &quot;thirdwitch&quot;.</p>
+      <p class="" style="">If the user does not specify a room nickname, the service SHOULD return a &quot;JID Malformed&quot; error:</p>
+      <p class="caption">Example 16. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;jid-malformed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.2 <a name="enter-muc">Basic MUC Protocol</a>
+</h3>
+      <p class="" style="">Compliant multi-user chat services MUST accept the foregoing as a request to enter a room from any Jabber client that knows either the &quot;groupchat 1.0&quot; (GC) protocol or the multi-user chat (MUC) protocol; however, MUC-compliant clients SHOULD signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
+      <p class="caption">Example 17. Jabber User Seeks to Enter a Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.3 <a name="enter-pres">Presence Broadcast</a>
+</h3>
+      <p class="" style="">If the service is able to add the user to the room, it MUST send presence from all the existing occupants' room JIDs to the new occupant's full JID, including extended presence information about roles in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;moderator&quot;, &quot;participant&quot;, &quot;visitor&quot;, or &quot;none&quot; and with the 'affiliation' attribute set to a value of &quot;owner&quot;, &quot;admin&quot;, &quot;member&quot;, or &quot;none&quot; as appropriate:</p>
+      <p class="caption">Example 18. Service Sends Presence from Existing Occupants to New Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, the user from the previous example has entered the room, by which time two other people had already entered the room: a user with a room nickname of &quot;firstwitch&quot; (who is the room owner) and a user with a room nickname of &quot;secondwitch&quot; (who is a room admin).</p>
+      <p class="" style="">The service MUST also send presence from the new occupant's room JID to the full JIDs of all the occupants (including the new occupant):</p>
+      <p class="caption">Example 19. Service Sends New Occupant's Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, initial room presence is being sent from the new occupant (thirdwitch) to all occupants, including the new occupant.</p>
+      <p class="" style="">The order of the presence stanzas sent to the new occupant is important. The service MUST first send the complete list of the existing occupants to the new occupant and only then send the new occupant's own presence to the new occupant. This helps the client know when it has received the complete &quot;room roster&quot;.</p>
+    </div>
+    <div class="indent">
+<h3>6.3.4 <a name="enter-roles">Default Roles</a>
+</h3>
+      <p class="" style="">The following table summarizes the initial default roles that a service should set based on the user's affiliation (there is no role associated with the &quot;outcast&quot; affiliation, since such users are never allowed to enter the room).</p>
+      <p class="caption">Table 6: Initial Role Based on Affiliation</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Room Type</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderated</td>
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Unmoderated</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Members-Only</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Open</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>6.3.5 <a name="enter-nonanon">Non-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is non-anonymous, the service MUST send the new occupant's full JID to all occupants using extended presence information in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with a 'jid' attribute specifying the occupant's full JID:</p>
+      <p class="caption">Example 20. Service Sends Full JID to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+      </pre></div>
+      <p class="" style="">If the user is entering a room that is non-anonymous (i.e., which informs all occupants of each occupant's full JID as shown above), the service SHOULD allow the user to enter the room but MAY warn the user that the room is not anonymous; this is done by sending a mesage type &quot;groupchat&quot; to the new occupant containing an &lt;x/&gt; child with a &lt;status/&gt; element that has the 'code' attribute set to a value of &quot;100&quot;:</p>
+      <p class="caption">Example 21. Service Warns New Occupant of Lack of Anonymity</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;This room is not anonymous.&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;status code='100'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality).</p>
+    </div>
+    <div class="indent">
+<h3>6.3.6 <a name="enter-semianon">Semi-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is semi-anonymous, the service MUST send the new occupant's full JID in the format shown above only to those occupants with a role of &quot;moderator&quot;.</p>
+      <p class="" style="">(Note: all subsequent examples include the 'jid' attribute for each &lt;item/&gt; element, even though this information is not sent to non-moderators in semi-anonymous rooms.)</p>
+    </div>
+    <div class="indent">
+<h3>6.3.7 <a name="enter-pw">Password-Protected Rooms</a>
+</h3>
+      <p class="" style="">If the room requires a password and the user did not supply one, the service MUST deny access to the room and inform the user that they are unauthorized; this is done by returning a presence stanza of type &quot;error&quot; specifying a &quot;Not Authorized&quot; error:</p>
+      <p class="caption">Example 22. Service Denies Access Because No Password Provided</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Passwords SHOULD be supplied with the presence stanza sent when entering the room, contained within an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace and containing a &lt;password/&gt; child. Passwords are to be sent as cleartext; no other authentication methods are supported at this time, and any such authentication or authorization methods shall be defined in a separate specification.</p>
+      <p class="caption">Example 23. User Provides Password On Entering a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.8 <a name="enter-members">Members-Only Rooms</a>
+</h3>
+      <p class="" style="">If the room is members-only but the user is not on the member list, the service MUST deny access to the room and inform the user that they are not allowed to enter the room; this is done by returning a presence stanza of type &quot;error&quot; specifying a &quot;Registration Required&quot; error condition:</p>
+      <p class="caption">Example 24. Service Denies Access Because User Is Not on Member List</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='407' type='auth'&gt;
+    &lt;registration-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.9 <a name="enter-banned">Banned Users</a>
+</h3>
+      <p class="" style="">If the user has been banned from the room (i.e., has an affiliation of &quot;outcast&quot;), the service MUST deny access to the room and inform the user of the fact that he or she is banned; this is done by returning a presence stanza of type &quot;error&quot; specifying a &quot;Forbidden&quot; error condition:</p>
+      <p class="caption">Example 25. Service Denies Access Because User is Banned</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.10 <a name="enter-conflict">Nickname Conflict</a>
+</h3>
+      <p class="" style="">If the room already contains an occupant with the nickname desired by the user seeking to enter the room (or if the nickname is reserved by a user on the member list), the service MUST deny access to the room and inform the user of the conflict; this is done by returning a presence stanza of type &quot;error&quot; specifying a &quot;Conflict&quot; error condition:</p>
+      <p class="caption">Example 26. Service Denies Access Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.11 <a name="enter-history">Discussion History</a>
+</h3>
+      <p class="" style="">After sending initial presence as shown above, a room MAY send discussion history to the new occupant. Whether such history is sent, and how many messages comprise the history, shall be determined by the chat service implementation or specific deployment.</p>
+      <p class="caption">Example 27. Delivery of Discussion History</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20021013T23:58:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20021013T23:58:43'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries 'Tis time, 'tis time.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='hag66@shakespeare.lit/pda'
+     stamp='20021013T23:58:49'/&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">Discussion history messages SHOULD be stamped with extended information in the 'jabber:x:delay' namespace (see <span class="ref">Delayed Delivery</span>  [<a href="#nt-id2607384">5</a>]) to indicate that they are sent with delayed delivery. The 'from' attribute SHOULD be the JID of the original sender in non-anonymous rooms, but MUST NOT be in semi-anonymous rooms (the 'from' attribute SHOULD be set to the room JID in semi-anonymous rooms).</p>
+    </div>
+    <div class="indent">
+<h3>6.3.12 <a name="enter-managehistory">Managing Discussion History</a>
+</h3>
+      <p class="" style="">A user MAY want to manage the amount of discussion history provided on entering a room (perhaps because the user is on a low-bandwidth connection or is using a small-footprint client). This can be accomplished by including a &lt;history/&gt; child in the initial presence stanza sent when joining the room. There are four allowable attributes for this element:</p>
+      <p class="caption">Table 7: History Management Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Attribute</th>
+          <th colspan="" rowspan="">Datatype</th>
+          <th colspan="" rowspan="">Meaning</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxchars</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of characters in the history to &quot;X&quot;.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxstanzas</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of messages in the history to &quot;X&quot;.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">seconds</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Send only the messages received in the last &quot;X&quot; seconds.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">since</td>
+          <td align="" colspan="" rowspan="">dateTime</td>
+          <td align="" colspan="" rowspan="">Send only the messages received since the dateTime specified (which MUST conform to <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2607608">6</a>]).</td>
+        </tr>
+      </table>
+      <p class="" style="">The service MUST send the smallest amount of traffic that meets any combination of the above criteria, taking into account service-level and room-level defaults. The service MUST send complete message stanzas only (i.e., it MUST not literally truncate the history at a certain number of characters, but MUST send the largest number of complete stanzas that results in a number of characters less than or equal to the 'maxchars' value specified). If the client wishes to receive no history, it MUST set the 'maxcharts' attribute to a value of &quot;0&quot; (zero).</p>
+      <p class="" style="">The following examples illustrate the use of this protocol.</p>
+      <p class="caption">Example 28. User Requests Limit on Number of Messages in History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxstanzas='20'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 29. User Requests History in Last 3 Minutes</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history seconds='180'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 30. User Requests All History Since the Beginning of the Unix Era</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history since='1970-01-01T00:00Z'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Obviously the service SHOULD NOT return all messages sent in the room since the beginning of the Unix era, and SHOULD appropriately limit the amount of history sent to the user based on service or room defaults.</p>
+      <p class="caption">Example 31. User Requests No History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxchars='0'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.13 <a name="enter-create">Room Creation</a>
+</h3>
+      <p class="" style="">If the room does not already exist when the user seeks to enter it, the service MAY be responsible for creating it; however, this is OPTIONAL, since an implementation or deployment MAY choose to restrict the privilege of creating rooms. See &quot;Owner Use Cases&quot; for details.</p>
+      <p class="" style="">If a user attempts to enter a room that does not exist or to enter a room while it is &quot;locked&quot; (i.e., before the room creator provides an initial configuration and therefore before the room officially exists), the service MUST refuse entry and return a &quot;Not Found&quot; error to the user:</p>
+      <p class="caption">Example 32. Service Denies Access Because Room Does Not Exist</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="exit">Exiting a Room</a>
+</h3>
+    <p class="" style="">In order to exit a multi-user chat room, an occupant sends a presence stanza of type &quot;unavailable&quot; to the room@service/nick it is currently using in the room.</p>
+    <p class="caption">Example 33. Occupant Exits a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send presence stanzas of type &quot;unavailable&quot; from the departing occupant's room JID to the full JIDs of the departing occupant and of the remaining occupants:</p>
+    <p class="caption">Example 34. Service Sends Presence Related to Departure of Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Presence stanzas of type &quot;unavailable&quot; reflected by the room MUST contain extended presence information about roles and affiliations, and MAY also contain normal &lt;show/&gt; and &lt;status/&gt; information (this last enables occupants to provide custom exit messages if desired).</p>
+    <p class="" style="">Normal presence stanza generation rules apply as defined in <span style="font-weight: bold">XMPP IM</span>, so that if the user sends a general unavailable presence stanza, the user's server will broadcast that stanza to the room@service/nick to which the user's client has sent directed presence.</p>
+    <p class="" style="">If the room is not persistent and this occupant is the last to exit, the service is responsible for destroying the room.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="changenick">Changing Nickname</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability for an occupant to change his or her nickname within the room. In Jabber this is done by sending updated presence information to the room, specifically by sending presence to a new room JID in the same room (changing only the resource identifier in the room JID).</p>
+    <p class="caption">Example 35. Occupant Changes Nickname</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'/&gt;
+    </pre></div>
+    <p class="" style="">The service then sends two presence packets to the full JID of each occupant (including the occupant who is changing his or her room nickname), one of type &quot;unavailable&quot; for the old nickname and one indicating availability for the new nickname. The unavailable presence MUST contain the new nickname and an appropriate status code (namely 303) as extended presence information in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace so that Jabber clients are able to provide relevant hints to occupants regarding the nickname change if desired.</p>
+    <p class="caption">Example 36. Service Updates Nick</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If the user attempts to change his or her room nickname to a room nickname that is already in use by another occupant (or that is reserved by someone affiliated with the room, e.g., a member or owner), the service MUST deny the nickname change request and inform the user of the conflict; this is done by returning a presence stanza of type &quot;error&quot; specifying a &quot;Conflict&quot; error condition:</p>
+    <p class="caption">Example 37. Service Denies Nickname Change Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="changepres">Changing Availability Status</a>
+</h3>
+    <p class="" style="">In multi-user chat systems such as IRC, one common use for changing one's room nickname is to indicate a change in one's availability (e.g., changing one's room nickname to &quot;thirdwitch|away&quot;). In Jabber, availability is of course noted by a change in presence (specifically the &lt;show/&gt; and &lt;status/&gt; elements), which can provide important context within a chatroom. An occupant changes availability status within the room by sending the updated presence to room@service/nick.</p>
+    <p class="caption">Example 38. Occupant Changes Availability Status</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The service then sends a presence packet from the occupant changing his or her presence to the full JID of each occupant, including extended presence information about the occupant's role and full JID to those with privileges to view such information:</p>
+    <p class="caption">Example 39. Service Passes Along Changed Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="invite">Inviting Another User to a Room</a>
+</h3>
+    <p class="" style="">It can be useful to invite another user to a room in which one is an occupant. Several different mechanisms have been suggested in the past to do this. The protocol most commonly used is for the inviting occupant to send a message directly to the invitee, containing extended content in the jabber:x:conference namespace. The server (not the chat service) adds a 'from' address to the invite message, which is delivered like any other message. This undocumented protocol, which is not part of &quot;groupchat 1.0&quot;, is as follows:</p>
+    <p class="caption">Example 40. Occupant Sends an Invitation (Existing Protocol)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;body&gt;You have been invited to darkcave@macbeth.&lt;/body&gt;
+    &lt;x jid='room@service' xmlns='jabber:x:conference'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While the current protocol meets the needs of existing implementations, it could not work within the context of a members-only room, since the service needs to keep track of who is registered as a member. Because we would like to support members-only rooms, it seems desirable for an occupant to send the invitation to the room itself and have the room keep track of the invitations (if the room is members-only) or simply forward the invitation to the invitee.</p>
+    <p class="" style="">Therefore the old undocumented protocol SHOULD be officially discouraged (it cannot be deprecated since it was never approved) and a MUC-compliant client MUST instead send XML of the following form to the room itself (the reason is OPTIONAL and the message MUST NOT possess a 'type' attribute; the service MAY ignore or reject invites that possess a 'type' attribute):</p>
+    <p class="caption">Example 41. Occupant Sends an Invitation by Way of Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The room itself MUST then add a 'from' address to the &lt;invite/&gt; element equal to the bare JID (or, optionally, the room JID) of the inviter and send the invitation to the invitee captured in the 'to' address (the service SHOULD include the jabber:x:conference information for backward compatibility and MAY if desired include a message body explaining the invitation or containing the reason; in addition, the room SHOULD add the password if the room is password-protected):</p>
+    <p class="caption">Example 42. Room Sends Invitation to Invitee on Behalf of Inviter</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+  &lt;x jid='room@service' xmlns='jabber:x:conference'&gt;
+    Hey Hecate, this is the place for all good witches!
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MAY also add the invitee to the member list. (Note that invitation privileges in members-only rooms SHOULD be restricted to room admins; if a member without privileges to edit the member list attempts to invite another user, the service SHOULD return a &quot;Forbidden&quot; error to the occupant; for details, see the &quot;Modifying the Member List&quot; use case under Moderator Use Cases.)</p>
+    <p class="" style="">If the inviter supplies a non-existent JID, the room SHOULD return a &quot;Not Found&quot; error to the inviter.</p>
+    <p class="" style="">The invitee MAY choose to formally decline (as opposed to ignore) the invitation; and this is something that the sender may want to be informed about. In order to decline the invitation, the invitee MUST send a message of the following form to the room itself:</p>
+
+    <p class="caption">Example 43. Invitee Declines Invitation</p>
+<div class="indent"><pre>
+&lt;message
+    from='hecate@shakespeare.lit/broom'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline to='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 44. Room Informs Inviter that Invitation Was Declined</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline from='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">It may be wondered why the invitee does not send the decline message directly to the inviter. The main reason is that certain implementations MAY choose to base invitations on room JIDs rather than bare JIDs (so that, for example, an occupant could invite someone from one room to another without knowing that person's bare JID), in which case the service MUST handle both the invites and declines.</p>
+  </div>
+  <div class="indent">
+<h3>6.8 <a name="subject-occupant">Occupant Modification of the Room Subject</a>
+</h3>
+    <p class="" style="">If allowed in accordance with room configuration, a mere occupant MAY have the privileges to change the subject in a room. For details, see the &quot;Modifying the Room Subject&quot; use case under &quot;Moderator Use Cases&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>6.9 <a name="privatemessage">Sending a Private Message</a>
+</h3>
+    <p class="" style="">Since each occupant has a unique room JID, an occupant MAY send a &quot;private message&quot; to a selected occupant via the service by sending a message to the occupant's room JID. The message type SHOULD be &quot;chat&quot; and MUST NOT be &quot;groupchat&quot;, but MAY be left unspecified (i.e., a normal message). This privilege SHOULD be allowed to any occupant (even a visitor in a moderated room).</p>
+    <p class="caption">Example 45. Occupant Sends Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for changing the 'from' address to the sender's room JID and delivering the message to the intended recipient's full JID.</p>
+    <p class="caption">Example 46. Recipient Receives the Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message of type &quot;groupchat&quot; to a particular occupant, the service MUST refuse to deliver the message and return a &quot;Bad Request&quot; error to the sender:</p>
+    <p class="caption">Example 47. Occupant Attempts to Send a Message of Type &quot;Groupchat&quot; to a Particular Occupant</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='groupchat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message to a room JID that does not exist, the service MUST return a &quot;Not Found&quot; error to the sender.</p>
+    <p class="" style="">If the sender is not an occupant of the room in which the intended recipient is visiting, the service MUST return a &quot;Not Acceptable&quot; error to the sender.</p>
+  </div>
+  <div class="indent">
+<h3>6.10 <a name="message">Sending a Message to All Occupants</a>
+</h3>
+    <p class="" style="">An occupant can send a message to all other occupants in the room by sending a message of type &quot;groupchat&quot; to the room itself (a service MAY ignore or reject messages that do not have a type of &quot;groupchat&quot;). In a moderated room, this privilege is restricted to occupants with a role of participant or higher. In an unmoderated room, any occupant can send a message to all other occupants by directing the message to the room itself and setting the 'type' attribute to a value of &quot;groupchat&quot;.</p>
+    <p class="caption">Example 48. Occupant Sends a Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender has voice in the room (this is the default except in moderated rooms), the service MUST change the 'from' attribute to the sender's room JID and reflect the message out to the full JID of each occupant.</p>
+    <p class="caption">Example 49. Service Reflects Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender is a visitor (i.e., does not have voice in a moderated room), the service MAY return a &quot;Forbidden&quot; error to the sender and MUST NOT reflect the message to all occupants. If the sender is not an occupant of the room, the service SHOULD return a &quot;Not Acceptable&quot; error to the sender and SHOULD NOT reflect the message to all occupants; however, an implementation MAY allow users with certain privileges (e.g., a room owner, room admin, or service-level admin) to send messages to the room even if that user is not an occupant.</p>
+  </div>
+  <div class="indent">
+<h3>6.11 <a name="register">Registering with a Room</a>
+</h3>
+    <p class="" style="">An implementation MAY allow an unaffiliated user (in a moderated room, probably a participant) to register with a room and thus become a member of the room (conversely, an implementation MAY restrict this privilege and allow only room admins to add new members). If allowed, this functionality SHOULD be implemented by enabling a user to send a request for registration requirements to the room in the 'jabber:iq:register' namespace:</p>
+    <p class="caption">Example 50. User Requests Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user requesting registration requirements is not allowed to register with the room (e.g., because that privilege has been restricted), the room MUST return a &quot;Not Allowed&quot; error to the user.</p>
+    <p class="" style="">Otherwise, the room MUST then return a form to the user in the 'jabber:x:data' namespace. The specific information required to register is not specified in this JEP and MAY vary by implementation or deployment. The following can be taken as a fairly typical example:</p>
+    <p class="caption">Example 51. Service Returns Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      To register on the web, visit http://shakespeare.lit/
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Dark Cave Registration&lt;/title&gt;
+      &lt;instructions&gt;
+        Please provide the following information
+        to register with this room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#user&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='First Name'
+          type='text-single'
+          var='muc#user_first'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Last Name'
+          type='text-single'
+          var='muc#user_last'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Desired Nickname'
+          type='text-single'
+          var='muc#user_roomnick'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Your URL'
+          type='text-single'
+          var='muc#user_url'/&gt;
+      &lt;field
+          label='Email Address'
+          type='text-single'
+          var='muc#user_email'/&gt;
+      &lt;field
+          label='FAQ Entry'
+          type='text-multi'
+          var='muc#user_faqentry'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The user SHOULD then submit the form:</p>
+    <p class="caption">Example 52. User Submits Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#user&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#user_first'&gt;
+        &lt;value&gt;Brunhilde&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#user_last'&gt;
+        &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#user_roomnick'&gt;
+        &lt;value&gt;thirdwitch&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#user_url'&gt;
+        &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#user_email'&gt;
+        &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#user_faqentry'&gt;
+        &lt;value&gt;Just another witch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the desired room nickname is already reserved for that room, the room MUST return a &quot;Conflict&quot; error to the user:</p>
+    <p class="caption">Example 53. Room Returns Conflict Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room or service does not support registration, it MUST return a &quot;Service Unavailable&quot; error to the user:</p>
+    <p class="caption">Example 54. Room Returns Service Unavailable Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the room MUST inform the user of successful registration:</p>
+    <p class="caption">Example 55. Room Informs User of Successful Registration</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After the user successfully submits the form, the service MAY queue the request for review by the room admins or MAY immediately add the user to the member list by changing the user's affiliation from &quot;none&quot; to &quot;member&quot;. If the service changes the user's affiliation and the user is in the room, it MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 56. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a user has registered with a room, the room MAY choose to restrict the user to use of the registered nickname only in that room. If it does so, it SHOULD return a &quot;Not Acceptable&quot; (406) error to the user if the user attempts to join the room with a roomnick other than the user's registered roomnick.</p>
+  </div>
+  <div class="indent">
+<h3>6.12 <a name="reservednick">Discovering Reserved Room Nickname</a>
+</h3>
+    <p class="" style="">A user MAY have a reserved room nickname, for example through explicit room registration or database integration. In such cases it may be desirable for the user to discover the reserved nickname before attempting to enter the room (e.g., because the user has forgotten his or her reserved nickname). This is done by sending a Service Discovery information request to the room JID while specifying a Service Discovery node of &quot;x-roomuser-item&quot;.</p>
+    <p class="caption">Example 57. User Requests Reserved Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='getnick1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It is OPTIONAL for a multi-user chat service to support the foregoing service discovery node. If it does and the user has a registered nickname, it MUST return the nickname to the user as value of the 'name' attribute of a Service Discovery &lt;identity/&gt; element (for which the category/type SHOULD be &quot;conference/member&quot;):</p>
+    <p class="caption">Example 58. Room Returns Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='getnick1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'&gt;
+    &lt;identity
+        category='conference'
+        name='thirdwitch'
+        type='text'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user does not have a registered nickname, the room MUST return a service discovery &lt;query/&gt; element that is empty (in accordance with JEP-0030).</p>
+    <p class="" style="">If the room or service does not support the foregoing service discovery node, it MUST return a &quot;Feature Not Implemented&quot; (502) error to the user.</p>
+    <p class="" style="">Even if a user has registered one room nickname, the service SHOULD allow the user to specify a different nickname on entering the room (e.g., in order to join from different client resources), although the service MAY choose to &quot;lock down&quot; nicknames and therefore deny entry to the user, including a &quot;Not Acceptable&quot; (406) error. The service MUST NOT return an error to the user if his or her client performs the foregoing request after having already joined the room.</p>
+    <p class="" style="">If another user attempts to join the room with a nickname reserved by the first user, the service MUST deny entry to the second user and return a &quot;Conflict&quot; error.</p>
+  </div>
+<h2>7.
+       <a name="moderator">Moderator Use Cases</a>
+</h2>
+  <p class="" style="">A moderator has privileges to perform certain actions within the room (e.g., to change the roles of some occupants) but does not have rights to change persistent information about affiliations, which can be changed only by an admin. Exactly which actions can be performed by a moderator is subject to configuration. However, for the purposes of the MUC framework, moderators are stipulated to have privileges to perform the following actions:</p>
+  <ol start="" type="">
+    <li>discover an occupant's full JID in a semi-anonymous room (occurs by default as shown above)</li>
+    <li>modify the subject</li>
+    <li>kick a participant or visitor from the room</li>
+    <li>grant or revoke voice in a moderated room</li>
+    <li>modify the list of occupants who have voice in a moderated room</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response &quot;conversation&quot; using &lt;iq/&gt; elements that contain children scoped by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the user@host of the 'from' address of the request does not match the full JID of one of the moderators; in this case, the service MUST return a &quot;Forbidden&quot; error.)</p>
+  <div class="indent">
+<h3>7.1 <a name="subject-mod">Modifying the Room Subject</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability to change the subject within the room. As a default, only users with a role of &quot;moderator&quot; SHOULD be allowed to change the subject in a room (although this SHOULD be configurable, with the result a mere participant or even visitor may be allowed to change the subject if desired). The subject can be changed by sending a message of type &quot;groupchat&quot; to the room@service, containing no body but a &lt;subject/&gt; that specifies the new subject:</p>
+    <p class="caption">Example 59. Moderator Changes Subject</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If a compliant service receives such a message, it MUST reflect the message to all other occupants with a 'from' address equal to the room JID that corresponds to the sender of the subject change:</p>
+    <p class="caption">Example 60. Service Informs All Occupants of Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the room SHOULD include the last subject change in the discussion history sent when a new occupant joins the room.</p>
+    <p class="" style="">A compliant client that receives such a message MAY choose to display an in-room message; the body of such in-room messages SHOULD NOT be generated by the sending client or the service, so as to ensure correct localization (however, the sending client or service MAY generate the body if desired). The in-room message could be something like the following:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+* secondwitch has changed the subject to: Fire Burn and Cauldron Bubble!
+    </pre></div>
+    <p class="" style="">If someone without appropriate privileges attempts to change the room subject, the service MUST return a message of type &quot;error&quot; specifying a &quot;Forbidden&quot; error condition:</p>
+    <p class="caption">Example 61. Service Returns Error Related to Unauthorized Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="kick">Kicking a Visitor or Participant from a Room</a>
+</h3>
+    <p class="" style="">A moderator has permissions kick a visitor or participant from a room. The kick is normally performed based on the occupant's room nickname (though it MAY be based on the full JID) and is effected by setting the role of a participant or visitor to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 62. Moderator Kicks Occupant</p>
+<div class="indent"><pre>
+&lt;iq from='fluellen@shakespeare.lit/pda'
+    id='kick1'
+    to='harfleur@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='pistol' role='none'&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the kicked occupant by sending a presence stanza of type &quot;unavailable&quot; to each kicked occupant, including status code 307 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the kick.</p>
+    <p class="caption">Example 63. Service Removes Kicked Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='pistol@shakespeare.lit/harfleur'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='fluellen@shakespeare.lit'/&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the kicked user to understand why he or she was kicked, and by whom if the kicked occupant would like to discuss the matter.</p>
+    <p class="" style="">After removing the kicked occupant(s), the service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 64. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='harfleur@henryv.shakespeare.lit'
+    id='kick1'
+    to='fluellen@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After informing the moderator, the service MUST then inform all of the remaining occupants that the kicked occupant is no longer in the room by sending presence stanzas of type &quot;unavailable&quot; from the kicked occupant to all the remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason.</p>
+    <p class="caption">Example 65. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='gower@shakespeare.lit/cell'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator cannot be kicked from a room, nor can any user with an affiliation of &quot;owner&quot; or &quot;admin&quot;. If a moderator attempts to kick such a user, the service MUST deny the request and return a &quot;Not Allowed&quot; error to the sender:</p>
+    <p class="caption">Example 66. Service Returns Error on Attempt to Kick Moderator, Admin, or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='kicktest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='firstwitch' role='none'&gt;
+      &lt;reason&gt;Be gone!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="grantvoice">Granting Voice to a Visitor</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to manage who does and does not have &quot;voice&quot; in the room. Voice is granted based on the visitor's room nickname, which the service will convert into the visitor's full JID internally. The moderator can grant voice to a visitor by changing the visitor's role to &quot;participant&quot; (the &lt;reason/&gt; element is optional):</p>
+    <p class="caption">Example 67. Moderator Grants Voice to a Visitor</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 68. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the addition of voice privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;participant&quot;.</p>
+    <p class="caption">Example 69. Service Sends Notice of Voice to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="revokevoice">Revoking Voice from a Participant</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to revoke a participant's privileges to speak. The moderator can revoke voice from a participant by changing the participant's role to &quot;visitor&quot;:</p>
+    <p class="caption">Example 70. Moderator Revokes Voice from a Participant</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 71. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of voice privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;visitor&quot;.</p>
+    <p class="caption">Example 72. Service Notes Loss of Voice</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='visitor'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator MUST NOT be able to revoke voice from a user whose affiliation is at or above the moderator's level. In addition, a service MUST NOT allow the voice privileges of an admin or owner to be removed by anyone. If a moderator attempts to revoke voice privileges from such a user, the service MUST deny the request and return a &quot;Not Allowed&quot; error to the sender:</p>
+    <p class="caption">Example 73. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voicetest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.5 <a name="modifyvoice">Modifying the Voice List</a>
+</h3>
+    <p class="" style="">A moderator in a moderated room may want to modify the voice list. To do so, the moderator first requests the voice list by querying the room for all occupants with a role of 'participant'.</p>
+    <p class="caption">Example 74. Moderator Requests Voice List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='voice3'
+    to='goodfolk@chat.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the voice list to the moderator; each item MUST include the 'nick' and 'role' attributes and SHOULD include the 'affiliation' and 'jid' attributes:</p>
+    <p class="caption">Example 75. Service Sends Voice List to Moderator</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='polonius@hamlet/castle'
+          nick='Polo'
+          role='participant'/&gt;
+    &lt;item affiliation='none'
+          jid='horatio@hamlet/castle'
+          nick='horotoro'
+          role='participant'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The moderator can then modify the voice list and send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'nick' and 'role' attributes but SHOULD NOT include the 'jid' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as owner rather than the participant role):</p>
+    <p class="caption">Example 76. Moderator Sends Modified Voice List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='voice4'
+    to='goodfolk@chat.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='Hecate'
+          role='visitor'/&gt;
+    &lt;item nick='rosencrantz'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item nick='guildenstern'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 77. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice1'
+    to='author@shakespeare.lit/globe'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in voice privileges by sending the appropriate extended presence packets as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, voice privileges cannot be revoked from a room owner or room admin, nor from any user with a higher affiliation than the moderator making the request. If a room admin attempts to revoke voice privileges from such a user by modifying the voice list, the service MUST deny the request and return a &quot;Not Allowed&quot; error to the sender:</p>
+    <p class="caption">Example 78. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voicetest'
+    to='author@shakespeare.lit/globe'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit'
+          nick='Hecate'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="admin">Admin Use Cases</a>
+</h2>
+  <p class="" style="">A room administrator has privileges to modify persistent information about user affiliations (e.g., by banning users) and to grant and revoke moderator privileges, but does not have rights to change the defining features of the room, which are the sole province of the room owner. Exactly which actions MAY be performed by a room admin will be subject to configuration. However, for the purposes of the MUC framework, room admins are stipulated to have privileges to perform the following actions:</p>
+  <ol start="" type="">
+    <li>ban a user from the room</li>
+    <li>modify the list of users who are banned from the room</li>
+    <li>grant or revoke membership</li>
+    <li>modify the member list</li>
+    <li>grant or revoke moderator privileges</li>
+    <li>modify the list of moderators</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response &quot;conversation&quot; using &lt;iq/&gt; elements that contain children scoped by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions proposed to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the user@host of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a &quot;Forbidden&quot; error.)</p>
+  <div class="indent">
+<h3>8.1 <a name="ban">Banning a User</a>
+</h3>
+    <p class="" style="">An admin or owner can ban one or more users from a room. The ban MUST be performed based on the occupant's bare JID. In order to ban a user, an admin MUST change the user's affiliation to &quot;outcast&quot;.</p>
+    <p class="caption">Example 79. Admin Bans User</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban1'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add that bare JID to the ban list and inform the admin or owner of success:</p>
+    <p class="caption">Example 80. Service Informs Admin or Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban1'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also remove any banned users who are in the room by sending a presence stanza of type &quot;unavailable&quot; to each banned occupant, including status code 301 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the ban.</p>
+    <p class="caption">Example 81. Service Removes Banned User</p>
+<div class="indent"><pre>
+&lt;presence
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='earlofcambridge@shakespeare.lit/stabber'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast' role='none'&gt;
+      &lt;actor jid='kinghenryv@shakespeare.lit'/&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the banned user to understand why he or she was banned, and by whom if the banned user would like to discuss the matter.</p>
+    <p class="" style="">The service MUST then inform all of the remaining occupants that the banned user is no longer in the room by sending presence stanzas of type &quot;unavailable&quot; from the banned user to all remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason:</p>
+    <p class="caption">Example 82. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    type='unavailable'
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='exeter@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit/stabber'
+          role='none'/&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">An owner or admin cannot be banned from a room. If a room admin attempts to ban such a user, the service MUST deny the request and return a &quot;Not Allowed&quot; error to the sender:</p>
+    <p class="caption">Example 83. Service Returns Error on Attempt to Ban an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='harfleur@henryv.shakespeare.lit'
+    id='bantest'
+    to='exeter@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='kinghenryv@shakespeare.lit'
+          nick='TheKing'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="modifyban">Modifying the Ban List</a>
+</h3>
+    <p class="" style="">A room admin may want to modify the ban list. Note that the ban list is always based on a user's bare JID (unlike the ban command which is usually based on a room nickname), although a nick (perhaps the last room nickname associated with that JID) MAY be included for convenience. To modify the list of banned JIDs, the admin first requests the ban list by querying the room for all users with an affiliation of 'outcast'.</p>
+    <p class="caption">Example 84. Admin Requests Ban List</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban2'
+    to='southampton@henryv.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the list of banned users to the admin; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' and 'role' attributes:</p>
+    <p class="caption">Example 85. Service Sends Ban List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban2'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin can then modify the ban list and send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the outcast affiliation); in addition, the reason and actor elements are OPTIONAL:</p>
+    <p class="caption">Example 86. Admin Sends Modified Ban List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban3'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'&gt;
+          jid='lordscroop@shakespeare.lit' 
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'
+          jid='sirthomasgrey@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">After updating the ban list, the service MUST inform the admin of success:</p>
+    <p class="caption">Example 87. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban3'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then remove the affected occupants (if they are in the room) and send updated presence (including the appropriate status code) from them to all the remaining occupants as described in the &quot;Banning a User&quot; use case. (The service SHOULD also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.)</p>
+    <p class="" style="">As noted, a room owner or room admin cannot be banned from a room. If a room admin attempts to ban such a user by means of modifying the ban list, the service MUST deny the request and return a &quot;Not Allowed&quot; error to the sender:</p>
+    <p class="caption">Example 88. Service Returns Error on Attempt to Ban an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='bantest'
+    to='lordscroop@shakespeare.lit'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='exeter@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">When an entity is banned from a room, an implementation SHOULD match JIDs in the following order (these matching rules are the same as those defined for privacy lists in <span class="ref">XMPP IM</span>  [<a href="#nt-id2610115">7</a>]):</p>
+    <ol start="" type="">
+      <li>&lt;user@domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;user@domain&gt; (any resource matches)</li>
+      <li>&lt;domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;domain&gt; (the domain itself matches, as does any user@domain, domain/resource, or address containing a subdomain)</li>
+    </ol>
+    <p class="" style="">Some administrators may wish to ban all users associated with a specific domain from all rooms hosted by a MUC service. Such functionality is a service-level feature and is therefore out of scope for this document.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="grantmember">Granting Membership</a>
+</h3>
+    <p class="" style="">An admin can grant membership to a user; this is done by changing the user's affiliation to &quot;member&quot; (normally based on nick if the user is in the room, or on bare JID if not; in either case, if the nick is provided, that nick becomes the user's default nick in the room if that functionality is supported by the implementation):</p>
+    <p class="caption">Example 89. Admin Grants Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 90. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 91. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="revokemember">Revoking Membership</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's membership; this is done by changing the user's affiliation to &quot;none&quot;:</p>
+    <p class="caption">Example 92. Admin Revokes Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          nick='thirdwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 93. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 94. Service Notes Loss of Membership</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MUST remove the user from the room, including a status code of 321 to indicate that the user was removed because of an affiliation change, and inform all remaining occupants:</p>
+    <p class="caption">Example 95. Service Removes Non-Member</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='author@shakespeare.lit'/&gt;
+    &lt;/item&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="modifymember">Modifying the Member List</a>
+</h3>
+    <p class="" style="">In the context of a members-only room, the member list is essentially a &quot;whitelist&quot; of people who are allowed to enter the room. Anyone who is not a member is effectively banned from entering the room, even if their affiliation is not &quot;outcast&quot;.</p>
+    <p class="" style="">In the context of an open room, the member list is simply a list of users (bare JID and reserved nick) who are registered with the room. Such users may appear in a room roster, have their room nickname reserved, be returned in search results or FAQ queries, and the like.</p>
+    <p class="" style="">It is RECOMMENDED that only room admins have the privilege to modify the member list in members-only rooms. To do so, the admin first requests the member list by querying the room for all users with an affiliation of &quot;member&quot;:</p>
+    <p class="caption">Example 96. Admin Requests Member List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">(A service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &quot;Forbidden&quot; error when a member in the room requests the member list. This functionality may assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited.)</p>
+    <p class="" style="">The service MUST then return the full member list to the admin in the 'http://jabber.org/protocol/muc#admin' namespace; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for each members that is currently an occupant.</p>
+    <p class="caption">Example 97. Service Sends Member List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'
+          nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin can then modify the member list and send the changed items (i.e., only the &quot;delta&quot;) to the service; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the member affiliation):</p>
+    <p class="caption">Example 98. Admin Sends Modified Member List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 99. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST change the affiliation of any affected user. If the user has been removed from the member list, the service MUST change the user's affiliation from &quot;member&quot; to &quot;none&quot;. If the user has been added to the member list, the service MUST change the user's affiliation to &quot;member&quot;.</p>
+    <p class="" style="">If the removed member is currently in a members-only room, the service SHOULD kick the occupant by changing the removed member's role to &quot;none&quot;. No matter whether the removed member was in or out of a members-only room, the service MUST subsequently refuse entry to the user.</p>
+    <p class="" style="">If the removed member is in an open room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 100. Service Sends Notice of Loss of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the service SHOULD send an invitation to any user who has been added to the member list of a members-only room (such a user would by definition not be in the room; note also that this example includes a password but not a reason -- both child elements are OPTIONAL):</p>
+    <p class="caption">Example 101. Room Sends Invitation to New Member</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='author@shakespeare.lit'/&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+  &lt;x jid='darkcave@macbeth.shakespeare.lit'
+     xmlns='jabber:x:conference'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While only admins and owners SHOULD be allowed to modify the member list, an implementation MAY provide a configuration option that opens invitation privileges to any member of a members-only room. In such a situation, any invitation sent SHOULD automatically trigger the addition of the invitee to the member list. However, if invitation privileges are restricted to admins and a mere member attempts to a send an invitation, the service MUST deny the invitation request and return a &quot;Forbidden&quot; error to the sender:</p>
+    <p class="caption">Example 102. Service Returns Error on Attempt by Mere Member to Invite Others to a Members-Only Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.</p>
+    <p class="" style="">If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 103. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.6 <a name="grantmod">Granting Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to grant moderator privileges to a participant or visitor; this is done by changing the user's role to &quot;moderator&quot;:</p>
+    <p class="caption">Example 104. Admin Grants Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 105. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 106. Service Sends Notice of Moderator Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.7 <a name="revokemod">Revoking Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's moderator privileges. An admin MAY revoke moderator privileges only from a user whose affiliation is &quot;member&quot; or &quot;none&quot; (i.e., not from an owner or admin). The privilege is revoked by changing the user's role to &quot;participant&quot;:</p>
+    <p class="caption">Example 107. Admin Revokes Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 108. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;participant&quot;.</p>
+    <p class="caption">Example 109. Service Notes Loss of Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As noted, an admin MUST NOT be allowed to revoke moderator privileges from a user whose affiliation is &quot;owner&quot; or &quot;admin&quot;. If an admin attempts to revoke moderator privileges from such a user, the service MUST deny the request and return a &quot;Not Allowed&quot; error to the sender:</p>
+    <p class="caption">Example 110. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.8 <a name="modifymod">Modifying the Moderator List</a>
+</h3>
+    <p class="" style="">An admin may want to modify the moderator list. To do so, the admin first requests the moderator list by querying the room for all users with a role of 'moderator'.</p>
+    <p class="caption">Example 111. Admin Requests Moderator List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the moderator list to the admin; each item MUST include the 'jid', 'nick', and 'role' attributes and MAY include the 'affiliation' attribute:</p>
+    <p class="caption">Example 112. Service Sends Moderator List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hag66@shakespeare.lit/pda'
+          nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin can then modify the moderator list and send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'jid' and 'role' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as admin rather than the moderator role):</p>
+    <p class="caption">Example 113. Admin Sends Modified Moderator List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 114. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator privileges by sending the appropriate extended presence packets as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, moderator privileges cannot be revoked from a room owner or room admin. If a room admin attempts to revoke moderator privileges from such a user by modifying the moderator list, the service MUST deny the request and return a &quot;Not Allowed&quot; error to the sender:</p>
+    <p class="caption">Example 115. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="owner">Owner Use Cases</a>
+</h2>
+  <p class="" style="">Every room MUST have at least one owner, and that owner (or a successor) is a long-lived attribute of the room for as long as the room exists (e.g., the owner does not lose ownership on exiting a persistent room). This JEP assumes that the (initial) room owner is the individual who creates the room and that only a room owner has the right to change defining room configuration settings such as the room type. Ideally, room owners will be able to specify not only the room types (password-protected, members-only, etc.) but also certain attributes of the room as listed under the requirements section of this JEP. In addition, it would be good if an owner were able to specify the JIDs of other owners, but that shall be determined by the implementation.</p>
+  <p class="" style="">In order to provide the necessary flexibility for a wide range of configuration options, <span class="ref">Data Forms</span>  [<a href="#nt-id2611110">8</a>] shall be used for room configuration, triggered by use of the 'http://jabber.org/protocol/muc' namespace.</p>
+  <p class="" style="">Note that the configuration options shown below address all of the features and room types listed in the requirements section of this JEP, but that the exact configuration options and form layout shall be determined by the implementation or specific deployment. Also, these are examples only and are not intended to define the only allowed or required configuration options for rooms. A given implementation or deployment MAY choose to provide many additional configuration options (profanity filters, setting the default language for a room, message logging, etc.), which is why the use of the jabber:x:data protocol is valuable here.</p>
+  <p class="" style="">Note also that the privilege to create rooms MAY be restricted to certain users or reserved to an administrator of the service. If access is restricted and a user attempts to create a room, the service MUST return a &quot;Not Allowed&quot; error:</p>
+  <p class="caption">Example 116. Service Informs User of Inability to Create a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">If access is not restricted, the service MUST allow the user to create a room as described below.</p>
+  <div class="indent">
+<h3>9.1 <a name="createroom">Creating a Room</a>
+</h3>
+    <p class="" style="">From the perspective of room creation, there are in essence two kinds of rooms:</p>
+    <ul>
+      <li><p class="" style="">&quot;Instant rooms&quot; -- these are available for immediate access and are automatically created based on some default configuration.</p></li>
+      <li><p class="" style="">&quot;Reserved rooms&quot; -- these are manually configured by the room creator before anyone is allowed to enter.</p></li>
+    </ul>
+    <p class="" style="">The workflow for creating and configuring such rooms is as follows:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The user MUST send presence to room@service/nick and signal his or her support for the Multi-User Chat protocol by including extended presence information in an empty &lt;x/&gt; child element scoped by the 'http://jabber.org/protocol/muc' namespace (note the lack of an '#owner' or '#user' fragment).</p></li>
+      <li><p class="" style="">If this user is allowed to create a room and the room does not yet exist, the service MUST create the room according to some default configuration, assign the requesting user as the initial room owner, and add the owner to the room but not allow anyone else to enter the room (effectively &quot;locking&quot; the room). The initial presence stanza received by the owner from the room MUST include extended presence information that indicates the user's status as an owner and that acknowledges that the room has been created (via status code 201) and is awaiting configuration.</p></li>
+      <li><p class="" style="">If the initial room owner would like to create and configure a reserved room, the room owner MUST then request a configuration form by sending an IQ stanza of type &quot;get&quot; to the room containing an empty &lt;query/&gt; element scoped by the 'http://jabber.org/protocol/muc#owner' namespace, then complete Steps 4 and 5. If the room owner would prefer to create an instant room, the room owner MUST send a query element scoped by the 'http://jabber.org/protocol/muc#owner' namespace and containing an empty &lt;x/&gt; element of type &quot;submit&quot; scoped by the 'jabber:x:data' namespace, then skip to Step 6.</p></li>
+      <li><p class="" style="">If the room owner requested a configuration form, the service MUST send an IQ to the room owner containing a configuration form in the 'jabber:x:data' namespace. If there are no configuration options available, the room MUST return an empty query element to the room owner.</p></li>
+      <li><p class="" style="">The initial room owner SHOULD provide a starting configuration for the room (or accept the default configuration) by sending an IQ of type &quot;set&quot; containing the completed configuration form. Alternatively, the room owner can cancel the configuration process. (An implementation MAY set a timeout for initial configuration, such that if the room owner does not configure the room within the timeout period, the room owner is assumed to have accepted the default configuration.)</p></li>
+      <li><p class="" style="">Once the service receives the completed configuration form from the initial room owner (or receives a request for an instant room), the service MUST &quot;unlock&quot; the room (i.e., allow other users to enter the room) and send an IQ of type &quot;result&quot; to the room owner. If the service receives a cancellation, it MUST destroy the room.</p></li>
+    </ol>
+    <p class="" style="">The protocol for this workflow is shown in the examples below.</p>
+    <p class="" style="">First, the Jabber user MUST send presence to the room, including and empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace (this is the same stanza sent when seeking to enter a room).</p>
+    <p class="caption">Example 117. Jabber User Creates a Room and Signals Support for Multi-User Chat</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If the room does not yet exist, the service SHOULD create the room (subject to local policies regarding room creation), assign the bare JID of the requesting user as the owner, add the owner to the room, and acknowledge successful creation of the room.</p>
+    <p class="caption">Example 118. Service Creates Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          role='moderator'/&gt;
+    &lt;status code='201'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The initial room owner can request an instant room by sending the following XML:</p>
+    <p class="caption">Example 119. Owner Requests Instant Room</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initial room owner wants to create and configure a reserved room, the room owner MUST request an initial configuration form for the room by not including empty data form in the creation request:</p>
+    <p class="caption">Example 120. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room does not already exist, the service MUST return an initial room configuration form to the user.</p>
+    <p class="caption">Example 121. Service Sends Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+          Your room darkcave@macbeth has been created!
+          The default configuration is as follows:
+            - No logging
+            - No moderation
+            - Up to 20 occupants
+            - No password required
+            - No invitation required
+            - Room is not persistent
+            - Only admins may change the subject
+            - Presence broadcasted for all users
+          To accept the default configuration, click OK. To
+          select a different configuration, please complete
+          this form.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#owner_roomname'/&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#owner_roomdesc'/&gt;
+      &lt;field
+          label='Natural Language for Room Discussions'
+          type='text-single'
+          var='muc#owner_roomlang'/&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#owner_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#owner_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#owner_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#owner_maxusers'&gt;
+        &lt;value&gt;20&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#owner_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#owner_publicroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#owner_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#owner_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members-Only?'
+          type='boolean'
+          var='muc#owner_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required to Enter?'
+          type='boolean'
+          var='muc#owner_passwordprotectedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#owner_roomsecret'/&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#owner_whois'&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#owner_roomadmins'/&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#owner_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner:</p>
+    <p class="caption">Example 122. Service Informs Owner that No Configuration is Possible</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The room owner SHOULD then fill out the form and submit it to the service.</p>
+    <p class="caption">Example 123. Owner Submits Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_changesubject'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#owner_roomadmins'&gt;
+        &lt;value&gt;
+          wiccarocks@shakespeare.lit
+          hecate@shakespeare.lit
+        &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If room creation is successful, the service MUST inform the new room owner of success:</p>
+    <p class="caption">Example 124. Service Informs New Room Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the room owner can cancel the configuration process:</p>
+    <p class="caption">Example 125. Owner Cancels Initial Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room owner cancels the initial configuration, the service SHOULD destroy the room, making sure to send unavailable presence to the room owner (see the &quot;Destroying a Room&quot; use case for protocol details).</p>
+    <p class="" style="">If the room owner becomes unavailable for any reason before submitting the form (e.g., a lost connection), the service will receive a presence stanza of type &quot;unavailable&quot; from the owner to the room@service/nick or room@service (or both). The service MUST then destroy the room, sending a presence stanza of type &quot;unavailable&quot; from the room to the owner including a &lt;destroy/&gt; element and reason (if provided) as defined under the &quot;Destroying a Room&quot; use case.</p>
+    <p class="" style="">If a user attempts to enter the room while the room is &quot;locked&quot; (i.e., before the room creator provides an initial configuration and therefore before the room officially exists), the service MUST refuse entry and return a &quot;Not Found&quot; error to the user:</p>
+    <p class="caption">Example 126. Service Denies Access Because Room Does Not Yet Exist</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="roomconfig">Subsequent Room Configuration</a>
+</h3>
+    <p class="" style="">At any time after specifying the initial configuration of the room, a room owner may want to change the configuration. In order to initiate this &quot;conversation&quot;, a room owner MUST request a new configuration form from the room by sending an IQ to room@service containing an empty &lt;query/&gt; element scoped by the 'http://jabber.org/protocol/muc#owner' namespace.</p>
+    <p class="caption">Example 127. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user@host of the 'from' address does not match the bare JID of a room owner, the service MUST return a &quot;Forbidden&quot; error to the sender:</p>
+    <p class="caption">Example 128. Service Denies Configuration Access to Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='configures'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the service MUST send a configuration form to the room owner with the current options set as defaults:</p>
+    <p class="caption">Example 129. Service Sends Configuration Form to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='config1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+        Complete this form to make changes to
+        the configuration of your room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#owner_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#owner_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#owner_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#owner_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#owner_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#owner_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#owner_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#owner_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#owner_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#owner_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members Only?'
+          type='boolean'
+          var='muc#owner_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required for Entry?'
+          type='boolean'
+          var='muc#owner_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#owner_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#owner_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#owner_roomadmins'&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#owner_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner as shown above.</p>
+    <p class="" style="">The room owner can then submit the form with updated configuration information.</p>
+    <p class="" style="">Alternatively, the room owner can cancel the configuration process:</p>
+    <p class="caption">Example 130. Owner Cancels Subsequent Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room owner cancels the subsequent configuration, the service MUST leave the configuration of the room as it was before the room owner initiated the subsequent configuration process.</p>
+    <p class="" style="">If as a result of a change in the room configuration a room admin loses administrative privileges while the admin is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot; and the 'role' attribute set to a value of &quot;participant&quot; or &quot;visitor&quot; as appropriate for the affiliation level and the room type:</p>
+    <p class="caption">Example 131. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a user gains administrative privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;admin&quot;:</p>
+    <p class="caption">Example 132. Service Notes Gain of Admin Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a room owner loses owner privileges while that owner is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;:</p>
+    <p class="caption">Example 133. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As noted, a service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &quot;Conflict&quot; error to the owner.</p>
+    <p class="" style="">If as a result of a change in the room configuration a user gains ownership privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;owner&quot; and the 'role' attribute set to a value of 'moderator'.</p>
+    <p class="caption">Example 134. Service Notes Gain of Owner Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration the room type is changed to members-only but there are non-members in the room, the service MUST remove any non-members from the room and include a status code of 322 in the presence unavailable stanzas sent to those users as well as any remaining occupants.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="grantowner">Granting Ownership Privileges</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, an owner MAY grant ownership privileges to another user; this is done by changing the user's affiliation to &quot;owner&quot;:</p>
+    <p class="caption">Example 135. Owner Grants Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 136. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of ownership privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;owner&quot; and the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 137. Service Sends Notice of Ownership Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.4 <a name="revokeowner">Revoking Ownership Privileges</a>
+</h3>
+    <p class="" style="">An owner may want to revoke a user's ownership privileges; this is done by changing the user's affiliation to &quot;admin&quot;:</p>
+    <p class="caption">Example 138. Owner Revokes Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &quot;Conflict&quot; error to the owner.</p>
+    <p class="" style="">In all other cases, the service MUST remove the user from the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 139. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of ownership privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;:</p>
+    <p class="caption">Example 140. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.5 <a name="modifyowner">Modifying the Owner List</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, a room owner may want to modify the owner list. To do so, the owner first requests the owner list by querying the room for all users with an affiliation of 'owner'.</p>
+    <p class="caption">Example 141. Owner Requests Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='owner3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the owner list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any owner that is currently an occupant:</p>
+    <p class="caption">Example 142. Service Sends Owner List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='crone1@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner can then modify the owner list and send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the owner affiliation):</p>
+    <p class="caption">Example 143. Owner Sends Modified Owner List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='owner4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As noted, a service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &quot;Conflict&quot; error to the owner.</p>
+    <p class="" style="">In all other cases, the service MUST modify owner list and then inform the owner of success:</p>
+    <p class="caption">Example 144. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a &quot;Forbidden&quot; error to the sender:</p>
+    <p class="caption">Example 145. Service Returns Error on Attempt by Non-Owner to Modify Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='ownertest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.6 <a name="grantadmin">Granting Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner can grant administrative privileges to a member or unaffiliated user; this is done by changing the user's affiliation to &quot;admin&quot;:</p>
+    <p class="caption">Example 146. Owner Grants Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 147. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of administrative privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 148. Service Sends Notice of Administrative Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.7 <a name="revokeadmin">Revoking Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner may want to revoke a user's administrative privileges; this is done by changing the user's affiliation to &quot;member&quot;:</p>
+    <p class="caption">Example 149. Owner Revokes Administrative Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='member'
+          nick='secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 150. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of administrative privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot; and the 'role' attribute set to a value of &quot;participant&quot; or &quot;visitor&quot; as appropriate for the affiliation level and the room type:</p>
+    <p class="caption">Example 151. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.8 <a name="modifyadmin">Modifying the Admin List</a>
+</h3>
+    <p class="" style="">A room owner may want to modify the admin list. To do so, the owner first requests the admin list by querying the room for all users with an affiliation of 'admin'.</p>
+    <p class="caption">Example 152. Owner Requests Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/desktopaffiliation
+    id='admin3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the admin list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any admin that is currently an occupant:</p>
+    <p class="caption">Example 153. Service Sends Admin List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'
+          nick='secondwitch'/&gt;
+    &lt;item affiliation='admin'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner can then modify the admin list and send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the admin affiliation):</p>
+    <p class="caption">Example 154. Owner Sends Modified Admin List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='admin4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 155. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a &quot;Forbidden&quot; error to the sender:</p>
+    <p class="caption">Example 156. Service Returns Error on Attempt by Non-Owner to Modify Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admintest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.9 <a name="destroyroom">Destroying a Room</a>
+</h3>
+    <p class="" style="">A room owner MUST be able to destroy a room that he or she has created, especially if the room is persistent. The workflow is as follows:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The room owner requests that the room be destroyed, specifying a reason and an alternate venue if desired.</p></li>
+      <li><p class="" style="">The room removes all users from the room (including appropriate information about the alternate location and the reason for being removed) and destroys the room, even if it was defined as persistent.</p></li>
+    </ol>
+    <p class="" style="">This JEP does not specify what if anything a compliant component implementation must do as a result of a room destruction request other than the foregoing. For example, if the room was defined as persistent, an implementation MAY choose to reserve the room ID or redirect enter requests to the alternate venue; however, such behavior is OPTIONAL.</p>
+    <p class="" style="">In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. The &lt;iq/&gt; stanza shall contain a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, which in turn shall contain a &lt;destroy/&gt; element. The address of the alternate venue shall be provided in the &lt;destroy/&gt; element's 'jid' attribute (this is OPTIONAL). The reason for the room destruction shall be provided as the XML character data of a &lt;reason/&gt; child element of the &lt;destroy/&gt; element (this, too, is OPTIONAL).</p>
+    <p class="" style="">The following examples illustrate the protocol elements to be sent and received:</p>
+    <p class="caption">Example 157. Owner Submits Room Destruction Request</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='begone'
+    to='heath@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for removing all the occupants. It SHOULD NOT broadcast presence stanzas of type &quot;unavailable&quot; from all occupants, instead sending only one presence stanza of type &quot;unavailable&quot; to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.</p>
+    <p class="caption">Example 158. Service Removes Each Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 159. Service Informs Owner of Successful Destruction</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='begone'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user@host of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a &quot;Forbidden&quot; error to the sender:</p>
+    <p class="caption">Example 160. Service Denies Destroy Request Submitted by Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='destroytest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+  <p class="" style="">The error codes associated with the 'http://jabber.org/protocol/muc#admin' namespace are fairly straightforward. However, in order to make it easier for client and component developers to understand the codes they need to send and receive, the table below provides a summary of all the error and status codes associated with the 'http://jabber.org/protocol/muc#user' namespace. For detailed information about mapping legacy error codes to XMPP-style error types and conditions, refer to <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2613134">9</a>]; compliant implementations SHOULD support both legacy and XMPP error handling (no such requirement applies to MUC status codes).</p>
+  <p class="caption">Table 8: Error and Status Codes for http://jabber.org/protocol/muc#user Namespace</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Code</th>
+      <th colspan="" rowspan="">Type</th>
+      <th colspan="" rowspan="">Element</th>
+      <th colspan="" rowspan="">Context</th>
+      <th colspan="" rowspan="">Purpose</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">100</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that any occupant is allowed to see the user's full JID</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">101</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message (out of band)</td>
+      <td align="" colspan="" rowspan="">Affiliation change</td>
+      <td align="" colspan="" rowspan="">Inform user that his or her affiliation changed while not in the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">102</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">In-room message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that room now shows unavailable members</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">103</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that room now does not show unavailable members</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">104</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that some room configuration has changed</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">201</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that a new room has been created</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">301</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she has been banned from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">303</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Exiting a room</td>
+      <td align="" colspan="" rowspan="">Inform all occupants of new room nickname</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">307</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she has been kicked from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">321</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because of an affiliation change</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">322</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because the room has been changed to members-only and the user is not a member</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">332</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because of a system shutdown</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">401</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that a password is required</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">403</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is banned from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">404</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that the room does not exist</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">405</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that room creation is restricted</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">407</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is not on the member list</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">409</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that his or her desired room nickname is taken</td>
+    </tr>
+  </table>
+  <p class="" style="">This JEP does not stipulate text messages associated with each error condition.</p>
+<h2>11.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">No room entrance authentication method more secure than cleartext passwords is defined or required by this JEP. This is recognized to be sub-optimal; a future proposal will need to address this shortcoming.</p>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2614214">10</a>].</p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2614152">11</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>13.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Multi-User Chat uses the following protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/muc</li>
+      <li>http://jabber.org/protocol/muc#admin</li>
+      <li>http://jabber.org/protocol/muc#owner</li>
+      <li>http://jabber.org/protocol/muc#user</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="registrar-discocat">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">A Multi-User Chat service or room is identified by the &quot;conference&quot; category and the &quot;text&quot; type within Service Discovery. A registry submission is not required, since this entry already exists.</p>
+  </div>
+  <div class="indent">
+<h3>13.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">There are many features related to a MUC service or room that can be discovered by means of Service Discovery. The most fundamental of these is the 'http://jabber.org/protocol/muc' namespace. In addition, a MUC room SHOULD provide information when queried about the specific room features it implements, such as password protection and room moderation.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc&lt;/name&gt;
+  &lt;desc&gt;Multi-User Chat (MUC) namespace&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_hidden&lt;/name&gt;
+  &lt;desc&gt;Hidden room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_membersonly&lt;/name&gt;
+  &lt;desc&gt;Members-only room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_moderated&lt;/name&gt;
+  &lt;desc&gt;Moderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_nonanonymous&lt;/name&gt;
+  &lt;desc&gt;Non-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_open&lt;/name&gt;
+  &lt;desc&gt;Open room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_passwordprotected&lt;/name&gt;
+  &lt;desc&gt;Password-protected room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_persistent&lt;/name&gt;
+  &lt;desc&gt;Persistent room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_public&lt;/name&gt;
+  &lt;desc&gt;Public room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_semianonymous&lt;/name&gt;
+  &lt;desc&gt;Semi-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_temporary&lt;/name&gt;
+  &lt;desc&gt;Temporary room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unmoderated&lt;/name&gt;
+  &lt;desc&gt;Unmoderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unsecured&lt;/name&gt;
+  &lt;desc&gt;Unsecured room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_rooms&lt;/name&gt;
+  &lt;desc&gt;List of MUC rooms (each as a separate item)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>13.4 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2614326">12</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. Within MUC, there are two uses of such forms: room registration within muc#user and room configuration within muc#owner. The reserved fields are defined below.</p>
+    <div class="indent">
+<h3>13.4.1 <a name="registrar-formtype-user">muc#user FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#user&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling user registration with a
+    Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#user_first'
+      type='text-single'
+      label='First Name'/&gt;
+  &lt;field
+      var='muc#user_last'
+      type='text-single'
+      label='Last Name'/&gt;
+  &lt;field
+      var='muc#user_roomnick'
+      type='text-single'
+      label='Desired Nickname'/&gt;
+  &lt;field
+      var='muc#user_url'
+      type='text-single'
+      label='Your URL'/&gt;
+  &lt;field
+      var='muc#user_email'
+      type='text-single'
+      label='Email Address'/&gt;
+  &lt;field
+      var='muc#user_faqentry'
+      type='text-multi'
+      label='FAQ Entry'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.4.2 <a name="registrar-formtype-owner">muc#owner FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#owner&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling owner creation and configuration of
+    a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#owner_roomname'
+      type='text-single'
+      label='Natural-Language Room Name'/&gt;
+  &lt;field
+      var='muc#owner_roomdesc'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#owner_enablelogging'
+      type='boolean'
+      label='Whether to Enable Logging of Room Conversations'/&gt;
+  &lt;field
+      var='muc#owner_changesubject'
+      type='boolean'
+      label='Whether to Allow Occupants to Change Subject'/&gt;
+  &lt;field
+      var='muc#owner_allowinvites'
+      type='boolean'
+      label='Whether to Allow Occupants to Invite Others'/&gt;
+  &lt;field
+      var='muc#owner_maxusers'
+      type='list-single'
+      label='Maximum Number of Room Occupants'/&gt;
+  &lt;field
+      var='muc#owner_presencebroadcast'
+      type='list-multi'
+      label='Roles for which Presence is Broadcast'/&gt;
+  &lt;field
+      var='muc#owner_publicroom'
+      type='boolean'
+      label='Whether to Allow Public Searching for Room'/&gt;
+  &lt;field
+      var='muc#owner_persistentroom'
+      type='boolean'
+      label='Whether to Make Room Persistent'/&gt;
+  &lt;field
+      var='muc#owner_membersonly'
+      type='boolean'
+      label='Whether an Make Room Members-Only'/&gt;
+  &lt;field
+      var='muc#owner_moderatedroom'
+      type='boolean'
+      label='Whether to Make Room Moderated'/&gt;
+  &lt;field
+      var='muc#owner_passwordprotectedroom'
+      type='boolean'
+      label='Whether a Password is Required to Enter'/&gt;
+  &lt;field
+      var='muc#owner_roomsecret'
+      type='text-private'
+      label='The Room Password'/&gt;
+  &lt;field
+      var='muc#owner_whois'
+      type='list-single'
+      label='Affiliations that May Discover Real JIDs of Occupants'/&gt;
+  &lt;field
+      var='muc#owner_roomadmins'
+      type='jid-multi'
+      label='List of Room Admins'/&gt;
+  &lt;field
+      var='muc#owner_roomowners'
+      type='jid-multi'
+      label='List of Room Owners'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.4.3 <a name="registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roominfo&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling the communication of extended service discovery
+    information about a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roominfo_description'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roominfo_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roominfo_occupants'
+      type='text-single'
+      label='Current Number of Occupants in Room'/&gt;
+  &lt;field
+      var='muc#roominfo_subject'
+      type='text-single'
+      label='Current Subject or Discussion Topic in Room'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>14.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="bizrules-jids">Room JIDs</a>
+</h3>
+    <p class="" style="">In order to provide consistency regarding the addresses captured in room JIDs, Room IDs MUST match the Nodeprep profile of Stringprep and Room Nicknames MUST match the Resourceprep profile of Stringprep (both of these are defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2614614">13</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>14.2 <a name="bizrules-message">Message</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">If an occupant wants to send a message to all other occupants, a compliant client MUST set the 'type' attribute to a value of &quot;groupchat&quot;. A service MAY ignore messages that are improperly typed, or reject them with a &quot;Bad Request&quot; error.</p></li>
+      <li><p class="" style="">If a compliant service receives a message directed to the room or to a single occupant from a Jabber user who has a role of &quot;none&quot;, the service MUST NOT deliver the message and SHOULD return the message to the sender with a &quot;Forbidden&quot; error.</p></li>
+      <li><p class="" style="">If a compliant service receives a message directed to a room that does not exist or is locked, the service SHOULD return the message to the sender with a &quot;Not Found&quot; error.</p></li>
+      <li><p class="" style="">A compliant service SHOULD pass extended information (e.g., an XHTML version of the message body) through to occupants unchanged.</p></li>
+      <li><p class="" style="">A compliant client MUST NOT generate message events as specified in <span class="ref">Message Events</span>  [<a href="#nt-id2614722">14</a>]; such message events are not intended for use in the context of groupchat.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>14.3 <a name="bizrules-presence">Presence</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">A room MUST silently ignore unavailable presence received from a user who has a role of &quot;none&quot;.</p></li>
+      <li><p class="" style="">Only a component SHOULD generate extended presence information about roles, affiliations, full JIDs, or status codes scoped by the 'http://jabber.org/protocol/muc#user' namespace (based on information the component knows about occupants, e.g., roles, or as a result of actions taken by a moderator or room administrator). A client SHOULD NOT presume to generate such information. If a compliant component receives such extended presence information from an occupant, it MUST NOT reflect it to other occupants. A client can generate extended presence information in the 'http://jabber.org/protocol/muc#user' namespace in order to supply a password, but naturally this is not reflected to other occupants.</p></li>
+      <li><p class="" style="">A component SHOULD allow all other presence information to pass through, although it MAY choose to block extended presence information. Thus effectively clients can send a custom exit message if desired (as is often done in IRC channels) by including a &lt;status/&gt; element in the presence stanza of type &quot;unavailable&quot; sent when exiting a room.</p></li>
+      <li><p class="" style="">In order to appropriately inform occupants of room roles and affiliations, and to make it easier for Jabber clients to track the current state of all users in the room, compliant component implementations MUST provide extended presence information about roles and affiliations in all presence stanzas, including presence stanzas of type &quot;unavailable&quot; sent when a user exits the room for any reason.</p></li>
+      <li><p class="" style="">If a privilege is revoked, the service MUST note that by sending an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child element with the 'role' and/or 'affiliation' attributes set to a value that indicates the loss of the relevant privilege. All future presence stanzas for the occupant MUST include the updated role and affiliation, until and unless they change again.</p></li>
+      <li><p class="" style="">A compliant service MUST send extended presence to a client even if the client did not send an empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace on entering the room; naturally, a Jabber-compliant client MUST ignore such information if it does not understand it.</p></li>
+      <li><p class="" style="">Extended presence about roles and affiliations sent in the muc#user namespace MUST include the full JID (not the bare JID) as the value of the 'jid' attribute.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>14.4 <a name="bizrules-iq">IQ</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a non-anonymous room, the sender SHOULD send the request directly to the recipient's bare JID or full JID, rather than attempting to send the request through the room (i.e., via the recipient's room JID).</p></li>
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a semi-anonymous room, the sender can direct the stanza to the recipient's room JID and the service MAY forward the stanza to the recipient's real JID. However, a compliant service MUST NOT reveal the sender's real JID to the recipient at any time, nor reveal the recipient's real JID to the sender.</p></li>
+      <li><p class="" style="">A compliant client MUST send only the 'affiliation' attribute or the 'role' attribute in the &lt;item/&gt; element contained within an IQ set scoped by the 'http://jabber.org/protocol/muc#admin' namespace; if a moderator, admin, or owner attempts to modify both the affiliation and role of the same item in the same IQ set, the service MUST return a &quot;Bad Request&quot; error to the sender. However, a compliant service MAY modify a role based on a change to an affiliation and thus MAY send presence updates that include both a modified role and a modified affiliation.</p></li>
+      <li><p class="" style="">In IQ sets regarding roles, a compliant client MUST include the 'nick' attribute only; in IQ results regarding roles, a compliant service MUST include the 'nick', 'role', 'affiliation', and 'jid' attributes (with the value of the latter set to the user's full JID).</p></li>
+      <li><p class="" style="">In IQ sets regarding affiliations, a compliant client MUST include the 'jid' attribute only (with the value set to the bare JID); in IQ results regarding affiliations, a compliant service MUST NOT include the 'role' attribute, MUST include the 'affiliation' attribute and the 'jid' attribute (with the value set to the bare JID), and SHOULD include the 'nick' attribute (except if the affiliation is &quot;outcast&quot;, since outcasts SHOULD NOT have reserved nicknames).</p></li>
+    </ol>
+  </div>
+<h2>15.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">The following guidelines may assist client and component developers in creating compliant implementations.</p>
+  <div class="indent">
+<h3>15.1 <a name="impl-service">Services</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">In handling messages sent by visitors in a moderated room, a chatroom service MAY queue each message for approval by a moderator and MAY inform the sender that the message is being held for approval; however, such behavior is OPTIONAL, and definition of a message approval protocol (e.g., using Data Forms as defined in JEP-0004) is out of scope for this JEP.</p></li>
+      <li><p class="" style="">It is common for chatroom services to provide in-room messages when certain events occur, such as when the subject changes, when an occupant enters or exits, or when a room is destroyed. Such messages are entirely OPTIONAL and are left up to the implementation or deployment, but if used MUST be messages of type &quot;groupchat&quot; sent from the room JID itself (room@service) rather than a specific occupant (room@service/nick). However, in general it is preferable for the receiving client to generate such messages based on events in the room (e.g., user entrances and exits) as well as specific status codes provided in MUC; this will help ensure correct localization of such messages.</p></li>
+      <li><p class="" style="">Out of courtesy, a chatroom service MAY send a &lt;message/&gt; to an occupant who is kicked or banned, and MAY broadcast an in-room &lt;message/&gt; to all remaining occupants informing them that the occupant has been kicked or banned from the room. However, such messages are OPTIONAL, and indeed are unnecessary since the information required for a receiving client to generate such messages is communicated in the presence stanzas (specifically the status codes) sent by a MUC-compliant service.</p></li>
+      <li><p class="" style="">Out of courtesy, a chatroom service MAY send a &lt;message/&gt; outside the context of the room if a user's affiliation changes while the user is not in the room; the message SHOULD be sent from the room to the user's bare JID, MAY contain a &lt;body/&gt; element describing the affiliation change, and MUST contain a status code of 101.</p></li>
+      <li><p class="" style="">There is no requirement that a chatroom service shall provide special treatment for users of the older &quot;groupchat 1.0&quot; protocol, such as messages that contain equivalents to the extended presence information that is sent in the 'http://jabber.org/protocol/muc#user' namespace.</p></li>
+      <li><p class="" style="">Room types can be configured in any combination. A chatroom service MAY support or allow any desired room types or combinations thereof.</p></li>
+      <li><p class="" style="">A chatroom service MAY limit the number of configuration options presented to an owner after initial configuration has been completed, e.g. because certain options cannot take effect without restarting the service.</p></li>
+      <li><p class="" style="">A chatroom service MAY provide an interface to room creation and configuration (e.g., in the form of a special Jabber user or a Web page), so that the ostensible room owner is actually the application as opposed to a human user.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to make available a special in-room resource that provides an interface to administrative functionality (e.g., a &quot;user&quot; named &quot;ChatBot&quot;), which occupants could interact with directly, thus enabling admins to type <tt>/command parameter</tt> in a private message to that &quot;user&quot;. Obviously this kind of implementation would require the service to add a 'ChatBot' user to the room when it is created, and to prevent any occupant from having the nickname 'ChatBot' in the room. This might be difficult to ensure in some implementations or deployments. In any case, any such interface is OPTIONAL.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to discard extended presence received from a client before updated presence is sent to the occupants. That is, an implementation MAY choose to reflect only the &lt;show/&gt;, &lt;status/&gt;, and &lt;priority/&gt; child elements of the presence element, with the result that presence &quot;changes&quot; in extended namespaces (e.g., gabber:x:music:info) are not passed through to occupants.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to send a message outside the context of the room to any user who is affected by a change in affiliation (e.g., if a user becomes an admin or owner). Such a message could include an appropriate status code in an extended child element scoped by the muc#user namespace.</p></li>
+      <li><p class="" style="">A chatroom service SHOULD remove a user if the service receives a delivery-related error in relation to a stanza it has previously sent to the user (remote server unreachable, user not found, etc.).</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>15.2 <a name="impl-client">Clients</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">Jabber clients MAY present room roles by showing ad-hoc groups for each role within a room roster. This will enable occupants to clearly visualize which occupants are moderators, participants, and visitors. However, such a representation is OPTIONAL.</p></li>
+      <li><p class="" style="">Jabber clients MAY implement a variety of interface styles that provide &quot;shortcuts&quot; to functionality such as changing one's nickname, kicking or banning users, discovering an occupant's full JID, or changing the subject. One option consists of IRC-style commands such as '/nick', '/kick', '/ban', and '/whois'; another is to enable a user to right-click items in a room roster. All such interface styles are OPTIONAL. However, for convenience, a mapping of IRC commands to MUC protocols is provided below.</p></li>
+    </ol>
+    <div class="indent">
+<h3>15.2.1 <a name="impl-client-irc">IRC Command Mapping</a>
+</h3>
+      <p class="" style="">Internet Relay Chat clients use a number of common &quot;shortcut&quot; commands that begin with a forward slash, such as '/nick' and '/ban'. The following table provides a mapping of IRC-style commands to MUC protocols, for use by Jabber clients that wish to support such functionality.</p>
+      <p class="caption">Table 9: IRC Command Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Command</th>
+          <th colspan="" rowspan="">Function</th>
+          <th colspan="" rowspan="">MUC protocol</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/ban &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">bans user with that roomnick from this room (client translates roomnick to jid)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='jid-of-roomnick'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/invite &lt;jid&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">invites jid to this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='jid'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/join &lt;roomname&gt; [pass]</td>
+          <td align="" colspan="" rowspan="">joins room on this service (roomnick is same as nick in this room)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;password&gt;pass&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/kick &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">kicks user with that roomnick from this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='roomnick' role='none'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/msg &lt;roomnick&gt; &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">sends private message &quot;foo&quot; to roomnick</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service/nick'&gt;
+  &lt;body&gt;foo&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/nick &lt;newnick&gt;</td>
+          <td align="" colspan="" rowspan="">changes nick in this room to &quot;newnick&quot;</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/newnick'/&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/part [comment]</td>
+          <td align="" colspan="" rowspan="">exits this room (some IRC clients also support /leave)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'
+          type='unavailable'&gt;
+  &lt;status&gt;comment&lt;/status&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/topic &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">changes subject of this room to &quot;foo&quot;</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service' type='groupchat'&gt;
+  &lt;subject&gt;foo&lt;/subject&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+      </table>
+      <p class="" style="">Note: Because MUC roomnicks follow the Resouceprep profile of stringprep, they are allowed to contain a space character, whereas IRC nicknames do not. Although a given client MAY support quotation characters for this purpose (resulting in commands such as '/ban &quot;king lear&quot; insanity is no defense'), most common quotation characters (such as &quot; and ') are also allowed by Resouceprep, thus leading to added complexity and potential problems with quotation of roomnicks that contain both spaces and quotation characters. Therefore it is NOT RECOMMENDED for Jabber clients to support IRC-style shortcut commands with roomnicks that contain space characters.</p>
+    </div>
+  </div>
+<h2>16.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="schemas-muc">http://jabber.org/protocol/muc</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc'
+    xmlns='http://jabber.org/protocol/muc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='history' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='history'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+         &lt;xs:attribute name='maxchars' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='maxstanzas' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='seconds' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='since' type='xs:dateTime' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.2 <a name="schemas-user">http://jabber.org/protocol/muc#user</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#user'
+    xmlns='http://jabber.org/protocol/muc#user'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='decline' minOccurs='0'/&gt;
+        &lt;xs:element ref='destroy' minOccurs='0'/&gt;
+        &lt;xs:element ref='invite' minOccurs='0'/&gt;
+        &lt;xs:element ref='item' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element ref='status' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='decline'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='invite'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='code' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:int'&gt;
+            &lt;xs:enumeration value='100'/&gt;
+            &lt;xs:enumeration value='201'/&gt;
+            &lt;xs:enumeration value='301'/&gt;
+            &lt;xs:enumeration value='303'/&gt;
+            &lt;xs:enumeration value='307'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.3 <a name="schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#admin'
+    xmlns='http://jabber.org/protocol/muc#admin'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.4 <a name="schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#owner'
+    xmlns='http://jabber.org/protocol/muc#owner'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='destroy' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>17.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The author would like to thank the following individuals for their many helpful comments on various drafts of this proposal: David Sutton, Peter Millard, Joe Hildebrand, Craig Kaes, Alexey Shchepin, David Waite, Jean-Louis Seguineau, Jacek Konieczny, Gaston Dombiak, and many others in the jdev@conference.jabber.org conference room and on the Standards-JIG mailing list.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602338">1</a>. RFC 1459: Internet Relay Chat &lt;<a href="http://www.ietf.org/rfc/rfc1459.txt">http://www.ietf.org/rfc/rfc1459.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602565">2</a>. <a href="http://www.jabber.org/protocol/groupchat.html">http://www.jabber.org/protocol/groupchat.html</a>
+</p>
+<p>
+<a name="nt-id2605990">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606189">4</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p>
+<a name="nt-id2607384">5</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p>
+<a name="nt-id2607608">6</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2610115">7</a>. XMPP IM &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2611110">8</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2613134">9</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2614214">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2614152">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2614326">12</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p>
+<a name="nt-id2614614">13</a>. XMPP Core &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2614722">14</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.16 (2004-06-30)</h4>
+<div class="indent">Added example and registry submission for service discovery extension. (psa)
+    </div>
+<h4>Version 1.15 (2004-06-24)</h4>
+<div class="indent">Removed jabber:iq:browse references; clarified order of presence stanzas sent to new occupant on entering room; specified format of in-room messages (type='groupchat', from='room@service'); clarified allowable attributes in various list-related operations; made admin/owner revocation text and examples consistent with state chart; clarified ownership revocation conflict scenarios; changed the 'muc#owner_inviteonly' field to 'muc#owner_membersonly'; changed attribute order in examples to match XML canonicalization rules; corrected several errors in the schemas. (psa)
+    </div>
+<h4>Version 1.14 (2004-05-03)</h4>
+<div class="indent">Corrected discovery of registered roomnicks; added note about error to return if nicks are locked down. (psa)
+    </div>
+<h4>Version 1.13 (2004-03-31)</h4>
+<div class="indent">Fixed an error in the muc#user schema. (psa)
+    </div>
+<h4>Version 1.12 (2004-03-01)</h4>
+<div class="indent">Corrected a few errors in the examples; added IQ results in order to clarify workflows. (psa)
+    </div>
+<h4>Version 1.11 (2004-02-05)</h4>
+<div class="indent">Clarified JID matching rules (same as for privacy lists in XMPP IM). (psa)
+    </div>
+<h4>Version 1.10 (2004-01-07)</h4>
+<div class="indent">Added XMPP error handling; fully specified all conformance terms. (psa)
+    </div>
+<h4>Version 1.9 (2003-12-14)</h4>
+<div class="indent">Removed protocol for requesting voice in a moderated room (should be performed using Ad-Hoc Commands). (psa)
+    </div>
+<h4>Version 1.8 (2003-12-04)</h4>
+<div class="indent">Added protocol for requesting voice in a moderated room; added (informational) mapping of IRC commands to MUC protocols. (psa)
+    </div>
+<h4>Version 1.7 (2003-10-21)</h4>
+<div class="indent">Added room configuration option for restricting presence broadcast to certain roles. (psa)
+    </div>
+<h4>Version 1.6 (2003-10-03)</h4>
+<div class="indent">Added history management protocol on entering a room. (psa)
+    </div>
+<h4>Version 1.5 (2003-09-11)</h4>
+<div class="indent">Specified that ban occurs by JID, not roomnick; allowed privileged users to send messages to the room even if not present in the room; added note that service should remove occupant if a delivery-related stanza error occurs; enabled user to disco the room in order to discover registered roomnick; specified that &quot;banning&quot; by domain or regex is a service-level configuration matter and therefore out of scope for MUC; specified that role should be decremented as appropriate if affiliation is lowered; added some clarifying text to room creation workflow; added implementation note about sending an out-of-band message if a user's affiliation changes while the user is not in the room; fixed stringprep references (room nicks use Resourceprep); clarified relationship between Room ID (i.e., node identifier of Room JID, which may be opaque) and natural-language Room Name; specified Field Standardization profile per JEP-0068; defined Jabber Registrar submissions; added schema locations. (psa)
+    </div>
+<h4>Version 1.4 (2003-02-16)</h4>
+<div class="indent">Added XML schemas. (psa)
+    </div>
+<h4>Version 1.3 (2003-02-11)</h4>
+<div class="indent">Added reference to nodeprep Internet-Draft. (psa)
+    </div>
+<h4>Version 1.2 (2003-01-30)</h4>
+<div class="indent">Commented out revision history prior to version 1.0 (too long); clarified business rules regarding when nicks, full JIDs, and bare JIDs are used in reference to roles and affiliations; consistently specified that extended presence information in the muc#user namespace must include the full JID as the value of the 'jid' attribute in all cases; cleaned up text and examples throughout; added open issue regarding syntax of room nicknames. (psa)
+    </div>
+<h4>Version 1.1 (2002-12-16)</h4>
+<div class="indent">Added protocol for declining an invitation; replaced &lt;created/&gt; element with status code 201; modified the destroy room protocol so that &lt;destroy/&gt; is a child of &lt;query/&gt;; clarified usage of 'nick' attribute when adding members; prohibited use of message events. (psa)
+    </div>
+<h4>Version 1.0 (2002-11-21)</h4>
+<div class="indent">Per a vote of the Jabber Council, revision 0.23 was advanced to Draft on 2002-11-21. (For earlier revision history, refer to XML source.) (psa)
+    </div>
+<h4>Version 0.23 (2002-11-06)</h4>
+<div class="indent">Added examples for disco#items queries sent to a room; prohibited 'type' attribute on invite messages sent from client to room; added dependencies for JEPs 11 and 30; changed 'room user' to 'occupant'; fixed many small errors throughout. (psa)
+    </div>
+<h4>Version 0.22 (2002-11-04)</h4>
+<div class="indent">Added example for disco#items; added support for cancellation of room configuration using type='cancel' from JEP-0004; noted 403 error for invites sent by non-admins in members-only room. (psa)
+    </div>
+<h4>Version 0.21 (2002-11-01)</h4>
+<div class="indent">Clarified several small ambiguities; made &lt;body/&gt; optional on invites sent from the service to the invitee; added error scenarios for changing nickname and for destroying the room; specified that the service must return the full member list for a members-only room (not only the members in the room); updated the disco examples to track protocol changes. (psa)
+    </div>
+<h4>Version 0.20 (2002-10-29)</h4>
+<div class="indent">Specified that messages sent to change the room subject must be of type &quot;groupchat&quot;; updated the legal notice to conform to the JSF IPR policy. (psa)
+    </div>
+<h4>Version 0.19 (2002-10-28)</h4>
+<div class="indent">Added ability to create an instant room within MUC (not by using gc-1.0 protocol); cleaned up disco examples. (psa)
+    </div>
+<h4>Version 0.18 (2002-10-27)</h4>
+<div class="indent">Added experimental support for disco; added sections for security, IANA, and JANA considerations; corrected typographical errors; cleaned up some DocBook formatting. (psa)
+    </div>
+<h4>Version 0.17 (2002-10-23)</h4>
+<div class="indent">Added the optional &lt;actor/&gt; element (with 'jid' attribute) to &lt;item/&gt; elements inside presence stanzas of type &quot;unavailable&quot; that are sent to users who are kicked or banned, as well as within IQs for tracking purposes; reverted all list editing use cases (ban, voice, member, moderator, admin, owner) to use of MUC format rather than 'jabber:x:data' namespace; added several guidelines regarding generation and handling of XML stanzas; cleaned up the change room subject use case; changed several ambiguous uses of 'would', 'can', and 'will' to 'should', 'may', or 'must'; fixed several small errors in the text, examples, and DTDs. (psa)
+    </div>
+<h4>Version 0.16 (2002-10-20)</h4>
+<div class="indent">Added the &lt;item/&gt; element to presence stanzas of type &quot;unavailable&quot; in order to improve the tracking of user states in the room; consolidated &lt;invitee/&gt; and &lt;inviter/&gt; elements into an &lt;invite/&gt; element with 'from' and 'to' attributes; made &lt;reason/&gt; element always a child of &lt;item/&gt; or &lt;invite/&gt; in the muc#user namespace; moved the alternate room location in room destruction to a 'jid' attribute of the &lt;alt/&gt; element; further specified several error messages; disallowed simultaneous modifications of both affiliations and roles by a moderator or admin; added several more rules regarding handling of XML stanzas; added use cases for granting and revoking administrative privileges; adjusted DTD to track all changes. (psa)
+    </div>
+<h4>Version 0.15 (2002-10-18)</h4>
+<div class="indent">Fully incorporated the change to affiliations + roles; moved a number of admin use cases to a new section for moderator use cases; added participant use case for requesting membership; added admin use cases for adding members, removing members, granting and revoking moderator privileges, and modifying the moderator list; organized the sections in a more logical manner. (psa)
+    </div>
+<h4>Version 0.14 (2002-10-17)</h4>
+<div class="indent">Significantly modified the privileges model by distinguishing between in-room &quot;roles&quot; and long-lived &quot;affiliations&quot;; specified the privileges of the various roles and affiliations; included state transition charts for both roles and affiliations; removed use of MUC protocol for editing ban, voice, and admin lists (but not for the actions of banning users and granting/revoking voice); added delivery rule regarding IQ stanzas; changed kick so that the action is based on changing the role to &quot;none&quot;. (psa)
+    </div>
+<h4>Version 0.13 (2002-10-16)</h4>
+<div class="indent">Corrected the change nickname examples (newnick sent on unavailable, no nick sent on available). (psa)
+    </div>
+<h4>Version 0.12 (2002-10-16)</h4>
+<div class="indent">Removed SHA1 passwords; specified that room shall add passwords on invitations to password-protected rooms (not supplied by inviter). (psa)
+    </div>
+<h4>Version 0.11 (2002-10-16)</h4>
+<div class="indent">Changed 'participant' to 'room user' and 'discussant' to 'participant'; clarified presence rule about client generation of extended presence information; added role of 'none'. (psa)
+    </div>
+<h4>Version 0.10 (2002-10-15)</h4>
+<div class="indent">Fixed extended presence on entering or creating a room (plain '...muc' with no fragment); harmonized #user with #admin regarding the use of the &lt;item/&gt; element and associated attributes (jid, nick, etc.), and added 'role' attribute; modified management of voice, ban, admin, and member lists to use &lt;query/&gt; wrapper and new &lt;item/&gt; structure; changed the 'member' role to 'discussant', added 'outcast' role for banned users, and added new 'member' role to enable management of member lists; changed invitation-only rooms to members-only rooms and made appropriate adjustments to apply member lists to both members-only rooms and open rooms; modified nickname change protocol slightly to send the old nickname in the unavailable presence and the new nickname in the available presence; removed prohibition on members-only rooms that are password-protected; removed the &lt;query/&gt; wrapper for the &lt;destroy/&gt; element; updated the DTDs. (psa)
+    </div>
+<h4>Version 0.9 (2002-10-13)</h4>
+<div class="indent">Added extended presence ('...#user') on entering a room for compliant clients; changed namespace on room creation request to '...#owner'; added a service discovery example using jabber:iq:browse; added information about discussion history; made small fixes to several examples; further defined the presence rules; transferred all implementation notes to a dedicated section; added a Terminology section. (psa)
+    </div>
+<h4>Version 0.8 (2002-10-10)</h4>
+<div class="indent">Made further changes to the room creation workflow (finally correct); removed feature discovery use case (this needs to be addressed by a real service discovery protocol!); added ability for room owners to edit the admin list; removed &lt;body/&gt; from invitations generated by the service; removed messages sent to kicked and banned users (handled by unavailable presence with status code); added a number of implementation notes; converted all examples to Shakespeare style. (psa)
+    </div>
+<h4>Version 0.7.6 (2002-10-09)</h4>
+<div class="indent">Fixed the room creation workflow; changed some terminology (&quot;join&quot; to &quot;enter&quot; and &quot;leave&quot; to &quot;exit&quot;). (psa)
+    </div>
+<h4>Version 0.7.5 (2002-10-08)</h4>
+<div class="indent">Specified and improved the handling of invitation-only rooms. In particular, added the ability for room admins to edit the invitation list and added a configuration option that limits the ability to send invitations to room admins only. (psa)
+    </div>
+<h4>Version 0.7.4 (2002-10-07)</h4>
+<div class="indent">Changed namespaces from http://jabber.org/protocol/muc/owner etc. to http://jabber.org/protocol/muc#owner etc. per Jabber Council discussion. (psa)
+    </div>
+<h4>Version 0.7.3 (2002-10-07)</h4>
+<div class="indent">Changed namespaces to HTTP URIs; left role handling up to the implementation; further clarified presence rules. (psa)
+    </div>
+<h4>Version 0.7.2 (2002-10-06)</h4>
+<div class="indent">Disallowed kicking, banning, and revoking voice with respect to room admins and room owners; replaced &lt;x/&gt; with &lt;query/&gt; in the Discovering Room Features and Destroying a Room use cases; corrected some small errors and made many clarifications throughout. (psa)
+    </div>
+<h4>Version 0.7.1 (2002-10-04)</h4>
+<div class="indent">Removed &lt;whois/&gt; command (unnecessary since participants with appropriate privileges receive the full JID of all participants in presence stanzas); completed many small fixes throughout. (psa)
+    </div>
+<h4>Version 0.7 (2002-10-03)</h4>
+<div class="indent">More clearly delineated participant roles and defined the hierarchy thereof (owner, admin, member, visitor); replaced &lt;voice/&gt; element in extended presence with &lt;item role='member'/&gt;; changed initial room configuration to use IQ rather than message; adjusted presence rules (especially regarding extended presence information); cleaned up examples throughout; updated DTD to track changes. (psa)
+    </div>
+<h4>Version 0.6 (2002-09-21)</h4>
+<div class="indent">More clearly defined the scope; removed fully anonymous rooms; changed meaning of semi-anonymous rooms and of non-anonymous rooms; added mechanism for notification of full JIDs in non-anonymous rooms; replaced the &lt;admin/&gt; element in extended presence with a &lt;role/&gt; element (more extensible); changed room passwords to cleartext; added status codes for various messages received from the service; added lists of valid error and status codes associated with the 'http://jabber.org/protocol/muc#user' namespace; added a &lt;reason/&gt; element for invitations; made kick and ban reasons child elements rather than attributes; replaced stopgap feature discovery mechanism with jabber:iq:negotiate; added extended presence element to room creation request and clarified the room creation process; specified presence reflection rules; added method for destroying a room; adjusted DTDs to track all changes. (psa)
+    </div>
+<h4>Version 0.5.1 (2002-09-20)</h4>
+<div class="indent">Added DTDs; changed feature discovery to use &lt;x/&gt; element rather than query and made service response come in IQ result; fixed reference to JEP 29; changed 'grant' to 'add' and 'revoke' to 'remove' for consistency in the item attributes; made several other small changes. (psa)
+    </div>
+<h4>Version 0.5 (2002-09-19)</h4>
+<div class="indent">Changed the kick, ban, and voice protocols; added a few more configuration options; specified the restrictions for roomnicks; and added a stopgap service discovery protocol. (psa)
+    </div>
+<h4>Version 0.4 (2002-09-18)</h4>
+<div class="indent">Changed all non-GC-1.0 use cases to jabber:gc:* namespaces or jabber:x:data; added use cases for ban list management and room moderation; added protocol for sending notice of admin and voice privileges in presence; cleaned up text and many examples. (psa)
+    </div>
+<h4>Version 0.3 (2002-09-17)</h4>
+<div class="indent">Changed admin use cases; cleaned up participant and owner use cases. (psa)
+    </div>
+<h4>Version 0.2 (2002-09-12)</h4>
+<div class="indent">Broke content out into three actors (participant, owner, and admin) and added more detail to owner and admin use cases. (psa)
+    </div>
+<h4>Version 0.1 (2002-09-09)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0045-1.17.html
+++ b/content/xep-0045-1.17.html
@@ -1,0 +1,5242 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0045: Multi-User Chat</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Multi-User Chat">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a robust protocol for XMPP-based text conferencing.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-04">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0045">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0045: Multi-User Chat</h1>
+<p>This JEP defines a robust protocol for XMPP-based text conferencing.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0045<br>
+            Version: 1.17<br>
+            Last Updated: 2004-10-04<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0004, JEP-0030, JEP-0068, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: muc<br>
+        Schema for muc: &lt;<a href="http://jabber.org/protocol/muc/muc.xsd">http://jabber.org/protocol/muc/muc.xsd</a>&gt;<br>
+        Schema for muc#admin: &lt;<a href="http://jabber.org/protocol/muc/admin.xsd">http://jabber.org/protocol/muc/admin.xsd</a>&gt;<br>
+        Schema for muc#owner: &lt;<a href="http://jabber.org/protocol/muc/owner.xsd">http://jabber.org/protocol/muc/owner.xsd</a>&gt;<br>
+        Schema for muc#user: &lt;<a href="http://jabber.org/protocol/muc/user.xsd">http://jabber.org/protocol/muc/user.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#scope">Scope</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#terms-general">General Terms</a>
+</dt>
+<dt>4.2.  <a href="#terms-rooms">Room Types</a>
+</dt>
+</dl>
+<dt>5.  <a href="#connections">Roles and Affiliations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#roles">Roles</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#roles-priv">Privileges</a>
+</dt>
+<dt>5.1.2.  <a href="#roles-change">Changing Roles</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#affil">Affiliations</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#affil-priv">Privileges</a>
+</dt>
+<dt>5.2.2.  <a href="#affil-change">Changing Affiliations</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#user">Occupant Use Cases</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#discovery">Discovering Component Support for MUC</a>
+</dt>
+<dt>6.2.  <a href="#discovery-client">Discovering Client Support for MUC</a>
+</dt>
+<dt>6.3.  <a href="#enter">Entering a Room</a>
+</dt>
+<dl>
+<dt>6.3.1.  <a href="#enter-gc">Groupchat 1.0 Protocol</a>
+</dt>
+<dt>6.3.2.  <a href="#enter-muc">Basic MUC Protocol</a>
+</dt>
+<dt>6.3.3.  <a href="#enter-pres">Presence Broadcast</a>
+</dt>
+<dt>6.3.4.  <a href="#enter-roles">Default Roles</a>
+</dt>
+<dt>6.3.5.  <a href="#enter-nonanon">Non-Anonymous Rooms</a>
+</dt>
+<dt>6.3.6.  <a href="#enter-semianon">Semi-Anonymous Rooms</a>
+</dt>
+<dt>6.3.7.  <a href="#enter-pw">Password-Protected Rooms</a>
+</dt>
+<dt>6.3.8.  <a href="#enter-members">Members-Only Rooms</a>
+</dt>
+<dt>6.3.9.  <a href="#enter-banned">Banned Users</a>
+</dt>
+<dt>6.3.10.  <a href="#enter-conflict">Nickname Conflict</a>
+</dt>
+<dt>6.3.11.  <a href="#enter-maxusers">Max Users</a>
+</dt>
+<dt>6.3.12.  <a href="#enter-history">Discussion History</a>
+</dt>
+<dt>6.3.13.  <a href="#enter-managehistory">Managing Discussion History</a>
+</dt>
+<dt>6.3.14.  <a href="#enter-create">Room Creation</a>
+</dt>
+</dl>
+<dt>6.4.  <a href="#exit">Exiting a Room</a>
+</dt>
+<dt>6.5.  <a href="#changenick">Changing Nickname</a>
+</dt>
+<dt>6.6.  <a href="#changepres">Changing Availability Status</a>
+</dt>
+<dt>6.7.  <a href="#invite">Inviting Another User to a Room</a>
+</dt>
+<dt>6.8.  <a href="#continue">Converting a One-to-One Chat Into a Conference</a>
+</dt>
+<dt>6.9.  <a href="#subject-occupant">Occupant Modification of the Room Subject</a>
+</dt>
+<dt>6.10.  <a href="#privatemessage">Sending a Private Message</a>
+</dt>
+<dt>6.11.  <a href="#message">Sending a Message to All Occupants</a>
+</dt>
+<dt>6.12.  <a href="#register">Registering with a Room</a>
+</dt>
+<dt>6.13.  <a href="#reservednick">Discovering Reserved Room Nickname</a>
+</dt>
+</dl>
+<dt>7.  <a href="#moderator">Moderator Use Cases</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#subject-mod">Modifying the Room Subject</a>
+</dt>
+<dt>7.2.  <a href="#kick">Kicking a Visitor or Participant from a Room</a>
+</dt>
+<dt>7.3.  <a href="#grantvoice">Granting Voice to a Visitor</a>
+</dt>
+<dt>7.4.  <a href="#revokevoice">Revoking Voice from a Participant</a>
+</dt>
+<dt>7.5.  <a href="#modifyvoice">Modifying the Voice List</a>
+</dt>
+</dl>
+<dt>8.  <a href="#admin">Admin Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#ban">Banning a User</a>
+</dt>
+<dt>8.2.  <a href="#modifyban">Modifying the Ban List</a>
+</dt>
+<dt>8.3.  <a href="#grantmember">Granting Membership</a>
+</dt>
+<dt>8.4.  <a href="#revokemember">Revoking Membership</a>
+</dt>
+<dt>8.5.  <a href="#modifymember">Modifying the Member List</a>
+</dt>
+<dt>8.6.  <a href="#grantmod">Granting Moderator Privileges</a>
+</dt>
+<dt>8.7.  <a href="#revokemod">Revoking Moderator Privileges</a>
+</dt>
+<dt>8.8.  <a href="#modifymod">Modifying the Moderator List</a>
+</dt>
+<dt>8.9.  <a href="#regapprove">Approving Registration Requests</a>
+</dt>
+</dl>
+<dt>9.  <a href="#owner">Owner Use Cases</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#createroom">Creating a Room</a>
+</dt>
+<dt>9.2.  <a href="#roomconfig">Subsequent Room Configuration</a>
+</dt>
+<dt>9.3.  <a href="#grantowner">Granting Ownership Privileges</a>
+</dt>
+<dt>9.4.  <a href="#revokeowner">Revoking Ownership Privileges</a>
+</dt>
+<dt>9.5.  <a href="#modifyowner">Modifying the Owner List</a>
+</dt>
+<dt>9.6.  <a href="#grantadmin">Granting Administrative Privileges</a>
+</dt>
+<dt>9.7.  <a href="#revokeadmin">Revoking Administrative Privileges</a>
+</dt>
+<dt>9.8.  <a href="#modifyadmin">Modifying the Admin List</a>
+</dt>
+<dt>9.9.  <a href="#destroyroom">Destroying a Room</a>
+</dt>
+</dl>
+<dt>10.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dt>11.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>13.2.  <a href="#registrar-discocat">Service Discovery Category/Type</a>
+</dt>
+<dt>13.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>13.4.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>13.5.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+<dl>
+<dt>13.5.1.  <a href="#registrar-formtype-register">muc#register FORM_TYPE</a>
+</dt>
+<dt>13.5.2.  <a href="#registrar-formtype-owner">muc#roomconfig FORM_TYPE</a>
+</dt>
+<dt>13.5.3.  <a href="#registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</dt>
+</dl>
+</dl>
+<dt>14.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#bizrules-jids">Room JIDs</a>
+</dt>
+<dt>14.2.  <a href="#bizrules-message">Message</a>
+</dt>
+<dt>14.3.  <a href="#bizrules-presence">Presence</a>
+</dt>
+<dt>14.4.  <a href="#bizrules-iq">IQ</a>
+</dt>
+</dl>
+<dt>15.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#impl-service">Services</a>
+</dt>
+<dl><dt>15.1.1.  <a href="#impl-service-traffic">Allowable Traffic</a>
+</dt></dl>
+<dt>15.2.  <a href="#impl-client">Clients</a>
+</dt>
+<dl><dt>15.2.1.  <a href="#impl-client-irc">IRC Command Mapping</a>
+</dt></dl>
+</dl>
+<dt>16.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#schemas-muc">http://jabber.org/protocol/muc</a>
+</dt>
+<dt>16.2.  <a href="#schemas-user">http://jabber.org/protocol/muc#user</a>
+</dt>
+<dt>16.3.  <a href="#schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</dt>
+<dt>16.4.  <a href="#schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</dt>
+</dl>
+<dt>17.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">It has long been recognized that the Jabber community needs a more robust protocol for text-based conferencing. This JEP defines extensions that enable Jabber systems to offer a much wider range of functionality, while still enabling older Jabber clients to access the minimal feature-set provided by the existing &quot;groupchat 1.0&quot; protocol. The extensions are implemented using protocol elements that fall into the 'http://jabber.org/protocol/muc' namespace and associated functionality areas (denoted by #owner, #admin, and #user fragments on the main namespace URI where appropriate).</p>
+<h2>2.
+       <a name="scope">Scope</a>
+</h2>
+  <p class="" style="">This JEP addresses common requirements related to configuration of, participation in, and administration of individual text-based conference rooms. All of the requirements addressed herein apply at the level of the individual room and are &quot;common&quot; in the sense that they have been widely discussed within the Jabber community or are familiar from existing text-based conference environments outside of Jabber (e.g., Internet Relay Chat as defined in <span class="ref">RFC 1459</span>  [<a href="#nt-id2602890">1</a>]).</p>
+  <p class="" style="">This JEP explicitly does <span style="font-style: italic">not</span> address the following:</p>
+  <ul>
+    <li>Relationships between rooms (e.g., hierarchies of rooms)</li>
+    <li>Management of multi-user chat services (e.g., managing permissions across an entire service or registering a global room nickname)</li>
+    <li>Moderation of individual messages</li>
+    <li>Security and encryption at the level of a room or service</li>
+    <li>Advanced features such as attaching files to a room, integrating whiteboards, and interfacing with audio chat services</li>
+    <li>Interaction between Jabber and foreign chat systems (e.g., gateways to IRC or to legacy IM systems)</li>
+  </ul>
+  <p class="" style="">This limited scope is not meant to disparage such topics, which are of inherent interest; however, it is meant to focus the discussion in this JEP and to present a comprehensible proposal that can be implemented by Jabber client and component developers alike. Future JEPs may of course address the topics mentioned above.</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP must address the minimal functionality provided by existing multi-user chat services in Jabber. For the sake of backward-compatibility, this JEP uses the original &quot;groupchat 1.0&quot; protocol for this baseline functionality, with the result that:</p>
+  <ul>
+    <li>Messages sent within multi-user chat rooms are of a special type &quot;groupchat&quot;.</li>
+    <li>Each room is identified as room@service (e.g., jdev@conference.jabber.org), where &quot;room&quot; is the name of the room and &quot;service&quot; is the hostname at which the multi-user chat service is running.</li>
+    <li>Each occupant in a room is identified as room@service/nick, where &quot;nick&quot; is the room nickname of the occupant as specified on entering the room or subsequently changed during the occupant's visit.</li>
+    <li>A user enters a room (i.e., becomes an occupant) by sending presence to it.</li>
+    <li>An occupant exits a room by sending presence of type &quot;unavailable&quot; to it.</li>
+    <li>An occupant can change his or her room nickname and availability status within the room by sending updated presence information.</li>
+  </ul>
+  <p class="" style="">The additional features and functionality addressed in this JEP include the following:</p>
+  <ol start="" type="">
+    <li>&quot;native&quot; conversation logging (no bot required)</li>
+    <li>enabling users to request membership in a room</li>
+    <li>enabling occupants to view an occupant's full JID in a non-anonymous room</li>
+    <li>enabling moderators to view an occupant's full JID in a semi-anonymous room</li>
+    <li>allowing only moderators to change the room subject</li>
+    <li>enabling moderators to kick participants and visitors from the room</li>
+    <li>enabling moderators to grant and revoke voice (i.e., the privilege to speak) in a moderated room, and to manage the voice list</li>
+    <li>enabling admins to grant and revoke moderator privileges, and to manage the moderator list</li>
+    <li>enabling admins to ban users from the room, and to manage the ban list</li>
+    <li>enabling admins to grant and revoke membership privileges, and to manage the member list for a members-only room</li>
+    <li>enabling owners to limit the number of occupants</li>
+    <li>enabling owners to specify other owners</li>
+    <li>enabling owners to grant and revoke administrative privileges, and to manage the admin list</li>
+    <li>enabling owners to destroy the room</li>
+  </ol>
+  <p class="" style="">In addition, this JEP provides protocol elements for supporting the following room types:</p>
+  <ol start="" type="">
+    <li>public or hidden</li>
+    <li>persistent or temporary</li>
+    <li>password-protected or unsecured</li>
+    <li>members-only or open</li>
+    <li>moderated or unmoderated</li>
+    <li>non-anonymous or semi-anonymous</li>
+  </ol>
+<h2>4.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="terms-general">General Terms</a>
+</h3>
+    <p class="" style="">Affiliation -- a long-lived association or connection with a room; the possible affiliations are &quot;owner&quot;, &quot;admin&quot;, &quot;member&quot;, and &quot;outcast&quot; (naturally it is also possible to have no affiliation); affiliation is orthogonal to role. An affiliation lasts across a user's visits to a room.</p>
+    <p class="" style="">Ban -- to remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). A banned user has an affiliation of &quot;outcast&quot;.</p>
+    <p class="" style="">Bare JID -- the user@host by which a user is identified outside the context of any existing session or resource; contrast with Full JID and Room JID.</p>
+    <p class="" style="">Full JID -- the user@host/resource by which an online user is identified outside the context of a room; contrast with Bare JID and Room JID.</p>
+    <p class="" style="">GC -- the minimal &quot;groupchat 1.0&quot; protocol  [<a href="#nt-id2603164">2</a>] currently in use for text-based conferencing in Jabber.</p>
+    <p class="" style="">History -- a limited number of message stanzas sent to a new occupant to provide the context of current discussion.</p>
+    <p class="" style="">Invitation -- a special message sent from one user to another asking the recipient to join a room.</p>
+    <p class="" style="">IRC -- Internet Relay Chat.</p>
+    <p class="" style="">Kick -- to temporarily remove a participant or visitor from a room; the user is allowed to re-enter the room at any time. A kicked user has a role of &quot;none&quot;.</p>
+    <p class="" style="">Logging -- storage of discussions that occur within a room for future retrieval inside or outside the context of the room.</p>
+    <p class="" style="">Member -- a user who is on the &quot;whitelist&quot; for a members-only room or who is registered with an open room. A member has an affiliation of &quot;member&quot;.</p>
+    <p class="" style="">Moderator -- a room role that is usually associated with room admins but that may be granted to non-admins; is allowed to kick users, grant and revoke voice, etc. A moderator has an affiliation of &quot;moderator&quot;.</p>
+    <p class="" style="">MUC -- the multi-user chat protocol for text-based conferencing documented in this JEP.</p>
+    <p class="" style="">Occupant -- any Jabber user who is in a room (this is an &quot;abstract class&quot; and does not correspond to any specific role).</p>
+    <p class="" style="">Outcast -- a user who has been banned from a room. An outcast has an affiliation of &quot;outcast&quot;.</p>
+    <p class="" style="">Participant -- an occupant who does not have administrative privileges; in a moderated room, a participant is further defined as having voice (in contrast to a visitor). A participant has a role of &quot;participant&quot;.</p>
+    <p class="" style="">Private Message -- a message sent from one occupant directly to another's room JID (not to the room itself for broadcasting to all occupants).</p>
+    <p class="" style="">Role -- a temporary position or privilege level within a room, orthogonal to a user's long-lived affiliation with the room; the possible roles are &quot;moderator&quot;, &quot;participant&quot;, and &quot;visitor&quot; (it is also possible to have no defined role). A role lasts only for the duration of an occupant's visit to a room.</p>
+    <p class="" style="">Room -- a virtual space that Jabber users figuratively enter in order to participate in real-time, text-based conferencing with more than one other user.</p>
+    <p class="" style="">Room Administrator -- a user empowered by the room owner to perform administrative functions such as banning users; however, is not allowed to change defining room features. An admin has an affiliation of &quot;admin&quot;.</p>
+    <p class="" style="">Room ID -- the node identifier portion of a Room JID, which may be opaque and thus lack meaning for human users (see Business Rules for syntax); contrast with Room Name.</p>
+    <p class="" style="">Room JID -- the &lt;room@service/nick&gt; by which an occupant is identified within the context of a room; contrast with Bare JID and Full JID.</p>
+    <p class="" style="">Room Name -- a user-friendly, natural-language name for a room, configured by the room owner and presented in Service Discovery queries; contrast with Room ID.</p>
+    <p class="" style="">Room Nickname -- the resource identifier portion of a Room JID (see Business Rules for syntax).</p>
+    <p class="" style="">Room Owner -- the Jabber user who created the room, or a Jabber user who has been designated by the room creator as someone with owner privileges (if allowed); is allowed to change defining room features as well as perform all administrative functions. An owner has an affiliation of &quot;owner&quot;.</p>
+    <p class="" style="">Room Roster -- a Jabber client's representation of the occupants in a room.</p>
+    <p class="" style="">Server -- a Jabber server that may or may not have associated with it a text-based conferencing service.</p>
+    <p class="" style="">Service -- a host that offers text-based conferencing capabilities; often but not necessarily a sub-domain of a Jabber server (e.g., conference.jabber.org).</p>
+    <p class="" style="">Subject -- a temporary discussion topic within a room.</p>
+    <p class="" style="">Visit -- a user's &quot;session&quot; in a room, beginning when the user enters the room (i.e., becomes an occupant) and ending when the user exits the room.</p>
+    <p class="" style="">Visitor -- in a moderated room, an occupant who does not have voice (in contrast to a participant). A visitor has a role of &quot;visitor&quot;.</p>
+    <p class="" style="">Voice -- in a moderated room, the privilege to send messages to all occupants.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="terms-rooms">Room Types</a>
+</h3>
+    <p class="" style="">Fully-Anonymous Room -- a room in which the full JIDs or bare JIDs of occupants cannot be discovered by anyone, including room admins and room owners; such rooms are NOT RECOMMENDED or explicitly supported by MUC, but are possible using this protocol; contrast with Non-Anonymous Room and Semi-Anonymous Room.</p>
+    <p class="" style="">Hidden Room -- a room that cannot be found by any user through normal means such as searching and service discovery; antonym: Public Room.</p>
+    <p class="" style="">Members-Only Room -- a room that a user cannot enter without being on the member list; antonym: Open Room.</p>
+    <p class="" style="">Moderated Room -- a room in which only those with &quot;voice&quot; may send messages to all occupants; antonym: Unmoderated Room.</p>
+    <p class="" style="">Non-Anonymous Room -- a room in which occupants' full JIDs are exposed to all occupants, although they may choose any desired room nickname; contrast with Semi-Anonymous Room and Fully-Anonymous Room.</p>
+    <p class="" style="">Open Room -- a room that anyone may enter without being on the member list; antonym: Members-Only Room.</p>
+    <p class="" style="">Password-Protected Room -- a room that a user cannot enter without first providing the correct password; antonym: Unsecured Room.</p>
+    <p class="" style="">Persistent Room -- a room that is not destroyed if the last occupant exits; antonym: Temporary Room.</p>
+    <p class="" style="">Public Room -- a room that can be found by any user through normal means such as searching and service discovery); antonym: Hidden Room.</p>
+    <p class="" style="">Semi-Anonymous Room -- a room in which occupants' full JIDs can be discovered by room admins only; contrast with Fully-Anonymous Room and Non-Anonymous Room.</p>
+    <p class="" style="">Temporary Room -- a room that is destroyed if the last occupant exits; antonym: Persistent Room.</p>
+    <p class="" style="">Unmoderated Room -- a room in which any occupant is allowed to send messages to all occupants; antonym: Moderated Room.</p>
+    <p class="" style="">Unsecured Room -- a room that anyone is allowed to enter without first providing the correct password; antonym: Password-Protected Room.</p>
+  </div>
+<h2>5.
+       <a name="connections">Roles and Affiliations</a>
+</h2>
+  <p class="" style="">There are two dimensions along which we can measure a user's connection with or position in a room. One is the user's long-lived affiliation with a room -- e.g., a user's status as an owner or an outcast. The other is a user's role while an occupant of a room -- e.g., an occupant's position as a moderator with the ability to kick visitors and participants. These two dimensions are orthogonal to each other, since an affiliation lasts across visits, while a role lasts only for the duration of a visit. In addition, there is no one-to-one correspondence between roles and affiliations; for example, someone who is not affiliated with a room may be a (temporary) moderator, and a member may be a participant or a visitor in a moderated room. These concepts are explained more fully below.</p>
+  <div class="indent">
+<h3>5.1 <a name="roles">Roles</a>
+</h3>
+    <p class="" style="">There are four defined roles that an occupant MAY have:</p>
+    <ol start="" type="">
+      <li>Moderator</li>
+      <li>Participant</li>
+      <li>Visitor</li>
+      <li>None (the absence of a role)</li>
+    </ol>
+    <p class="" style="">These roles are temporary in that they do not persist across a user's visits to the room and MAY change during the course of an occupant's visit to the room. In addition, there is no one-to-one mapping between these roles and a user's affiliation with the room (e.g., a member could be a participant or a visitor).</p>
+    <p class="" style="">A moderator is the most powerful occupant within the context of the room, and can to some extent manage other occupants' roles in the room. A participant has fewer privileges than a moderator, although he or she always has the right to speak. A visitor is a more restricted role within the context of a moderated room, since visitors are not allowed to send messages to all occupants.</p>
+    <p class="" style="">Roles are granted, revoked, and maintained based on the occupant's room nickname or full JID rather than bare JID. The privileges associated with these roles, as well as the actions that trigger changes in roles, are defined below.</p>
+    <p class="" style="">Information about roles MUST be sent in all presence stanzas generated or reflected by the room and thus sent to occupants.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="roles-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, roles exist in a hierarchy. For instance, a participant can do anything a visitor can do, and a moderator can do anything a participant can do. Each role has privileges not possessed by the next-lowest role; these privileges are specified in the following table as defaults (naturally an implementation MAY provide configuration options that override these defaults).</p>
+      <p class="caption">Table 1: Privileges Associated With Roles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Present in Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Receive Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Availability Status</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Nickname</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Private Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Invite Other Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Messages to All</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No**</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Modify Subject</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Kick Participants and Visitors</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Grant Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Revoke Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes***</td>
+        </tr>
+      </table>
+      <p class="" style="">* Default; configuration settings MAY further restrict this privilege.</p>
+      <p class="" style="">** An implementation MAY grant voice by default to visitors in unmoderated rooms.</p>
+      <p class="" style="">*** A moderator MUST NOT be able to revoke voice privileges from an admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="roles-change">Changing Roles</a>
+</h3>
+      <p class="" style="">The ways in which an occupant's role changes are well-defined. Sometimes the change results from the occupant's own action (e.g., entering or exiting the room), whereas sometimes the change results from an action taken by a moderator, admin, or owner. If an occupant's role changes, a compliant component implementation MUST change the occupant's role to reflect the change and communicate that to all occupants. Role changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 2: Role State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">&gt;</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Enter moderated room</td>
+          <td align="" colspan="" rowspan="">Enter unmoderated room</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Moderator grants voice</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">Moderator revokes voice</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Exit room</td>
+          <td align="" colspan="" rowspan="">Admin changes role to visitor</td>
+          <td align="" colspan="" rowspan="">Admin changes role to participant or revokes moderator privileges **</td>
+          <td align="" colspan="" rowspan="">--</td>
+        </tr>
+      </table>
+      <p class="" style="">* A moderator MUST NOT be able to revoke moderator privileges from an occupant who is equal to or above the moderator in the hierarchy of affiliations.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="affil">Affiliations</a>
+</h3>
+    <p class="" style="">There are five defined affiliations that a user MAY have in relation to a room:</p>
+    <ol start="" type="">
+      <li>Owner</li>
+      <li>Admin</li>
+      <li>Member</li>
+      <li>Outcast</li>
+      <li>None (the absence of an affiliation)</li>
+    </ol>
+    <p class="" style="">These affiliations are long-lived in that they persist across a user's visits to the room and are not affected by happenings in the room. In addition, there is no one-to-one mapping between these affiliations and an occupant's role within the room. Affiliations are granted, revoked, and maintained based on the user's bare JID.</p>
+    <p class="" style="">If a user without a defined affiliation enters a room, the user's affiliation is defined as &quot;none&quot;; however, this affiliation does not persist across visits.</p>
+    <p class="" style="">Owners and admins are by definition immune from certain actions. Specifically, an owner or admin cannot be kicked from a room and cannot be banned from a room. An admin MUST first lose his or her affiliation (i.e., have an affiliation of &quot;none&quot; or &quot;member&quot;) before such actions could be performed on them.</p>
+    <p class="" style="">The member affiliation provides a way for a room owner or admin to specify a &quot;whitelist&quot; of users who are allowed to enter a members-only room. When a member enters a members-only room, his or her affiliation does not change, no matter what his or her role is. The member affiliation also provides a way for users to effectively register with an open room and thus be lastingly associated with that room in some way (one result may be that the user's nickname is reserved in the room).</p>
+    <p class="" style="">An outcast is a user who has been banned from a room and who is not allowed to enter the room.</p>
+    <p class="" style="">Information about affiliations MUST be sent in all presence stanzas generated or reflected by the room and sent to occupants.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="affil-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, affiliations exist in a hierarchy. For instance, an owner can do anything an admin can do, and an admin can do anything a member can do. Each affiliation has privileges not possessed by the next-lowest affiliation; these privileges are specified in the following table.</p>
+      <p class="caption">Table 3: Privileges Associated With Affiliations</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Register with an Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Members-Only Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Ban Members and Unaffiliated Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Member List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Moderator List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Admin List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Owner List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Definition</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Destroy Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+      </table>
+      <p class="" style="">* As a default, an unaffiliated user enters a moderated room as a visitor, and enters an open room as a participant. A member enters a room as a participant. An admin or owner enters a room as a moderator.</p>
+      <p class="" style="">** An admin or owner MUST NOT be able to revoke moderation privileges from another admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="affil-change">Changing Affiliations</a>
+</h3>
+      <p class="" style="">The ways in which a user's affiliation changes are well-defined. Sometimes the change results from the user's own action (e.g., registering as a member of the room), whereas sometimes the change results from an action taken by an admin or owner. If a user's affiliation changes, a compliant component implementation MUST change the user's affiliation to reflect the change and communicate that to all occupants. Affiliation changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 4: Affiliation State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">-&gt;</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Outcast</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner removes ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes affiliation to &quot;member&quot;</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;admin&quot;</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;owner&quot;</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin adds user to member list, or user registers as member (if allowed)</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Member</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes affiliation to &quot;none&quot;</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Admin</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes affiliation to &quot;none&quot;</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;member&quot;</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Owner</td>
+          <td align="" colspan="" rowspan="">Owner applies ban</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;none&quot;</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;member&quot;</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;admin&quot;</td>
+          <td align="" colspan="" rowspan="">--</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+<h2>6.
+       <a name="user">Occupant Use Cases</a>
+</h2>
+  <p class="" style="">The main actor in a multi-user chat environment is the occupant, who can be said to be located &quot;in&quot; a multi-user chat room and to participate in the discussions held in that room (for the purposes of this JEP, participants and visitors are considered to be &quot;mere&quot; occupants, since they possess no administrative privileges). As will become clear, the protocol elements proposed in this JEP to fulfill the occupant use cases fall into three categories:</p>
+  <ol start="" type="">
+    <li><p class="" style="">existing &quot;groupchat 1.0&quot; protocol for minimal functionality</p></li>
+    <li><p class="" style="">straightforward applications of the &quot;groupchat 1.0&quot; protocol, for example to handle some of the errors related to new room types</p></li>
+    <li><p class="" style="">new protocol elements to handle functionality not covered by &quot;groupchat 1.0&quot; (room invites, room passwords, extended presence related to room roles and affiliations); these are contained in the new 'http://jabber.org/protocol/muc#user' namespace</p></li>
+  </ol>
+  <p class="" style="">Note: All client-generated examples herein are presented from the perspective of the service, with the result that all stanzas received by a service contain a 'from' attribute corresponding to the sender's full JID as added by a normal Jabber router or session manager. In addition, normal IQ result stanzas sent upon successful completion of a request are not shown. Most of the examples in this document use the scenario of the witches' meeting held in a dark cave at the beginning of Act IV, Scene I of Shakespeare's <span style="font-style: italic">Macbeth</span>. The characters are as follows:</p>
+  <p class="caption">Table 5: Dramatis Personae</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Room Nickname</th>
+      <th colspan="" rowspan="">Full JID</th>
+      <th colspan="" rowspan="">Affiliation</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">firstwitch</td>
+      <td align="" colspan="" rowspan="">crone1@shakespeare.lit/desktop</td>
+      <td align="" colspan="" rowspan="">Owner</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">secondwitch</td>
+      <td align="" colspan="" rowspan="">wiccarocks@shakespeare.lit/laptop</td>
+      <td align="" colspan="" rowspan="">Admin</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">thirdwitch</td>
+      <td align="" colspan="" rowspan="">hag66@shakespeare.lit/pda</td>
+      <td align="" colspan="" rowspan="">None</td>
+    </tr>
+  </table>
+  <div class="indent">
+<h3>6.1 <a name="discovery">Discovering Component Support for MUC</a>
+</h3>
+    <p class="" style="">Before entering a room, a Jabber user may want to discover if the room complies with the Multi-User Chat protocol.</p>
+    <p class="" style="">A compliant implementation MUST support <span class="ref">Service Discovery</span>  [<a href="#nt-id2606440">3</a>].</p>
+    <p class="caption">Example 1. User Queries Chat Service for MUC Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco1'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST return its identity and the features it supports:</p>
+    <p class="caption">Example 2. Service Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='Macbeth Chat Service'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: because MUC is a superset of the old &quot;Groupchat 1.0&quot; protocol, a MUC service SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result.</p>
+    <p class="" style="">The disco protocol also enables a user to query a service for a list of associated items, which in the case of a chat service would mainly consist of the specific chat rooms hosted by the service.</p>
+    <p class="caption">Example 3. User Queries Chat Service for Associated Items</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco2'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Returns Disco Item Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='heath@macbeth.shakespeare.lit'
+          name='A Lonely Heath'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='A Dark Cave'/&gt;
+    &lt;item jid='forres@macbeth.shakespeare.lit'
+          name='The Palace'/&gt;
+    &lt;item jid='inverness@macbeth.shakespeare.lit'
+          name='Macbeth&amp;apos;s Castle'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Using disco, a user may also query a specific chat room for more detailed information:</p>
+    <p class="caption">Example 5. User Queries for Information about a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The room MUST return its identity and SHOULD return the features it supports:</p>
+    <p class="caption">Example 6. Room Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: because MUC is a superset of the old &quot;Groupchat 1.0&quot; protocol, a MUC room SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result. The room SHOULD return the materially-relevant features it supports, such as password protection and room moderation (these are listed fully in the feature var registry maintained by the Jabber Registrar; see also the registry submission in this document).</p>
+    <p class="" style="">A chatroom MAY return more detailed information in its disco#info response using <span class="ref">Service Discovery Extensions</span>  [<a href="#nt-id2606557">4</a>]. Such information might include a more verbose description of the room, the current room subject, and the current number of occupants in the room:</p>
+    <p class="caption">Example 7. Room Returns Extended Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3a'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roominfo&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_description' label='Description'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_subject' label='Subject'&gt;
+        &lt;value&gt;Spells&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_occupants' label='Number of occupants'&gt;
+        &lt;value&gt;3&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_lang' label='Language of discussion'&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The foregoing extended service discovery fields for the 'http://jabber.org/protocol/muc#roominfo' FORM_TYPE may be supplemented in the future via the mechanisms described in the <a href="#registrar-formtype">Field Standardization</a> section of this document.</p>
+    <p class="" style="">Finally, a user may also query a specific chat room for its associated items:</p>
+    <p class="caption">Example 8. User Queries for Items Associated with a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">An implementation MAY return a list of existing occupants if that information is publicly available, or return no list at all if this information is kept private.</p>
+    <p class="caption">Example 9. Room Returns Disco Item Results (Items are Public)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/firstwitch'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note that these &lt;item/&gt; elements are in the disco#items namespace, not the muc namespace. This means that they cannot possess 'affiliation' or 'role' attributes, for example.</p>
+    <p class="caption">Example 10. Room Returns Empty Disco Item Results (Items are Private)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If an entity attempts to send a disco request to an address of the form &lt;room@service/nick&gt;, a compliant component SHOULD return the request to the entity and specify a &lt;bad-request/&gt; error condition.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="discovery-client">Discovering Client Support for MUC</a>
+</h3>
+    <p class="" style="">A Jabber user may want to discover if one of the user's contacts supports the Multi-User Chat protocol. This is done using Service Discovery.</p>
+    <p class="caption">Example 11. User Queries Contact regarding MUC Support</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco5'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client SHOULD return its identity and the features it supports:</p>
+    <p class="caption">Example 12. Contact Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='disco5'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='client'
+        type='pc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A user may also query a contact regarding which rooms the contact is in. This is done by querying the contact's full JID (user@host/resource) while specifying the well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms':</p>
+    <p class="caption">Example 13. User Queries Contact for Current Rooms</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='rooms1'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Contact Returns Room Query Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='rooms1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'/&gt;
+    &lt;item jid='characters@conference.shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Optionally, the contact MAY include its roomnick as the value of the 'name' attribute:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+    ...
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='secondwitch'/&gt;
+    ...
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="enter">Entering a Room</a>
+</h3>
+    <div class="indent">
+<h3>6.3.1 <a name="enter-gc">Groupchat 1.0 Protocol</a>
+</h3>
+      <p class="" style="">In order to participate in the discussions held in a multi-user chat room, a Jabber user MUST first become an occupant by entering the room. In the old &quot;groupchat 1.0&quot; protocol, this is done by sending presence to room@service/nick, where &quot;room&quot; is the room ID, &quot;service&quot; is the hostname of the chat service, and &quot;nick&quot; is the user's desired nickname within the room:</p>
+      <p class="caption">Example 15. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'/&gt;
+      </pre></div>
+      <p class="" style="">In this example, a user with a full JID of &quot;hag66@shakespeare.lit/pda&quot; has requested to enter the room &quot;darkcave&quot; on the &quot;macbeth.shakespeare.lit&quot; chat service with a room nickname of &quot;thirdwitch&quot;.</p>
+      <p class="" style="">If the user does not specify a room nickname, the service SHOULD return a &lt;jid-malformed/&gt; error:</p>
+      <p class="caption">Example 16. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;jid-malformed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.2 <a name="enter-muc">Basic MUC Protocol</a>
+</h3>
+      <p class="" style="">Compliant multi-user chat services MUST accept the foregoing as a request to enter a room from any Jabber client that knows either the &quot;groupchat 1.0&quot; (GC) protocol or the multi-user chat (MUC) protocol; however, MUC-compliant clients SHOULD signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
+      <p class="caption">Example 17. Jabber User Seeks to Enter a Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.3 <a name="enter-pres">Presence Broadcast</a>
+</h3>
+      <p class="" style="">If the service is able to add the user to the room, it MUST send presence from all the existing occupants' room JIDs to the new occupant's full JID, including extended presence information about roles in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;moderator&quot;, &quot;participant&quot;, &quot;visitor&quot;, or &quot;none&quot; and with the 'affiliation' attribute set to a value of &quot;owner&quot;, &quot;admin&quot;, &quot;member&quot;, or &quot;none&quot; as appropriate:</p>
+      <p class="caption">Example 18. Service Sends Presence from Existing Occupants to New Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, the user from the previous example has entered the room, by which time two other people had already entered the room: a user with a room nickname of &quot;firstwitch&quot; (who is the room owner) and a user with a room nickname of &quot;secondwitch&quot; (who is a room admin).</p>
+      <p class="" style="">The service MUST also send presence from the new occupant's room JID to the full JIDs of all the occupants (including the new occupant):</p>
+      <p class="caption">Example 19. Service Sends New Occupant's Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, initial room presence is being sent from the new occupant (thirdwitch) to all occupants, including the new occupant.</p>
+      <p class="" style="">The order of the presence stanzas sent to the new occupant is important. The service MUST first send the complete list of the existing occupants to the new occupant and only then send the new occupant's own presence to the new occupant. This helps the client know when it has received the complete &quot;room roster&quot;.</p>
+    </div>
+    <div class="indent">
+<h3>6.3.4 <a name="enter-roles">Default Roles</a>
+</h3>
+      <p class="" style="">The following table summarizes the initial default roles that a service should set based on the user's affiliation (there is no role associated with the &quot;outcast&quot; affiliation, since such users are never allowed to enter the room).</p>
+      <p class="caption">Table 6: Initial Role Based on Affiliation</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Room Type</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderated</td>
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Unmoderated</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Members-Only</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Open</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>6.3.5 <a name="enter-nonanon">Non-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is non-anonymous, the service MUST send the new occupant's full JID to all occupants using extended presence information in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with a 'jid' attribute specifying the occupant's full JID:</p>
+      <p class="caption">Example 20. Service Sends Full JID to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+      </pre></div>
+      <p class="" style="">If the user is entering a room that is non-anonymous (i.e., which informs all occupants of each occupant's full JID as shown above), the service SHOULD allow the user to enter the room but MAY warn the user that the room is not anonymous; this is done by sending a message of type &quot;groupchat&quot; to the new occupant containing an &lt;x/&gt; child with a &lt;status/&gt; element that has the 'code' attribute set to a value of &quot;100&quot;:</p>
+      <p class="caption">Example 21. Service Warns New Occupant of Lack of Anonymity</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;This room is not anonymous.&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;status code='100'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality).</p>
+    </div>
+    <div class="indent">
+<h3>6.3.6 <a name="enter-semianon">Semi-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is semi-anonymous, the service MUST send the new occupant's full JID in the format shown above only to those occupants with a role of &quot;moderator&quot;.</p>
+      <p class="" style="">(Note: all subsequent examples include the 'jid' attribute for each &lt;item/&gt; element, even though this information is not sent to non-moderators in semi-anonymous rooms.)</p>
+    </div>
+    <div class="indent">
+<h3>6.3.7 <a name="enter-pw">Password-Protected Rooms</a>
+</h3>
+      <p class="" style="">If the room requires a password and the user did not supply one, the service MUST deny access to the room and inform the user that they are unauthorized; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;not-authorized/&gt; error:</p>
+      <p class="caption">Example 22. Service Denies Access Because No Password Provided</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Passwords SHOULD be supplied with the presence stanza sent when entering the room, contained within an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace and containing a &lt;password/&gt; child. Passwords are to be sent as cleartext; no other authentication methods are supported at this time, and any such authentication or authorization methods shall be defined in a separate specification.</p>
+      <p class="caption">Example 23. User Provides Password On Entering a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.8 <a name="enter-members">Members-Only Rooms</a>
+</h3>
+      <p class="" style="">If the room is members-only but the user is not on the member list, the service MUST deny access to the room and inform the user that they are not allowed to enter the room; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;registration-required/&gt; error condition:</p>
+      <p class="caption">Example 24. Service Denies Access Because User Is Not on Member List</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='407' type='auth'&gt;
+    &lt;registration-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.9 <a name="enter-banned">Banned Users</a>
+</h3>
+      <p class="" style="">If the user has been banned from the room (i.e., has an affiliation of &quot;outcast&quot;), the service MUST deny access to the room and inform the user of the fact that he or she is banned; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;forbidden/&gt; error condition:</p>
+      <p class="caption">Example 25. Service Denies Access Because User is Banned</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.10 <a name="enter-conflict">Nickname Conflict</a>
+</h3>
+      <p class="" style="">If the room already contains an occupant with the nickname desired by the user seeking to enter the room (or if the nickname is reserved by a user on the member list), the service MUST deny access to the room and inform the user of the conflict; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;conflict/&gt; error condition:</p>
+      <p class="caption">Example 26. Service Denies Access Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.11 <a name="enter-maxusers">Max Users</a>
+</h3>
+      <p class="" style="">If the room has reached its maximum number of uses, the service SHOULD deny access to the room and inform the user of the restriction; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;not-allowed/&gt; error condition:</p>
+  <p class="caption">Example 27. Service Informs User that Room Occupant Limit Has Been Reached</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+  </pre></div>
+
+    </div>
+    <div class="indent">
+<h3>6.3.12 <a name="enter-history">Discussion History</a>
+</h3>
+      <p class="" style="">After sending initial presence as shown above, a room MAY send discussion history to the new occupant. Whether such history is sent, and how many messages comprise the history, shall be determined by the chat service implementation or specific deployment.</p>
+      <p class="caption">Example 28. Delivery of Discussion History</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20021013T23:58:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20021013T23:58:43'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries 'Tis time, 'tis time.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='hag66@shakespeare.lit/pda'
+     stamp='20021013T23:58:49'/&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">Discussion history messages SHOULD be stamped with extended information in the 'jabber:x:delay' namespace (see <span class="ref">Delayed Delivery</span>  [<a href="#nt-id2607933">5</a>]) to indicate that they are sent with delayed delivery. The 'from' attribute SHOULD be the JID of the original sender in non-anonymous rooms, but MUST NOT be in semi-anonymous rooms (the 'from' attribute SHOULD be set to the room JID in semi-anonymous rooms).</p>
+    </div>
+    <div class="indent">
+<h3>6.3.13 <a name="enter-managehistory">Managing Discussion History</a>
+</h3>
+      <p class="" style="">A user MAY want to manage the amount of discussion history provided on entering a room (perhaps because the user is on a low-bandwidth connection or is using a small-footprint client). This MUST be accomplished by including a &lt;history/&gt; child in the initial presence stanza sent when joining the room. There are four allowable attributes for this element:</p>
+      <p class="caption">Table 7: History Management Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Attribute</th>
+          <th colspan="" rowspan="">Datatype</th>
+          <th colspan="" rowspan="">Meaning</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxchars</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of characters in the history to &quot;X&quot;.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxstanzas</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of messages in the history to &quot;X&quot;.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">seconds</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Send only the messages received in the last &quot;X&quot; seconds.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">since</td>
+          <td align="" colspan="" rowspan="">dateTime</td>
+          <td align="" colspan="" rowspan="">Send only the messages received since the dateTime specified (which MUST conform to <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2608256">6</a>]).</td>
+        </tr>
+      </table>
+      <p class="" style="">The service MUST send the smallest amount of traffic that meets any combination of the above criteria, taking into account service-level and room-level defaults. The service MUST send complete message stanzas only (i.e., it MUST not literally truncate the history at a certain number of characters, but MUST send the largest number of complete stanzas that results in a number of characters less than or equal to the 'maxchars' value specified). If the client wishes to receive no history, it MUST set the 'maxcharts' attribute to a value of &quot;0&quot; (zero).</p>
+      <p class="" style="">The following examples illustrate the use of this protocol.</p>
+      <p class="caption">Example 29. User Requests Limit on Number of Messages in History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxstanzas='20'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 30. User Requests History in Last 3 Minutes</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history seconds='180'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 31. User Requests All History Since the Beginning of the Unix Era</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history since='1970-01-01T00:00Z'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Obviously the service SHOULD NOT return all messages sent in the room since the beginning of the Unix era, and SHOULD appropriately limit the amount of history sent to the user based on service or room defaults.</p>
+      <p class="caption">Example 32. User Requests No History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxchars='0'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.14 <a name="enter-create">Room Creation</a>
+</h3>
+      <p class="" style="">If the room does not already exist when the user seeks to enter it, the service MAY be responsible for creating it; however, this is OPTIONAL, since an implementation or deployment MAY choose to restrict the privilege of creating rooms. See &quot;Owner Use Cases&quot; for details.</p>
+      <p class="" style="">If a user attempts to enter a room that does not exist or to enter a room while it is &quot;locked&quot; (i.e., before the room creator provides an initial configuration and therefore before the room officially exists), the service MUST refuse entry and return a &lt;item-not-found/&gt; error to the user:</p>
+      <p class="caption">Example 33. Service Denies Access Because Room Does Not Exist</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="exit">Exiting a Room</a>
+</h3>
+    <p class="" style="">In order to exit a multi-user chat room, an occupant sends a presence stanza of type &quot;unavailable&quot; to the room@service/nick it is currently using in the room.</p>
+    <p class="caption">Example 34. Occupant Exits a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send presence stanzas of type &quot;unavailable&quot; from the departing occupant's room JID to the full JIDs of the departing occupant and of the remaining occupants:</p>
+    <p class="caption">Example 35. Service Sends Presence Related to Departure of Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Presence stanzas of type &quot;unavailable&quot; reflected by the room MUST contain extended presence information about roles and affiliations, and MAY also contain normal &lt;show/&gt; and &lt;status/&gt; information (this last enables occupants to provide custom exit messages if desired).</p>
+    <p class="" style="">Normal presence stanza generation rules apply as defined in <span style="font-weight: bold">XMPP IM</span>, so that if the user sends a general unavailable presence stanza, the user's server will broadcast that stanza to the room@service/nick to which the user's client has sent directed presence.</p>
+    <p class="" style="">If the room is not persistent and this occupant is the last to exit, the service is responsible for destroying the room.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="changenick">Changing Nickname</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability for an occupant to change his or her nickname within the room. In Jabber this is done by sending updated presence information to the room, specifically by sending presence to a new room JID in the same room (changing only the resource identifier in the room JID).</p>
+    <p class="caption">Example 36. Occupant Changes Nickname</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'/&gt;
+    </pre></div>
+    <p class="" style="">The service then sends two presence packets to the full JID of each occupant (including the occupant who is changing his or her room nickname), one of type &quot;unavailable&quot; for the old nickname and one indicating availability for the new nickname. The unavailable presence MUST contain the new nickname and an appropriate status code (namely 303) as extended presence information in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace so that Jabber clients are able to provide relevant hints to occupants regarding the nickname change if desired.</p>
+    <p class="caption">Example 37. Service Updates Nick</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If the user attempts to change his or her room nickname to a room nickname that is already in use by another occupant (or that is reserved by someone affiliated with the room, e.g., a member or owner), the service MUST deny the nickname change request and inform the user of the conflict; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;conflict/&gt; error condition:</p>
+    <p class="caption">Example 38. Service Denies Nickname Change Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="changepres">Changing Availability Status</a>
+</h3>
+    <p class="" style="">In multi-user chat systems such as IRC, one common use for changing one's room nickname is to indicate a change in one's availability (e.g., changing one's room nickname to &quot;thirdwitch|away&quot;). In Jabber, availability is of course noted by a change in presence (specifically the &lt;show/&gt; and &lt;status/&gt; elements), which can provide important context within a chatroom. An occupant changes availability status within the room by sending the updated presence to room@service/nick.</p>
+    <p class="caption">Example 39. Occupant Changes Availability Status</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The service then sends a presence packet from the occupant changing his or her presence to the full JID of each occupant, including extended presence information about the occupant's role and full JID to those with privileges to view such information:</p>
+    <p class="caption">Example 40. Service Passes Along Changed Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="invite">Inviting Another User to a Room</a>
+</h3>
+    <p class="" style="">It can be useful to invite another user to a room in which one is an occupant. Several different mechanisms have been suggested in the past to do this. The protocol most commonly used is for the inviting occupant to send a message directly to the invitee, containing extended content in the jabber:x:conference namespace. The server (not the chat service) adds a 'from' address to the invite message, which is delivered like any other message. This undocumented protocol, which is not part of &quot;groupchat 1.0&quot;, is as follows:</p>
+    <p class="caption">Example 41. Occupant Sends an Invitation (Existing Protocol)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;body&gt;You have been invited to darkcave@macbeth.&lt;/body&gt;
+    &lt;x jid='room@service' xmlns='jabber:x:conference'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While the current protocol meets the needs of existing implementations, it could not work within the context of a members-only room, since the service needs to keep track of who is registered as a member. Because we would like to support members-only rooms, it seems desirable for an occupant to send the invitation to the room itself and have the room keep track of the invitations (if the room is members-only) or simply forward the invitation to the invitee.</p>
+    <p class="" style="">Therefore the old undocumented protocol SHOULD be officially discouraged (it cannot be deprecated since it was never approved) and a MUC-compliant client MUST instead send XML of the following form to the room itself (the reason is OPTIONAL and the message MUST NOT possess a 'type' attribute; the service MAY ignore or reject invites that possess a 'type' attribute):</p>
+    <p class="caption">Example 42. Occupant Sends an Invitation by Way of Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The room itself MUST then add a 'from' address to the &lt;invite/&gt; element equal to the bare JID (or, optionally, the room JID) of the inviter and send the invitation to the invitee captured in the 'to' address (the service SHOULD include the jabber:x:conference information for backward compatibility and MAY if desired include a message body explaining the invitation or containing the reason; in addition, the room SHOULD add the password if the room is password-protected):</p>
+    <p class="caption">Example 43. Room Sends Invitation to Invitee on Behalf of Inviter</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+  &lt;x jid='room@service' xmlns='jabber:x:conference'&gt;
+    Hey Hecate, this is the place for all good witches!
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MAY also add the invitee to the member list. (Note that invitation privileges in members-only rooms SHOULD be restricted to room admins; if a member without privileges to edit the member list attempts to invite another user, the service SHOULD return a &lt;forbidden/&gt; error to the occupant; for details, see the &quot;Modifying the Member List&quot; use case under Moderator Use Cases.)</p>
+    <p class="" style="">If the inviter supplies a non-existent JID, the room SHOULD return a &lt;item-not-found/&gt; error to the inviter.</p>
+    <p class="" style="">The invitee MAY choose to formally decline (as opposed to ignore) the invitation; and this is something that the sender may want to be informed about. In order to decline the invitation, the invitee MUST send a message of the following form to the room itself:</p>
+
+    <p class="caption">Example 44. Invitee Declines Invitation</p>
+<div class="indent"><pre>
+&lt;message
+    from='hecate@shakespeare.lit/broom'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline to='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 45. Room Informs Inviter that Invitation Was Declined</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline from='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">It may be wondered why the invitee does not send the decline message directly to the inviter. The main reason is that certain implementations MAY choose to base invitations on room JIDs rather than bare JIDs (so that, for example, an occupant could invite someone from one room to another without knowing that person's bare JID), in which case the service MUST handle both the invites and declines.</p>
+  </div>
+  <div class="indent">
+<h3>6.8 <a name="continue">Converting a One-to-One Chat Into a Conference</a>
+</h3>
+    <p class="" style="">Sometimes it is desirable to convert a one-to-one chat into a multi-user conference. This can be done by including a &lt;continue/&gt; child in the invitation. The process flow is shown in the following examples.</p>
+    <p class="" style="">First, two users begin a one-to-one chat.</p>
+    <p class="caption">Example 46. A One-to-One Chat</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='chat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Now the first person decides to include a third person in the discussion, so she (or, more precisely, her client) does the following:</p>
+    <ol start="" type="">
+      <li>Creates a new room (which SHOULD be non-anonymous and MAY be an instant room as specified below)</li>
+      <li>Optionally sends history of the one-to-one chat to the room</li>
+      <li>Sends an invitation to the second person and the third person, including a &lt;continue/&gt; flag.</li> 
+    </ol>
+    <p class="caption">Example 47. Continuing the Discussion I: User Creates Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 48. Continuing the Discussion II: Owner Sends History to Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20040929T01:54:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20040929T01:55:21'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Use of the <span style="font-weight: bold">Delayed Delivery</span> protocol enables the room creator to specify the datetime of each message from the one-to-one chat history (via the 'stamp' attribute), as well as JID of the original sender of each message (via the 'from' attribute). The room creator SHOULD send the complete one-to-one chat history before inviting additional users to the room, and SHOULD also send as history any messages appearing in the one-to-one chat interface after joining the room and before the second person joins the room; if the one-to-one history is especially large, the sending client may want to send the history over a few seconds rather than all at once (to avoid triggering rate limits). The service SHOULD NOT add its own delay elements (as described in the under <a href="#enter-history">Discussion History</a>) to prior chat history messages received from the room owner.</p>
+    <p class="caption">Example 49. Continuing the Discussion III: Owner Sends Invitations, Including Continue Flag</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='wiccarocks@shakespeare.lit/laptop'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hag66@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The invitations are delivered to the invitees:</p>
+    <p class="caption">Example 50. Invitations Delivered</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'&gt;
+    from='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'&gt;
+    from='hag66@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Since the inviter's client knows the full JID of the person with whom the inviter was having a one-to-one chat, it SHOULD include the full JID (rather than the bare JID) in the invitation.</p>
+    <p class="" style="">When the client being used by &lt;wiccarocks@shakespeare.lit/laptop&gt; receives the invitation, it SHOULD (subject to user preferences) auto-join the room and seamlessly convert the existing one-to-one chat window into a multi-user conferencing window:</p>
+    <p class="caption">Example 51. Invitee Accepts Invitation, Joins Room, and Receives Presence and History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/secondwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20040929T01:54:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20040929T01:55:21'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: The fact that the messages come from the room itself rather than room@service/nick is a clue to the receiving client that these messages are prior chat history, since any message from a room occupant will have a 'from' address equal to the sender's room JID.</p>
+  </div>
+  <div class="indent">
+<h3>6.9 <a name="subject-occupant">Occupant Modification of the Room Subject</a>
+</h3>
+    <p class="" style="">If allowed in accordance with room configuration, a mere occupant MAY have the privileges to change the subject in a room. For details, see the &quot;Modifying the Room Subject&quot; use case under &quot;Moderator Use Cases&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>6.10 <a name="privatemessage">Sending a Private Message</a>
+</h3>
+    <p class="" style="">Since each occupant has a unique room JID, an occupant MAY send a &quot;private message&quot; to a selected occupant via the service by sending a message to the occupant's room JID. The message type SHOULD be &quot;chat&quot; and MUST NOT be &quot;groupchat&quot;, but MAY be left unspecified (i.e., a normal message). This privilege SHOULD be allowed to any occupant (even a visitor in a moderated room).</p>
+    <p class="caption">Example 52. Occupant Sends Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for changing the 'from' address to the sender's room JID and delivering the message to the intended recipient's full JID.</p>
+    <p class="caption">Example 53. Recipient Receives the Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message of type &quot;groupchat&quot; to a particular occupant, the service MUST refuse to deliver the message and return a &lt;bad-request/&gt; error to the sender:</p>
+    <p class="caption">Example 54. Occupant Attempts to Send a Message of Type &quot;Groupchat&quot; to a Particular Occupant</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='groupchat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message to a room JID that does not exist, the service MUST return a &lt;item-not-found/&gt; error to the sender.</p>
+    <p class="" style="">If the sender is not an occupant of the room in which the intended recipient is visiting, the service MUST return a &lt;not-acceptable/&gt; error to the sender.</p>
+  </div>
+  <div class="indent">
+<h3>6.11 <a name="message">Sending a Message to All Occupants</a>
+</h3>
+    <p class="" style="">An occupant sends a message to all other occupants in the room by sending a message of type &quot;groupchat&quot; to the room itself (a service MAY ignore or reject messages that do not have a type of &quot;groupchat&quot;). In a moderated room, this privilege is restricted to occupants with a role of participant or higher. In an unmoderated room, any occupant sends a message to all other occupants by directing the message to the room itself and setting the 'type' attribute to a value of &quot;groupchat&quot;.</p>
+    <p class="caption">Example 55. Occupant Sends a Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender has voice in the room (this is the default except in moderated rooms), the service MUST change the 'from' attribute to the sender's room JID and reflect the message out to the full JID of each occupant.</p>
+    <p class="caption">Example 56. Service Reflects Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender is a visitor (i.e., does not have voice in a moderated room), the service MAY return a &lt;forbidden/&gt; error to the sender and MUST NOT reflect the message to all occupants. If the sender is not an occupant of the room, the service SHOULD return a &lt;not-acceptable/&gt; error to the sender and SHOULD NOT reflect the message to all occupants; however, an implementation MAY allow users with certain privileges (e.g., a room owner, room admin, or service-level admin) to send messages to the room even if that user is not an occupant.</p>
+  </div>
+  <div class="indent">
+<h3>6.12 <a name="register">Registering with a Room</a>
+</h3>
+    <p class="" style="">An implementation MAY allow an unaffiliated user (in a moderated room, probably a participant) to register with a room and thus become a member of the room (conversely, an implementation MAY restrict this privilege and allow only room admins to add new members). If allowed, this functionality SHOULD be implemented by enabling a user to send a request for registration requirements to the room in the 'jabber:iq:register' namespace as described in <span class="ref">In-Band Registration</span>  [<a href="#nt-id2609497">7</a>]:</p>
+    <p class="caption">Example 57. User Requests Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user requesting registration requirements is not allowed to register with the room (e.g., because that privilege has been restricted), the room MUST return a &lt;not-allowed/&gt; error to the user. If the user is already registered, the room MUST reply with an IQ stanza of type &quot;result&quot; that contains an empty &lt;register/&gt; element as described in JEP-0077. If the room does not exist, the service MUST return a &lt;item-not-found/&gt; error.</p>
+    <p class="" style="">Otherwise, the room MUST then return a form to the user in the 'jabber:x:data' namespace. The specific information required to register is not specified in this JEP and MAY vary by implementation or deployment. The following can be taken as a fairly typical example:</p>
+    <p class="caption">Example 58. Service Returns Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      To register on the web, visit http://shakespeare.lit/
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Dark Cave Registration&lt;/title&gt;
+      &lt;instructions&gt;
+        Please provide the following information
+        to register with this room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='First Name'
+          type='text-single'
+          var='muc#register_first'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Last Name'
+          type='text-single'
+          var='muc#register_last'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Desired Nickname'
+          type='text-single'
+          var='muc#register_roomnick'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Your URL'
+          type='text-single'
+          var='muc#register_url'/&gt;
+      &lt;field
+          label='Email Address'
+          type='text-single'
+          var='muc#register_email'/&gt;
+      &lt;field
+          label='FAQ Entry'
+          type='text-multi'
+          var='muc#register_faqentry'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The user SHOULD then submit the form:</p>
+    <p class="caption">Example 59. User Submits Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_first'&gt;
+        &lt;value&gt;Brunhilde&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_last'&gt;
+        &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_roomnick'&gt;
+        &lt;value&gt;thirdwitch&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_url'&gt;
+        &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_email'&gt;
+        &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_faqentry'&gt;
+        &lt;value&gt;Just another witch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the desired room nickname is already reserved for that room, the room MUST return a &lt;conflict/&gt; error to the user:</p>
+    <p class="caption">Example 60. Room Returns Conflict Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room or service does not support registration, it MUST return a &lt;service-unavailable/&gt; error to the user:</p>
+    <p class="caption">Example 61. Room Returns Service Unavailable Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user did not include a valid data form does, the room MUST return a &lt;bad-request/&gt; error to the user:</p>
+    <p class="caption">Example 62. Room Returns Service Bad Request Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the room MUST inform the user of successful registration:</p>
+    <p class="caption">Example 63. Room Informs User of Successful Registration</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After the user successfully submits the form, the service MAY request that the submission be approved by a room admin/owner (see <a href="#regapprove">Approving Registration Requests</a>) or MAY immediately add the user to the member list by changing the user's affiliation from &quot;none&quot; to &quot;member&quot;. If the service changes the user's affiliation and the user is in the room, it MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 64. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a user has registered with a room, the room MAY choose to restrict the user to use of the registered nickname only in that room. If it does so, it SHOULD return a &quot;Not Acceptable&quot; (406) error to the user if the user attempts to join the room with a roomnick other than the user's registered roomnick.</p>
+  </div>
+  <div class="indent">
+<h3>6.13 <a name="reservednick">Discovering Reserved Room Nickname</a>
+</h3>
+    <p class="" style="">A user MAY have a reserved room nickname, for example through explicit room registration or database integration. In such cases it may be desirable for the user to discover the reserved nickname before attempting to enter the room (e.g., because the user has forgotten his or her reserved nickname). This is done by sending a Service Discovery information request to the room JID while specifying a Service Discovery node of &quot;x-roomuser-item&quot;.</p>
+    <p class="caption">Example 65. User Requests Reserved Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='getnick1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It is OPTIONAL for a multi-user chat service to support the foregoing service discovery node. If it does and the user has a registered nickname, it MUST return the nickname to the user as value of the 'name' attribute of a Service Discovery &lt;identity/&gt; element (for which the category/type SHOULD be &quot;conference/member&quot;):</p>
+    <p class="caption">Example 66. Room Returns Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='getnick1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'&gt;
+    &lt;identity
+        category='conference'
+        name='thirdwitch'
+        type='text'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user does not have a registered nickname, the room MUST return a service discovery &lt;query/&gt; element that is empty (in accordance with JEP-0030).</p>
+    <p class="" style="">If the room or service does not support the foregoing service discovery node, it MUST return a &quot;Feature Not Implemented&quot; (502) error to the user.</p>
+    <p class="" style="">Even if a user has registered one room nickname, the service SHOULD allow the user to specify a different nickname on entering the room (e.g., in order to join from different client resources), although the service MAY choose to &quot;lock down&quot; nicknames and therefore deny entry to the user, including a &quot;Not Acceptable&quot; (406) error. The service MUST NOT return an error to the user if his or her client performs the foregoing request after having already joined the room.</p>
+    <p class="" style="">If another user attempts to join the room with a nickname reserved by the first user, the service MUST deny entry to the second user and return a &lt;conflict/&gt; error.</p>
+  </div>
+<h2>7.
+       <a name="moderator">Moderator Use Cases</a>
+</h2>
+  <p class="" style="">A moderator has privileges to perform certain actions within the room (e.g., to change the roles of some occupants) but does not have rights to change persistent information about affiliations, which MAY be changed only by an admin (or owner). Exactly which actions may be performed by a moderator is subject to configuration. However, for the purposes of the MUC framework, moderators are stipulated to have privileges to perform the following actions:</p>
+  <ol start="" type="">
+    <li>discover an occupant's full JID in a semi-anonymous room (occurs by default as shown above)</li>
+    <li>modify the subject</li>
+    <li>kick a participant or visitor from the room</li>
+    <li>grant or revoke voice in a moderated room</li>
+    <li>modify the list of occupants who have voice in a moderated room</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response &quot;conversation&quot; using &lt;iq/&gt; elements that contain children scoped by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the user@host of the 'from' address of the request does not match the full JID of one of the moderators; in this case, the service MUST return a &lt;forbidden/&gt; error.)</p>
+  <div class="indent">
+<h3>7.1 <a name="subject-mod">Modifying the Room Subject</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability to change the subject within the room. As a default, only users with a role of &quot;moderator&quot; SHOULD be allowed to change the subject in a room (although this SHOULD be configurable, with the result a mere participant or even visitor may be allowed to change the subject if desired). The subject is changed by sending a message of type &quot;groupchat&quot; to the room@service, containing no body but a &lt;subject/&gt; that specifies the new subject:</p>
+    <p class="caption">Example 67. Moderator Changes Subject</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If a compliant service receives such a message, it MUST reflect the message to all other occupants with a 'from' address equal to the room JID that corresponds to the sender of the subject change:</p>
+    <p class="caption">Example 68. Service Informs All Occupants of Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the room SHOULD include the last subject change in the discussion history sent when a new occupant joins the room.</p>
+    <p class="" style="">A compliant client that receives such a message MAY choose to display an in-room message; the body of such in-room messages SHOULD NOT be generated by the sending client or the service, so as to ensure correct localization (however, the sending client or service MAY generate the body if desired). The in-room message could be something like the following:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+* secondwitch has changed the subject to: Fire Burn and Cauldron Bubble!
+    </pre></div>
+    <p class="" style="">If someone without appropriate privileges attempts to change the room subject, the service MUST return a message of type &quot;error&quot; specifying a &lt;forbidden/&gt; error condition:</p>
+    <p class="caption">Example 69. Service Returns Error Related to Unauthorized Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="kick">Kicking a Visitor or Participant from a Room</a>
+</h3>
+    <p class="" style="">A moderator has permissions kick a visitor or participant from a room. The kick is normally performed based on the occupant's room nickname (though it MAY be based on the full JID) and is effected by setting the role of a participant or visitor to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 70. Moderator Kicks Occupant</p>
+<div class="indent"><pre>
+&lt;iq from='fluellen@shakespeare.lit/pda'
+    id='kick1'
+    to='harfleur@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='pistol' role='none'&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the kicked occupant by sending a presence stanza of type &quot;unavailable&quot; to each kicked occupant, including status code 307 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the kick.</p>
+    <p class="caption">Example 71. Service Removes Kicked Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='pistol@shakespeare.lit/harfleur'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='fluellen@shakespeare.lit'/&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the kicked user to understand why he or she was kicked, and by whom if the kicked occupant would like to discuss the matter.</p>
+    <p class="" style="">After removing the kicked occupant(s), the service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 72. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='harfleur@henryv.shakespeare.lit'
+    id='kick1'
+    to='fluellen@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After informing the moderator, the service MUST then inform all of the remaining occupants that the kicked occupant is no longer in the room by sending presence stanzas of type &quot;unavailable&quot; from the kicked occupant to all the remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason.</p>
+    <p class="caption">Example 73. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='gower@shakespeare.lit/cell'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator cannot be kicked from a room, nor can any user with an affiliation of &quot;owner&quot; or &quot;admin&quot;. If a moderator attempts to kick such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 74. Service Returns Error on Attempt to Kick Moderator, Admin, or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='kicktest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='firstwitch' role='none'&gt;
+      &lt;reason&gt;Be gone!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="grantvoice">Granting Voice to a Visitor</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to manage who does and does not have &quot;voice&quot; in the room. Voice is granted based on the visitor's room nickname, which the service will convert into the visitor's full JID internally. The moderator can grant voice to a visitor by changing the visitor's role to &quot;participant&quot; (the &lt;reason/&gt; element is optional):</p>
+    <p class="caption">Example 75. Moderator Grants Voice to a Visitor</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 76. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the addition of voice privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;participant&quot;.</p>
+    <p class="caption">Example 77. Service Sends Notice of Voice to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="revokevoice">Revoking Voice from a Participant</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to revoke a participant's privileges to speak. The moderator can revoke voice from a participant by changing the participant's role to &quot;visitor&quot;:</p>
+    <p class="caption">Example 78. Moderator Revokes Voice from a Participant</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 79. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of voice privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;visitor&quot;.</p>
+    <p class="caption">Example 80. Service Notes Loss of Voice</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='visitor'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator MUST NOT be able to revoke voice from a user whose affiliation is at or above the moderator's level. In addition, a service MUST NOT allow the voice privileges of an admin or owner to be removed by anyone. If a moderator attempts to revoke voice privileges from such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 81. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voicetest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.5 <a name="modifyvoice">Modifying the Voice List</a>
+</h3>
+    <p class="" style="">A moderator in a moderated room may want to modify the voice list. To do so, the moderator first requests the voice list by querying the room for all occupants with a role of 'participant'.</p>
+    <p class="caption">Example 82. Moderator Requests Voice List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='voice3'
+    to='goodfolk@chat.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the voice list to the moderator; each item MUST include the 'nick' and 'role' attributes and SHOULD include the 'affiliation' and 'jid' attributes:</p>
+    <p class="caption">Example 83. Service Sends Voice List to Moderator</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='polonius@hamlet/castle'
+          nick='Polo'
+          role='participant'/&gt;
+    &lt;item affiliation='none'
+          jid='horatio@hamlet/castle'
+          nick='horotoro'
+          role='participant'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The moderator MAY then modify the voice list. In order to do so, the moderator MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'nick' attribute and 'role' attribute (normally set to a value of &quot;participant&quot; or &quot;visitor&quot;) but SHOULD NOT include the 'jid' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as owner rather than the participant role):</p>
+    <p class="caption">Example 84. Moderator Sends Modified Voice List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='voice4'
+    to='goodfolk@chat.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='Hecate'
+          role='visitor'/&gt;
+    &lt;item nick='rosencrantz'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item nick='guildenstern'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 85. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice1'
+    to='author@shakespeare.lit/globe'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in voice privileges by sending the appropriate extended presence packets as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, voice privileges cannot be revoked from a room owner or room admin, nor from any user with a higher affiliation than the moderator making the request. If a room admin attempts to revoke voice privileges from such a user by modifying the voice list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 86. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voicetest'
+    to='author@shakespeare.lit/globe'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit'
+          nick='Hecate'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="admin">Admin Use Cases</a>
+</h2>
+  <p class="" style="">A room administrator has privileges to modify persistent information about user affiliations (e.g., by banning users) and to grant and revoke moderator privileges, but does not have rights to change the defining features of the room, which are the sole province of the room owner. Exactly which actions MAY be performed by a room admin will be subject to configuration. However, for the purposes of the MUC framework, room admins are stipulated to have privileges to perform the following actions:</p>
+  <ol start="" type="">
+    <li>ban a user from the room</li>
+    <li>modify the list of users who are banned from the room</li>
+    <li>grant or revoke membership</li>
+    <li>modify the member list</li>
+    <li>grant or revoke moderator privileges</li>
+    <li>modify the list of moderators</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response &quot;conversation&quot; using &lt;iq/&gt; elements that contain children scoped by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions proposed to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the user@host of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a &lt;forbidden/&gt; error.)</p>
+  <div class="indent">
+<h3>8.1 <a name="ban">Banning a User</a>
+</h3>
+    <p class="" style="">An admin or owner can ban one or more users from a room. The ban MUST be performed based on the occupant's bare JID. In order to ban a user, an admin MUST change the user's affiliation to &quot;outcast&quot;.</p>
+    <p class="caption">Example 87. Admin Bans User</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban1'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add that bare JID to the ban list and inform the admin or owner of success:</p>
+    <p class="caption">Example 88. Service Informs Admin or Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban1'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also remove any banned users who are in the room by sending a presence stanza of type &quot;unavailable&quot; to each banned occupant, including status code 301 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the ban.</p>
+    <p class="caption">Example 89. Service Removes Banned User</p>
+<div class="indent"><pre>
+&lt;presence
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='earlofcambridge@shakespeare.lit/stabber'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast' role='none'&gt;
+      &lt;actor jid='kinghenryv@shakespeare.lit'/&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the banned user to understand why he or she was banned, and by whom if the banned user would like to discuss the matter.</p>
+    <p class="" style="">The service MUST then inform all of the remaining occupants that the banned user is no longer in the room by sending presence stanzas of type &quot;unavailable&quot; from the banned user to all remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason:</p>
+    <p class="caption">Example 90. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    type='unavailable'
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='exeter@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit/stabber'
+          role='none'/&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">An owner or admin cannot be banned from a room. If a room admin attempts to ban such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 91. Service Returns Error on Attempt to Ban an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='harfleur@henryv.shakespeare.lit'
+    id='bantest'
+    to='exeter@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='kinghenryv@shakespeare.lit'
+          nick='TheKing'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="modifyban">Modifying the Ban List</a>
+</h3>
+    <p class="" style="">A room admin may want to modify the ban list. Note that the ban list is always based on a user's bare JID (unlike the ban command which is usually based on a room nickname), although a nick (perhaps the last room nickname associated with that JID) MAY be included for convenience. To modify the list of banned JIDs, the admin first requests the ban list by querying the room for all users with an affiliation of 'outcast'.</p>
+    <p class="caption">Example 92. Admin Requests Ban List</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban2'
+    to='southampton@henryv.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the list of banned users to the admin; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' and 'role' attributes:</p>
+    <p class="caption">Example 93. Service Sends Ban List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban2'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the ban list. In order to do so, the admin MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'affiliation' attribute (normally set to a value of &quot;outcast&quot; or &quot;none&quot;) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the outcast affiliation); in addition, the reason and actor elements are OPTIONAL:</p>
+    <p class="caption">Example 94. Admin Sends Modified Ban List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban3'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'&gt;
+          jid='lordscroop@shakespeare.lit' 
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'
+          jid='sirthomasgrey@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">After updating the ban list, the service MUST inform the admin of success:</p>
+    <p class="caption">Example 95. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban3'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then remove the affected occupants (if they are in the room) and send updated presence (including the appropriate status code) from them to all the remaining occupants as described in the &quot;Banning a User&quot; use case. (The service SHOULD also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.)</p>
+    <p class="" style="">As noted, a room owner or room admin cannot be banned from a room. If a room admin attempts to ban such a user by means of modifying the ban list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 96. Service Returns Error on Attempt to Ban an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='bantest'
+    to='lordscroop@shakespeare.lit'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='exeter@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">When an entity is banned from a room, an implementation SHOULD match JIDs in the following order (these matching rules are the same as those defined for privacy lists in <span class="ref">XMPP IM</span>  [<a href="#nt-id2611399">8</a>]):</p>
+    <ol start="" type="">
+      <li>&lt;user@domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;user@domain&gt; (any resource matches)</li>
+      <li>&lt;domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;domain&gt; (the domain itself matches, as does any user@domain, domain/resource, or address containing a subdomain)</li>
+    </ol>
+    <p class="" style="">Some administrators may wish to ban all users associated with a specific domain from all rooms hosted by a MUC service. Such functionality is a service-level feature and is therefore out of scope for this document.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="grantmember">Granting Membership</a>
+</h3>
+    <p class="" style="">An admin can grant membership to a user; this is done by changing the user's affiliation to &quot;member&quot; (normally based on nick if the user is in the room, or on bare JID if not; in either case, if the nick is provided, that nick becomes the user's default nick in the room if that functionality is supported by the implementation):</p>
+    <p class="caption">Example 97. Admin Grants Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 98. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 99. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="revokemember">Revoking Membership</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's membership; this is done by changing the user's affiliation to &quot;none&quot;:</p>
+    <p class="caption">Example 100. Admin Revokes Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          nick='thirdwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 101. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 102. Service Notes Loss of Membership</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MUST remove the user from the room, including a status code of 321 to indicate that the user was removed because of an affiliation change, and inform all remaining occupants:</p>
+    <p class="caption">Example 103. Service Removes Non-Member</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='author@shakespeare.lit'/&gt;
+    &lt;/item&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="modifymember">Modifying the Member List</a>
+</h3>
+    <p class="" style="">In the context of a members-only room, the member list is essentially a &quot;whitelist&quot; of people who are allowed to enter the room. Anyone who is not a member is effectively banned from entering the room, even if their affiliation is not &quot;outcast&quot;.</p>
+    <p class="" style="">In the context of an open room, the member list is simply a list of users (bare JID and reserved nick) who are registered with the room. Such users may appear in a room roster, have their room nickname reserved, be returned in search results or FAQ queries, and the like.</p>
+    <p class="" style="">It is RECOMMENDED that only room admins have the privilege to modify the member list in members-only rooms. To do so, the admin first requests the member list by querying the room for all users with an affiliation of &quot;member&quot;:</p>
+    <p class="caption">Example 104. Admin Requests Member List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">(A service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &lt;forbidden/&gt; error when a member in the room requests the member list. This functionality may assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited.)</p>
+    <p class="" style="">The service MUST then return the full member list to the admin in the 'http://jabber.org/protocol/muc#admin' namespace; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for each members that is currently an occupant.</p>
+    <p class="caption">Example 105. Service Sends Member List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'
+          nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the member list. In order to do so, the admin MUST send the changed items (i.e., only the &quot;delta&quot;) to the service; each item MUST include the 'affiliation' attribute (normally set to a value of &quot;member&quot; or &quot;none&quot;) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the member affiliation):</p>
+    <p class="caption">Example 106. Admin Sends Modified Member List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 107. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST change the affiliation of any affected user. If the user has been removed from the member list, the service MUST change the user's affiliation from &quot;member&quot; to &quot;none&quot;. If the user has been added to the member list, the service MUST change the user's affiliation to &quot;member&quot;.</p>
+    <p class="" style="">If the removed member is currently in a members-only room, the service SHOULD kick the occupant by changing the removed member's role to &quot;none&quot;. No matter whether the removed member was in or out of a members-only room, the service MUST subsequently refuse entry to the user.</p>
+    <p class="" style="">If the removed member is in an open room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 108. Service Sends Notice of Loss of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the service SHOULD send an invitation to any user who has been added to the member list of a members-only room if the user is not currently affiliated with the room, for example as an admin or owner (such a user would by definition not be in the room; note also that this example includes a password but not a reason -- both child elements are OPTIONAL):</p>
+    <p class="caption">Example 109. Room Sends Invitation to New Member</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='author@shakespeare.lit'/&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+  &lt;x jid='darkcave@macbeth.shakespeare.lit'
+     xmlns='jabber:x:conference'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While only admins and owners SHOULD be allowed to modify the member list, an implementation MAY provide a configuration option that opens invitation privileges to any member of a members-only room. In such a situation, any invitation sent SHOULD automatically trigger the addition of the invitee to the member list. However, if invitation privileges are restricted to admins and a mere member attempts to a send an invitation, the service MUST deny the invitation request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 110. Service Returns Error on Attempt by Mere Member to Invite Others to a Members-Only Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.</p>
+    <p class="" style="">If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 111. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.6 <a name="grantmod">Granting Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to grant moderator privileges to a participant or visitor; this is done by changing the user's role to &quot;moderator&quot;:</p>
+    <p class="caption">Example 112. Admin Grants Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 113. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 114. Service Sends Notice of Moderator Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.7 <a name="revokemod">Revoking Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's moderator privileges. An admin MAY revoke moderator privileges only from a user whose affiliation is &quot;member&quot; or &quot;none&quot; (i.e., not from an owner or admin). The privilege is revoked by changing the user's role to &quot;participant&quot;:</p>
+    <p class="caption">Example 115. Admin Revokes Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 116. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;participant&quot;.</p>
+    <p class="caption">Example 117. Service Notes Loss of Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As noted, an admin MUST NOT be allowed to revoke moderator privileges from a user whose affiliation is &quot;owner&quot; or &quot;admin&quot;. If an admin attempts to revoke moderator privileges from such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 118. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.8 <a name="modifymod">Modifying the Moderator List</a>
+</h3>
+    <p class="" style="">An admin may want to modify the moderator list. To do so, the admin first requests the moderator list by querying the room for all users with a role of 'moderator'.</p>
+    <p class="caption">Example 119. Admin Requests Moderator List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the moderator list to the admin; each item MUST include the 'jid', 'nick', and 'role' attributes and MAY include the 'affiliation' attribute:</p>
+    <p class="caption">Example 120. Service Sends Moderator List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hag66@shakespeare.lit/pda'
+          nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the moderator list. In order to do so, the admin MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'jid' attribute and 'role' attribute (normally set to a value of &quot;member&quot; or &quot;participant&quot;) but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as admin rather than the moderator role):</p>
+    <p class="caption">Example 121. Admin Sends Modified Moderator List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 122. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator privileges by sending the appropriate extended presence packets as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, moderator privileges cannot be revoked from a room owner or room admin. If a room admin attempts to revoke moderator privileges from such a user by modifying the moderator list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 123. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.9 <a name="regapprove">Approving Registration Requests</a>
+</h3>
+    <p class="" style="">If a service does not automatically accept requests to register with a room, it MAY provide a way for room admins to approve or deny registration requests over Jabber (alternatively, it could provide a web interface or some other admin tool). The simplest way to do so is for the service to send a &lt;message/&gt; stanza to the room admin(s) when the registration request is received, where the &lt;message/&gt; stanza contains a Data Form asking for approval or denial of the request. The following Data Form is RECOMMENDED but implementations MAY use a different form entirely, or supplement the following form with additional fields.</p>
+    <p class="caption">Example 124. Registration Request Approval Form</p>
+<div class="indent"><pre>
+&lt;message from='darkcave@macbeth.shakespeare.lit'
+         id='approve'
+         to='crone1@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='jabber:x:data' type='form'&gt;
+    &lt;title&gt;Registration request&lt;/title&gt;
+    &lt;instructions&gt;
+      To approve this registration request, select the
+      &amp;quot;Allow this person to register with the room?&amp;quot;
+      checkbox and click OK. To skip this request, click the 
+      cancel button.
+    &lt;/instructions&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_first'
+           type='text-single'
+           label='First Name'&gt;
+      &lt;value&gt;Brunhilde&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_last'
+           type=&quot;text-single&quot;
+           label=&quot;Last Name&quot;&gt;
+      &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_roomnick'
+           type=&quot;text-single&quot;
+           label=&quot;Desired Nickname&quot;&gt;
+      &lt;value&gt;thirdwitch&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_url'
+           type=&quot;text-single&quot;
+           label=&quot;User URL&quot;&gt;
+      &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_email'
+           type=&quot;text-single&quot;
+           label=&quot;Email Address&quot;&gt;
+      &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_faqentry'
+           type=&quot;text-single&quot;
+           label=&quot;FAQ Entry&quot;&gt;
+      &lt;value&gt;Just another witch.&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_allow'
+           type='boolean'
+           label='Allow this person to register with the room?'&gt;
+      &lt;value&gt;0&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the admin approves the registration request, the service shall register the user with the room.</p>
+    <p class="" style="">More advanced registration approval mechanisms (e.g., retrieving a list of reqistration requests using <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2612348">9</a>] as is done in <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2612369">10</a>]) are out of scope for this JEP.</p>, 
+  </div>
+<h2>9.
+       <a name="owner">Owner Use Cases</a>
+</h2>
+  <p class="" style="">Every room MUST have at least one owner, and that owner (or a successor) is a long-lived attribute of the room for as long as the room exists (e.g., the owner does not lose ownership on exiting a persistent room). This JEP assumes that the (initial) room owner is the individual who creates the room and that only a room owner has the right to change defining room configuration settings such as the room type. Ideally, room owners will be able to specify not only the room types (password-protected, members-only, etc.) but also certain attributes of the room as listed under the requirements section of this JEP. In addition, it would be good if an owner were able to specify the JIDs of other owners, but that shall be determined by the implementation.</p>
+  <p class="" style="">In order to provide the necessary flexibility for a wide range of configuration options, <span class="ref">Data Forms</span>  [<a href="#nt-id2612545">11</a>] shall be used for room configuration, triggered by use of the 'http://jabber.org/protocol/muc' namespace.</p>
+  <p class="" style="">Note that the configuration options shown below address all of the features and room types listed in the requirements section of this JEP, but that the exact configuration options and form layout shall be determined by the implementation or specific deployment. Also, these are examples only and are not intended to define the only allowed or required configuration options for rooms. A given implementation or deployment MAY choose to provide many additional configuration options (profanity filters, setting the default language for a room, message logging, etc., which MAY include items defined in other FORM_TYPEs), which is why the use of the jabber:x:data protocol is valuable here.</p>
+  <p class="" style="">Note also that the privilege to create rooms MAY be restricted to certain users or reserved to an administrator of the service. If access is restricted and a user attempts to create a room, the service MUST return a &lt;not-allowed/&gt; error:</p>
+  <p class="caption">Example 125. Service Informs User of Inability to Create a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">If access is not restricted, the service MUST allow the user to create a room as described below.</p>
+  <div class="indent">
+<h3>9.1 <a name="createroom">Creating a Room</a>
+</h3>
+    <p class="" style="">From the perspective of room creation, there are in essence two kinds of rooms:</p>
+    <ul>
+      <li><p class="" style="">&quot;Instant rooms&quot; -- these are available for immediate access and are automatically created based on some default configuration.</p></li>
+      <li><p class="" style="">&quot;Reserved rooms&quot; -- these are manually configured by the room creator before anyone is allowed to enter.</p></li>
+    </ul>
+    <p class="" style="">The workflow for creating and configuring such rooms is as follows:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The user MUST send presence to room@service/nick and signal his or her support for the Multi-User Chat protocol by including extended presence information in an empty &lt;x/&gt; child element scoped by the 'http://jabber.org/protocol/muc' namespace (note the lack of an '#owner' or '#user' fragment).</p></li>
+      <li><p class="" style="">If this user is allowed to create a room and the room does not yet exist, the service MUST create the room according to some default configuration, assign the requesting user as the initial room owner, and add the owner to the room but not allow anyone else to enter the room (effectively &quot;locking&quot; the room). The initial presence stanza received by the owner from the room MUST include extended presence information that indicates the user's status as an owner and that acknowledges that the room has been created (via status code 201) and is awaiting configuration.</p></li>
+      <li><p class="" style="">If the initial room owner would like to create and configure a reserved room, the room owner MUST then request a configuration form by sending an IQ stanza of type &quot;get&quot; to the room containing an empty &lt;query/&gt; element scoped by the 'http://jabber.org/protocol/muc#owner' namespace, then complete Steps 4 and 5. If the room owner would prefer to create an instant room, the room owner MUST send a query element scoped by the 'http://jabber.org/protocol/muc#owner' namespace and containing an empty &lt;x/&gt; element of type &quot;submit&quot; scoped by the 'jabber:x:data' namespace, then skip to Step 6.</p></li>
+      <li><p class="" style="">If the room owner requested a configuration form, the service MUST send an IQ to the room owner containing a configuration form in the 'jabber:x:data' namespace. If there are no configuration options available, the room MUST return an empty query element to the room owner.</p></li>
+      <li><p class="" style="">The initial room owner SHOULD provide a starting configuration for the room (or accept the default configuration) by sending an IQ of type &quot;set&quot; containing the completed configuration form. Alternatively, the room owner can cancel the configuration process. (An implementation MAY set a timeout for initial configuration, such that if the room owner does not configure the room within the timeout period, the room owner is assumed to have accepted the default configuration.)</p></li>
+      <li><p class="" style="">Once the service receives the completed configuration form from the initial room owner (or receives a request for an instant room), the service MUST &quot;unlock&quot; the room (i.e., allow other users to enter the room) and send an IQ of type &quot;result&quot; to the room owner. If the service receives a cancellation, it MUST destroy the room.</p></li>
+    </ol>
+    <p class="" style="">The protocol for this workflow is shown in the examples below.</p>
+    <p class="" style="">First, the Jabber user MUST send presence to the room, including and empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace (this is the same stanza sent when seeking to enter a room).</p>
+    <p class="caption">Example 126. Jabber User Creates a Room and Signals Support for Multi-User Chat</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If the room does not yet exist, the service SHOULD create the room (subject to local policies regarding room creation), assign the bare JID of the requesting user as the owner, add the owner to the room, and acknowledge successful creation of the room.</p>
+    <p class="caption">Example 127. Service Creates Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          role='moderator'/&gt;
+    &lt;status code='201'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The initial room owner can request an instant room by sending the following XML:</p>
+    <p class="caption">Example 128. Owner Requests Instant Room</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initial room owner wants to create and configure a reserved room, the room owner MUST request an initial configuration form for the room by not including empty data form in the creation request:</p>
+    <p class="caption">Example 129. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room does not already exist, the service MUST return an initial room configuration form to the user. (Note: The following example shows a representative sample of configuration options. A full list of x:data fields registered for use in room creation and configuration is maintained by the Jabber Registrar; see <a href="#registrar">Jabber Registrar Considerations</a> below.)</p>
+    <p class="caption">Example 130. Service Sends Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+          Your room darkcave@macbeth has been created!
+          The default configuration is as follows:
+            - No logging
+            - No moderation
+            - Up to 20 occupants
+            - No password required
+            - No invitation required
+            - Room is not persistent
+            - Only admins may change the subject
+            - Presence broadcasted for all users
+          To accept the default configuration, click OK. To
+          select a different configuration, please complete
+          this form.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#roomconfig_roomname'/&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#roomconfig_roomdesc'/&gt;
+      &lt;field
+          label='Natural Language for Room Discussions'
+          type='text-single'
+          var='muc#roomconfig_roomlang'/&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;20&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#roomconfig_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members-Only?'
+          type='boolean'
+          var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required to Enter?'
+          type='boolean'
+          var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#roomconfig_roomsecret'/&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#roomconfig_whois'&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#roomconfig_roomadmins'/&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#roomconfig_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner:</p>
+    <p class="caption">Example 131. Service Informs Owner that No Configuration is Possible</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The room owner SHOULD then fill out the form and submit it to the service.</p>
+    <p class="caption">Example 132. Owner Submits Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomadmins'&gt;
+        &lt;value&gt;
+          wiccarocks@shakespeare.lit
+          hecate@shakespeare.lit
+        &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If room creation is successful, the service MUST inform the new room owner of success:</p>
+    <p class="caption">Example 133. Service Informs New Room Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the room owner can cancel the configuration process:</p>
+    <p class="caption">Example 134. Owner Cancels Initial Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room owner cancels the initial configuration, the service SHOULD destroy the room, making sure to send unavailable presence to the room owner (see the &quot;Destroying a Room&quot; use case for protocol details).</p>
+    <p class="" style="">If the room owner becomes unavailable for any reason before submitting the form (e.g., a lost connection), the service will receive a presence stanza of type &quot;unavailable&quot; from the owner to the room@service/nick or room@service (or both). The service MUST then destroy the room, sending a presence stanza of type &quot;unavailable&quot; from the room to the owner including a &lt;destroy/&gt; element and reason (if provided) as defined under the &quot;Destroying a Room&quot; use case.</p>
+    <p class="" style="">If a user attempts to enter the room while the room is &quot;locked&quot; (i.e., before the room creator provides an initial configuration and therefore before the room officially exists), the service MUST refuse entry and return a &lt;item-not-found/&gt; error to the user:</p>
+    <p class="caption">Example 135. Service Denies Access Because Room Does Not Yet Exist</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="roomconfig">Subsequent Room Configuration</a>
+</h3>
+    <p class="" style="">At any time after specifying the initial configuration of the room, a room owner may want to change the configuration. In order to initiate this &quot;conversation&quot;, a room owner MUST request a new configuration form from the room by sending an IQ to room@service containing an empty &lt;query/&gt; element scoped by the 'http://jabber.org/protocol/muc#owner' namespace.</p>
+    <p class="caption">Example 136. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user@host of the 'from' address does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 137. Service Denies Configuration Access to Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='configures'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the service MUST send a configuration form to the room owner with the current options set as defaults:</p>
+    <p class="caption">Example 138. Service Sends Configuration Form to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='config1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+        Complete this form to make changes to
+        the configuration of your room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#roomconfig_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#roomconfig_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#roomconfig_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members Only?'
+          type='boolean'
+          var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required for Entry?'
+          type='boolean'
+          var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#roomconfig_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#roomconfig_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#roomconfig_roomadmins'&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#roomconfig_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner as shown above.</p>
+    <p class="" style="">The room owner MAY then submit the form with updated configuration information.</p>
+    <p class="" style="">Alternatively, the room owner MAY cancel the configuration process:</p>
+    <p class="caption">Example 139. Owner Cancels Subsequent Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room owner cancels the subsequent configuration, the service MUST leave the configuration of the room as it was before the room owner initiated the subsequent configuration process.</p>
+    <p class="" style="">If as a result of a change in the room configuration a room admin loses administrative privileges while the admin is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot; and the 'role' attribute set to a value of &quot;participant&quot; or &quot;visitor&quot; as appropriate for the affiliation level and the room type:</p>
+    <p class="caption">Example 140. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a user gains administrative privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;admin&quot;:</p>
+    <p class="caption">Example 141. Service Notes Gain of Admin Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a room owner loses owner privileges while that owner is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;:</p>
+    <p class="caption">Example 142. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As noted, a service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner.</p>
+    <p class="" style="">If as a result of a change in the room configuration a user gains ownership privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;owner&quot; and the 'role' attribute set to a value of 'moderator'.</p>
+    <p class="caption">Example 143. Service Notes Gain of Owner Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration the room type is changed to members-only but there are non-members in the room, the service MUST remove any non-members from the room and include a status code of 322 in the presence unavailable stanzas sent to those users as well as any remaining occupants.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="grantowner">Granting Ownership Privileges</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, an owner MAY grant ownership privileges to another user; this is done by changing the user's affiliation to &quot;owner&quot;:</p>
+    <p class="caption">Example 144. Owner Grants Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 145. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of ownership privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;owner&quot; and the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 146. Service Sends Notice of Ownership Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.4 <a name="revokeowner">Revoking Ownership Privileges</a>
+</h3>
+    <p class="" style="">An owner may want to revoke a user's ownership privileges; this is done by changing the user's affiliation to &quot;admin&quot;:</p>
+    <p class="caption">Example 147. Owner Revokes Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner.</p>
+    <p class="" style="">In all other cases, the service MUST remove the user from the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 148. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of ownership privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;:</p>
+    <p class="caption">Example 149. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.5 <a name="modifyowner">Modifying the Owner List</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, a room owner may want to modify the owner list. To do so, the owner first requests the owner list by querying the room for all users with an affiliation of 'owner'.</p>
+    <p class="caption">Example 150. Owner Requests Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='owner3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the owner list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any owner that is currently an occupant:</p>
+    <p class="caption">Example 151. Service Sends Owner List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='crone1@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner MAY then modify the owner list. In order to do is, it MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service;  [<a href="#nt-id2613822">12</a>] each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the owner affiliation):</p>
+    <p class="caption">Example 152. Owner Sends Modified Owner List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='owner4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As noted, a service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner.</p>
+    <p class="" style="">In all other cases, the service MUST modify owner list and then inform the owner of success:</p>
+    <p class="caption">Example 153. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 154. Service Returns Error on Attempt by Non-Owner to Modify Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='ownertest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.6 <a name="grantadmin">Granting Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner can grant administrative privileges to a member or unaffiliated user; this is done by changing the user's affiliation to &quot;admin&quot;:</p>
+    <p class="caption">Example 155. Owner Grants Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 156. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of administrative privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 157. Service Sends Notice of Administrative Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.7 <a name="revokeadmin">Revoking Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner may want to revoke a user's administrative privileges; this is done by changing the user's affiliation to &quot;member&quot;:</p>
+    <p class="caption">Example 158. Owner Revokes Administrative Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='member'
+          nick='secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 159. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of administrative privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot; and the 'role' attribute set to a value of &quot;participant&quot; or &quot;visitor&quot; as appropriate for the affiliation level and the room type:</p>
+    <p class="caption">Example 160. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.8 <a name="modifyadmin">Modifying the Admin List</a>
+</h3>
+    <p class="" style="">A room owner may want to modify the admin list. To do so, the owner first requests the admin list by querying the room for all users with an affiliation of 'admin'.</p>
+    <p class="caption">Example 161. Owner Requests Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/desktopaffiliation
+    id='admin3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the admin list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any admin that is currently an occupant:</p>
+    <p class="caption">Example 162. Service Sends Admin List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'
+          nick='secondwitch'/&gt;
+    &lt;item affiliation='admin'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner MAY then modify the admin list. In order to do so, the owner MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service;  [<a href="#nt-id2614174">13</a>] each item MUST include the 'affiliation' attribute (normally set to a value of &quot;admin&quot; or &quot;none&quot;) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the admin affiliation):</p>
+    <p class="caption">Example 163. Owner Sends Modified Admin List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='admin4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 164. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 165. Service Returns Error on Attempt by Non-Owner to Modify Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admintest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.9 <a name="destroyroom">Destroying a Room</a>
+</h3>
+    <p class="" style="">A room owner MUST be able to destroy a room that he or she has created, especially if the room is persistent. The workflow is as follows:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The room owner requests that the room be destroyed, specifying a reason and an alternate venue if desired.</p></li>
+      <li><p class="" style="">The room removes all users from the room (including appropriate information about the alternate location and the reason for being removed) and destroys the room, even if it was defined as persistent.</p></li>
+    </ol>
+    <p class="" style="">This JEP does not specify what if anything a compliant component implementation must do as a result of a room destruction request other than the foregoing. For example, if the room was defined as persistent, an implementation MAY choose to reserve the room ID or redirect enter requests to the alternate venue; however, such behavior is OPTIONAL.</p>
+    <p class="" style="">In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. The &lt;iq/&gt; stanza shall contain a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, which in turn shall contain a &lt;destroy/&gt; element. The address of the alternate venue shall be provided in the &lt;destroy/&gt; element's 'jid' attribute (this is OPTIONAL). The reason for the room destruction shall be provided as the XML character data of a &lt;reason/&gt; child element of the &lt;destroy/&gt; element (this, too, is OPTIONAL).</p>
+    <p class="" style="">The following examples illustrate the protocol elements to be sent and received:</p>
+    <p class="caption">Example 166. Owner Submits Room Destruction Request</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='begone'
+    to='heath@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for removing all the occupants. It SHOULD NOT broadcast presence stanzas of type &quot;unavailable&quot; from all occupants, instead sending only one presence stanza of type &quot;unavailable&quot; to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.</p>
+    <p class="caption">Example 167. Service Removes Each Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 168. Service Informs Owner of Successful Destruction</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='begone'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user@host of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 169. Service Denies Destroy Request Submitted by Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='destroytest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+  <p class="" style="">The error codes associated with the 'http://jabber.org/protocol/muc#admin' namespace are fairly straightforward. However, in order to make it easier for client and component developers to understand the codes they need to send and receive, the table below provides a summary of all the error and status codes associated with the 'http://jabber.org/protocol/muc#user' namespace. For detailed information about mapping legacy error codes to XMPP-style error types and conditions, refer to <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2614590">14</a>]; compliant implementations SHOULD support both legacy and XMPP error handling (no such requirement applies to MUC status codes).</p>
+  <p class="caption">Table 8: Error and Status Codes for http://jabber.org/protocol/muc#user Namespace</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Code</th>
+      <th colspan="" rowspan="">Type</th>
+      <th colspan="" rowspan="">Element</th>
+      <th colspan="" rowspan="">Context</th>
+      <th colspan="" rowspan="">Purpose</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">100</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that any occupant is allowed to see the user's full JID</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">101</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message (out of band)</td>
+      <td align="" colspan="" rowspan="">Affiliation change</td>
+      <td align="" colspan="" rowspan="">Inform user that his or her affiliation changed while not in the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">102</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">In-room message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that room now shows unavailable members</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">103</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that room now does not show unavailable members</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">104</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that some room configuration has changed</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">201</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that a new room has been created</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">301</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she has been banned from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">303</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Exiting a room</td>
+      <td align="" colspan="" rowspan="">Inform all occupants of new room nickname</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">307</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she has been kicked from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">321</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because of an affiliation change</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">322</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because the room has been changed to members-only and the user is not a member</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">332</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because of a system shutdown</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">401</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that a password is required</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">403</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is banned from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">404</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that the room does not exist</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">405</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that room creation is restricted</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">407</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is not on the member list</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">409</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that his or her desired room nickname is taken</td>
+    </tr>
+  </table>
+  <p class="" style="">This JEP does not stipulate text messages associated with each error condition.</p>
+<h2>11.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">No room entrance authentication method more secure than cleartext passwords is defined or required by this JEP. This is recognized to be sub-optimal; a future proposal will need to address this shortcoming.</p>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2615670">15</a>].</p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2615608">16</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>13.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the following MUC-related namespaces in its registry of protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/muc</li>
+      <li>http://jabber.org/protocol/muc#admin</li>
+      <li>http://jabber.org/protocol/muc#owner</li>
+      <li>http://jabber.org/protocol/muc#user</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="registrar-discocat">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">A Multi-User Chat service or room is identified by the &quot;conference&quot; category and the &quot;text&quot; type within Service Discovery.</p>
+  </div>
+  <div class="indent">
+<h3>13.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">There are many features related to a MUC service or room that can be discovered by means of Service Discovery. The most fundamental of these is the 'http://jabber.org/protocol/muc' namespace. In addition, a MUC room SHOULD provide information when queried about the specific room features it implements, such as password protection and room moderation.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc&lt;/name&gt;
+  &lt;desc&gt;Multi-User Chat (MUC) namespace&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_hidden&lt;/name&gt;
+  &lt;desc&gt;Hidden room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_membersonly&lt;/name&gt;
+  &lt;desc&gt;Members-only room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_moderated&lt;/name&gt;
+  &lt;desc&gt;Moderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_nonanonymous&lt;/name&gt;
+  &lt;desc&gt;Non-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_open&lt;/name&gt;
+  &lt;desc&gt;Open room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_passwordprotected&lt;/name&gt;
+  &lt;desc&gt;Password-protected room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_persistent&lt;/name&gt;
+  &lt;desc&gt;Persistent room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_public&lt;/name&gt;
+  &lt;desc&gt;Public room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_semianonymous&lt;/name&gt;
+  &lt;desc&gt;Semi-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_temporary&lt;/name&gt;
+  &lt;desc&gt;Temporary room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unmoderated&lt;/name&gt;
+  &lt;desc&gt;Unmoderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unsecured&lt;/name&gt;
+  &lt;desc&gt;Unsecured room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_rooms&lt;/name&gt;
+  &lt;desc&gt;List of MUC rooms (each as a separate item)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>13.4 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms' enables discovery of the rooms in which a user is an occupant.</p>
+    <p class="" style="">The well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' enables discovery of the namespaces that are allowed in traffic sent through a room.</p>
+  </div>
+  <div class="indent">
+<h3>13.5 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2615925">17</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. Within MUC, there are two uses of such forms: room registration within muc#user and room configuration within muc#owner. The reserved fields are defined below.</p>
+    <div class="indent">
+<h3>13.5.1 <a name="registrar-formtype-register">muc#register FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#register&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling user registration with a
+    Multi-User Chat (MUC) room or admin approval
+    of user registration requests.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#register_first'
+      type='text-single'
+      label='First Name'/&gt;
+  &lt;field
+      var='muc#register_last'
+      type='text-single'
+      label='Last Name'/&gt;
+  &lt;field
+      var='muc#register_roomnick'
+      type='text-single'
+      label='Desired Nickname'/&gt;
+  &lt;field
+      var='muc#register_url'
+      type='text-single'
+      label='Your URL'/&gt;
+  &lt;field
+      var='muc#register_email'
+      type='text-single'
+      label='Email Address'/&gt;
+  &lt;field
+      var='muc#register_faqentry'
+      type='text-multi'
+      label='FAQ Entry'/&gt;
+    &lt;field 
+       var='muc#register_allow'
+       type='boolean'
+       label='Allow this person to register with the room?'&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.5.2 <a name="registrar-formtype-owner">muc#roomconfig FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roomconfig&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling creation and configuration of
+    a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roomconfig_allowinvites'
+      type='boolean'
+      label='Whether to Allow Occupants to Invite Others'/&gt;
+  &lt;field
+      var='muc#roomconfig_changesubject'
+      type='boolean'
+      label='Whether to Allow Occupants to Change Subject'/&gt;
+  &lt;field
+      var='muc#roomconfig_enablelogging'
+      type='boolean'
+      label='Whether to Enable Logging of Room Conversations'/&gt;
+  &lt;field
+      var='muc#roomconfig_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roomconfig_maxusers'
+      type='list-single'
+      label='Maximum Number of Room Occupants'/&gt;
+  &lt;field
+      var='muc#roomconfig_membersonly'
+      type='boolean'
+      label='Whether an Make Room Members-Only'/&gt;
+  &lt;field
+      var='muc#roomconfig_moderatedroom'
+      type='boolean'
+      label='Whether to Make Room Moderated'/&gt;
+  &lt;field
+      var='muc#roomconfig_passwordprotectedroom'
+      type='boolean'
+      label='Whether a Password is Required to Enter'/&gt;
+  &lt;field
+      var='muc#roomconfig_persistentroom'
+      type='boolean'
+      label='Whether to Make Room Persistent'/&gt;
+  &lt;field
+      var='muc#roomconfig_presencebroadcast'
+      type='list-multi'
+      label='Roles for which Presence is Broadcast'/&gt;
+  &lt;field
+      var='muc#roomconfig_publicroom'
+      type='boolean'
+      label='Whether to Allow Public Searching for Room'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomadmins'
+      type='jid-multi'
+      label='Full List of Room Admins'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomdesc'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomname'
+      type='text-single'
+      label='Natural-Language Room Name'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomowners'
+      type='jid-multi'
+      label='Full List of Room Owners'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomsecret'
+      type='text-private'
+      label='The Room Password'/&gt;
+  &lt;field
+      var='muc#roomconfig_whois'
+      type='list-single'
+      label='Affiliations that May Discover Real JIDs of Occupants'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.5.3 <a name="registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roominfo&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling the communication of extended service discovery
+    information about a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roominfo_description'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roominfo_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roominfo_occupants'
+      type='text-single'
+      label='Current Number of Occupants in Room'/&gt;
+  &lt;field
+      var='muc#roominfo_subject'
+      type='text-single'
+      label='Current Subject or Discussion Topic in Room'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>14.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="bizrules-jids">Room JIDs</a>
+</h3>
+    <p class="" style="">In order to provide consistency regarding the addresses captured in room JIDs, Room IDs MUST match the Nodeprep profile of Stringprep and Room Nicknames MUST match the Resourceprep profile of Stringprep (both of these are defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2615990">18</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>14.2 <a name="bizrules-message">Message</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">If an occupant wants to send a message to all other occupants, a compliant client MUST set the 'type' attribute to a value of &quot;groupchat&quot;. A service MAY ignore messages that are improperly typed, or reject them with a &lt;bad-request/&gt; error.</p></li>
+      <li><p class="" style="">If a compliant service receives a message directed to the room or to a single occupant from a Jabber user who has a role of &quot;none&quot;, the service MUST NOT deliver the message and SHOULD return the message to the sender with a &lt;forbidden/&gt; error.</p></li>
+      <li><p class="" style="">If a compliant service receives a message directed to a room that does not exist or is locked, the service SHOULD return the message to the sender with a &lt;item-not-found/&gt; error.</p></li>
+      <li><p class="" style="">A compliant service SHOULD pass extended information (e.g., an XHTML version of the message body) through to occupants unchanged.</p></li>
+      <li><p class="" style="">A compliant client MUST NOT generate message events as specified in <span class="ref">Message Events</span>  [<a href="#nt-id2616221">19</a>]; such message events are not intended for use in the context of groupchat.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>14.3 <a name="bizrules-presence">Presence</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">A room MUST silently ignore unavailable presence received from a user who has a role of &quot;none&quot;.</p></li>
+      <li><p class="" style="">Only a component SHOULD generate extended presence information about roles, affiliations, full JIDs, or status codes scoped by the 'http://jabber.org/protocol/muc#user' namespace (based on information the component knows about occupants, e.g., roles, or as a result of actions taken by a moderator or room administrator). A client SHOULD NOT presume to generate such information. If a compliant component receives such extended presence information from an occupant, it MUST NOT reflect it to other occupants. A client can generate extended presence information in the 'http://jabber.org/protocol/muc#user' namespace in order to supply a password, but naturally this is not reflected to other occupants.</p></li>
+      <li><p class="" style="">A component SHOULD allow all other presence information to pass through, although it MAY choose to block extended presence information. Thus effectively clients can send a custom exit message if desired (as is often done in IRC channels) by including a &lt;status/&gt; element in the presence stanza of type &quot;unavailable&quot; sent when exiting a room.</p></li>
+      <li><p class="" style="">In order to appropriately inform occupants of room roles and affiliations, and to make it easier for Jabber clients to track the current state of all users in the room, compliant component implementations MUST provide extended presence information about roles and affiliations in all presence stanzas, including presence stanzas of type &quot;unavailable&quot; sent when a user exits the room for any reason.</p></li>
+      <li><p class="" style="">If a privilege is revoked, the service MUST note that by sending an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child element with the 'role' and/or 'affiliation' attributes set to a value that indicates the loss of the relevant privilege. All future presence stanzas for the occupant MUST include the updated role and affiliation, until and unless they change again.</p></li>
+      <li><p class="" style="">A compliant service MUST send extended presence to a client even if the client did not send an empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace on entering the room; naturally, a Jabber-compliant client MUST ignore such information if it does not understand it.</p></li>
+      <li><p class="" style="">Extended presence about roles and affiliations sent in the muc#user namespace MUST include the full JID (not the bare JID) as the value of the 'jid' attribute.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>14.4 <a name="bizrules-iq">IQ</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a non-anonymous room, the sender SHOULD send the request directly to the recipient's bare JID or full JID, rather than attempting to send the request through the room (i.e., via the recipient's room JID).</p></li>
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a semi-anonymous room, the sender can direct the stanza to the recipient's room JID and the service MAY forward the stanza to the recipient's real JID. However, a compliant service MUST NOT reveal the sender's real JID to the recipient at any time, nor reveal the recipient's real JID to the sender.</p></li>
+      <li><p class="" style="">A compliant client MUST send only the 'affiliation' attribute or the 'role' attribute in the &lt;item/&gt; element contained within an IQ set scoped by the 'http://jabber.org/protocol/muc#admin' namespace; if a moderator, admin, or owner attempts to modify both the affiliation and role of the same item in the same IQ set, the service MUST return a &lt;bad-request/&gt; error to the sender. However, a compliant service MAY modify a role based on a change to an affiliation and thus MAY send presence updates that include both a modified role and a modified affiliation.</p></li>
+      <li><p class="" style="">In IQ sets regarding roles, a compliant client MUST include the 'nick' attribute only; in IQ results regarding roles, a compliant service MUST include the 'nick', 'role', 'affiliation', and 'jid' attributes (with the value of the latter set to the user's full JID).</p></li>
+      <li><p class="" style="">In IQ sets regarding affiliations, a compliant client MUST include the 'jid' attribute only (with the value set to the bare JID); in IQ results regarding affiliations, a compliant service MUST NOT include the 'role' attribute, MUST include the 'affiliation' attribute and the 'jid' attribute (with the value set to the bare JID), and SHOULD include the 'nick' attribute (except if the affiliation is &quot;outcast&quot;, since outcasts SHOULD NOT have reserved nicknames).</p></li>
+    </ol>
+  </div>
+<h2>15.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">The following guidelines may assist client and component developers in creating compliant implementations.</p>
+  <div class="indent">
+<h3>15.1 <a name="impl-service">Services</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">In handling messages sent by visitors in a moderated room, a chatroom service MAY queue each message for approval by a moderator and MAY inform the sender that the message is being held for approval; however, such behavior is OPTIONAL, and definition of a message approval protocol (e.g., using Data Forms as defined in JEP-0004) is out of scope for this JEP.</p></li>
+      <li><p class="" style="">It is common for chatroom services to provide in-room messages when certain events occur, such as when the subject changes, when an occupant enters or exits, or when a room is destroyed. Such messages are entirely OPTIONAL and are left up to the implementation or deployment, but if used MUST be messages of type &quot;groupchat&quot; sent from the room JID itself (room@service) rather than a specific occupant (room@service/nick). However, in general it is preferable for the receiving client to generate such messages based on events in the room (e.g., user entrances and exits) as well as specific status codes provided in MUC; this will help ensure correct localization of such messages.</p></li>
+      <li><p class="" style="">Out of courtesy, a chatroom service MAY send a &lt;message/&gt; to an occupant who is kicked or banned, and MAY broadcast an in-room &lt;message/&gt; to all remaining occupants informing them that the occupant has been kicked or banned from the room. However, such messages are OPTIONAL, and indeed are unnecessary since the information required for a receiving client to generate such messages is communicated in the presence stanzas (specifically the status codes) sent by a MUC-compliant service.</p></li>
+      <li><p class="" style="">Out of courtesy, a chatroom service MAY send a &lt;message/&gt; outside the context of the room if a user's affiliation changes while the user is not in the room; the message SHOULD be sent from the room to the user's bare JID, MAY contain a &lt;body/&gt; element describing the affiliation change, and MUST contain a status code of 101.</p></li>
+      <li><p class="" style="">There is no requirement that a chatroom service shall provide special treatment for users of the older &quot;groupchat 1.0&quot; protocol, such as messages that contain equivalents to the extended presence information that is sent in the 'http://jabber.org/protocol/muc#user' namespace.</p></li>
+      <li><p class="" style="">Room types can be configured in any combination. A chatroom service MAY support or allow any desired room types or combinations thereof.</p></li>
+      <li><p class="" style="">A chatroom service MAY limit the number of configuration options presented to an owner after initial configuration has been completed, e.g. because certain options cannot take effect without restarting the service.</p></li>
+      <li><p class="" style="">A chatroom service MAY provide an interface to room creation and configuration (e.g., in the form of a special Jabber user or a Web page), so that the ostensible room owner is actually the application as opposed to a human user.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to make available a special in-room resource that provides an interface to administrative functionality (e.g., a &quot;user&quot; named &quot;ChatBot&quot;), which occupants could interact with directly, thus enabling admins to type <tt>/command parameter</tt> in a private message to that &quot;user&quot;. Obviously this kind of implementation would require the service to add a 'ChatBot' user to the room when it is created, and to prevent any occupant from having the nickname 'ChatBot' in the room. This might be difficult to ensure in some implementations or deployments. In any case, any such interface is OPTIONAL.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to send a message outside the context of the room to any user who is affected by a change in affiliation (e.g., if a user becomes an admin or owner). Such a message could include an appropriate status code in an extended child element scoped by the muc#user namespace.</p></li>
+      <li><p class="" style="">A chatroom service SHOULD remove a user if the service receives a delivery-related error in relation to a stanza it has previously sent to the user (remote server unreachable, user not found, etc.).</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to discard extended presence information that is attached to &lt;presence/&gt; stanza before reflecting the presence change to the occupants of a room. That is, an implementation MAY choose to reflect only the &lt;show/&gt;, &lt;status/&gt;, and &lt;priority/&gt; child elements of the presence element as specified in the XML schema for the 'jabber:client' namespace, with the result that presence &quot;changes&quot; in extended namespaces (e.g., gabber:x:music:info) are not passed through to occupants. If a service prohibits certain extended namespaces, it SHOULD provide a description of allowable traffic at the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' as described below.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to discard extended information attached to &lt;message/&gt; stanzas before reflecting the message to the occupants of a room. An example of such extended information is the lightweight text markup specified by <span class="ref">XHTML-IM</span>  [<a href="#nt-id2616749">20</a>]. If a service prohibits certain extended namespaces, it SHOULD provide a description of allowable traffic at the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' as described below.</p></li>
+    </ol>
+    <div class="indent">
+<h3>15.1.1 <a name="impl-service-traffic">Allowable Traffic</a>
+</h3>
+      <p class="" style="">As noted, a service (more precisely, a properly-configured room) MAY discard some or all extended namespaces attached to messages and presence stanzas that are intended for reflection from the sender through the room to all of the room occupants. If the room does so, it SHOULD enable senders to discover the list of allowable extensions by sending a disco#info query to the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic', one namespace in each &lt;feature/&gt; element (it is not necessary to list the 'jabber:client' namespace, since support for that namespace is required). If the room does not prohibit any extended namespaces, it SHOULD return a &lt;feature-not-implemented/&gt; error in response to queries sent to the 'http://jabber.org/protocol/muc#traffic' node.</p>
+      <p class="" style="">The following example shows a room that allows the 'http://jabber.org/protocol/xhtml-im' and 'jabber:x:roster' namespaces only, but no other extended namespaces.</p>
+      <p class="caption">Example 170. User Queries Service Regarding Allowable Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    to='heath@macbeth.shakespeare.lit'
+    id='allow1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 171. Service Returns Allowable Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    to='heath@macbeth.shakespeare.lit'
+    id='allow1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'&gt;
+    &lt;feature var='http://jabber.org/protocol/xhtml-im'/&gt;
+    &lt;feature var='jabber:x:roster/'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>15.2 <a name="impl-client">Clients</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">Jabber clients MAY present room roles by showing ad-hoc groups for each role within a room roster. This will enable occupants to clearly visualize which occupants are moderators, participants, and visitors. However, such a representation is OPTIONAL.</p></li>
+      <li><p class="" style="">Jabber clients MAY implement a variety of interface styles that provide &quot;shortcuts&quot; to functionality such as changing one's nickname, kicking or banning users, discovering an occupant's full JID, or changing the subject. One option consists of IRC-style commands such as '/nick', '/kick', '/ban', and '/whois'; another is to enable a user to right-click items in a room roster. All such interface styles are OPTIONAL. However, for convenience, a mapping of IRC commands to MUC protocols is provided below.</p></li>
+    </ol>
+    <div class="indent">
+<h3>15.2.1 <a name="impl-client-irc">IRC Command Mapping</a>
+</h3>
+      <p class="" style="">Internet Relay Chat clients use a number of common &quot;shortcut&quot; commands that begin with a forward slash, such as '/nick' and '/ban'. The following table provides a mapping of IRC-style commands to MUC protocols, for use by Jabber clients that wish to support such functionality.</p>
+      <p class="caption">Table 9: IRC Command Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Command</th>
+          <th colspan="" rowspan="">Function</th>
+          <th colspan="" rowspan="">MUC protocol</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/ban &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">bans user with that roomnick from this room (client translates roomnick to jid)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='jid-of-roomnick'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/invite &lt;jid&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">invites jid to this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='jid'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/join &lt;roomname&gt; [pass]</td>
+          <td align="" colspan="" rowspan="">joins room on this service (roomnick is same as nick in this room)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;password&gt;pass&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/kick &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">kicks user with that roomnick from this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='roomnick' role='none'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/msg &lt;roomnick&gt; &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">sends private message &quot;foo&quot; to roomnick</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service/nick'&gt;
+  &lt;body&gt;foo&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/nick &lt;newnick&gt;</td>
+          <td align="" colspan="" rowspan="">changes nick in this room to &quot;newnick&quot;</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/newnick'/&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/part [comment]</td>
+          <td align="" colspan="" rowspan="">exits this room (some IRC clients also support /leave)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'
+          type='unavailable'&gt;
+  &lt;status&gt;comment&lt;/status&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/topic &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">changes subject of this room to &quot;foo&quot;</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service' type='groupchat'&gt;
+  &lt;subject&gt;foo&lt;/subject&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+      </table>
+      <p class="" style="">Note: Because MUC roomnicks follow the Resouceprep profile of stringprep, they are allowed to contain a space character, whereas IRC nicknames do not. Although a given client MAY support quotation characters for this purpose (resulting in commands such as '/ban &quot;king lear&quot; insanity is no defense'), most common quotation characters (such as &quot; and ') are also allowed by Resouceprep, thus leading to added complexity and potential problems with quotation of roomnicks that contain both spaces and quotation characters. Therefore it is NOT RECOMMENDED for Jabber clients to support IRC-style shortcut commands with roomnicks that contain space characters.</p>
+    </div>
+  </div>
+<h2>16.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="schemas-muc">http://jabber.org/protocol/muc</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc'
+    xmlns='http://jabber.org/protocol/muc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='history' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='history'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+         &lt;xs:attribute name='maxchars' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='maxstanzas' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='seconds' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='since' type='xs:dateTime' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.2 <a name="schemas-user">http://jabber.org/protocol/muc#user</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#user'
+    xmlns='http://jabber.org/protocol/muc#user'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='decline' minOccurs='0'/&gt;
+        &lt;xs:element ref='destroy' minOccurs='0'/&gt;
+        &lt;xs:element ref='invite' minOccurs='0'/&gt;
+        &lt;xs:element ref='item' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element ref='status' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='decline'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='invite'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+        &lt;xs:element ref='continue' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='code' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:int'&gt;
+            &lt;xs:enumeration value='100'/&gt;
+            &lt;xs:enumeration value='201'/&gt;
+            &lt;xs:enumeration value='301'/&gt;
+            &lt;xs:enumeration value='303'/&gt;
+            &lt;xs:enumeration value='307'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:element name='continue' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.3 <a name="schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#admin'
+    xmlns='http://jabber.org/protocol/muc#admin'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.4 <a name="schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#owner'
+    xmlns='http://jabber.org/protocol/muc#owner'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='destroy' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>17.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The author would like to thank the following individuals for their many helpful comments on various drafts of this proposal: David Sutton, Peter Millard, Joe Hildebrand, Craig Kaes, Alexey Shchepin, David Waite, Jean-Louis Seguineau, Jacek Konieczny, Gaston Dombiak, and many others in the jdev@conference.jabber.org conference room and on the Standards-JIG mailing list.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602890">1</a>. RFC 1459: Internet Relay Chat &lt;<a href="http://www.ietf.org/rfc/rfc1459.txt">http://www.ietf.org/rfc/rfc1459.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603164">2</a>. <a href="http://www.jabber.org/protocol/groupchat.html">http://www.jabber.org/protocol/groupchat.html</a>
+</p>
+<p>
+<a name="nt-id2606440">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606557">4</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p>
+<a name="nt-id2607933">5</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p>
+<a name="nt-id2608256">6</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2609497">7</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2611399">8</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2612348">9</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2612369">10</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2612545">11</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2613822">12</a>. This is different from the behavior of room configuration, wherein the 'muc#roomconfig_roomowners' field specifies the full list of room owners, not the delta.</p>
+<p>
+<a name="nt-id2614174">13</a>. This is different from the behavior of room configuration, wherein the 'muc#roomconfig_roomadmins' field specifies the full list of room admins, not the delta.</p>
+<p>
+<a name="nt-id2614590">14</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2615670">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2615608">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2615925">17</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p>
+<a name="nt-id2615990">18</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2616221">19</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p>
+<a name="nt-id2616749">20</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.17 (2004-10-04)</h4>
+<div class="indent">Added text about allowable extension namespaces and related service discovery mechanisms; specified well-known service discovery nodes; added conformance terms to clarify some descriptions; modified affiliation state chart to allow more flexible state changes; per list dicussion, added ability to convert a one-to-one chat into a conference, including sending of history; specified error to use when max users limit is reached; specified form for admin approval of user registration requests and modified FORM_TYPE from http://jabber.org/protocol/muc#register to http://jabber.org/protocol/muc#user; modified FORM_TYPE for room configuration from http://jabber.org/protocol/muc#owner to http://jabber.org/protocol/muc#roomconfig. (psa)
+    </div>
+<h4>Version 1.16 (2004-06-30)</h4>
+<div class="indent">Added example and registry submission for service discovery extension. (psa)
+    </div>
+<h4>Version 1.15 (2004-06-24)</h4>
+<div class="indent">Removed jabber:iq:browse references; clarified order of presence stanzas sent to new occupant on entering room; specified format of in-room messages (type='groupchat', from='room@service'); clarified allowable attributes in various list-related operations; made admin/owner revocation text and examples consistent with state chart; clarified ownership revocation conflict scenarios; changed the 'muc#roomconfig_inviteonly' field to 'muc#roomconfig_membersonly'; changed attribute order in examples to match XML canonicalization rules; corrected several errors in the schemas. (psa)
+    </div>
+<h4>Version 1.14 (2004-05-03)</h4>
+<div class="indent">Corrected discovery of registered roomnicks; added note about error to return if nicks are locked down. (psa)
+    </div>
+<h4>Version 1.13 (2004-03-31)</h4>
+<div class="indent">Fixed an error in the muc#user schema. (psa)
+    </div>
+<h4>Version 1.12 (2004-03-01)</h4>
+<div class="indent">Corrected a few errors in the examples; added IQ results in order to clarify workflows. (psa)
+    </div>
+<h4>Version 1.11 (2004-02-05)</h4>
+<div class="indent">Clarified JID matching rules (same as for privacy lists in XMPP IM). (psa)
+    </div>
+<h4>Version 1.10 (2004-01-07)</h4>
+<div class="indent">Added XMPP error handling; fully specified all conformance terms. (psa)
+    </div>
+<h4>Version 1.9 (2003-12-14)</h4>
+<div class="indent">Removed protocol for requesting voice in a moderated room (should be performed using Ad-Hoc Commands). (psa)
+    </div>
+<h4>Version 1.8 (2003-12-04)</h4>
+<div class="indent">Added protocol for requesting voice in a moderated room; added (informational) mapping of IRC commands to MUC protocols. (psa)
+    </div>
+<h4>Version 1.7 (2003-10-21)</h4>
+<div class="indent">Added room configuration option for restricting presence broadcast to certain roles. (psa)
+    </div>
+<h4>Version 1.6 (2003-10-03)</h4>
+<div class="indent">Added history management protocol on entering a room. (psa)
+    </div>
+<h4>Version 1.5 (2003-09-11)</h4>
+<div class="indent">Specified that ban occurs by JID, not roomnick; allowed privileged users to send messages to the room even if not present in the room; added note that service should remove occupant if a delivery-related stanza error occurs; enabled user to disco the room in order to discover registered roomnick; specified that &quot;banning&quot; by domain or regex is a service-level configuration matter and therefore out of scope for MUC; specified that role should be decremented as appropriate if affiliation is lowered; added some clarifying text to room creation workflow; added implementation note about sending an out-of-band message if a user's affiliation changes while the user is not in the room; fixed stringprep references (room nicks use Resourceprep); clarified relationship between Room ID (i.e., node identifier of Room JID, which may be opaque) and natural-language Room Name; specified Field Standardization profile per JEP-0068; defined Jabber Registrar submissions; added schema locations. (psa)
+    </div>
+<h4>Version 1.4 (2003-02-16)</h4>
+<div class="indent">Added XML schemas. (psa)
+    </div>
+<h4>Version 1.3 (2003-02-11)</h4>
+<div class="indent">Added reference to nodeprep Internet-Draft. (psa)
+    </div>
+<h4>Version 1.2 (2003-01-30)</h4>
+<div class="indent">Commented out revision history prior to version 1.0 (too long); clarified business rules regarding when nicks, full JIDs, and bare JIDs are used in reference to roles and affiliations; consistently specified that extended presence information in the muc#user namespace must include the full JID as the value of the 'jid' attribute in all cases; cleaned up text and examples throughout; added open issue regarding syntax of room nicknames. (psa)
+    </div>
+<h4>Version 1.1 (2002-12-16)</h4>
+<div class="indent">Added protocol for declining an invitation; replaced &lt;created/&gt; element with status code 201; modified the destroy room protocol so that &lt;destroy/&gt; is a child of &lt;query/&gt;; clarified usage of 'nick' attribute when adding members; prohibited use of message events. (psa)
+    </div>
+<h4>Version 1.0 (2002-11-21)</h4>
+<div class="indent">Per a vote of the Jabber Council, revision 0.23 was advanced to Draft on 2002-11-21. (For earlier revision history, refer to XML source.) (psa)
+    </div>
+<h4>Version 0.23 (2002-11-06)</h4>
+<div class="indent">Added examples for disco#items queries sent to a room; prohibited 'type' attribute on invite messages sent from client to room; added dependencies for JEPs 11 and 30; changed 'room user' to 'occupant'; fixed many small errors throughout. (psa)
+    </div>
+<h4>Version 0.22 (2002-11-04)</h4>
+<div class="indent">Added example for disco#items; added support for cancellation of room configuration using type='cancel' from JEP-0004; noted 403 error for invites sent by non-admins in members-only room. (psa)
+    </div>
+<h4>Version 0.21 (2002-11-01)</h4>
+<div class="indent">Clarified several small ambiguities; made &lt;body/&gt; optional on invites sent from the service to the invitee; added error scenarios for changing nickname and for destroying the room; specified that the service must return the full member list for a members-only room (not only the members in the room); updated the disco examples to track protocol changes. (psa)
+    </div>
+<h4>Version 0.20 (2002-10-29)</h4>
+<div class="indent">Specified that messages sent to change the room subject must be of type &quot;groupchat&quot;; updated the legal notice to conform to the JSF IPR policy. (psa)
+    </div>
+<h4>Version 0.19 (2002-10-28)</h4>
+<div class="indent">Added ability to create an instant room within MUC (not by using gc-1.0 protocol); cleaned up disco examples. (psa)
+    </div>
+<h4>Version 0.18 (2002-10-27)</h4>
+<div class="indent">Added experimental support for disco; added sections for security, IANA, and JANA considerations; corrected typographical errors; cleaned up some DocBook formatting. (psa)
+    </div>
+<h4>Version 0.17 (2002-10-23)</h4>
+<div class="indent">Added the optional &lt;actor/&gt; element (with 'jid' attribute) to &lt;item/&gt; elements inside presence stanzas of type &quot;unavailable&quot; that are sent to users who are kicked or banned, as well as within IQs for tracking purposes; reverted all list editing use cases (ban, voice, member, moderator, admin, owner) to use of MUC format rather than 'jabber:x:data' namespace; added several guidelines regarding generation and handling of XML stanzas; cleaned up the change room subject use case; changed several ambiguous uses of 'would', 'can', and 'will' to 'should', 'may', or 'must'; fixed several small errors in the text, examples, and DTDs. (psa)
+    </div>
+<h4>Version 0.16 (2002-10-20)</h4>
+<div class="indent">Added the &lt;item/&gt; element to presence stanzas of type &quot;unavailable&quot; in order to improve the tracking of user states in the room; consolidated &lt;invitee/&gt; and &lt;inviter/&gt; elements into an &lt;invite/&gt; element with 'from' and 'to' attributes; made &lt;reason/&gt; element always a child of &lt;item/&gt; or &lt;invite/&gt; in the muc#user namespace; moved the alternate room location in room destruction to a 'jid' attribute of the &lt;alt/&gt; element; further specified several error messages; disallowed simultaneous modifications of both affiliations and roles by a moderator or admin; added several more rules regarding handling of XML stanzas; added use cases for granting and revoking administrative privileges; adjusted DTD to track all changes. (psa)
+    </div>
+<h4>Version 0.15 (2002-10-18)</h4>
+<div class="indent">Fully incorporated the change to affiliations + roles; moved a number of admin use cases to a new section for moderator use cases; added participant use case for requesting membership; added admin use cases for adding members, removing members, granting and revoking moderator privileges, and modifying the moderator list; organized the sections in a more logical manner. (psa)
+    </div>
+<h4>Version 0.14 (2002-10-17)</h4>
+<div class="indent">Significantly modified the privileges model by distinguishing between in-room &quot;roles&quot; and long-lived &quot;affiliations&quot;; specified the privileges of the various roles and affiliations; included state transition charts for both roles and affiliations; removed use of MUC protocol for editing ban, voice, and admin lists (but not for the actions of banning users and granting/revoking voice); added delivery rule regarding IQ stanzas; changed kick so that the action is based on changing the role to &quot;none&quot;. (psa)
+    </div>
+<h4>Version 0.13 (2002-10-16)</h4>
+<div class="indent">Corrected the change nickname examples (newnick sent on unavailable, no nick sent on available). (psa)
+    </div>
+<h4>Version 0.12 (2002-10-16)</h4>
+<div class="indent">Removed SHA1 passwords; specified that room shall add passwords on invitations to password-protected rooms (not supplied by inviter). (psa)
+    </div>
+<h4>Version 0.11 (2002-10-16)</h4>
+<div class="indent">Changed 'participant' to 'room user' and 'discussant' to 'participant'; clarified presence rule about client generation of extended presence information; added role of 'none'. (psa)
+    </div>
+<h4>Version 0.10 (2002-10-15)</h4>
+<div class="indent">Fixed extended presence on entering or creating a room (plain '...muc' with no fragment); harmonized #user with #admin regarding the use of the &lt;item/&gt; element and associated attributes (jid, nick, etc.), and added 'role' attribute; modified management of voice, ban, admin, and member lists to use &lt;query/&gt; wrapper and new &lt;item/&gt; structure; changed the 'member' role to 'discussant', added 'outcast' role for banned users, and added new 'member' role to enable management of member lists; changed invitation-only rooms to members-only rooms and made appropriate adjustments to apply member lists to both members-only rooms and open rooms; modified nickname change protocol slightly to send the old nickname in the unavailable presence and the new nickname in the available presence; removed prohibition on members-only rooms that are password-protected; removed the &lt;query/&gt; wrapper for the &lt;destroy/&gt; element; updated the DTDs. (psa)
+    </div>
+<h4>Version 0.9 (2002-10-13)</h4>
+<div class="indent">Added extended presence ('...#user') on entering a room for compliant clients; changed namespace on room creation request to '...#owner'; added a service discovery example using jabber:iq:browse; added information about discussion history; made small fixes to several examples; further defined the presence rules; transferred all implementation notes to a dedicated section; added a Terminology section. (psa)
+    </div>
+<h4>Version 0.8 (2002-10-10)</h4>
+<div class="indent">Made further changes to the room creation workflow (finally correct); removed feature discovery use case (this needs to be addressed by a real service discovery protocol!); added ability for room owners to edit the admin list; removed &lt;body/&gt; from invitations generated by the service; removed messages sent to kicked and banned users (handled by unavailable presence with status code); added a number of implementation notes; converted all examples to Shakespeare style. (psa)
+    </div>
+<h4>Version 0.7.6 (2002-10-09)</h4>
+<div class="indent">Fixed the room creation workflow; changed some terminology (&quot;join&quot; to &quot;enter&quot; and &quot;leave&quot; to &quot;exit&quot;). (psa)
+    </div>
+<h4>Version 0.7.5 (2002-10-08)</h4>
+<div class="indent">Specified and improved the handling of invitation-only rooms. In particular, added the ability for room admins to edit the invitation list and added a configuration option that limits the ability to send invitations to room admins only. (psa)
+    </div>
+<h4>Version 0.7.4 (2002-10-07)</h4>
+<div class="indent">Changed namespaces from http://jabber.org/protocol/muc/owner etc. to http://jabber.org/protocol/muc#owner etc. per Jabber Council discussion. (psa)
+    </div>
+<h4>Version 0.7.3 (2002-10-07)</h4>
+<div class="indent">Changed namespaces to HTTP URIs; left role handling up to the implementation; further clarified presence rules. (psa)
+    </div>
+<h4>Version 0.7.2 (2002-10-06)</h4>
+<div class="indent">Disallowed kicking, banning, and revoking voice with respect to room admins and room owners; replaced &lt;x/&gt; with &lt;query/&gt; in the Discovering Room Features and Destroying a Room use cases; corrected some small errors and made many clarifications throughout. (psa)
+    </div>
+<h4>Version 0.7.1 (2002-10-04)</h4>
+<div class="indent">Removed &lt;whois/&gt; command (unnecessary since participants with appropriate privileges receive the full JID of all participants in presence stanzas); completed many small fixes throughout. (psa)
+    </div>
+<h4>Version 0.7 (2002-10-03)</h4>
+<div class="indent">More clearly delineated participant roles and defined the hierarchy thereof (owner, admin, member, visitor); replaced &lt;voice/&gt; element in extended presence with &lt;item role='member'/&gt;; changed initial room configuration to use IQ rather than message; adjusted presence rules (especially regarding extended presence information); cleaned up examples throughout; updated DTD to track changes. (psa)
+    </div>
+<h4>Version 0.6 (2002-09-21)</h4>
+<div class="indent">More clearly defined the scope; removed fully anonymous rooms; changed meaning of semi-anonymous rooms and of non-anonymous rooms; added mechanism for notification of full JIDs in non-anonymous rooms; replaced the &lt;admin/&gt; element in extended presence with a &lt;role/&gt; element (more extensible); changed room passwords to cleartext; added status codes for various messages received from the service; added lists of valid error and status codes associated with the 'http://jabber.org/protocol/muc#user' namespace; added a &lt;reason/&gt; element for invitations; made kick and ban reasons child elements rather than attributes; replaced stopgap feature discovery mechanism with jabber:iq:negotiate; added extended presence element to room creation request and clarified the room creation process; specified presence reflection rules; added method for destroying a room; adjusted DTDs to track all changes. (psa)
+    </div>
+<h4>Version 0.5.1 (2002-09-20)</h4>
+<div class="indent">Added DTDs; changed feature discovery to use &lt;x/&gt; element rather than query and made service response come in IQ result; fixed reference to JEP 29; changed 'grant' to 'add' and 'revoke' to 'remove' for consistency in the item attributes; made several other small changes. (psa)
+    </div>
+<h4>Version 0.5 (2002-09-19)</h4>
+<div class="indent">Changed the kick, ban, and voice protocols; added a few more configuration options; specified the restrictions for roomnicks; and added a stopgap service discovery protocol. (psa)
+    </div>
+<h4>Version 0.4 (2002-09-18)</h4>
+<div class="indent">Changed all non-GC-1.0 use cases to jabber:gc:* namespaces or jabber:x:data; added use cases for ban list management and room moderation; added protocol for sending notice of admin and voice privileges in presence; cleaned up text and many examples. (psa)
+    </div>
+<h4>Version 0.3 (2002-09-17)</h4>
+<div class="indent">Changed admin use cases; cleaned up participant and owner use cases. (psa)
+    </div>
+<h4>Version 0.2 (2002-09-12)</h4>
+<div class="indent">Broke content out into three actors (participant, owner, and admin) and added more detail to owner and admin use cases. (psa)
+    </div>
+<h4>Version 0.1 (2002-09-09)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0045-1.18.html
+++ b/content/xep-0045-1.18.html
@@ -1,0 +1,5247 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0045: Multi-User Chat</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Multi-User Chat">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a robust protocol for XMPP-based text conferencing.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0045">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0045: Multi-User Chat</h1>
+<p>This JEP defines a robust protocol for XMPP-based text conferencing.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0045<br>
+            Version: 1.18<br>
+            Last Updated: 2004-11-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0004, JEP-0030, JEP-0068, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: muc<br>
+        Schema for muc: &lt;<a href="http://jabber.org/protocol/muc/muc.xsd">http://jabber.org/protocol/muc/muc.xsd</a>&gt;<br>
+        Schema for muc#admin: &lt;<a href="http://jabber.org/protocol/muc/admin.xsd">http://jabber.org/protocol/muc/admin.xsd</a>&gt;<br>
+        Schema for muc#owner: &lt;<a href="http://jabber.org/protocol/muc/owner.xsd">http://jabber.org/protocol/muc/owner.xsd</a>&gt;<br>
+        Schema for muc#user: &lt;<a href="http://jabber.org/protocol/muc/user.xsd">http://jabber.org/protocol/muc/user.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#scope">Scope</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#terms-general">General Terms</a>
+</dt>
+<dt>4.2.  <a href="#terms-rooms">Room Types</a>
+</dt>
+</dl>
+<dt>5.  <a href="#connections">Roles and Affiliations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#roles">Roles</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#roles-priv">Privileges</a>
+</dt>
+<dt>5.1.2.  <a href="#roles-change">Changing Roles</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#affil">Affiliations</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#affil-priv">Privileges</a>
+</dt>
+<dt>5.2.2.  <a href="#affil-change">Changing Affiliations</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#user">Occupant Use Cases</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#discovery">Discovering Component Support for MUC</a>
+</dt>
+<dt>6.2.  <a href="#discovery-client">Discovering Client Support for MUC</a>
+</dt>
+<dt>6.3.  <a href="#enter">Entering a Room</a>
+</dt>
+<dl>
+<dt>6.3.1.  <a href="#enter-gc">Groupchat 1.0 Protocol</a>
+</dt>
+<dt>6.3.2.  <a href="#enter-muc">Basic MUC Protocol</a>
+</dt>
+<dt>6.3.3.  <a href="#enter-pres">Presence Broadcast</a>
+</dt>
+<dt>6.3.4.  <a href="#enter-roles">Default Roles</a>
+</dt>
+<dt>6.3.5.  <a href="#enter-nonanon">Non-Anonymous Rooms</a>
+</dt>
+<dt>6.3.6.  <a href="#enter-semianon">Semi-Anonymous Rooms</a>
+</dt>
+<dt>6.3.7.  <a href="#enter-pw">Password-Protected Rooms</a>
+</dt>
+<dt>6.3.8.  <a href="#enter-members">Members-Only Rooms</a>
+</dt>
+<dt>6.3.9.  <a href="#enter-banned">Banned Users</a>
+</dt>
+<dt>6.3.10.  <a href="#enter-conflict">Nickname Conflict</a>
+</dt>
+<dt>6.3.11.  <a href="#enter-maxusers">Max Users</a>
+</dt>
+<dt>6.3.12.  <a href="#enter-history">Discussion History</a>
+</dt>
+<dt>6.3.13.  <a href="#enter-managehistory">Managing Discussion History</a>
+</dt>
+<dt>6.3.14.  <a href="#enter-create">Room Creation</a>
+</dt>
+</dl>
+<dt>6.4.  <a href="#exit">Exiting a Room</a>
+</dt>
+<dt>6.5.  <a href="#changenick">Changing Nickname</a>
+</dt>
+<dt>6.6.  <a href="#changepres">Changing Availability Status</a>
+</dt>
+<dt>6.7.  <a href="#invite">Inviting Another User to a Room</a>
+</dt>
+<dt>6.8.  <a href="#continue">Converting a One-to-One Chat Into a Conference</a>
+</dt>
+<dt>6.9.  <a href="#subject-occupant">Occupant Modification of the Room Subject</a>
+</dt>
+<dt>6.10.  <a href="#privatemessage">Sending a Private Message</a>
+</dt>
+<dt>6.11.  <a href="#message">Sending a Message to All Occupants</a>
+</dt>
+<dt>6.12.  <a href="#register">Registering with a Room</a>
+</dt>
+<dt>6.13.  <a href="#reservednick">Discovering Reserved Room Nickname</a>
+</dt>
+</dl>
+<dt>7.  <a href="#moderator">Moderator Use Cases</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#subject-mod">Modifying the Room Subject</a>
+</dt>
+<dt>7.2.  <a href="#kick">Kicking a Visitor or Participant from a Room</a>
+</dt>
+<dt>7.3.  <a href="#grantvoice">Granting Voice to a Visitor</a>
+</dt>
+<dt>7.4.  <a href="#revokevoice">Revoking Voice from a Participant</a>
+</dt>
+<dt>7.5.  <a href="#modifyvoice">Modifying the Voice List</a>
+</dt>
+</dl>
+<dt>8.  <a href="#admin">Admin Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#ban">Banning a User</a>
+</dt>
+<dt>8.2.  <a href="#modifyban">Modifying the Ban List</a>
+</dt>
+<dt>8.3.  <a href="#grantmember">Granting Membership</a>
+</dt>
+<dt>8.4.  <a href="#revokemember">Revoking Membership</a>
+</dt>
+<dt>8.5.  <a href="#modifymember">Modifying the Member List</a>
+</dt>
+<dt>8.6.  <a href="#grantmod">Granting Moderator Privileges</a>
+</dt>
+<dt>8.7.  <a href="#revokemod">Revoking Moderator Privileges</a>
+</dt>
+<dt>8.8.  <a href="#modifymod">Modifying the Moderator List</a>
+</dt>
+<dt>8.9.  <a href="#regapprove">Approving Registration Requests</a>
+</dt>
+</dl>
+<dt>9.  <a href="#owner">Owner Use Cases</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#createroom">Creating a Room</a>
+</dt>
+<dt>9.2.  <a href="#roomconfig">Subsequent Room Configuration</a>
+</dt>
+<dt>9.3.  <a href="#grantowner">Granting Ownership Privileges</a>
+</dt>
+<dt>9.4.  <a href="#revokeowner">Revoking Ownership Privileges</a>
+</dt>
+<dt>9.5.  <a href="#modifyowner">Modifying the Owner List</a>
+</dt>
+<dt>9.6.  <a href="#grantadmin">Granting Administrative Privileges</a>
+</dt>
+<dt>9.7.  <a href="#revokeadmin">Revoking Administrative Privileges</a>
+</dt>
+<dt>9.8.  <a href="#modifyadmin">Modifying the Admin List</a>
+</dt>
+<dt>9.9.  <a href="#destroyroom">Destroying a Room</a>
+</dt>
+</dl>
+<dt>10.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dt>11.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>13.2.  <a href="#registrar-discocat">Service Discovery Category/Type</a>
+</dt>
+<dt>13.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>13.4.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>13.5.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+<dl>
+<dt>13.5.1.  <a href="#registrar-formtype-register">muc#register FORM_TYPE</a>
+</dt>
+<dt>13.5.2.  <a href="#registrar-formtype-owner">muc#roomconfig FORM_TYPE</a>
+</dt>
+<dt>13.5.3.  <a href="#registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</dt>
+</dl>
+</dl>
+<dt>14.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#bizrules-jids">Room JIDs</a>
+</dt>
+<dt>14.2.  <a href="#bizrules-message">Message</a>
+</dt>
+<dt>14.3.  <a href="#bizrules-presence">Presence</a>
+</dt>
+<dt>14.4.  <a href="#bizrules-iq">IQ</a>
+</dt>
+</dl>
+<dt>15.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#impl-service">Services</a>
+</dt>
+<dl><dt>15.1.1.  <a href="#impl-service-traffic">Allowable Traffic</a>
+</dt></dl>
+<dt>15.2.  <a href="#impl-client">Clients</a>
+</dt>
+<dl><dt>15.2.1.  <a href="#impl-client-irc">IRC Command Mapping</a>
+</dt></dl>
+</dl>
+<dt>16.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#schemas-muc">http://jabber.org/protocol/muc</a>
+</dt>
+<dt>16.2.  <a href="#schemas-user">http://jabber.org/protocol/muc#user</a>
+</dt>
+<dt>16.3.  <a href="#schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</dt>
+<dt>16.4.  <a href="#schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</dt>
+</dl>
+<dt>17.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">It has long been recognized that the Jabber community needs a more robust protocol for text-based conferencing. This JEP defines extensions that enable Jabber systems to offer a much wider range of functionality, while still enabling older Jabber clients to access the minimal feature-set provided by the existing &quot;groupchat 1.0&quot; protocol. The extensions are implemented using protocol elements that fall into the 'http://jabber.org/protocol/muc' namespace and associated functionality areas (denoted by #owner, #admin, and #user fragments on the main namespace URI where appropriate).</p>
+<h2>2.
+       <a name="scope">Scope</a>
+</h2>
+  <p class="" style="">This JEP addresses common requirements related to configuration of, participation in, and administration of individual text-based conference rooms. All of the requirements addressed herein apply at the level of the individual room and are &quot;common&quot; in the sense that they have been widely discussed within the Jabber community or are familiar from existing text-based conference environments outside of Jabber (e.g., Internet Relay Chat as defined in <span class="ref">RFC 1459</span>  [<a href="#nt-id2603060">1</a>]).</p>
+  <p class="" style="">This JEP explicitly does <span style="font-style: italic">not</span> address the following:</p>
+  <ul>
+    <li>Relationships between rooms (e.g., hierarchies of rooms)</li>
+    <li>Management of multi-user chat services (e.g., managing permissions across an entire service or registering a global room nickname)</li>
+    <li>Moderation of individual messages</li>
+    <li>Security and encryption at the level of a room or service</li>
+    <li>Advanced features such as attaching files to a room, integrating whiteboards, and interfacing with audio chat services</li>
+    <li>Interaction between Jabber and foreign chat systems (e.g., gateways to IRC or to legacy IM systems)</li>
+  </ul>
+  <p class="" style="">This limited scope is not meant to disparage such topics, which are of inherent interest; however, it is meant to focus the discussion in this JEP and to present a comprehensible proposal that can be implemented by Jabber client and component developers alike. Future JEPs may of course address the topics mentioned above.</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP must address the minimal functionality provided by existing multi-user chat services in Jabber. For the sake of backward-compatibility, this JEP uses the original &quot;groupchat 1.0&quot; protocol for this baseline functionality, with the result that:</p>
+  <ul>
+    <li>Messages sent within multi-user chat rooms are of a special type &quot;groupchat&quot;.</li>
+    <li>Each room is identified as room@service (e.g., jdev@conference.jabber.org), where &quot;room&quot; is the name of the room and &quot;service&quot; is the hostname at which the multi-user chat service is running.</li>
+    <li>Each occupant in a room is identified as room@service/nick, where &quot;nick&quot; is the room nickname of the occupant as specified on entering the room or subsequently changed during the occupant's visit.</li>
+    <li>A user enters a room (i.e., becomes an occupant) by sending presence to it.</li>
+    <li>An occupant exits a room by sending presence of type &quot;unavailable&quot; to it.</li>
+    <li>An occupant can change his or her room nickname and availability status within the room by sending updated presence information.</li>
+  </ul>
+  <p class="" style="">The additional features and functionality addressed in this JEP include the following:</p>
+  <ol start="" type="">
+    <li>&quot;native&quot; conversation logging (no bot required)</li>
+    <li>enabling users to request membership in a room</li>
+    <li>enabling occupants to view an occupant's full JID in a non-anonymous room</li>
+    <li>enabling moderators to view an occupant's full JID in a semi-anonymous room</li>
+    <li>allowing only moderators to change the room subject</li>
+    <li>enabling moderators to kick participants and visitors from the room</li>
+    <li>enabling moderators to grant and revoke voice (i.e., the privilege to speak) in a moderated room, and to manage the voice list</li>
+    <li>enabling admins to grant and revoke moderator privileges, and to manage the moderator list</li>
+    <li>enabling admins to ban users from the room, and to manage the ban list</li>
+    <li>enabling admins to grant and revoke membership privileges, and to manage the member list for a members-only room</li>
+    <li>enabling owners to limit the number of occupants</li>
+    <li>enabling owners to specify other owners</li>
+    <li>enabling owners to grant and revoke administrative privileges, and to manage the admin list</li>
+    <li>enabling owners to destroy the room</li>
+  </ol>
+  <p class="" style="">In addition, this JEP provides protocol elements for supporting the following room types:</p>
+  <ol start="" type="">
+    <li>public or hidden</li>
+    <li>persistent or temporary</li>
+    <li>password-protected or unsecured</li>
+    <li>members-only or open</li>
+    <li>moderated or unmoderated</li>
+    <li>non-anonymous or semi-anonymous</li>
+  </ol>
+<h2>4.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="terms-general">General Terms</a>
+</h3>
+    <p class="" style="">Affiliation -- a long-lived association or connection with a room; the possible affiliations are &quot;owner&quot;, &quot;admin&quot;, &quot;member&quot;, and &quot;outcast&quot; (naturally it is also possible to have no affiliation); affiliation is orthogonal to role. An affiliation lasts across a user's visits to a room.</p>
+    <p class="" style="">Ban -- to remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). A banned user has an affiliation of &quot;outcast&quot;.</p>
+    <p class="" style="">Bare JID -- the user@host by which a user is identified outside the context of any existing session or resource; contrast with Full JID and Room JID.</p>
+    <p class="" style="">Full JID -- the user@host/resource by which an online user is identified outside the context of a room; contrast with Bare JID and Room JID.</p>
+    <p class="" style="">GC -- the minimal &quot;groupchat 1.0&quot; protocol  [<a href="#nt-id2603334">2</a>] currently in use for text-based conferencing in Jabber.</p>
+    <p class="" style="">History -- a limited number of message stanzas sent to a new occupant to provide the context of current discussion.</p>
+    <p class="" style="">Invitation -- a special message sent from one user to another asking the recipient to join a room.</p>
+    <p class="" style="">IRC -- Internet Relay Chat.</p>
+    <p class="" style="">Kick -- to temporarily remove a participant or visitor from a room; the user is allowed to re-enter the room at any time. A kicked user has a role of &quot;none&quot;.</p>
+    <p class="" style="">Logging -- storage of discussions that occur within a room for future retrieval inside or outside the context of the room.</p>
+    <p class="" style="">Member -- a user who is on the &quot;whitelist&quot; for a members-only room or who is registered with an open room. A member has an affiliation of &quot;member&quot;.</p>
+    <p class="" style="">Moderator -- a room role that is usually associated with room admins but that may be granted to non-admins; is allowed to kick users, grant and revoke voice, etc. A moderator has an affiliation of &quot;moderator&quot;.</p>
+    <p class="" style="">MUC -- the multi-user chat protocol for text-based conferencing documented in this JEP.</p>
+    <p class="" style="">Occupant -- any Jabber user who is in a room (this is an &quot;abstract class&quot; and does not correspond to any specific role).</p>
+    <p class="" style="">Outcast -- a user who has been banned from a room. An outcast has an affiliation of &quot;outcast&quot;.</p>
+    <p class="" style="">Participant -- an occupant who does not have administrative privileges; in a moderated room, a participant is further defined as having voice (in contrast to a visitor). A participant has a role of &quot;participant&quot;.</p>
+    <p class="" style="">Private Message -- a message sent from one occupant directly to another's room JID (not to the room itself for broadcasting to all occupants).</p>
+    <p class="" style="">Role -- a temporary position or privilege level within a room, orthogonal to a user's long-lived affiliation with the room; the possible roles are &quot;moderator&quot;, &quot;participant&quot;, and &quot;visitor&quot; (it is also possible to have no defined role). A role lasts only for the duration of an occupant's visit to a room.</p>
+    <p class="" style="">Room -- a virtual space that Jabber users figuratively enter in order to participate in real-time, text-based conferencing with more than one other user.</p>
+    <p class="" style="">Room Administrator -- a user empowered by the room owner to perform administrative functions such as banning users; however, is not allowed to change defining room features. An admin has an affiliation of &quot;admin&quot;.</p>
+    <p class="" style="">Room ID -- the node identifier portion of a Room JID, which may be opaque and thus lack meaning for human users (see Business Rules for syntax); contrast with Room Name.</p>
+    <p class="" style="">Room JID -- the &lt;room@service/nick&gt; by which an occupant is identified within the context of a room; contrast with Bare JID and Full JID.</p>
+    <p class="" style="">Room Name -- a user-friendly, natural-language name for a room, configured by the room owner and presented in Service Discovery queries; contrast with Room ID.</p>
+    <p class="" style="">Room Nickname -- the resource identifier portion of a Room JID (see Business Rules for syntax).</p>
+    <p class="" style="">Room Owner -- the Jabber user who created the room, or a Jabber user who has been designated by the room creator as someone with owner privileges (if allowed); is allowed to change defining room features as well as perform all administrative functions. An owner has an affiliation of &quot;owner&quot;.</p>
+    <p class="" style="">Room Roster -- a Jabber client's representation of the occupants in a room.</p>
+    <p class="" style="">Server -- a Jabber server that may or may not have associated with it a text-based conferencing service.</p>
+    <p class="" style="">Service -- a host that offers text-based conferencing capabilities; often but not necessarily a sub-domain of a Jabber server (e.g., conference.jabber.org).</p>
+    <p class="" style="">Subject -- a temporary discussion topic within a room.</p>
+    <p class="" style="">Visit -- a user's &quot;session&quot; in a room, beginning when the user enters the room (i.e., becomes an occupant) and ending when the user exits the room.</p>
+    <p class="" style="">Visitor -- in a moderated room, an occupant who does not have voice (in contrast to a participant). A visitor has a role of &quot;visitor&quot;.</p>
+    <p class="" style="">Voice -- in a moderated room, the privilege to send messages to all occupants.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="terms-rooms">Room Types</a>
+</h3>
+    <p class="" style="">Fully-Anonymous Room -- a room in which the full JIDs or bare JIDs of occupants cannot be discovered by anyone, including room admins and room owners; such rooms are NOT RECOMMENDED or explicitly supported by MUC, but are possible using this protocol; contrast with Non-Anonymous Room and Semi-Anonymous Room.</p>
+    <p class="" style="">Hidden Room -- a room that cannot be found by any user through normal means such as searching and service discovery; antonym: Public Room.</p>
+    <p class="" style="">Members-Only Room -- a room that a user cannot enter without being on the member list; antonym: Open Room.</p>
+    <p class="" style="">Moderated Room -- a room in which only those with &quot;voice&quot; may send messages to all occupants; antonym: Unmoderated Room.</p>
+    <p class="" style="">Non-Anonymous Room -- a room in which occupants' full JIDs are exposed to all occupants, although they may choose any desired room nickname; contrast with Semi-Anonymous Room and Fully-Anonymous Room.</p>
+    <p class="" style="">Open Room -- a room that anyone may enter without being on the member list; antonym: Members-Only Room.</p>
+    <p class="" style="">Password-Protected Room -- a room that a user cannot enter without first providing the correct password; antonym: Unsecured Room.</p>
+    <p class="" style="">Persistent Room -- a room that is not destroyed if the last occupant exits; antonym: Temporary Room.</p>
+    <p class="" style="">Public Room -- a room that can be found by any user through normal means such as searching and service discovery); antonym: Hidden Room.</p>
+    <p class="" style="">Semi-Anonymous Room -- a room in which occupants' full JIDs can be discovered by room admins only; contrast with Fully-Anonymous Room and Non-Anonymous Room.</p>
+    <p class="" style="">Temporary Room -- a room that is destroyed if the last occupant exits; antonym: Persistent Room.</p>
+    <p class="" style="">Unmoderated Room -- a room in which any occupant is allowed to send messages to all occupants; antonym: Moderated Room.</p>
+    <p class="" style="">Unsecured Room -- a room that anyone is allowed to enter without first providing the correct password; antonym: Password-Protected Room.</p>
+  </div>
+<h2>5.
+       <a name="connections">Roles and Affiliations</a>
+</h2>
+  <p class="" style="">There are two dimensions along which we can measure a user's connection with or position in a room. One is the user's long-lived affiliation with a room -- e.g., a user's status as an owner or an outcast. The other is a user's role while an occupant of a room -- e.g., an occupant's position as a moderator with the ability to kick visitors and participants. These two dimensions are orthogonal to each other, since an affiliation lasts across visits, while a role lasts only for the duration of a visit. In addition, there is no one-to-one correspondence between roles and affiliations; for example, someone who is not affiliated with a room may be a (temporary) moderator, and a member may be a participant or a visitor in a moderated room. These concepts are explained more fully below.</p>
+  <div class="indent">
+<h3>5.1 <a name="roles">Roles</a>
+</h3>
+    <p class="" style="">There are four defined roles that an occupant MAY have:</p>
+    <ol start="" type="">
+      <li>Moderator</li>
+      <li>Participant</li>
+      <li>Visitor</li>
+      <li>None (the absence of a role)</li>
+    </ol>
+    <p class="" style="">These roles are temporary in that they do not persist across a user's visits to the room and MAY change during the course of an occupant's visit to the room. In addition, there is no one-to-one mapping between these roles and a user's affiliation with the room (e.g., a member could be a participant or a visitor).</p>
+    <p class="" style="">A moderator is the most powerful occupant within the context of the room, and can to some extent manage other occupants' roles in the room. A participant has fewer privileges than a moderator, although he or she always has the right to speak. A visitor is a more restricted role within the context of a moderated room, since visitors are not allowed to send messages to all occupants.</p>
+    <p class="" style="">Roles are granted, revoked, and maintained based on the occupant's room nickname or full JID rather than bare JID. The privileges associated with these roles, as well as the actions that trigger changes in roles, are defined below.</p>
+    <p class="" style="">Information about roles MUST be sent in all presence stanzas generated or reflected by the room and thus sent to occupants.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="roles-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, roles exist in a hierarchy. For instance, a participant can do anything a visitor can do, and a moderator can do anything a participant can do. Each role has privileges not possessed by the next-lowest role; these privileges are specified in the following table as defaults (naturally an implementation MAY provide configuration options that override these defaults).</p>
+      <p class="caption">Table 1: Privileges Associated With Roles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Present in Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Receive Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Availability Status</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Nickname</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Private Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Invite Other Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Messages to All</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No**</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Modify Subject</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Kick Participants and Visitors</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Grant Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Revoke Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes***</td>
+        </tr>
+      </table>
+      <p class="" style="">* Default; configuration settings MAY further restrict this privilege.</p>
+      <p class="" style="">** An implementation MAY grant voice by default to visitors in unmoderated rooms.</p>
+      <p class="" style="">*** A moderator MUST NOT be able to revoke voice privileges from an admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="roles-change">Changing Roles</a>
+</h3>
+      <p class="" style="">The ways in which an occupant's role changes are well-defined. Sometimes the change results from the occupant's own action (e.g., entering or exiting the room), whereas sometimes the change results from an action taken by a moderator, admin, or owner. If an occupant's role changes, a compliant component implementation MUST change the occupant's role to reflect the change and communicate that to all occupants. Role changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 2: Role State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">&gt;</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Enter moderated room</td>
+          <td align="" colspan="" rowspan="">Enter unmoderated room</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Moderator grants voice</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">Moderator revokes voice</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Exit room</td>
+          <td align="" colspan="" rowspan="">Admin changes role to visitor</td>
+          <td align="" colspan="" rowspan="">Admin changes role to participant or revokes moderator privileges **</td>
+          <td align="" colspan="" rowspan="">--</td>
+        </tr>
+      </table>
+      <p class="" style="">* A moderator MUST NOT be able to revoke moderator privileges from an occupant who is equal to or above the moderator in the hierarchy of affiliations.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="affil">Affiliations</a>
+</h3>
+    <p class="" style="">There are five defined affiliations that a user MAY have in relation to a room:</p>
+    <ol start="" type="">
+      <li>Owner</li>
+      <li>Admin</li>
+      <li>Member</li>
+      <li>Outcast</li>
+      <li>None (the absence of an affiliation)</li>
+    </ol>
+    <p class="" style="">These affiliations are long-lived in that they persist across a user's visits to the room and are not affected by happenings in the room. In addition, there is no one-to-one mapping between these affiliations and an occupant's role within the room. Affiliations are granted, revoked, and maintained based on the user's bare JID.</p>
+    <p class="" style="">If a user without a defined affiliation enters a room, the user's affiliation is defined as &quot;none&quot;; however, this affiliation does not persist across visits.</p>
+    <p class="" style="">Owners and admins are by definition immune from certain actions. Specifically, an owner or admin cannot be kicked from a room and cannot be banned from a room. An admin MUST first lose his or her affiliation (i.e., have an affiliation of &quot;none&quot; or &quot;member&quot;) before such actions could be performed on them.</p>
+    <p class="" style="">The member affiliation provides a way for a room owner or admin to specify a &quot;whitelist&quot; of users who are allowed to enter a members-only room. When a member enters a members-only room, his or her affiliation does not change, no matter what his or her role is. The member affiliation also provides a way for users to effectively register with an open room and thus be lastingly associated with that room in some way (one result may be that the user's nickname is reserved in the room).</p>
+    <p class="" style="">An outcast is a user who has been banned from a room and who is not allowed to enter the room.</p>
+    <p class="" style="">Information about affiliations MUST be sent in all presence stanzas generated or reflected by the room and sent to occupants.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="affil-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, affiliations exist in a hierarchy. For instance, an owner can do anything an admin can do, and an admin can do anything a member can do. Each affiliation has privileges not possessed by the next-lowest affiliation; these privileges are specified in the following table.</p>
+      <p class="caption">Table 3: Privileges Associated With Affiliations</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Register with an Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Members-Only Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Ban Members and Unaffiliated Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Member List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Moderator List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Admin List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Owner List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Definition</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Destroy Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+      </table>
+      <p class="" style="">* As a default, an unaffiliated user enters a moderated room as a visitor, and enters an open room as a participant. A member enters a room as a participant. An admin or owner enters a room as a moderator.</p>
+      <p class="" style="">** An admin or owner MUST NOT be able to revoke moderation privileges from another admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="affil-change">Changing Affiliations</a>
+</h3>
+      <p class="" style="">The ways in which a user's affiliation changes are well-defined. Sometimes the change results from the user's own action (e.g., registering as a member of the room), whereas sometimes the change results from an action taken by an admin or owner. If a user's affiliation changes, a compliant component implementation MUST change the user's affiliation to reflect the change and communicate that to all occupants. Affiliation changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 4: Affiliation State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">-&gt;</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Outcast</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner removes ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to member list</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to member list, or user registers as member (if allowed)</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Member</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes affiliation to &quot;none&quot;</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Admin</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes affiliation to &quot;none&quot;</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes affiliation to &quot;member&quot;</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Owner</td>
+          <td align="" colspan="" rowspan="">Owner applies ban</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;none&quot;</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;member&quot;</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to &quot;admin&quot;</td>
+          <td align="" colspan="" rowspan="">--</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+<h2>6.
+       <a name="user">Occupant Use Cases</a>
+</h2>
+  <p class="" style="">The main actor in a multi-user chat environment is the occupant, who can be said to be located &quot;in&quot; a multi-user chat room and to participate in the discussions held in that room (for the purposes of this JEP, participants and visitors are considered to be &quot;mere&quot; occupants, since they possess no administrative privileges). As will become clear, the protocol elements proposed in this JEP to fulfill the occupant use cases fall into three categories:</p>
+  <ol start="" type="">
+    <li><p class="" style="">existing &quot;groupchat 1.0&quot; protocol for minimal functionality</p></li>
+    <li><p class="" style="">straightforward applications of the &quot;groupchat 1.0&quot; protocol, for example to handle some of the errors related to new room types</p></li>
+    <li><p class="" style="">new protocol elements to handle functionality not covered by &quot;groupchat 1.0&quot; (room invites, room passwords, extended presence related to room roles and affiliations); these are contained in the new 'http://jabber.org/protocol/muc#user' namespace</p></li>
+  </ol>
+  <p class="" style="">Note: All client-generated examples herein are presented from the perspective of the service, with the result that all stanzas received by a service contain a 'from' attribute corresponding to the sender's full JID as added by a normal Jabber router or session manager. In addition, normal IQ result stanzas sent upon successful completion of a request are not shown. Most of the examples in this document use the scenario of the witches' meeting held in a dark cave at the beginning of Act IV, Scene I of Shakespeare's <span style="font-style: italic">Macbeth</span>. The characters are as follows:</p>
+  <p class="caption">Table 5: Dramatis Personae</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Room Nickname</th>
+      <th colspan="" rowspan="">Full JID</th>
+      <th colspan="" rowspan="">Affiliation</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">firstwitch</td>
+      <td align="" colspan="" rowspan="">crone1@shakespeare.lit/desktop</td>
+      <td align="" colspan="" rowspan="">Owner</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">secondwitch</td>
+      <td align="" colspan="" rowspan="">wiccarocks@shakespeare.lit/laptop</td>
+      <td align="" colspan="" rowspan="">Admin</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">thirdwitch</td>
+      <td align="" colspan="" rowspan="">hag66@shakespeare.lit/pda</td>
+      <td align="" colspan="" rowspan="">None</td>
+    </tr>
+  </table>
+  <div class="indent">
+<h3>6.1 <a name="discovery">Discovering Component Support for MUC</a>
+</h3>
+    <p class="" style="">Before entering a room, a Jabber user may want to discover if the room complies with the Multi-User Chat protocol.</p>
+    <p class="" style="">A compliant implementation MUST support <span class="ref">Service Discovery</span>  [<a href="#nt-id2606754">3</a>].</p>
+    <p class="caption">Example 1. User Queries Chat Service for MUC Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco1'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST return its identity and the features it supports:</p>
+    <p class="caption">Example 2. Service Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='Macbeth Chat Service'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: because MUC is a superset of the old &quot;Groupchat 1.0&quot; protocol, a MUC service SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result.</p>
+    <p class="" style="">The disco protocol also enables a user to query a service for a list of associated items, which in the case of a chat service would mainly consist of the specific chat rooms hosted by the service.</p>
+    <p class="caption">Example 3. User Queries Chat Service for Associated Items</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco2'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Returns Disco Item Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='heath@macbeth.shakespeare.lit'
+          name='A Lonely Heath'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='A Dark Cave'/&gt;
+    &lt;item jid='forres@macbeth.shakespeare.lit'
+          name='The Palace'/&gt;
+    &lt;item jid='inverness@macbeth.shakespeare.lit'
+          name='Macbeth&amp;apos;s Castle'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Using disco, a user may also query a specific chat room for more detailed information:</p>
+    <p class="caption">Example 5. User Queries for Information about a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The room MUST return its identity and SHOULD return the features it supports:</p>
+    <p class="caption">Example 6. Room Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: because MUC is a superset of the old &quot;Groupchat 1.0&quot; protocol, a MUC room SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result. The room SHOULD return the materially-relevant features it supports, such as password protection and room moderation (these are listed fully in the feature var registry maintained by the Jabber Registrar; see also the registry submission in this document).</p>
+    <p class="" style="">A chatroom MAY return more detailed information in its disco#info response using <span class="ref">Service Discovery Extensions</span>  [<a href="#nt-id2606953">4</a>]. Such information might include a more verbose description of the room, the current room subject, and the current number of occupants in the room:</p>
+    <p class="caption">Example 7. Room Returns Extended Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3a'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roominfo&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_description' label='Description'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_subject' label='Subject'&gt;
+        &lt;value&gt;Spells&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_occupants' label='Number of occupants'&gt;
+        &lt;value&gt;3&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_lang' label='Language of discussion'&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The foregoing extended service discovery fields for the 'http://jabber.org/protocol/muc#roominfo' FORM_TYPE may be supplemented in the future via the mechanisms described in the <a href="#registrar-formtype">Field Standardization</a> section of this document.</p>
+    <p class="" style="">Finally, a user may also query a specific chat room for its associated items:</p>
+    <p class="caption">Example 8. User Queries for Items Associated with a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">An implementation MAY return a list of existing occupants if that information is publicly available, or return no list at all if this information is kept private.</p>
+    <p class="caption">Example 9. Room Returns Disco Item Results (Items are Public)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/firstwitch'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note that these &lt;item/&gt; elements are in the disco#items namespace, not the muc namespace. This means that they cannot possess 'affiliation' or 'role' attributes, for example.</p>
+    <p class="caption">Example 10. Room Returns Empty Disco Item Results (Items are Private)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If an entity attempts to send a disco request to an address of the form &lt;room@service/nick&gt;, a compliant component SHOULD return the request to the entity and specify a &lt;bad-request/&gt; error condition.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="discovery-client">Discovering Client Support for MUC</a>
+</h3>
+    <p class="" style="">A Jabber user may want to discover if one of the user's contacts supports the Multi-User Chat protocol. This is done using Service Discovery.</p>
+    <p class="caption">Example 11. User Queries Contact regarding MUC Support</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco5'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client SHOULD return its identity and the features it supports:</p>
+    <p class="caption">Example 12. Contact Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='disco5'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='client'
+        type='pc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A user may also query a contact regarding which rooms the contact is in. This is done by querying the contact's full JID (user@host/resource) while specifying the well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms':</p>
+    <p class="caption">Example 13. User Queries Contact for Current Rooms</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='rooms1'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Contact Returns Room Query Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='rooms1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'/&gt;
+    &lt;item jid='characters@conference.shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Optionally, the contact MAY include its roomnick as the value of the 'name' attribute:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+    ...
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='secondwitch'/&gt;
+    ...
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="enter">Entering a Room</a>
+</h3>
+    <div class="indent">
+<h3>6.3.1 <a name="enter-gc">Groupchat 1.0 Protocol</a>
+</h3>
+      <p class="" style="">In order to participate in the discussions held in a multi-user chat room, a Jabber user MUST first become an occupant by entering the room. In the old &quot;groupchat 1.0&quot; protocol, this is done by sending presence to room@service/nick, where &quot;room&quot; is the room ID, &quot;service&quot; is the hostname of the chat service, and &quot;nick&quot; is the user's desired nickname within the room:</p>
+      <p class="caption">Example 15. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'/&gt;
+      </pre></div>
+      <p class="" style="">In this example, a user with a full JID of &quot;hag66@shakespeare.lit/pda&quot; has requested to enter the room &quot;darkcave&quot; on the &quot;macbeth.shakespeare.lit&quot; chat service with a room nickname of &quot;thirdwitch&quot;.</p>
+      <p class="" style="">If the user does not specify a room nickname, the service SHOULD return a &lt;jid-malformed/&gt; error:</p>
+      <p class="caption">Example 16. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;jid-malformed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.2 <a name="enter-muc">Basic MUC Protocol</a>
+</h3>
+      <p class="" style="">Compliant multi-user chat services MUST accept the foregoing as a request to enter a room from any Jabber client that knows either the &quot;groupchat 1.0&quot; (GC) protocol or the multi-user chat (MUC) protocol; however, MUC-compliant clients SHOULD signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
+      <p class="caption">Example 17. Jabber User Seeks to Enter a Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.3 <a name="enter-pres">Presence Broadcast</a>
+</h3>
+      <p class="" style="">If the service is able to add the user to the room, it MUST send presence from all the existing occupants' room JIDs to the new occupant's full JID, including extended presence information about roles in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;moderator&quot;, &quot;participant&quot;, &quot;visitor&quot;, or &quot;none&quot; and with the 'affiliation' attribute set to a value of &quot;owner&quot;, &quot;admin&quot;, &quot;member&quot;, or &quot;none&quot; as appropriate:</p>
+      <p class="caption">Example 18. Service Sends Presence from Existing Occupants to New Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, the user from the previous example has entered the room, by which time two other people had already entered the room: a user with a room nickname of &quot;firstwitch&quot; (who is the room owner) and a user with a room nickname of &quot;secondwitch&quot; (who is a room admin).</p>
+      <p class="" style="">The service MUST also send presence from the new occupant's room JID to the full JIDs of all the occupants (including the new occupant):</p>
+      <p class="caption">Example 19. Service Sends New Occupant's Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, initial room presence is being sent from the new occupant (thirdwitch) to all occupants, including the new occupant.</p>
+      <p class="" style="">The order of the presence stanzas sent to the new occupant is important. The service MUST first send the complete list of the existing occupants to the new occupant and only then send the new occupant's own presence to the new occupant. This helps the client know when it has received the complete &quot;room roster&quot;.</p>
+    </div>
+    <div class="indent">
+<h3>6.3.4 <a name="enter-roles">Default Roles</a>
+</h3>
+      <p class="" style="">The following table summarizes the initial default roles that a service should set based on the user's affiliation (there is no role associated with the &quot;outcast&quot; affiliation, since such users are never allowed to enter the room).</p>
+      <p class="caption">Table 6: Initial Role Based on Affiliation</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Room Type</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderated</td>
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Unmoderated</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Members-Only</td>
+          <td align="" colspan="" rowspan="">n/a</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Open</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>6.3.5 <a name="enter-nonanon">Non-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is non-anonymous, the service MUST send the new occupant's full JID to all occupants using extended presence information in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with a 'jid' attribute specifying the occupant's full JID:</p>
+      <p class="caption">Example 20. Service Sends Full JID to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+      </pre></div>
+      <p class="" style="">If the user is entering a room that is non-anonymous (i.e., which informs all occupants of each occupant's full JID as shown above), the service SHOULD allow the user to enter the room but MAY warn the user that the room is not anonymous; this is done by sending a message of type &quot;groupchat&quot; to the new occupant containing an &lt;x/&gt; child with a &lt;status/&gt; element that has the 'code' attribute set to a value of &quot;100&quot;:</p>
+      <p class="caption">Example 21. Service Warns New Occupant of Lack of Anonymity</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;This room is not anonymous.&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;status code='100'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality).</p>
+    </div>
+    <div class="indent">
+<h3>6.3.6 <a name="enter-semianon">Semi-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is semi-anonymous, the service MUST send the new occupant's full JID in the format shown above only to those occupants with a role of &quot;moderator&quot;.</p>
+      <p class="" style="">(Note: all subsequent examples include the 'jid' attribute for each &lt;item/&gt; element, even though this information is not sent to non-moderators in semi-anonymous rooms.)</p>
+    </div>
+    <div class="indent">
+<h3>6.3.7 <a name="enter-pw">Password-Protected Rooms</a>
+</h3>
+      <p class="" style="">If the room requires a password and the user did not supply one, the service MUST deny access to the room and inform the user that they are unauthorized; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;not-authorized/&gt; error:</p>
+      <p class="caption">Example 22. Service Denies Access Because No Password Provided</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Passwords SHOULD be supplied with the presence stanza sent when entering the room, contained within an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace and containing a &lt;password/&gt; child. Passwords are to be sent as cleartext; no other authentication methods are supported at this time, and any such authentication or authorization methods shall be defined in a separate specification.</p>
+      <p class="caption">Example 23. User Provides Password On Entering a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.8 <a name="enter-members">Members-Only Rooms</a>
+</h3>
+      <p class="" style="">If the room is members-only but the user is not on the member list, the service MUST deny access to the room and inform the user that they are not allowed to enter the room; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;registration-required/&gt; error condition:</p>
+      <p class="caption">Example 24. Service Denies Access Because User Is Not on Member List</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='407' type='auth'&gt;
+    &lt;registration-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.9 <a name="enter-banned">Banned Users</a>
+</h3>
+      <p class="" style="">If the user has been banned from the room (i.e., has an affiliation of &quot;outcast&quot;), the service MUST deny access to the room and inform the user of the fact that he or she is banned; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;forbidden/&gt; error condition:</p>
+      <p class="caption">Example 25. Service Denies Access Because User is Banned</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.10 <a name="enter-conflict">Nickname Conflict</a>
+</h3>
+      <p class="" style="">If the room already contains an occupant with the nickname desired by the user seeking to enter the room (or if the nickname is reserved by a user on the member list), the service MUST deny access to the room and inform the user of the conflict; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;conflict/&gt; error condition:</p>
+      <p class="caption">Example 26. Service Denies Access Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.11 <a name="enter-maxusers">Max Users</a>
+</h3>
+      <p class="" style="">If the room has reached its maximum number of uses, the service SHOULD deny access to the room and inform the user of the restriction; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;not-allowed/&gt; error condition:</p>
+  <p class="caption">Example 27. Service Informs User that Room Occupant Limit Has Been Reached</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+  </pre></div>
+
+    </div>
+    <div class="indent">
+<h3>6.3.12 <a name="enter-history">Discussion History</a>
+</h3>
+      <p class="" style="">After sending initial presence as shown above, a room MAY send discussion history to the new occupant. Whether such history is sent, and how many messages comprise the history, shall be determined by the chat service implementation or specific deployment.</p>
+      <p class="caption">Example 28. Delivery of Discussion History</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20021013T23:58:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20021013T23:58:43'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries 'Tis time, 'tis time.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='hag66@shakespeare.lit/pda'
+     stamp='20021013T23:58:49'/&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">Discussion history messages SHOULD be stamped with extended information in the 'jabber:x:delay' namespace (see <span class="ref">Delayed Delivery</span>  [<a href="#nt-id2608200">5</a>]) to indicate that they are sent with delayed delivery. The 'from' attribute SHOULD be the JID of the original sender in non-anonymous rooms, but MUST NOT be in semi-anonymous rooms (the 'from' attribute SHOULD be set to the room JID in semi-anonymous rooms).</p>
+    </div>
+    <div class="indent">
+<h3>6.3.13 <a name="enter-managehistory">Managing Discussion History</a>
+</h3>
+      <p class="" style="">A user MAY want to manage the amount of discussion history provided on entering a room (perhaps because the user is on a low-bandwidth connection or is using a small-footprint client). This MUST be accomplished by including a &lt;history/&gt; child in the initial presence stanza sent when joining the room. There are four allowable attributes for this element:</p>
+      <p class="caption">Table 7: History Management Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Attribute</th>
+          <th colspan="" rowspan="">Datatype</th>
+          <th colspan="" rowspan="">Meaning</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxchars</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of characters in the history to &quot;X&quot;.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxstanzas</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of messages in the history to &quot;X&quot;.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">seconds</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Send only the messages received in the last &quot;X&quot; seconds.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">since</td>
+          <td align="" colspan="" rowspan="">dateTime</td>
+          <td align="" colspan="" rowspan="">Send only the messages received since the dateTime specified (which MUST conform to <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2608423">6</a>]).</td>
+        </tr>
+      </table>
+      <p class="" style="">The service MUST send the smallest amount of traffic that meets any combination of the above criteria, taking into account service-level and room-level defaults. The service MUST send complete message stanzas only (i.e., it MUST not literally truncate the history at a certain number of characters, but MUST send the largest number of complete stanzas that results in a number of characters less than or equal to the 'maxchars' value specified). If the client wishes to receive no history, it MUST set the 'maxcharts' attribute to a value of &quot;0&quot; (zero).</p>
+      <p class="" style="">The following examples illustrate the use of this protocol.</p>
+      <p class="caption">Example 29. User Requests Limit on Number of Messages in History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxstanzas='20'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 30. User Requests History in Last 3 Minutes</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history seconds='180'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 31. User Requests All History Since the Beginning of the Unix Era</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history since='1970-01-01T00:00Z'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Obviously the service SHOULD NOT return all messages sent in the room since the beginning of the Unix era, and SHOULD appropriately limit the amount of history sent to the user based on service or room defaults.</p>
+      <p class="caption">Example 32. User Requests No History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxchars='0'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.14 <a name="enter-create">Room Creation</a>
+</h3>
+      <p class="" style="">If the room does not already exist when the user seeks to enter it, the service MAY be responsible for creating it; however, this is OPTIONAL, since an implementation or deployment MAY choose to restrict the privilege of creating rooms. See &quot;Owner Use Cases&quot; for details.</p>
+      <p class="" style="">If a user attempts to enter a room that does not exist or to enter a room while it is &quot;locked&quot; (i.e., before the room creator provides an initial configuration and therefore before the room officially exists), the service MUST refuse entry and return a &lt;item-not-found/&gt; error to the user:</p>
+      <p class="caption">Example 33. Service Denies Access Because Room Does Not Exist</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="exit">Exiting a Room</a>
+</h3>
+    <p class="" style="">In order to exit a multi-user chat room, an occupant sends a presence stanza of type &quot;unavailable&quot; to the room@service/nick it is currently using in the room.</p>
+    <p class="caption">Example 34. Occupant Exits a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send presence stanzas of type &quot;unavailable&quot; from the departing occupant's room JID to the full JIDs of the departing occupant and of the remaining occupants:</p>
+    <p class="caption">Example 35. Service Sends Presence Related to Departure of Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Presence stanzas of type &quot;unavailable&quot; reflected by the room MUST contain extended presence information about roles and affiliations, and MAY also contain normal &lt;show/&gt; and &lt;status/&gt; information (this last enables occupants to provide custom exit messages if desired).</p>
+    <p class="" style="">Normal presence stanza generation rules apply as defined in <span style="font-weight: bold">XMPP IM</span>, so that if the user sends a general unavailable presence stanza, the user's server will broadcast that stanza to the room@service/nick to which the user's client has sent directed presence.</p>
+    <p class="" style="">If the room is not persistent and this occupant is the last to exit, the service is responsible for destroying the room.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="changenick">Changing Nickname</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability for an occupant to change his or her nickname within the room. In Jabber this is done by sending updated presence information to the room, specifically by sending presence to a new room JID in the same room (changing only the resource identifier in the room JID).</p>
+    <p class="caption">Example 36. Occupant Changes Nickname</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'/&gt;
+    </pre></div>
+    <p class="" style="">The service then sends two presence packets to the full JID of each occupant (including the occupant who is changing his or her room nickname), one of type &quot;unavailable&quot; for the old nickname and one indicating availability for the new nickname. The unavailable presence MUST contain the new nickname and an appropriate status code (namely 303) as extended presence information in an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace so that Jabber clients are able to provide relevant hints to occupants regarding the nickname change if desired.</p>
+    <p class="caption">Example 37. Service Updates Nick</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If the user attempts to change his or her room nickname to a room nickname that is already in use by another occupant (or that is reserved by someone affiliated with the room, e.g., a member or owner), the service MUST deny the nickname change request and inform the user of the conflict; this is done by returning a presence stanza of type &quot;error&quot; specifying a &lt;conflict/&gt; error condition:</p>
+    <p class="caption">Example 38. Service Denies Nickname Change Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="changepres">Changing Availability Status</a>
+</h3>
+    <p class="" style="">In multi-user chat systems such as IRC, one common use for changing one's room nickname is to indicate a change in one's availability (e.g., changing one's room nickname to &quot;thirdwitch|away&quot;). In Jabber, availability is of course noted by a change in presence (specifically the &lt;show/&gt; and &lt;status/&gt; elements), which can provide important context within a chatroom. An occupant changes availability status within the room by sending the updated presence to room@service/nick.</p>
+    <p class="caption">Example 39. Occupant Changes Availability Status</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The service then sends a presence packet from the occupant changing his or her presence to the full JID of each occupant, including extended presence information about the occupant's role and full JID to those with privileges to view such information:</p>
+    <p class="caption">Example 40. Service Passes Along Changed Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="invite">Inviting Another User to a Room</a>
+</h3>
+    <p class="" style="">It can be useful to invite another user to a room in which one is an occupant. Several different mechanisms have been suggested in the past to do this. The protocol most commonly used is for the inviting occupant to send a message directly to the invitee, containing extended content in the jabber:x:conference namespace. The server (not the chat service) adds a 'from' address to the invite message, which is delivered like any other message. This undocumented protocol, which is not part of &quot;groupchat 1.0&quot;, is as follows:</p>
+    <p class="caption">Example 41. Occupant Sends an Invitation (Existing Protocol)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;body&gt;You have been invited to darkcave@macbeth.&lt;/body&gt;
+    &lt;x jid='room@service' xmlns='jabber:x:conference'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While the current protocol meets the needs of existing implementations, it could not work within the context of a members-only room, since the service needs to keep track of who is registered as a member. Because we would like to support members-only rooms, it seems desirable for an occupant to send the invitation to the room itself and have the room keep track of the invitations (if the room is members-only) or simply forward the invitation to the invitee.</p>
+    <p class="" style="">Therefore the old undocumented protocol SHOULD be officially discouraged (it cannot be deprecated since it was never approved) and a MUC-compliant client MUST instead send XML of the following form to the room itself (the reason is OPTIONAL and the message MUST NOT possess a 'type' attribute; the service MAY ignore or reject invites that possess a 'type' attribute):</p>
+    <p class="caption">Example 42. Occupant Sends an Invitation by Way of Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The room itself MUST then add a 'from' address to the &lt;invite/&gt; element equal to the bare JID (or, optionally, the room JID) of the inviter and send the invitation to the invitee captured in the 'to' address (the service SHOULD include the jabber:x:conference information for backward compatibility and MAY if desired include a message body explaining the invitation or containing the reason; in addition, the room SHOULD add the password if the room is password-protected):</p>
+    <p class="caption">Example 43. Room Sends Invitation to Invitee on Behalf of Inviter</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+  &lt;x jid='room@service' xmlns='jabber:x:conference'&gt;
+    Hey Hecate, this is the place for all good witches!
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MAY also add the invitee to the member list. (Note that invitation privileges in members-only rooms SHOULD be restricted to room admins; if a member without privileges to edit the member list attempts to invite another user, the service SHOULD return a &lt;forbidden/&gt; error to the occupant; for details, see the &quot;Modifying the Member List&quot; use case under Moderator Use Cases.)</p>
+    <p class="" style="">If the inviter supplies a non-existent JID, the room SHOULD return a &lt;item-not-found/&gt; error to the inviter.</p>
+    <p class="" style="">The invitee MAY choose to formally decline (as opposed to ignore) the invitation; and this is something that the sender may want to be informed about. In order to decline the invitation, the invitee MUST send a message of the following form to the room itself:</p>
+
+    <p class="caption">Example 44. Invitee Declines Invitation</p>
+<div class="indent"><pre>
+&lt;message
+    from='hecate@shakespeare.lit/broom'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline to='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 45. Room Informs Inviter that Invitation Was Declined</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline from='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">It may be wondered why the invitee does not send the decline message directly to the inviter. The main reason is that certain implementations MAY choose to base invitations on room JIDs rather than bare JIDs (so that, for example, an occupant could invite someone from one room to another without knowing that person's bare JID), in which case the service MUST handle both the invites and declines.</p>
+  </div>
+  <div class="indent">
+<h3>6.8 <a name="continue">Converting a One-to-One Chat Into a Conference</a>
+</h3>
+    <p class="" style="">Sometimes it is desirable to convert a one-to-one chat into a multi-user conference. This can be done by including a &lt;continue/&gt; child in the invitation. The process flow is shown in the following examples.</p>
+    <p class="" style="">First, two users begin a one-to-one chat.</p>
+    <p class="caption">Example 46. A One-to-One Chat</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='chat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Now the first person decides to include a third person in the discussion, so she (or, more precisely, her client) does the following:</p>
+    <ol start="" type="">
+      <li>Creates a new room (which SHOULD be non-anonymous and MAY be an instant room as specified below)</li>
+      <li>Optionally sends history of the one-to-one chat to the room</li>
+      <li>Sends an invitation to the second person and the third person, including a &lt;continue/&gt; flag.</li> 
+    </ol>
+    <p class="caption">Example 47. Continuing the Discussion I: User Creates Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 48. Continuing the Discussion II: Owner Sends History to Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20040929T01:54:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20040929T01:55:21'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Use of the <span style="font-weight: bold">Delayed Delivery</span> protocol enables the room creator to specify the datetime of each message from the one-to-one chat history (via the 'stamp' attribute), as well as JID of the original sender of each message (via the 'from' attribute). The room creator SHOULD send the complete one-to-one chat history before inviting additional users to the room, and SHOULD also send as history any messages appearing in the one-to-one chat interface after joining the room and before the second person joins the room; if the one-to-one history is especially large, the sending client may want to send the history over a few seconds rather than all at once (to avoid triggering rate limits). The service SHOULD NOT add its own delay elements (as described in the under <a href="#enter-history">Discussion History</a>) to prior chat history messages received from the room owner.</p>
+    <p class="caption">Example 49. Continuing the Discussion III: Owner Sends Invitations, Including Continue Flag</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='wiccarocks@shakespeare.lit/laptop'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hag66@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The invitations are delivered to the invitees:</p>
+    <p class="caption">Example 50. Invitations Delivered</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'&gt;
+    from='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'&gt;
+    from='hag66@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Since the inviter's client knows the full JID of the person with whom the inviter was having a one-to-one chat, it SHOULD include the full JID (rather than the bare JID) in the invitation.</p>
+    <p class="" style="">When the client being used by &lt;wiccarocks@shakespeare.lit/laptop&gt; receives the invitation, it SHOULD (subject to user preferences) auto-join the room and seamlessly convert the existing one-to-one chat window into a multi-user conferencing window:</p>
+    <p class="caption">Example 51. Invitee Accepts Invitation, Joins Room, and Receives Presence and History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/secondwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20040929T01:54:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20040929T01:55:21'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: The fact that the messages come from the room itself rather than room@service/nick is a clue to the receiving client that these messages are prior chat history, since any message from a room occupant will have a 'from' address equal to the sender's room JID.</p>
+  </div>
+  <div class="indent">
+<h3>6.9 <a name="subject-occupant">Occupant Modification of the Room Subject</a>
+</h3>
+    <p class="" style="">If allowed in accordance with room configuration, a mere occupant MAY have the privileges to change the subject in a room. For details, see the &quot;Modifying the Room Subject&quot; use case under &quot;Moderator Use Cases&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>6.10 <a name="privatemessage">Sending a Private Message</a>
+</h3>
+    <p class="" style="">Since each occupant has a unique room JID, an occupant MAY send a &quot;private message&quot; to a selected occupant via the service by sending a message to the occupant's room JID. The message type SHOULD be &quot;chat&quot; and MUST NOT be &quot;groupchat&quot;, but MAY be left unspecified (i.e., a normal message). This privilege SHOULD be allowed to any occupant (even a visitor in a moderated room).</p>
+    <p class="caption">Example 52. Occupant Sends Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for changing the 'from' address to the sender's room JID and delivering the message to the intended recipient's full JID.</p>
+    <p class="caption">Example 53. Recipient Receives the Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message of type &quot;groupchat&quot; to a particular occupant, the service MUST refuse to deliver the message and return a &lt;bad-request/&gt; error to the sender:</p>
+    <p class="caption">Example 54. Occupant Attempts to Send a Message of Type &quot;Groupchat&quot; to a Particular Occupant</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='groupchat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message to a room JID that does not exist, the service MUST return a &lt;item-not-found/&gt; error to the sender.</p>
+    <p class="" style="">If the sender is not an occupant of the room in which the intended recipient is visiting, the service MUST return a &lt;not-acceptable/&gt; error to the sender.</p>
+  </div>
+  <div class="indent">
+<h3>6.11 <a name="message">Sending a Message to All Occupants</a>
+</h3>
+    <p class="" style="">An occupant sends a message to all other occupants in the room by sending a message of type &quot;groupchat&quot; to the room itself (a service MAY ignore or reject messages that do not have a type of &quot;groupchat&quot;). In a moderated room, this privilege is restricted to occupants with a role of participant or higher. In an unmoderated room, any occupant sends a message to all other occupants by directing the message to the room itself and setting the 'type' attribute to a value of &quot;groupchat&quot;.</p>
+    <p class="caption">Example 55. Occupant Sends a Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender has voice in the room (this is the default except in moderated rooms), the service MUST change the 'from' attribute to the sender's room JID and reflect the message out to the full JID of each occupant.</p>
+    <p class="caption">Example 56. Service Reflects Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender is a visitor (i.e., does not have voice in a moderated room), the service MAY return a &lt;forbidden/&gt; error to the sender and MUST NOT reflect the message to all occupants. If the sender is not an occupant of the room, the service SHOULD return a &lt;not-acceptable/&gt; error to the sender and SHOULD NOT reflect the message to all occupants; however, an implementation MAY allow users with certain privileges (e.g., a room owner, room admin, or service-level admin) to send messages to the room even if that user is not an occupant.</p>
+  </div>
+  <div class="indent">
+<h3>6.12 <a name="register">Registering with a Room</a>
+</h3>
+    <p class="" style="">An implementation MAY allow an unaffiliated user (in a moderated room, probably a participant) to register with a room and thus become a member of the room (conversely, an implementation MAY restrict this privilege and allow only room admins to add new members). If allowed, this functionality SHOULD be implemented by enabling a user to send a request for registration requirements to the room in the 'jabber:iq:register' namespace as described in <span class="ref">In-Band Registration</span>  [<a href="#nt-id2609660">7</a>]:</p>
+    <p class="caption">Example 57. User Requests Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user requesting registration requirements is not allowed to register with the room (e.g., because that privilege has been restricted), the room MUST return a &lt;not-allowed/&gt; error to the user. If the user is already registered, the room MUST reply with an IQ stanza of type &quot;result&quot; that contains an empty &lt;register/&gt; element as described in JEP-0077. If the room does not exist, the service MUST return a &lt;item-not-found/&gt; error.</p>
+    <p class="" style="">Otherwise, the room MUST then return a form to the user in the 'jabber:x:data' namespace. The specific information required to register is not specified in this JEP and MAY vary by implementation or deployment. The following can be taken as a fairly typical example:</p>
+    <p class="caption">Example 58. Service Returns Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      To register on the web, visit http://shakespeare.lit/
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Dark Cave Registration&lt;/title&gt;
+      &lt;instructions&gt;
+        Please provide the following information
+        to register with this room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='First Name'
+          type='text-single'
+          var='muc#register_first'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Last Name'
+          type='text-single'
+          var='muc#register_last'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Desired Nickname'
+          type='text-single'
+          var='muc#register_roomnick'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Your URL'
+          type='text-single'
+          var='muc#register_url'/&gt;
+      &lt;field
+          label='Email Address'
+          type='text-single'
+          var='muc#register_email'/&gt;
+      &lt;field
+          label='FAQ Entry'
+          type='text-multi'
+          var='muc#register_faqentry'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The user SHOULD then submit the form:</p>
+    <p class="caption">Example 59. User Submits Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_first'&gt;
+        &lt;value&gt;Brunhilde&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_last'&gt;
+        &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_roomnick'&gt;
+        &lt;value&gt;thirdwitch&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_url'&gt;
+        &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_email'&gt;
+        &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_faqentry'&gt;
+        &lt;value&gt;Just another witch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the desired room nickname is already reserved for that room, the room MUST return a &lt;conflict/&gt; error to the user:</p>
+    <p class="caption">Example 60. Room Returns Conflict Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room or service does not support registration, it MUST return a &lt;service-unavailable/&gt; error to the user:</p>
+    <p class="caption">Example 61. Room Returns Service Unavailable Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user did not include a valid data form does, the room MUST return a &lt;bad-request/&gt; error to the user:</p>
+    <p class="caption">Example 62. Room Returns Service Bad Request Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the room MUST inform the user of successful registration:</p>
+    <p class="caption">Example 63. Room Informs User of Successful Registration</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After the user successfully submits the form, the service MAY request that the submission be approved by a room admin/owner (see <a href="#regapprove">Approving Registration Requests</a>) or MAY immediately add the user to the member list by changing the user's affiliation from &quot;none&quot; to &quot;member&quot;. If the service changes the user's affiliation and the user is in the room, it MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 64. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a user has registered with a room, the room MAY choose to restrict the user to use of the registered nickname only in that room. If it does so, it SHOULD return a &quot;Not Acceptable&quot; (406) error to the user if the user attempts to join the room with a roomnick other than the user's registered roomnick.</p>
+  </div>
+  <div class="indent">
+<h3>6.13 <a name="reservednick">Discovering Reserved Room Nickname</a>
+</h3>
+    <p class="" style="">A user MAY have a reserved room nickname, for example through explicit room registration or database integration. In such cases it may be desirable for the user to discover the reserved nickname before attempting to enter the room (e.g., because the user has forgotten his or her reserved nickname). This is done by sending a Service Discovery information request to the room JID while specifying a Service Discovery node of &quot;x-roomuser-item&quot;.</p>
+    <p class="caption">Example 65. User Requests Reserved Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='getnick1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It is OPTIONAL for a multi-user chat service to support the foregoing service discovery node. If it does and the user has a registered nickname, it MUST return the nickname to the user as value of the 'name' attribute of a Service Discovery &lt;identity/&gt; element (for which the category/type SHOULD be &quot;conference/member&quot;):</p>
+    <p class="caption">Example 66. Room Returns Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='getnick1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'&gt;
+    &lt;identity
+        category='conference'
+        name='thirdwitch'
+        type='text'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user does not have a registered nickname, the room MUST return a service discovery &lt;query/&gt; element that is empty (in accordance with JEP-0030).</p>
+    <p class="" style="">If the room or service does not support the foregoing service discovery node, it MUST return a &quot;Feature Not Implemented&quot; (502) error to the user.</p>
+    <p class="" style="">Even if a user has registered one room nickname, the service SHOULD allow the user to specify a different nickname on entering the room (e.g., in order to join from different client resources), although the service MAY choose to &quot;lock down&quot; nicknames and therefore deny entry to the user, including a &quot;Not Acceptable&quot; (406) error. The service MUST NOT return an error to the user if his or her client performs the foregoing request after having already joined the room.</p>
+    <p class="" style="">If another user attempts to join the room with a nickname reserved by the first user, the service MUST deny entry to the second user and return a &lt;conflict/&gt; error.</p>
+  </div>
+<h2>7.
+       <a name="moderator">Moderator Use Cases</a>
+</h2>
+  <p class="" style="">A moderator has privileges to perform certain actions within the room (e.g., to change the roles of some occupants) but does not have rights to change persistent information about affiliations, which MAY be changed only by an admin (or owner). Exactly which actions may be performed by a moderator is subject to configuration. However, for the purposes of the MUC framework, moderators are stipulated to have privileges to perform the following actions:</p>
+  <ol start="" type="">
+    <li>discover an occupant's full JID in a semi-anonymous room (occurs by default as shown above)</li>
+    <li>modify the subject</li>
+    <li>kick a participant or visitor from the room</li>
+    <li>grant or revoke voice in a moderated room</li>
+    <li>modify the list of occupants who have voice in a moderated room</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response &quot;conversation&quot; using &lt;iq/&gt; elements that contain children scoped by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the user@host of the 'from' address of the request does not match the full JID of one of the moderators; in this case, the service MUST return a &lt;forbidden/&gt; error.)</p>
+  <div class="indent">
+<h3>7.1 <a name="subject-mod">Modifying the Room Subject</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability to change the subject within the room. As a default, only users with a role of &quot;moderator&quot; SHOULD be allowed to change the subject in a room (although this SHOULD be configurable, with the result a mere participant or even visitor may be allowed to change the subject if desired). The subject is changed by sending a message of type &quot;groupchat&quot; to the room@service, containing no body but a &lt;subject/&gt; that specifies the new subject:</p>
+    <p class="caption">Example 67. Moderator Changes Subject</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If a compliant service receives such a message, it MUST reflect the message to all other occupants with a 'from' address equal to the room JID that corresponds to the sender of the subject change:</p>
+    <p class="caption">Example 68. Service Informs All Occupants of Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the room SHOULD include the last subject change in the discussion history sent when a new occupant joins the room.</p>
+    <p class="" style="">A compliant client that receives such a message MAY choose to display an in-room message; the body of such in-room messages SHOULD NOT be generated by the sending client or the service, so as to ensure correct localization (however, the sending client or service MAY generate the body if desired). The in-room message could be something like the following:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+* secondwitch has changed the subject to: Fire Burn and Cauldron Bubble!
+    </pre></div>
+    <p class="" style="">If someone without appropriate privileges attempts to change the room subject, the service MUST return a message of type &quot;error&quot; specifying a &lt;forbidden/&gt; error condition:</p>
+    <p class="caption">Example 69. Service Returns Error Related to Unauthorized Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="kick">Kicking a Visitor or Participant from a Room</a>
+</h3>
+    <p class="" style="">A moderator has permissions kick a visitor or participant from a room. The kick is normally performed based on the occupant's room nickname (though it MAY be based on the full JID) and is effected by setting the role of a participant or visitor to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 70. Moderator Kicks Occupant</p>
+<div class="indent"><pre>
+&lt;iq from='fluellen@shakespeare.lit/pda'
+    id='kick1'
+    to='harfleur@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='pistol' role='none'&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the kicked occupant by sending a presence stanza of type &quot;unavailable&quot; to each kicked occupant, including status code 307 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the kick.</p>
+    <p class="caption">Example 71. Service Removes Kicked Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='pistol@shakespeare.lit/harfleur'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='fluellen@shakespeare.lit'/&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the kicked user to understand why he or she was kicked, and by whom if the kicked occupant would like to discuss the matter.</p>
+    <p class="" style="">After removing the kicked occupant(s), the service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 72. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='harfleur@henryv.shakespeare.lit'
+    id='kick1'
+    to='fluellen@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After informing the moderator, the service MUST then inform all of the remaining occupants that the kicked occupant is no longer in the room by sending presence stanzas of type &quot;unavailable&quot; from the kicked occupant to all the remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason.</p>
+    <p class="caption">Example 73. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='gower@shakespeare.lit/cell'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator cannot be kicked from a room, nor can any user with an affiliation of &quot;owner&quot; or &quot;admin&quot;. If a moderator attempts to kick such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 74. Service Returns Error on Attempt to Kick Moderator, Admin, or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='kicktest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='firstwitch' role='none'&gt;
+      &lt;reason&gt;Be gone!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="grantvoice">Granting Voice to a Visitor</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to manage who does and does not have &quot;voice&quot; in the room. Voice is granted based on the visitor's room nickname, which the service will convert into the visitor's full JID internally. The moderator can grant voice to a visitor by changing the visitor's role to &quot;participant&quot; (the &lt;reason/&gt; element is optional):</p>
+    <p class="caption">Example 75. Moderator Grants Voice to a Visitor</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 76. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the addition of voice privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;participant&quot;.</p>
+    <p class="caption">Example 77. Service Sends Notice of Voice to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="revokevoice">Revoking Voice from a Participant</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to revoke a participant's privileges to speak. The moderator can revoke voice from a participant by changing the participant's role to &quot;visitor&quot;:</p>
+    <p class="caption">Example 78. Moderator Revokes Voice from a Participant</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 79. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of voice privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;visitor&quot;.</p>
+    <p class="caption">Example 80. Service Notes Loss of Voice</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='visitor'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator MUST NOT be able to revoke voice from a user whose affiliation is at or above the moderator's level. In addition, a service MUST NOT allow the voice privileges of an admin or owner to be removed by anyone. If a moderator attempts to revoke voice privileges from such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 81. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voicetest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.5 <a name="modifyvoice">Modifying the Voice List</a>
+</h3>
+    <p class="" style="">A moderator in a moderated room may want to modify the voice list. To do so, the moderator first requests the voice list by querying the room for all occupants with a role of 'participant'.</p>
+    <p class="caption">Example 82. Moderator Requests Voice List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='voice3'
+    to='goodfolk@chat.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the voice list to the moderator; each item MUST include the 'nick' and 'role' attributes and SHOULD include the 'affiliation' and 'jid' attributes:</p>
+    <p class="caption">Example 83. Service Sends Voice List to Moderator</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='polonius@hamlet/castle'
+          nick='Polo'
+          role='participant'/&gt;
+    &lt;item affiliation='none'
+          jid='horatio@hamlet/castle'
+          nick='horotoro'
+          role='participant'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The moderator MAY then modify the voice list. In order to do so, the moderator MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'nick' attribute and 'role' attribute (normally set to a value of &quot;participant&quot; or &quot;visitor&quot;) but SHOULD NOT include the 'jid' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as owner rather than the participant role):</p>
+    <p class="caption">Example 84. Moderator Sends Modified Voice List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='voice4'
+    to='goodfolk@chat.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='Hecate'
+          role='visitor'/&gt;
+    &lt;item nick='rosencrantz'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item nick='guildenstern'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 85. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice1'
+    to='author@shakespeare.lit/globe'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in voice privileges by sending the appropriate extended presence packets as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, voice privileges cannot be revoked from a room owner or room admin, nor from any user with a higher affiliation than the moderator making the request. If a room admin attempts to revoke voice privileges from such a user by modifying the voice list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 86. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voicetest'
+    to='author@shakespeare.lit/globe'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit'
+          nick='Hecate'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="admin">Admin Use Cases</a>
+</h2>
+  <p class="" style="">A room administrator has privileges to modify persistent information about user affiliations (e.g., by banning users) and to grant and revoke moderator privileges, but does not have rights to change the defining features of the room, which are the sole province of the room owner. Exactly which actions MAY be performed by a room admin will be subject to configuration. However, for the purposes of the MUC framework, room admins are stipulated to have privileges to perform the following actions:</p>
+  <ol start="" type="">
+    <li>ban a user from the room</li>
+    <li>modify the list of users who are banned from the room</li>
+    <li>grant or revoke membership</li>
+    <li>modify the member list</li>
+    <li>grant or revoke moderator privileges</li>
+    <li>modify the list of moderators</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response &quot;conversation&quot; using &lt;iq/&gt; elements that contain children scoped by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions proposed to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the user@host of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a &lt;forbidden/&gt; error.)</p>
+  <div class="indent">
+<h3>8.1 <a name="ban">Banning a User</a>
+</h3>
+    <p class="" style="">An admin or owner can ban one or more users from a room. The ban MUST be performed based on the occupant's bare JID. In order to ban a user, an admin MUST change the user's affiliation to &quot;outcast&quot;.</p>
+    <p class="caption">Example 87. Admin Bans User</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban1'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add that bare JID to the ban list and inform the admin or owner of success:</p>
+    <p class="caption">Example 88. Service Informs Admin or Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban1'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also remove any banned users who are in the room by sending a presence stanza of type &quot;unavailable&quot; to each banned occupant, including status code 301 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the ban.</p>
+    <p class="caption">Example 89. Service Removes Banned User</p>
+<div class="indent"><pre>
+&lt;presence
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='earlofcambridge@shakespeare.lit/stabber'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast' role='none'&gt;
+      &lt;actor jid='kinghenryv@shakespeare.lit'/&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the banned user to understand why he or she was banned, and by whom if the banned user would like to discuss the matter.</p>
+    <p class="" style="">The service MUST then inform all of the remaining occupants that the banned user is no longer in the room by sending presence stanzas of type &quot;unavailable&quot; from the banned user to all remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason:</p>
+    <p class="caption">Example 90. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    type='unavailable'
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='exeter@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit/stabber'
+          role='none'/&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">An owner or admin cannot be banned from a room. If a room admin attempts to ban such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 91. Service Returns Error on Attempt to Ban an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='harfleur@henryv.shakespeare.lit'
+    id='bantest'
+    to='exeter@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='kinghenryv@shakespeare.lit'
+          nick='TheKing'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="modifyban">Modifying the Ban List</a>
+</h3>
+    <p class="" style="">A room admin may want to modify the ban list. Note that the ban list is always based on a user's bare JID (unlike the ban command which is usually based on a room nickname), although a nick (perhaps the last room nickname associated with that JID) MAY be included for convenience. To modify the list of banned JIDs, the admin first requests the ban list by querying the room for all users with an affiliation of 'outcast'.</p>
+    <p class="caption">Example 92. Admin Requests Ban List</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban2'
+    to='southampton@henryv.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the list of banned users to the admin; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' and 'role' attributes:</p>
+    <p class="caption">Example 93. Service Sends Ban List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban2'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the ban list. In order to do so, the admin MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'affiliation' attribute (normally set to a value of &quot;outcast&quot; or &quot;none&quot;) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the outcast affiliation); in addition, the reason and actor elements are OPTIONAL:</p>
+    <p class="caption">Example 94. Admin Sends Modified Ban List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban3'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'&gt;
+          jid='lordscroop@shakespeare.lit' 
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'
+          jid='sirthomasgrey@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">After updating the ban list, the service MUST inform the admin of success:</p>
+    <p class="caption">Example 95. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban3'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then remove the affected occupants (if they are in the room) and send updated presence (including the appropriate status code) from them to all the remaining occupants as described in the &quot;Banning a User&quot; use case. (The service SHOULD also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.)</p>
+    <p class="" style="">As noted, a room owner or room admin cannot be banned from a room. If a room admin attempts to ban such a user by means of modifying the ban list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 96. Service Returns Error on Attempt to Ban an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='bantest'
+    to='lordscroop@shakespeare.lit'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='exeter@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">When an entity is banned from a room, an implementation SHOULD match JIDs in the following order (these matching rules are the same as those defined for privacy lists in <span class="ref">XMPP IM</span>  [<a href="#nt-id2611244">8</a>]):</p>
+    <ol start="" type="">
+      <li>&lt;user@domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;user@domain&gt; (any resource matches)</li>
+      <li>&lt;domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;domain&gt; (the domain itself matches, as does any user@domain, domain/resource, or address containing a subdomain)</li>
+    </ol>
+    <p class="" style="">Some administrators may wish to ban all users associated with a specific domain from all rooms hosted by a MUC service. Such functionality is a service-level feature and is therefore out of scope for this document.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="grantmember">Granting Membership</a>
+</h3>
+    <p class="" style="">An admin can grant membership to a user; this is done by changing the user's affiliation to &quot;member&quot; (normally based on nick if the user is in the room, or on bare JID if not; in either case, if the nick is provided, that nick becomes the user's default nick in the room if that functionality is supported by the implementation):</p>
+    <p class="caption">Example 97. Admin Grants Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 98. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 99. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="revokemember">Revoking Membership</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's membership; this is done by changing the user's affiliation to &quot;none&quot;:</p>
+    <p class="caption">Example 100. Admin Revokes Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          nick='thirdwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 101. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 102. Service Notes Loss of Membership</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MUST remove the user from the room, including a status code of 321 to indicate that the user was removed because of an affiliation change, and inform all remaining occupants:</p>
+    <p class="caption">Example 103. Service Removes Non-Member</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='author@shakespeare.lit'/&gt;
+    &lt;/item&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="modifymember">Modifying the Member List</a>
+</h3>
+    <p class="" style="">In the context of a members-only room, the member list is essentially a &quot;whitelist&quot; of people who are allowed to enter the room. Anyone who is not a member is effectively banned from entering the room, even if their affiliation is not &quot;outcast&quot;.</p>
+    <p class="" style="">In the context of an open room, the member list is simply a list of users (bare JID and reserved nick) who are registered with the room. Such users may appear in a room roster, have their room nickname reserved, be returned in search results or FAQ queries, and the like.</p>
+    <p class="" style="">It is RECOMMENDED that only room admins have the privilege to modify the member list in members-only rooms. To do so, the admin first requests the member list by querying the room for all users with an affiliation of &quot;member&quot;:</p>
+    <p class="caption">Example 104. Admin Requests Member List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">(A service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &lt;forbidden/&gt; error when a member in the room requests the member list. This functionality may assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited.)</p>
+    <p class="" style="">The service MUST then return the full member list to the admin in the 'http://jabber.org/protocol/muc#admin' namespace; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for each members that is currently an occupant.</p>
+    <p class="caption">Example 105. Service Sends Member List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'
+          nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the member list. In order to do so, the admin MUST send the changed items (i.e., only the &quot;delta&quot;) to the service; each item MUST include the 'affiliation' attribute (normally set to a value of &quot;member&quot; or &quot;none&quot;) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the member affiliation):</p>
+    <p class="caption">Example 106. Admin Sends Modified Member List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 107. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST change the affiliation of any affected user. If the user has been removed from the member list, the service MUST change the user's affiliation from &quot;member&quot; to &quot;none&quot;. If the user has been added to the member list, the service MUST change the user's affiliation to &quot;member&quot;.</p>
+    <p class="" style="">If the removed member is currently in a members-only room, the service SHOULD kick the occupant by changing the removed member's role to &quot;none&quot;. No matter whether the removed member was in or out of a members-only room, the service MUST subsequently refuse entry to the user.</p>
+    <p class="" style="">If the removed member is in an open room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;none&quot;.</p>
+    <p class="caption">Example 108. Service Sends Notice of Loss of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the service SHOULD send an invitation to any user who has been added to the member list of a members-only room if the user is not currently affiliated with the room, for example as an admin or owner (such a user would by definition not be in the room; note also that this example includes a password but not a reason -- both child elements are OPTIONAL):</p>
+    <p class="caption">Example 109. Room Sends Invitation to New Member</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='author@shakespeare.lit'/&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+  &lt;x jid='darkcave@macbeth.shakespeare.lit'
+     xmlns='jabber:x:conference'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While only admins and owners SHOULD be allowed to modify the member list, an implementation MAY provide a configuration option that opens invitation privileges to any member of a members-only room. In such a situation, any invitation sent SHOULD automatically trigger the addition of the invitee to the member list. However, if invitation privileges are restricted to admins and a mere member attempts to a send an invitation, the service MUST deny the invitation request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 110. Service Returns Error on Attempt by Mere Member to Invite Others to a Members-Only Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.</p>
+    <p class="" style="">If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot;.</p>
+    <p class="caption">Example 111. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.6 <a name="grantmod">Granting Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to grant moderator privileges to a participant or visitor; this is done by changing the user's role to &quot;moderator&quot;:</p>
+    <p class="caption">Example 112. Admin Grants Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 113. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 114. Service Sends Notice of Moderator Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.7 <a name="revokemod">Revoking Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's moderator privileges. An admin MAY revoke moderator privileges only from a user whose affiliation is &quot;member&quot; or &quot;none&quot; (i.e., not from an owner or admin). The privilege is revoked by changing the user's role to &quot;participant&quot;:</p>
+    <p class="caption">Example 115. Admin Revokes Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 116. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of &quot;participant&quot;.</p>
+    <p class="caption">Example 117. Service Notes Loss of Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As noted, an admin MUST NOT be allowed to revoke moderator privileges from a user whose affiliation is &quot;owner&quot; or &quot;admin&quot;. If an admin attempts to revoke moderator privileges from such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 118. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.8 <a name="modifymod">Modifying the Moderator List</a>
+</h3>
+    <p class="" style="">An admin may want to modify the moderator list. To do so, the admin first requests the moderator list by querying the room for all users with a role of 'moderator'.</p>
+    <p class="caption">Example 119. Admin Requests Moderator List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the moderator list to the admin; each item MUST include the 'jid', 'nick', and 'role' attributes and MAY include the 'affiliation' attribute:</p>
+    <p class="caption">Example 120. Service Sends Moderator List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hag66@shakespeare.lit/pda'
+          nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the moderator list. In order to do so, the admin MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service; each item MUST include the 'jid' attribute and 'role' attribute (normally set to a value of &quot;member&quot; or &quot;participant&quot;) but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as admin rather than the moderator role):</p>
+    <p class="caption">Example 121. Admin Sends Modified Moderator List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 122. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator privileges by sending the appropriate extended presence packets as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, moderator privileges cannot be revoked from a room owner or room admin. If a room admin attempts to revoke moderator privileges from such a user by modifying the moderator list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 123. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.9 <a name="regapprove">Approving Registration Requests</a>
+</h3>
+    <p class="" style="">If a service does not automatically accept requests to register with a room, it MAY provide a way for room admins to approve or deny registration requests over Jabber (alternatively, it could provide a web interface or some other admin tool). The simplest way to do so is for the service to send a &lt;message/&gt; stanza to the room admin(s) when the registration request is received, where the &lt;message/&gt; stanza contains a Data Form asking for approval or denial of the request. The following Data Form is RECOMMENDED but implementations MAY use a different form entirely, or supplement the following form with additional fields.</p>
+    <p class="caption">Example 124. Registration Request Approval Form</p>
+<div class="indent"><pre>
+&lt;message from='darkcave@macbeth.shakespeare.lit'
+         id='approve'
+         to='crone1@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='jabber:x:data' type='form'&gt;
+    &lt;title&gt;Registration request&lt;/title&gt;
+    &lt;instructions&gt;
+      To approve this registration request, select the
+      &amp;quot;Allow this person to register with the room?&amp;quot;
+      checkbox and click OK. To skip this request, click the 
+      cancel button.
+    &lt;/instructions&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_first'
+           type='text-single'
+           label='First Name'&gt;
+      &lt;value&gt;Brunhilde&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_last'
+           type=&quot;text-single&quot;
+           label=&quot;Last Name&quot;&gt;
+      &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_roomnick'
+           type=&quot;text-single&quot;
+           label=&quot;Desired Nickname&quot;&gt;
+      &lt;value&gt;thirdwitch&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_url'
+           type=&quot;text-single&quot;
+           label=&quot;User URL&quot;&gt;
+      &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_email'
+           type=&quot;text-single&quot;
+           label=&quot;Email Address&quot;&gt;
+      &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_faqentry'
+           type=&quot;text-single&quot;
+           label=&quot;FAQ Entry&quot;&gt;
+      &lt;value&gt;Just another witch.&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_allow'
+           type='boolean'
+           label='Allow this person to register with the room?'&gt;
+      &lt;value&gt;0&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the admin approves the registration request, the service shall register the user with the room.</p>
+    <p class="" style="">More advanced registration approval mechanisms (e.g., retrieving a list of reqistration requests using <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2612185">9</a>] as is done in <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2612206">10</a>]) are out of scope for this JEP.</p>, 
+  </div>
+<h2>9.
+       <a name="owner">Owner Use Cases</a>
+</h2>
+  <p class="" style="">Every room MUST have at least one owner, and that owner (or a successor) is a long-lived attribute of the room for as long as the room exists (e.g., the owner does not lose ownership on exiting a persistent room). This JEP assumes that the (initial) room owner is the individual who creates the room and that only a room owner has the right to change defining room configuration settings such as the room type. Ideally, room owners will be able to specify not only the room types (password-protected, members-only, etc.) but also certain attributes of the room as listed under the requirements section of this JEP. In addition, it would be good if an owner were able to specify the JIDs of other owners, but that shall be determined by the implementation.</p>
+  <p class="" style="">In order to provide the necessary flexibility for a wide range of configuration options, <span class="ref">Data Forms</span>  [<a href="#nt-id2612397">11</a>] shall be used for room configuration, triggered by use of the 'http://jabber.org/protocol/muc' namespace.</p>
+  <p class="" style="">Note that the configuration options shown below address all of the features and room types listed in the requirements section of this JEP, but that the exact configuration options and form layout shall be determined by the implementation or specific deployment. Also, these are examples only and are not intended to define the only allowed or required configuration options for rooms. A given implementation or deployment MAY choose to provide many additional configuration options (profanity filters, setting the default language for a room, message logging, etc., which MAY include items defined in other FORM_TYPEs), which is why the use of the jabber:x:data protocol is valuable here.</p>
+  <p class="" style="">Note also that the privilege to create rooms MAY be restricted to certain users or reserved to an administrator of the service. If access is restricted and a user attempts to create a room, the service MUST return a &lt;not-allowed/&gt; error:</p>
+  <p class="caption">Example 125. Service Informs User of Inability to Create a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">If access is not restricted, the service MUST allow the user to create a room as described below.</p>
+  <div class="indent">
+<h3>9.1 <a name="createroom">Creating a Room</a>
+</h3>
+    <p class="" style="">From the perspective of room creation, there are in essence two kinds of rooms:</p>
+    <ul>
+      <li><p class="" style="">&quot;Instant rooms&quot; -- these are available for immediate access and are automatically created based on some default configuration.</p></li>
+      <li><p class="" style="">&quot;Reserved rooms&quot; -- these are manually configured by the room creator before anyone is allowed to enter.</p></li>
+    </ul>
+    <p class="" style="">The workflow for creating and configuring such rooms is as follows:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The user MUST send presence to room@service/nick and signal his or her support for the Multi-User Chat protocol by including extended presence information in an empty &lt;x/&gt; child element scoped by the 'http://jabber.org/protocol/muc' namespace (note the lack of an '#owner' or '#user' fragment).</p></li>
+      <li><p class="" style="">If this user is allowed to create a room and the room does not yet exist, the service MUST create the room according to some default configuration, assign the requesting user as the initial room owner, and add the owner to the room but not allow anyone else to enter the room (effectively &quot;locking&quot; the room). The initial presence stanza received by the owner from the room MUST include extended presence information that indicates the user's status as an owner and that acknowledges that the room has been created (via status code 201) and is awaiting configuration.</p></li>
+      <li><p class="" style="">If the initial room owner would like to create and configure a reserved room, the room owner MUST then request a configuration form by sending an IQ stanza of type &quot;get&quot; to the room containing an empty &lt;query/&gt; element scoped by the 'http://jabber.org/protocol/muc#owner' namespace, then complete Steps 4 and 5. If the room owner would prefer to create an instant room, the room owner MUST send a query element scoped by the 'http://jabber.org/protocol/muc#owner' namespace and containing an empty &lt;x/&gt; element of type &quot;submit&quot; scoped by the 'jabber:x:data' namespace, then skip to Step 6.</p></li>
+      <li><p class="" style="">If the room owner requested a configuration form, the service MUST send an IQ to the room owner containing a configuration form in the 'jabber:x:data' namespace. If there are no configuration options available, the room MUST return an empty query element to the room owner.</p></li>
+      <li><p class="" style="">The initial room owner SHOULD provide a starting configuration for the room (or accept the default configuration) by sending an IQ of type &quot;set&quot; containing the completed configuration form. Alternatively, the room owner can cancel the configuration process. (An implementation MAY set a timeout for initial configuration, such that if the room owner does not configure the room within the timeout period, the room owner is assumed to have accepted the default configuration.)</p></li>
+      <li><p class="" style="">Once the service receives the completed configuration form from the initial room owner (or receives a request for an instant room), the service MUST &quot;unlock&quot; the room (i.e., allow other users to enter the room) and send an IQ of type &quot;result&quot; to the room owner. If the service receives a cancellation, it MUST destroy the room.</p></li>
+    </ol>
+    <p class="" style="">The protocol for this workflow is shown in the examples below.</p>
+    <p class="" style="">First, the Jabber user MUST send presence to the room, including and empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace (this is the same stanza sent when seeking to enter a room).</p>
+    <p class="caption">Example 126. Jabber User Creates a Room and Signals Support for Multi-User Chat</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If the room does not yet exist, the service SHOULD create the room (subject to local policies regarding room creation), assign the bare JID of the requesting user as the owner, add the owner to the room, and acknowledge successful creation of the room.</p>
+    <p class="caption">Example 127. Service Creates Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          role='moderator'/&gt;
+    &lt;status code='201'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The initial room owner can request an instant room by sending the following XML:</p>
+    <p class="caption">Example 128. Owner Requests Instant Room</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initial room owner wants to create and configure a reserved room, the room owner MUST request an initial configuration form for the room by not including empty data form in the creation request:</p>
+    <p class="caption">Example 129. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room does not already exist, the service MUST return an initial room configuration form to the user. (Note: The following example shows a representative sample of configuration options. A full list of x:data fields registered for use in room creation and configuration is maintained by the Jabber Registrar; see <a href="#registrar">Jabber Registrar Considerations</a> below.)</p>
+    <p class="caption">Example 130. Service Sends Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+          Your room darkcave@macbeth has been created!
+          The default configuration is as follows:
+            - No logging
+            - No moderation
+            - Up to 20 occupants
+            - No password required
+            - No invitation required
+            - Room is not persistent
+            - Only admins may change the subject
+            - Presence broadcasted for all users
+          To accept the default configuration, click OK. To
+          select a different configuration, please complete
+          this form.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#roomconfig_roomname'/&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#roomconfig_roomdesc'/&gt;
+      &lt;field
+          label='Natural Language for Room Discussions'
+          type='text-single'
+          var='muc#roomconfig_roomlang'/&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;20&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#roomconfig_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members-Only?'
+          type='boolean'
+          var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required to Enter?'
+          type='boolean'
+          var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#roomconfig_roomsecret'/&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#roomconfig_whois'&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#roomconfig_roomadmins'/&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#roomconfig_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner:</p>
+    <p class="caption">Example 131. Service Informs Owner that No Configuration is Possible</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The room owner SHOULD then fill out the form and submit it to the service.</p>
+    <p class="caption">Example 132. Owner Submits Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomadmins'&gt;
+        &lt;value&gt;
+          wiccarocks@shakespeare.lit
+          hecate@shakespeare.lit
+        &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If room creation is successful, the service MUST inform the new room owner of success:</p>
+    <p class="caption">Example 133. Service Informs New Room Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the room owner can cancel the configuration process:</p>
+    <p class="caption">Example 134. Owner Cancels Initial Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room owner cancels the initial configuration, the service SHOULD destroy the room, making sure to send unavailable presence to the room owner (see the &quot;Destroying a Room&quot; use case for protocol details).</p>
+    <p class="" style="">If the room owner becomes unavailable for any reason before submitting the form (e.g., a lost connection), the service will receive a presence stanza of type &quot;unavailable&quot; from the owner to the room@service/nick or room@service (or both). The service MUST then destroy the room, sending a presence stanza of type &quot;unavailable&quot; from the room to the owner including a &lt;destroy/&gt; element and reason (if provided) as defined under the &quot;Destroying a Room&quot; use case.</p>
+    <p class="" style="">If a user attempts to enter the room while the room is &quot;locked&quot; (i.e., before the room creator provides an initial configuration and therefore before the room officially exists), the service MUST refuse entry and return a &lt;item-not-found/&gt; error to the user:</p>
+    <p class="caption">Example 135. Service Denies Access Because Room Does Not Yet Exist</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="roomconfig">Subsequent Room Configuration</a>
+</h3>
+    <p class="" style="">At any time after specifying the initial configuration of the room, a room owner may want to change the configuration. In order to initiate this &quot;conversation&quot;, a room owner MUST request a new configuration form from the room by sending an IQ to room@service containing an empty &lt;query/&gt; element scoped by the 'http://jabber.org/protocol/muc#owner' namespace.</p>
+    <p class="caption">Example 136. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user@host of the 'from' address does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 137. Service Denies Configuration Access to Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='configures'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the service MUST send a configuration form to the room owner with the current options set as defaults:</p>
+    <p class="caption">Example 138. Service Sends Configuration Form to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='config1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+        Complete this form to make changes to
+        the configuration of your room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#roomconfig_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#roomconfig_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#roomconfig_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members Only?'
+          type='boolean'
+          var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required for Entry?'
+          type='boolean'
+          var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#roomconfig_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#roomconfig_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#roomconfig_roomadmins'&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#roomconfig_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner as shown above.</p>
+    <p class="" style="">The room owner MAY then submit the form with updated configuration information.</p>
+    <p class="" style="">Alternatively, the room owner MAY cancel the configuration process:</p>
+    <p class="caption">Example 139. Owner Cancels Subsequent Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room owner cancels the subsequent configuration, the service MUST leave the configuration of the room as it was before the room owner initiated the subsequent configuration process.</p>
+    <p class="" style="">If as a result of a change in the room configuration a room admin loses administrative privileges while the admin is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot; and the 'role' attribute set to a value of &quot;participant&quot; or &quot;visitor&quot; as appropriate for the affiliation level and the room type:</p>
+    <p class="caption">Example 140. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a user gains administrative privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;admin&quot;:</p>
+    <p class="caption">Example 141. Service Notes Gain of Admin Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a room owner loses owner privileges while that owner is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;:</p>
+    <p class="caption">Example 142. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As noted, a service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner.</p>
+    <p class="" style="">If as a result of a change in the room configuration a user gains ownership privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;owner&quot; and the 'role' attribute set to a value of 'moderator'.</p>
+    <p class="caption">Example 143. Service Notes Gain of Owner Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration the room type is changed to members-only but there are non-members in the room, the service MUST remove any non-members from the room and include a status code of 322 in the presence unavailable stanzas sent to those users as well as any remaining occupants.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="grantowner">Granting Ownership Privileges</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, an owner MAY grant ownership privileges to another user; this is done by changing the user's affiliation to &quot;owner&quot;:</p>
+    <p class="caption">Example 144. Owner Grants Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 145. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of ownership privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;owner&quot; and the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 146. Service Sends Notice of Ownership Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.4 <a name="revokeowner">Revoking Ownership Privileges</a>
+</h3>
+    <p class="" style="">An owner may want to revoke a user's ownership privileges; this is done by changing the user's affiliation to &quot;admin&quot;:</p>
+    <p class="caption">Example 147. Owner Revokes Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner.</p>
+    <p class="" style="">In all other cases, the service MUST remove the user from the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 148. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of ownership privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;:</p>
+    <p class="caption">Example 149. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.5 <a name="modifyowner">Modifying the Owner List</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, a room owner may want to modify the owner list. To do so, the owner first requests the owner list by querying the room for all users with an affiliation of 'owner'.</p>
+    <p class="caption">Example 150. Owner Requests Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='owner3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the owner list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any owner that is currently an occupant:</p>
+    <p class="caption">Example 151. Service Sends Owner List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='crone1@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner MAY then modify the owner list. In order to do is, it MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service;  [<a href="#nt-id2613680">12</a>] each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the owner affiliation):</p>
+    <p class="caption">Example 152. Owner Sends Modified Owner List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='owner4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As noted, a service MUST NOT allow an owner to revoke his or her own privilege of ownership if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner.</p>
+    <p class="" style="">In all other cases, the service MUST modify owner list and then inform the owner of success:</p>
+    <p class="caption">Example 153. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 154. Service Returns Error on Attempt by Non-Owner to Modify Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='ownertest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='owner' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.6 <a name="grantadmin">Granting Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner can grant administrative privileges to a member or unaffiliated user; this is done by changing the user's affiliation to &quot;admin&quot;:</p>
+    <p class="caption">Example 155. Owner Grants Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 156. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of administrative privileges by including an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;admin&quot; and the 'role' attribute set to a value of &quot;moderator&quot;.</p>
+    <p class="caption">Example 157. Service Sends Notice of Administrative Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.7 <a name="revokeadmin">Revoking Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner may want to revoke a user's administrative privileges; this is done by changing the user's affiliation to &quot;member&quot;:</p>
+    <p class="caption">Example 158. Owner Revokes Administrative Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='member'
+          nick='secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 159. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of administrative privileges by sending a presence element that contains an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of &quot;member&quot; and the 'role' attribute set to a value of &quot;participant&quot; or &quot;visitor&quot; as appropriate for the affiliation level and the room type:</p>
+    <p class="caption">Example 160. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.8 <a name="modifyadmin">Modifying the Admin List</a>
+</h3>
+    <p class="" style="">A room owner may want to modify the admin list. To do so, the owner first requests the admin list by querying the room for all users with an affiliation of 'admin'.</p>
+    <p class="caption">Example 161. Owner Requests Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/desktopaffiliation
+    id='admin3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the admin list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any admin that is currently an occupant:</p>
+    <p class="caption">Example 162. Service Sends Admin List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin3'
+    to='author@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'
+          nick='secondwitch'/&gt;
+    &lt;item affiliation='admin'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner MAY then modify the admin list. In order to do so, the owner MUST send the changed items (i.e., only the &quot;delta&quot;) back to the service;  [<a href="#nt-id2614033">13</a>] each item MUST include the 'affiliation' attribute (normally set to a value of &quot;admin&quot; or &quot;none&quot;) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the admin affiliation):</p>
+    <p class="caption">Example 163. Owner Sends Modified Admin List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='author@shakespeare.lit/globe'
+    id='admin4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 164. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 165. Service Returns Error on Attempt by Non-Owner to Modify Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admintest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;item affiliation='admin' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.9 <a name="destroyroom">Destroying a Room</a>
+</h3>
+    <p class="" style="">A room owner MUST be able to destroy a room that he or she has created, especially if the room is persistent. The workflow is as follows:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The room owner requests that the room be destroyed, specifying a reason and an alternate venue if desired.</p></li>
+      <li><p class="" style="">The room removes all users from the room (including appropriate information about the alternate location and the reason for being removed) and destroys the room, even if it was defined as persistent.</p></li>
+    </ol>
+    <p class="" style="">This JEP does not specify what if anything a compliant component implementation must do as a result of a room destruction request other than the foregoing. For example, if the room was defined as persistent, an implementation MAY choose to reserve the room ID or redirect enter requests to the alternate venue; however, such behavior is OPTIONAL.</p>
+    <p class="" style="">In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. The &lt;iq/&gt; stanza shall contain a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, which in turn shall contain a &lt;destroy/&gt; element. The address of the alternate venue shall be provided in the &lt;destroy/&gt; element's 'jid' attribute (this is OPTIONAL). The reason for the room destruction shall be provided as the XML character data of a &lt;reason/&gt; child element of the &lt;destroy/&gt; element (this, too, is OPTIONAL).</p>
+    <p class="" style="">The following examples illustrate the protocol elements to be sent and received:</p>
+    <p class="caption">Example 166. Owner Submits Room Destruction Request</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='begone'
+    to='heath@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for removing all the occupants. It SHOULD NOT broadcast presence stanzas of type &quot;unavailable&quot; from all occupants, instead sending only one presence stanza of type &quot;unavailable&quot; to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.</p>
+    <p class="caption">Example 167. Service Removes Each Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 168. Service Informs Owner of Successful Destruction</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='begone'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user@host of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 169. Service Denies Destroy Request Submitted by Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='destroytest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+  <p class="" style="">The error codes associated with the 'http://jabber.org/protocol/muc#admin' namespace are fairly straightforward. However, in order to make it easier for client and component developers to understand the codes they need to send and receive, the table below provides a summary of all the error and status codes associated with the 'http://jabber.org/protocol/muc#user' namespace. For detailed information about mapping legacy error codes to XMPP-style error types and conditions, refer to <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2614458">14</a>]; compliant implementations SHOULD support both legacy and XMPP error handling (no such requirement applies to MUC status codes).</p>
+  <p class="caption">Table 8: Error and Status Codes for http://jabber.org/protocol/muc#user Namespace</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Code</th>
+      <th colspan="" rowspan="">Type</th>
+      <th colspan="" rowspan="">Element</th>
+      <th colspan="" rowspan="">Context</th>
+      <th colspan="" rowspan="">Purpose</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">100</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that any occupant is allowed to see the user's full JID</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">101</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message (out of band)</td>
+      <td align="" colspan="" rowspan="">Affiliation change</td>
+      <td align="" colspan="" rowspan="">Inform user that his or her affiliation changed while not in the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">102</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">In-room message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that room now shows unavailable members</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">103</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that room now does not show unavailable members</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">104</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Message</td>
+      <td align="" colspan="" rowspan="">Configuration change</td>
+      <td align="" colspan="" rowspan="">Inform occupants that some room configuration has changed</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">201</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that a new room has been created</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">301</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she has been banned from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">303</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Exiting a room</td>
+      <td align="" colspan="" rowspan="">Inform all occupants of new room nickname</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">307</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she has been kicked from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">321</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because of an affiliation change</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">322</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because the room has been changed to members-only and the user is not a member</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">332</td>
+      <td align="" colspan="" rowspan="">Status</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Removal from room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is being removed from the room because of a system shutdown</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">401</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that a password is required</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">403</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is banned from the room</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">404</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that the room does not exist</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">405</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that room creation is restricted</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">407</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that he or she is not on the member list</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">409</td>
+      <td align="" colspan="" rowspan="">Error</td>
+      <td align="" colspan="" rowspan="">Presence</td>
+      <td align="" colspan="" rowspan="">Entering a room</td>
+      <td align="" colspan="" rowspan="">Inform user that his or her desired room nickname is taken</td>
+    </tr>
+  </table>
+  <p class="" style="">This JEP does not stipulate text messages associated with each error condition.</p>
+<h2>11.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">No room entrance authentication method more secure than cleartext passwords is defined or required by this JEP. This is recognized to be sub-optimal; a future proposal will need to address this shortcoming.</p>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2615538">15</a>].</p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2615477">16</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>13.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the following MUC-related namespaces in its registry of protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/muc</li>
+      <li>http://jabber.org/protocol/muc#admin</li>
+      <li>http://jabber.org/protocol/muc#owner</li>
+      <li>http://jabber.org/protocol/muc#user</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="registrar-discocat">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">A Multi-User Chat service or room is identified by the &quot;conference&quot; category and the &quot;text&quot; type within Service Discovery.</p>
+  </div>
+  <div class="indent">
+<h3>13.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">There are many features related to a MUC service or room that can be discovered by means of Service Discovery. The most fundamental of these is the 'http://jabber.org/protocol/muc' namespace. In addition, a MUC room SHOULD provide information when queried about the specific room features it implements, such as password protection and room moderation.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc&lt;/name&gt;
+  &lt;desc&gt;Multi-User Chat (MUC) namespace&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_hidden&lt;/name&gt;
+  &lt;desc&gt;Hidden room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_membersonly&lt;/name&gt;
+  &lt;desc&gt;Members-only room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_moderated&lt;/name&gt;
+  &lt;desc&gt;Moderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_nonanonymous&lt;/name&gt;
+  &lt;desc&gt;Non-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_open&lt;/name&gt;
+  &lt;desc&gt;Open room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_passwordprotected&lt;/name&gt;
+  &lt;desc&gt;Password-protected room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_persistent&lt;/name&gt;
+  &lt;desc&gt;Persistent room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_public&lt;/name&gt;
+  &lt;desc&gt;Public room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_semianonymous&lt;/name&gt;
+  &lt;desc&gt;Semi-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_temporary&lt;/name&gt;
+  &lt;desc&gt;Temporary room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unmoderated&lt;/name&gt;
+  &lt;desc&gt;Unmoderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unsecured&lt;/name&gt;
+  &lt;desc&gt;Unsecured room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_rooms&lt;/name&gt;
+  &lt;desc&gt;List of MUC rooms (each as a separate item)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>13.4 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms' enables discovery of the rooms in which a user is an occupant.</p>
+    <p class="" style="">The well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' enables discovery of the namespaces that are allowed in traffic sent through a room.</p>
+  </div>
+  <div class="indent">
+<h3>13.5 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2615794">17</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. Within MUC, there are two uses of such forms: room registration within muc#user and room configuration within muc#owner. The reserved fields are defined below.</p>
+    <div class="indent">
+<h3>13.5.1 <a name="registrar-formtype-register">muc#register FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#register&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling user registration with a
+    Multi-User Chat (MUC) room or admin approval
+    of user registration requests.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#register_first'
+      type='text-single'
+      label='First Name'/&gt;
+  &lt;field
+      var='muc#register_last'
+      type='text-single'
+      label='Last Name'/&gt;
+  &lt;field
+      var='muc#register_roomnick'
+      type='text-single'
+      label='Desired Nickname'/&gt;
+  &lt;field
+      var='muc#register_url'
+      type='text-single'
+      label='Your URL'/&gt;
+  &lt;field
+      var='muc#register_email'
+      type='text-single'
+      label='Email Address'/&gt;
+  &lt;field
+      var='muc#register_faqentry'
+      type='text-multi'
+      label='FAQ Entry'/&gt;
+    &lt;field 
+       var='muc#register_allow'
+       type='boolean'
+       label='Allow this person to register with the room?'&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.5.2 <a name="registrar-formtype-owner">muc#roomconfig FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roomconfig&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling creation and configuration of
+    a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roomconfig_allowinvites'
+      type='boolean'
+      label='Whether to Allow Occupants to Invite Others'/&gt;
+  &lt;field
+      var='muc#roomconfig_changesubject'
+      type='boolean'
+      label='Whether to Allow Occupants to Change Subject'/&gt;
+  &lt;field
+      var='muc#roomconfig_enablelogging'
+      type='boolean'
+      label='Whether to Enable Logging of Room Conversations'/&gt;
+  &lt;field
+      var='muc#roomconfig_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roomconfig_maxusers'
+      type='list-single'
+      label='Maximum Number of Room Occupants'/&gt;
+  &lt;field
+      var='muc#roomconfig_membersonly'
+      type='boolean'
+      label='Whether an Make Room Members-Only'/&gt;
+  &lt;field
+      var='muc#roomconfig_moderatedroom'
+      type='boolean'
+      label='Whether to Make Room Moderated'/&gt;
+  &lt;field
+      var='muc#roomconfig_passwordprotectedroom'
+      type='boolean'
+      label='Whether a Password is Required to Enter'/&gt;
+  &lt;field
+      var='muc#roomconfig_persistentroom'
+      type='boolean'
+      label='Whether to Make Room Persistent'/&gt;
+  &lt;field
+      var='muc#roomconfig_presencebroadcast'
+      type='list-multi'
+      label='Roles for which Presence is Broadcast'/&gt;
+  &lt;field
+      var='muc#roomconfig_publicroom'
+      type='boolean'
+      label='Whether to Allow Public Searching for Room'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomadmins'
+      type='jid-multi'
+      label='Full List of Room Admins'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomdesc'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomname'
+      type='text-single'
+      label='Natural-Language Room Name'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomowners'
+      type='jid-multi'
+      label='Full List of Room Owners'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomsecret'
+      type='text-private'
+      label='The Room Password'/&gt;
+  &lt;field
+      var='muc#roomconfig_whois'
+      type='list-single'
+      label='Affiliations that May Discover Real JIDs of Occupants'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.5.3 <a name="registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roominfo&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling the communication of extended service discovery
+    information about a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roominfo_description'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roominfo_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roominfo_occupants'
+      type='text-single'
+      label='Current Number of Occupants in Room'/&gt;
+  &lt;field
+      var='muc#roominfo_subject'
+      type='text-single'
+      label='Current Subject or Discussion Topic in Room'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>14.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="bizrules-jids">Room JIDs</a>
+</h3>
+    <p class="" style="">In order to provide consistency regarding the addresses captured in room JIDs, Room IDs MUST match the Nodeprep profile of Stringprep and Room Nicknames MUST match the Resourceprep profile of Stringprep (both of these are defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2615858">18</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>14.2 <a name="bizrules-message">Message</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">If an occupant wants to send a message to all other occupants, a compliant client MUST set the 'type' attribute to a value of &quot;groupchat&quot;. A service MAY ignore messages that are improperly typed, or reject them with a &lt;bad-request/&gt; error.</p></li>
+      <li><p class="" style="">If a compliant service receives a message directed to the room or to a single occupant from a Jabber user who has a role of &quot;none&quot;, the service MUST NOT deliver the message and SHOULD return the message to the sender with a &lt;forbidden/&gt; error.</p></li>
+      <li><p class="" style="">If a compliant service receives a message directed to a room that does not exist or is locked, the service SHOULD return the message to the sender with a &lt;item-not-found/&gt; error.</p></li>
+      <li><p class="" style="">A compliant service SHOULD pass extended information (e.g., an XHTML version of the message body) through to occupants unchanged.</p></li>
+      <li><p class="" style="">A compliant client MUST NOT generate message events as specified in <span class="ref">Message Events</span>  [<a href="#nt-id2616089">19</a>]; such message events are not intended for use in the context of groupchat.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>14.3 <a name="bizrules-presence">Presence</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">A room MUST silently ignore unavailable presence received from a user who has a role of &quot;none&quot;.</p></li>
+      <li><p class="" style="">Only a component SHOULD generate extended presence information about roles, affiliations, full JIDs, or status codes scoped by the 'http://jabber.org/protocol/muc#user' namespace (based on information the component knows about occupants, e.g., roles, or as a result of actions taken by a moderator or room administrator). A client SHOULD NOT presume to generate such information. If a compliant component receives such extended presence information from an occupant, it MUST NOT reflect it to other occupants. A client can generate extended presence information in the 'http://jabber.org/protocol/muc#user' namespace in order to supply a password, but naturally this is not reflected to other occupants.</p></li>
+      <li><p class="" style="">A component SHOULD allow all other presence information to pass through, although it MAY choose to block extended presence information. Thus effectively clients can send a custom exit message if desired (as is often done in IRC channels) by including a &lt;status/&gt; element in the presence stanza of type &quot;unavailable&quot; sent when exiting a room.</p></li>
+      <li><p class="" style="">In order to appropriately inform occupants of room roles and affiliations, and to make it easier for Jabber clients to track the current state of all users in the room, compliant component implementations MUST provide extended presence information about roles and affiliations in all presence stanzas, including presence stanzas of type &quot;unavailable&quot; sent when a user exits the room for any reason.</p></li>
+      <li><p class="" style="">If a privilege is revoked, the service MUST note that by sending an &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child element with the 'role' and/or 'affiliation' attributes set to a value that indicates the loss of the relevant privilege. All future presence stanzas for the occupant MUST include the updated role and affiliation, until and unless they change again.</p></li>
+      <li><p class="" style="">A compliant service MUST send extended presence to a client even if the client did not send an empty &lt;x/&gt; element scoped by the 'http://jabber.org/protocol/muc' namespace on entering the room; naturally, a Jabber-compliant client MUST ignore such information if it does not understand it.</p></li>
+      <li><p class="" style="">Extended presence about roles and affiliations sent in the muc#user namespace MUST include the full JID (not the bare JID) as the value of the 'jid' attribute.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>14.4 <a name="bizrules-iq">IQ</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a non-anonymous room, the sender SHOULD send the request directly to the recipient's bare JID or full JID, rather than attempting to send the request through the room (i.e., via the recipient's room JID).</p></li>
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a semi-anonymous room, the sender can direct the stanza to the recipient's room JID and the service MAY forward the stanza to the recipient's real JID. However, a compliant service MUST NOT reveal the sender's real JID to the recipient at any time, nor reveal the recipient's real JID to the sender.</p></li>
+      <li><p class="" style="">A compliant client MUST send only the 'affiliation' attribute or the 'role' attribute in the &lt;item/&gt; element contained within an IQ set scoped by the 'http://jabber.org/protocol/muc#admin' namespace; if a moderator, admin, or owner attempts to modify both the affiliation and role of the same item in the same IQ set, the service MUST return a &lt;bad-request/&gt; error to the sender. However, a compliant service MAY modify a role based on a change to an affiliation and thus MAY send presence updates that include both a modified role and a modified affiliation.</p></li>
+      <li><p class="" style="">In IQ sets regarding roles, a compliant client MUST include the 'nick' attribute only; in IQ results regarding roles, a compliant service MUST include the 'nick', 'role', 'affiliation', and 'jid' attributes (with the value of the latter set to the user's full JID).</p></li>
+      <li><p class="" style="">In IQ sets regarding affiliations, a compliant client MUST include the 'jid' attribute only (with the value set to the bare JID); in IQ results regarding affiliations, a compliant service MUST NOT include the 'role' attribute, MUST include the 'affiliation' attribute and the 'jid' attribute (with the value set to the bare JID), and SHOULD include the 'nick' attribute (except if the affiliation is &quot;outcast&quot;, since outcasts SHOULD NOT have reserved nicknames).</p></li>
+    </ol>
+  </div>
+<h2>15.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">The following guidelines may assist client and component developers in creating compliant implementations.</p>
+  <div class="indent">
+<h3>15.1 <a name="impl-service">Services</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">In handling messages sent by visitors in a moderated room, a chatroom service MAY queue each message for approval by a moderator and MAY inform the sender that the message is being held for approval; however, such behavior is OPTIONAL, and definition of a message approval protocol (e.g., using Data Forms as defined in JEP-0004) is out of scope for this JEP.</p></li>
+      <li><p class="" style="">It is common for chatroom services to provide in-room messages when certain events occur, such as when the subject changes, when an occupant enters or exits, or when a room is destroyed. Such messages are entirely OPTIONAL and are left up to the implementation or deployment, but if used MUST be messages of type &quot;groupchat&quot; sent from the room JID itself (room@service) rather than a specific occupant (room@service/nick). However, in general it is preferable for the receiving client to generate such messages based on events in the room (e.g., user entrances and exits) as well as specific status codes provided in MUC; this will help ensure correct localization of such messages.</p></li>
+      <li><p class="" style="">Out of courtesy, a chatroom service MAY send a &lt;message/&gt; to an occupant who is kicked or banned, and MAY broadcast an in-room &lt;message/&gt; to all remaining occupants informing them that the occupant has been kicked or banned from the room. However, such messages are OPTIONAL, and indeed are unnecessary since the information required for a receiving client to generate such messages is communicated in the presence stanzas (specifically the status codes) sent by a MUC-compliant service.</p></li>
+      <li><p class="" style="">Out of courtesy, a chatroom service MAY send a &lt;message/&gt; outside the context of the room if a user's affiliation changes while the user is not in the room; the message SHOULD be sent from the room to the user's bare JID, MAY contain a &lt;body/&gt; element describing the affiliation change, and MUST contain a status code of 101.</p></li>
+      <li><p class="" style="">There is no requirement that a chatroom service shall provide special treatment for users of the older &quot;groupchat 1.0&quot; protocol, such as messages that contain equivalents to the extended presence information that is sent in the 'http://jabber.org/protocol/muc#user' namespace.</p></li>
+      <li><p class="" style="">Room types can be configured in any combination. A chatroom service MAY support or allow any desired room types or combinations thereof.</p></li>
+      <li><p class="" style="">A chatroom service MAY limit the number of configuration options presented to an owner after initial configuration has been completed, e.g. because certain options cannot take effect without restarting the service.</p></li>
+      <li><p class="" style="">A chatroom service MAY provide an interface to room creation and configuration (e.g., in the form of a special Jabber user or a Web page), so that the ostensible room owner is actually the application as opposed to a human user.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to make available a special in-room resource that provides an interface to administrative functionality (e.g., a &quot;user&quot; named &quot;ChatBot&quot;), which occupants could interact with directly, thus enabling admins to type <tt>/command parameter</tt> in a private message to that &quot;user&quot;. Obviously this kind of implementation would require the service to add a 'ChatBot' user to the room when it is created, and to prevent any occupant from having the nickname 'ChatBot' in the room. This might be difficult to ensure in some implementations or deployments. In any case, any such interface is OPTIONAL.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to send a message outside the context of the room to any user who is affected by a change in affiliation (e.g., if a user becomes an admin or owner). Such a message could include an appropriate status code in an extended child element scoped by the muc#user namespace.</p></li>
+      <li><p class="" style="">A chatroom service SHOULD remove a user if the service receives a delivery-related error in relation to a stanza it has previously sent to the user (remote server unreachable, user not found, etc.).</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to discard extended presence information that is attached to &lt;presence/&gt; stanza before reflecting the presence change to the occupants of a room. That is, an implementation MAY choose to reflect only the &lt;show/&gt;, &lt;status/&gt;, and &lt;priority/&gt; child elements of the presence element as specified in the XML schema for the 'jabber:client' namespace, with the result that presence &quot;changes&quot; in extended namespaces (e.g., gabber:x:music:info) are not passed through to occupants. If a service prohibits certain extended namespaces, it SHOULD provide a description of allowable traffic at the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' as described below.</p></li>
+      <li><p class="" style="">A chatroom service MAY choose to discard extended information attached to &lt;message/&gt; stanzas before reflecting the message to the occupants of a room. An example of such extended information is the lightweight text markup specified by <span class="ref">XHTML-IM</span>  [<a href="#nt-id2616611">20</a>]. If a service prohibits certain extended namespaces, it SHOULD provide a description of allowable traffic at the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' as described below.</p></li>
+    </ol>
+    <div class="indent">
+<h3>15.1.1 <a name="impl-service-traffic">Allowable Traffic</a>
+</h3>
+      <p class="" style="">As noted, a service (more precisely, a properly-configured room) MAY discard some or all extended namespaces attached to messages and presence stanzas that are intended for reflection from the sender through the room to all of the room occupants. If the room does so, it SHOULD enable senders to discover the list of allowable extensions by sending a disco#info query to the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic', one namespace in each &lt;feature/&gt; element (it is not necessary to list the 'jabber:client' namespace, since support for that namespace is required). If the room does not prohibit any extended namespaces, it SHOULD return a &lt;feature-not-implemented/&gt; error in response to queries sent to the 'http://jabber.org/protocol/muc#traffic' node.</p>
+      <p class="" style="">The following example shows a room that allows the 'http://jabber.org/protocol/xhtml-im' and 'jabber:x:roster' namespaces only, but no other extended namespaces.</p>
+      <p class="caption">Example 170. User Queries Service Regarding Allowable Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    to='heath@macbeth.shakespeare.lit'
+    id='allow1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 171. Service Returns Allowable Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    to='heath@macbeth.shakespeare.lit'
+    id='allow1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'&gt;
+    &lt;feature var='http://jabber.org/protocol/xhtml-im'/&gt;
+    &lt;feature var='jabber:x:roster/'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>15.2 <a name="impl-client">Clients</a>
+</h3>
+    <ol start="" type="">
+      <li><p class="" style="">Jabber clients MAY present room roles by showing ad-hoc groups for each role within a room roster. This will enable occupants to clearly visualize which occupants are moderators, participants, and visitors. However, such a representation is OPTIONAL.</p></li>
+      <li><p class="" style="">Jabber clients MAY implement a variety of interface styles that provide &quot;shortcuts&quot; to functionality such as changing one's nickname, kicking or banning users, discovering an occupant's full JID, or changing the subject. One option consists of IRC-style commands such as '/nick', '/kick', '/ban', and '/whois'; another is to enable a user to right-click items in a room roster. All such interface styles are OPTIONAL. However, for convenience, a mapping of IRC commands to MUC protocols is provided below.</p></li>
+    </ol>
+    <div class="indent">
+<h3>15.2.1 <a name="impl-client-irc">IRC Command Mapping</a>
+</h3>
+      <p class="" style="">Internet Relay Chat clients use a number of common &quot;shortcut&quot; commands that begin with a forward slash, such as '/nick' and '/ban'. The following table provides a mapping of IRC-style commands to MUC protocols, for use by Jabber clients that wish to support such functionality.</p>
+      <p class="caption">Table 9: IRC Command Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Command</th>
+          <th colspan="" rowspan="">Function</th>
+          <th colspan="" rowspan="">MUC protocol</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/ban &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">bans user with that roomnick from this room (client translates roomnick to jid)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='jid-of-roomnick'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/invite &lt;jid&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">invites jid to this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='jid'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/join &lt;roomname&gt; [pass]</td>
+          <td align="" colspan="" rowspan="">joins room on this service (roomnick is same as nick in this room)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;password&gt;pass&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/kick &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">kicks user with that roomnick from this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='roomnick' role='none'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/msg &lt;roomnick&gt; &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">sends private message &quot;foo&quot; to roomnick</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service/nick'&gt;
+  &lt;body&gt;foo&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/nick &lt;newnick&gt;</td>
+          <td align="" colspan="" rowspan="">changes nick in this room to &quot;newnick&quot;</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/newnick'/&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/part [comment]</td>
+          <td align="" colspan="" rowspan="">exits this room (some IRC clients also support /leave)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'
+          type='unavailable'&gt;
+  &lt;status&gt;comment&lt;/status&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/topic &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">changes subject of this room to &quot;foo&quot;</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service' type='groupchat'&gt;
+  &lt;subject&gt;foo&lt;/subject&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+      </table>
+      <p class="" style="">Note: Because MUC roomnicks follow the Resouceprep profile of stringprep, they are allowed to contain a space character, whereas IRC nicknames do not. Although a given client MAY support quotation characters for this purpose (resulting in commands such as '/ban &quot;king lear&quot; insanity is no defense'), most common quotation characters (such as &quot; and ') are also allowed by Resouceprep, thus leading to added complexity and potential problems with quotation of roomnicks that contain both spaces and quotation characters. Therefore it is NOT RECOMMENDED for Jabber clients to support IRC-style shortcut commands with roomnicks that contain space characters.</p>
+      <p class="" style="">Note: Many Jabber clients also implement a '/me ' command, where the command is followed by a verb or verb phrase (e.g., '/me laughs'). This command does not result in any MUC or IRC protocol action and is therefore not shown in the table. Instead, the message is sent as-is (e.g., &lt;message&gt;/me laughs&lt;'\;/message&gt;) and the receiving client performs string-matching on the character data of the &lt;message/&gt; element to determine if the message begins with the string '/me '; if it does the receiving client will show the message in a special format, usually italicized text sometimes prepended by the &quot;*&quot; character:</p>
+      <p class="" style="margin-left: 5%"><span style="font-style: italic">* stpeter laughs</span></p>
+    </div>
+  </div>
+<h2>16.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="schemas-muc">http://jabber.org/protocol/muc</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc'
+    xmlns='http://jabber.org/protocol/muc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='history' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='history'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+         &lt;xs:attribute name='maxchars' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='maxstanzas' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='seconds' type='xs:int' use='optional'/&gt;
+         &lt;xs:attribute name='since' type='xs:dateTime' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.2 <a name="schemas-user">http://jabber.org/protocol/muc#user</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#user'
+    xmlns='http://jabber.org/protocol/muc#user'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='decline' minOccurs='0'/&gt;
+        &lt;xs:element ref='destroy' minOccurs='0'/&gt;
+        &lt;xs:element ref='invite' minOccurs='0'/&gt;
+        &lt;xs:element ref='item' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element ref='status' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='decline'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='invite'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+        &lt;xs:element ref='continue' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='code' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:int'&gt;
+            &lt;xs:enumeration value='100'/&gt;
+            &lt;xs:enumeration value='201'/&gt;
+            &lt;xs:enumeration value='301'/&gt;
+            &lt;xs:enumeration value='303'/&gt;
+            &lt;xs:enumeration value='307'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:element name='continue' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.3 <a name="schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#admin'
+    xmlns='http://jabber.org/protocol/muc#admin'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>16.4 <a name="schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#owner'
+    xmlns='http://jabber.org/protocol/muc#owner'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='destroy' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>17.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The author would like to thank the following individuals for their many helpful comments on various drafts of this proposal: David Sutton, Peter Millard, Joe Hildebrand, Craig Kaes, Alexey Shchepin, David Waite, Jean-Louis Seguineau, Jacek Konieczny, Gaston Dombiak, and many others in the jdev@conference.jabber.org conference room and on the Standards-JIG mailing list.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2603060">1</a>. RFC 1459: Internet Relay Chat &lt;<a href="http://www.ietf.org/rfc/rfc1459.txt">http://www.ietf.org/rfc/rfc1459.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603334">2</a>. <a href="http://www.jabber.org/protocol/groupchat.html">http://www.jabber.org/protocol/groupchat.html</a>
+</p>
+<p>
+<a name="nt-id2606754">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606953">4</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p>
+<a name="nt-id2608200">5</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p>
+<a name="nt-id2608423">6</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2609660">7</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2611244">8</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2612185">9</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2612206">10</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2612397">11</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2613680">12</a>. This is different from the behavior of room configuration, wherein the 'muc#roomconfig_roomowners' field specifies the full list of room owners, not the delta.</p>
+<p>
+<a name="nt-id2614033">13</a>. This is different from the behavior of room configuration, wherein the 'muc#roomconfig_roomadmins' field specifies the full list of room admins, not the delta.</p>
+<p>
+<a name="nt-id2614458">14</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2615538">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2615477">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2615794">17</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p>
+<a name="nt-id2615858">18</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2616089">19</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p>
+<a name="nt-id2616611">20</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.18 (2004-11-02)</h4>
+<div class="indent">Corrected several errors in the affiliation state chart and in the examples (wrong FORM_TYPE values); mentioned /me command. (psa)
+    </div>
+<h4>Version 1.17 (2004-10-04)</h4>
+<div class="indent">Added text about allowable extension namespaces and related service discovery mechanisms; specified well-known service discovery nodes; added conformance terms to clarify some descriptions; modified affiliation state chart to allow more flexible state changes; per list dicussion, added ability to convert a one-to-one chat into a conference, including sending of history; specified error to use when max users limit is reached; specified form for admin approval of user registration requests and modified FORM_TYPE from http://jabber.org/protocol/muc#user to http://jabber.org/protocol/muc#register; modified FORM_TYPE for room configuration from http://jabber.org/protocol/muc#owner to http://jabber.org/protocol/muc#roomconfig. (psa)
+    </div>
+<h4>Version 1.16 (2004-06-30)</h4>
+<div class="indent">Added example and registry submission for service discovery extension. (psa)
+    </div>
+<h4>Version 1.15 (2004-06-24)</h4>
+<div class="indent">Removed jabber:iq:browse references; clarified order of presence stanzas sent to new occupant on entering room; specified format of in-room messages (type='groupchat', from='room@service'); clarified allowable attributes in various list-related operations; made admin/owner revocation text and examples consistent with state chart; clarified ownership revocation conflict scenarios; changed the 'muc#roomconfig_inviteonly' field to 'muc#roomconfig_membersonly'; changed attribute order in examples to match XML canonicalization rules; corrected several errors in the schemas. (psa)
+    </div>
+<h4>Version 1.14 (2004-05-03)</h4>
+<div class="indent">Corrected discovery of registered roomnicks; added note about error to return if nicks are locked down. (psa)
+    </div>
+<h4>Version 1.13 (2004-03-31)</h4>
+<div class="indent">Fixed an error in the muc#user schema. (psa)
+    </div>
+<h4>Version 1.12 (2004-03-01)</h4>
+<div class="indent">Corrected a few errors in the examples; added IQ results in order to clarify workflows. (psa)
+    </div>
+<h4>Version 1.11 (2004-02-05)</h4>
+<div class="indent">Clarified JID matching rules (same as for privacy lists in XMPP IM). (psa)
+    </div>
+<h4>Version 1.10 (2004-01-07)</h4>
+<div class="indent">Added XMPP error handling; fully specified all conformance terms. (psa)
+    </div>
+<h4>Version 1.9 (2003-12-14)</h4>
+<div class="indent">Removed protocol for requesting voice in a moderated room (should be performed using Ad-Hoc Commands). (psa)
+    </div>
+<h4>Version 1.8 (2003-12-04)</h4>
+<div class="indent">Added protocol for requesting voice in a moderated room; added (informational) mapping of IRC commands to MUC protocols. (psa)
+    </div>
+<h4>Version 1.7 (2003-10-21)</h4>
+<div class="indent">Added room configuration option for restricting presence broadcast to certain roles. (psa)
+    </div>
+<h4>Version 1.6 (2003-10-03)</h4>
+<div class="indent">Added history management protocol on entering a room. (psa)
+    </div>
+<h4>Version 1.5 (2003-09-11)</h4>
+<div class="indent">Specified that ban occurs by JID, not roomnick; allowed privileged users to send messages to the room even if not present in the room; added note that service should remove occupant if a delivery-related stanza error occurs; enabled user to disco the room in order to discover registered roomnick; specified that &quot;banning&quot; by domain or regex is a service-level configuration matter and therefore out of scope for MUC; specified that role should be decremented as appropriate if affiliation is lowered; added some clarifying text to room creation workflow; added implementation note about sending an out-of-band message if a user's affiliation changes while the user is not in the room; fixed stringprep references (room nicks use Resourceprep); clarified relationship between Room ID (i.e., node identifier of Room JID, which may be opaque) and natural-language Room Name; specified Field Standardization profile per JEP-0068; defined Jabber Registrar submissions; added schema locations. (psa)
+    </div>
+<h4>Version 1.4 (2003-02-16)</h4>
+<div class="indent">Added XML schemas. (psa)
+    </div>
+<h4>Version 1.3 (2003-02-11)</h4>
+<div class="indent">Added reference to nodeprep Internet-Draft. (psa)
+    </div>
+<h4>Version 1.2 (2003-01-30)</h4>
+<div class="indent">Commented out revision history prior to version 1.0 (too long); clarified business rules regarding when nicks, full JIDs, and bare JIDs are used in reference to roles and affiliations; consistently specified that extended presence information in the muc#user namespace must include the full JID as the value of the 'jid' attribute in all cases; cleaned up text and examples throughout; added open issue regarding syntax of room nicknames. (psa)
+    </div>
+<h4>Version 1.1 (2002-12-16)</h4>
+<div class="indent">Added protocol for declining an invitation; replaced &lt;created/&gt; element with status code 201; modified the destroy room protocol so that &lt;destroy/&gt; is a child of &lt;query/&gt;; clarified usage of 'nick' attribute when adding members; prohibited use of message events. (psa)
+    </div>
+<h4>Version 1.0 (2002-11-21)</h4>
+<div class="indent">Per a vote of the Jabber Council, revision 0.23 was advanced to Draft on 2002-11-21. (For earlier revision history, refer to XML source.) (psa)
+    </div>
+<h4>Version 0.23 (2002-11-06)</h4>
+<div class="indent">Added examples for disco#items queries sent to a room; prohibited 'type' attribute on invite messages sent from client to room; added dependencies for JEPs 11 and 30; changed 'room user' to 'occupant'; fixed many small errors throughout. (psa)
+    </div>
+<h4>Version 0.22 (2002-11-04)</h4>
+<div class="indent">Added example for disco#items; added support for cancellation of room configuration using type='cancel' from JEP-0004; noted 403 error for invites sent by non-admins in members-only room. (psa)
+    </div>
+<h4>Version 0.21 (2002-11-01)</h4>
+<div class="indent">Clarified several small ambiguities; made &lt;body/&gt; optional on invites sent from the service to the invitee; added error scenarios for changing nickname and for destroying the room; specified that the service must return the full member list for a members-only room (not only the members in the room); updated the disco examples to track protocol changes. (psa)
+    </div>
+<h4>Version 0.20 (2002-10-29)</h4>
+<div class="indent">Specified that messages sent to change the room subject must be of type &quot;groupchat&quot;; updated the legal notice to conform to the JSF IPR policy. (psa)
+    </div>
+<h4>Version 0.19 (2002-10-28)</h4>
+<div class="indent">Added ability to create an instant room within MUC (not by using gc-1.0 protocol); cleaned up disco examples. (psa)
+    </div>
+<h4>Version 0.18 (2002-10-27)</h4>
+<div class="indent">Added experimental support for disco; added sections for security, IANA, and JANA considerations; corrected typographical errors; cleaned up some DocBook formatting. (psa)
+    </div>
+<h4>Version 0.17 (2002-10-23)</h4>
+<div class="indent">Added the optional &lt;actor/&gt; element (with 'jid' attribute) to &lt;item/&gt; elements inside presence stanzas of type &quot;unavailable&quot; that are sent to users who are kicked or banned, as well as within IQs for tracking purposes; reverted all list editing use cases (ban, voice, member, moderator, admin, owner) to use of MUC format rather than 'jabber:x:data' namespace; added several guidelines regarding generation and handling of XML stanzas; cleaned up the change room subject use case; changed several ambiguous uses of 'would', 'can', and 'will' to 'should', 'may', or 'must'; fixed several small errors in the text, examples, and DTDs. (psa)
+    </div>
+<h4>Version 0.16 (2002-10-20)</h4>
+<div class="indent">Added the &lt;item/&gt; element to presence stanzas of type &quot;unavailable&quot; in order to improve the tracking of user states in the room; consolidated &lt;invitee/&gt; and &lt;inviter/&gt; elements into an &lt;invite/&gt; element with 'from' and 'to' attributes; made &lt;reason/&gt; element always a child of &lt;item/&gt; or &lt;invite/&gt; in the muc#user namespace; moved the alternate room location in room destruction to a 'jid' attribute of the &lt;alt/&gt; element; further specified several error messages; disallowed simultaneous modifications of both affiliations and roles by a moderator or admin; added several more rules regarding handling of XML stanzas; added use cases for granting and revoking administrative privileges; adjusted DTD to track all changes. (psa)
+    </div>
+<h4>Version 0.15 (2002-10-18)</h4>
+<div class="indent">Fully incorporated the change to affiliations + roles; moved a number of admin use cases to a new section for moderator use cases; added participant use case for requesting membership; added admin use cases for adding members, removing members, granting and revoking moderator privileges, and modifying the moderator list; organized the sections in a more logical manner. (psa)
+    </div>
+<h4>Version 0.14 (2002-10-17)</h4>
+<div class="indent">Significantly modified the privileges model by distinguishing between in-room &quot;roles&quot; and long-lived &quot;affiliations&quot;; specified the privileges of the various roles and affiliations; included state transition charts for both roles and affiliations; removed use of MUC protocol for editing ban, voice, and admin lists (but not for the actions of banning users and granting/revoking voice); added delivery rule regarding IQ stanzas; changed kick so that the action is based on changing the role to &quot;none&quot;. (psa)
+    </div>
+<h4>Version 0.13 (2002-10-16)</h4>
+<div class="indent">Corrected the change nickname examples (newnick sent on unavailable, no nick sent on available). (psa)
+    </div>
+<h4>Version 0.12 (2002-10-16)</h4>
+<div class="indent">Removed SHA1 passwords; specified that room shall add passwords on invitations to password-protected rooms (not supplied by inviter). (psa)
+    </div>
+<h4>Version 0.11 (2002-10-16)</h4>
+<div class="indent">Changed 'participant' to 'room user' and 'discussant' to 'participant'; clarified presence rule about client generation of extended presence information; added role of 'none'. (psa)
+    </div>
+<h4>Version 0.10 (2002-10-15)</h4>
+<div class="indent">Fixed extended presence on entering or creating a room (plain '...muc' with no fragment); harmonized #user with #admin regarding the use of the &lt;item/&gt; element and associated attributes (jid, nick, etc.), and added 'role' attribute; modified management of voice, ban, admin, and member lists to use &lt;query/&gt; wrapper and new &lt;item/&gt; structure; changed the 'member' role to 'discussant', added 'outcast' role for banned users, and added new 'member' role to enable management of member lists; changed invitation-only rooms to members-only rooms and made appropriate adjustments to apply member lists to both members-only rooms and open rooms; modified nickname change protocol slightly to send the old nickname in the unavailable presence and the new nickname in the available presence; removed prohibition on members-only rooms that are password-protected; removed the &lt;query/&gt; wrapper for the &lt;destroy/&gt; element; updated the DTDs. (psa)
+    </div>
+<h4>Version 0.9 (2002-10-13)</h4>
+<div class="indent">Added extended presence ('...#user') on entering a room for compliant clients; changed namespace on room creation request to '...#owner'; added a service discovery example using jabber:iq:browse; added information about discussion history; made small fixes to several examples; further defined the presence rules; transferred all implementation notes to a dedicated section; added a Terminology section. (psa)
+    </div>
+<h4>Version 0.8 (2002-10-10)</h4>
+<div class="indent">Made further changes to the room creation workflow (finally correct); removed feature discovery use case (this needs to be addressed by a real service discovery protocol!); added ability for room owners to edit the admin list; removed &lt;body/&gt; from invitations generated by the service; removed messages sent to kicked and banned users (handled by unavailable presence with status code); added a number of implementation notes; converted all examples to Shakespeare style. (psa)
+    </div>
+<h4>Version 0.7.6 (2002-10-09)</h4>
+<div class="indent">Fixed the room creation workflow; changed some terminology (&quot;join&quot; to &quot;enter&quot; and &quot;leave&quot; to &quot;exit&quot;). (psa)
+    </div>
+<h4>Version 0.7.5 (2002-10-08)</h4>
+<div class="indent">Specified and improved the handling of invitation-only rooms. In particular, added the ability for room admins to edit the invitation list and added a configuration option that limits the ability to send invitations to room admins only. (psa)
+    </div>
+<h4>Version 0.7.4 (2002-10-07)</h4>
+<div class="indent">Changed namespaces from http://jabber.org/protocol/muc/owner etc. to http://jabber.org/protocol/muc#owner etc. per Jabber Council discussion. (psa)
+    </div>
+<h4>Version 0.7.3 (2002-10-07)</h4>
+<div class="indent">Changed namespaces to HTTP URIs; left role handling up to the implementation; further clarified presence rules. (psa)
+    </div>
+<h4>Version 0.7.2 (2002-10-06)</h4>
+<div class="indent">Disallowed kicking, banning, and revoking voice with respect to room admins and room owners; replaced &lt;x/&gt; with &lt;query/&gt; in the Discovering Room Features and Destroying a Room use cases; corrected some small errors and made many clarifications throughout. (psa)
+    </div>
+<h4>Version 0.7.1 (2002-10-04)</h4>
+<div class="indent">Removed &lt;whois/&gt; command (unnecessary since participants with appropriate privileges receive the full JID of all participants in presence stanzas); completed many small fixes throughout. (psa)
+    </div>
+<h4>Version 0.7 (2002-10-03)</h4>
+<div class="indent">More clearly delineated participant roles and defined the hierarchy thereof (owner, admin, member, visitor); replaced &lt;voice/&gt; element in extended presence with &lt;item role='member'/&gt;; changed initial room configuration to use IQ rather than message; adjusted presence rules (especially regarding extended presence information); cleaned up examples throughout; updated DTD to track changes. (psa)
+    </div>
+<h4>Version 0.6 (2002-09-21)</h4>
+<div class="indent">More clearly defined the scope; removed fully anonymous rooms; changed meaning of semi-anonymous rooms and of non-anonymous rooms; added mechanism for notification of full JIDs in non-anonymous rooms; replaced the &lt;admin/&gt; element in extended presence with a &lt;role/&gt; element (more extensible); changed room passwords to cleartext; added status codes for various messages received from the service; added lists of valid error and status codes associated with the 'http://jabber.org/protocol/muc#user' namespace; added a &lt;reason/&gt; element for invitations; made kick and ban reasons child elements rather than attributes; replaced stopgap feature discovery mechanism with jabber:iq:negotiate; added extended presence element to room creation request and clarified the room creation process; specified presence reflection rules; added method for destroying a room; adjusted DTDs to track all changes. (psa)
+    </div>
+<h4>Version 0.5.1 (2002-09-20)</h4>
+<div class="indent">Added DTDs; changed feature discovery to use &lt;x/&gt; element rather than query and made service response come in IQ result; fixed reference to JEP 29; changed 'grant' to 'add' and 'revoke' to 'remove' for consistency in the item attributes; made several other small changes. (psa)
+    </div>
+<h4>Version 0.5 (2002-09-19)</h4>
+<div class="indent">Changed the kick, ban, and voice protocols; added a few more configuration options; specified the restrictions for roomnicks; and added a stopgap service discovery protocol. (psa)
+    </div>
+<h4>Version 0.4 (2002-09-18)</h4>
+<div class="indent">Changed all non-GC-1.0 use cases to jabber:gc:* namespaces or jabber:x:data; added use cases for ban list management and room moderation; added protocol for sending notice of admin and voice privileges in presence; cleaned up text and many examples. (psa)
+    </div>
+<h4>Version 0.3 (2002-09-17)</h4>
+<div class="indent">Changed admin use cases; cleaned up participant and owner use cases. (psa)
+    </div>
+<h4>Version 0.2 (2002-09-12)</h4>
+<div class="indent">Broke content out into three actors (participant, owner, and admin) and added more detail to owner and admin use cases. (psa)
+    </div>
+<h4>Version 0.1 (2002-09-09)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0045-1.19.html
+++ b/content/xep-0045-1.19.html
@@ -1,0 +1,5188 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0045: Multi-User Chat</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Multi-User Chat">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a robust protocol for XMPP-based text conferencing.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0045">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0045: Multi-User Chat</h1>
+<p>This JEP defines a robust protocol for XMPP-based text conferencing.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0045<br>
+            Version: 1.19<br>
+            Last Updated: 2005-04-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0004, JEP-0030, JEP-0068, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: muc<br>
+        Schema for muc: &lt;<a href="http://jabber.org/protocol/muc/muc.xsd">http://jabber.org/protocol/muc/muc.xsd</a>&gt;<br>
+        Schema for muc#admin: &lt;<a href="http://jabber.org/protocol/muc/admin.xsd">http://jabber.org/protocol/muc/admin.xsd</a>&gt;<br>
+        Schema for muc#owner: &lt;<a href="http://jabber.org/protocol/muc/owner.xsd">http://jabber.org/protocol/muc/owner.xsd</a>&gt;<br>
+        Schema for muc#user: &lt;<a href="http://jabber.org/protocol/muc/user.xsd">http://jabber.org/protocol/muc/user.xsd</a>&gt;<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/muc.html">http://www.jabber.org/registrar/muc.html</a>&gt;
+              <br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#scope">Scope</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#terms-general">General Terms</a>
+</dt>
+<dt>4.2.  <a href="#terms-rooms">Room Types</a>
+</dt>
+</dl>
+<dt>5.  <a href="#connections">Roles and Affiliations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#roles">Roles</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#roles-priv">Privileges</a>
+</dt>
+<dt>5.1.2.  <a href="#roles-change">Changing Roles</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#affil">Affiliations</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#affil-priv">Privileges</a>
+</dt>
+<dt>5.2.2.  <a href="#affil-change">Changing Affiliations</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#user">Occupant Use Cases</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#discovery">Discovering Component Support for MUC</a>
+</dt>
+<dt>6.2.  <a href="#discovery-client">Discovering Client Support for MUC</a>
+</dt>
+<dt>6.3.  <a href="#enter">Entering a Room</a>
+</dt>
+<dl>
+<dt>6.3.1.  <a href="#enter-gc">Groupchat 1.0 Protocol</a>
+</dt>
+<dt>6.3.2.  <a href="#enter-muc">Basic MUC Protocol</a>
+</dt>
+<dt>6.3.3.  <a href="#enter-pres">Presence Broadcast</a>
+</dt>
+<dt>6.3.4.  <a href="#enter-roles">Default Roles</a>
+</dt>
+<dt>6.3.5.  <a href="#enter-nonanon">Non-Anonymous Rooms</a>
+</dt>
+<dt>6.3.6.  <a href="#enter-semianon">Semi-Anonymous Rooms</a>
+</dt>
+<dt>6.3.7.  <a href="#enter-pw">Password-Protected Rooms</a>
+</dt>
+<dt>6.3.8.  <a href="#enter-members">Members-Only Rooms</a>
+</dt>
+<dt>6.3.9.  <a href="#enter-banned">Banned Users</a>
+</dt>
+<dt>6.3.10.  <a href="#enter-conflict">Nickname Conflict</a>
+</dt>
+<dt>6.3.11.  <a href="#enter-maxusers">Max Users</a>
+</dt>
+<dt>6.3.12.  <a href="#enter-history">Discussion History</a>
+</dt>
+<dt>6.3.13.  <a href="#enter-managehistory">Managing Discussion History</a>
+</dt>
+<dt>6.3.14.  <a href="#enter-locked">Locked Room</a>
+</dt>
+<dt>6.3.15.  <a href="#enter-nonexistent">Nonexistent Room</a>
+</dt>
+</dl>
+<dt>6.4.  <a href="#exit">Exiting a Room</a>
+</dt>
+<dt>6.5.  <a href="#changenick">Changing Nickname</a>
+</dt>
+<dt>6.6.  <a href="#changepres">Changing Availability Status</a>
+</dt>
+<dt>6.7.  <a href="#invite">Inviting Another User to a Room</a>
+</dt>
+<dt>6.8.  <a href="#continue">Converting a One-to-One Chat Into a Conference</a>
+</dt>
+<dt>6.9.  <a href="#subject-occupant">Occupant Modification of the Room Subject</a>
+</dt>
+<dt>6.10.  <a href="#privatemessage">Sending a Private Message</a>
+</dt>
+<dt>6.11.  <a href="#message">Sending a Message to All Occupants</a>
+</dt>
+<dt>6.12.  <a href="#register">Registering with a Room</a>
+</dt>
+<dt>6.13.  <a href="#reservednick">Discovering Reserved Room Nickname</a>
+</dt>
+</dl>
+<dt>7.  <a href="#moderator">Moderator Use Cases</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#subject-mod">Modifying the Room Subject</a>
+</dt>
+<dt>7.2.  <a href="#kick">Kicking a Visitor or Participant from a Room</a>
+</dt>
+<dt>7.3.  <a href="#grantvoice">Granting Voice to a Visitor</a>
+</dt>
+<dt>7.4.  <a href="#revokevoice">Revoking Voice from a Participant</a>
+</dt>
+<dt>7.5.  <a href="#modifyvoice">Modifying the Voice List</a>
+</dt>
+</dl>
+<dt>8.  <a href="#admin">Admin Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#ban">Banning a User</a>
+</dt>
+<dt>8.2.  <a href="#modifyban">Modifying the Ban List</a>
+</dt>
+<dt>8.3.  <a href="#grantmember">Granting Membership</a>
+</dt>
+<dt>8.4.  <a href="#revokemember">Revoking Membership</a>
+</dt>
+<dt>8.5.  <a href="#modifymember">Modifying the Member List</a>
+</dt>
+<dt>8.6.  <a href="#grantmod">Granting Moderator Privileges</a>
+</dt>
+<dt>8.7.  <a href="#revokemod">Revoking Moderator Privileges</a>
+</dt>
+<dt>8.8.  <a href="#modifymod">Modifying the Moderator List</a>
+</dt>
+<dt>8.9.  <a href="#regapprove">Approving Registration Requests</a>
+</dt>
+</dl>
+<dt>9.  <a href="#owner">Owner Use Cases</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#createroom">Creating a Room</a>
+</dt>
+<dl>
+<dt>9.1.1.  <a href="#createroom-general">General Considerations</a>
+</dt>
+<dt>9.1.2.  <a href="#createroom-instant">Creating an Instant Room</a>
+</dt>
+<dt>9.1.3.  <a href="#createroom-reserved">Creating a Reserved Room</a>
+</dt>
+</dl>
+<dt>9.2.  <a href="#roomconfig">Subsequent Room Configuration</a>
+</dt>
+<dt>9.3.  <a href="#grantowner">Granting Ownership Privileges</a>
+</dt>
+<dt>9.4.  <a href="#revokeowner">Revoking Ownership Privileges</a>
+</dt>
+<dt>9.5.  <a href="#modifyowner">Modifying the Owner List</a>
+</dt>
+<dt>9.6.  <a href="#grantadmin">Granting Administrative Privileges</a>
+</dt>
+<dt>9.7.  <a href="#revokeadmin">Revoking Administrative Privileges</a>
+</dt>
+<dt>9.8.  <a href="#modifyadmin">Modifying the Admin List</a>
+</dt>
+<dt>9.9.  <a href="#destroyroom">Destroying a Room</a>
+</dt>
+</dl>
+<dt>10.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#errorcodes">Error Codes</a>
+</dt>
+<dt>10.2.  <a href="#statuscodes">Status Codes</a>
+</dt>
+</dl>
+<dt>11.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>12.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>13.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>14.2.  <a href="#registrar-discocat">Service Discovery Category/Type</a>
+</dt>
+<dt>14.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>14.4.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>14.5.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+<dl>
+<dt>14.5.1.  <a href="#registrar-formtype-register">muc#register FORM_TYPE</a>
+</dt>
+<dt>14.5.2.  <a href="#registrar-formtype-owner">muc#roomconfig FORM_TYPE</a>
+</dt>
+<dt>14.5.3.  <a href="#registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</dt>
+</dl>
+<dt>14.6.  <a href="#registrar-statuscodes">Status Codes Registry</a>
+</dt>
+<dl>
+<dt>14.6.1.  <a href="#registrar-statuscodes-process">Process</a>
+</dt>
+<dt>14.6.2.  <a href="#registrar-statuscodes-init">Initial Submission</a>
+</dt>
+</dl>
+</dl>
+<dt>15.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#bizrules-jids">Addresses</a>
+</dt>
+<dt>15.2.  <a href="#bizrules-message">Message</a>
+</dt>
+<dt>15.3.  <a href="#bizrules-presence">Presence</a>
+</dt>
+<dt>15.4.  <a href="#bizrules-iq">IQ</a>
+</dt>
+</dl>
+<dt>16.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#impl-service">Services</a>
+</dt>
+<dl><dt>16.1.1.  <a href="#impl-service-traffic">Allowable Traffic</a>
+</dt></dl>
+<dt>16.2.  <a href="#impl-client">Clients</a>
+</dt>
+<dl><dt>16.2.1.  <a href="#impl-client-irc">IRC Command Mapping</a>
+</dt></dl>
+</dl>
+<dt>17.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>17.1.  <a href="#schemas-muc">http://jabber.org/protocol/muc</a>
+</dt>
+<dt>17.2.  <a href="#schemas-user">http://jabber.org/protocol/muc#user</a>
+</dt>
+<dt>17.3.  <a href="#schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</dt>
+<dt>17.4.  <a href="#schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</dt>
+</dl>
+<dt>18.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Traditionally, instant messaging is thought to consist of one-to-one chat rather than many-to-many chat, which is called variously "groupchat" or "text conferencing". Groupchat functionality is familiar from systems such as Internet Relay Chat (IRC) and the chatroom functionality offered by popular consumer IM services. The Jabber community developed and implemented a basic groupchat protocol as long ago as 1999. This "groupchat 1.0" protocol provided a minimal feature set for chat rooms but was rather limited in scope. This JEP builds on the older "groupchat 1.0" protocol in a backwards-compatible manner but provides advanced features such as invitations, room moderation and administration, and specialized room types. These extensions are implemented using protocol elements qualified by the 'http://jabber.org/protocol/muc' namespace (and the #owner, #admin, and #user fragments on the main namespace URI).</p>
+<h2>2.
+       <a name="scope">Scope</a>
+</h2>
+  <p class="" style="">This JEP addresses common requirements related to configuration of, participation in, and administration of individual text-based conference rooms. All of the requirements addressed herein apply at the level of the individual room and are "common" in the sense that they have been widely discussed within the Jabber community or are familiar from existing text-based conference environments outside of Jabber (e.g., Internet Relay Chat as defined in <span class="ref" style="">RFC 1459</span>  [<a href="#nt-id2250245">1</a>] and its successors).</p>
+  <p class="" style="">This JEP explicitly does <span style="font-style: italic">not</span> address the following:</p>
+  <ul>
+    <li>Relationships between rooms (e.g., hierarchies of rooms)</li>
+    <li>Management of multi-user chat services (e.g., managing permissions across an entire service or registering a global room nickname)</li>
+    <li>Moderation of individual messages</li>
+    <li>Security and encryption at the level of a room or service</li>
+    <li>Advanced features such as attaching files to a room, integrating whiteboards, and interfacing with audio chat services</li>
+    <li>Interaction between MUC deployments and foreign chat systems (e.g., gateways to IRC or to legacy IM systems)</li>
+  </ul>
+  <p class="" style="">This limited scope is not meant to disparage such topics, which are of inherent interest; however, it is meant to focus the discussion in this JEP and to present a comprehensible proposal that can be implemented by Jabber client and component developers alike. Future JEPs may of course address the topics mentioned above.</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the minimal functionality provided by existing multi-user chat services in Jabber. For the sake of backwards-compatibility, this JEP uses the original "groupchat 1.0" protocol for this baseline functionality, with the result that:</p>
+  <ul>
+    <li>Each room is identified as &lt;room@service&gt; (e.g., &lt;jdev@conference.jabber.org&gt;), where "room" is the name of the room and "service" is the hostname at which the multi-user chat service is running.</li>
+    <li>Each occupant in a room is identified as &lt;room@service/nick&gt;, where "nick" is the room nickname of the occupant as specified on entering the room or subsequently changed during the occupant's visit.</li>
+    <li>A user enters a room (i.e., becomes an occupant) by sending presence to &lt;room@service/nick&gt;.</li>
+    <li>Messages sent within multi-user chat rooms are of a special type "groupchat" and are addressed to the room itself (room@service), then reflected to all occupants.</li>
+    <li>An occupant can change his or her room nickname and availability status within the room by sending presence information to &lt;room@service/newnick&gt;.</li>
+    <li>An occupant exits a room by sending presence of type "unavailable" to its current &lt;room@service/nick&gt;.</li>
+  </ul>
+  <p class="" style="">The additional features and functionality addressed in this JEP include the following:</p>
+  <ol start="1" type="">
+    <li>native conversation logging (no in-room bot required)</li>
+    <li>enabling users to request membership in a room</li>
+    <li>enabling occupants to view an occupant's full JID in a non-anonymous room</li>
+    <li>enabling moderators to view an occupant's full JID in a semi-anonymous room</li>
+    <li>allowing only moderators to change the room subject</li>
+    <li>enabling moderators to kick participants and visitors from the room</li>
+    <li>enabling moderators to grant and revoke voice (i.e., the privilege to speak) in a moderated room, and to manage the voice list</li>
+    <li>enabling admins to grant and revoke moderator privileges, and to manage the moderator list</li>
+    <li>enabling admins to ban users from the room, and to manage the ban list</li>
+    <li>enabling admins to grant and revoke membership privileges, and to manage the member list for a members-only room</li>
+    <li>enabling owners to limit the number of occupants</li>
+    <li>enabling owners to specify other owners</li>
+    <li>enabling owners to grant and revoke administrative privileges, and to manage the admin list</li>
+    <li>enabling owners to destroy the room</li>
+  </ol>
+  <p class="" style="">In addition, this JEP provides protocol elements for supporting the following room types:</p>
+  <ol start="1" type="">
+    <li>public or hidden</li>
+    <li>persistent or temporary</li>
+    <li>password-protected or unsecured</li>
+    <li>members-only or open</li>
+    <li>moderated or unmoderated</li>
+    <li>non-anonymous or semi-anonymous</li>
+  </ol>
+<h2>4.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="terms-general">General Terms</a>
+</h3>
+    <p class="" style="">Affiliation -- a long-lived association or connection with a room; the possible affiliations are "owner", "admin", "member", and "outcast" (naturally it is also possible to have no affiliation); affiliation is distinct from role. An affiliation lasts across a user's visits to a room.</p>
+    <p class="" style="">Ban -- to remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). A banned user has an affiliation of "outcast".</p>
+    <p class="" style="">Bare JID -- the &lt;user@host&gt; by which a user is identified outside the context of any existing session or resource; contrast with Full JID and Room JID.</p>
+    <p class="" style="">Full JID -- the &lt;user@host/resource&gt; by which an online user is identified outside the context of a room; contrast with Bare JID and Room JID.</p>
+    <p class="" style="">GC -- the minimal "groupchat 1.0" protocol  [<a href="#nt-id2256104">2</a>] developed within the Jabber community in 1999; MUC is backwards-compatible with GC.</p>
+    <p class="" style="">History -- a limited number of message stanzas sent to a new occupant to provide the context of current discussion.</p>
+    <p class="" style="">Invitation -- a special message sent from one user to another asking the recipient to join a room.</p>
+    <p class="" style="">IRC -- Internet Relay Chat.</p>
+    <p class="" style="">Kick -- to temporarily remove a participant or visitor from a room; the user is allowed to re-enter the room at any time. A kicked user has a role of "none".</p>
+    <p class="" style="">Logging -- storage of discussions that occur within a room for future retrieval inside or outside the context of the room.</p>
+    <p class="" style="">Member -- a user who is on the "whitelist" for a members-only room or who is registered with an open room. A member has an affiliation of "member".</p>
+    <p class="" style="">Moderator -- a room role that is usually associated with room admins but that may be granted to non-admins; is allowed to kick users, grant and revoke voice, etc. A moderator has an affiliation of "moderator".</p>
+    <p class="" style="">MUC -- the multi-user chat protocol for text-based conferencing specified in this JEP.</p>
+    <p class="" style="">Occupant -- any Jabber user who is in a room (this is an "abstract class" and does not correspond to any specific role).</p>
+    <p class="" style="">Outcast -- a user who has been banned from a room. An outcast has an affiliation of "outcast".</p>
+    <p class="" style="">Participant -- an occupant who does not have administrative privileges; in a moderated room, a participant is further defined as having voice (in contrast to a visitor). A participant has a role of "participant".</p>
+    <p class="" style="">Private Message -- a message sent from one occupant directly to another's room JID (not to the room itself for broadcasting to all occupants).</p>
+    <p class="" style="">Role -- a temporary position or privilege level within a room, distinct from a user's long-lived affiliation with the room; the possible roles are "moderator", "participant", and "visitor" (it is also possible to have no defined role). A role lasts only for the duration of an occupant's visit to a room.</p>
+    <p class="" style="">Room -- a virtual space that Jabber users figuratively enter in order to participate in real-time, text-based conferencing with other users.</p>
+    <p class="" style="">Room Administrator -- a user empowered by the room owner to perform administrative functions such as banning users; however, is not allowed to change defining room features. An admin has an affiliation of "admin".</p>
+    <p class="" style="">Room ID -- the node identifier portion of a Room JID, which may be opaque and thus lack meaning for human users (see Business Rules for syntax); contrast with Room Name.</p>
+    <p class="" style="">Room JID -- the &lt;&lt;room@service/nick&gt;&gt; by which an occupant is identified within the context of a room; contrast with Bare JID and Full JID.</p>
+    <p class="" style="">Room Name -- a user-friendly, natural-language name for a room, configured by the room owner and presented in Service Discovery queries; contrast with Room ID.</p>
+    <p class="" style="">Room Nickname -- the resource identifier portion of a Room JID (see Business Rules for syntax); this is the "friendly name" by which an occupant is known in the room.</p>
+    <p class="" style="">Room Owner -- the Jabber user who created the room or a Jabber user who has been designated by the room creator or owner as someone with owner privileges (if allowed); is allowed to change defining room features as well as perform all administrative functions. An owner has an affiliation of "owner".</p>
+    <p class="" style="">Room Roster -- a Jabber client's representation of the occupants in a room.</p>
+    <p class="" style="">Server -- a Jabber server that may or may not have associated with it a text-based conferencing service.</p>
+    <p class="" style="">Service -- a host that offers text-based conferencing capabilities; often but not necessarily a sub-domain of a Jabber server (e.g., conference.jabber.org).</p>
+    <p class="" style="">Subject -- a temporary discussion topic within a room.</p>
+    <p class="" style="">Visit -- a user's "session" in a room, beginning when the user enters the room (i.e., becomes an occupant) and ending when the user exits the room.</p>
+    <p class="" style="">Visitor -- in a moderated room, an occupant who does not have voice (in contrast to a participant). A visitor has a role of "visitor".</p>
+    <p class="" style="">Voice -- in a moderated room, the privilege to send messages to all occupants.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="terms-rooms">Room Types</a>
+</h3>
+    <p class="" style="">Fully-Anonymous Room -- a room in which the full JIDs or bare JIDs of occupants cannot be discovered by anyone, including room admins and room owners; such rooms are NOT RECOMMENDED or explicitly supported by MUC, but are possible using this protocol if a service implementation offers the appropriate configuration options; contrast with Non-Anonymous Room and Semi-Anonymous Room.</p>
+    <p class="" style="">Hidden Room -- a room that cannot be found by any user through normal means such as searching and service discovery; antonym: Public Room.</p>
+    <p class="" style="">Members-Only Room -- a room that a user cannot enter without being on the member list; antonym: Open Room.</p>
+    <p class="" style="">Moderated Room -- a room in which only those with "voice" may send messages to all occupants; antonym: Unmoderated Room.</p>
+    <p class="" style="">Non-Anonymous Room -- a room in which an occupant's full JID is exposed to all other occupants, although the occupant may choose any desired room nickname; contrast with Semi-Anonymous Room and Fully-Anonymous Room.</p>
+    <p class="" style="">Open Room -- a room that anyone may enter without being on the member list; antonym: Members-Only Room.</p>
+    <p class="" style="">Password-Protected Room -- a room that a user cannot enter without first providing the correct password; antonym: Unsecured Room.</p>
+    <p class="" style="">Persistent Room -- a room that is not destroyed if the last occupant exits; antonym: Temporary Room.</p>
+    <p class="" style="">Public Room -- a room that can be found by any user through normal means such as searching and service discovery; antonym: Hidden Room.</p>
+    <p class="" style="">Semi-Anonymous Room -- a room in which an occupant's full JID can be discovered by room admins only; contrast with Fully-Anonymous Room and Non-Anonymous Room.</p>
+    <p class="" style="">Temporary Room -- a room that is destroyed if the last occupant exits; antonym: Persistent Room.</p>
+    <p class="" style="">Unmoderated Room -- a room in which any occupant is allowed to send messages to all occupants; antonym: Moderated Room.</p>
+    <p class="" style="">Unsecured Room -- a room that anyone is allowed to enter without first providing the correct password; antonym: Password-Protected Room.</p>
+  </div>
+<h2>5.
+       <a name="connections">Roles and Affiliations</a>
+</h2>
+  <p class="" style="">There are two dimensions along which we can measure a user's connection with or position in a room. One is the user's long-lived affiliation with a room -- e.g., a user's status as an owner or an outcast. The other is a user's role while an occupant of a room -- e.g., an occupant's position as a moderator with the ability to kick visitors and participants. These two dimensions are distinct from each other, since an affiliation lasts across visits, while a role lasts only for the duration of a visit. In addition, there is no one-to-one correspondence between roles and affiliations; for example, someone who is not affiliated with a room may be a (temporary) moderator, and a member may be a participant or a visitor in a moderated room. These concepts are explained more fully below.</p>
+  <div class="indent">
+<h3>5.1 <a name="roles">Roles</a>
+</h3>
+    <p class="" style="">There are four defined roles that an occupant may have:</p>
+    <ol start="1" type="">
+      <li>Moderator</li>
+      <li>Participant</li>
+      <li>Visitor</li>
+      <li>None (the absence of a role)</li>
+    </ol>
+    <p class="" style="">These roles are temporary in that they do not persist across a user's visits to the room and MAY change during the course of an occupant's visit to the room. In addition, there is no one-to-one mapping between these roles and a user's affiliation with the room (e.g., a member could be a participant or a visitor).</p>
+    <p class="" style="">A moderator is the most powerful occupant within the context of the room, and can to some extent manage other occupants' roles in the room. A participant has fewer privileges than a moderator, although he or she always has the right to speak. A visitor is a more restricted role within the context of a moderated room, since visitors are not allowed to send messages to all occupants.</p>
+    <p class="" style="">Roles are granted, revoked, and maintained based on the occupant's room nickname or full JID rather than bare JID. The privileges associated with these roles, as well as the actions that trigger changes in roles, are defined below.</p>
+    <p class="" style="">Information about roles MUST be sent in all presence stanzas generated or reflected by the room and thus sent to occupants.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="roles-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, roles exist in a hierarchy. For instance, a participant can do anything a visitor can do, and a moderator can do anything a participant can do. Each role has privileges not possessed by the next-lowest role; these privileges are specified in the following table as defaults (an implementation MAY provide configuration options that override these defaults).</p>
+      <p class="caption">Table 1: Privileges Associated With Roles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Present in Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Receive Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Availability Status</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Nickname</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Private Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Invite Other Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Messages to All</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No**</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Modify Subject</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No*</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Kick Participants and Visitors</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Grant Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Revoke Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes***</td>
+        </tr>
+      </table>
+      <p class="" style="">* Default; configuration settings MAY modify this privilege.</p>
+      <p class="" style="">** An implementation MAY grant voice by default to visitors in unmoderated rooms.</p>
+      <p class="" style="">*** A moderator MUST NOT be able to revoke voice privileges from an admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="roles-change">Changing Roles</a>
+</h3>
+      <p class="" style="">The ways in which an occupant's role changes are well-defined. Sometimes the change results from the occupant's own action (e.g., entering or exiting the room), whereas sometimes the change results from an action taken by a moderator, admin, or owner. If an occupant's role changes, a MUC service implementation MUST change the occupant's role to reflect the change and communicate the change to all occupants. Role changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 2: Role State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">&gt;</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Enter moderated room</td>
+          <td align="" colspan="" rowspan="">Enter unmoderated room</td>
+          <td align="" colspan="" rowspan="">Admin or owner enters room</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Moderator grants voice</td>
+          <td align="" colspan="" rowspan="">Admin or owner grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">Moderator revokes voice</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Exit room</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes role to visitor *</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes role to participant or revokes moderator privileges *</td>
+          <td align="" colspan="" rowspan="">--</td>
+        </tr>
+      </table>
+      <p class="" style="">* A moderator MUST NOT be able to revoke moderator privileges from an occupant who is equal to or above the moderator in the hierarchy of affiliations.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="affil">Affiliations</a>
+</h3>
+    <p class="" style="">There are five defined affiliations that a user may have in relation to a room:</p>
+    <ol start="1" type="">
+      <li>Owner</li>
+      <li>Admin</li>
+      <li>Member</li>
+      <li>Outcast</li>
+      <li>None (the absence of an affiliation)</li>
+    </ol>
+    <p class="" style="">These affiliations are long-lived in that they persist across a user's visits to the room and are not affected by happenings in the room. In addition, there is no one-to-one mapping between these affiliations and an occupant's role within the room. Affiliations are granted, revoked, and maintained based on the user's bare JID.</p>
+    <p class="" style="">If a user without a defined affiliation enters a room, the user's affiliation is defined as "none"; however, this affiliation does not persist across visits (i.e., a service does not maintain a "none list" across visits).</p>
+    <p class="" style="">The member affiliation provides a way for a room owner or admin to specify a "whitelist" of users who are allowed to enter a members-only room. When a member enters a members-only room, his or her affiliation does not change, no matter what his or her role is. The member affiliation also provides a way for users to effectively register with an open room and thus be lastingly associated with that room in some way (one result may be that the user's nickname is reserved in the room).</p>
+    <p class="" style="">An outcast is a user who has been banned from a room and who is not allowed to enter the room.</p>
+    <p class="" style="">Information about affiliations MUST be sent in all presence stanzas generated or reflected by the room and sent to occupants.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="affil-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, affiliations exist in a hierarchy. For instance, an owner can do anything an admin can do, and an admin can do anything a member can do. Each affiliation has privileges not possessed by the next-lowest affiliation; these privileges are specified in the following table.</p>
+      <p class="caption">Table 3: Privileges Associated With Affiliations</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Register with an Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">N/A</td>
+          <td align="" colspan="" rowspan="">N/A</td>
+          <td align="" colspan="" rowspan="">N/A</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Members-Only Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Ban Members and Unaffiliated Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Member List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Moderator List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Admin List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Owner List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Definition</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Destroy Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+      </table>
+      <p class="" style="">* As a default, an unaffiliated user enters a moderated room as a visitor, and enters an open room as a participant. A member enters a room as a participant. An admin or owner enters a room as a moderator.</p>
+      <p class="" style="">** An admin or owner MUST NOT be able to revoke moderation privileges from another admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="affil-change">Changing Affiliations</a>
+</h3>
+      <p class="" style="">The ways in which a user's affiliation changes are well-defined. Sometimes the change results from the user's own action (e.g., registering as a member of the room), whereas sometimes the change results from an action taken by an admin or owner. If a user's affiliation changes, a MUC service implementation MUST change the user's affiliation to reflect the change and communicate that to all occupants. Affiliation changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 4: Affiliation State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">&gt;</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Outcast</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner removes ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to member list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to member list, or user registers as member (if allowed)</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Member</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes affiliation to "none"</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Admin</td>
+          <td align="" colspan="" rowspan="">Owner applies ban</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "none"</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "member"</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Owner</td>
+          <td align="" colspan="" rowspan="">Owner applies ban</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "none"</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "member"</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "admin"</td>
+          <td align="" colspan="" rowspan="">--</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+<h2>6.
+       <a name="user">Occupant Use Cases</a>
+</h2>
+  <p class="" style="">The main actor in a multi-user chat environment is the occupant, who can be said to be located "in" a multi-user chat room and to participate in the discussions held in that room (for the purposes of this JEP, participants and visitors are considered to be "mere" occupants, since they possess no administrative privileges). As will become clear, the protocol elements proposed in this JEP to fulfill the occupant use cases fall into three categories:</p>
+  <ol start="1" type="">
+    <li><p class="" style="">existing "groupchat 1.0" protocol for minimal functionality</p></li>
+    <li><p class="" style="">straightforward applications of the "groupchat 1.0" protocol, for example to handle some of the errors related to new room types</p></li>
+    <li><p class="" style="">additional protocol elements to handle functionality not covered by "groupchat 1.0" (room invites, room passwords, extended presence related to room roles and affiliations); these are qualified by the 'http://jabber.org/protocol/muc#user' namespace</p></li>
+  </ol>
+  <p class="" style="">Note: All client-generated examples herein are presented from the perspective of the service, with the result that all stanzas received by a service contain a 'from' attribute corresponding to the sender's full JID as added by a normal Jabber router or session manager. In addition, normal IQ result stanzas sent upon successful completion of a request (as required by <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2259172">3</a>]) are not shown. Most of the examples in this document use the scenario of the witches' meeting held in a dark cave at the beginning of Act IV, Scene I of Shakespeare's <span style="font-style: italic">Macbeth</span>, represented here as the "darkcave@macbeth.shakespeare.lit" chatroom. The characters are as follows:</p>
+  <p class="caption">Table 5: Dramatis Personae</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Room Nickname</th>
+      <th colspan="" rowspan="">Full JID</th>
+      <th colspan="" rowspan="">Affiliation</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">firstwitch</td>
+      <td align="" colspan="" rowspan="">crone1@shakespeare.lit/desktop</td>
+      <td align="" colspan="" rowspan="">Owner</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">secondwitch</td>
+      <td align="" colspan="" rowspan="">wiccarocks@shakespeare.lit/laptop</td>
+      <td align="" colspan="" rowspan="">Admin</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">thirdwitch</td>
+      <td align="" colspan="" rowspan="">hag66@shakespeare.lit/pda</td>
+      <td align="" colspan="" rowspan="">None</td>
+    </tr>
+  </table>
+  <div class="indent">
+<h3>6.1 <a name="discovery">Discovering Component Support for MUC</a>
+</h3>
+    <p class="" style="">Before entering a room, a Jabber user may want to discover if the room implements the Multi-User Chat protocol.</p>
+    <p class="" style="">A MUC implementation MUST support <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259349">4</a>].</p>
+    <p class="caption">Example 1. User Queries Chat Service for MUC Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco1'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST return its identity and the features it supports:</p>
+    <p class="caption">Example 2. Service Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='Macbeth Chat Service'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Because MUC is a superset of the old "groupchat 1.0" protocol, a MUC service SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result.</p>
+    <p class="" style="">The disco protocol also enables a user to query a service for a list of associated items, which in the case of a chat service would mainly consist of the specific chat rooms hosted by the service.</p>
+    <p class="caption">Example 3. User Queries Chat Service for Associated Items</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco2'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Returns Disco Item Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='heath@macbeth.shakespeare.lit'
+          name='A Lonely Heath'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='A Dark Cave'/&gt;
+    &lt;item jid='forres@macbeth.shakespeare.lit'
+          name='The Palace'/&gt;
+    &lt;item jid='inverness@macbeth.shakespeare.lit'
+          name='Macbeth&amp;apos;s Castle'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Using disco, a user may also query a specific chat room for more detailed information about the room:</p>
+    <p class="caption">Example 5. User Queries for Information about a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The room MUST return its identity and SHOULD return the features it supports:</p>
+    <p class="caption">Example 6. Room Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Because MUC is a superset of the old "groupchat 1.0" protocol, a MUC room SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result. The room SHOULD return the materially-relevant features it supports, such as password protection and room moderation (these are listed fully in the feature registry maintained by the Jabber Registrar; see also the <a href="#registrar">Jabber Registrar</a> section of this document).</p>
+    <p class="" style="">A chatroom MAY return more detailed information in its disco#info response using <span class="ref" style="">Service Discovery Extensions</span>  [<a href="#nt-id2259520">5</a>], identified by inclusion of a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/muc#roominfo". Such information might include a more verbose description of the room, the current room subject, and the current number of occupants in the room:</p>
+    <p class="caption">Example 7. Room Returns Extended Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3a'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roominfo&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_description' label='Description'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_subject' label='Subject'&gt;
+        &lt;value&gt;Spells&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_occupants' label='Number of occupants'&gt;
+        &lt;value&gt;3&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_lang' label='Language of discussion'&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The foregoing extended service discovery fields for the 'http://jabber.org/protocol/muc#roominfo' FORM_TYPE may be supplemented in the future via the mechanisms described in the <a href="#registrar-formtype">Field Standardization</a> section of this document.</p>
+    <p class="" style="">Finally, a user MAY also query a specific chat room for its associated items:</p>
+    <p class="caption">Example 8. User Queries for Items Associated with a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">An implementation MAY return a list of existing occupants if that information is publicly available, or return no list at all if this information is kept private.</p>
+    <p class="caption">Example 9. Room Returns Disco Item Results (Items are Public)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/firstwitch'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: These &lt;item/&gt; elements are qualified by the disco#items namespace, not the muc namespace; this means that they cannot possess 'affiliation' or 'role' attributes, for example.</p>
+    <p class="caption">Example 10. Room Returns Empty Disco Item Results (Items are Private)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a non-occupant attempts to send a disco request to an address of the form &lt;&lt;room@service/nick&gt;&gt;, a MUC service SHOULD return the request to the entity and specify a &lt;bad-request/&gt; error condition. If an occupant sends such a request, the service MAY pass it through the intended recipient; see the <a href="#impl">Implementation Guidelines</a> section of this document for details.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="discovery-client">Discovering Client Support for MUC</a>
+</h3>
+    <p class="" style="">A Jabber user may want to discover if one of the user's contacts supports the Multi-User Chat protocol. This is done using Service Discovery.</p>
+    <p class="caption">Example 11. User Queries Contact Regarding MUC Support</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco5'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client SHOULD return its identity and the features it supports:</p>
+    <p class="caption">Example 12. Contact Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='disco5'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='client'
+        type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A user may also query a contact regarding which rooms the contact is in. This is done by querying the contact's full JID (&lt;user@host/resource&gt;) while specifying the well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms':</p>
+    <p class="caption">Example 13. User Queries Contact for Current Rooms</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='rooms1'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Contact Returns Room Query Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='rooms1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'/&gt;
+    &lt;item jid='characters@conference.shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Optionally, the contact MAY include its roomnick as the value of the 'name' attribute:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+    ...
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='secondwitch'/&gt;
+    ...
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="enter">Entering a Room</a>
+</h3>
+    <div class="indent">
+<h3>6.3.1 <a name="enter-gc">Groupchat 1.0 Protocol</a>
+</h3>
+      <p class="" style="">In order to participate in the discussions held in a multi-user chat room, a Jabber user MUST first become an occupant by entering the room. In the old "groupchat 1.0" protocol, this was done by sending presence to &lt;room@service/nick&gt;, where "room" is the room ID, "service" is the hostname of the chat service, and "nick" is the user's desired nickname within the room:</p>
+      <p class="caption">Example 15. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'/&gt;
+      </pre></div>
+      <p class="" style="">In this example, a user with a full JID of "hag66@shakespeare.lit/pda" has requested to enter the room "darkcave" on the "macbeth.shakespeare.lit" chat service with a room nickname of "thirdwitch".</p>
+      <p class="" style="">If the user does not specify a room nickname, the service SHOULD return a &lt;jid-malformed/&gt; error:</p>
+      <p class="caption">Example 16. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;jid-malformed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.2 <a name="enter-muc">Basic MUC Protocol</a>
+</h3>
+      <p class="" style="">Compliant multi-user chat services MUST accept the foregoing as a request to enter a room from any Jabber client that knows either the "groupchat 1.0" (GC) protocol or the multi-user chat (MUC) protocol; however, MUC clients SHOULD signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
+      <p class="caption">Example 17. Jabber User Seeks to Enter a Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.3 <a name="enter-pres">Presence Broadcast</a>
+</h3>
+      <p class="" style="">If the service is able to add the user to the room, it MUST send presence from all the existing occupants' room JIDs to the new occupant's full JID, including extended presence information about roles in an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "moderator", "participant", "visitor", or "none" and with the 'affiliation' attribute set to a value of "owner", "admin", "member", or "none" as appropriate:</p>
+      <p class="caption">Example 18. Service Sends Presence from Existing Occupants to New Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, the user from the previous example has entered the room, by which time two other people had already entered the room: a user with a room nickname of "firstwitch" (who is a room owner) and a user with a room nickname of "secondwitch" (who is a room admin).</p>
+      <p class="" style="">The service MUST also send presence from the new occupant's room JID to the full JIDs of all the occupants (including the new occupant):</p>
+      <p class="caption">Example 19. Service Sends New Occupant's Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, initial room presence is being sent from the new occupant (thirdwitch) to all occupants, including the new occupant.</p>
+      <p class="" style="">The order of the presence stanzas sent to the new occupant is important. The service MUST first send the complete list of the existing occupants to the new occupant and only then send the new occupant's own presence to the new occupant. This helps the client know when it has received the complete "room roster".</p>
+    </div>
+    <div class="indent">
+<h3>6.3.4 <a name="enter-roles">Default Roles</a>
+</h3>
+      <p class="" style="">The following table summarizes the initial default roles that a service should set based on the user's affiliation (there is no role associated with the "outcast" affiliation, since such users are not allowed to enter the room).</p>
+      <p class="caption">Table 6: Initial Role Based on Affiliation</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Room Type</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderated</td>
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Unmoderated</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Members-Only</td>
+          <td align="" colspan="" rowspan="">N/A *</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Open</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+      </table>
+      <p class="" style="">* Entry is not permitted.</p>
+    </div>
+    <div class="indent">
+<h3>6.3.5 <a name="enter-nonanon">Non-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is non-anonymous, the service MUST send the new occupant's full JID to all occupants using extended presence information in an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with a 'jid' attribute specifying the occupant's full JID:</p>
+      <p class="caption">Example 20. Service Sends Full JID to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+      </pre></div>
+      <p class="" style="">If the user is entering a room that is non-anonymous (i.e., which informs all occupants of each occupant's full JID as shown above), the service SHOULD allow the user to enter the room but MAY warn the user that the room is not anonymous; this is done by sending a message of type "groupchat" to the new occupant containing an &lt;x/&gt; child with a &lt;status/&gt; element that has the 'code' attribute set to a value of "100":</p>
+      <p class="caption">Example 21. Service Warns New Occupant About Lack of Anonymity</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;This room is not anonymous.&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;status code='100'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality).</p>
+    </div>
+    <div class="indent">
+<h3>6.3.6 <a name="enter-semianon">Semi-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is semi-anonymous, the service MUST send the new occupant's full JID in the format shown above only to those occupants with a role of "moderator".</p>
+      <p class="" style="">(Note: All subsequent examples include the 'jid' attribute for each &lt;item/&gt; element, even though this information is not sent to non-moderators in semi-anonymous rooms.)</p>
+    </div>
+    <div class="indent">
+<h3>6.3.7 <a name="enter-pw">Password-Protected Rooms</a>
+</h3>
+      <p class="" style="">If the room requires a password and the user did not supply one (or the password provided is incorrect), the service MUST deny access to the room and inform the user that they are unauthorized; this is done by returning a presence stanza of type "error" specifying a &lt;not-authorized/&gt; error:</p>
+      <p class="caption">Example 22. Service Denies Access Because No Password Provided</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Passwords SHOULD be supplied with the presence stanza sent when entering the room, contained within an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace and containing a &lt;password/&gt; child. Passwords are to be sent as cleartext; no other authentication methods are supported at this time, and any such authentication or authorization methods shall be defined in a separate specification (see the <a href="#security">Security Considerations</a> section of this document).</p>
+      <p class="caption">Example 23. User Provides Password On Entering a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.8 <a name="enter-members">Members-Only Rooms</a>
+</h3>
+      <p class="" style="">If the room is members-only but the user is not on the member list, the service MUST deny access to the room and inform the user that they are not allowed to enter the room; this is done by returning a presence stanza of type "error" specifying a &lt;registration-required/&gt; error condition:</p>
+      <p class="caption">Example 24. Service Denies Access Because User Is Not on Member List</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='407' type='auth'&gt;
+    &lt;registration-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.9 <a name="enter-banned">Banned Users</a>
+</h3>
+      <p class="" style="">If the user has been banned from the room (i.e., has an affiliation of "outcast"), the service MUST deny access to the room and inform the user of the fact that he or she is banned; this is done by returning a presence stanza of type "error" specifying a &lt;forbidden/&gt; error condition:</p>
+      <p class="caption">Example 25. Service Denies Access Because User is Banned</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.10 <a name="enter-conflict">Nickname Conflict</a>
+</h3>
+      <p class="" style="">If the room already contains an occupant with the nickname desired by the user seeking to enter the room (or if the nickname is reserved by a user on the member list), the service MUST deny access to the room and inform the user of the conflict; this is done by returning a presence stanza of type "error" specifying a &lt;conflict/&gt; error condition:</p>
+      <p class="caption">Example 26. Service Denies Access Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.11 <a name="enter-maxusers">Max Users</a>
+</h3>
+      <p class="" style="">If the room has reached its maximum number of uses, the service SHOULD deny access to the room and inform the user of the restriction; this is done by returning a presence stanza of type "error" specifying a &lt;service-unavailable/&gt; error condition:</p>
+      <p class="caption">Example 27. Service Informs User that Room Occupant Limit Has Been Reached</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='503' type='wait'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Alternatively, the room could kick an "idle user" in order to free up space. Also, a room MUST always allow entry by a room admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>6.3.12 <a name="enter-history">Discussion History</a>
+</h3>
+      <p class="" style="">After sending initial presence as shown above, a room MAY send discussion history to the new occupant. Whether such history is sent, and how many messages comprise the history, shall be determined by the chat service implementation or specific deployment.</p>
+      <p class="caption">Example 28. Delivery of Discussion History</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20021013T23:58:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20021013T23:58:43'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries 'Tis time, 'tis time.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='hag66@shakespeare.lit/pda'
+     stamp='20021013T23:58:49'/&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">Discussion history messages SHOULD be stamped with extended information qualified by the 'jabber:x:delay' namespace (see <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2260620">6</a>]) to indicate that they are sent with delayed delivery. The 'from' attribute SHOULD be the full JID of the original sender in non-anonymous rooms, but MUST NOT be in semi-anonymous rooms (the 'from' attribute SHOULD be set to the room JID in semi-anonymous rooms). The service SHOULD send all discussion history messages before delivering any "live" messages sent after the user enters the room.</p>
+    </div>
+    <div class="indent">
+<h3>6.3.13 <a name="enter-managehistory">Managing Discussion History</a>
+</h3>
+      <p class="" style="">A user MAY want to manage the amount of discussion history provided on entering a room (perhaps because the user is on a low-bandwidth connection or is using a small-footprint client). This MUST be accomplished by including a &lt;history/&gt; child in the initial presence stanza sent when joining the room. There are four allowable attributes for this element:</p>
+      <p class="caption">Table 7: History Management Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Attribute</th>
+          <th colspan="" rowspan="">Datatype</th>
+          <th colspan="" rowspan="">Meaning</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxchars</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of characters in the history to "X" (where the character count is the characters of the complete XML stanzas, not only their XML character data).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxstanzas</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of messages in the history to "X".</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">seconds</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Send only the messages received in the last "X" seconds.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">since</td>
+          <td align="" colspan="" rowspan="">dateTime</td>
+          <td align="" colspan="" rowspan="">Send only the messages received since the datetime specified (which MUST conform to the DateTime profile specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2260811">7</a>]).</td>
+        </tr>
+      </table>
+      <p class="" style="">The service MUST send the smallest amount of traffic that meets any combination of the above criteria, taking into account service-level and room-level defaults. The service MUST send complete message stanzas only (i.e., it MUST not literally truncate the history at a certain number of characters, but MUST send the largest number of complete stanzas that results in a number of characters less than or equal to the 'maxchars' value specified). If the client wishes to receive no history, it MUST set the 'maxchars' attribute to a value of "0" (zero).</p>
+      <p class="" style="">The following examples illustrate the use of this protocol.</p>
+      <p class="caption">Example 29. User Requests Limit on Number of Messages in History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxstanzas='20'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 30. User Requests History in Last 3 Minutes</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history seconds='180'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 31. User Requests All History Since the Beginning of the Unix Era</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history since='1970-01-01T00:00Z'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Obviously the service SHOULD NOT return all messages sent in the room since the beginning of the Unix era, and SHOULD appropriately limit the amount of history sent to the user based on service or room defaults.</p>
+      <p class="caption">Example 32. User Requests No History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxchars='0'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.14 <a name="enter-locked">Locked Room</a>
+</h3>
+      <p class="" style="">If a user attempts to enter a room while it is "locked" (i.e., before the room creator provides an initial configuration and therefore before the room officially exists), the service MUST refuse entry and return an &lt;item-not-found/&gt; error to the user:</p>
+      <p class="caption">Example 33. Service Denies Access Because Room Does Not Exist</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.15 <a name="enter-nonexistent">Nonexistent Room</a>
+</h3>
+      <p class="" style="">If the room does not already exist when the user seeks to enter it, the service SHOULD create it; however, this is not required, since an implementation or deployment MAY choose to restrict the privilege of creating rooms. For details, see the <a href="#createroom">Creating a Room</a> section of this document.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="exit">Exiting a Room</a>
+</h3>
+    <p class="" style="">In order to exit a multi-user chat room, an occupant sends a presence stanza of type "unavailable" to the &lt;room@service/nick&gt; it is currently using in the room.</p>
+    <p class="caption">Example 34. Occupant Exits a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send presence stanzas of type "unavailable" from the departing occupant's room JID to the full JIDs of the departing occupant and of the remaining occupants:</p>
+    <p class="caption">Example 35. Service Sends Presence Related to Departure of Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Presence stanzas of type "unavailable" reflected by the room MUST contain extended presence information about roles and affiliations, and MAY also contain normal &lt;show/&gt; and &lt;status/&gt; information (this last enables occupants to provide custom exit messages if desired).</p>
+    <p class="caption">Example 36. Custom Exit Message</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'
+    type='unavailable'&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Normal presence stanza generation rules apply as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2261053">8</a>], so that if the user sends a general unavailable presence stanza, the user's server will broadcast that stanza to the &lt;room@service/nick&gt; to which the user's client has sent directed presence.</p>
+    <p class="" style="">If the room is not persistent and this occupant is the last to exit, the service is responsible for destroying the room.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="changenick">Changing Nickname</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability for an occupant to change his or her nickname within the room. In MUC this is done by sending updated presence information to the room, specifically by sending presence to a new room JID in the same room (changing only the resource identifier in the room JID).</p>
+    <p class="caption">Example 37. Occupant Changes Nickname</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'/&gt;
+    </pre></div>
+    <p class="" style="">The service then sends two presence stanzas to the full JID of each occupant (including the occupant who is changing his or her room nickname), one of type "unavailable" for the old nickname and one indicating availability for the new nickname. The unavailable presence MUST contain the new nickname and an appropriate status code (namely 303) as extended presence information in an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace so that Jabber clients are able to provide relevant hints to occupants regarding the nickname change if desired.</p>
+    <p class="caption">Example 38. Service Updates Nick</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If the user attempts to change his or her room nickname to a room nickname that is already in use by another occupant (or that is reserved by someone affiliated with the room, e.g., a member or owner), the service MUST deny the nickname change request and inform the user of the conflict; this is done by returning a presence stanza of type "error" specifying a &lt;conflict/&gt; error condition:</p>
+    <p class="caption">Example 39. Service Denies Nickname Change Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="changepres">Changing Availability Status</a>
+</h3>
+    <p class="" style="">In multi-user chat systems such as IRC, one common use for changing one's room nickname is to indicate a change in one's availability (e.g., changing one's room nickname to "thirdwitch|away"). In Jabber, availability is of course noted by a change in presence (specifically the &lt;show/&gt; and &lt;status/&gt; elements), which can provide important context within a chatroom. An occupant changes availability status within the room by sending the updated presence to its &lt;room@service/nick&gt;.</p>
+    <p class="caption">Example 40. Occupant Changes Availability Status</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The service then sends a presence stanza from the occupant changing his or her presence to the full JID of each occupant, including extended presence information about the occupant's role and full JID to those with privileges to view such information:</p>
+    <p class="caption">Example 41. Service Passes Along Changed Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="invite">Inviting Another User to a Room</a>
+</h3>
+    <p class="" style="">It can be useful to invite another user to a room in which one is an occupant. Several different mechanisms have been suggested in the past to do this. One existing protocol is for the inviting occupant to send a message directly to the invitee, containing extended content qualified by the 'jabber:x:conference' namespace. The server (not the chat service) adds a 'from' address to the invite message, which is delivered like any other message. This undocumented protocol, which is <span style="font-style: italic">not</span> part of "groupchat 1.0", is as follows:</p>
+    <p class="caption">Example 42. Occupant Sends an Invitation (Not Recommended)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;body&gt;You have been invited to darkcave@macbeth.&lt;/body&gt;
+    &lt;x jid='room@service' xmlns='jabber:x:conference'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While the current protocol meets the needs of "groupchat 1.0" implementations, it could not work within the context of a members-only room, since the service needs to keep track of who is registered as a member. Because we would like to support members-only rooms, it seems desirable for an occupant to send the invitation to the &lt;room@service&gt; itself and have the room keep track of the invitations (if the room is members-only) or simply forward the invitation to the invitee.</p>
+    <p class="" style="">Therefore the old undocumented protocol SHOULD NOT be used (it cannot be deprecated since it was never approved) and a MUC client MUST send XML of the following form to the &lt;room@service&gt; itself (the reason is OPTIONAL and the message MUST NOT possess a 'type' attribute; the service MAY ignore or reject invites that possess a 'type' attribute):</p>
+    <p class="caption">Example 43. Occupant Sends an Invitation by Way of Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The &lt;room@service&gt; itself MUST then add a 'from' address to the &lt;invite/&gt; element whose value is the bare JID (or, optionally, the room JID) of the invitor and send the invitation to the invitee captured in the 'to' address (the service SHOULD include a message body explaining the invitation or containing the reason, for the sake of older clients; in addition, the room SHOULD add the password if the room is password-protected) and MAY include the old jabber:x:conference extension as well for backwards-compatibility:</p>
+    <p class="caption">Example 44. Room Sends Invitation to Invitee on Behalf of Invitor</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;body&gt;You have been invited to darkcave@macbeth by crone1@shakespeare.lit.&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+  &lt;x jid='darkcave@macbeth.shakespeare.lit' xmlns='jabber:x:conference'&gt;
+    Hey Hecate, this is the place for all good witches!
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MAY also add the invitee to the member list. (Note: Invitation privileges in members-only rooms SHOULD be restricted to room admins; if a member without privileges to edit the member list attempts to invite another user, the service SHOULD return a &lt;forbidden/&gt; error to the occupant; for details, see the <a href="#modifymember">Modifying the Member List</a> section of this document.)</p>
+    <p class="" style="">If the invitor supplies a non-existent JID, the room SHOULD return an &lt;item-not-found/&gt; error to the invitor.</p>
+    <p class="" style="">The invitee MAY choose to formally decline (as opposed to ignore) the invitation; and this is something that the sender may want to be informed about. In order to decline the invitation, the invitee MUST send a message of the following form to the &lt;room@service&gt; itself:</p>
+
+    <p class="caption">Example 45. Invitee Declines Invitation</p>
+<div class="indent"><pre>
+&lt;message
+    from='hecate@shakespeare.lit/broom'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline to='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 46. Room Informs Invitor that Invitation Was Declined</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline from='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">It may be wondered why the invitee does not send the decline message directly to the invitor. The main reason is that certain implementations MAY choose to base invitations on room JIDs rather than bare JIDs (so that, for example, an occupant could invite someone from one room to another without knowing that person's bare JID). Thus the service MUST handle both the invites and declines.</p>
+  </div>
+  <div class="indent">
+<h3>6.8 <a name="continue">Converting a One-to-One Chat Into a Conference</a>
+</h3>
+    <p class="" style="">Sometimes it is desirable to convert a one-to-one chat into a multi-user conference. The process flow is shown in the following examples.</p>
+    <p class="" style="">First, two users begin a one-to-one chat.</p>
+    <p class="caption">Example 47. A One-to-One Chat</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='chat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Now the first person decides to include a third person in the discussion, so she (or, more precisely, her client) does the following:</p>
+    <ol start="1" type="">
+      <li>Creates a new room (which SHOULD be non-anonymous and MAY be an instant room as specified below)</li>
+      <li>Optionally sends history of the one-to-one chat to the room</li>
+      <li>Sends an invitation to the second person and the third person, including a &lt;continue/&gt; flag.</li> 
+    </ol>
+    <p class="caption">Example 48. Continuing the Discussion I: User Creates Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 49. Continuing the Discussion II: Owner Sends History to Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20040929T01:54:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20040929T01:55:21'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Use of the <span style="font-weight: bold">Delayed Delivery</span> protocol enables the room creator to specify the datetime of each message from the one-to-one chat history (via the 'stamp' attribute), as well as the JID of the original sender of each message (via the 'from' attribute). The room creator SHOULD send the complete one-to-one chat history before inviting additional users to the room, and SHOULD also send as history any messages appearing in the one-to-one chat interface after joining the room and before the second person joins the room; if the one-to-one history is especially large, the sending client may want to send the history over a few seconds rather than all at once (to avoid triggering rate limits). The service SHOULD NOT add its own delay elements (as described in the <a href="#enter-history">Discussion History</a> section of this document) to prior chat history messages received from the room owner.</p>
+    <p class="caption">Example 50. Continuing the Discussion III: Owner Sends Invitations, Including Continue Flag</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='wiccarocks@shakespeare.lit/laptop'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+    &lt;invite to='hag66@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Since the invitor's client knows the full JID of the person with whom the invitor was having a one-to-one chat, it SHOULD include the full JID (rather than the bare JID) in the invitation.</p>
+    <p class="" style="">The invitations are delivered to the invitees:</p>
+    <p class="caption">Example 51. Invitations Delivered</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'&gt;
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'&gt;
+    to='hag66@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When the client being used by &lt;wiccarocks@shakespeare.lit/laptop&gt; receives the invitation, it SHOULD auto-join the room or prompt the user whether to join (subject to user preferences) and then seamlessly convert the existing one-to-one chat window into a multi-user conferencing window:</p>
+    <p class="caption">Example 52. Invitee Accepts Invitation, Joins Room, and Receives Presence and History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/secondwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20040929T01:54:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20040929T01:55:21'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: The fact that the messages come from the &lt;room@service&gt; itself rather than &lt;room@service/nick&gt; is a clue to the receiving client that these messages are prior chat history, since any message from a room occupant will have a 'from' address equal to the sender's room JID.</p>
+  </div>
+  <div class="indent">
+<h3>6.9 <a name="subject-occupant">Occupant Modification of the Room Subject</a>
+</h3>
+    <p class="" style="">If allowed in accordance with room configuration, a mere occupant MAY be allowed to change the subject in a room. For details, see the <a href="#subject-mod">Modifying the Room Subject</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>6.10 <a name="privatemessage">Sending a Private Message</a>
+</h3>
+    <p class="" style="">Since each occupant has a unique room JID, an occupant MAY send a "private message" to a selected occupant via the service by sending a message to the occupant's room JID. The message type SHOULD be "chat" and MUST NOT be "groupchat", but MAY be left unspecified (i.e., a normal message). This privilege SHOULD be allowed to any occupant (even a visitor in a moderated room).</p>
+    <p class="caption">Example 53. Occupant Sends Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for changing the 'from' address to the sender's room JID and delivering the message to the intended recipient's full JID.</p>
+    <p class="caption">Example 54. Recipient Receives the Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message of type "groupchat" to a particular occupant, the service MUST refuse to deliver the message (since the recipient's client would expect in-room messages to be of type "groupchat") and return a &lt;bad-request/&gt; error to the sender:</p>
+    <p class="caption">Example 55. Occupant Attempts to Send a Message of Type "Groupchat" to a Particular Occupant</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='groupchat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message to a room JID that does not exist, the service MUST return an &lt;item-not-found/&gt; error to the sender.</p>
+    <p class="" style="">If the sender is not an occupant of the room in which the intended recipient is visiting, the service MUST return a &lt;not-acceptable/&gt; error to the sender.</p>
+  </div>
+  <div class="indent">
+<h3>6.11 <a name="message">Sending a Message to All Occupants</a>
+</h3>
+    <p class="" style="">An occupant sends a message to all other occupants in the room by sending a message of type "groupchat" to the &lt;room@service&gt; itself (a service MAY ignore or reject messages that do not have a type of "groupchat"). In a moderated room, this privilege is restricted to occupants with a role of participant or higher.</p>
+    <p class="caption">Example 56. Occupant Sends a Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender has voice in the room (this is the default except in moderated rooms), the service MUST change the 'from' attribute to the sender's room JID and reflect the message out to the full JID of each occupant.</p>
+    <p class="caption">Example 57. Service Reflects Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender is a visitor (i.e., does not have voice in a moderated room), the service MAY return a &lt;forbidden/&gt; error to the sender and MUST NOT reflect the message to all occupants. If the sender is not an occupant of the room, the service SHOULD return a &lt;not-acceptable/&gt; error to the sender and SHOULD NOT reflect the message to all occupants; the only exception to this rule is that an implementation MAY allow users with certain privileges (e.g., a room owner, room admin, or service-level admin) to send messages to the room even if those users are not occupants.</p>
+  </div>
+  <div class="indent">
+<h3>6.12 <a name="register">Registering with a Room</a>
+</h3>
+    <p class="" style="">An implementation MAY allow an unaffiliated user (in a moderated room, probably a participant) to register with a room and thus become a member of the room (conversely, an implementation MAY restrict this privilege and allow only room admins to add new members). If allowed, this functionality SHOULD be implemented by enabling a user to send a request for registration requirements to the room qualified by the 'jabber:iq:register' namespace as described in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2262006">9</a>]:</p>
+    <p class="caption">Example 58. User Requests Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user requesting registration requirements is not allowed to register with the room (e.g., because that privilege has been restricted), the room MUST return a &lt;not-allowed/&gt; error to the user. If the user is already registered, the room MUST reply with an IQ stanza of type "result" that contains an empty &lt;register/&gt; element as described in JEP-0077. If the room does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="" style="">Otherwise, the room MUST then return a Data Form to the user (as described in <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2262026">10</a>]). The information required to register MAY vary by implementation or deployment and is not fully specified in this JEP (e.g., the fields registered by this JEP for the 'http://jabber.org/protocol/muc#register' FORM_TYPE may be supplemented in the future via the mechanisms described in the <a href="#registrar-formtype">Field Standardization</a> section of this document). The following can be taken as a fairly typical example:</p>
+    <p class="caption">Example 59. Service Returns Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      To register on the web, visit http://shakespeare.lit/
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Dark Cave Registration&lt;/title&gt;
+      &lt;instructions&gt;
+        Please provide the following information
+        to register with this room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='First Name'
+          type='text-single'
+          var='muc#register_first'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Last Name'
+          type='text-single'
+          var='muc#register_last'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Desired Nickname'
+          type='text-single'
+          var='muc#register_roomnick'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Your URL'
+          type='text-single'
+          var='muc#register_url'/&gt;
+      &lt;field
+          label='Email Address'
+          type='text-single'
+          var='muc#register_email'/&gt;
+      &lt;field
+          label='FAQ Entry'
+          type='text-multi'
+          var='muc#register_faqentry'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The user SHOULD then submit the form:</p>
+    <p class="caption">Example 60. User Submits Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_first'&gt;
+        &lt;value&gt;Brunhilde&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_last'&gt;
+        &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_roomnick'&gt;
+        &lt;value&gt;thirdwitch&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_url'&gt;
+        &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_email'&gt;
+        &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_faqentry'&gt;
+        &lt;value&gt;Just another witch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the desired room nickname is already reserved for that room, the room MUST return a &lt;conflict/&gt; error to the user:</p>
+    <p class="caption">Example 61. Room Returns Conflict Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room or service does not support registration, it MUST return a &lt;service-unavailable/&gt; error to the user:</p>
+    <p class="caption">Example 62. Room Returns Service Unavailable Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user did not include a valid data form, the room MUST return a &lt;bad-request/&gt; error to the user:</p>
+    <p class="caption">Example 63. Room Returns Service Bad Request Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the room MUST inform the user of successful registration:</p>
+    <p class="caption">Example 64. Room Informs User of Successful Registration</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After the user successfully submits the form, the service MAY request that the submission be approved by a room admin/owner (see the <a href="#regapprove">Approving Registration Requests</a> section of this document) or MAY immediately add the user to the member list by changing the user's affiliation from "none" to "member". If the service changes the user's affiliation and the user is in the room, it MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
+    <p class="caption">Example 65. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a user has registered with a room, the room MAY choose to restrict the user to use of the registered nickname only in that room. If it does so, it SHOULD return a &lt;not-acceptable/&gt; error to the user if the user attempts to join the room with a roomnick other than the user's registered roomnick (this enables a room to "lock down" roomnicks for consistent identification of occupants).</p>
+  </div>
+  <div class="indent">
+<h3>6.13 <a name="reservednick">Discovering Reserved Room Nickname</a>
+</h3>
+    <p class="" style="">A user MAY have a reserved room nickname, for example through explicit room registration or database integration. In such cases it may be desirable for the user to discover his or her reserved nickname before attempting to enter the room (e.g., because the user has forgotten his or her reserved nickname). This is done by sending a Service Discovery information request to the room JID while specifying a well-known Service Discovery node of "x-roomuser-item".</p>
+    <p class="caption">Example 66. User Requests Reserved Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='getnick1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It is OPTIONAL for a multi-user chat service to support the foregoing service discovery node. If the room or service does not support the foregoing service discovery node, it MUST return a &lt;feature-not-implemented/&gt; error to the user. If it does and the user has a registered nickname, it MUST return the nickname to the user as the value of the 'name' attribute of a Service Discovery &lt;identity/&gt; element (for which the category/type SHOULD be "conference/text"):</p>
+    <p class="caption">Example 67. Room Returns Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='getnick1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'&gt;
+    &lt;identity
+        category='conference'
+        name='thirdwitch'
+        type='text'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user does not have a registered nickname, the room MUST return a service discovery &lt;query/&gt; element that is empty (in accordance with JEP-0030).</p>
+    <p class="" style="">Even if a user has registered one room nickname, the service SHOULD allow the user to specify a different nickname on entering the room (e.g., in order to join from different client resources), although the service MAY choose to "lock down" nicknames and therefore deny entry to the user, including a &lt;not-acceptable/&gt; error. The service MUST NOT return an error to the user if his or her client sends the foregoing request after having already joined the room, but instead SHOULD reply as described above.</p>
+    <p class="" style="">If another user attempts to join the room with a nickname reserved by the first user, the service MUST deny entry to the second user and return a &lt;conflict/&gt; error as previously described.</p>
+  </div>
+<h2>7.
+       <a name="moderator">Moderator Use Cases</a>
+</h2>
+  <p class="" style="">A moderator has privileges to perform certain actions within the room (e.g., to change the roles of some occupants) but does not have rights to change persistent information about affiliations (which may be changed only by an admin or owner) or defining information about the room. Exactly which actions may be performed by a moderator is subject to configuration. However, for the purposes of the MUC framework, moderators are stipulated to have privileges to perform the following actions:</p>
+  <ol start="1" type="">
+    <li>discover an occupant's full JID in a semi-anonymous room (occurs by default as shown above)</li>
+    <li>modify the subject</li>
+    <li>kick a participant or visitor from the room</li>
+    <li>grant or revoke voice in a moderated room</li>
+    <li>modify the list of occupants who have voice in a moderated room</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response exchange using &lt;iq/&gt; elements that contain children qualified by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the &lt;user@host&gt; of the 'from' address of the request does not match the bare JID portion of one of the moderators; in this case, the service MUST return a &lt;forbidden/&gt; error.)</p>
+  <div class="indent">
+<h3>7.1 <a name="subject-mod">Modifying the Room Subject</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability to change the subject within the room. By default, only users with a role of "moderator" SHOULD be allowed to change the subject in a room (although this SHOULD be configurable, with the result that a mere participant or even visitor may be allowed to change the subject if desired). The subject is changed by sending a message of type "groupchat" to the &lt;room@service&gt;, containing no body but a &lt;subject/&gt; that specifies the new subject:</p>
+    <p class="caption">Example 68. Moderator Changes Subject</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If a MUC service receives such a message, it MUST reflect the message to all other occupants with a 'from' address equal to the room JID that corresponds to the sender of the subject change:</p>
+    <p class="caption">Example 69. Service Informs All Occupants of Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the room SHOULD include the last subject change in the discussion history sent when a new occupant joins the room.</p>
+    <p class="" style="">A MUC client that receives such a message MAY choose to display an in-room message; the body of such in-room messages SHOULD NOT be generated by the sending client or the service, so as to ensure correct localization (however, the sending client or service MAY generate the body if desired). The in-room message could be something like the following:</p>
+    <p class="caption">Example 70. Service Sends In-Room Subject Change Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+  &lt;body&gt;* secondwitch has changed the subject to: Fire Burn and Cauldron Bubble!&lt;/body&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If someone without appropriate privileges attempts to change the room subject, the service MUST return a message of type "error" specifying a &lt;forbidden/&gt; error condition:</p>
+    <p class="caption">Example 71. Service Returns Error Related to Unauthorized Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="kick">Kicking a Visitor or Participant from a Room</a>
+</h3>
+    <p class="" style="">A moderator has permissions kick a visitor or participant from a room. The kick is normally performed based on the occupant's room nickname (though it MAY be based on the full JID) and is completed by setting the role of a participant or visitor to a value of "none".</p>
+    <p class="caption">Example 72. Moderator Kicks Occupant</p>
+<div class="indent"><pre>
+&lt;iq from='fluellen@shakespeare.lit/pda'
+    id='kick1'
+    to='harfleur@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='pistol' role='none'&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the kicked occupant by sending a presence stanza of type "unavailable" to each kicked occupant, including status code 307 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the kick.</p>
+    <p class="caption">Example 73. Service Removes Kicked Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='pistol@shakespeare.lit/harfleur'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='fluellen@shakespeare.lit'/&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the kicked user to understand why he or she was kicked, and by whom if the kicked occupant would like to discuss the matter.  [<a href="#nt-id2262587">11</a>]</p>
+    <p class="" style="">After removing the kicked occupant(s), the service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 74. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='harfleur@henryv.shakespeare.lit'
+    id='kick1'
+    to='fluellen@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After informing the moderator, the service MUST then inform all of the remaining occupants that the kicked occupant is no longer in the room by sending presence stanzas of type "unavailable" from the individual's roomnick (&lt;room@service/nick&gt;) to all the remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason and actor.</p>
+    <p class="caption">Example 75. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='gower@shakespeare.lit/cell'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator cannot be kicked from a room, nor can any user with an affiliation of "owner" or "admin". If a moderator attempts to kick such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 76. Service Returns Error on Attempt to Kick Moderator, Admin, or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='kicktest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='firstwitch' role='none'&gt;
+      &lt;reason&gt;Be gone!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="grantvoice">Granting Voice to a Visitor</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to manage who does and does not have "voice" in the room (i.e., the ability to send messages to all occupants). Voice is granted based on the visitor's room nickname, which the service will convert into the visitor's full JID internally. The moderator grants voice to a visitor by changing the visitor's role to "participant" (the &lt;reason/&gt; element is optional):</p>
+    <p class="caption">Example 77. Moderator Grants Voice to a Visitor</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 78. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual's &lt;room@service/nick&gt; to all occupants, indicating the addition of voice privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
+    <p class="caption">Example 79. Service Sends Notice of Voice to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="revokevoice">Revoking Voice from a Participant</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to revoke a participant's privileges to speak. The moderator can revoke voice from a participant by changing the participant's role to "visitor":</p>
+    <p class="caption">Example 80. Moderator Revokes Voice from a Participant</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 81. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of voice privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "visitor".</p>
+    <p class="caption">Example 82. Service Notes Loss of Voice</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='visitor'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator MUST NOT be able to revoke voice from a user whose affiliation is at or above the moderator's level. In addition, a service MUST NOT allow the voice privileges of an admin or owner to be removed by anyone. If a moderator attempts to revoke voice privileges from such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender along with the offending item(s):</p>
+    <p class="caption">Example 83. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voicetest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.5 <a name="modifyvoice">Modifying the Voice List</a>
+</h3>
+    <p class="" style="">A moderator in a moderated room may want to modify the voice list. To do so, the moderator first requests the voice list by querying the room for all occupants with a role of 'participant'.</p>
+    <p class="caption">Example 84. Moderator Requests Voice List</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='voice3'
+    to='goodfolk@chat.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the voice list to the moderator; each item MUST include the 'nick' and 'role' attributes and SHOULD include the 'affiliation' and 'jid' attributes:</p>
+    <p class="caption">Example 85. Service Sends Voice List to Moderator</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice3'
+    to='bard@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='polonius@hamlet/castle'
+          nick='Polo'
+          role='participant'/&gt;
+    &lt;item affiliation='none'
+          jid='horatio@hamlet/castle'
+          nick='horotoro'
+          role='participant'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The moderator MAY then modify the voice list. In order to do so, the moderator MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'nick' attribute and 'role' attribute (normally set to a value of "participant" or "visitor") but SHOULD NOT include the 'jid' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as owner rather than the participant role):</p>
+    <p class="caption">Example 86. Moderator Sends Modified Voice List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='voice4'
+    to='goodfolk@chat.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='Hecate'
+          role='visitor'/&gt;
+    &lt;item nick='rosencrantz'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item nick='guildenstern'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 87. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice1'
+    to='bard@shakespeare.lit/globe'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in voice privileges by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, voice privileges cannot be revoked from a room owner or room admin, nor from any user with a higher affiliation than the moderator making the request. If a room admin attempts to revoke voice privileges from such a user by modifying the voice list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 88. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voicetest'
+    to='bard@shakespeare.lit/globe'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit'
+          nick='Hecate'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="admin">Admin Use Cases</a>
+</h2>
+  <p class="" style="">A room administrator has privileges to modify persistent information about user affiliations (e.g., by banning users) and to grant and revoke moderator privileges, but does not have rights to change the defining features of the room, which are the sole province of the room owner(s). Exactly which actions may be performed by a room admin will be subject to configuration. However, for the purposes of the MUC framework, room admins are stipulated to at a minimum have privileges to perform the following actions:</p>
+  <ol start="1" type="">
+    <li>ban a user from the room</li>
+    <li>modify the list of users who are banned from the room</li>
+    <li>grant or revoke membership</li>
+    <li>modify the member list</li>
+    <li>grant or revoke moderator privileges</li>
+    <li>modify the list of moderators</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response exchange using &lt;iq/&gt; elements that contain children qualified by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions that implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the &lt;user@host&gt; of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a &lt;forbidden/&gt; error.)</p>
+  <div class="indent">
+<h3>8.1 <a name="ban">Banning a User</a>
+</h3>
+    <p class="" style="">An admin or owner can ban one or more users from a room. The ban MUST be performed based on the occupant's bare JID. In order to ban a user, an admin MUST change the user's affiliation to "outcast".</p>
+    <p class="caption">Example 89. Admin Bans User</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban1'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add that bare JID to the ban list, SHOULD remove the outcast's nickname from the list of registered nicknames, and MUST inform the admin or owner of success:</p>
+    <p class="caption">Example 90. Service Informs Admin or Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban1'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also remove any banned users who are in the room by sending a presence stanza of type "unavailable" to each banned occupant, including status code 301 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the ban.</p>
+    <p class="caption">Example 91. Service Removes Banned User</p>
+<div class="indent"><pre>
+&lt;presence
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='earlofcambridge@shakespeare.lit/stabber'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast' role='none'&gt;
+      &lt;actor jid='kinghenryv@shakespeare.lit'/&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the banned user to understand why he or she was banned, and by whom if the banned user would like to discuss the matter.</p>
+    <p class="" style="">The service MUST then inform all of the remaining occupants that the banned user is no longer in the room by sending presence stanzas of type "unavailable" from the banned user to all remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason and actor:</p>
+    <p class="caption">Example 92. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    type='unavailable'
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='exeter@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit/stabber'
+          role='none'/&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="modifyban">Modifying the Ban List</a>
+</h3>
+    <p class="" style="">A room admin may want to modify the ban list. Note: The ban list is always based on a user's bare JID, although a nick (perhaps the last room nickname associated with that JID) MAY be included for convenience. To modify the list of banned JIDs, the admin first requests the ban list by querying the room for all users with an affiliation of 'outcast'.</p>
+    <p class="caption">Example 93. Admin Requests Ban List</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban2'
+    to='southampton@henryv.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the list of banned users to the admin; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' and 'role' attributes:</p>
+    <p class="caption">Example 94. Service Sends Ban List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban2'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the ban list. In order to do so, the admin MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'affiliation' attribute (normally set to a value of "outcast" to ban or "none" to remove ban) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the outcast affiliation); in addition, the reason and actor elements are OPTIONAL:</p>
+    <p class="caption">Example 95. Admin Sends Modified Ban List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban3'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'&gt;
+          jid='lordscroop@shakespeare.lit' 
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'
+          jid='sirthomasgrey@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">After updating the ban list, the service MUST inform the admin of success:</p>
+    <p class="caption">Example 96. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban3'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then remove the affected occupants (if they are in the room) and send updated presence (including the appropriate status code) from them to all the remaining occupants as described in the "Banning a User" use case. (The service SHOULD also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.)</p>
+    <p class="" style="">When an entity is banned from a room, an implementation SHOULD match JIDs in the following order (these matching rules are the same as those defined for privacy lists in <span style="font-weight: bold">RFC 3921</span>):</p>
+    <ol start="1" type="">
+      <li>&lt;user@domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;user@domain&gt; (any resource matches)</li>
+      <li>&lt;domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;domain&gt; (the domain itself matches, as does any user@domain, domain/resource, or address containing a subdomain)</li>
+    </ol>
+    <p class="" style="">Some administrators may wish to ban all users associated with a specific domain from all rooms hosted by a MUC service. Such functionality is a service-level feature and is therefore out of scope for this document (but see <span class="ref" style="">Service Administration</span>  [<a href="#nt-id2263361">12</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="grantmember">Granting Membership</a>
+</h3>
+    <p class="" style="">An admin can grant membership to a user; this is done by changing the user's affiliation to "member" (normally based on nick if the user is in the room, or on bare JID if not; in either case, if the nick is provided, that nick becomes the user's default nick in the room if that functionality is supported by the implementation):</p>
+    <p class="caption">Example 97. Admin Grants Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the member list and then inform the admin of success:</p>
+    <p class="caption">Example 98. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
+    <p class="caption">Example 99. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="revokemember">Revoking Membership</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's membership; this is done by changing the user's affiliation to "none":</p>
+    <p class="caption">Example 100. Admin Revokes Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          nick='thirdwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 101. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
+    <p class="caption">Example 102. Service Notes Loss of Membership</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MUST remove the user from the room, including a status code of 321 to indicate that the user was removed because of an affiliation change, and inform all remaining occupants:</p>
+    <p class="caption">Example 103. Service Removes Non-Member</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='bard@shakespeare.lit'/&gt;
+    &lt;/item&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="modifymember">Modifying the Member List</a>
+</h3>
+    <p class="" style="">In the context of a members-only room, the member list is essentially a "whitelist" of people who are allowed to enter the room. Anyone who is not a member is effectively banned from entering the room, even if their affiliation is not "outcast".</p>
+    <p class="" style="">In the context of an open room, the member list is simply a list of users (bare JID and reserved nick) who are registered with the room. Such users may appear in a room roster, have their room nickname reserved, be returned in search results or FAQ queries, and the like.</p>
+    <p class="" style="">It is RECOMMENDED that only room admins have the privilege to modify the member list in members-only rooms. To do so, the admin first requests the member list by querying the room for all users with an affiliation of "member":</p>
+    <p class="caption">Example 104. Admin Requests Member List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">(A service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &lt;forbidden/&gt; error when a member in the room requests the member list. This functionality may assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited.)</p>
+    <p class="" style="">The service MUST then return the full member list to the admin qualified by the 'http://jabber.org/protocol/muc#admin' namespace; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for each members that is currently an occupant.</p>
+    <p class="caption">Example 105. Service Sends Member List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'
+          nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the member list. In order to do so, the admin MUST send the changed items (i.e., only the "delta") to the service; each item MUST include the 'affiliation' attribute (normally set to a value of "member" or "none") and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the member affiliation):</p>
+    <p class="caption">Example 106. Admin Sends Modified Member List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 107. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST change the affiliation of any affected user. If the user has been removed from the member list, the service MUST change the user's affiliation from "member" to "none". If the user has been added to the member list, the service MUST change the user's affiliation to "member".</p>
+    <p class="" style="">If a removed member is currently in a members-only room, the service SHOULD kick the occupant by changing the removed member's role to "none" and send appropriate presence to the removed member as previously described. No matter whether the removed member was in or out of a members-only room, the service MUST subsequently refuse entry to the user.</p>
+    <p class="" style="">For all room types, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
+    <p class="caption">Example 108. Service Sends Notice of Loss of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the service SHOULD send an invitation to any user who has been added to the member list of a members-only room if the user is not currently affiliated with the room, for example as an admin or owner (such a user would by definition not be in the room; note also that this example includes a password but not a reason -- both child elements are OPTIONAL):</p>
+    <p class="caption">Example 109. Room Sends Invitation to New Member</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='bard@shakespeare.lit'/&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+  &lt;x jid='darkcave@macbeth.shakespeare.lit'
+     xmlns='jabber:x:conference'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While only admins and owners SHOULD be allowed to modify the member list, an implementation MAY provide a configuration option that opens invitation privileges to any member of a members-only room. In such a situation, any invitation sent SHOULD automatically trigger the addition of the invitee to the member list. However, if invitation privileges are restricted to admins and a mere member attempts to a send an invitation, the service MUST deny the invitation request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 110. Service Returns Error on Attempt by Mere Member to Invite Others to a Members-Only Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.</p>
+    <p class="" style="">If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
+    <p class="caption">Example 111. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.6 <a name="grantmod">Granting Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to grant moderator privileges to a participant or visitor; this is done by changing the user's role to "moderator":</p>
+    <p class="caption">Example 112. Admin Grants Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 113. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "moderator".</p>
+    <p class="caption">Example 114. Service Sends Notice of Moderator Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.7 <a name="revokemod">Revoking Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's moderator privileges. An admin MAY revoke moderator privileges only from a user whose affiliation is "member" or "none" (i.e., not from an owner or admin). The privilege is revoked by changing the user's role to "participant":</p>
+    <p class="caption">Example 115. Admin Revokes Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 116. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
+    <p class="caption">Example 117. Service Notes Loss of Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As noted, an admin MUST NOT be allowed to revoke moderator privileges from a user whose affiliation is "owner" or "admin". If an admin attempts to revoke moderator privileges from such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 118. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.8 <a name="modifymod">Modifying the Moderator List</a>
+</h3>
+    <p class="" style="">An admin may want to modify the moderator list. To do so, the admin first requests the moderator list by querying the room for all users with a role of 'moderator'.</p>
+    <p class="caption">Example 119. Admin Requests Moderator List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the moderator list to the admin; each item MUST include the 'jid', 'nick', and 'role' attributes and SHOULD include the 'affiliation' attribute:</p>
+    <p class="caption">Example 120. Service Sends Moderator List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the moderator list. In order to do so, the admin MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'jid' attribute and 'role' attribute (normally set to a value of "member" or "participant") but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as admin rather than the moderator role):</p>
+    <p class="caption">Example 121. Admin Sends Modified Moderator List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 122. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator privileges by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, moderator privileges cannot be revoked from a room owner or room admin. If a room admin attempts to revoke moderator privileges from such a user by modifying the moderator list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 123. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.9 <a name="regapprove">Approving Registration Requests</a>
+</h3>
+    <p class="" style="">If a service does not automatically accept requests to register with a room, it MAY provide a way for room admins to approve or deny registration requests over Jabber (alternatively, it could provide a web interface or some other admin tool). The simplest way to do so is for the service to send a &lt;message/&gt; stanza to the room admin(s) when the registration request is received, where the &lt;message/&gt; stanza contains a Data Form asking for approval or denial of the request. The following Data Form is RECOMMENDED but implementations MAY use a different form entirely, or supplement the following form with additional fields.</p>
+    <p class="caption">Example 124. Registration Request Approval Form</p>
+<div class="indent"><pre>
+&lt;message from='darkcave@macbeth.shakespeare.lit'
+         id='approve'
+         to='crone1@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='jabber:x:data' type='form'&gt;
+    &lt;title&gt;Registration request&lt;/title&gt;
+    &lt;instructions&gt;
+      To approve this registration request, select the
+      &amp;quot;Allow this person to register with the room?&amp;quot;
+      checkbox and click OK. To skip this request, click the 
+      cancel button.
+    &lt;/instructions&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_first'
+           type='text-single'
+           label='First Name'&gt;
+      &lt;value&gt;Brunhilde&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_last'
+           type="text-single"
+           label="Last Name"&gt;
+      &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_roomnick'
+           type="text-single"
+           label="Desired Nickname"&gt;
+      &lt;value&gt;thirdwitch&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_url'
+           type="text-single"
+           label="User URL"&gt;
+      &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_email'
+           type="text-single"
+           label="Email Address"&gt;
+      &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_faqentry'
+           type="text-single"
+           label="FAQ Entry"&gt;
+      &lt;value&gt;Just another witch.&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_allow'
+           type='boolean'
+           label='Allow this person to register with the room?'&gt;
+      &lt;value&gt;0&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the admin approves the registration request, the service shall register the user with the room.</p>
+    <p class="" style="">More advanced registration approval mechanisms (e.g., retrieving a list of registration requests using <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2264223">13</a>] as is done in <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2264245">14</a>]) are out of scope for this JEP.</p>
+  </div>
+<h2>9.
+       <a name="owner">Owner Use Cases</a>
+</h2>
+  <p class="" style="">Every room MUST have at least one owner, and that owner (or a successor) is a long-lived attribute of the room for as long as the room exists (e.g., the owner does not lose ownership on exiting a persistent room). This JEP assumes that the (initial) room owner is the individual who creates the room and that only a room owner has the right to change defining room configuration settings such as the room type. Ideally, room owners will be able to specify not only the room types (password-protected, members-only, etc.) but also certain attributes of the room as listed in the <a href="#reqs">Requirements</a> section of this document. In addition, it would be good if an owner were able to specify the JIDs of other owners, but that shall be determined by the implementation.</p>
+  <p class="" style="">In order to provide the necessary flexibility for a wide range of configuration options, Data Forms (JEP-0004) shall be used for room configuration, triggered by use of the 'http://jabber.org/protocol/muc' namespace.</p>
+  <p class="" style="">Note: The configuration options shown below address all of the features and room types listed in the requirements section of this JEP; however, the exact configuration options and form layout shall be determined by the implementation or specific deployment. Also, these are examples only and are not intended to define the only allowed or required configuration options for rooms. A given implementation or deployment MAY choose to provide additional configuration options (profanity filters, setting the default language for a room, message logging, etc.), which is why the use of the 'jabber:x:data' protocol is valuable here.</p>
+  <div class="indent">
+<h3>9.1 <a name="createroom">Creating a Room</a>
+</h3>
+    <div class="indent">
+<h3>9.1.1 <a name="createroom-general">General Considerations</a>
+</h3>
+      <p class="" style="">The privilege to create rooms MAY be restricted to certain users or may be reserved to an administrator of the service. If access is restricted and a user attempts to create a room, the service MUST return a &lt;not-allowed/&gt; error:</p>
+      <p class="caption">Example 125. Service Informs User of Inability to Create a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">If access is not restricted, the service MUST allow the user to create a room as described below.</p>
+      <p class="" style="">From the perspective of room creation, there are in essence two kinds of rooms:</p>
+      <ul>
+        <li><p class="" style="">"Instant rooms" -- these are available for immediate access and are automatically created based on some default configuration.</p></li>
+        <li><p class="" style="">"Reserved rooms" -- these are manually configured by the room creator before anyone is allowed to enter.</p></li>
+      </ul>
+      <p class="" style="">The workflow for creating and configuring such rooms is as follows:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">The user MUST send presence to &lt;room@service/nick&gt; and signal his or her support for the Multi-User Chat protocol by including extended presence information in an empty &lt;x/&gt; child element qualified by the 'http://jabber.org/protocol/muc' namespace (note the lack of an '#owner' or '#user' fragment).</p></li>
+        <li><p class="" style="">If this user is allowed to create a room and the room does not yet exist, the service MUST create the room according to some default configuration, assign the requesting user as the initial room owner, and add the owner to the room but not allow anyone else to enter the room (effectively "locking" the room). The initial presence stanza received by the owner from the room MUST include extended presence information indicating the user's status as an owner and acknowledging that the room has been created (via status code 201) and is awaiting configuration.</p></li>
+        <li><p class="" style="">If the initial room owner would like to create and configure a reserved room, the room owner MUST then request a configuration form by sending an IQ stanza of type "get" to the room containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, then complete Steps 4 and 5. If the room owner would prefer to create an instant room, the room owner MUST send a query element qualified by the 'http://jabber.org/protocol/muc#owner' namespace and containing an empty &lt;x/&gt; element of type "submit" qualified by the 'jabber:x:data' namespace, then skip to Step 6.</p></li>
+        <li><p class="" style="">If the room owner requested a configuration form, the service MUST send an IQ to the room owner containing a configuration form qualified by the 'jabber:x:data' namespace. If there are no configuration options available, the room MUST return an empty query element to the room owner.</p></li>
+        <li><p class="" style="">The initial room owner SHOULD provide a starting configuration for the room (or accept the default configuration) by sending an IQ of type "set" containing the completed configuration form. Alternatively, the room owner MAY cancel the configuration process. (An implementation MAY set a timeout for initial configuration, such that if the room owner does not configure the room within the timeout period, the room owner is assumed to have accepted the default configuration or to have cancelled the configuration process.)</p></li>
+        <li><p class="" style="">Once the service receives the completed configuration form from the initial room owner (or receives a request for an instant room), the service MUST "unlock" the room (i.e., allow other users to enter the room) and send an IQ of type "result" to the room owner. If the service receives a cancellation, it MUST destroy the room.</p></li>
+      </ol>
+      <p class="" style="">The protocol for this workflow is shown in the examples below.</p>
+      <p class="" style="">First, the Jabber user MUST send presence to the room, including and empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace (this is the same stanza sent when seeking to enter a room).</p>
+      <p class="caption">Example 126. Jabber User Creates a Room and Signals Support for Multi-User Chat</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">If the room does not yet exist, the service SHOULD create the room (subject to local policies regarding room creation), assign the bare JID of the requesting user as the owner, add the owner to the room, and acknowledge successful creation of the room by sending a presence stanza of the following form:</p>
+      <p class="caption">Example 127. Service Acknowledges Room Creation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          role='moderator'/&gt;
+    &lt;status code='201'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">After receiving notification that the room has been created, the room owner needs to decide whether to accept the default room configuration (i.e., create an "instant room") or configure the room to have something other than the default room configuration (i.e., create a "reserved room"). The protocol flows for completing those two use cases are shown in the following sections.</p>
+      <p class="" style="">Note: If the presence stanza sent to a nonexistent room does not include an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace as shown above, the service SHOULD create a default room without delay (i.e., it MUST assume that the client supports "groupchat 1.0" rather than Multi-User Chat and therefore it MUST NOT lock the room while waiting for the room creator to either accept an instant room or configure a reserved room).</p>
+    </div>
+    <div class="indent">
+<h3>9.1.2 <a name="createroom-instant">Creating an Instant Room</a>
+</h3>
+      <p class="" style="">If the initial room owner wants to accept the default room configuration (i.e., create an "instant room"), the room owner MUST decline an initial configuration form by sending an IQ set to the &lt;room@service&gt; itself containing a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, where the only child of the &lt;query/&gt; is an empty &lt;x/&gt; element that is qualified by the 'jabber:x:data' namespace and that possesses a 'type' attribute whose value is "submit":</p>
+      <p class="caption">Example 128. Owner Requests Instant Room</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The service MUST then unlock the room and allow other entities to join it.</p>
+    </div>
+    <div class="indent">
+<h3>9.1.3 <a name="createroom-reserved">Creating a Reserved Room</a>
+</h3>
+      <p class="" style="">If the initial room owner wants to create and configure a reserved room, the room owner MUST request an initial configuration form by sending an IQ get to the &lt;room@service&gt; itself containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace:</p>
+      <p class="caption">Example 129. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the room does not already exist, the service MUST return an initial room configuration form to the user. (Note: The following example shows a representative sample of configuration options. A full list of x:data fields registered for use in room creation and configuration is maintained by the Jabber Registrar; see the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.)</p>
+      <p class="caption">Example 130. Service Sends Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for "darkcave" Room&lt;/title&gt;
+      &lt;instructions&gt;
+          Your room darkcave@macbeth has been created!
+          The default configuration is as follows:
+            - No logging
+            - No moderation
+            - Up to 20 occupants
+            - No password required
+            - No invitation required
+            - Room is not persistent
+            - Only admins may change the subject
+            - Presence broadcasted for all users
+          To accept the default configuration, click OK. To
+          select a different configuration, please complete
+          this form.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#roomconfig_roomname'/&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#roomconfig_roomdesc'/&gt;
+      &lt;field
+          label='Natural Language for Room Discussions'
+          type='text-single'
+          var='muc#roomconfig_lang'/&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;20&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#roomconfig_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members-Only?'
+          type='boolean'
+          var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required to Enter?'
+          type='boolean'
+          var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#roomconfig_roomsecret'/&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#roomconfig_whois'&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#roomconfig_roomadmins'/&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#roomconfig_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner:</p>
+      <p class="caption">Example 131. Service Informs Owner that No Configuration is Possible</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+      <p class="" style="">The room owner SHOULD then fill out the form and submit it to the service.</p>
+      <p class="caption">Example 132. Owner Submits Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomadmins'&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If room creation is successful, the service MUST inform the new room owner of success:</p>
+      <p class="caption">Example 133. Service Informs New Room Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+      </pre></div>
+      <p class="" style="">Alternatively, the room owner MAY cancel the configuration process:</p>
+      <p class="caption">Example 134. Owner Cancels Initial Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the room owner cancels the initial configuration, the service SHOULD destroy the room, making sure to send unavailable presence to the room owner (see the "Destroying a Room" use case for protocol details).</p>
+      <p class="" style="">If the room owner becomes unavailable for any reason before submitting the form (e.g., a lost connection), the service will receive a presence stanza of type "unavailable" from the owner to the owner's &lt;room@service/nick&gt; or to &lt;room@service&gt; (or both). The service MUST then destroy the room, sending a presence stanza of type "unavailable" from the room to the owner including a &lt;destroy/&gt; element and reason (if provided) as defined in the <a href="#destroyroom">Destroying a Room</a> section of this document.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="roomconfig">Subsequent Room Configuration</a>
+</h3>
+    <p class="" style="">At any time after specifying the initial configuration of the room, a room owner may want to change the configuration. In order to initiate this process, a room owner MUST request a new configuration form from the room by sending an IQ to &lt;room@service&gt; containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace.</p>
+    <p class="caption">Example 135. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 136. Service Denies Configuration Access to Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='configures'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the service MUST send a configuration form to the room owner with the current options set as defaults:</p>
+    <p class="caption">Example 137. Service Sends Configuration Form to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='config1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for "darkcave" Room&lt;/title&gt;
+      &lt;instructions&gt;
+        Complete this form to make changes to
+        the configuration of your room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#roomconfig_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#roomconfig_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#roomconfig_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members Only?'
+          type='boolean'
+          var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required for Entry?'
+          type='boolean'
+          var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#roomconfig_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#roomconfig_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#roomconfig_roomadmins'&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#roomconfig_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner as shown in the previous use case.</p>
+    <p class="" style="">The room owner SHOULD then submit the form with updated configuration information.</p>
+    <p class="" style="">Alternatively, the room owner MAY cancel the configuration process:</p>
+    <p class="caption">Example 138. Owner Cancels Subsequent Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room owner cancels the subsequent configuration, the service MUST leave the configuration of the room as it was before the room owner initiated the subsequent configuration process.</p>
+    <p class="" style="">If as a result of a change in the room configuration a room admin loses administrative privileges while the admin is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member" and the 'role' attribute set to a value of "participant" or "visitor" as appropriate for the affiliation level and the room type:</p>
+    <p class="caption">Example 139. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a user gains administrative privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to a value of "admin":</p>
+    <p class="caption">Example 140. Service Notes Gain of Admin Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a room owner loses owner privileges while that owner is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to a value of "moderator":</p>
+    <p class="caption">Example 141. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own ownership privileges if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner. However, a service SHOULD allow an owner to revoke his or her own ownership privileges if there are other owners.</p>
+    <p class="" style="">If as a result of a change in the room configuration a user gains ownership privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner" and the 'role' attribute set to a value of 'moderator'.</p>
+    <p class="caption">Example 142. Service Notes Gain of Owner Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration the room type is changed to members-only but there are non-members in the room, the service MUST remove any non-members from the room and include a status code of 322 in the presence unavailable stanzas sent to those users as well as any remaining occupants.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="grantowner">Granting Ownership Privileges</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, an owner MAY grant ownership privileges to another user; this is done by changing the user's affiliation to "owner":</p>
+    <p class="caption">Example 143. Owner Grants Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 144. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of ownership privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner" and the 'role' attribute set to a value of "moderator".</p>
+    <p class="caption">Example 145. Service Sends Notice of Ownership Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.4 <a name="revokeowner">Revoking Ownership Privileges</a>
+</h3>
+    <p class="" style="">An implementation MAY allow an owner to revoke another user's ownership privileges; this is done by changing the user's affiliation to something other than "owner":</p>
+    <p class="caption">Example 146. Owner Revokes Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own ownership privileges if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner. However, a service SHOULD allow an owner to revoke his or her own ownership privileges if there are other owners.</p>
+    <p class="" style="">If an implementation does not allow one owner to revoke another user's ownership privileges, the implementation MUST return a &lt;not-authorized/&gt; error to the owner who made the request.</p>
+    <p class="" style="">In all other cases, the service MUST remove the user from the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 147. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of ownership privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "owner" and the 'role' attribute set to an appropriate value:</p>
+    <p class="caption">Example 148. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">Note: Allowing an owner to remove another user's ownership privileges can compromise the control model for room management; therefore this feature is OPTIONAL, and implementations are encouraged to support owner removal through an interface that is open only to individuals with service-wide administrative privileges.</p>
+  </div>
+  <div class="indent">
+<h3>9.5 <a name="modifyowner">Modifying the Owner List</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, a room owner may want to modify the owner list. To do so, the owner first requests the owner list by querying the room for all users with an affiliation of 'owner'.</p>
+    <p class="caption">Example 149. Owner Requests Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='owner3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender.</p>
+    <p class="" style="">Otherwise, the service MUST then return the owner list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any owner that is currently an occupant:</p>
+    <p class="caption">Example 150. Service Sends Owner List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner3'
+    to='bard@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner'
+          jid='crone1@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner MAY then modify the owner list. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service;  [<a href="#nt-id2265574">15</a>] each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the owner affiliation):</p>
+    <p class="caption">Example 151. Owner Sends Modified Owner List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='owner4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 152. Service Returns Error on Attempt by Non-Owner to Modify Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='ownertest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own ownership privileges if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner. However, a service SHOULD allow an owner to revoke his or her own ownership privileges if there are other owners.</p>
+    <p class="" style="">In all other cases, the service MUST modify owner list and then inform the owner of success:</p>
+    <p class="caption">Example 153. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also send presence notifications related to any affiliation changes that result from modifying the owner list as previously described.</p>
+  </div>
+  <div class="indent">
+<h3>9.6 <a name="grantadmin">Granting Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner can grant administrative privileges to a member or unaffiliated user; this is done by changing the user's affiliation to "admin":</p>
+    <p class="caption">Example 154. Owner Grants Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 155. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of administrative privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to a value of "moderator".</p>
+    <p class="caption">Example 156. Service Sends Notice of Administrative Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.7 <a name="revokeadmin">Revoking Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner may want to revoke a user's administrative privileges; this is done by changing the user's affiliation to something other than "admin" or "owner":</p>
+    <p class="caption">Example 157. Owner Revokes Administrative Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          nick='secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 158. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of administrative privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "admin" or "owner" and the 'role' attribute set to an appropriate value given the affiliation level and the room type:</p>
+    <p class="caption">Example 159. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.8 <a name="modifyadmin">Modifying the Admin List</a>
+</h3>
+    <p class="" style="">A room owner may want to modify the admin list. To do so, the owner first requests the admin list by querying the room for all users with an affiliation of 'admin'.</p>
+    <p class="caption">Example 160. Owner Requests Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/desktopaffiliation
+    id='admin3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender.</p>
+    <p class="" style="">Otherwise, the service MUST then return the admin list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any admin that is currently an occupant:</p>
+    <p class="caption">Example 161. Service Sends Admin List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin3'
+    to='bard@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'
+          nick='secondwitch'/&gt;
+    &lt;item affiliation='admin'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner MAY then modify the admin list. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service;  [<a href="#nt-id2265898">16</a>] each item MUST include the 'affiliation' attribute (normally set to a value of "admin" or "none") and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the admin affiliation):</p>
+    <p class="caption">Example 162. Owner Sends Modified Admin List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='admin4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 163. Service Returns Error on Attempt by Non-Owner to Modify Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admintest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the service MUST modify the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 164. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also send presence notifications related to any affiliation changes that result from modifying the admin list as previously described.</p>
+  </div>
+  <div class="indent">
+<h3>9.9 <a name="destroyroom">Destroying a Room</a>
+</h3>
+    <p class="" style="">A room owner MUST be able to destroy a room, especially if the room is persistent. The workflow is as follows:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">The room owner requests that the room be destroyed, specifying a reason and an alternate venue if desired.</p></li>
+      <li><p class="" style="">The room removes all users from the room (including appropriate information about the alternate location and the reason for being removed) and destroys the room, even if it was defined as persistent.</p></li>
+    </ol>
+    <p class="" style="">Other than the foregoing, this JEP does not specify what (if anything) a MUC service implementation shall do as a result of a room destruction request. For example, if the room was defined as persistent, an implementation MAY choose to lock the room ID so that it cannot be re-used, redirect enter requests to the alternate venue, or invite the current participants to the new room; however, such behavior is OPTIONAL.</p>
+    <p class="" style="">In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. The &lt;iq/&gt; stanza shall contain a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, which in turn shall contain a &lt;destroy/&gt; element. The address of the alternate venue MAY be provided as the value of the &lt;destroy/&gt; element's 'jid' attribute. A password for the alternate venue MAY be provided as the XML character data of a &lt;password/&gt; child element of the &lt;destroy/&gt; element. The reason for the room destruction MAY be provided as the XML character data of a &lt;reason/&gt; child element of the &lt;destroy/&gt; element.</p>
+    <p class="" style="">The following examples illustrate the protocol elements to be sent and received:</p>
+    <p class="caption">Example 165. Owner Submits Room Destruction Request</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='begone'
+    to='heath@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for removing all the occupants. It SHOULD NOT broadcast presence stanzas of type "unavailable" from all occupants, instead sending only one presence stanza of type "unavailable" to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.</p>
+    <p class="caption">Example 166. Service Removes Each Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 167. Service Informs Owner of Successful Destruction</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='begone'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;user@host&gt; of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 168. Service Denies Destroy Request Submitted by Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='destroytest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="errorcodes">Error Codes</a>
+</h3>
+    <p class="" style="">The error codes associated with the 'http://jabber.org/protocol/muc#user' namespace are fairly straightforward, as summarized in the following table. For detailed information about mapping legacy error codes to XMPP-style error types and conditions, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2266207">17</a>]; implementations SHOULD support both legacy and XMPP error handling.</p>
+    <p class="caption">Table 8: Error Codes for http://jabber.org/protocol/muc#user Namespace</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Code</th>
+        <th colspan="" rowspan="">Type</th>
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Context</th>
+        <th colspan="" rowspan="">Purpose</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">401</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that a password is required</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">403</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that he or she is banned from the room</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">404</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that the room does not exist</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">405</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that room creation is restricted</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">406</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that the reserved roomnick must be used</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">407</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that he or she is not on the member list</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">409</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that his or her desired room nickname is in use or registered by another user</td>
+      </tr>
+    </table>
+    <p class="" style="">This JEP does not stipulate text strings (i.e., values of the XMPP &lt;text/&gt; element) associated with the foregoing error conditions.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="statuscodes">Status Codes</a>
+</h3>
+    <p class="" style="">Multi-User Chat uses a &lt;status/&gt; element (specifically, the 'code' attribute of the &lt;status/&gt; element) to communicate information about a user's status in a room. Over time, the number of status codes has grown quite large, and new status codes continue to be requested of the JEP author. Therefore, these codes are now documented in a registry maintained by the Jabber Registrar. For details, refer to the <a href="#registrar-statuscodes">Status Codes Registry</a> section of this document.</p>
+    <p class="" style="">Note: In general, MUC status codes tend to follow the "philosophy" of status codes that is implicit in <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2266646">18</a>] and <span class="ref" style="">RFC 1893</span>  [<a href="#nt-id2266668">19</a>] (1xx codes are informational, 2xx codes specify that it is fine to continue, 3xx codes specify redirects such as being kicked or banned, x3x codes refer to system status, x7x codes refer to security or policy matters, etc.).</p>
+    <p class="" style="">Note: If the MUC protocol were being designed today, it would specify a more flexible, XML-friendly approach rather than hardcoded status numbers; however, at this point the pain of changing the status reporting system would be greater than the benefit of doing so, which is why the status code numbers remain in use. A future version of this JEP may define a more XMPP-like approach to status conditions, retaining the code numbers but supplementing them with more descriptive child elements as is done in <span style="font-weight: bold">RFC 3920</span>.</p>
+  </div>
+<h2>11.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">As specified in <span style="font-weight: bold">RFC 3920</span>, XMPP entities (including MUC rooms and MUC services) SHOULD respect the value of the 'xml:lang' attribute provided with any given stanza. However, simultaneous translation of groupchat messages is out of scope for this document.</p>
+  <p class="" style="">The status and error codes defined herein enable a client implementation to present a localized interface; however, definition of the localized text strings for any given language community is out of scope for this document.</p>
+<h2>12.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">No room entrance authentication or authorization method more secure than cleartext passwords is defined or required by this document. This is recognized to be sub-optimal.</p>
+  <p class="" style="">No end-to-end message or session encryption method is specified herein.</p>
+<h2>13.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2266788">20</a>].</p>
+<h2>14.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2266835">21</a>] includes the following information in its registries.</p>
+  <div class="indent">
+<h3>14.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the following MUC-related namespaces in its registry of protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/muc</li>
+      <li>http://jabber.org/protocol/muc#admin</li>
+      <li>http://jabber.org/protocol/muc#owner</li>
+      <li>http://jabber.org/protocol/muc#user</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>14.2 <a name="registrar-discocat">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">A Multi-User Chat service or room is identified by the "conference" category and the "text" type within Service Discovery.</p>
+  </div>
+  <div class="indent">
+<h3>14.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">There are many features related to a MUC service or room that can be discovered by means of Service Discovery. The most fundamental of these is the 'http://jabber.org/protocol/muc' namespace. In addition, a MUC room SHOULD provide information about the specific room features it implements, such as password protection and room moderation.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#register&lt;/name&gt;
+  &lt;desc&gt;Support for the muc#register FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roomconfig&lt;/name&gt;
+  &lt;desc&gt;Support for the muc#roomconfig FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roominfo&lt;/name&gt;
+  &lt;desc&gt;Support for the muc#roominfo FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_hidden&lt;/name&gt;
+  &lt;desc&gt;Hidden room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_membersonly&lt;/name&gt;
+  &lt;desc&gt;Members-only room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_moderated&lt;/name&gt;
+  &lt;desc&gt;Moderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_nonanonymous&lt;/name&gt;
+  &lt;desc&gt;Non-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_open&lt;/name&gt;
+  &lt;desc&gt;Open room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_passwordprotected&lt;/name&gt;
+  &lt;desc&gt;Password-protected room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_persistent&lt;/name&gt;
+  &lt;desc&gt;Persistent room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_public&lt;/name&gt;
+  &lt;desc&gt;Public room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_rooms&lt;/name&gt;
+  &lt;desc&gt;List of MUC rooms (each as a separate item)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_semianonymous&lt;/name&gt;
+  &lt;desc&gt;Semi-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_temporary&lt;/name&gt;
+  &lt;desc&gt;Temporary room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unmoderated&lt;/name&gt;
+  &lt;desc&gt;Unmoderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unsecured&lt;/name&gt;
+  &lt;desc&gt;Unsecured room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>14.4 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms' enables discovery of the rooms in which a user is an occupant.</p>
+    <p class="" style="">The well-known Service Discovery node 'x-roomuser-item' enables a user to discover his or registered roomnick from outside the room.</p>
+    <p class="" style="">The well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' enables discovery of the namespaces that are allowed in traffic sent through a room (see the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document).</p>
+  </div>
+  <div class="indent">
+<h3>14.5 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2267032">22</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. Within MUC, there are three uses of such forms: room registration within muc#user, room configuration within muc#owner, and service discovery extensions for room information. The reserved fields are defined below.</p>
+    <div class="indent">
+<h3>14.5.1 <a name="registrar-formtype-register">muc#register FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#register&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling user registration with a
+    Multi-User Chat (MUC) room or admin approval
+    of user registration requests.
+  &lt;/desc&gt;
+  &lt;field 
+     var='muc#register_allow'
+     type='boolean'
+     label='Allow this person to register with the room?'/&gt;
+  &lt;field
+      var='muc#register_email'
+      type='text-single'
+      label='Email Address'/&gt;
+  &lt;field
+      var='muc#register_faqentry'
+      type='text-multi'
+      label='FAQ Entry'/&gt;
+  &lt;field
+      var='muc#register_first'
+      type='text-single'
+      label='First Name'/&gt;
+  &lt;field
+      var='muc#register_last'
+      type='text-single'
+      label='Last Name'/&gt;
+  &lt;field
+      var='muc#register_roomnick'
+      type='text-single'
+      label='Desired Nickname'/&gt;
+  &lt;field
+      var='muc#register_url'
+      type='text-single'
+      label='Your URL'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>14.5.2 <a name="registrar-formtype-owner">muc#roomconfig FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roomconfig&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling creation and configuration of
+    a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roomconfig_allowinvites'
+      type='boolean'
+      label='Whether to Allow Occupants to Invite Others'/&gt;
+  &lt;field
+      var='muc#roomconfig_changesubject'
+      type='boolean'
+      label='Whether to Allow Occupants to Change Subject'/&gt;
+  &lt;field
+      var='muc#roomconfig_enablelogging'
+      type='boolean'
+      label='Whether to Enable Logging of Room Conversations'/&gt;
+  &lt;field
+      var='muc#roomconfig_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roomconfig_maxusers'
+      type='list-single'
+      label='Maximum Number of Room Occupants'/&gt;
+  &lt;field
+      var='muc#roomconfig_membersonly'
+      type='boolean'
+      label='Whether an Make Room Members-Only'/&gt;
+  &lt;field
+      var='muc#roomconfig_moderatedroom'
+      type='boolean'
+      label='Whether to Make Room Moderated'/&gt;
+  &lt;field
+      var='muc#roomconfig_passwordprotectedroom'
+      type='boolean'
+      label='Whether a Password is Required to Enter'/&gt;
+  &lt;field
+      var='muc#roomconfig_persistentroom'
+      type='boolean'
+      label='Whether to Make Room Persistent'/&gt;
+  &lt;field
+      var='muc#roomconfig_presencebroadcast'
+      type='list-multi'
+      label='Roles for which Presence is Broadcast'/&gt;
+  &lt;field
+      var='muc#roomconfig_publicroom'
+      type='boolean'
+      label='Whether to Allow Public Searching for Room'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomadmins'
+      type='jid-multi'
+      label='Full List of Room Admins'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomdesc'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomname'
+      type='text-single'
+      label='Natural-Language Room Name'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomowners'
+      type='jid-multi'
+      label='Full List of Room Owners'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomsecret'
+      type='text-private'
+      label='The Room Password'/&gt;
+  &lt;field
+      var='muc#roomconfig_whois'
+      type='list-single'
+      label='Affiliations that May Discover Real JIDs of Occupants'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>14.5.3 <a name="registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roominfo&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling the communication of extended service discovery
+    information about a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roominfo_description'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roominfo_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roominfo_occupants'
+      type='text-single'
+      label='Current Number of Occupants in Room'/&gt;
+  &lt;field
+      var='muc#roominfo_subject'
+      type='text-single'
+      label='Current Subject or Discussion Topic in Room'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>14.6 <a name="registrar-statuscodes">Status Codes Registry</a>
+</h3>
+    <div class="indent">
+<h3>14.6.1 <a name="registrar-statuscodes-process">Process</a>
+</h3>
+      <p class="" style="">The Jabber Registrar maintains a registry of values for the 'code' attribute of the &lt;status/&gt; element when qualified by the 'http://jabber.org/protocol/muc#user' namespace.</p>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;statuscode&gt;
+  &lt;number&gt;the three-digit code number&lt;/number&gt;
+  &lt;stanza&gt;the stanza type of which it is a child (message or presence)&lt;/desc&gt;
+  &lt;context&gt;the use case or situation in which the status is used&lt;/context&gt;
+  &lt;purpose&gt;a natural-language description of the meaning&lt;/purpose&gt;
+  &lt;child&gt;the descriptive child element (reserved for future use)&lt;/child&gt;
+&lt;/statuscode&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one status code at a time, each contained in a separate &lt;statuscode/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>14.6.2 <a name="registrar-statuscodes-init">Initial Submission</a>
+</h3>
+      <p class="" style="">As part of this document, the following status codes are registered:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;statuscode&gt;
+  &lt;number&gt;100&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Entering a room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that any occupant is allowed to see the user's full JID&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;101&lt;/number&gt;
+  &lt;stanza&gt;message (out of band)&lt;/stanza&gt;
+  &lt;context&gt;Affiliation change&lt;/context&gt;
+  &lt;purpose&gt;Inform user that his or her affiliation changed while not in the room&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;102&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that room now shows unavailable members&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;103&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that room now does not show unavailable members&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;104&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that some room configuration has changed&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;201&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Entering a room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that a new room has been created&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;301&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she has been banned from the room&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;303&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Exiting a room&lt;/context&gt;
+  &lt;purpose&gt;Inform all occupants of new room nickname&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;307&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she has been kicked from the room&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;321&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she is being removed from the room 
+    because of an affiliation change&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;322&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she is being removed from the room 
+    because the room has been changed to members-only and the user 
+    is not a member&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;332&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she is being removed from the room 
+    because of a system shutdown&lt;/purpose&gt;
+&lt;/statuscode&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>15.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>15.1 <a name="bizrules-jids">Addresses</a>
+</h3>
+    <p class="" style="">In order to provide consistency regarding the addresses captured in room JIDs, Room IDs MUST match the Nodeprep profile of Stringprep and Room Nicknames MUST match the Resourceprep profile of Stringprep (both of these are defined in <span style="font-weight: bold">RFC 3920</span>)).</p>
+  </div>
+  <div class="indent">
+<h3>15.2 <a name="bizrules-message">Message</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">If an occupant wants to send a message to all other occupants, a MUC client MUST set the 'type' attribute to a value of "groupchat". A service MAY ignore messages that are improperly typed, or reject them with a &lt;bad-request/&gt; error.</p></li>
+      <li><p class="" style="">If a MUC service receives a message directed to the room or to a single occupant from a Jabber user who has a role of "none", the service MUST NOT deliver the message and SHOULD return the message to the sender with a &lt;forbidden/&gt; error.</p></li>
+      <li><p class="" style="">If a MUC service receives a message directed to a room that does not exist or is not yet unlocked, the service SHOULD return the message to the sender with an &lt;item-not-found/&gt; error.</p></li>
+      <li><p class="" style="">A MUC service SHOULD pass extended information (e.g., an XHTML version of the message body) through to occupants unchanged; however, a MUC service MAY disallow message specific extensions (see the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document).</p></li>
+      <li><p class="" style="">A MUC client MAY generate extensions that conform to the <span class="ref" style="">Message Events</span>  [<a href="#nt-id2267409">23</a>] or <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2267432">24</a>] specification; however, a MUC service MAY disallow these extensions (see the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document).</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>15.3 <a name="bizrules-presence">Presence</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">A room MUST silently ignore unavailable presence received from a user who has a role of "none".</p></li>
+      <li><p class="" style="">Only the MUC service itself SHOULD generate extended presence information about roles, affiliations, full JIDs, or status codes qualified by the 'http://jabber.org/protocol/muc#user' namespace (based on information the service knows about occupants, e.g., roles, or as a result of actions taken by a moderator or room administrator). A client SHOULD NOT presume to generate such information. If a MUC service receives such extended presence information from an occupant, it MUST NOT reflect it to other occupants. (A client MAY generate extended presence information qualified by the 'http://jabber.org/protocol/muc#user' namespace in order to supply a password, but naturally this is not reflected to other occupants.)</p></li>
+      <li><p class="" style="">A MUC service SHOULD allow all other presence information to pass through, although it MAY choose to block extended presence information; see the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document.</p></li>
+      <li><p class="" style="">In order to appropriately inform occupants of room roles and affiliations, and to make it easier for Jabber clients to track the current state of all users in the room, MUC service implementations MUST provide extended presence information about roles and affiliations in all presence stanzas, including presence stanzas of type "unavailable" sent when a user exits the room for any reason.</p></li>
+      <li><p class="" style="">If a privilege is revoked, the service MUST note that by sending an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child element with the 'role' and/or 'affiliation' attributes set to a value that indicates the loss of the relevant privilege. All future presence stanzas for the occupant MUST include the updated role and affiliation, until and unless they change again.</p></li>
+      <li><p class="" style="">A MUC service MUST send extended presence to a client even if the client did not send an empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace on entering the room; naturally, a client MUST ignore such information if it does not understand it (in accordance with <span style="font-weight: bold">RFC 3920</span>).</p></li>
+      <li><p class="" style="">Extended presence about roles and affiliations sent in the muc#user namespace MUST include the full JID (not the bare JID) as the value of the 'jid' attribute.</p></li>
+      <li><p class="" style="">A client MAY send a custom exit message if desired (as is often done in IRC channels) by including a &lt;status/&gt; element in the presence stanza of type "unavailable" sent when exiting a room.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>15.4 <a name="bizrules-iq">IQ</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a non-anonymous room, the sender SHOULD send the request directly to the recipient's bare JID or full JID, rather than attempting to send the request through the room (i.e., via the recipient's room JID).</p></li>
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a semi-anonymous room, the sender can direct the stanza to the recipient's room JID and the service MAY forward the stanza to the recipient's real JID. However, a MUC service MUST NOT reveal the sender's real JID to the recipient at any time, nor reveal the recipient's real JID to the sender.</p></li>
+      <li><p class="" style="">A MUC client MUST send only the 'affiliation' attribute or the 'role' attribute in the &lt;item/&gt; element contained within an IQ set qualified by the 'http://jabber.org/protocol/muc#admin' namespace; if a moderator, admin, or owner attempts to modify both the affiliation and role of the same item in the same IQ set, the service MUST return a &lt;bad-request/&gt; error to the sender. However, a MUC service MAY modify a role based on a change to an affiliation and thus MAY send presence updates that include both a modified role and a modified affiliation.</p></li>
+      <li><p class="" style="">In IQ sets regarding roles, a MUC client MUST include the 'nick' attribute only; in IQ results regarding roles, a MUC service MUST include the 'nick', 'role', 'affiliation', and 'jid' attributes (with the value of the latter set to the user's full JID).</p></li>
+      <li><p class="" style="">In IQ sets regarding affiliations, a MUC client MUST include the 'jid' attribute only (with the value set to the bare JID); in IQ results regarding affiliations, a MUC service MUST NOT include the 'role' attribute, MUST include the 'affiliation' attribute and the 'jid' attribute (with the value set to the bare JID), and SHOULD include the 'nick' attribute (except if the affiliation is "outcast", since outcasts SHOULD NOT have reserved nicknames).</p></li>
+    </ol>
+  </div>
+<h2>16.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">The following guidelines may assist client and component developers in creating MUC implementations.</p>
+  <div class="indent">
+<h3>16.1 <a name="impl-service">Services</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">In handling messages sent by visitors in a moderated room, a MUC service MAY queue each message for approval by a moderator and MAY inform the sender that the message is being held for approval; however, such behavior is OPTIONAL, and definition of a message approval protocol (e.g., using Data Forms as defined in JEP-0004) is out of scope for this JEP.</p></li>
+      <li><p class="" style="">It is common for MUC services to provide in-room messages when certain events occur, such as when the subject changes, when an occupant enters or exits, or when a room is destroyed. Such messages are entirely OPTIONAL and are left up to the implementation or deployment, but if used MUST be messages of type "groupchat" sent from the room JID itself (room@service) rather than a specific occupant (&lt;room@service/nick&gt;). However, in general it is preferable for the receiving client to generate such messages based on events in the room (e.g., user entrances and exits) as well as specific status codes provided in MUC; this will help ensure correct localization of such messages.</p></li>
+      <li><p class="" style="">Out of courtesy, a MUC service MAY send an out-of-room &lt;message/&gt; to an occupant who is kicked or banned, and MAY broadcast an in-room &lt;message/&gt; to all remaining occupants informing them that the occupant has been kicked or banned from the room. However, such messages are OPTIONAL, and indeed are unnecessary since the information required for a receiving client to generate such messages is communicated in the presence stanzas (specifically the status codes) sent by a MUC service.</p></li>
+      <li><p class="" style="">Out of courtesy, a MUC service MAY send an out-of-room &lt;message/&gt; if a user's affiliation changes while the user is not in the room; the message SHOULD be sent from the room to the user's bare JID, MAY contain a &lt;body/&gt; element describing the affiliation change, and MUST contain a status code of 101.</p></li>
+      <li><p class="" style="">There is no requirement that a MUC service shall provide special treatment for users of the older "groupchat 1.0" protocol, such as messages that contain equivalents to the extended presence information that is qualified by the 'http://jabber.org/protocol/muc#user' namespace.</p></li>
+      <li><p class="" style="">Room types MAY be configured in any combination. A MUC service MAY support or allow any desired room types or combinations thereof.</p></li>
+      <li><p class="" style="">A MUC service MAY limit the number of configuration options presented to an owner after initial configuration has been completed, e.g. because certain options cannot take effect without restarting the service.</p></li>
+      <li><p class="" style="">A MUC service MAY provide an interface to room creation and configuration (e.g., in the form of a special Jabber user or a Web page), so that the ostensible room owner is actually the application instead of a human user.</p></li>
+      <li><p class="" style="">A MUC service MAY choose to make available a special in-room resource that provides an interface to administrative functionality (e.g., a "user" named "ChatBot"), which occupants could interact with directly, thus enabling admins to type <tt>'/command parameter'</tt> in a private message to that "user". Obviously this kind of implementation would require the service to add a 'ChatBot' user to the room when it is created, and to prevent any occupant from having the nickname 'ChatBot' in the room. This might be difficult to ensure in some implementations or deployments. In any case, any such interface is OPTIONAL.</p></li>
+      <li><p class="" style="">A MUC service SHOULD remove a user if the service receives a delivery-related error in relation to a stanza it has previously sent to the user (remote server unreachable, user not found, etc.).</p></li>
+      <li><p class="" style="">A MUC service MAY choose to discard extended presence information that is attached to a &lt;presence/&gt; stanza before reflecting the presence change to the occupants of a room. That is, an implementation MAY choose to reflect only the &lt;show/&gt;, &lt;status/&gt;, and &lt;priority/&gt; child elements of the presence element as specified in the XML schema for the 'jabber:client' namespace, with the result that presence "changes" in extended namespaces (e.g., gabber:x:music:info) are not passed through to occupants. If a service prohibits certain extended namespaces, it SHOULD provide a description of allowable traffic at the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' as described in the <a href="impl-service-traffic">Allowable Traffic</a> section of this document.</p></li>
+      <li><p class="" style="">A MUC service MAY choose to discard extended information attached to &lt;message/&gt; stanzas before reflecting the message to the occupants of a room. An example of such extended information is the lightweight text markup specified by <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2267963">25</a>]. If a service prohibits certain extended namespaces, it SHOULD provide a description of allowable traffic at the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' as described in the <a href="impl-service-traffic">Allowable Traffic</a> section of this document..</p></li>
+    </ol>
+    <div class="indent">
+<h3>16.1.1 <a name="impl-service-traffic">Allowable Traffic</a>
+</h3>
+      <p class="" style="">As noted, a service (more precisely, a properly-configured room) MAY discard some or all extended namespaces attached to &lt;message/&gt; and &lt;presence/&gt; stanzas that are intended for reflection from the sender through the room to all of the room occupants. If the room does so, it SHOULD enable senders to discover the list of allowable extensions by sending a disco#info query to the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic', returning one &lt;feature/&gt; element for each namespace supported in the result. If the room does not allow any extended namespaces, it MUST return an empty query as specified in JEP-0030. If the room does not support the "#traffic" node, it MUST return a &lt;feature-not-implemented/&gt; error in response to queries sent to the 'http://jabber.org/protocol/muc#traffic' node.</p>
+      <p class="" style="">The following example shows a room that allows the 'http://jabber.org/protocol/xhtml-im' and 'http://jabber.org/protocol/rosterx' namespaces only, but no other extended namespaces.</p>
+      <p class="caption">Example 169. User Queries Service Regarding Allowable Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    to='heath@macbeth.shakespeare.lit'
+    id='allow1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 170. Service Returns Allowable Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    id='allow1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'&gt;
+    &lt;feature var='http://jabber.org/protocol/xhtml-im'/&gt;
+    &lt;feature var='http://jabber.org/protocolhttp://jabber.org/protocol//rosterx'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>16.2 <a name="impl-client">Clients</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">Jabber clients MAY present room roles by showing ad-hoc groups for each role within a room roster. This will enable occupants to clearly visualize which occupants are moderators, participants, and visitors. However, such a representation is OPTIONAL.</p></li>
+      <li><p class="" style="">Jabber clients MAY implement a variety of interface styles that provide "shortcuts" to functionality such as changing one's nickname, kicking or banning users, discovering an occupant's full JID, or changing the subject. One option consists of IRC-style commands such as '/nick', '/kick', '/ban', and '/whois'; another is to enable a user to right-click items in a room roster. All such interface styles are OPTIONAL. However, for convenience, a mapping of IRC commands to MUC protocols is provided below.</p></li>
+    </ol>
+    <div class="indent">
+<h3>16.2.1 <a name="impl-client-irc">IRC Command Mapping</a>
+</h3>
+      <p class="" style="">Internet Relay Chat clients use a number of common "shortcut" commands that begin with a forward slash, such as '/nick' and '/ban'. The following table provides a mapping of IRC-style commands to MUC protocols, for use by Jabber clients that wish to support such functionality.</p>
+      <p class="caption">Table 9: IRC Command Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Command</th>
+          <th colspan="" rowspan="">Function</th>
+          <th colspan="" rowspan="">MUC protocol</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/ban &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">bans user with that roomnick from this room (client translates roomnick to bare JID)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='jid-of-roomnick'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/invite &lt;jid&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">invites user with that JID to this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='jid'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/join &lt;roomname&gt; [pass]</td>
+          <td align="" colspan="" rowspan="">joins room on this service (roomnick is same as nick in this room)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;password&gt;pass&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/kick &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">kicks user with that roomnick from this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='roomnick' role='none'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/msg &lt;roomnick&gt; &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">sends private message "foo" to roomnick</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service/nick' type='chat'&gt;
+  &lt;body&gt;foo&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/nick &lt;newnick&gt;</td>
+          <td align="" colspan="" rowspan="">changes nick in this room to "newnick"</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/newnick'/&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/part [comment]</td>
+          <td align="" colspan="" rowspan="">exits this room (some IRC clients also support /leave)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'
+          type='unavailable'&gt;
+  &lt;status&gt;comment&lt;/status&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/topic &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">changes subject of this room to "foo"</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service' type='groupchat'&gt;
+  &lt;subject&gt;foo&lt;/subject&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+      </table>
+      <p class="" style="">Note: Because MUC roomnicks follow the Resourceprep profile of stringprep, they are allowed to contain a space character, whereas IRC nicknames do not. Although a given client MAY support quotation characters for this purpose (resulting in commands such as '/ban "king lear" insanity is no defense'), most common quotation characters (such as " and ') are also allowed by Resourceprep, thus leading to added complexity and potential problems with quotation of roomnicks that contain both spaces and quotation characters. Therefore it is NOT RECOMMENDED for Jabber clients to support IRC-style shortcut commands with roomnicks that contain space characters.</p>
+      <p class="" style="">Note: Many Jabber clients also implement a '/me ' command, where the command is followed by a verb or verb phrase (e.g., '/me laughs'). This command does not result in any MUC or IRC protocol action and is therefore not shown in the foregoing table. Instead, the message is sent as-is (e.g., &lt;body&gt;/me laughs&lt;/body&gt;) and the receiving client performs string-matching on the character data of the &lt;body/&gt; element to determine if the message begins with the string '/me '; if it does the receiving client will show the message in a special format, usually italicized text sometimes prepended by the "*" character:</p>
+      <p class="" style="margin-left: 5%"><span style="font-style: italic">* stpeter laughs</span></p>
+    </div>
+  </div>
+<h2>17.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>17.1 <a name="schemas-muc">http://jabber.org/protocol/muc</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc'
+    xmlns='http://jabber.org/protocol/muc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='history' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='history'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='maxchars' type='xs:int' use='optional'/&gt;
+          &lt;xs:attribute name='maxstanzas' type='xs:int' use='optional'/&gt;
+          &lt;xs:attribute name='seconds' type='xs:int' use='optional'/&gt;
+          &lt;xs:attribute name='since' type='xs:dateTime' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>17.2 <a name="schemas-user">http://jabber.org/protocol/muc#user</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#user'
+    xmlns='http://jabber.org/protocol/muc#user'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='decline' minOccurs='0'/&gt;
+        &lt;xs:element ref='destroy' minOccurs='0'/&gt;
+        &lt;xs:element ref='invite' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='item' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element ref='status' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='decline'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='invite'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+        &lt;xs:element name='continue' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='code' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:int'&gt;
+            &lt;xs:length value='3'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>17.3 <a name="schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#admin'
+    xmlns='http://jabber.org/protocol/muc#admin'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>17.4 <a name="schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#owner'
+    xmlns='http://jabber.org/protocol/muc#owner'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import 
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:xdata='jabber:x:data' minOccurs='0'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+        &lt;xs:element ref='destroy'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='reason' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>18.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The author would like to thank the following individuals for their many helpful comments on various drafts of this proposal: David Sutton, Peter Millard, Joe Hildebrand, Craig Kaes, Alexey Shchepin, David Waite, Jean-Louis Seguineau, Jacek Konieczny, Gaston Dombiak, and many others in the jdev@conference.jabber.org conference room and on the Standards-JIG mailing list.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250245">1</a>. RFC 1459: Internet Relay Chat &lt;<a href="http://www.ietf.org/rfc/rfc1459.txt">http://www.ietf.org/rfc/rfc1459.txt</a>&gt;.</p>
+<p><a name="nt-id2256104">2</a>. <a href="http://www.jabber.org/protocol/groupchat.html">http://www.jabber.org/protocol/groupchat.html</a></p>
+<p><a name="nt-id2259172">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2259349">4</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259520">5</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p><a name="nt-id2260620">6</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2260811">7</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2261053">8</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2262006">9</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2262026">10</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2262587">11</a>. Some commentors have complained that this opens room owners and administrators up to potential abuse; however, with power comes responsibility.</p>
+<p><a name="nt-id2263361">12</a>. JEP-0133: Service Administration &lt;<a href="http://www.jabber.org/jeps/jep-0133.html">http://www.jabber.org/jeps/jep-0133.html</a>&gt;.</p>
+<p><a name="nt-id2264223">13</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2264245">14</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2265574">15</a>. This is different from the behavior of room configuration, wherein the 'muc#roomconfig_roomowners' field specifies the full list of room owners, not the delta.</p>
+<p><a name="nt-id2265898">16</a>. This is different from the behavior of room configuration, wherein the 'muc#roomconfig_roomadmins' field specifies the full list of room admins, not the delta.</p>
+<p><a name="nt-id2266207">17</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2266646">18</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2266668">19</a>. RFC 1893: Enhanced Mail System Status Codes &lt;<a href="http://www.ietf.org/rfc/rfc1893.txt">http://www.ietf.org/rfc/rfc1893.txt</a>&gt;.</p>
+<p><a name="nt-id2266788">20</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2266835">21</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2267032">22</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2267409">23</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2267432">24</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2267963">25</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.19 (2005-04-21)</h4>
+<div class="indent">Specified how to send multiple invitations simultaneously; corrected some errors regarding consistency of affiliation state changes; changed message events prohibition from MUST NOT to SHOULD NOT; corrected error handling related to the #traffic disco node; allowed &lt;password/&gt; as a child of &lt;destroy/&gt;; changed max users error from &lt;not-allowed/&gt; to &lt;service-unavailable/&gt;; specified that the maxchars attribute counts characters in complete XML stanzas; added disco features for FORM_TYPEs; defined registry for status codes; split Create Instant Room into separate use case for protocol compliance purposes; adjusted XML schemas to reflect the foregoing changes; re-wrote the introduction; clarified small textual matters throughout. (psa)
+    </div>
+<h4>Version 1.18 (2004-11-02)</h4>
+<div class="indent">Corrected several errors in the affiliation state chart and in the examples (wrong FORM_TYPE values); mentioned /me command. (psa)
+    </div>
+<h4>Version 1.17 (2004-10-04)</h4>
+<div class="indent">Added text about allowable extension namespaces and related service discovery mechanisms; specified well-known service discovery nodes; added conformance terms to clarify some descriptions; modified affiliation state chart to allow more flexible state changes; per list dicussion, added ability to convert a one-to-one chat into a conference, including sending of history; specified error to use when max users limit is reached; specified form for admin approval of user registration requests and modified FORM_TYPE from http://jabber.org/protocol/muc#user to http://jabber.org/protocol/muc#register; modified FORM_TYPE for room configuration from http://jabber.org/protocol/muc#owner to http://jabber.org/protocol/muc#roomconfig. (psa)
+    </div>
+<h4>Version 1.16 (2004-06-30)</h4>
+<div class="indent">Added example and registry submission for service discovery extension. (psa)
+    </div>
+<h4>Version 1.15 (2004-06-24)</h4>
+<div class="indent">Removed jabber:iq:browse references; clarified order of presence stanzas sent to new occupant on entering room; specified format of in-room messages (type='groupchat', from='room@service'); clarified allowable attributes in various list-related operations; made admin/owner revocation text and examples consistent with state chart; clarified ownership revocation conflict scenarios; changed the 'muc#roomconfig_inviteonly' field to 'muc#roomconfig_membersonly'; changed attribute order in examples to match XML canonicalization rules; corrected several errors in the schemas. (psa)
+    </div>
+<h4>Version 1.14 (2004-05-03)</h4>
+<div class="indent">Corrected discovery of registered roomnicks; added note about error to return if nicks are locked down. (psa)
+    </div>
+<h4>Version 1.13 (2004-03-31)</h4>
+<div class="indent">Fixed an error in the muc#user schema. (psa)
+    </div>
+<h4>Version 1.12 (2004-03-01)</h4>
+<div class="indent">Corrected a few errors in the examples; added IQ results in order to clarify workflows. (psa)
+    </div>
+<h4>Version 1.11 (2004-02-05)</h4>
+<div class="indent">Clarified JID matching rules (same as for privacy lists in XMPP IM). (psa)
+    </div>
+<h4>Version 1.10 (2004-01-07)</h4>
+<div class="indent">Added XMPP error handling; fully specified all conformance terms. (psa)
+    </div>
+<h4>Version 1.9 (2003-12-14)</h4>
+<div class="indent">Removed protocol for requesting voice in a moderated room (should be performed using Ad-Hoc Commands). (psa)
+    </div>
+<h4>Version 1.8 (2003-12-04)</h4>
+<div class="indent">Added protocol for requesting voice in a moderated room; added (informational) mapping of IRC commands to MUC protocols. (psa)
+    </div>
+<h4>Version 1.7 (2003-10-21)</h4>
+<div class="indent">Added room configuration option for restricting presence broadcast to certain roles. (psa)
+    </div>
+<h4>Version 1.6 (2003-10-03)</h4>
+<div class="indent">Added history management protocol on entering a room. (psa)
+    </div>
+<h4>Version 1.5 (2003-09-11)</h4>
+<div class="indent">Specified that ban occurs by JID, not roomnick; allowed privileged users to send messages to the room even if not present in the room; added note that service should remove occupant if a delivery-related stanza error occurs; enabled user to disco the room in order to discover registered roomnick; specified that "banning" by domain or regex is a service-level configuration matter and therefore out of scope for MUC; specified that role should be decremented as appropriate if affiliation is lowered; added some clarifying text to room creation workflow; added implementation note about sending an out-of-band message if a user's affiliation changes while the user is not in the room; fixed stringprep references (room nicks use Resourceprep); clarified relationship between Room ID (i.e., node identifier of Room JID, which may be opaque) and natural-language Room Name; specified Field Standardization profile per JEP-0068; defined Jabber Registrar submissions; added schema locations. (psa)
+    </div>
+<h4>Version 1.4 (2003-02-16)</h4>
+<div class="indent">Added XML schemas. (psa)
+    </div>
+<h4>Version 1.3 (2003-02-11)</h4>
+<div class="indent">Added reference to nodeprep Internet-Draft. (psa)
+    </div>
+<h4>Version 1.2 (2003-01-30)</h4>
+<div class="indent">Commented out revision history prior to version 1.0 (too long); clarified business rules regarding when nicks, full JIDs, and bare JIDs are used in reference to roles and affiliations; consistently specified that extended presence information in the muc#user namespace must include the full JID as the value of the 'jid' attribute in all cases; cleaned up text and examples throughout; added open issue regarding syntax of room nicknames. (psa)
+    </div>
+<h4>Version 1.1 (2002-12-16)</h4>
+<div class="indent">Added protocol for declining an invitation; replaced &lt;created/&gt; element with status code 201; modified the destroy room protocol so that &lt;destroy/&gt; is a child of &lt;query/&gt;; clarified usage of 'nick' attribute when adding members; prohibited use of message events. (psa)
+    </div>
+<h4>Version 1.0 (2002-11-21)</h4>
+<div class="indent">Per a vote of the Jabber Council, revision 0.23 was advanced to Draft on 2002-11-21. (For earlier revision history, refer to XML source.) (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0045-1.20.html
+++ b/content/xep-0045-1.20.html
@@ -1,0 +1,5660 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0045: Multi-User Chat</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Multi-User Chat">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a robust protocol for XMPP-based text conferencing.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="in progress, revised 2006-05-04">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0045">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0045: Multi-User Chat</h1>
+<p>This document defines a robust protocol for XMPP-based text conferencing.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0045<br>
+            Version: 1.21pre3<br>
+            Last Updated: in progress, revised 2006-05-04<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0004, JEP-0030, JEP-0068, JEP-0082, JEP-0128<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: muc<br>
+        XML Schema for muc: &lt;<a href="http://jabber.org/protocol/muc/muc.xsd">http://jabber.org/protocol/muc/muc.xsd</a>&gt;<br>
+        XML Schema for muc#admin: &lt;<a href="http://jabber.org/protocol/muc/admin.xsd">http://jabber.org/protocol/muc/admin.xsd</a>&gt;<br>
+        XML Schema for muc#owner: &lt;<a href="http://jabber.org/protocol/muc/owner.xsd">http://jabber.org/protocol/muc/owner.xsd</a>&gt;<br>
+        XML Schema for muc#user: &lt;<a href="http://jabber.org/protocol/muc/user.xsd">http://jabber.org/protocol/muc/user.xsd</a>&gt;<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/muc.html">http://www.jabber.org/registrar/muc.html</a>&gt;
+              <br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Multi-User%20Chat%20(JEP-0045)">http://wiki.jabber.org/index.php/Multi-User Chat (JEP-0045)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#scope">Scope</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#terms-general">General Terms</a>
+</dt>
+<dt>4.2.  <a href="#terms-rooms">Room Types</a>
+</dt>
+<dt>4.3.  <a href="#terms-personae">Dramatis Personae</a>
+</dt>
+</dl>
+<dt>5.  <a href="#connections">Roles and Affiliations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#roles">Roles</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#roles-priv">Privileges</a>
+</dt>
+<dt>5.1.2.  <a href="#roles-change">Changing Roles</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#affil">Affiliations</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#affil-priv">Privileges</a>
+</dt>
+<dt>5.2.2.  <a href="#affil-change">Changing Affiliations</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#entity">Entity Use Cases</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#disco-component">Discovering Component Support for MUC</a>
+</dt>
+<dt>6.2.  <a href="#disco-rooms">Discovering Rooms</a>
+</dt>
+<dt>6.3.  <a href="#disco-roominfo">Querying for Room Information</a>
+</dt>
+<dt>6.4.  <a href="#disco-roomitems">Querying for Room Items</a>
+</dt>
+<dt>6.5.  <a href="#disco-occupant">Querying a Room Occupant</a>
+</dt>
+<dt>6.6.  <a href="#disco-client">Discovering Client Support for MUC</a>
+</dt>
+<dt>6.7.  <a href="#requestinvite">Requesting an Invitation</a>
+</dt>
+</dl>
+<dt>7.  <a href="#user">Occupant Use Cases</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#enter">Entering a Room</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#enter-gc">Groupchat 1.0 Protocol</a>
+</dt>
+<dt>7.1.2.  <a href="#enter-muc">Basic MUC Protocol</a>
+</dt>
+<dt>7.1.3.  <a href="#enter-pres">Presence Broadcast</a>
+</dt>
+<dt>7.1.4.  <a href="#enter-roles">Default Roles</a>
+</dt>
+<dt>7.1.5.  <a href="#enter-nonanon">Non-Anonymous Rooms</a>
+</dt>
+<dt>7.1.6.  <a href="#enter-semianon">Semi-Anonymous Rooms</a>
+</dt>
+<dt>7.1.7.  <a href="#enter-pw">Password-Protected Rooms</a>
+</dt>
+<dt>7.1.8.  <a href="#enter-members">Members-Only Rooms</a>
+</dt>
+<dt>7.1.9.  <a href="#enter-banned">Banned Users</a>
+</dt>
+<dt>7.1.10.  <a href="#enter-conflict">Nickname Conflict</a>
+</dt>
+<dt>7.1.11.  <a href="#enter-maxusers">Max Users</a>
+</dt>
+<dt>7.1.12.  <a href="#enter-history">Discussion History</a>
+</dt>
+<dt>7.1.13.  <a href="#enter-managehistory">Managing Discussion History</a>
+</dt>
+<dt>7.1.14.  <a href="#enter-locked">Locked Room</a>
+</dt>
+<dt>7.1.15.  <a href="#enter-nonexistent">Nonexistent Room</a>
+</dt>
+</dl>
+<dt>7.2.  <a href="#exit">Exiting a Room</a>
+</dt>
+<dt>7.3.  <a href="#changenick">Changing Nickname</a>
+</dt>
+<dt>7.4.  <a href="#changepres">Changing Availability Status</a>
+</dt>
+<dt>7.5.  <a href="#invite">Inviting Another User to a Room</a>
+</dt>
+<dt>7.6.  <a href="#continue">Converting a One-to-One Chat Into a Conference</a>
+</dt>
+<dt>7.7.  <a href="#subject-occupant">Occupant Modification of the Room Subject</a>
+</dt>
+<dt>7.8.  <a href="#privatemessage">Sending a Private Message</a>
+</dt>
+<dt>7.9.  <a href="#message">Sending a Message to All Occupants</a>
+</dt>
+<dt>7.10.  <a href="#register">Registering with a Room</a>
+</dt>
+<dt>7.11.  <a href="#reservednick">Discovering Reserved Room Nickname</a>
+</dt>
+<dt>7.12.  <a href="#requestvoice">Requesting Voice</a>
+</dt>
+</dl>
+<dt>8.  <a href="#moderator">Moderator Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#subject-mod">Modifying the Room Subject</a>
+</dt>
+<dt>8.2.  <a href="#kick">Kicking an Occupant</a>
+</dt>
+<dt>8.3.  <a href="#grantvoice">Granting Voice to a Visitor</a>
+</dt>
+<dt>8.4.  <a href="#revokevoice">Revoking Voice from a Participant</a>
+</dt>
+<dt>8.5.  <a href="#modifyvoice">Modifying the Voice List</a>
+</dt>
+</dl>
+<dt>9.  <a href="#admin">Admin Use Cases</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#ban">Banning a User</a>
+</dt>
+<dt>9.2.  <a href="#modifyban">Modifying the Ban List</a>
+</dt>
+<dt>9.3.  <a href="#grantmember">Granting Membership</a>
+</dt>
+<dt>9.4.  <a href="#revokemember">Revoking Membership</a>
+</dt>
+<dt>9.5.  <a href="#modifymember">Modifying the Member List</a>
+</dt>
+<dt>9.6.  <a href="#grantmod">Granting Moderator Privileges</a>
+</dt>
+<dt>9.7.  <a href="#revokemod">Revoking Moderator Privileges</a>
+</dt>
+<dt>9.8.  <a href="#modifymod">Modifying the Moderator List</a>
+</dt>
+<dt>9.9.  <a href="#regapprove">Approving Registration Requests</a>
+</dt>
+</dl>
+<dt>10.  <a href="#owner">Owner Use Cases</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#createroom">Creating a Room</a>
+</dt>
+<dl>
+<dt>10.1.1.  <a href="#createroom-general">General Considerations</a>
+</dt>
+<dt>10.1.2.  <a href="#createroom-instant">Creating an Instant Room</a>
+</dt>
+<dt>10.1.3.  <a href="#createroom-reserved">Creating a Reserved Room</a>
+</dt>
+</dl>
+<dt>10.2.  <a href="#roomconfig">Subsequent Room Configuration</a>
+</dt>
+<dl><dt>10.2.1.  <a href="#roomconfig-notify">Notification of Configuration Changes</a>
+</dt></dl>
+<dt>10.3.  <a href="#grantowner">Granting Ownership Privileges</a>
+</dt>
+<dt>10.4.  <a href="#revokeowner">Revoking Ownership Privileges</a>
+</dt>
+<dt>10.5.  <a href="#modifyowner">Modifying the Owner List</a>
+</dt>
+<dt>10.6.  <a href="#grantadmin">Granting Administrative Privileges</a>
+</dt>
+<dt>10.7.  <a href="#revokeadmin">Revoking Administrative Privileges</a>
+</dt>
+<dt>10.8.  <a href="#modifyadmin">Modifying the Admin List</a>
+</dt>
+<dt>10.9.  <a href="#destroyroom">Destroying a Room</a>
+</dt>
+</dl>
+<dt>11.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#errorcodes">Error Codes</a>
+</dt>
+<dt>11.2.  <a href="#statuscodes">Status Codes</a>
+</dt>
+</dl>
+<dt>12.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>13.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#security-auth">User Authentication and Authorization</a>
+</dt>
+<dt>13.2.  <a href="#security-e2e">End-to-End Encryption</a>
+</dt>
+<dt>13.3.  <a href="#security-privacy">Privacy</a>
+</dt>
+<dt>13.4.  <a href="#security-anon">Anonymity</a>
+</dt>
+</dl>
+<dt>14.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>15.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>15.2.  <a href="#registrar-discocat">Service Discovery Category/Type</a>
+</dt>
+<dt>15.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>15.4.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>15.5.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+<dl>
+<dt>15.5.1.  <a href="#registrar-formtype-register">muc#register FORM_TYPE</a>
+</dt>
+<dt>15.5.2.  <a href="#registrar-formtype-owner">muc#roomconfig FORM_TYPE</a>
+</dt>
+<dt>15.5.3.  <a href="#registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</dt>
+</dl>
+<dt>15.6.  <a href="#registrar-statuscodes">Status Codes Registry</a>
+</dt>
+<dl>
+<dt>15.6.1.  <a href="#registrar-statuscodes-process">Process</a>
+</dt>
+<dt>15.6.2.  <a href="#registrar-statuscodes-init">Initial Submission</a>
+</dt>
+</dl>
+<dt>15.7.  <a href="#registrar-querytypes">URI Query Types</a>
+</dt>
+<dl>
+<dt>15.7.1.  <a href="#registrar-querytypes-join">join</a>
+</dt>
+<dt>15.7.2.  <a href="#registrar-querytypes-invite">invite</a>
+</dt>
+</dl>
+</dl>
+<dt>16.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#bizrules-jids">Addresses</a>
+</dt>
+<dt>16.2.  <a href="#bizrules-message">Message</a>
+</dt>
+<dt>16.3.  <a href="#bizrules-presence">Presence</a>
+</dt>
+<dt>16.4.  <a href="#bizrules-iq">IQ</a>
+</dt>
+</dl>
+<dt>17.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>17.1.  <a href="#impl-service">Services</a>
+</dt>
+<dl><dt>17.1.1.  <a href="#impl-service-traffic">Allowable Traffic</a>
+</dt></dl>
+<dt>17.2.  <a href="#impl-client">Clients</a>
+</dt>
+<dl><dt>17.2.1.  <a href="#impl-client-irc">IRC Command Mapping</a>
+</dt></dl>
+</dl>
+<dt>18.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>18.1.  <a href="#schemas-muc">http://jabber.org/protocol/muc</a>
+</dt>
+<dt>18.2.  <a href="#schemas-user">http://jabber.org/protocol/muc#user</a>
+</dt>
+<dt>18.3.  <a href="#schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</dt>
+<dt>18.4.  <a href="#schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</dt>
+</dl>
+<dt>19.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Traditionally, instant messaging is thought to consist of one-to-one chat rather than many-to-many chat, which is called variously "groupchat" or "text conferencing". Groupchat functionality is familiar from systems such as Internet Relay Chat (IRC) and the chatroom functionality offered by popular consumer IM services. The Jabber community developed and implemented a basic groupchat protocol as long ago as 1999. This "groupchat 1.0" protocol provided a minimal feature set for chat rooms but was rather limited in scope. This specification builds on the older "groupchat 1.0" protocol in a backwards-compatible manner but provides advanced features such as invitations, room moderation and administration, and specialized room types. These extensions are implemented using protocol elements qualified by the 'http://jabber.org/protocol/muc' namespace (and the #owner, #admin, and #user fragments on the main namespace URI).</p>
+<h2>2.
+       <a name="scope">Scope</a>
+</h2>
+  <p class="" style="">This document addresses common requirements related to configuration of, participation in, and administration of individual text-based conference rooms. All of the requirements addressed herein apply at the level of the individual room and are "common" in the sense that they have been widely discussed within the Jabber community or are familiar from existing text-based conference environments outside of Jabber (e.g., Internet Relay Chat as defined in <span class="ref" style="">RFC 1459</span>  [<a href="#nt-id2251350">1</a>] and its successors).</p>
+  <p class="" style="">This document explicitly does <span style="font-style: italic">not</span> address the following:</p>
+  <ul>
+    <li>Relationships between rooms (e.g., hierarchies of rooms)</li>
+    <li>Management of multi-user chat services (e.g., managing permissions across an entire service or registering a global room nickname)</li>
+    <li>Moderation of individual messages</li>
+    <li>Security and encryption at the level of a room or service</li>
+    <li>Advanced features such as attaching files to a room, integrating whiteboards, and interfacing with audio chat services</li>
+    <li>Interaction between MUC deployments and foreign chat systems (e.g., gateways to IRC or to legacy IM systems)</li>
+  </ul>
+  <p class="" style="">This limited scope is not meant to disparage such topics, which are of inherent interest; however, it is meant to focus the discussion in this document and to present a comprehensible protocol that can be implemented by Jabber client and component developers alike. Future specifications may of course address the topics mentioned above.</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This document addresses the minimal functionality provided by existing multi-user chat services in Jabber. For the sake of backwards-compatibility, this document uses the original "groupchat 1.0" protocol for this baseline functionality, with the result that:</p>
+  <ul>
+    <li>Each room is identified as &lt;room@service&gt; (e.g., &lt;jdev@conference.jabber.org&gt;), where "room" is the name of the room and "service" is the hostname at which the multi-user chat service is running.</li>
+    <li>Each occupant in a room is identified as &lt;room@service/nick&gt;, where "nick" is the room nickname of the occupant as specified on entering the room or subsequently changed during the occupant's visit.</li>
+    <li>A user enters a room (i.e., becomes an occupant) by sending presence to &lt;room@service/nick&gt;.</li>
+    <li>Messages sent within multi-user chat rooms are of a special type "groupchat" and are addressed to the room itself (room@service), then reflected to all occupants.</li>
+    <li>An occupant can change his or her room nickname and availability status within the room by sending presence information to &lt;room@service/newnick&gt;.</li>
+    <li>An occupant exits a room by sending presence of type "unavailable" to its current &lt;room@service/nick&gt;.</li>
+  </ul>
+  <p class="" style="">The additional features and functionality addressed in this document include the following:</p>
+  <ol start="1" type="">
+    <li>native conversation logging (no in-room bot required)</li>
+    <li>enabling users to request membership in a room</li>
+    <li>enabling occupants to view an occupant's full JID in a non-anonymous room</li>
+    <li>enabling moderators to view an occupant's full JID in a semi-anonymous room</li>
+    <li>allowing only moderators to change the room subject</li>
+    <li>enabling moderators to kick participants and visitors from the room</li>
+    <li>enabling moderators to grant and revoke voice (i.e., the privilege to speak) in a moderated room, and to manage the voice list</li>
+    <li>enabling admins to grant and revoke moderator privileges, and to manage the moderator list</li>
+    <li>enabling admins to ban users from the room, and to manage the ban list</li>
+    <li>enabling admins to grant and revoke membership privileges, and to manage the member list for a members-only room</li>
+    <li>enabling owners to limit the number of occupants</li>
+    <li>enabling owners to specify other owners</li>
+    <li>enabling owners to grant and revoke administrative privileges, and to manage the admin list</li>
+    <li>enabling owners to destroy the room</li>
+  </ol>
+  <p class="" style="">In addition, this document provides protocol elements for supporting the following room types:</p>
+  <ol start="1" type="">
+    <li>public or hidden</li>
+    <li>persistent or temporary</li>
+    <li>password-protected or unsecured</li>
+    <li>members-only or open</li>
+    <li>moderated or unmoderated</li>
+    <li>non-anonymous or semi-anonymous</li>
+  </ol>
+<h2>4.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="terms-general">General Terms</a>
+</h3>
+    <p class="" style="">Affiliation -- a long-lived association or connection with a room; the possible affiliations are "owner", "admin", "member", and "outcast" (naturally it is also possible to have no affiliation); affiliation is distinct from role. An affiliation lasts across a user's visits to a room.</p>
+    <p class="" style="">Ban -- to remove a user from a room such that the user is not allowed to re-enter the room (until and unless the ban has been removed). A banned user has an affiliation of "outcast".</p>
+    <p class="" style="">Bare JID -- the &lt;user@host&gt; by which a user is identified outside the context of any existing session or resource; contrast with Full JID and Room JID.</p>
+    <p class="" style="">Full JID -- the &lt;user@host/resource&gt; by which an online user is identified outside the context of a room; contrast with Bare JID and Room JID.</p>
+    <p class="" style="">GC -- the minimal "groupchat 1.0" protocol  [<a href="#nt-id2251668">2</a>] developed within the Jabber community in 1999; MUC is backwards-compatible with GC.</p>
+    <p class="" style="">History -- a limited number of message stanzas sent to a new occupant to provide the context of current discussion.</p>
+    <p class="" style="">Invitation -- a special message sent from one user to another asking the recipient to join a room.</p>
+    <p class="" style="">IRC -- Internet Relay Chat.</p>
+    <p class="" style="">Kick -- to temporarily remove a participant or visitor from a room; the user is allowed to re-enter the room at any time. A kicked user has a role of "none".</p>
+    <p class="" style="">Logging -- storage of discussions that occur within a room for future retrieval inside or outside the context of the room.</p>
+    <p class="" style="">Member -- a user who is on the "whitelist" for a members-only room or who is registered with an open room. A member has an affiliation of "member".</p>
+    <p class="" style="">Moderator -- a room role that is usually associated with room admins but that may be granted to non-admins; is allowed to kick users, grant and revoke voice, etc. A moderator has an role of "moderator".</p>
+    <p class="" style="">MUC -- the multi-user chat protocol for text-based conferencing specified in this document.</p>
+    <p class="" style="">Occupant -- any Jabber user who is in a room (this is an "abstract class" and does not correspond to any specific role).</p>
+    <p class="" style="">Outcast -- a user who has been banned from a room. An outcast has an affiliation of "outcast".</p>
+    <p class="" style="">Participant -- an occupant who does not have administrative privileges; in a moderated room, a participant is further defined as having voice (in contrast to a visitor). A participant has a role of "participant".</p>
+    <p class="" style="">Private Message -- a message sent from one occupant directly to another's room JID (not to the room itself for broadcasting to all occupants).</p>
+    <p class="" style="">Role -- a temporary position or privilege level within a room, distinct from a user's long-lived affiliation with the room; the possible roles are "moderator", "participant", and "visitor" (it is also possible to have no defined role). A role lasts only for the duration of an occupant's visit to a room.</p>
+    <p class="" style="">Room -- a virtual space that Jabber users figuratively enter in order to participate in real-time, text-based conferencing with other users.</p>
+    <p class="" style="">Room Administrator -- a user empowered by the room owner to perform administrative functions such as banning users; however, is not allowed to change defining room features. An admin has an affiliation of "admin".</p>
+    <p class="" style="">Room ID -- the node identifier portion of a Room JID, which may be opaque and thus lack meaning for human users (see Business Rules for syntax); contrast with Room Name.</p>
+    <p class="" style="">Room JID -- the &lt;room@service/nick&gt; by which an occupant is identified within the context of a room; contrast with Bare JID and Full JID.</p>
+    <p class="" style="">Room Name -- a user-friendly, natural-language name for a room, configured by the room owner and presented in Service Discovery queries; contrast with Room ID.</p>
+    <p class="" style="">Room Nickname -- the resource identifier portion of a Room JID (see Business Rules for syntax); this is the "friendly name" by which an occupant is known in the room.</p>
+    <p class="" style="">Room Owner -- the Jabber user who created the room or a Jabber user who has been designated by the room creator or owner as someone with owner privileges (if allowed); is allowed to change defining room features as well as perform all administrative functions. An owner has an affiliation of "owner".</p>
+    <p class="" style="">Room Roster -- a Jabber client's representation of the occupants in a room.</p>
+    <p class="" style="">Server -- a Jabber server that may or may not have associated with it a text-based conferencing service.</p>
+    <p class="" style="">Service -- a host that offers text-based conferencing capabilities; often but not necessarily a sub-domain of a Jabber server (e.g., conference.jabber.org).</p>
+    <p class="" style="">Subject -- a temporary discussion topic within a room.</p>
+    <p class="" style="">Visit -- a user's "session" in a room, beginning when the user enters the room (i.e., becomes an occupant) and ending when the user exits the room.</p>
+    <p class="" style="">Visitor -- in a moderated room, an occupant who does not have voice (in contrast to a participant). A visitor has a role of "visitor".</p>
+    <p class="" style="">Voice -- in a moderated room, the privilege to send messages to all occupants.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="terms-rooms">Room Types</a>
+</h3>
+    <p class="" style="">Fully-Anonymous Room -- a room in which the full JIDs or bare JIDs of occupants cannot be discovered by anyone, including room admins and room owners; such rooms are NOT RECOMMENDED or explicitly supported by MUC, but are possible using this protocol if a service implementation offers the appropriate configuration options; contrast with Non-Anonymous Room and Semi-Anonymous Room.</p>
+    <p class="" style="">Hidden Room -- a room that cannot be found by any user through normal means such as searching and service discovery; antonym: Public Room.</p>
+    <p class="" style="">Members-Only Room -- a room that a user cannot enter without being on the member list; antonym: Open Room.</p>
+    <p class="" style="">Moderated Room -- a room in which only those with "voice" may send messages to all occupants; antonym: Unmoderated Room.</p>
+    <p class="" style="">Non-Anonymous Room -- a room in which an occupant's full JID is exposed to all other occupants, although the occupant may choose any desired room nickname; contrast with Semi-Anonymous Room and Fully-Anonymous Room.</p>
+    <p class="" style="">Open Room -- a room that anyone may enter without being on the member list; antonym: Members-Only Room.</p>
+    <p class="" style="">Password-Protected Room -- a room that a user cannot enter without first providing the correct password; antonym: Unsecured Room.</p>
+    <p class="" style="">Persistent Room -- a room that is not destroyed if the last occupant exits; antonym: Temporary Room.</p>
+    <p class="" style="">Public Room -- a room that can be found by any user through normal means such as searching and service discovery; antonym: Hidden Room.</p>
+    <p class="" style="">Semi-Anonymous Room -- a room in which an occupant's full JID can be discovered by room admins only; contrast with Fully-Anonymous Room and Non-Anonymous Room.</p>
+    <p class="" style="">Temporary Room -- a room that is destroyed if the last occupant exits; antonym: Persistent Room.</p>
+    <p class="" style="">Unmoderated Room -- a room in which any occupant is allowed to send messages to all occupants; antonym: Moderated Room.</p>
+    <p class="" style="">Unsecured Room -- a room that anyone is allowed to enter without first providing the correct password; antonym: Password-Protected Room.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="terms-personae">Dramatis Personae</a>
+</h3>
+    <p class="" style="">Most of the examples in this document use the scenario of the witches' meeting held in a dark cave at the beginning of Act IV, Scene I of Shakespeare's <span style="font-weight: bold">Macbeth</span>, represented here as the "darkcave@macbeth.shakespeare.lit" chatroom. The characters are as follows:</p>
+    <p class="caption">Table 1: Dramatis Personae</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Room Nickname</th>
+        <th colspan="" rowspan="">Full JID</th>
+        <th colspan="" rowspan="">Affiliation</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">firstwitch</td>
+        <td align="" colspan="" rowspan="">crone1@shakespeare.lit/desktop</td>
+        <td align="" colspan="" rowspan="">Owner</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">secondwitch</td>
+        <td align="" colspan="" rowspan="">wiccarocks@shakespeare.lit/laptop</td>
+        <td align="" colspan="" rowspan="">Admin</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">thirdwitch</td>
+        <td align="" colspan="" rowspan="">hag66@shakespeare.lit/pda</td>
+        <td align="" colspan="" rowspan="">None</td>
+      </tr>
+    </table>
+  </div>
+<h2>5.
+       <a name="connections">Roles and Affiliations</a>
+</h2>
+  <p class="" style="">There are two dimensions along which we can measure a user's connection with or position in a room. One is the user's long-lived affiliation with a room -- e.g., a user's status as an owner or an outcast. The other is a user's role while an occupant of a room -- e.g., an occupant's position as a moderator with the ability to kick visitors and participants. These two dimensions are distinct from each other, since an affiliation lasts across visits, while a role lasts only for the duration of a visit. In addition, there is no one-to-one correspondence between roles and affiliations; for example, someone who is not affiliated with a room may be a (temporary) moderator, and a member may be a participant or a visitor in a moderated room. These concepts are explained more fully below.</p>
+  <div class="indent">
+<h3>5.1 <a name="roles">Roles</a>
+</h3>
+    <p class="" style="">There are four defined roles that an occupant may have:</p>
+    <ol start="1" type="">
+      <li>Moderator</li>
+      <li>Participant</li>
+      <li>Visitor</li>
+      <li>None (the absence of a role)</li>
+    </ol>
+    <p class="" style="">Roles are temporary in that they do not necessarily persist across a user's visits to the room and MAY change during the course of an occupant's visit to the room. An implementation MAY persist roles across visits and SHOULD do so for moderated rooms (since the distinction between visitor and participant is critical to the functioning of a moderated room).</p>
+    <p class="" style="">There is no one-to-one mapping between roles and affiliations (e.g., a member could be a participant or a visitor).</p>
+    <p class="" style="">A moderator is the most powerful occupant within the context of the room, and can to some extent manage other occupants' roles in the room. A participant has fewer privileges than a moderator, although he or she always has the right to speak. A visitor is a more restricted role within the context of a moderated room, since visitors are not allowed to send messages to all occupants.</p>
+    <p class="" style="">Roles are granted, revoked, and maintained based on the occupant's room nickname or full JID rather than bare JID. The privileges associated with these roles, as well as the actions that trigger changes in roles, are defined below.</p>
+    <p class="" style="">Information about roles MUST be sent in all presence stanzas generated or reflected by the room and thus sent to occupants.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="roles-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, roles exist in a hierarchy. For instance, a participant can do anything a visitor can do, and a moderator can do anything a participant can do. Each role has privileges not possessed by the next-lowest role; these privileges are specified in the following table as defaults (an implementation MAY provide configuration options that override these defaults).</p>
+      <p class="caption">Table 2: Privileges Associated With Roles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Present in Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Receive Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Availability Status</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Nickname</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Private Messages</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Invite Other Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Send Messages to All</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No**</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Modify Subject</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No*</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Kick Participants and Visitors</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Grant Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Revoke Voice</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes***</td>
+        </tr>
+      </table>
+      <p class="" style="">* Default; configuration settings MAY modify this privilege.</p>
+      <p class="" style="">** An implementation MAY grant voice by default to visitors in unmoderated rooms.</p>
+      <p class="" style="">*** A moderator MUST NOT be able to revoke voice privileges from an admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="roles-change">Changing Roles</a>
+</h3>
+      <p class="" style="">The ways in which an occupant's role changes are well-defined. Sometimes the change results from the occupant's own action (e.g., entering or exiting the room), whereas sometimes the change results from an action taken by a moderator, admin, or owner. If an occupant's role changes, a MUC service implementation MUST change the occupant's role to reflect the change and communicate the change to all occupants. Role changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 3: Role State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">&gt;</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Visitor</th>
+          <th colspan="" rowspan="">Participant</th>
+          <th colspan="" rowspan="">Moderator</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Enter moderated room</td>
+          <td align="" colspan="" rowspan="">Enter unmoderated room</td>
+          <td align="" colspan="" rowspan="">Admin or owner enters room</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Moderator grants voice</td>
+          <td align="" colspan="" rowspan="">Admin or owner grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Exit room or be kicked by a moderator</td>
+          <td align="" colspan="" rowspan="">Moderator revokes voice</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner grants moderator privileges</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Exit room</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes role to visitor *</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes role to participant or revokes moderator privileges *</td>
+          <td align="" colspan="" rowspan="">--</td>
+        </tr>
+      </table>
+      <p class="" style="">* A moderator MUST NOT be able to revoke moderator privileges from an occupant who is equal to or above the moderator in the hierarchy of affiliations.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="affil">Affiliations</a>
+</h3>
+    <p class="" style="">There are five defined affiliations that a user may have in relation to a room:</p>
+    <ol start="1" type="">
+      <li>Owner</li>
+      <li>Admin</li>
+      <li>Member</li>
+      <li>Outcast</li>
+      <li>None (the absence of an affiliation)</li>
+    </ol>
+    <p class="" style="">These affiliations are long-lived in that they persist across a user's visits to the room and are not affected by happenings in the room. In addition, there is no one-to-one mapping between these affiliations and an occupant's role within the room. Affiliations are granted, revoked, and maintained based on the user's bare JID.</p>
+    <p class="" style="">If a user without a defined affiliation enters a room, the user's affiliation is defined as "none"; however, this affiliation does not persist across visits (i.e., a service does not maintain a "none list" across visits).</p>
+    <p class="" style="">The member affiliation provides a way for a room owner or admin to specify a "whitelist" of users who are allowed to enter a members-only room. When a member enters a members-only room, his or her affiliation does not change, no matter what his or her role is. The member affiliation also provides a way for users to effectively register with an open room and thus be lastingly associated with that room in some way (one result may be that the user's nickname is reserved in the room).</p>
+    <p class="" style="">An outcast is a user who has been banned from a room and who is not allowed to enter the room.</p>
+    <p class="" style="">Information about affiliations MUST be sent in all presence stanzas generated or reflected by the room and sent to occupants.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="affil-priv">Privileges</a>
+</h3>
+      <p class="" style="">For the most part, affiliations exist in a hierarchy. For instance, an owner can do anything an admin can do, and an admin can do anything a member can do. Each affiliation has privileges not possessed by the next-lowest affiliation; these privileges are specified in the following table.</p>
+      <p class="caption">Table 4: Privileges Associated With Affiliations</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Privilege</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Register with an Open Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">N/A</td>
+          <td align="" colspan="" rowspan="">N/A</td>
+          <td align="" colspan="" rowspan="">N/A</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Enter Members-Only Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes*</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Ban Members and Unaffiliated Users</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Member List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Moderator List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+          <td align="" colspan="" rowspan="">Yes**</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Admin List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Edit Owner List</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Change Room Definition</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Destroy Room</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">No</td>
+          <td align="" colspan="" rowspan="">Yes</td>
+        </tr>
+      </table>
+      <p class="" style="">* As a default, an unaffiliated user enters a moderated room as a visitor, and enters an open room as a participant. A member enters a room as a participant. An admin or owner enters a room as a moderator.</p>
+      <p class="" style="">** An admin or owner MUST NOT be able to revoke moderation privileges from another admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="affil-change">Changing Affiliations</a>
+</h3>
+      <p class="" style="">The ways in which a user's affiliation changes are well-defined. Sometimes the change results from the user's own action (e.g., registering as a member of the room), whereas sometimes the change results from an action taken by an admin or owner. If a user's affiliation changes, a MUC service implementation MUST change the user's affiliation to reflect the change and communicate that to all occupants. Affiliation changes and their triggering actions are specified in the following table.</p>
+      <p class="caption">Table 5: Affiliation State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">&gt;</th>
+          <th colspan="" rowspan="">Outcast</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Outcast</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner removes ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to member list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">None</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Admin or owner adds user to member list, or user registers as member (if allowed)</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Member</td>
+          <td align="" colspan="" rowspan="">Admin or owner applies ban</td>
+          <td align="" colspan="" rowspan="">Admin or owner changes affiliation to "none"</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Owner adds user to admin list</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Admin</td>
+          <td align="" colspan="" rowspan="">Owner applies ban</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "none"</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "member"</td>
+          <td align="" colspan="" rowspan="">--</td>
+          <td align="" colspan="" rowspan="">Owner adds user to owner list</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Owner</td>
+          <td align="" colspan="" rowspan="">Owner applies ban</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "none"</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "member"</td>
+          <td align="" colspan="" rowspan="">Owner changes affiliation to "admin"</td>
+          <td align="" colspan="" rowspan="">--</td>
+        </tr>
+      </table>
+    </div>
+  </div>
+<h2>6.
+       <a name="entity">Entity Use Cases</a>
+</h2>
+  <p class="" style="">A MUC implementation MUST support <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2254279">3</a>].</p>
+  <div class="indent">
+<h3>6.1 <a name="disco-component">Discovering Component Support for MUC</a>
+</h3>
+    <p class="" style="">A Jabber entity may wish to discover if a service implements the Multi-User Chat protocol; in order to do so, it sends a service discovery information ("disco#info") query to the component's JID:</p>
+    <p class="caption">Example 1. User Queries Chat Service for MUC Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco1'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST return its identity and the features it supports:</p>
+    <p class="caption">Example 2. Service Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='Macbeth Chat Service'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Because MUC is a superset of the old "groupchat 1.0" protocol, a MUC service SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="disco-rooms">Discovering Rooms</a>
+</h3>
+    <p class="" style="">The service discovery items ("disco#items") protocol enables a user to query a service for a list of associated items, which in the case of a chat service would consist of the specific chat rooms hosted by the service.</p>
+    <p class="caption">Example 3. User Queries Chat Service for Rooms</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco2'
+    to='macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service SHOULD return a full list of the rooms it hosts.</p>
+    <p class="caption">Example 4. Service Returns Disco Item Results</p>
+<div class="indent"><pre>
+&lt;iq from='macbeth.shakespeare.lit'
+    id='disco2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='heath@macbeth.shakespeare.lit'
+          name='A Lonely Heath'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='A Dark Cave'/&gt;
+    &lt;item jid='forres@macbeth.shakespeare.lit'
+          name='The Palace'/&gt;
+    &lt;item jid='inverness@macbeth.shakespeare.lit'
+          name='Macbeth&amp;apos;s Castle'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the full list of rooms is large (see <span style="font-weight: bold">JEP-0030</span> for details), the service MAY return only a partial list of rooms.</p>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="disco-roominfo">Querying for Room Information</a>
+</h3>
+    <p class="" style="">Using the disco#info protocol, a user may also query a specific chat room for more detailed information about the room. A user SHOULD do so before entering a room in order to determine the privacy and security profile of the room configuration (see the <a href="#secrity">Security Considerations</a> for details).</p>
+    <p class="caption">Example 5. User Queries for Information about a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The room MUST return its identity and SHOULD return the features it supports:</p>
+    <p class="caption">Example 6. Room Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Because MUC is a superset of the old "groupchat 1.0" protocol, a MUC room SHOULD NOT return a &lt;feature var='gc-1.0'/&gt; entry in a disco#info result. The room SHOULD return the materially-relevant features it supports, such as password protection and room moderation (these are listed fully in the feature registry maintained by the Jabber Registrar; see also the <a href="#registrar">Jabber Registrar</a> section of this document).</p>
+    <p class="" style="">A chatroom MAY return more detailed information in its disco#info response using <span class="ref" style="">Service Discovery Extensions</span>  [<a href="#nt-id2254522">4</a>], identified by inclusion of a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/muc#roominfo". Such information might include a more verbose description of the room, the current room subject, and the current number of occupants in the room:</p>
+    <p class="caption">Example 7. Room Returns Extended Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco3a'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        name='A Dark Cave'
+        type='text'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='muc_passwordprotected'/&gt;
+    &lt;feature var='muc_hidden'/&gt;
+    &lt;feature var='muc_temporary'/&gt;
+    &lt;feature var='muc_open'/&gt;
+    &lt;feature var='muc_unmoderated'/&gt;
+    &lt;feature var='muc_nonanonymous'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roominfo&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_description' label='Description'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_changesubject' label='Whether Occupants May Change the Subject'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_contactjid' label='Contact Addresses'&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_subject' label='Subject'&gt;
+        &lt;value&gt;Spells&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_occupants' label='Number of occupants'&gt;
+        &lt;value&gt;3&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_lang' label='Language of discussion'&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_logs' label='URL for discussion logs'&gt;
+        &lt;value&gt;http://www.shakespeare.lit/chatlogs/darkcave/&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_pubsub' label='Associated pubsub node'&gt;
+        &lt;value&gt;xmpp:pubsub.shakespeare.lit?node=chatrooms/darkcave&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Some extended room information may be dynamically generated (e.g., the URL for discussion logs, which may be based on service-wide configuration) whereas other information may be based on the room configuration.</p>
+    <p class="" style="">Note: The foregoing extended service discovery fields for the 'http://jabber.org/protocol/muc#roominfo' FORM_TYPE may be supplemented in the future via the mechanisms described in the <a href="#registrar-formtype">Field Standardization</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="disco-roomitems">Querying for Room Items</a>
+</h3>
+    <p class="" style="">A user MAY also query a specific chat room for its associated items:</p>
+    <p class="caption">Example 8. User Queries for Items Associated with a Specific Chat Room</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">An implementation MAY return a list of existing occupants if that information is publicly available, or return no list at all if this information is kept private.</p>
+    <p class="caption">Example 9. Room Returns Disco Item Results (Items are Public)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/firstwitch'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit/secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: These &lt;item/&gt; elements are qualified by the disco#items namespace, not the muc namespace; this means that they cannot possess 'affiliation' or 'role' attributes, for example.</p>
+    <p class="caption">Example 10. Room Returns Empty Disco Item Results (Items are Private)</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='disco4'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="disco-occupant">Querying a Room Occupant</a>
+</h3>
+    <p class="" style="">If a non-occupant attempts to send a disco request to an address of the form &lt;room@service/nick&gt;, a MUC service SHOULD return the request to the entity and specify a &lt;bad-request/&gt; error condition. If an occupant sends such a request, the service MAY pass it through the intended recipient; see the <a href="#impl">Implementation Guidelines</a> section of this document for details.</p>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="disco-client">Discovering Client Support for MUC</a>
+</h3>
+    <p class="" style="">A Jabber user may want to discover if one of the user's contacts supports the Multi-User Chat protocol. This is done using Service Discovery.</p>
+    <p class="caption">Example 11. User Queries Contact Regarding MUC Support</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='disco5'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client SHOULD return its identity and the features it supports:</p>
+    <p class="caption">Example 12. Contact Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='disco5'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='client'
+        type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A user may also query a contact regarding which rooms the contact is in. This is done by querying the contact's full JID (&lt;user@host/resource&gt;) while specifying the well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms':</p>
+    <p class="caption">Example 13. User Queries Contact for Current Rooms</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='rooms1'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Contact Returns Room Query Results</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    id='rooms1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/muc#rooms'/&gt;
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'/&gt;
+    &lt;item jid='characters@conference.shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Optionally, the contact MAY include its roomnick as the value of the 'name' attribute:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+    ...
+    &lt;item jid='darkcave@macbeth.shakespeare.lit'
+          name='secondwitch'/&gt;
+    ...
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="requestinvite">Requesting an Invitation</a>
+</h3>
+    <p class="" style="">It is not possible to join a members-only room without being on the member list. Therefore an entity may want to request an invitation in order to join such a room. An entity may do so by sending XML of the following form to the room itself.</p>
+    <p class="" style="">To follow.</p>
+  </div>
+<h2>7.
+       <a name="user">Occupant Use Cases</a>
+</h2>
+  <p class="" style="">The main actor in a multi-user chat environment is the occupant, who can be said to be located "in" a multi-user chat room and to participate in the discussions held in that room (for the purposes of this specification, participants and visitors are considered to be "mere" occupants, since they possess no administrative privileges). As will become clear, the protocol elements proposed in this document to fulfill the occupant use cases fall into three categories:</p>
+  <ol start="1" type="">
+    <li><p class="" style="">existing "groupchat 1.0" protocol for minimal functionality</p></li>
+    <li><p class="" style="">straightforward applications of the "groupchat 1.0" protocol, for example to handle some of the errors related to new room types</p></li>
+    <li><p class="" style="">additional protocol elements to handle functionality not covered by "groupchat 1.0" (room invites, room passwords, extended presence related to room roles and affiliations); these are qualified by the 'http://jabber.org/protocol/muc#user' namespace</p></li>
+  </ol>
+  <p class="" style="">Note: All client-generated examples herein are presented from the perspective of the service, with the result that all stanzas received by a service contain a 'from' attribute corresponding to the sender's full JID as added by a normal Jabber router or session manager. In addition, normal IQ result stanzas sent upon successful completion of a request (as required by <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2254925">5</a>]) are not shown.</p>
+  <div class="indent">
+<h3>7.1 <a name="enter">Entering a Room</a>
+</h3>
+    <div class="indent">
+<h3>7.1.1 <a name="enter-gc">Groupchat 1.0 Protocol</a>
+</h3>
+      <p class="" style="">In order to participate in the discussions held in a multi-user chat room, a Jabber user MUST first become an occupant by entering the room. In the old "groupchat 1.0" protocol, this was done by sending presence to &lt;room@service/nick&gt;, where "room" is the room ID, "service" is the hostname of the chat service, and "nick" is the user's desired nickname within the room:</p>
+      <p class="caption">Example 15. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'/&gt;
+      </pre></div>
+      <p class="" style="">In this example, a user with a full JID of "hag66@shakespeare.lit/pda" has requested to enter the room "darkcave" on the "macbeth.shakespeare.lit" chat service with a room nickname of "thirdwitch".</p>
+      <p class="" style="">If the user does not specify a room nickname, the service SHOULD return a &lt;jid-malformed/&gt; error:</p>
+      <p class="caption">Example 16. Jabber User Seeks to Enter a Room (Groupchat 1.0)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;jid-malformed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="enter-muc">Basic MUC Protocol</a>
+</h3>
+      <p class="" style="">Compliant multi-user chat services MUST accept the foregoing as a request to enter a room from any Jabber client that knows either the "groupchat 1.0" (GC) protocol or the multi-user chat (MUC) protocol; however, MUC clients SHOULD signal their ability to speak the MUC protocol by including in the initial presence stanza an empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace (note the absence of the '#user' fragment):</p>
+      <p class="caption">Example 17. Jabber User Seeks to Enter a Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.3 <a name="enter-pres">Presence Broadcast</a>
+</h3>
+      <p class="" style="">If the service is able to add the user to the room, it MUST send presence from all the existing occupants' room JIDs to the new occupant's full JID, including extended presence information about roles in an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "moderator", "participant", or "visitor", and with the 'affiliation' attribute set to a value of "owner", "admin", "member", or "none" as appropriate:</p>
+      <p class="caption">Example 18. Service Sends Presence from Existing Occupants to New Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, the user from the previous example has entered the room, by which time two other people had already entered the room: a user with a room nickname of "firstwitch" (who is a room owner) and a user with a room nickname of "secondwitch" (who is a room admin).</p>
+      <p class="" style="">The service MUST also send presence from the new occupant's room JID to the full JIDs of all the occupants (including the new occupant):</p>
+      <p class="caption">Example 19. Service Sends New Occupant's Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">In this example, initial room presence is being sent from the new occupant (thirdwitch) to all occupants, including the new occupant.</p>
+      <p class="" style="">The order of the presence stanzas sent to the new occupant is important. The service MUST first send the complete list of the existing occupants to the new occupant and only then send the new occupant's own presence to the new occupant. This helps the client know when it has received the complete "room roster".</p>
+    </div>
+    <div class="indent">
+<h3>7.1.4 <a name="enter-roles">Default Roles</a>
+</h3>
+      <p class="" style="">The following table summarizes the initial default roles that a service should set based on the user's affiliation (there is no role associated with the "outcast" affiliation, since such users are not allowed to enter the room).</p>
+      <p class="caption">Table 6: Initial Role Based on Affiliation</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Room Type</th>
+          <th colspan="" rowspan="">None</th>
+          <th colspan="" rowspan="">Member</th>
+          <th colspan="" rowspan="">Admin</th>
+          <th colspan="" rowspan="">Owner</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Moderated</td>
+          <td align="" colspan="" rowspan="">Visitor</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Unmoderated</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Members-Only</td>
+          <td align="" colspan="" rowspan="">N/A *</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">Open</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Participant</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+          <td align="" colspan="" rowspan="">Moderator</td>
+        </tr>
+      </table>
+      <p class="" style="">* Entry is not permitted.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.5 <a name="enter-nonanon">Non-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is non-anonymous, the service MUST send the new occupant's full JID to all occupants using extended presence information in an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with a 'jid' attribute specifying the occupant's full JID:</p>
+      <p class="caption">Example 20. Service Sends Full JID to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+      </pre></div>
+      <p class="" style="">If the user is entering a room that is non-anonymous (i.e., which informs all occupants of each occupant's full JID as shown above), the service SHOULD allow the user to enter the room but MAY warn the user that the room is not anonymous; this is done by sending a message of type "groupchat" to the new occupant containing an &lt;x/&gt; child with a &lt;status/&gt; element that has the 'code' attribute set to a value of "100":</p>
+      <p class="caption">Example 21. Service Warns New Occupant About Lack of Anonymity</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;This room is not anonymous.&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;status code='100'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality).</p>
+    </div>
+    <div class="indent">
+<h3>7.1.6 <a name="enter-semianon">Semi-Anonymous Rooms</a>
+</h3>
+      <p class="" style="">If the room is semi-anonymous, the service MUST send the new occupant's full JID in the format shown above only to those occupants with a role of "moderator".</p>
+      <p class="" style="">(Note: All subsequent examples include the 'jid' attribute for each &lt;item/&gt; element, even though this information is not sent to non-moderators in semi-anonymous rooms.)</p>
+    </div>
+    <div class="indent">
+<h3>7.1.7 <a name="enter-pw">Password-Protected Rooms</a>
+</h3>
+      <p class="" style="">If the room requires a password and the user did not supply one (or the password provided is incorrect), the service MUST deny access to the room and inform the user that they are unauthorized; this is done by returning a presence stanza of type "error" specifying a &lt;not-authorized/&gt; error:</p>
+      <p class="caption">Example 22. Service Denies Access Because No Password Provided</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Passwords SHOULD be supplied with the presence stanza sent when entering the room, contained within an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace and containing a &lt;password/&gt; child. Passwords are to be sent as cleartext; no other authentication methods are supported at this time, and any such authentication or authorization methods shall be defined in a separate specification (see the <a href="#security">Security Considerations</a> section of this document).</p>
+      <p class="caption">Example 23. User Provides Password On Entering a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.8 <a name="enter-members">Members-Only Rooms</a>
+</h3>
+      <p class="" style="">If the room is members-only but the user is not on the member list, the service MUST deny access to the room and inform the user that they are not allowed to enter the room; this is done by returning a presence stanza of type "error" specifying a &lt;registration-required/&gt; error condition:</p>
+      <p class="caption">Example 24. Service Denies Access Because User Is Not on Member List</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='407' type='auth'&gt;
+    &lt;registration-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.9 <a name="enter-banned">Banned Users</a>
+</h3>
+      <p class="" style="">If the user has been banned from the room (i.e., has an affiliation of "outcast"), the service MUST deny access to the room and inform the user of the fact that he or she is banned; this is done by returning a presence stanza of type "error" specifying a &lt;forbidden/&gt; error condition:</p>
+      <p class="caption">Example 25. Service Denies Access Because User is Banned</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.10 <a name="enter-conflict">Nickname Conflict</a>
+</h3>
+      <p class="" style="">If the room already contains another user with the nickname desired by the user seeking to enter the room (or if the nickname is reserved by another user on the member list), the service MUST deny access to the room and inform the user of the conflict; this is done by returning a presence stanza of type "error" specifying a &lt;conflict/&gt; error condition:</p>
+      <p class="caption">Example 26. Service Denies Access Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">However, if the bare JID (&lt;node@domain.tld&gt;) of the present occupant matches the bare JID of the user seeking to enter the room, then the service MAY allow entry to the new occupant instead of or (preferably) in addition to the existing occupant. Note: If a service allows more than one occupant with the same bare JID and the same room nickname, it is up to the implementation to determine how to appropriately handle presence from the user's resources, route in-room messages to both resources, route private messages to both or only one resource as desired (based on presence priority or some other algorithm), etc.; all of these matters are implementation-specific and are not defined herein.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.11 <a name="enter-maxusers">Max Users</a>
+</h3>
+      <p class="" style="">If the room has reached its maximum number of users, the service SHOULD deny access to the room and inform the user of the restriction; this is done by returning a presence stanza of type "error" specifying a &lt;service-unavailable/&gt; error condition:</p>
+      <p class="caption">Example 27. Service Informs User that Room Occupant Limit Has Been Reached</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='503' type='wait'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Alternatively, the room could kick an "idle user" in order to free up space. Also, a room MUST always allow entry by a room admin or owner.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.12 <a name="enter-history">Discussion History</a>
+</h3>
+      <p class="" style="">After sending initial presence as shown above, a room MAY send discussion history to the new occupant. Whether such history is sent, and how many messages comprise the history, shall be determined by the chat service implementation or specific deployment.</p>
+      <p class="caption">Example 28. Delivery of Discussion History</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20021013T23:58:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20021013T23:58:43'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hecate@shakespeare.lit/broom'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries 'Tis time, 'tis time.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='hag66@shakespeare.lit/pda'
+     stamp='20021013T23:58:49'/&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">Discussion history messages MUST be stamped with extended information qualified by the 'jabber:x:delay' namespace (see <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2255807">6</a>]) to indicate that they are sent with delayed delivery and specify the times at which they were originally sent. The 'from' attribute SHOULD be the full JID of the original sender in non-anonymous rooms, but MUST NOT be in semi-anonymous rooms (the 'from' attribute SHOULD be set to the room JID in semi-anonymous rooms). The service SHOULD send all discussion history messages before delivering any "live" messages sent after the user enters the room.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.13 <a name="enter-managehistory">Managing Discussion History</a>
+</h3>
+      <p class="" style="">A user MAY want to manage the amount of discussion history provided on entering a room (perhaps because the user is on a low-bandwidth connection or is using a small-footprint client). This MUST be accomplished by including a &lt;history/&gt; child in the initial presence stanza sent when joining the room. There are four allowable attributes for this element:</p>
+      <p class="caption">Table 7: History Management Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Attribute</th>
+          <th colspan="" rowspan="">Datatype</th>
+          <th colspan="" rowspan="">Meaning</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxchars</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of characters in the history to "X" (where the character count is the characters of the complete XML stanzas, not only their XML character data).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">maxstanzas</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Limit the total number of messages in the history to "X".</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">seconds</td>
+          <td align="" colspan="" rowspan="">int</td>
+          <td align="" colspan="" rowspan="">Send only the messages received in the last "X" seconds.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">since</td>
+          <td align="" colspan="" rowspan="">dateTime</td>
+          <td align="" colspan="" rowspan="">Send only the messages received since the datetime specified (which MUST conform to the DateTime profile specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2256008">7</a>]).</td>
+        </tr>
+      </table>
+      <p class="" style="">The service MUST send the smallest amount of traffic that meets any combination of the above criteria, taking into account service-level and room-level defaults. The service MUST send complete message stanzas only (i.e., it MUST not literally truncate the history at a certain number of characters, but MUST send the largest number of complete stanzas that results in a number of characters less than or equal to the 'maxchars' value specified). If the client wishes to receive no history, it MUST set the 'maxchars' attribute to a value of "0" (zero).</p>
+      <p class="" style="">The following examples illustrate the use of this protocol.</p>
+      <p class="caption">Example 29. User Requests Limit on Number of Messages in History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxstanzas='20'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 30. User Requests History in Last 3 Minutes</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history seconds='180'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="caption">Example 31. User Requests All History Since the Beginning of the Unix Era</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history since='1970-01-01T00:00Z'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Obviously the service SHOULD NOT return all messages sent in the room since the beginning of the Unix era, and SHOULD appropriately limit the amount of history sent to the user based on service or room defaults.</p>
+      <p class="caption">Example 32. User Requests No History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;history maxchars='0'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.14 <a name="enter-locked">Locked Room</a>
+</h3>
+      <p class="" style="">If a user attempts to enter a room while it is "locked" (i.e., before the room creator provides an initial configuration and therefore before the room officially exists), the service MUST refuse entry and return an &lt;item-not-found/&gt; error to the user:</p>
+      <p class="caption">Example 33. Service Denies Access Because Room Does Not Exist</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.15 <a name="enter-nonexistent">Nonexistent Room</a>
+</h3>
+      <p class="" style="">If the room does not already exist when the user seeks to enter it, the service SHOULD create it; however, this is not required, since an implementation or deployment MAY choose to restrict the privilege of creating rooms. For details, see the <a href="#createroom">Creating a Room</a> section of this document.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="exit">Exiting a Room</a>
+</h3>
+    <p class="" style="">In order to exit a multi-user chat room, an occupant sends a presence stanza of type "unavailable" to the &lt;room@service/nick&gt; it is currently using in the room.</p>
+    <p class="caption">Example 34. Occupant Exits a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send presence stanzas of type "unavailable" from the departing occupant's room JID to the full JIDs of the departing occupant and of the remaining occupants:</p>
+    <p class="caption">Example 35. Service Sends Presence Related to Departure of Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='none'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Presence stanzas of type "unavailable" reflected by the room MUST contain extended presence information about roles and affiliations, and MAY also contain normal &lt;status/&gt; information (which enables occupants to provide custom exit messages if desired).</p>
+    <p class="caption">Example 36. Custom Exit Message</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'
+    type='unavailable'&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Normal presence stanza generation rules apply as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256251">8</a>], so that if the user sends a general unavailable presence stanza, the user's server will broadcast that stanza to the &lt;room@service/nick&gt; to which the user's client has sent directed presence.</p>
+    <p class="" style="">If the room is not persistent and this occupant is the last to exit, the service is responsible for destroying the room.</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="changenick">Changing Nickname</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability for an occupant to change his or her nickname within the room. In MUC this is done by sending updated presence information to the room, specifically by sending presence to a new room JID in the same room (changing only the resource identifier in the room JID).</p>
+    <p class="caption">Example 37. Occupant Changes Nickname</p>
+<div class="indent"><pre>
+&lt;presence
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'/&gt;
+    </pre></div>
+    <p class="" style="">The service then sends two presence stanzas to the full JID of each occupant (including the occupant who is changing his or her room nickname), one of type "unavailable" for the old nickname and one indicating availability for the new nickname. The unavailable presence MUST contain the new nickname and an appropriate status code (namely 303) as extended presence information in an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace so that Jabber clients are able to provide relevant hints to occupants regarding the nickname change if desired.</p>
+    <p class="caption">Example 38. Service Updates Nick</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='oldhag'
+          role='participant'/&gt;
+    &lt;status code='303'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/oldhag'
+    to='hag66@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If the user attempts to change his or her room nickname to a room nickname that is already in use by another user (or that is reserved by another user affiliated with the room, e.g., a member or owner), the service MUST deny the nickname change request and inform the user of the conflict; this is done by returning a presence stanza of type "error" specifying a &lt;conflict/&gt; error condition:</p>
+    <p class="caption">Example 39. Service Denies Nickname Change Because of Nick Conflict</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">However, if the bare JID (&lt;node@domain.tld&gt;) of the present occupant matches the bare JID of the user seeking to change his or her nickname, then the service MAY allow the nickname change. See the <a href="enter-conflict">Nickname Conflict</a> section of this document for details.</p>
+    <p class="" style="">If the user attempts to change his or her room nickname but room nicknames are "locked down", the service MUST deny the nickname change request and return a presence stanza of type "error" specifying a &lt;not-acceptable/&gt; error condition:</p>
+    <p class="caption">Example 40. Service Denies Nickname Change Because Roomnicks Are Locked Down</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='406' type='cancel'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="changepres">Changing Availability Status</a>
+</h3>
+    <p class="" style="">In multi-user chat systems such as IRC, one common use for changing one's room nickname is to indicate a change in one's availability (e.g., changing one's room nickname to "thirdwitch|away"). In Jabber, availability is of course noted by a change in presence (specifically the &lt;show/&gt; and &lt;status/&gt; elements), which can provide important context within a chatroom. An occupant changes availability status within the room by sending the updated presence to its &lt;room@service/nick&gt;.</p>
+    <p class="caption">Example 41. Occupant Changes Availability Status</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/oldhag'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The service then sends a presence stanza from the occupant changing his or her presence to the full JID of each occupant, including extended presence information about the occupant's role and full JID to those with privileges to view such information:</p>
+    <p class="caption">Example 42. Service Passes Along Changed Presence to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;show&gt;xa&lt;/show&gt;
+  &lt;status&gt;gone where the goblins go&lt;/status&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.5 <a name="invite">Inviting Another User to a Room</a>
+</h3>
+    <p class="" style="">It can be useful to invite another user to a room in which one is an occupant. To do this, a MUC client MUST send XML of the following form to the &lt;room@service&gt; itself (the reason is OPTIONAL and the message MUST NOT possess a 'type' attribute; the service MAY ignore or reject invites that possess a 'type' attribute):</p>
+    <p class="caption">Example 43. Occupant Sends an Invitation by Way of Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The &lt;room@service&gt; itself MUST then add a 'from' address to the &lt;invite/&gt; element whose value is the bare JID (or, optionally, the room JID) of the invitor and send the invitation to the invitee captured in the 'to' address (the service SHOULD include a message body explaining the invitation or containing the reason, for the sake of older clients; in addition, the room SHOULD add the password if the room is password-protected):</p>
+    <p class="caption">Example 44. Room Sends Invitation to Invitee on Behalf of Invitor</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;body&gt;You have been invited to darkcave@macbeth by crone1@shakespeare.lit.&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MAY also add the invitee to the member list. (Note: Invitation privileges in members-only rooms SHOULD be restricted to room admins; if a member without privileges to edit the member list attempts to invite another user, the service SHOULD return a &lt;forbidden/&gt; error to the occupant; for details, see the <a href="#modifymember">Modifying the Member List</a> section of this document.)</p>
+    <p class="" style="">If the invitor supplies a non-existent JID, the room SHOULD return an &lt;item-not-found/&gt; error to the invitor.</p>
+    <p class="" style="">The invitee MAY choose to formally decline (as opposed to ignore) the invitation; and this is something that the sender may want to be informed about. In order to decline the invitation, the invitee MUST send a message of the following form to the &lt;room@service&gt; itself:</p>
+
+    <p class="caption">Example 45. Invitee Declines Invitation</p>
+<div class="indent"><pre>
+&lt;message
+    from='hecate@shakespeare.lit/broom'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline to='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 46. Room Informs Invitor that Invitation Was Declined</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;decline from='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Sorry, I'm too busy right now.
+      &lt;/reason&gt;
+    &lt;/decline&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">It may be wondered why the invitee does not send the decline message directly to the invitor. The main reason is that certain implementations MAY choose to base invitations on room JIDs rather than bare JIDs (so that, for example, an occupant could invite someone from one room to another without knowing that person's bare JID). Thus the service MUST handle both the invites and declines.</p>
+  </div>
+  <div class="indent">
+<h3>7.6 <a name="continue">Converting a One-to-One Chat Into a Conference</a>
+</h3>
+    <p class="" style="">Sometimes it is desirable to convert a one-to-one chat into a multi-user conference. The process flow is shown in the following examples.</p>
+    <p class="" style="">First, two users begin a one-to-one chat.</p>
+    <p class="caption">Example 47. A One-to-One Chat</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='chat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Now the first person decides to include a third person in the discussion, so she (or, more precisely, her client) does the following:</p>
+    <ol start="1" type="">
+      <li>Creates a new room (which SHOULD be non-anonymous and MAY be an instant room as specified below)</li>
+      <li>Optionally sends history of the one-to-one chat to the room</li>
+      <li>Sends an invitation to the second person and the third person, including a &lt;continue/&gt; flag.</li> 
+    </ol>
+    <p class="caption">Example 48. Continuing the Discussion I: User Creates Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 49. Continuing the Discussion II: Owner Sends History to Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20040929T01:54:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20040929T01:55:21'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Use of the <span style="font-weight: bold">Delayed Delivery</span> protocol enables the room creator to specify the datetime of each message from the one-to-one chat history (via the 'stamp' attribute), as well as the JID of the original sender of each message (via the 'from' attribute). The room creator SHOULD send the complete one-to-one chat history before inviting additional users to the room, and SHOULD also send as history any messages appearing in the one-to-one chat interface after joining the room and before the second person joins the room; if the one-to-one history is especially large, the sending client may want to send the history over a few seconds rather than all at once (to avoid triggering rate limits). The service SHOULD NOT add its own delay elements (as described in the <a href="#enter-history">Discussion History</a> section of this document) to prior chat history messages received from the room owner.</p>
+    <p class="caption">Example 50. Continuing the Discussion III: Owner Sends Invitations, Including Continue Flag</p>
+<div class="indent"><pre>
+&lt;message
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='wiccarocks@shakespeare.lit/laptop'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+    &lt;invite to='hag66@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Since the invitor's client knows the full JID of the person with whom the invitor was having a one-to-one chat, it SHOULD include the full JID (rather than the bare JID) in the invitation.</p>
+    <p class="" style="">The invitations are delivered to the invitees:</p>
+    <p class="caption">Example 51. Invitations Delivered</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'&gt;
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'&gt;
+    to='hag66@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='crone1@shakespeare.lit'&gt;
+      &lt;reason&gt;This coven needs both wiccarocks and hag66.&lt;/reason&gt;
+      &lt;continue/&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When the client being used by &lt;wiccarocks@shakespeare.lit/laptop&gt; receives the invitation, it SHOULD auto-join the room or prompt the user whether to join (subject to user preferences) and then seamlessly convert the existing one-to-one chat window into a multi-user conferencing window:</p>
+    <p class="caption">Example 52. Invitee Accepts Invitation, Joins Room, and Receives Presence and History</p>
+<div class="indent"><pre>
+&lt;presence
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/secondwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner' role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member' role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice the brinded cat hath mew'd.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='crone1@shakespeare.lit/desktop'
+     stamp='20040929T01:54:37'/&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Thrice and once the hedge-pig whined.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:delay'
+     from='wiccarocks@shakespeare.lit/laptop'
+     stamp='20040929T01:55:21'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: The fact that the messages come from the &lt;room@service&gt; itself rather than &lt;room@service/nick&gt; is a clue to the receiving client that these messages are prior chat history, since any message from a room occupant will have a 'from' address equal to the sender's room JID.</p>
+  </div>
+  <div class="indent">
+<h3>7.7 <a name="subject-occupant">Occupant Modification of the Room Subject</a>
+</h3>
+    <p class="" style="">If allowed in accordance with room configuration, a mere occupant MAY be allowed to change the subject in a room. For details, see the <a href="#subject-mod">Modifying the Room Subject</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>7.8 <a name="privatemessage">Sending a Private Message</a>
+</h3>
+    <p class="" style="">Since each occupant has a unique room JID, an occupant MAY send a "private message" to a selected occupant via the service by sending a message to the occupant's room JID. The message type SHOULD be "chat" and MUST NOT be "groupchat", but MAY be left unspecified (i.e., a normal message). This privilege SHOULD be allowed to any occupant (even a visitor in a moderated room).</p>
+    <p class="caption">Example 53. Occupant Sends Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for changing the 'from' address to the sender's room JID and delivering the message to the intended recipient's full JID.</p>
+    <p class="caption">Example 54. Recipient Receives the Private Message</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='chat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message of type "groupchat" to a particular occupant, the service MUST refuse to deliver the message (since the recipient's client would expect in-room messages to be of type "groupchat") and return a &lt;bad-request/&gt; error to the sender:</p>
+    <p class="caption">Example 55. Occupant Attempts to Send a Message of Type "Groupchat" to a Particular Occupant</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'
+    type='groupchat'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+&lt;/message&gt;
+
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;body&gt;I'll give thee a wind.&lt;/body&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender attempts to send a private message to a room JID that does not exist, the service MUST return an &lt;item-not-found/&gt; error to the sender.</p>
+    <p class="" style="">If the sender is not an occupant of the room in which the intended recipient is visiting, the service MUST return a &lt;not-acceptable/&gt; error to the sender.</p>
+  </div>
+  <div class="indent">
+<h3>7.9 <a name="message">Sending a Message to All Occupants</a>
+</h3>
+    <p class="" style="">An occupant sends a message to all other occupants in the room by sending a message of type "groupchat" to the &lt;room@service&gt; itself (a service MAY ignore or reject messages that do not have a type of "groupchat"). In a moderated room, this privilege is restricted to occupants with a role of participant or higher.</p>
+    <p class="caption">Example 56. Occupant Sends a Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender has voice in the room (this is the default except in moderated rooms), the service MUST change the 'from' attribute to the sender's room JID and reflect the message out to the full JID of each occupant.</p>
+    <p class="caption">Example 57. Service Reflects Message to All Occupants</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='groupchat'&gt;
+  &lt;body&gt;Harpier cries: 'tis time, 'tis time.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the sender is a visitor (i.e., does not have voice in a moderated room), the service MAY return a &lt;forbidden/&gt; error to the sender and MUST NOT reflect the message to all occupants. If the sender is not an occupant of the room, the service SHOULD return a &lt;not-acceptable/&gt; error to the sender and SHOULD NOT reflect the message to all occupants; the only exception to this rule is that an implementation MAY allow users with certain privileges (e.g., a room owner, room admin, or service-level admin) to send messages to the room even if those users are not occupants.</p>
+  </div>
+  <div class="indent">
+<h3>7.10 <a name="register">Registering with a Room</a>
+</h3>
+    <p class="" style="">An implementation MAY allow an unaffiliated user (in a moderated room, probably a participant) to register with a room and thus become a member of the room (conversely, an implementation MAY restrict this privilege and allow only room admins to add new members). If allowed, this functionality SHOULD be implemented by enabling a user to send a request for registration requirements to the room qualified by the 'jabber:iq:register' namespace as described in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2257109">9</a>]:</p>
+    <p class="caption">Example 58. User Requests Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user requesting registration requirements is not allowed to register with the room (e.g., because that privilege has been restricted), the room MUST return a &lt;not-allowed/&gt; error to the user. If the user is already registered, the room MUST reply with an IQ stanza of type "result" that contains an empty &lt;register/&gt; element as described in <span style="font-weight: bold">JEP-0077</span>. If the room does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="" style="">Otherwise, the room MUST then return a Data Form to the user (as described in <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2257174">10</a>]). The information required to register MAY vary by implementation or deployment and is not fully specified in this document (e.g., the fields registered by this document for the 'http://jabber.org/protocol/muc#register' FORM_TYPE may be supplemented in the future via the mechanisms described in the <a href="#registrar-formtype">Field Standardization</a> section of this document). The following can be taken as a fairly typical example:</p>
+    <p class="caption">Example 59. Service Returns Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      To register on the web, visit http://shakespeare.lit/
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Dark Cave Registration&lt;/title&gt;
+      &lt;instructions&gt;
+        Please provide the following information
+        to register with this room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='First Name'
+          type='text-single'
+          var='muc#register_first'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Last Name'
+          type='text-single'
+          var='muc#register_last'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Desired Nickname'
+          type='text-single'
+          var='muc#register_roomnick'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Your URL'
+          type='text-single'
+          var='muc#register_url'/&gt;
+      &lt;field
+          label='Email Address'
+          type='text-single'
+          var='muc#register_email'/&gt;
+      &lt;field
+          label='FAQ Entry'
+          type='text-multi'
+          var='muc#register_faqentry'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The user SHOULD then submit the form:</p>
+    <p class="caption">Example 60. User Submits Registration Form</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='reg2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_first'&gt;
+        &lt;value&gt;Brunhilde&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_last'&gt;
+        &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_roomnick'&gt;
+        &lt;value&gt;thirdwitch&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_url'&gt;
+        &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_email'&gt;
+        &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#register_faqentry'&gt;
+        &lt;value&gt;Just another witch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the desired room nickname is already reserved for that room, the room MUST return a &lt;conflict/&gt; error to the user:</p>
+    <p class="caption">Example 61. Room Returns Conflict Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room or service does not support registration, it MUST return a &lt;service-unavailable/&gt; error to the user:</p>
+    <p class="caption">Example 62. Room Returns Service Unavailable Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user did not include a valid data form, the room MUST return a &lt;bad-request/&gt; error to the user:</p>
+    <p class="caption">Example 63. Room Returns Service Bad Request Error to User</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the room MUST inform the user of successful registration:</p>
+    <p class="caption">Example 64. Room Informs User of Successful Registration</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='reg2'
+    to='hag66@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After the user successfully submits the form, the service MAY request that the submission be approved by a room admin/owner (see the <a href="#regapprove">Approving Registration Requests</a> section of this document) or MAY immediately add the user to the member list by changing the user's affiliation from "none" to "member". If the service changes the user's affiliation and the user is in the room, it MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
+    <p class="caption">Example 65. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a user has registered with a room, the room MAY choose to restrict the user to use of the registered nickname only in that room. If it does so, it SHOULD return a &lt;not-acceptable/&gt; error to the user if the user attempts to join the room with a roomnick other than the user's registered roomnick (this enables a room to "lock down" roomnicks for consistent identification of occupants).</p>
+  </div>
+  <div class="indent">
+<h3>7.11 <a name="reservednick">Discovering Reserved Room Nickname</a>
+</h3>
+    <p class="" style="">A user MAY have a reserved room nickname, for example through explicit room registration or database integration. In such cases it may be desirable for the user to discover his or her reserved nickname before attempting to enter the room (e.g., because the user has forgotten his or her reserved nickname). This is done by sending a Service Discovery information request to the room JID while specifying a well-known Service Discovery node of "x-roomuser-item".</p>
+    <p class="caption">Example 66. User Requests Reserved Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='hag66@shakespeare.lit/pda'
+    id='getnick1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It is OPTIONAL for a multi-user chat service to support the foregoing service discovery node. If the room or service does not support the foregoing service discovery node, it MUST return a &lt;feature-not-implemented/&gt; error to the user. If it does and the user has a registered nickname, it MUST return the nickname to the user as the value of the 'name' attribute of a Service Discovery &lt;identity/&gt; element (for which the category/type SHOULD be "conference/text"):</p>
+    <p class="caption">Example 67. Room Returns Nickname</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='getnick1'
+    to='hag66@shakespeare.lit/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='x-roomuser-item'&gt;
+    &lt;identity
+        category='conference'
+        name='thirdwitch'
+        type='text'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user does not have a registered nickname, the room MUST return a service discovery &lt;query/&gt; element that is empty (in accordance with <span style="font-weight: bold">JEP-0030</span>).</p>
+    <p class="" style="">Even if a user has registered one room nickname, the service SHOULD allow the user to specify a different nickname on entering the room (e.g., in order to join from different client resources), although the service MAY choose to "lock down" nicknames and therefore deny entry to the user, including a &lt;not-acceptable/&gt; error. The service MUST NOT return an error to the user if his or her client sends the foregoing request after having already joined the room, but instead SHOULD reply as described above.</p>
+    <p class="" style="">If another user attempts to join the room with a nickname reserved by the first user, the service MUST deny entry to the second user and return a &lt;conflict/&gt; error as previously described.</p>
+  </div>
+  <div class="indent">
+<h3>7.12 <a name="requestvoice">Requesting Voice</a>
+</h3>
+    <p class="" style="">It is not possible for a visitor to speak (i.e., send a message to all occupants) in a moderated room. To request voice, a visitor SHOULD send XML of the following form to the room itself.</p>
+    <p class="" style="">To follow.</p>
+  </div>
+<h2>8.
+       <a name="moderator">Moderator Use Cases</a>
+</h2>
+  <p class="" style="">A moderator has privileges to perform certain actions within the room (e.g., to change the roles of some occupants) but does not have rights to change persistent information about affiliations (which may be changed only by an admin or owner) or defining information about the room. Exactly which actions may be performed by a moderator is subject to configuration. However, for the purposes of the MUC framework, moderators are stipulated to have privileges to perform the following actions:</p>
+  <ol start="1" type="">
+    <li>discover an occupant's full JID in a semi-anonymous room (occurs by default as shown above)</li>
+    <li>modify the subject</li>
+    <li>kick a participant or visitor from the room</li>
+    <li>grant or revoke voice in a moderated room</li>
+    <li>modify the list of occupants who have voice in a moderated room</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response exchange using &lt;iq/&gt; elements that contain children qualified by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions to implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the &lt;user@host&gt; of the 'from' address of the request does not match the bare JID portion of one of the moderators; in this case, the service MUST return a &lt;forbidden/&gt; error.)</p>
+  <div class="indent">
+<h3>8.1 <a name="subject-mod">Modifying the Room Subject</a>
+</h3>
+    <p class="" style="">A common feature of multi-user chat rooms is the ability to change the subject within the room. By default, only users with a role of "moderator" SHOULD be allowed to change the subject in a room (although this SHOULD be configurable, with the result that a mere participant or even visitor may be allowed to change the subject if desired). The subject is changed by sending a message of type "groupchat" to the &lt;room@service&gt;, containing no body but a &lt;subject/&gt; that specifies the new subject:</p>
+    <p class="caption">Example 68. Moderator Changes Subject</p>
+<div class="indent"><pre>
+&lt;message
+    from='wiccarocks@shakespeare.lit/laptop'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If a MUC service receives such a message, it MUST reflect the message to all other occupants with a 'from' address equal to the room JID that corresponds to the sender of the subject change:</p>
+    <p class="caption">Example 69. Service Informs All Occupants of Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='groupchat'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the room SHOULD include the last subject change in the discussion history sent when a new occupant joins the room.</p>
+    <p class="" style="">A MUC client that receives such a message MAY choose to display an in-room message, such as the following:</p>
+    <p class="caption">Example 70. Client Displays Room Subject Change Message</p>
+<div class="indent"><pre>
+* secondwitch has changed the subject to: Fire Burn and Cauldron Bubble!
+    </pre></div>
+    <p class="" style="">If someone without appropriate privileges attempts to change the room subject, the service MUST return a message of type "error" specifying a &lt;forbidden/&gt; error condition:</p>
+    <p class="caption">Example 71. Service Returns Error Related to Unauthorized Subject Change</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;subject&gt;Fire Burn and Cauldron Bubble!&lt;/subject&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="kick">Kicking an Occupant</a>
+</h3>
+    <p class="" style="">A moderator has permissions kick a visitor or participant from a room. The kick is normally performed based on the occupant's room nickname (though it MAY be based on the full JID) and is completed by setting the role of a participant or visitor to a value of "none".</p>
+    <p class="caption">Example 72. Moderator Kicks Occupant</p>
+<div class="indent"><pre>
+&lt;iq from='fluellen@shakespeare.lit/pda'
+    id='kick1'
+    to='harfleur@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='pistol' role='none'&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the kicked occupant by sending a presence stanza of type "unavailable" to each kicked occupant, including status code 307 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the kick.</p>
+    <p class="caption">Example 73. Service Removes Kicked Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='pistol@shakespeare.lit/harfleur'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='fluellen@shakespeare.lit'/&gt;
+      &lt;reason&gt;Avaunt, you cullion!&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the kicked user to understand why he or she was kicked, and by whom if the kicked occupant would like to discuss the matter.  [<a href="#nt-id2257756">11</a>]</p>
+    <p class="" style="">After removing the kicked occupant(s), the service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 74. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='harfleur@henryv.shakespeare.lit'
+    id='kick1'
+    to='fluellen@shakespeare.lit/pda'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">After informing the moderator, the service MUST then inform all of the remaining occupants that the kicked occupant is no longer in the room by sending presence stanzas of type "unavailable" from the individual's roomnick (&lt;room@service/nick&gt;) to all the remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason and actor.</p>
+    <p class="caption">Example 75. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='harfleur@henryv.shakespeare.lit/pistol'
+    to='gower@shakespeare.lit/cell'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='307'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A user cannot be kicked by a moderator with a lower affiliation. Therefore, if a moderator who is a participant attempts to kick an admin or a moderator who is a participant or admin attempts to kick an owner, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 76. Service Returns Error on Attempt to Kick User With Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='kicktest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='firstwitch' role='none'&gt;
+      &lt;reason&gt;Be gone!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a moderator attempts to kick himself, the service MAY deny the request and return a &lt;conflict/&gt; error to the sender. (Although the act of kicking oneself may seem odd, it is common in IRC as a way of apologizing for one's actions in the room.)</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="grantvoice">Granting Voice to a Visitor</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to manage who does and does not have "voice" in the room (i.e., the ability to send messages to all occupants). Voice is granted based on the visitor's room nickname, which the service will convert into the visitor's full JID internally. The moderator grants voice to a visitor by changing the visitor's role to "participant" (the &lt;reason/&gt; element is optional):</p>
+    <p class="caption">Example 77. Moderator Grants Voice to a Visitor</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 78. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual's &lt;room@service/nick&gt; to all occupants, indicating the addition of voice privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
+    <p class="caption">Example 79. Service Sends Notice of Voice to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          nick='thirdwitch'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy witch indeed!&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="revokevoice">Revoking Voice from a Participant</a>
+</h3>
+    <p class="" style="">In a moderated room, a moderator may want to revoke a participant's privileges to speak. The moderator can revoke voice from a participant by changing the participant's role to "visitor":</p>
+    <p class="caption">Example 80. Moderator Revokes Voice from a Participant</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='voice2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 81. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voice2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of voice privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "visitor".</p>
+    <p class="caption">Example 82. Service Notes Loss of Voice</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='visitor'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A moderator MUST NOT be able to revoke voice from a user whose affiliation is at or above the moderator's level. In addition, a service MUST NOT allow the voice privileges of an admin or owner to be removed by anyone. If a moderator attempts to revoke voice privileges from such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender along with the offending item(s):</p>
+    <p class="caption">Example 83. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='voicetest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="modifyvoice">Modifying the Voice List</a>
+</h3>
+    <p class="" style="">A moderator in a moderated room may want to modify the voice list. To do so, the moderator first requests the voice list by querying the room for all occupants with a role of 'participant'.</p>
+    <p class="caption">Example 84. Moderator Requests Voice List</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='voice3'
+    to='goodfolk@chat.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the voice list to the moderator; each item MUST include the 'nick' and 'role' attributes and SHOULD include the 'affiliation' and 'jid' attributes:</p>
+    <p class="caption">Example 85. Service Sends Voice List to Moderator</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice3'
+    to='bard@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='polonius@hamlet/castle'
+          nick='Polo'
+          role='participant'/&gt;
+    &lt;item affiliation='none'
+          jid='horatio@hamlet/castle'
+          nick='horotoro'
+          role='participant'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The moderator MAY then modify the voice list. In order to do so, the moderator MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'nick' attribute and 'role' attribute (normally set to a value of "participant" or "visitor") but SHOULD NOT include the 'jid' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as owner rather than the participant role):</p>
+    <p class="caption">Example 86. Moderator Sends Modified Voice List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='voice4'
+    to='goodfolk@chat.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='Hecate'
+          role='visitor'/&gt;
+    &lt;item nick='rosencrantz'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item nick='guildenstern'
+          role='participant'&gt;
+      &lt;reason&gt;A worthy fellow.&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then inform the moderator of success:</p>
+    <p class="caption">Example 87. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voice1'
+    to='bard@shakespeare.lit/globe'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in voice privileges by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, voice privileges cannot be revoked from a room owner or room admin, nor from any user with a higher affiliation than the moderator making the request. If a room admin attempts to revoke voice privileges from such a user by modifying the voice list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 88. Service Returns Error on Attempt to Revoke Voice from an Admin, Owner, or User with a Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='goodfolk@chat.shakespeare.lit'
+    id='voicetest'
+    to='bard@shakespeare.lit/globe'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit'
+          nick='Hecate'
+          role='visitor'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="admin">Admin Use Cases</a>
+</h2>
+  <p class="" style="">A room administrator has privileges to modify persistent information about user affiliations (e.g., by banning users) and to grant and revoke moderator privileges, but does not have rights to change the defining features of the room, which are the sole province of the room owner(s). Exactly which actions may be performed by a room admin will be subject to configuration. However, for the purposes of the MUC framework, room admins are stipulated to at a minimum have privileges to perform the following actions:</p>
+  <ol start="1" type="">
+    <li>ban a user from the room</li>
+    <li>modify the list of users who are banned from the room</li>
+    <li>grant or revoke membership</li>
+    <li>modify the member list</li>
+    <li>grant or revoke moderator privileges</li>
+    <li>modify the list of moderators</li>
+  </ol>
+  <p class="" style="">These features shall be implemented with a request/response exchange using &lt;iq/&gt; elements that contain children qualified by the 'http://jabber.org/protocol/muc#admin' namespace. The examples below illustrate the protocol interactions that implement the desired functionality. (Except where explicitly noted below, any of the following administrative requests MUST be denied if the &lt;user@host&gt; of the 'from' address of the request does not match the bare JID of one of the room admins; in this case, the service MUST return a &lt;forbidden/&gt; error.)</p>
+  <div class="indent">
+<h3>9.1 <a name="ban">Banning a User</a>
+</h3>
+    <p class="" style="">An admin or owner can ban one or more users from a room. The ban MUST be performed based on the occupant's bare JID. In order to ban a user, an admin MUST change the user's affiliation to "outcast".</p>
+    <p class="caption">Example 89. Admin Bans User</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban1'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add that bare JID to the ban list, SHOULD remove the outcast's nickname from the list of registered nicknames, and MUST inform the admin or owner of success:</p>
+    <p class="caption">Example 90. Service Informs Admin or Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban1'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also remove any banned users who are in the room by sending a presence stanza of type "unavailable" to each banned occupant, including status code 301 in the extended presence information, optionally along with the reason (if provided) and the bare JID of the user who initiated the ban.</p>
+    <p class="caption">Example 91. Service Removes Banned User</p>
+<div class="indent"><pre>
+&lt;presence
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='earlofcambridge@shakespeare.lit/stabber'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast' role='none'&gt;
+      &lt;actor jid='kinghenryv@shakespeare.lit'/&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The inclusion of the status code assists clients in presenting their own notification messages (e.g., information appropriate to the user's locality). The optional inclusion of the reason and actor enable the banned user to understand why he or she was banned, and by whom if the banned user would like to discuss the matter.</p>
+    <p class="" style="">The service MUST then inform all of the remaining occupants that the banned user is no longer in the room by sending presence stanzas of type "unavailable" from the banned user to all remaining occupants (just as it does when occupants exit the room of their own volition), including the status code and optionally the reason and actor:</p>
+    <p class="caption">Example 92. Service Informs Remaining Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    type='unavailable'
+    from='southampton@henryv.shakespeare.lit/cambridge'
+    to='exeter@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit/stabber'
+          role='none'/&gt;
+    &lt;status code='301'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As with <a href="#kick">Kicking an Occupant</a>, a user cannot be banned by an admin with a lower affiliation. Therefore, if an admin attempts to ban an owner, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 93. Service Returns Error on Attempt to Ban User With Higher Affiliation</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban1'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If an admin or owner attempts to ban himself, the service MUST deny the request and return a &lt;conflict/&gt; error to the sender. (Note: This is different from the recommended service behavior on kicking oneself, which a service may allow.)</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="modifyban">Modifying the Ban List</a>
+</h3>
+    <p class="" style="">A room admin may want to modify the ban list. Note: The ban list is always based on a user's bare JID, although a nick (perhaps the last room nickname associated with that JID) MAY be included for convenience. To modify the list of banned JIDs, the admin first requests the ban list by querying the room for all users with an affiliation of 'outcast'.</p>
+    <p class="caption">Example 94. Admin Requests Ban List</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban2'
+    to='southampton@henryv.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the list of banned users to the admin; each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' and 'role' attributes:</p>
+    <p class="caption">Example 95. Service Sends Ban List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban2'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the ban list. In order to do so, the admin MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'affiliation' attribute (normally set to a value of "outcast" to ban or "none" to remove ban) and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the outcast affiliation); in addition, the reason and actor elements are OPTIONAL:</p>
+    <p class="caption">Example 96. Admin Sends Modified Ban List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='kinghenryv@shakespeare.lit/throne'
+    id='ban3'
+    to='southampton@henryv.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='earlofcambridge@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'&gt;
+          jid='lordscroop@shakespeare.lit' 
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='outcast'
+          jid='sirthomasgrey@shakespeare.lit'&gt;
+      &lt;reason&gt;Treason&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">After updating the ban list, the service MUST inform the admin of success:</p>
+    <p class="caption">Example 97. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='southampton@henryv.shakespeare.lit'
+    id='ban3'
+    to='kinghenryv@shakespeare.lit/throne'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then remove the affected occupants (if they are in the room) and send updated presence (including the appropriate status code) from them to all the remaining occupants as described in the "Banning a User" use case. (The service SHOULD also remove each banned user's reserved nickname from the list of reserved roomnicks, if appropriate.)</p>
+    <p class="" style="">When an entity is banned from a room, an implementation SHOULD match JIDs in the following order (these matching rules are the same as those defined for privacy lists in <span style="font-weight: bold">RFC 3921</span>):</p>
+    <ol start="1" type="">
+      <li>&lt;user@domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;user@domain&gt; (any resource matches)</li>
+      <li>&lt;domain/resource&gt; (only that resource matches)</li>
+      <li>&lt;domain&gt; (the domain itself matches, as does any user@domain, domain/resource, or address containing a subdomain)</li>
+    </ol>
+    <p class="" style="">Some administrators may wish to ban all users associated with a specific domain from all rooms hosted by a MUC service. Such functionality is a service-level feature and is therefore out of scope for this document (but see <span class="ref" style="">Service Administration</span>  [<a href="#nt-id2258587">12</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="grantmember">Granting Membership</a>
+</h3>
+    <p class="" style="">An admin can grant membership to a user; this is done by changing the user's affiliation to "member" (normally based on nick if the user is in the room, or on bare JID if not; in either case, if the nick is provided, that nick becomes the user's default nick in the room if that functionality is supported by the implementation):</p>
+    <p class="caption">Example 98. Admin Grants Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the member list and then inform the admin of success:</p>
+    <p class="caption">Example 99. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of membership by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
+    <p class="caption">Example 100. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.4 <a name="revokemember">Revoking Membership</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's membership; this is done by changing the user's affiliation to "none":</p>
+    <p class="caption">Example 101. Admin Revokes Membership</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          nick='thirdwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 102. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of membership by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
+    <p class="caption">Example 103. Service Notes Loss of Membership</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If the room is members-only, the service MUST remove the user from the room, including a status code of 321 to indicate that the user was removed because of an affiliation change, and inform all remaining occupants:</p>
+    <p class="caption">Example 104. Service Removes Non-Member</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'&gt;
+      &lt;actor jid='bard@shakespeare.lit'/&gt;
+    &lt;/item&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;status code='321'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.5 <a name="modifymember">Modifying the Member List</a>
+</h3>
+    <p class="" style="">In the context of a members-only room, the member list is essentially a "whitelist" of people who are allowed to enter the room. Anyone who is not a member is effectively banned from entering the room, even if their affiliation is not "outcast".</p>
+    <p class="" style="">In the context of an open room, the member list is simply a list of users (bare JID and reserved nick) who are registered with the room. Such users may appear in a room roster, have their room nickname reserved, be returned in search results or FAQ queries, and the like.</p>
+    <p class="" style="">It is RECOMMENDED that only room admins have the privilege to modify the member list in members-only rooms. To do so, the admin first requests the member list by querying the room for all users with an affiliation of "member":</p>
+    <p class="caption">Example 105. Admin Requests Member List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">(A service SHOULD also return the member list to any occupant in a members-only room; i.e., it SHOULD NOT generate a &lt;forbidden/&gt; error when a member in the room requests the member list. This functionality may assist clients in showing all the existing members even if some of them are not in the room, e.g. to help a member determine if another user should be invited.)</p>
+    <p class="" style="">The service MUST then return the full member list to the admin qualified by the 'http://jabber.org/protocol/muc#admin' namespace; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for each members that is currently an occupant.</p>
+    <p class="caption">Example 106. Service Sends Member List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit'
+          nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the member list. In order to do so, the admin MUST send the changed items (i.e., only the "delta") to the service; each item MUST include the 'affiliation' attribute (normally set to a value of "member" or "none") and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the member affiliation):</p>
+    <p class="caption">Example 107. Admin Sends Modified Member List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='member4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'/&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the member list and then inform the moderator of success:</p>
+    <p class="caption">Example 108. Service Informs Moderator of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='member4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST change the affiliation of any affected user. If the user has been removed from the member list, the service MUST change the user's affiliation from "member" to "none". If the user has been added to the member list, the service MUST change the user's affiliation to "member".</p>
+    <p class="" style="">If a removed member is currently in a members-only room, the service SHOULD kick the occupant by changing the removed member's role to "none" and send appropriate presence to the removed member as previously described. No matter whether the removed member was in or out of a members-only room, the service MUST subsequently refuse entry to the user.</p>
+    <p class="" style="">For all room types, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "none".</p>
+    <p class="caption">Example 109. Service Sends Notice of Loss of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">In addition, the service SHOULD send an invitation to any user who has been added to the member list of a members-only room if the user is not currently affiliated with the room, for example as an admin or owner (such a user would by definition not be in the room; note also that this example includes a password but not a reason -- both child elements are OPTIONAL):</p>
+    <p class="caption">Example 110. Room Sends Invitation to New Member</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hecate@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='bard@shakespeare.lit'/&gt;
+    &lt;password&gt;cauldron&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">While only admins and owners SHOULD be allowed to modify the member list, an implementation MAY provide a configuration option that opens invitation privileges to any member of a members-only room. In such a situation, any invitation sent SHOULD automatically trigger the addition of the invitee to the member list. However, if invitation privileges are restricted to admins and a mere member attempts to a send an invitation, the service MUST deny the invitation request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 111. Service Returns Error on Attempt by Mere Member to Invite Others to a Members-Only Room</p>
+<div class="indent"><pre>
+&lt;message
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'&gt;
+      &lt;reason&gt;
+        Hey Hecate, this is the place for all good witches!
+      &lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Invitations sent through an open room MUST NOT trigger the addition of the invitee to the member list.</p>
+    <p class="" style="">If a user is added to the member list of an open room and the user is in the room, the service MUST send updated presence from this individual to all occupants, indicating the change in affiliation by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member".</p>
+    <p class="caption">Example 112. Service Sends Notice of Membership to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hecate@shakespeare.lit/broom'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.6 <a name="grantmod">Granting Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to grant moderator privileges to a participant or visitor; this is done by changing the user's role to "moderator":</p>
+    <p class="caption">Example 113. Admin Grants Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 114. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the addition of moderator privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "moderator".</p>
+    <p class="caption">Example 115. Service Sends Notice of Moderator Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.7 <a name="revokemod">Revoking Moderator Privileges</a>
+</h3>
+    <p class="" style="">An admin may want to revoke a user's moderator privileges. An admin MAY revoke moderator privileges only from a user whose affiliation is "member" or "none" (i.e., not from an owner or admin). The privilege is revoked by changing the user's role to "participant":</p>
+    <p class="caption">Example 116. Admin Revokes Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='thirdwitch'
+          role='participant'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 117. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the removal of moderator privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'role' attribute set to a value of "participant".</p>
+    <p class="caption">Example 118. Service Notes Loss of Moderator Privileges</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As noted, an admin MUST NOT be allowed to revoke moderator privileges from a user whose affiliation is "owner" or "admin". If an admin attempts to revoke moderator privileges from such a user, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 119. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='secondwitch' role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.8 <a name="modifymod">Modifying the Moderator List</a>
+</h3>
+    <p class="" style="">An admin may want to modify the moderator list. To do so, the admin first requests the moderator list by querying the room for all users with a role of 'moderator'.</p>
+    <p class="caption">Example 120. Admin Requests Moderator List</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then return the moderator list to the admin; each item MUST include the 'jid', 'nick', and 'role' attributes and SHOULD include the 'affiliation' attribute:</p>
+    <p class="caption">Example 121. Service Sends Moderator List to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod3'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          jid='hag66@shakespeare.lit/pda'
+          nick='thirdwitch'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The admin MAY then modify the moderator list. In order to do so, the admin MUST send the changed items (i.e., only the "delta") back to the service; each item MUST include the 'jid' attribute and 'role' attribute (normally set to a value of "member" or "participant") but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'affiliation' attribute (which is used to manage affiliations such as admin rather than the moderator role):</p>
+    <p class="caption">Example 122. Admin Sends Modified Moderator List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='mod4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hag66@shakespeare.lit/pda'
+          role='participant'/&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST modify the moderator list and then inform the admin of success:</p>
+    <p class="caption">Example 123. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='mod4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence for any affected individuals to all occupants, indicating the change in moderator privileges by sending the appropriate extended presence stanzas as described in the foregoing use cases.</p>
+    <p class="" style="">As noted, moderator privileges cannot be revoked from a room owner or room admin. If a room admin attempts to revoke moderator privileges from such a user by modifying the moderator list, the service MUST deny the request and return a &lt;not-allowed/&gt; error to the sender:</p>
+    <p class="caption">Example 124. Service Returns Error on Attempt to Revoke Moderator Privileges from an Admin or Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='modtest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item jid='hecate@shakespeare.lit/broom'
+          nick='Hecate'
+          role='participant'/&gt;
+  &lt;/query&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.9 <a name="regapprove">Approving Registration Requests</a>
+</h3>
+    <p class="" style="">If a service does not automatically accept requests to register with a room, it MAY provide a way for room admins to approve or deny registration requests over Jabber (alternatively, it could provide a web interface or some other admin tool). The simplest way to do so is for the service to send a &lt;message/&gt; stanza to the room admin(s) when the registration request is received, where the &lt;message/&gt; stanza contains a Data Form asking for approval or denial of the request. The following Data Form is RECOMMENDED but implementations MAY use a different form entirely, or supplement the following form with additional fields.</p>
+    <p class="caption">Example 125. Registration Request Approval Form</p>
+<div class="indent"><pre>
+&lt;message from='darkcave@macbeth.shakespeare.lit'
+         id='approve'
+         to='crone1@shakespeare.lit/pda'&gt;
+  &lt;x xmlns='jabber:x:data' type='form'&gt;
+    &lt;title&gt;Registration request&lt;/title&gt;
+    &lt;instructions&gt;
+      To approve this registration request, select the
+      &amp;quot;Allow this person to register with the room?&amp;quot;
+      checkbox and click OK. To skip this request, click the 
+      cancel button.
+    &lt;/instructions&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#register&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_first'
+           type='text-single'
+           label='First Name'&gt;
+      &lt;value&gt;Brunhilde&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_last'
+           type="text-single"
+           label="Last Name"&gt;
+      &lt;value&gt;Entwhistle-Throckmorton&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_roomnick'
+           type="text-single"
+           label="Desired Nickname"&gt;
+      &lt;value&gt;thirdwitch&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_url'
+           type="text-single"
+           label="User URL"&gt;
+      &lt;value&gt;http://witchesonline/~hag66/&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_email'
+           type="text-single"
+           label="Email Address"&gt;
+      &lt;value&gt;hag66@witchesonline&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_faqentry'
+           type="text-single"
+           label="FAQ Entry"&gt;
+      &lt;value&gt;Just another witch.&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='muc#register_allow'
+           type='boolean'
+           label='Allow this person to register with the room?'&gt;
+      &lt;value&gt;0&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the admin approves the registration request, the service shall register the user with the room.</p>
+    <p class="" style="">More advanced registration approval mechanisms (e.g., retrieving a list of registration requests using <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2259447">13</a>] as is done in <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2259470">14</a>]) are out of scope for this document.</p>
+  </div>
+<h2>10.
+       <a name="owner">Owner Use Cases</a>
+</h2>
+  <p class="" style="">Every room MUST have at least one owner, and that owner (or a successor) is a long-lived attribute of the room for as long as the room exists (e.g., the owner does not lose ownership on exiting a persistent room). This document assumes that the (initial) room owner is the individual who creates the room and that only a room owner has the right to change defining room configuration settings such as the room type. Ideally, room owners will be able to specify not only the room types (password-protected, members-only, etc.) but also certain attributes of the room as listed in the <a href="#reqs">Requirements</a> section of this document. In addition, it would be good if an owner were able to specify the JIDs of other owners, but that shall be determined by the implementation.</p>
+  <p class="" style="">In order to provide the necessary flexibility for a wide range of configuration options, Data Forms (<span style="font-weight: bold">JEP-0004</span>) shall be used for room configuration, triggered by use of the 'http://jabber.org/protocol/muc' namespace. That is, if an entity does not include the MUC namespace in its room join/create request, then the service shall create the room and not wait for configuration via Data Forms before creating the room (this ensures backwards-compatibility with the old "groupchat 1.0" protocol); however, if the room join/create request includes the MUC extension, then the service shall require configuration via Data Forms before creating and unlocking the room.</p>
+  <p class="" style="">Note: The configuration options shown below address all of the features and room types listed in the requirements section of this document; however, the exact configuration options and form layout shall be determined by the implementation or specific deployment. Also, these are examples only and are not intended to define the only allowed or required configuration options for rooms. A given implementation or deployment MAY choose to provide additional configuration options (profanity filters, setting the default language for a room, message logging, etc.), which is why the use of the 'jabber:x:data' protocol is valuable here.</p>
+  <div class="indent">
+<h3>10.1 <a name="createroom">Creating a Room</a>
+</h3>
+    <div class="indent">
+<h3>10.1.1 <a name="createroom-general">General Considerations</a>
+</h3>
+      <p class="" style="">The privilege to create rooms MAY be restricted to certain users or MAY be reserved to an administrator of the service. If access is restricted and a user attempts to create a room, the service MUST return a &lt;not-allowed/&gt; error:</p>
+      <p class="caption">Example 126. Service Informs User of Inability to Create a Room</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">If access is not restricted, the service MUST allow the user to create a room as described below.</p>
+      <p class="" style="">From the perspective of room creation, there are in essence two kinds of rooms:</p>
+      <ul>
+        <li><p class="" style="">"Instant rooms" -- these are available for immediate access and are automatically created based on some default configuration.</p></li>
+        <li><p class="" style="">"Reserved rooms" -- these are manually configured by the room creator before anyone is allowed to enter.</p></li>
+      </ul>
+      <p class="" style="">The workflow for creating and configuring such rooms is as follows:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">The user MUST send presence to &lt;room@service/nick&gt; and signal his or her support for the Multi-User Chat protocol by including extended presence information in an empty &lt;x/&gt; child element qualified by the 'http://jabber.org/protocol/muc' namespace (note the lack of an '#owner' or '#user' fragment).</p></li>
+        <li><p class="" style="">If this user is allowed to create a room and the room does not yet exist, the service MUST create the room according to some default configuration, assign the requesting user as the initial room owner, and add the owner to the room but not allow anyone else to enter the room (effectively "locking" the room). The initial presence stanza received by the owner from the room MUST include extended presence information indicating the user's status as an owner and acknowledging that the room has been created (via status code 201) and is awaiting configuration.</p></li>
+        <li><p class="" style="">If the initial room owner would like to create and configure a reserved room, the room owner MUST then request a configuration form by sending an IQ stanza of type "get" to the room containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, then complete Steps 4 and 5. If the room owner would prefer to create an instant room, the room owner MUST send a query element qualified by the 'http://jabber.org/protocol/muc#owner' namespace and containing an empty &lt;x/&gt; element of type "submit" qualified by the 'jabber:x:data' namespace, then skip to Step 6.</p></li>
+        <li><p class="" style="">If the room owner requested a configuration form, the service MUST send an IQ to the room owner containing a configuration form qualified by the 'jabber:x:data' namespace. If there are no configuration options available, the room MUST return an empty query element to the room owner.</p></li>
+        <li><p class="" style="">The initial room owner SHOULD provide a starting configuration for the room (or accept the default configuration) by sending an IQ of type "set" containing the completed configuration form. Alternatively, the room owner MAY cancel the configuration process. (An implementation MAY set a timeout for initial configuration, such that if the room owner does not configure the room within the timeout period, the room owner is assumed to have accepted the default configuration or to have cancelled the configuration process.)</p></li>
+        <li><p class="" style="">Once the service receives the completed configuration form from the initial room owner (or receives a request for an instant room), the service MUST "unlock" the room (i.e., allow other users to enter the room) and send an IQ of type "result" to the room owner. If the service receives a cancellation, it MUST destroy the room.</p></li>
+      </ol>
+      <p class="" style="">The protocol for this workflow is shown in the examples below.</p>
+      <p class="" style="">First, the Jabber user MUST send presence to the room, including and empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace (this is the same stanza sent when seeking to enter a room).</p>
+      <p class="caption">Example 127. Jabber User Creates a Room and Signals Support for Multi-User Chat</p>
+<div class="indent"><pre>
+&lt;presence
+    from='crone1@shakespeare.lit/desktop'
+    to='darkcave@macbeth.shakespeare.lit/firstwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">If the room does not yet exist, the service SHOULD create the room (subject to local policies regarding room creation), assign the bare JID of the requesting user as the owner, add the owner to the room, and acknowledge successful creation of the room by sending a presence stanza of the following form:</p>
+      <p class="caption">Example 128. Service Acknowledges Room Creation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          role='moderator'/&gt;
+    &lt;status code='201'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">After receiving notification that the room has been created, the room owner needs to decide whether to accept the default room configuration (i.e., create an "instant room") or configure the room to have something other than the default room configuration (i.e., create a "reserved room"). The protocol flows for completing those two use cases are shown in the following sections.</p>
+      <p class="" style="">Note: If the presence stanza sent to a nonexistent room does not include an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace as shown above, the service SHOULD create a default room without delay (i.e., it MUST assume that the client supports "groupchat 1.0" rather than Multi-User Chat and therefore it MUST NOT lock the room while waiting for the room creator to either accept an instant room or configure a reserved room).</p>
+    </div>
+    <div class="indent">
+<h3>10.1.2 <a name="createroom-instant">Creating an Instant Room</a>
+</h3>
+      <p class="" style="">If the initial room owner wants to accept the default room configuration (i.e., create an "instant room"), the room owner MUST decline an initial configuration form by sending an IQ set to the &lt;room@service&gt; itself containing a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, where the only child of the &lt;query/&gt; is an empty &lt;x/&gt; element that is qualified by the 'jabber:x:data' namespace and that possesses a 'type' attribute whose value is "submit":</p>
+      <p class="caption">Example 129. Owner Requests Instant Room</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The service MUST then unlock the room and allow other entities to join it.</p>
+    </div>
+    <div class="indent">
+<h3>10.1.3 <a name="createroom-reserved">Creating a Reserved Room</a>
+</h3>
+      <p class="" style="">If the initial room owner wants to create and configure a reserved room, the room owner MUST request an initial configuration form by sending an IQ get to the &lt;room@service&gt; itself containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace:</p>
+      <p class="caption">Example 130. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the room does not already exist, the service MUST return an initial room configuration form to the user. (Note: The following example shows a representative sample of configuration options. A full list of x:data fields registered for use in room creation and configuration is maintained by the Jabber Registrar; see the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.)</p>
+      <p class="caption">Example 131. Service Sends Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for "darkcave" Room&lt;/title&gt;
+      &lt;instructions&gt;
+          Your room darkcave@macbeth has been created!
+          The default configuration is as follows:
+            - No logging
+            - No moderation
+            - Up to 20 occupants
+            - No password required
+            - No invitation required
+            - Room is not persistent
+            - Only admins may change the subject
+            - Presence broadcasted for all users
+          To accept the default configuration, click OK. To
+          select a different configuration, please complete
+          this form.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#roomconfig_roomname'/&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#roomconfig_roomdesc'/&gt;
+      &lt;field
+          label='Natural Language for Room Discussions'
+          type='text-single'
+          var='muc#roomconfig_lang'/&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;20&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#roomconfig_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members-Only?'
+          type='boolean'
+          var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required to Enter?'
+          type='boolean'
+          var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#roomconfig_roomsecret'/&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#roomconfig_whois'&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#roomconfig_roomadmins'/&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#roomconfig_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Note: The _whois configuration option specifies whether the room is non-anonymous (a value of "anyone"), semi-anonymous (a value of "moderators"), or fully anonmyous (a value of "none", not shown here).</p>
+      <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner:</p>
+      <p class="caption">Example 132. Service Informs Owner that No Configuration is Possible</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The room owner SHOULD then fill out the form and submit it to the service.</p>
+      <p class="caption">Example 133. Owner Submits Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roomconfig_roomadmins'&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If room creation is successful, the service MUST inform the new room owner of success:</p>
+      <p class="caption">Example 134. Service Informs New Room Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+      </pre></div>
+      <p class="" style="">If the room creation fails because the specified room configuration options violate one or more service policies (e.g., because the password for a password-protected room is blank), the service MUST return a &lt;not-acceptable/&gt; error.</p>
+      <p class="caption">Example 135. Service Informs Owner that Requested Configuration Options Are Unacceptable</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='create2'
+    to='crone1@shakespeare.lit/desktop'
+    type='error'&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Alternatively, the room owner MAY cancel the configuration process:</p>
+      <p class="caption">Example 136. Owner Cancels Initial Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='create2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the room owner cancels the initial configuration, the service SHOULD destroy the room, making sure to send unavailable presence to the room owner (see the "Destroying a Room" use case for protocol details).</p>
+      <p class="" style="">If the room owner becomes unavailable for any reason before submitting the form (e.g., a lost connection), the service will receive a presence stanza of type "unavailable" from the owner to the owner's &lt;room@service/nick&gt; or to &lt;room@service&gt; (or both). The service MUST then destroy the room, sending a presence stanza of type "unavailable" from the room to the owner including a &lt;destroy/&gt; element and reason (if provided) as defined in the <a href="#destroyroom">Destroying a Room</a> section of this document.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="roomconfig">Subsequent Room Configuration</a>
+</h3>
+    <p class="" style="">At any time after specifying the initial configuration of the room, a room owner may want to change the configuration. In order to initiate this process, a room owner MUST request a new configuration form from the room by sending an IQ to &lt;room@service&gt; containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace.</p>
+    <p class="caption">Example 137. Owner Requests Configuration Form</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 138. Service Denies Configuration Access to Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='configures'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the service MUST send a configuration form to the room owner with the current options set as defaults:</p>
+    <p class="caption">Example 139. Service Sends Configuration Form to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='config1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for "darkcave" Room&lt;/title&gt;
+      &lt;instructions&gt;
+        Complete this form to make changes to
+        the configuration of your room.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roomconfig&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Natural-Language Room Name'
+          type='text-single'
+          var='muc#roomconfig_roomname'&gt;
+        &lt;value&gt;A Dark Cave&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Short Description of Room'
+          type='text-single'
+          var='muc#roomconfig_roomdesc'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Enable Logging?'
+          type='boolean'
+          var='muc#roomconfig_enablelogging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Change Subject?'
+          type='boolean'
+          var='muc#roomconfig_changesubject'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Allow Occupants to Invite Others?'
+          type='boolean'
+          var='muc#roomconfig_allowinvites'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Maximum Number of Occupants'
+          type='list-single'
+          var='muc#roomconfig_maxusers'&gt;
+        &lt;value&gt;10&lt;/value&gt;
+        &lt;option label='10'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='20'&gt;&lt;value&gt;20&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='30'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Roles for which Presence is Broadcast'
+          type='list-multi'
+          var='muc#roomconfig_presencebroadcast'&gt;
+        &lt;value&gt;moderator&lt;/value&gt;
+        &lt;value&gt;participant&lt;/value&gt;
+        &lt;value&gt;visitor&lt;/value&gt;
+        &lt;option label='Moderator'&gt;&lt;value&gt;moderator&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Participant'&gt;&lt;value&gt;participant&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Visitor'&gt;&lt;value&gt;visitor&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Publicly Searchable?'
+          type='boolean'
+          var='muc#roomconfig_publicroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Persistent?'
+          type='boolean'
+          var='muc#roomconfig_persistentroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Moderated?'
+          type='boolean'
+          var='muc#roomconfig_moderatedroom'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Make Room Members Only?'
+          type='boolean'
+          var='muc#roomconfig_membersonly'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password Required for Entry?'
+          type='boolean'
+          var='muc#roomconfig_passwordprotectedroom'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          If a password is required to enter this room,
+          you must specify the password below.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Password'
+          type='text-private'
+          var='muc#roomconfig_roomsecret'&gt;
+        &lt;value&gt;cauldron&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Who May Discover Real JIDs?'
+          type='list-single'
+          var='muc#roomconfig_whois'&gt;
+        &lt;value&gt;moderators&lt;/value&gt;
+        &lt;option label='Moderators Only'&gt;
+          &lt;value&gt;moderators&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Anyone'&gt;
+          &lt;value&gt;anyone&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional people who have
+          administrative privileges in the room. Please
+          provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Admins'
+          type='jid-multi'
+          var='muc#roomconfig_roomadmins'&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='fixed'&gt;
+        &lt;value&gt;
+          You may specify additional owners for this
+          room. Please provide one Jabber ID per line.
+        &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          label='Room Owners'
+          type='jid-multi'
+          var='muc#roomconfig_roomowners'/&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no configuration options available, the service MUST return an empty query element to the room owner as shown in the previous use case.</p>
+    <p class="" style="">The room owner SHOULD then submit the form with updated configuration information.</p>
+    <p class="" style="">Alternatively, the room owner MAY cancel the configuration process:</p>
+    <p class="caption">Example 140. Owner Cancels Subsequent Configuration</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='config2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the room owner cancels the subsequent configuration, the service MUST leave the configuration of the room as it was before the room owner initiated the subsequent configuration process.</p>
+    <p class="" style="">If as a result of a change in the room configuration a room admin loses administrative privileges while the admin is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "member" and the 'role' attribute set to a value of "participant" or "visitor" as appropriate for the affiliation level and the room type:</p>
+    <p class="caption">Example 141. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a user gains administrative privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to a value of "admin":</p>
+    <p class="caption">Example 142. Service Notes Gain of Admin Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration a room owner loses owner privileges while that owner is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to an appropriate value given the affiliation and room type ("moderator" is recommended).</p>
+    <p class="caption">Example 143. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own ownership privileges if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner. However, a service SHOULD allow an owner to revoke his or her own ownership privileges if there are other owners.</p>
+    <p class="" style="">If as a result of a change in the room configuration a user gains ownership privileges while the user is in the room, the room MUST send updated presence for that individual to all occupants, denoting the change in status by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner" and the 'role' attribute set to an appropriate value given the affiliation and room type ("moderator" is recommended).</p>
+    <p class="caption">Example 144. Service Notes Gain of Owner Affiliation to All Users</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If as a result of a change in the room configuration the room type is changed to members-only but there are non-members in the room, the service MUST remove any non-members from the room and include a status code of 322 in the presence unavailable stanzas sent to those users as well as any remaining occupants.</p>
+    <div class="indent">
+<h3>10.2.1 <a name="roomconfig-notify">Notification of Configuration Changes</a>
+</h3>
+      <p class="" style="">A room MUST send notification to all occupants when the room configuration changes in a way that has an impact on the privacy or security profile of the room. This notification shall consist of a &lt;message/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace, which shall contain only a &lt;status/&gt; element with an appropriate value for the 'code' attribute. Here is an example:</p>
+      <p class="caption">Example 145. Configuration Status Code</p>
+<div class="indent"><pre>
+&lt;message from='darkcave@macbeth.shakespeare.lit'
+         to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;status code='170'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The codes to be generated as a result of a privacy-related change in room configuration are as follows:</p>
+      <ul>
+        <li>If room logging is now enabled, status code 170.</li>
+        <li>If room logging is now disabled, status code 171.</li>
+        <li>If the room is now non-anonymous, status code 172.</li>
+        <li>If the room is now semi-anonymous, status code 173.</li>
+        <li>If the room is now fully-anonymous, status code 174.</li>
+      </ul>
+      <p class="" style="">For any other configuration change, the room SHOULD send status code 104 so that interested occupants can retrieve the updated room configuration if desired.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="grantowner">Granting Ownership Privileges</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, an owner MAY grant ownership privileges to another user; this is done by changing the user's affiliation to "owner":</p>
+    <p class="caption">Example 146. Owner Grants Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 147. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of ownership privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "owner" and the 'role' attribute set to an appropriate value given the affiliation and room type ("moderator" is recommended).</p>
+    <p class="caption">Example 148. Service Sends Notice of Ownership Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/hecate'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.4 <a name="revokeowner">Revoking Ownership Privileges</a>
+</h3>
+    <p class="" style="">An implementation MAY allow an owner to revoke another user's ownership privileges; this is done by changing the user's affiliation to something other than "owner":</p>
+    <p class="caption">Example 149. Owner Revokes Ownership Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='owner2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own ownership privileges if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner. However, a service SHOULD allow an owner to revoke his or her own ownership privileges if there are other owners.</p>
+    <p class="" style="">If an implementation does not allow one owner to revoke another user's ownership privileges, the implementation MUST return a &lt;not-authorized/&gt; error to the owner who made the request.</p>
+    <p class="" style="">In all other cases, the service MUST remove the user from the owner list and then inform the owner of success:</p>
+    <p class="caption">Example 150. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the loss of ownership privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "owner" and the 'role' attribute set to an appropriate value:</p>
+    <p class="caption">Example 151. Service Notes Loss of Owner Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit/broom'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">Note: Allowing an owner to remove another user's ownership privileges can compromise the control model for room management; therefore this feature is OPTIONAL, and implementations are encouraged to support owner removal through an interface that is open only to individuals with service-wide administrative privileges.</p>
+  </div>
+  <div class="indent">
+<h3>10.5 <a name="modifyowner">Modifying the Owner List</a>
+</h3>
+    <p class="" style="">If allowed by an implementation, a room owner may want to modify the owner list. To do so, the owner first requests the owner list by querying the room for all users with an affiliation of 'owner'.</p>
+    <p class="caption">Example 152. Owner Requests Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='owner3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender.</p>
+    <p class="" style="">Otherwise, the service MUST then return the owner list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any owner that is currently an occupant:</p>
+    <p class="caption">Example 153. Service Sends Owner List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner3'
+    to='bard@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner'
+          jid='crone1@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner MAY then modify the owner list. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service;  [<a href="#nt-id2260963">15</a>] each item MUST include the 'affiliation' and 'jid' attributes but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the owner affiliation):</p>
+    <p class="caption">Example 154. Owner Sends Modified Owner List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='owner4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner'
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the owner list. If a non-owner attempts to view or modify the owner list, the service MUST deny the request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 155. Service Returns Error on Attempt by Non-Owner to Modify Owner List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='ownertest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='owner' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MUST NOT allow an owner to revoke his or her own ownership privileges if there are no other owners; if an owner attempts to do this, the service MUST return a &lt;conflict/&gt; error to the owner. However, a service SHOULD allow an owner to revoke his or her own ownership privileges if there are other owners.</p>
+    <p class="" style="">In all other cases, the service MUST modify owner list and then inform the owner of success:</p>
+    <p class="caption">Example 156. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='owner4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also send presence notifications related to any affiliation changes that result from modifying the owner list as previously described.</p>
+  </div>
+  <div class="indent">
+<h3>10.6 <a name="grantadmin">Granting Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner can grant administrative privileges to a member or unaffiliated user; this is done by changing the user's affiliation to "admin":</p>
+    <p class="caption">Example 157. Owner Grants Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin1'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST add the user to the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 158. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin1'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the user is in the room, the service MUST then send updated presence from this individual to all occupants, indicating the granting of administrative privileges by including an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value of "admin" and the 'role' attribute set to an appropriate value given the affiliation and room type.</p>
+    <p class="caption">Example 159. Service Sends Notice of Administrative Privileges to All Occupants</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='moderator'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.7 <a name="revokeadmin">Revoking Administrative Privileges</a>
+</h3>
+    <p class="" style="">An owner may want to revoke a user's administrative privileges; this is done by changing the user's affiliation to something other than "admin" or "owner":</p>
+    <p class="caption">Example 160. Owner Revokes Administrative Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='admin2'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='member'
+          nick='secondwitch'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MUST remove the user from the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 161. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin2'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST then send updated presence from this individual to all occupants, indicating the loss of administrative privileges by sending a presence element that contains an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child with the 'affiliation' attribute set to a value other than "admin" or "owner" and the 'role' attribute set to an appropriate value given the affiliation level and the room type:</p>
+    <p class="caption">Example 162. Service Notes Loss of Admin Affiliation</p>
+<div class="indent"><pre>
+&lt;presence
+    from='darkcave@macbeth.shakespeare.lit/secondwitch'
+    to='crone1@shakespeare.lit/desktop'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='member'
+          jid='wiccarocks@shakespeare.lit/laptop'
+          role='participant'/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.8 <a name="modifyadmin">Modifying the Admin List</a>
+</h3>
+    <p class="" style="">A room owner may want to modify the admin list. To do so, the owner first requests the admin list by querying the room for all users with an affiliation of 'admin'.</p>
+    <p class="caption">Example 163. Owner Requests Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/desktopaffiliation
+    id='admin3'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;user@host&gt; of the 'from' address does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender.</p>
+    <p class="" style="">Otherwise, the service MUST then return the admin list to the owner; each item MUST include the 'affiliation' and 'jid' attributes and MAY include the 'nick' and 'role' attributes for any admin that is currently an occupant:</p>
+    <p class="caption">Example 164. Service Sends Admin List to Owner</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin3'
+    to='bard@shakespeare.lit/globe'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin'
+          jid='wiccarocks@shakespeare.lit'
+          nick='secondwitch'/&gt;
+    &lt;item affiliation='admin'
+          jid='hag66@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The owner MAY then modify the admin list. In order to do so, the owner MUST send the changed items (i.e., only the "delta") back to the service;  [<a href="#nt-id2261289">16</a>] each item MUST include the 'affiliation' attribute (normally set to a value of "admin" or "none") and 'jid' attribute but SHOULD NOT include the 'nick' attribute and MUST NOT include the 'role' attribute (which is used to manage roles such as participant rather than the admin affiliation):</p>
+    <p class="caption">Example 165. Owner Sends Modified Admin List to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    id='admin4'
+    to='darkcave@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='none'
+          jid='hag66@shakespeare.lit'&gt;
+    &lt;/item&gt;
+    &lt;item affiliation='admin'
+          jid='hecate@shakespeare.lit'&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Only owners shall be allowed to modify the admin list. If a non-owner attempts to view or modify the admin list, the service MUST deny the request and return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 166. Service Returns Error on Attempt by Non-Owner to Modify Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admintest'
+    to='hag66@shakespeare.lit/pda'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='admin' 
+          jid='hecate@shakespeare.lit'/&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, the service MUST modify the admin list and then inform the owner of success:</p>
+    <p class="caption">Example 167. Service Informs Owner of Success</p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit'
+    id='admin4'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">The service MUST also send presence notifications related to any affiliation changes that result from modifying the admin list as previously described.</p>
+  </div>
+  <div class="indent">
+<h3>10.9 <a name="destroyroom">Destroying a Room</a>
+</h3>
+    <p class="" style="">A room owner MUST be able to destroy a room, especially if the room is persistent. The workflow is as follows:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">The room owner requests that the room be destroyed, specifying a reason and an alternate venue if desired.</p></li>
+      <li><p class="" style="">The room removes all users from the room (including appropriate information about the alternate location and the reason for being removed) and destroys the room, even if it was defined as persistent.</p></li>
+    </ol>
+    <p class="" style="">Other than the foregoing, this document does not specify what (if anything) a MUC service implementation shall do as a result of a room destruction request. For example, if the room was defined as persistent, an implementation MAY choose to lock the room ID so that it cannot be re-used, redirect enter requests to the alternate venue, or invite the current participants to the new room; however, such behavior is OPTIONAL.</p>
+    <p class="" style="">In order to destroy a room, the room owner MUST send an IQ set to the address of the room to be destroyed. The &lt;iq/&gt; stanza shall contain a &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/muc#owner' namespace, which in turn shall contain a &lt;destroy/&gt; element. The address of the alternate venue MAY be provided as the value of the &lt;destroy/&gt; element's 'jid' attribute. A password for the alternate venue MAY be provided as the XML character data of a &lt;password/&gt; child element of the &lt;destroy/&gt; element. The reason for the room destruction MAY be provided as the XML character data of a &lt;reason/&gt; child element of the &lt;destroy/&gt; element.</p>
+    <p class="" style="">The following examples illustrate the protocol elements to be sent and received:</p>
+    <p class="caption">Example 168. Owner Submits Room Destruction Request</p>
+<div class="indent"><pre>
+&lt;iq from='crone1@shakespeare.lit/desktop'
+    id='begone'
+    to='heath@macbeth.shakespeare.lit'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service is responsible for removing all the occupants. It SHOULD NOT broadcast presence stanzas of type "unavailable" from all occupants, instead sending only one presence stanza of type "unavailable" to each occupant so that the user knows he or she has been removed from the room. If extended presence information specifying the JID of an alternate location and the reason for the room destruction was provided by the room owner, the presence stanza MUST include that information.</p>
+    <p class="caption">Example 169. Service Removes Each Occupant</p>
+<div class="indent"><pre>
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/firstwitch'
+    to='crone1@shakespeare.lit/desktop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/secondwitch'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+
+&lt;presence
+    from='heath@macbeth.shakespeare.lit/thirdwitch'
+    to='hag66@shakespeare.lit/pda'
+    type='unavailable'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;item affiliation='none' role='none'/&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 170. Service Informs Owner of Successful Destruction</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='begone'
+    to='crone1@shakespeare.lit/desktop'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;user@host&gt; of the 'from' address received on a destroy request does not match the bare JID of a room owner, the service MUST return a &lt;forbidden/&gt; error to the sender:</p>
+    <p class="caption">Example 171. Service Denies Destroy Request Submitted by Non-Owner</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    id='destroytest'
+    to='wiccarocks@shakespeare.lit/laptop'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;destroy jid='darkcave@macbeth.shakespeare.lit'&gt;
+      &lt;reason&gt;Macbeth doth come.&lt;/reason&gt;
+    &lt;/destroy&gt;
+  &lt;/query&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="errorcodes">Error Codes</a>
+</h3>
+    <p class="" style="">The error codes associated with the 'http://jabber.org/protocol/muc#user' namespace are fairly straightforward, as summarized in the following table. For detailed information about mapping legacy error codes to XMPP-style error types and conditions, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2261598">17</a>]; implementations SHOULD support both legacy and XMPP error handling.</p>
+    <p class="caption">Table 8: Error Codes for http://jabber.org/protocol/muc#user Namespace</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Code</th>
+        <th colspan="" rowspan="">Type</th>
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Context</th>
+        <th colspan="" rowspan="">Purpose</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">401</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that a password is required</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">403</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that he or she is banned from the room</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">404</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that the room does not exist</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">405</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that room creation is restricted</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">406</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that the reserved roomnick must be used</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">407</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that he or she is not on the member list</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">409</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that his or her desired room nickname is in use or registered by another user</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">503</td>
+        <td align="" colspan="" rowspan="">Error</td>
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Entering a room</td>
+        <td align="" colspan="" rowspan="">Inform user that the maximum number of users has been reached</td>
+      </tr>
+    </table>
+    <p class="" style="">This document does not stipulate text strings (i.e., values of the XMPP &lt;text/&gt; element) associated with the foregoing error conditions.</p>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="statuscodes">Status Codes</a>
+</h3>
+    <p class="" style="">Multi-User Chat uses a &lt;status/&gt; element (specifically, the 'code' attribute of the &lt;status/&gt; element) to communicate information about a user's status in a room. Over time, the number of status codes has grown quite large, and new status codes continue to be requested of the JEP author. Therefore, these codes are now documented in a registry maintained by the Jabber Registrar. For details, refer to the <a href="#registrar-statuscodes">Status Codes Registry</a> section of this document.</p>
+    <p class="" style="">Note: In general, MUC status codes tend to follow the "philosophy" of status codes that is implicit in <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2262080">18</a>] and <span class="ref" style="">RFC 1893</span>  [<a href="#nt-id2262103">19</a>] (1xx codes are informational, 2xx codes specify that it is fine to continue, 3xx codes specify redirects such as being kicked or banned, x3x codes refer to system status, x7x codes refer to security or policy matters, etc.).</p>
+    <p class="" style="">Note: If the MUC protocol were being designed today, it would specify a more flexible, XML-friendly approach rather than hardcoded status numbers; however, at this point the pain of changing the status reporting system would be greater than the benefit of doing so, which is why the status code numbers remain in use. A future version of this document may define a more XMPP-like approach to status conditions, retaining the code numbers but supplementing them with more descriptive child elements as is done in <span style="font-weight: bold">RFC 3920</span>.</p>
+  </div>
+<h2>12.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">As specified in <span style="font-weight: bold">RFC 3920</span>, XMPP entities (including MUC rooms and MUC services) SHOULD respect the value of the 'xml:lang' attribute provided with any given stanza. However, simultaneous translation of groupchat messages is out of scope for this document.</p>
+  <p class="" style="">The status and error codes defined herein enable a client implementation to present a localized interface; however, definition of the localized text strings for any given language community is out of scope for this document.</p>
+  <p class="" style="">Although the labels for various data form fields are shown here in English, MUC clients SHOULD present localized text for these fields rather than the English text.</p>
+<h2>13.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="security-auth">User Authentication and Authorization</a>
+</h3>
+    <p class="" style="">No room entrance authentication or authorization method more secure than cleartext passwords is defined or required by this document. However, the risks involved can mitigated by the use of channel encryption and strong authentication via TLS and SASL as described in <span style="font-weight: bold">RFC 3920</span>.</p>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="security-e2e">End-to-End Encryption</a>
+</h3>
+    <p class="" style="">No end-to-end message or session encryption method is specified herein. Users SHOULD NOT trust a service to keep secret any text sent through a room.</p>
+  </div>
+  <div class="indent">
+<h3>13.3 <a name="security-privacy">Privacy</a>
+</h3>
+    <p class="" style="">Depending on room configuration, a room MAY publicly log all discussions held in the room. A user's client MUST query the room for its configuration prior to allowing the user to enter and MUST warn the user if the room is logged. A client MUST also warn the user if the room's configuration is subsequently modified to allow room logging (which the client will discover when the room sends status code 170). Note: In-room history is different from public room logging, and naturally a room cannot effectively prevent occupants from separately maintaining their own room logs, which may become public; users SHOULD exercise due caution and consider any room discussions to be effectively public.</p>
+  </div>
+  <div class="indent">
+<h3>13.4 <a name="security-anon">Anonymity</a>
+</h3>
+    <p class="" style="">Depending on room configuration, a room MAY expose each occupant's real JID to other occupants (if the room is non-anonymous) and will almost certainly expose each occupant's real JID to the room owners and administrators (if the room is not fully-anonymous). A user's client MUST query the room for its configuration prior to allowing the user to enter and MUST warn the user if the room is non-anonmyous. A client MUST also warn the user if the room's configuration is subsequently modified from semi-anonymous or fully-anonymous to non-anonymous (which the client will discover when the room sends status code 172) and SHOULD warn the user if the room's configuration is subsequently modified from fully-anonymous to semi-anonymous (which the client will discover when the room sends status code 173).</p>
+  </div>
+<h2>14.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2262314">20</a>].</p>
+<h2>15.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2262360">21</a>] includes the following information in its registries.</p>
+  <div class="indent">
+<h3>15.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the following MUC-related namespaces in its registry of protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/muc</li>
+      <li>http://jabber.org/protocol/muc#admin</li>
+      <li>http://jabber.org/protocol/muc#owner</li>
+      <li>http://jabber.org/protocol/muc#user</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>15.2 <a name="registrar-discocat">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">A Multi-User Chat service or room is identified by the "conference" category and the "text" type within Service Discovery.</p>
+  </div>
+  <div class="indent">
+<h3>15.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">There are many features related to a MUC service or room that can be discovered by means of Service Discovery. The most fundamental of these is the 'http://jabber.org/protocol/muc' namespace. In addition, a MUC room SHOULD provide information about the specific room features it implements, such as password protection and room moderation.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#register&lt;/name&gt;
+  &lt;desc&gt;Support for the muc#register FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roomconfig&lt;/name&gt;
+  &lt;desc&gt;Support for the muc#roomconfig FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roominfo&lt;/name&gt;
+  &lt;desc&gt;Support for the muc#roominfo FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_hidden&lt;/name&gt;
+  &lt;desc&gt;Hidden room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_membersonly&lt;/name&gt;
+  &lt;desc&gt;Members-only room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_moderated&lt;/name&gt;
+  &lt;desc&gt;Moderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_nonanonymous&lt;/name&gt;
+  &lt;desc&gt;Non-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_open&lt;/name&gt;
+  &lt;desc&gt;Open room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_passwordprotected&lt;/name&gt;
+  &lt;desc&gt;Password-protected room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_persistent&lt;/name&gt;
+  &lt;desc&gt;Persistent room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_public&lt;/name&gt;
+  &lt;desc&gt;Public room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_rooms&lt;/name&gt;
+  &lt;desc&gt;List of MUC rooms (each as a separate item)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_semianonymous&lt;/name&gt;
+  &lt;desc&gt;Semi-anonymous room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_temporary&lt;/name&gt;
+  &lt;desc&gt;Temporary room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unmoderated&lt;/name&gt;
+  &lt;desc&gt;Unmoderated room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;muc_unsecured&lt;/name&gt;
+  &lt;desc&gt;Unsecured room in Multi-User Chat (MUC)&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>15.4 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The well-known Service Discovery node 'http://jabber.org/protocol/muc#rooms' enables discovery of the rooms in which a user is an occupant.</p>
+    <p class="" style="">The well-known Service Discovery node 'x-roomuser-item' enables a user to discover his or registered roomnick from outside the room.</p>
+    <p class="" style="">The well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' enables discovery of the namespaces that are allowed in traffic sent through a room (see the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document).</p>
+  </div>
+  <div class="indent">
+<h3>15.5 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2262557">22</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. Within MUC, there are three uses of such forms: room registration within muc#user, room configuration within muc#owner, and service discovery extensions for room information. The reserved fields are defined below.</p>
+    <div class="indent">
+<h3>15.5.1 <a name="registrar-formtype-register">muc#register FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#register&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling user registration with a
+    Multi-User Chat (MUC) room or admin approval
+    of user registration requests.
+  &lt;/desc&gt;
+  &lt;field 
+     var='muc#register_allow'
+     type='boolean'
+     label='Allow this person to register with the room?'/&gt;
+  &lt;field
+      var='muc#register_email'
+      type='text-single'
+      label='Email Address'/&gt;
+  &lt;field
+      var='muc#register_faqentry'
+      type='text-multi'
+      label='FAQ Entry'/&gt;
+  &lt;field
+      var='muc#register_first'
+      type='text-single'
+      label='First Name'/&gt;
+  &lt;field
+      var='muc#register_last'
+      type='text-single'
+      label='Last Name'/&gt;
+  &lt;field
+      var='muc#register_roomnick'
+      type='text-single'
+      label='Desired Nickname'/&gt;
+  &lt;field
+      var='muc#register_url'
+      type='text-single'
+      label='Your URL'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>15.5.2 <a name="registrar-formtype-owner">muc#roomconfig FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roomconfig&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling creation and configuration of
+    a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roomconfig_allowinvites'
+      type='boolean'
+      label='Whether to Allow Occupants to Invite Others'/&gt;
+  &lt;field
+      var='muc#roomconfig_changesubject'
+      type='boolean'
+      label='Whether to Allow Occupants to Change Subject'/&gt;
+  &lt;field
+      var='muc#roomconfig_enablelogging'
+      type='boolean'
+      label='Whether to Enable Logging of Room Conversations'/&gt;
+  &lt;field
+      var='muc#roomconfig_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roomconfig_pubsub'
+      type='text-single'
+      label='XMPP URI of Associated Publish-Subcribe Node'/&gt;
+  &lt;field
+      var='muc#roomconfig_maxusers'
+      type='list-single'
+      label='Maximum Number of Room Occupants'/&gt;
+  &lt;field
+      var='muc#roomconfig_membersonly'
+      type='boolean'
+      label='Whether an Make Room Members-Only'/&gt;
+  &lt;field
+      var='muc#roomconfig_moderatedroom'
+      type='boolean'
+      label='Whether to Make Room Moderated'/&gt;
+  &lt;field
+      var='muc#roomconfig_passwordprotectedroom'
+      type='boolean'
+      label='Whether a Password is Required to Enter'/&gt;
+  &lt;field
+      var='muc#roomconfig_persistentroom'
+      type='boolean'
+      label='Whether to Make Room Persistent'/&gt;
+  &lt;field
+      var='muc#roomconfig_presencebroadcast'
+      type='list-multi'
+      label='Roles for which Presence is Broadcast'/&gt;
+  &lt;field
+      var='muc#roomconfig_publicroom'
+      type='boolean'
+      label='Whether to Allow Public Searching for Room'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomadmins'
+      type='jid-multi'
+      label='Full List of Room Admins'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomdesc'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomname'
+      type='text-single'
+      label='Natural-Language Room Name'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomowners'
+      type='jid-multi'
+      label='Full List of Room Owners'/&gt;
+  &lt;field
+      var='muc#roomconfig_roomsecret'
+      type='text-private'
+      label='The Room Password'/&gt;
+  &lt;field
+      var='muc#roomconfig_whois'
+      type='list-single'
+      label='Affiliations that May Discover Real JIDs of Occupants'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>15.5.3 <a name="registrar-formtype-roominfo">muc#roominfo FORM_TYPE</a>
+</h3>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/muc#roominfo&lt;/name&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling the communication of extended service discovery
+    information about a Multi-User Chat (MUC) room.
+  &lt;/desc&gt;
+  &lt;field
+      var='muc#roominfo_contactjid'
+      type='jid-multi'
+      label='Contact Addresses (normally, room owner or owners)'/&gt;
+  &lt;field
+      var='muc#roominfo_description'
+      type='text-single'
+      label='Short Description of Room'/&gt;
+  &lt;field
+      var='muc#roominfo_lang'
+      type='text-single'
+      label='Natural Language for Room Discussions'/&gt;
+  &lt;field
+      var='muc#roominfo_logs'
+      type='text-single'
+      label='URL for Archived Discussion Logs'/&gt;
+  &lt;field
+      var='muc#roominfo_occupants'
+      type='text-single'
+      label='Current Number of Occupants in Room'/&gt;
+  &lt;field
+      var='muc#roominfo_subject'
+      type='text-single'
+      label='Current Subject or Discussion Topic in Room'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>15.6 <a name="registrar-statuscodes">Status Codes Registry</a>
+</h3>
+    <div class="indent">
+<h3>15.6.1 <a name="registrar-statuscodes-process">Process</a>
+</h3>
+      <p class="" style="">The Jabber Registrar maintains a registry of values for the 'code' attribute of the &lt;status/&gt; element when qualified by the 'http://jabber.org/protocol/muc#user' namespace.</p>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;statuscode&gt;
+  &lt;number&gt;the three-digit code number&lt;/number&gt;
+  &lt;stanza&gt;the stanza type of which it is a child (message or presence)&lt;/desc&gt;
+  &lt;context&gt;the use case or situation in which the status is used&lt;/context&gt;
+  &lt;purpose&gt;a natural-language description of the meaning&lt;/purpose&gt;
+  &lt;child&gt;the descriptive child element (reserved for future use)&lt;/child&gt;
+&lt;/statuscode&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one status code at a time, each contained in a separate &lt;statuscode/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>15.6.2 <a name="registrar-statuscodes-init">Initial Submission</a>
+</h3>
+      <p class="" style="">As part of this document, the following status codes are registered:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;statuscode&gt;
+  &lt;number&gt;100&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Entering a room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that any occupant is allowed to see the user's full JID&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;101&lt;/number&gt;
+  &lt;stanza&gt;message (out of band)&lt;/stanza&gt;
+  &lt;context&gt;Affiliation change&lt;/context&gt;
+  &lt;purpose&gt;Inform user that his or her affiliation changed while not in the room&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;102&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that room now shows unavailable members&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;103&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that room now does not show unavailable members&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;104&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that a non-privacy-related room configuration change has occurred&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;170&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that room logging is now enabled&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;171&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that room logging is now disabled&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;172&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that the room is now non-anonymous&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;173&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that the room is now semi-anonymous&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;174&lt;/number&gt;
+  &lt;stanza&gt;message&lt;/stanza&gt;
+  &lt;context&gt;Configuration change&lt;/context&gt;
+  &lt;purpose&gt;Inform occupants that the room is now fully-anonymous&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;201&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Entering a room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that a new room has been created&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;301&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she has been banned from the room&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;303&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Exiting a room&lt;/context&gt;
+  &lt;purpose&gt;Inform all occupants of new room nickname&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;307&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she has been kicked from the room&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;321&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she is being removed from the room 
+    because of an affiliation change&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;322&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she is being removed from the room 
+    because the room has been changed to members-only and the user 
+    is not a member&lt;/purpose&gt;
+&lt;/statuscode&gt;
+&lt;statuscode&gt;
+  &lt;number&gt;332&lt;/number&gt;
+  &lt;stanza&gt;presence&lt;/stanza&gt;
+  &lt;context&gt;Removal from room&lt;/context&gt;
+  &lt;purpose&gt;Inform user that he or she is being removed from the room 
+    because of a system shutdown&lt;/purpose&gt;
+&lt;/statuscode&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>15.7 <a name="registrar-querytypes">URI Query Types</a>
+</h3>
+    <p class="" style="">As authorized by <span class="ref" style="">XMPP URI Query Components</span>  [<a href="#nt-id2262787">23</a>], the Jabber Registrar maintains a registry of queries and key-value pairs for use in XMPP URIs (see &lt;<a href="http://www.jabber.org/registrar/querytypes.html">http://www.jabber.org/registrar/querytypes.html</a>&gt;).</p>
+    <div class="indent">
+<h3>15.7.1 <a name="registrar-querytypes-join">join</a>
+</h3>
+      <p class="" style="">The "join" querytype is registered as a MUC-related action, with an optional key of "password".</p>
+      <p class="caption">Example 172. Join Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join
+      </pre></div>
+      <p class="" style="">The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences or nickname discovery.</p> 
+      <p class="caption">Example 173. Join Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">The join action MAY include a password for the room. Naturally, access to a URI that includes a room password MUST be appropriately controlled.</p>
+      <p class="caption">Example 174. Join Action with Password: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join;password=cauldronburn
+      </pre></div>
+      <p class="caption">Example 175. Join Action with Password: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'&gt;
+    &lt;password&gt;cauldronburn&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">The following submission registers the "join" querytype.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;join&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables joining a multi-user chat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;password&lt;/name&gt;
+      &lt;desc&gt;the password required to enter a multi-user chat room&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>15.7.2 <a name="registrar-querytypes-invite">invite</a>
+</h3>
+      <p class="" style="">The "invite" querytype is registered as a MUC-related action, with an optional key of "jid".</p>
+      <p class="caption">Example 176. Invite Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?invite;jid=hecate@shakespeare.lit
+      </pre></div>
+      <p class="" style="">If the joining user is not yet in the room, the application MUST send two stanzas: the first to join the room and the second to invite the other individual. If the joining user is in the room already, the application shall send only the invitation stanza.</p>
+      <p class="caption">Example 177. Invite Action: Resulting Stanza(s)</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;message to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The following submission registers the "invite" querytype.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;invite&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables simultaneously joining a groupchat room and inviting others&lt;/desc&gt;
+  &lt;doc&gt;JEP-0045&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;jid&lt;/name&gt;
+      &lt;desc&gt;the Jabber ID of the invitee&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>16.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="bizrules-jids">Addresses</a>
+</h3>
+    <p class="" style="">In order to provide consistency regarding the addresses captured in room JIDs, Room IDs MUST match the Nodeprep profile of Stringprep and Room Nicknames MUST match the Resourceprep profile of Stringprep (both of these are defined in <span style="font-weight: bold">RFC 3920</span>). Although not explicitly stated in <span style="font-weight: bold">RFC 3920</span>, both the Room ID (node) and Room Nickname (resource) portions of a Room JID MUST be of non-zero length. In addition, a MUC service MUST NOT allow empty or invisible Room Nicknames (i.e., Room Nicknames that consist only of one or more space characters).</p>
+  </div>
+  <div class="indent">
+<h3>16.2 <a name="bizrules-message">Message</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">If an occupant wants to send a message to all other occupants, a MUC client MUST set the 'type' attribute to a value of "groupchat". A service MAY ignore messages that are improperly typed, or reject them with a &lt;bad-request/&gt; error.</p></li>
+      <li><p class="" style="">If a MUC service receives a message directed to the room or to a single occupant from a Jabber user who has a role of "none", the service MUST NOT deliver the message and SHOULD return the message to the sender with a &lt;forbidden/&gt; error.</p></li>
+      <li><p class="" style="">If a MUC service receives a message directed to a room that does not exist or is not yet unlocked, the service SHOULD return the message to the sender with an &lt;item-not-found/&gt; error.</p></li>
+      <li><p class="" style="">A MUC service SHOULD pass extended information (e.g., an XHTML version of the message body) through to occupants unchanged; however, a MUC service MAY disallow message specific extensions (see the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document).</p></li>
+      <li><p class="" style="">A MUC client MAY generate extensions that conform to the <span class="ref" style="">Message Events</span>  [<a href="#nt-id2263168">24</a>] or <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2263192">25</a>] specification; however, a MUC service MAY disallow these extensions (see the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document).</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>16.3 <a name="bizrules-presence">Presence</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">A room MUST silently ignore unavailable presence received from a user who has a role of "none".</p></li>
+      <li><p class="" style="">Only the MUC service itself SHOULD generate extended presence information about roles, affiliations, full JIDs, or status codes qualified by the 'http://jabber.org/protocol/muc#user' namespace (based on information the service knows about occupants, e.g., roles, or as a result of actions taken by a moderator or room administrator). A client SHOULD NOT presume to generate such information. If a MUC service receives such extended presence information from an occupant, it MUST NOT reflect it to other occupants. (A client MAY generate extended presence information qualified by the 'http://jabber.org/protocol/muc#user' namespace in order to supply a password, but naturally this is not reflected to other occupants.)</p></li>
+      <li><p class="" style="">A MUC service SHOULD allow all other presence information to pass through, although it MAY choose to block extended presence information; see the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document.</p></li>
+      <li><p class="" style="">In order to appropriately inform occupants of room roles and affiliations, and to make it easier for Jabber clients to track the current state of all users in the room, MUC service implementations MUST provide extended presence information about roles and affiliations in all presence stanzas, including presence stanzas of type "unavailable" sent when a user exits the room for any reason.</p></li>
+      <li><p class="" style="">If a privilege is revoked, the service MUST note that by sending an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc#user' namespace and containing an &lt;item/&gt; child element with the 'role' and/or 'affiliation' attributes set to a value that indicates the loss of the relevant privilege. All future presence stanzas for the occupant MUST include the updated role and affiliation, until and unless they change again.</p></li>
+      <li><p class="" style="">A MUC service MUST send extended presence to a client even if the client did not send an empty &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/muc' namespace on entering the room; naturally, a client MUST ignore such information if it does not understand it (in accordance with <span style="font-weight: bold">RFC 3920</span>).</p></li>
+      <li><p class="" style="">Extended presence about roles and affiliations sent in the muc#user namespace MUST include the full JID (not the bare JID) as the value of the 'jid' attribute.</p></li>
+      <li><p class="" style="">A client MAY send a custom exit message if desired (as is often done in IRC channels) by including a &lt;status/&gt; element in the presence stanza of type "unavailable" sent when exiting a room.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>16.4 <a name="bizrules-iq">IQ</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a non-anonymous room, the sender SHOULD send the request directly to the recipient's bare JID or full JID, rather than attempting to send the request through the room (i.e., via the recipient's room JID).</p></li>
+      <li><p class="" style="">If an occupant wants to send an IQ stanza to another user in a semi-anonymous room, the sender can direct the stanza to the recipient's room JID and the service MAY forward the stanza to the recipient's real JID. However, a MUC service MUST NOT reveal the sender's real JID to the recipient at any time, nor reveal the recipient's real JID to the sender.</p></li>
+      <li><p class="" style="">A MUC client MUST send only the 'affiliation' attribute or the 'role' attribute in the &lt;item/&gt; element contained within an IQ set qualified by the 'http://jabber.org/protocol/muc#admin' namespace; if a moderator, admin, or owner attempts to modify both the affiliation and role of the same item in the same IQ set, the service MUST return a &lt;bad-request/&gt; error to the sender. However, a MUC service MAY modify a role based on a change to an affiliation and thus MAY send presence updates that include both a modified role and a modified affiliation.</p></li>
+      <li><p class="" style="">In IQ sets regarding roles, a MUC client MUST include the 'nick' attribute only; in IQ results regarding roles, a MUC service MUST include the 'nick', 'role', 'affiliation', and 'jid' attributes (with the value of the latter set to the user's full JID).</p></li>
+      <li><p class="" style="">In IQ sets regarding affiliations, a MUC client MUST include the 'jid' attribute only (with the value set to the bare JID); in IQ results regarding affiliations, a MUC service MUST NOT include the 'role' attribute, MUST include the 'affiliation' attribute and the 'jid' attribute (with the value set to the bare JID), and SHOULD include the 'nick' attribute (except if the affiliation is "outcast", since outcasts SHOULD NOT have reserved nicknames).</p></li>
+    </ol>
+  </div>
+<h2>17.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">The following guidelines may assist client and component developers in creating MUC implementations.</p>
+  <div class="indent">
+<h3>17.1 <a name="impl-service">Services</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">In handling messages sent by visitors in a moderated room, a MUC service MAY queue each message for approval by a moderator and MAY inform the sender that the message is being held for approval; however, such behavior is OPTIONAL, and definition of a message approval protocol (e.g., using Data Forms as defined in <span style="font-weight: bold">JEP-0004</span>) is out of scope for this document.</p></li>
+      <li><p class="" style="">It is common for MUC services to provide in-room messages when certain events occur, such as when the subject changes, when an occupant enters or exits, or when a room is destroyed. Such messages are entirely OPTIONAL and are left up to the implementation or deployment, but if used MUST be messages of type "groupchat" sent from the room JID itself (&lt;room@service&gt;) rather than a specific occupant (&lt;room@service/nick&gt;). However, in general it is preferable for the receiving client to generate such messages based on events in the room (e.g., user entrances and exits) as well as specific status codes provided in MUC; this will help ensure correct localization of such messages.</p></li>
+      <li><p class="" style="">Out of courtesy, a MUC service MAY send an out-of-room &lt;message/&gt; to an occupant who is kicked or banned, and MAY broadcast an in-room &lt;message/&gt; to all remaining occupants informing them that the occupant has been kicked or banned from the room. However, such messages are OPTIONAL, and indeed are unnecessary since the information required for a receiving client to generate such messages is communicated in the presence stanzas (specifically the status codes) sent by a MUC service.</p></li>
+      <li><p class="" style="">Out of courtesy, a MUC service MAY send an out-of-room &lt;message/&gt; if a user's affiliation changes while the user is not in the room; the message SHOULD be sent from the room to the user's bare JID, MAY contain a &lt;body/&gt; element describing the affiliation change, and MUST contain a status code of 101.</p></li>
+      <li><p class="" style="">There is no requirement that a MUC service shall provide special treatment for users of the older "groupchat 1.0" protocol, such as messages that contain equivalents to the extended presence information that is qualified by the 'http://jabber.org/protocol/muc#user' namespace.</p></li>
+      <li><p class="" style="">Room types MAY be configured in any combination. A MUC service MAY support or allow any desired room types or combinations thereof.</p></li>
+      <li><p class="" style="">A MUC service MAY limit the number of configuration options presented to an owner after initial configuration has been completed, e.g. because certain options cannot take effect without restarting the service.</p></li>
+      <li><p class="" style="">A MUC service MAY provide an interface to room creation and configuration (e.g., in the form of a special Jabber user or a Web page), so that the ostensible room owner is actually the application instead of a human user.</p></li>
+      <li><p class="" style="">A MUC service MAY choose to make available a special in-room resource that provides an interface to administrative functionality (e.g., a "user" named "ChatBot"), which occupants could interact with directly, thus enabling admins to type <tt>'/command parameter'</tt> in a private message to that "user". Obviously this kind of implementation would require the service to add a 'ChatBot' user to the room when it is created, and to prevent any occupant from having the nickname 'ChatBot' in the room. This might be difficult to ensure in some implementations or deployments. In any case, any such interface is OPTIONAL.</p></li>
+      <li><p class="" style="">A MUC service SHOULD remove a user if the service receives a delivery-related error in relation to a stanza it has previously sent to the user (remote server unreachable, user not found, etc.).</p></li>
+      <li><p class="" style="">A MUC service MAY choose to discard extended presence information that is attached to a &lt;presence/&gt; stanza before reflecting the presence change to the occupants of a room. That is, an implementation MAY choose to reflect only the &lt;show/&gt;, &lt;status/&gt;, and &lt;priority/&gt; child elements of the presence element as specified in the XML schema for the 'jabber:client' namespace, with the result that presence "changes" in extended namespaces (e.g., gabber:x:music:info) are not passed through to occupants. If a service prohibits certain extended namespaces, it SHOULD provide a description of allowable traffic at the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' as described in the <a href="#impl-service-traffic">Allowable Traffic</a> section of this document.</p></li>
+      <li><p class="" style="">A MUC service MAY choose to discard extended information attached to &lt;message/&gt; stanzas before reflecting the message to the occupants of a room. An example of such extended information is the lightweight text markup specified by <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2263723">26</a>]. If a service prohibits certain extended namespaces, it SHOULD provide a description of allowable traffic at the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic' as described in the <a href="impl-service-traffic">Allowable Traffic</a> section of this document..</p></li>
+    </ol>
+    <div class="indent">
+<h3>17.1.1 <a name="impl-service-traffic">Allowable Traffic</a>
+</h3>
+      <p class="" style="">As noted, a service (more precisely, a properly-configured room) MAY discard some or all extended namespaces attached to &lt;message/&gt; and &lt;presence/&gt; stanzas that are intended for reflection from the sender through the room to all of the room occupants. If the room does so, it SHOULD enable senders to discover the list of allowable extensions by sending a disco#info query to the well-known Service Discovery node 'http://jabber.org/protocol/muc#traffic', returning one &lt;feature/&gt; element for each namespace supported in the result. If the room does not allow any extended namespaces, it MUST return an empty query as specified in <span style="font-weight: bold">JEP-0030</span>. If the room does not support the "#traffic" node, it MUST return a &lt;feature-not-implemented/&gt; error in response to queries sent to the 'http://jabber.org/protocol/muc#traffic' node.</p>
+      <p class="" style="">The following example shows a room that allows the 'http://jabber.org/protocol/xhtml-im' and 'http://jabber.org/protocol/rosterx' namespaces only, but no other extended namespaces.</p>
+      <p class="caption">Example 178. User Queries Service Regarding Allowable Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='wiccarocks@shakespeare.lit/laptop'
+    to='heath@macbeth.shakespeare.lit'
+    id='allow1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 179. Service Returns Allowable Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    id='allow1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'&gt;
+    &lt;feature var='http://jabber.org/protocol/xhtml-im'/&gt;
+    &lt;feature var='http://jabber.org/protocolhttp://jabber.org/protocol//rosterx'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If a service does not discard any namespaces or does not implement this feature, it MUST return a &lt;service-unavailable/&gt; error:</p>
+      <p class="caption">Example 180. Service Returns Service Unavailable</p>
+<div class="indent"><pre>
+&lt;iq from='heath@macbeth.shakespeare.lit'
+    to='wiccarocks@shakespeare.lit/laptop'
+    id='allow1'
+    type='error'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/muc#traffic'/&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>17.2 <a name="impl-client">Clients</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">Jabber clients MAY present room roles by showing ad-hoc groups for each role within a room roster. This will enable occupants to clearly visualize which occupants are moderators, participants, and visitors. However, such a representation is OPTIONAL.</p></li>
+      <li><p class="" style="">Jabber clients MAY implement a variety of interface styles that provide "shortcuts" to functionality such as changing one's nickname, kicking or banning users, discovering an occupant's full JID, or changing the subject. One option consists of IRC-style commands such as '/nick', '/kick', '/ban', and '/whois'; another is to enable a user to right-click items in a room roster. All such interface styles are OPTIONAL. However, for convenience, a mapping of IRC commands to MUC protocols is provided below.</p></li>
+    </ol>
+    <div class="indent">
+<h3>17.2.1 <a name="impl-client-irc">IRC Command Mapping</a>
+</h3>
+      <p class="" style="">Internet Relay Chat clients use a number of common "shortcut" commands that begin with a forward slash, such as '/nick' and '/ban'. The following table provides a mapping of IRC-style commands to MUC protocols, for use by Jabber clients that wish to support such functionality.</p>
+      <p class="caption">Table 9: IRC Command Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Command</th>
+          <th colspan="" rowspan="">Function</th>
+          <th colspan="" rowspan="">MUC protocol</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/ban &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">bans user with that roomnick from this room (client translates roomnick to bare JID)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item affiliation='outcast'
+          jid='jid-of-roomnick'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/invite &lt;jid&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">invites user with that JID to this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='jid'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/join &lt;roomname&gt; [pass]</td>
+          <td align="" colspan="" rowspan="">joins room on this service (roomnick is same as nick in this room)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;password&gt;pass&lt;/password&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/kick &lt;roomnick&gt; [comment]</td>
+          <td align="" colspan="" rowspan="">kicks user with that roomnick from this room</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq id='someid'
+    to='room@service'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#admin'&gt;
+    &lt;item nick='roomnick' role='none'&gt;
+      &lt;reason&gt;comment&lt;/reason&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/msg &lt;roomnick&gt; &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">sends private message "foo" to roomnick</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service/nick' type='chat'&gt;
+  &lt;body&gt;foo&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/nick &lt;newnick&gt;</td>
+          <td align="" colspan="" rowspan="">changes nick in this room to "newnick"</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/newnick'/&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/part [comment]</td>
+          <td align="" colspan="" rowspan="">exits this room (some IRC clients also support /leave)</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;presence to='room@service/nick'
+          type='unavailable'&gt;
+  &lt;status&gt;comment&lt;/status&gt;
+&lt;/presence&gt;
+          </pre></div>
+</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">/topic &lt;foo&gt;</td>
+          <td align="" colspan="" rowspan="">changes subject of this room to "foo"</td>
+          <td align="" colspan="" rowspan="">
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;message to='room@service' type='groupchat'&gt;
+  &lt;subject&gt;foo&lt;/subject&gt;
+&lt;/message&gt;
+          </pre></div>
+</td>
+        </tr>
+      </table>
+      <p class="" style="">Note: Because MUC roomnicks follow the Resourceprep profile of stringprep, they are allowed to contain a space character, whereas IRC nicknames do not. Although a given client MAY support quotation characters for this purpose (resulting in commands such as '/ban "king lear" insanity is no defense'), most common quotation characters (such as " and ') are also allowed by Resourceprep, thus leading to added complexity and potential problems with quotation of roomnicks that contain both spaces and quotation characters. Therefore it is NOT RECOMMENDED for Jabber clients to support IRC-style shortcut commands with roomnicks that contain space characters.</p>
+      <p class="" style="">Note: Many Jabber clients also implement a '/me ' command, where the command is followed by a verb or verb phrase (e.g., '/me laughs'). This command does not result in any MUC or IRC protocol action and is therefore not shown in the foregoing table. Instead, the message is sent as-is (e.g., &lt;body&gt;/me laughs&lt;/body&gt;) and the receiving client performs string-matching on the character data of the &lt;body/&gt; element to determine if the message begins with the string '/me '; if it does the receiving client will show the message in a special format, usually italicized text sometimes prepended by the "*" character:</p>
+      <p class="" style="margin-left: 5%"><span style="font-style: italic">* stpeter laughs</span></p>
+    </div>
+  </div>
+<h2>18.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>18.1 <a name="schemas-muc">http://jabber.org/protocol/muc</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc'
+    xmlns='http://jabber.org/protocol/muc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='history' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='history'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='maxchars' type='xs:int' use='optional'/&gt;
+          &lt;xs:attribute name='maxstanzas' type='xs:int' use='optional'/&gt;
+          &lt;xs:attribute name='seconds' type='xs:int' use='optional'/&gt;
+          &lt;xs:attribute name='since' type='xs:dateTime' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>18.2 <a name="schemas-user">http://jabber.org/protocol/muc#user</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#user'
+    xmlns='http://jabber.org/protocol/muc#user'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='decline' minOccurs='0'/&gt;
+        &lt;xs:element ref='destroy' minOccurs='0'/&gt;
+        &lt;xs:element ref='invite' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='item' minOccurs='0'/&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element ref='status' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='decline'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='invite'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+        &lt;xs:element name='continue' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='code' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:int'&gt;
+            &lt;xs:length value='3'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>18.3 <a name="schemas-admin">http://jabber.org/protocol/muc#admin</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#admin'
+    xmlns='http://jabber.org/protocol/muc#admin'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='actor' minOccurs='0'/&gt;
+        &lt;xs:element ref='reason' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='admin'/&gt;
+            &lt;xs:enumeration value='member'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='nick' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='role' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='moderator'/&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='participant'/&gt;
+            &lt;xs:enumeration value='visitor'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='actor'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='reason' type='xs:string'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>18.4 <a name="schemas-owner">http://jabber.org/protocol/muc#owner</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/muc#owner'
+    xmlns='http://jabber.org/protocol/muc#owner'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0045: http://www.jabber.org/jeps/jep-0045.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import 
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:xdata='jabber:x:data' minOccurs='0'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+        &lt;xs:element ref='destroy'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='destroy'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='reason' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>19.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The author would like to thank the following individuals for their many helpful comments on various drafts of this proposal: David Sutton, Peter Millard, Joe Hildebrand, Craig Kaes, Alexey Shchepin, David Waite, Jean-Louis Seguineau, Jacek Konieczny, Gaston Dombiak, and many others in the jdev@conference.jabber.org conference room and on the Standards-JIG mailing list.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251350">1</a>. RFC 1459: Internet Relay Chat &lt;<a href="http://www.ietf.org/rfc/rfc1459.txt">http://www.ietf.org/rfc/rfc1459.txt</a>&gt;.</p>
+<p><a name="nt-id2251668">2</a>. <a href="http://www.jabber.org/protocol/groupchat.html">http://www.jabber.org/protocol/groupchat.html</a></p>
+<p><a name="nt-id2254279">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2254522">4</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p><a name="nt-id2254925">5</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2255807">6</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2256008">7</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2256251">8</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257109">9</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2257174">10</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2257756">11</a>. Some commentors have complained that this opens room owners and administrators up to potential abuse; unfortunately, with great power comes great responsibility.</p>
+<p><a name="nt-id2258587">12</a>. JEP-0133: Service Administration &lt;<a href="http://www.jabber.org/jeps/jep-0133.html">http://www.jabber.org/jeps/jep-0133.html</a>&gt;.</p>
+<p><a name="nt-id2259447">13</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2259470">14</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2260963">15</a>. This is different from the behavior of room configuration, wherein the 'muc#roomconfig_roomowners' field specifies the full list of room owners, not the delta.</p>
+<p><a name="nt-id2261289">16</a>. This is different from the behavior of room configuration, wherein the 'muc#roomconfig_roomadmins' field specifies the full list of room admins, not the delta.</p>
+<p><a name="nt-id2261598">17</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2262080">18</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2262103">19</a>. RFC 1893: Enhanced Mail System Status Codes &lt;<a href="http://www.ietf.org/rfc/rfc1893.txt">http://www.ietf.org/rfc/rfc1893.txt</a>&gt;.</p>
+<p><a name="nt-id2262314">20</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2262360">21</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2262557">22</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2262787">23</a>. JEP-0147: XMPP URI Query Components &lt;<a href="http://www.jabber.org/jeps/jep-0147.html">http://www.jabber.org/jeps/jep-0147.html</a>&gt;.</p>
+<p><a name="nt-id2263168">24</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2263192">25</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2263723">26</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.21pre3 (in progress, revised 2006-05-04)</h4>
+<div class="indent">
+      <ul>
+        <li>Clarified that inclusion of MUC extension in room join/create request triggers Data Forms flow but that absence of MUC extension leads to automatic room creation for backwards compatibility with older groupchat 1.0 protocol.</li>
+        <li>Specified use of &lt;not-acceptable/&gt; error on nickname change if nicks are locked down.</li>
+        <li>Required clients to discover room configuration prior to entering room and specified related security considerations, including use of privacy-related status codes 170, 171, 172, 173, and 174.</li>
+        <li>Specified use of &lt;not-acceptable/&gt; error if room configuration options cannot be processed or violate service policies.</li>
+        <li>Made explicit that roomnicks must not consist only of spaces.</li>
+        <li>Moved all service discovery use cases into dedicated section.</li>
+        <li>Changed jabber:x:delay support from SHOULD to MUST.</li>
+        <li>Clarified that _whois room configuration option specifies room type.</li>
+        <li>Defined JEP-0128 room information fields for discussion logs, associated pubsub node, and contact JID.</li>
+        <li>Specified that changing role to moderator upon affiliation change to admin or owner is recommended, not required.</li>
+        <li>Added internationalization consideration about localization of field labels for various data forms.</li>
+        <li>Specified that implementations may persist roles across visits and should do so for moderated rooms.</li>
+      </ul>
+     (psa)
+    </div>
+<h4>Version 1.20 (2005-09-08)</h4>
+<div class="indent">
+<p class="" style="">Harmonized ability to kick and ban users, and clarified that a user cannot be kicked or banned by a moderator or admin with a lower affiliation.</p> (psa)
+    </div>
+<h4>Version 1.19 (2005-04-21)</h4>
+<div class="indent">
+<p class="" style="">Specified how to send multiple invitations simultaneously; corrected some errors regarding consistency of affiliation state changes; changed message events prohibition from MUST NOT to SHOULD NOT; corrected error handling related to the #traffic disco node; allowed &lt;password/&gt; as a child of &lt;destroy/&gt;; changed max users error from &lt;not-allowed/&gt; to &lt;service-unavailable/&gt;; specified that the maxchars attribute counts characters in complete XML stanzas; added disco features for FORM_TYPEs; defined registry for status codes; split Create Instant Room into separate use case for protocol compliance purposes; adjusted XML schemas to reflect the foregoing changes; re-wrote the introduction; clarified small textual matters throughout.</p> (psa)
+    </div>
+<h4>Version 1.18 (2004-11-02)</h4>
+<div class="indent">
+<p class="" style="">Corrected several errors in the affiliation state chart and in the examples (wrong FORM_TYPE values); mentioned /me command.</p> (psa)
+    </div>
+<h4>Version 1.17 (2004-10-04)</h4>
+<div class="indent">
+<p class="" style="">Added text about allowable extension namespaces and related service discovery mechanisms; specified well-known service discovery nodes; added conformance terms to clarify some descriptions; modified affiliation state chart to allow more flexible state changes; per list dicussion, added ability to convert a one-to-one chat into a conference, including sending of history; specified error to use when max users limit is reached; specified form for admin approval of user registration requests and modified FORM_TYPE from http://jabber.org/protocol/muc#user to http://jabber.org/protocol/muc#register; modified FORM_TYPE for room configuration from http://jabber.org/protocol/muc#owner to http://jabber.org/protocol/muc#roomconfig.</p> (psa)
+    </div>
+<h4>Version 1.16 (2004-06-30)</h4>
+<div class="indent">
+<p class="" style="">Added example and registry submission for service discovery extension.</p> (psa)
+    </div>
+<h4>Version 1.15 (2004-06-24)</h4>
+<div class="indent">
+<p class="" style="">Removed jabber:iq:browse references; clarified order of presence stanzas sent to new occupant on entering room; specified format of in-room messages (type='groupchat', from='room@service'); clarified allowable attributes in various list-related operations; made admin/owner revocation text and examples consistent with state chart; clarified ownership revocation conflict scenarios; changed the 'muc#roomconfig_inviteonly' field to 'muc#roomconfig_membersonly'; changed attribute order in examples to match XML canonicalization rules; corrected several errors in the schemas.</p> (psa)
+    </div>
+<h4>Version 1.14 (2004-05-03)</h4>
+<div class="indent">
+<p class="" style="">Corrected discovery of registered roomnicks; added note about error to return if nicks are locked down.</p> (psa)
+    </div>
+<h4>Version 1.13 (2004-03-31)</h4>
+<div class="indent">
+<p class="" style="">Fixed an error in the muc#user schema.</p> (psa)
+    </div>
+<h4>Version 1.12 (2004-03-01)</h4>
+<div class="indent">
+<p class="" style="">Corrected a few errors in the examples; added IQ results in order to clarify workflows.</p> (psa)
+    </div>
+<h4>Version 1.11 (2004-02-05)</h4>
+<div class="indent">
+<p class="" style="">Clarified JID matching rules (same as for privacy lists in XMPP IM).</p> (psa)
+    </div>
+<h4>Version 1.10 (2004-01-07)</h4>
+<div class="indent">
+<p class="" style="">Added XMPP error handling; fully specified all conformance terms.</p> (psa)
+    </div>
+<h4>Version 1.9 (2003-12-14)</h4>
+<div class="indent">
+<p class="" style="">Removed protocol for requesting voice in a moderated room (should be performed using Ad-Hoc Commands).</p> (psa)
+    </div>
+<h4>Version 1.8 (2003-12-04)</h4>
+<div class="indent">
+<p class="" style="">Added protocol for requesting voice in a moderated room; added (informational) mapping of IRC commands to MUC protocols.</p> (psa)
+    </div>
+<h4>Version 1.7 (2003-10-21)</h4>
+<div class="indent">
+<p class="" style="">Added room configuration option for restricting presence broadcast to certain roles.</p> (psa)
+    </div>
+<h4>Version 1.6 (2003-10-03)</h4>
+<div class="indent">
+<p class="" style="">Added history management protocol on entering a room.</p> (psa)
+    </div>
+<h4>Version 1.5 (2003-09-11)</h4>
+<div class="indent">
+<p class="" style="">Specified that ban occurs by JID, not roomnick; allowed privileged users to send messages to the room even if not present in the room; added note that service should remove occupant if a delivery-related stanza error occurs; enabled user to disco the room in order to discover registered roomnick; specified that "banning" by domain or regex is a service-level configuration matter and therefore out of scope for MUC; specified that role should be decremented as appropriate if affiliation is lowered; added some clarifying text to room creation workflow; added implementation note about sending an out-of-band message if a user's affiliation changes while the user is not in the room; fixed stringprep references (room nicks use Resourceprep); clarified relationship between Room ID (i.e., node identifier of Room JID, which may be opaque) and natural-language Room Name; specified Field Standardization profile per JEP-0068; defined Jabber Registrar submissions; added schema locations.</p> (psa)
+    </div>
+<h4>Version 1.4 (2003-02-16)</h4>
+<div class="indent">
+<p class="" style="">Added XML schemas.</p> (psa)
+    </div>
+<h4>Version 1.3 (2003-02-11)</h4>
+<div class="indent">
+<p class="" style="">Added reference to nodeprep Internet-Draft.</p> (psa)
+    </div>
+<h4>Version 1.2 (2003-01-30)</h4>
+<div class="indent">
+<p class="" style="">Commented out revision history prior to version 1.0 (too long); clarified business rules regarding when nicks, full JIDs, and bare JIDs are used in reference to roles and affiliations; consistently specified that extended presence information in the muc#user namespace must include the full JID as the value of the 'jid' attribute in all cases; cleaned up text and examples throughout; added open issue regarding syntax of room nicknames.</p> (psa)
+    </div>
+<h4>Version 1.1 (2002-12-16)</h4>
+<div class="indent">
+<p class="" style="">Added protocol for declining an invitation; replaced &lt;created/&gt; element with status code 201; modified the destroy room protocol so that &lt;destroy/&gt; is a child of &lt;query/&gt;; clarified usage of 'nick' attribute when adding members; prohibited use of message events.</p> (psa)
+    </div>
+<h4>Version 1.0 (2002-11-21)</h4>
+<div class="indent">
+<p class="" style="">Per a vote of the Jabber Council, revision 0.23 was advanced to Draft on 2002-11-21. (For earlier revision history, refer to XML source.)</p> (psa)
+    </div>
+<h4>Version 0.23 (2002-11-06)</h4>
+<div class="indent">
+<p class="" style="">Added examples for disco#items queries sent to a room; prohibited 'type' attribute on invite messages sent from client to room; added dependencies for JEPs 11 and 30; changed 'room user' to 'occupant'; fixed many small errors throughout.</p> (psa)
+    </div>
+<h4>Version 0.22 (2002-11-04)</h4>
+<div class="indent">
+<p class="" style="">Added example for disco#items; added support for cancellation of room configuration using type='cancel' from JEP-0004; noted 403 error for invites sent by non-admins in members-only room.</p> (psa)
+    </div>
+<h4>Version 0.21 (2002-11-01)</h4>
+<div class="indent">
+<p class="" style="">Clarified several small ambiguities; made &lt;body/&gt; optional on invites sent from the service to the invitee; added error scenarios for changing nickname and for destroying the room; specified that the service must return the full member list for a members-only room (not only the members in the room); updated the disco examples to track protocol changes.</p> (psa)
+    </div>
+<h4>Version 0.20 (2002-10-29)</h4>
+<div class="indent">
+<p class="" style="">Specified that messages sent to change the room subject must be of type "groupchat"; updated the legal notice to conform to the JSF IPR policy.</p> (psa)
+    </div>
+<h4>Version 0.19 (2002-10-28)</h4>
+<div class="indent">
+<p class="" style="">Added ability to create an instant room within MUC (not by using gc-1.0 protocol); cleaned up disco examples.</p> (psa)
+    </div>
+<h4>Version 0.18 (2002-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added experimental support for disco; added sections for security, IANA, and JANA considerations; corrected typographical errors; cleaned up some DocBook formatting.</p> (psa)
+    </div>
+<h4>Version 0.17 (2002-10-23)</h4>
+<div class="indent">
+<p class="" style="">Added the optional &lt;actor/&gt; element (with 'jid' attribute) to &lt;item/&gt; elements inside presence stanzas of type "unavailable" that are sent to users who are kicked or banned, as well as within IQs for tracking purposes; reverted all list editing use cases (ban, voice, member, moderator, admin, owner) to use of MUC format rather than 'jabber:x:data' namespace; added several guidelines regarding generation and handling of XML stanzas; cleaned up the change room subject use case; changed several ambiguous uses of 'would', 'can', and 'will' to 'should', 'may', or 'must'; fixed several small errors in the text, examples, and DTDs.</p> (psa)
+    </div>
+<h4>Version 0.16 (2002-10-20)</h4>
+<div class="indent">
+<p class="" style="">Added the &lt;item/&gt; element to presence stanzas of type "unavailable" in order to improve the tracking of user states in the room; consolidated &lt;invitee/&gt; and &lt;invitor/&gt; elements into an &lt;invite/&gt; element with 'from' and 'to' attributes; made &lt;reason/&gt; element always a child of &lt;item/&gt; or &lt;invite/&gt; in the muc#user namespace; moved the alternate room location in room destruction to a 'jid' attribute of the &lt;alt/&gt; element; further specified several error messages; disallowed simultaneous modifications of both affiliations and roles by a moderator or admin; added several more rules regarding handling of XML stanzas; added use cases for granting and revoking administrative privileges; adjusted DTD to track all changes.</p> (psa)
+    </div>
+<h4>Version 0.15 (2002-10-18)</h4>
+<div class="indent">
+<p class="" style="">Fully incorporated the change to affiliations + roles; moved a number of admin use cases to a new section for moderator use cases; added participant use case for requesting membership; added admin use cases for adding members, removing members, granting and revoking moderator privileges, and modifying the moderator list; organized the sections in a more logical manner.</p> (psa)
+    </div>
+<h4>Version 0.14 (2002-10-17)</h4>
+<div class="indent">
+<p class="" style="">Significantly modified the privileges model by distinguishing between in-room "roles" and long-lived "affiliations"; specified the privileges of the various roles and affiliations; included state transition charts for both roles and affiliations; removed use of MUC protocol for editing ban, voice, and admin lists (but not for the actions of banning users and granting/revoking voice); added delivery rule regarding IQ stanzas; changed kick so that the action is based on changing the role to "none".</p> (psa)
+    </div>
+<h4>Version 0.13 (2002-10-16)</h4>
+<div class="indent">
+<p class="" style="">Corrected the change nickname examples (newnick sent on unavailable, no nick sent on available).</p> (psa)
+    </div>
+<h4>Version 0.12 (2002-10-16)</h4>
+<div class="indent">
+<p class="" style="">Removed SHA1 passwords; specified that room shall add passwords on invitations to password-protected rooms (not supplied by invitor).</p> (psa)
+    </div>
+<h4>Version 0.11 (2002-10-16)</h4>
+<div class="indent">
+<p class="" style="">Changed 'participant' to 'room user' and 'discussant' to 'participant'; clarified presence rule about client generation of extended presence information; added role of 'none'.</p> (psa)
+    </div>
+<h4>Version 0.10 (2002-10-15)</h4>
+<div class="indent">
+<p class="" style="">Fixed extended presence on entering or creating a room (plain '...muc' with no fragment); harmonized #user with #admin regarding the use of the &lt;item/&gt; element and associated attributes (jid, nick, etc.), and added 'role' attribute; modified management of voice, ban, admin, and member lists to use &lt;query/&gt; wrapper and new &lt;item/&gt; structure; changed the 'member' role to 'discussant', added 'outcast' role for banned users, and added new 'member' role to enable management of member lists; changed invitation-only rooms to members-only rooms and made appropriate adjustments to apply member lists to both members-only rooms and open rooms; modified nickname change protocol slightly to send the old nickname in the unavailable presence and the new nickname in the available presence; removed prohibition on members-only rooms that are password-protected; removed the &lt;query/&gt; wrapper for the &lt;destroy/&gt; element; updated the DTDs.</p> (psa)
+    </div>
+<h4>Version 0.9 (2002-10-13)</h4>
+<div class="indent">
+<p class="" style="">Added extended presence ('...#user') on entering a room for MUC clients; changed namespace on room creation request to '...#owner'; added a service discovery example using jabber:iq:browse; added information about discussion history; made small fixes to several examples; further defined the presence rules; transferred all implementation notes to a dedicated section; added a Terminology section.</p> (psa)
+    </div>
+<h4>Version 0.8 (2002-10-10)</h4>
+<div class="indent">
+<p class="" style="">Made further changes to the room creation workflow (finally correct); removed feature discovery use case (this needs to be addressed by a real service discovery protocol!); added ability for room owners to edit the admin list; removed &lt;body/&gt; from invitations generated by the service; removed messages sent to kicked and banned users (handled by unavailable presence with status code); added a number of implementation notes; converted all examples to Shakespeare style.</p> (psa)
+    </div>
+<h4>Version 0.7.6 (2002-10-09)</h4>
+<div class="indent">
+<p class="" style="">Fixed the room creation workflow; changed some terminology ("join" to "enter" and "leave" to "exit").</p> (psa)
+    </div>
+<h4>Version 0.7.5 (2002-10-08)</h4>
+<div class="indent">
+<p class="" style="">Specified and improved the handling of invitation-only rooms. In particular, added the ability for room admins to edit the invitation list and added a configuration option that limits the ability to send invitations to room admins only.</p> (psa)
+    </div>
+<h4>Version 0.7.4 (2002-10-07)</h4>
+<div class="indent">
+<p class="" style="">Changed namespaces from http://jabber.org/protocol/muc/owner etc. to http://jabber.org/protocol/muc#owner etc. per Jabber Council discussion.</p> (psa)
+    </div>
+<h4>Version 0.7.3 (2002-10-07)</h4>
+<div class="indent">
+<p class="" style="">Changed namespaces to HTTP URIs; left role handling up to the implementation; further clarified presence rules.</p> (psa)
+    </div>
+<h4>Version 0.7.2 (2002-10-06)</h4>
+<div class="indent">
+<p class="" style="">Disallowed kicking, banning, and revoking voice with respect to room admins and room owners; replaced &lt;x/&gt; with &lt;query/&gt; in the Discovering Room Features and Destroying a Room use cases; corrected some small errors and made many clarifications throughout.</p> (psa)
+    </div>
+<h4>Version 0.7.1 (2002-10-04)</h4>
+<div class="indent">
+<p class="" style="">Removed &lt;whois/&gt; command (unnecessary since participants with appropriate privileges receive the full JID of all participants in presence stanzas); completed many small fixes throughout.</p> (psa)
+    </div>
+<h4>Version 0.7 (2002-10-03)</h4>
+<div class="indent">
+<p class="" style="">More clearly delineated participant roles and defined the hierarchy thereof (owner, admin, member, visitor); replaced &lt;voice/&gt; element in extended presence with &lt;item role='member'/&gt;; changed initial room configuration to use IQ rather than message; adjusted presence rules (especially regarding extended presence information); cleaned up examples throughout; updated DTD to track changes.</p> (psa)
+    </div>
+<h4>Version 0.6 (2002-09-21)</h4>
+<div class="indent">
+<p class="" style="">More clearly defined the scope; removed fully anonymous rooms; changed meaning of semi-anonymous rooms and of non-anonymous rooms; added mechanism for notification of full JIDs in non-anonymous rooms; replaced the &lt;admin/&gt; element in extended presence with a &lt;role/&gt; element (more extensible); changed room passwords to cleartext; added status codes for various messages received from the service; added lists of valid error and status codes associated with the 'http://jabber.org/protocol/muc#user' namespace; added a &lt;reason/&gt; element for invitations; made kick and ban reasons child elements rather than attributes; replaced stopgap feature discovery mechanism with jabber:iq:negotiate; added extended presence element to room creation request and clarified the room creation process; specified presence reflection rules; added method for destroying a room; adjusted DTDs to track all changes.</p> (psa)
+    </div>
+<h4>Version 0.5.1 (2002-09-20)</h4>
+<div class="indent">
+<p class="" style="">Added DTDs; changed feature discovery to use &lt;x/&gt; element rather than query and made service response come in IQ result; fixed reference to JEP 29; changed 'grant' to 'add' and 'revoke' to 'remove' for consistency in the item attributes; made several other small changes.</p> (psa)
+    </div>
+<h4>Version 0.5 (2002-09-19)</h4>
+<div class="indent">
+<p class="" style="">Changed the kick, ban, and voice protocols; added a few more configuration options; specified the restrictions for roomnicks; and added a stopgap service discovery protocol.</p> (psa)
+    </div>
+<h4>Version 0.4 (2002-09-18)</h4>
+<div class="indent">
+<p class="" style="">Changed all non-GC-1.0 use cases to jabber:gc:* namespaces or jabber:x:data; added use cases for ban list management and room moderation; added protocol for sending notice of admin and voice privileges in presence; cleaned up text and many examples.</p> (psa)
+    </div>
+<h4>Version 0.3 (2002-09-17)</h4>
+<div class="indent">
+<p class="" style="">Changed admin use cases; cleaned up participant and owner use cases.</p> (psa)
+    </div>
+<h4>Version 0.2 (2002-09-12)</h4>
+<div class="indent">
+<p class="" style="">Broke content out into three actors (participant, owner, and admin) and added more detail to owner and admin use cases.</p> (psa)
+    </div>
+<h4>Version 0.1 (2002-09-09)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.1.html
+++ b/content/xep-0059-0.1.html
@@ -1,0 +1,203 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Limiting and Paging Extension</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Limiting and Paging Extension">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Description" content="An XMPP extension to handle generic limit specifying metadata.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2002-11-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Limiting and Paging Extension</h1>
+<p>An XMPP extension to handle generic limit specifying metadata.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0059<br>
+            Version: 0.1<br>
+            Last Updated: 2002-11-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: <br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Limiting%20and%20Paging%20Extension%20(JEP-0059)">http://wiki.jabber.org/index.php/Limiting and Paging Extension (JEP-0059)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jean-louis.seguineau@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#sect-id2251758">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2251796">Requirements</a>
+</dt>
+<dt>3.  <a href="#sect-id2251594">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2251600">Limiting search results reply</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2251685">Setting a Measuring Instrument</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2250532">DTD</a>
+</dt>
+<dt>5.  <a href="#sect-id2250541">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2250562">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2250579">JANA Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2250603">Conclusion</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2251758">Introduction</a>
+</h2>
+  <p class="" style="">There is a generic need in the protocol for specifying granular limit metadata to limit the amount of data held in a reply sent by a service. The interpretation of the metadata is entirely context specific, and outside the scope of this document. Such limits may be applied in cases like:</p>
+  <ol start="" type="">
+    <li>limiting the number of items returned by a search feature, and allowing a server based pagination among the results.</li>
+    <li>specifying the number of items returned by a discovery service in a given category.</li>
+  </ol>
+<h2>2.
+       <a name="sect-id2251796">Requirements</a>
+</h2>
+  <p class="" style="">This extension sould be embedable in any XMPP packet to represent limiting metadata.</p>
+	<h2>3.
+       <a name="sect-id2251594">Use Cases</a>
+</h2>
+		<div class="indent">
+<h3>3.1 <a name="sect-id2251600">Limiting search results reply</a>
+</h3>
+			<p class="" style="">A user has issued the relevant info query to a search service to discover what search fields are supported by the service.</p>
+			<p class="" style="">The user may then submit a search request, specifying values for any desired fields, and addding the limit metadata that it deem appropriate. In the following case we want to limit the number of returned results:</p>
+			<p class="caption">Example 1. Upper Limiting a Search Request</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='users.jabber.org' id='search2'&gt;
+  &lt;query xmlns="jabber:iq:search"&gt;
+    &lt;first&gt;peter&lt;/first&gt;
+    &lt;x xmlns='xmpp:x:limit' &gt;
+	&lt;limit type="max"&gt;20&lt;/limit&gt; 
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+	<p class="" style="">The service should then return a list of search results that match the values provided, but not more than 20 results</p>
+	<p class="" style="">It could also be intersting to provide a way to specify a pagination behaviour for the result. In this case the user will issue its search request by specifying a starting point in the result set and a number of item to be returned in addition to the maximum number of items.</p>
+	<p class="caption">Example 2. Specifying Pagination into a Search Request</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='users.jabber.org' id='search2'&gt;
+  &lt;query xmlns="jabber:iq:search"&gt;
+    &lt;first&gt;peter&lt;/first&gt;
+    &lt;x xmlns='xmpp:x:limit' &gt;
+	&lt;limit type="max"&gt;100&lt;/limit&gt; 
+	&lt;limit type="start"&gt;0&lt;/limit&gt; 
+	&lt;limit type="count"&gt;10&lt;/limit&gt; 
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+	<p class="" style="">Subsequent requests could then be sent to the search service to change the returned items window.</p>
+	<p class="caption">Example 3. Paginating into a Search Request</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='users.jabber.org' id='search2'&gt;
+  &lt;query xmlns="jabber:iq:search"&gt;
+    &lt;x xmlns='xmpp:x:limit' &gt;
+	&lt;limit type="start"&gt;30&lt;/limit&gt; 
+	&lt;limit type="count"&gt;10&lt;/limit&gt; 
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+		</div>
+		<div class="indent">
+<h3>3.2 <a name="sect-id2251685">Setting a Measuring Instrument</a>
+</h3>
+			<p class="" style="">One can imagine a monitoring service, with several instruments that need to have their reading characteristics set once and a while.</p>
+			<p class="" style="">A user may submit a setting instruction, specifying minimum and maximum recording values as well as sampling interval for a measuring instrument in a way similar to:</p>
+			<p class="caption">Example 4. Setting a measuring instrument</p>
+<div class="indent"><pre>
+&lt;presence to='gage@monitor.jabber.org'&gt;
+    &lt;x xmlns='xmpp:x:limit' &gt;
+	&lt;limit type="min"&gt;0&lt;/limit&gt; 
+	&lt;limit type="max"&gt;1000&lt;/limit&gt; 
+	&lt;limit type="count"&gt;60&lt;/limit&gt; 
+    &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+		</div>
+	<h2>4.
+       <a name="sect-id2250532">DTD</a>
+</h2>
+<p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;!ELEMENT x (limit*)&gt;
+&lt;!ATTLIST x
+	xmlns (xmpp:x:limit) #REQUIRED
+&gt;
+&lt;!ELEMENT limit (#PCDATA)&gt;
+&lt;!ATTLIST limit
+	type (count | min | max | start | stop) #IMPLIED
+&gt;
+    </pre></div>
+<h2>5.
+       <a name="sect-id2250541">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>6.
+       <a name="sect-id2250562">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the IANA.</p>
+<h2>7.
+       <a name="sect-id2250579">JANA Considerations</a>
+</h2>
+  <p class="" style="">The namespaces needs to be registered with JANA as a result of this JEP. See Jabber Assigned Names Authority (JANA)  [<a href="#nt-id2250594">1</a>]</p>
+<h2>8.
+       <a name="sect-id2250603">Conclusion</a>
+</h2>
+  <p class="" style="">As required, the namespace is easily integrated into any existing high level element of the XMPP protocol. Again, it is only intended to provide a generic way to convey metadata that will influence or limit the behaviour of another XMPP namespace. The meaning and behaviour of the receiving service is entirely implementation dependent.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent"><p><a name="nt-id2250594">1</a>. <a href="http://www.jabber.org/jana/">http://www.jabber.org/jana/</a></p></div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">Initial version. (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.10.html
+++ b/content/xep-0059-0.10.html
@@ -1,0 +1,648 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Management">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Management</h1>
+<p>This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.10<br>
+            Last Updated: 2006-08-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Management%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Management (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#count">Getting the Item Count</a>
+</dt>
+<dt>2.2.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#forwards">Paging Forwards Through a Result Set</a>
+</dt>
+<dt>2.4.  <a href="#backwards">Paging Backwards Through a Result Set</a>
+</dt>
+<dt>2.5.  <a href="#notfound">Page Not Found</a>
+</dt>
+<dt>2.6.  <a href="#last">Requesting the Last Page in a Result Set</a>
+</dt>
+<dt>2.7.  <a href="#jump">Retrieving a Page Out of Order</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250898">1</a>], <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250921">2</a>], <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250945">3</a>], <span class="ref" style="">Message Archiving</span>  [<a href="#nt-id2250964">4</a>], and perhaps other future XMPP extensions, it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250984">5</a>] service). Thus it would be helpful to define an XMPP protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of a result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity specifies a request type of "count":</p>
+    <p class="caption">Example 1. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Peter&lt;/first&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 2. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no items in the full result set, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search", "http://jabber.org/protocol/disco#items", or "http://jabber.org/protocol/pubsub"). For both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity shall return an empty &lt;query/&gt; element; for <span style="font-weight: bold">JEP-0060</span>, that means the responding entity shall return an empty &lt;pubsub/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set (via XML character data of  the &lt;max/&gt; element):</p>
+    <p class="caption">Example 3. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 4. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="forwards">Paging Forwards Through a Result Set</a>
+</h3>
+    <p class="" style="">Note: The set of items that match a query MAY change over time, even during the time that a requesting entity pages through a result set (e.g., a set of chatrooms, since rooms can be created and destroyed at any time). The paging protocol outlined in this section is designed to make the following features <span style="font-style: italic">possible</span>:</p>
+    <ul>
+      <li>Each result page is up-to-date at the time it is sent (not just at the time the first page was sent).</li>
+      <li>No items will be omitted from pages not yet sent (even if, after earlier pages were sent, some of the items they contained were removed from the set).</li>
+      <li>When paging through the list in order, duplicate items are never received.</li>
+      <li>Responding entity maintains no state (or a single minimal state for all requestors containing the positions of all recently deleted items).</li>
+      <li>Rapid calculation of which items should appear on a requested page by responding entity (even for large result sets).</li>
+    </ul>
+    <p class="" style="">Note: If a responding entity implements dynamic result sets then receiving entities paging through the complete result set should be aware that it may not correspond to the result set as it existed at any one point in time.</p>
+    <p class="" style="">The request for the first page is the same as when <a href="#limit">Limiting the Size of a Result Set</a>:</p>
+    <p class="caption">Example 5. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Responding entity support for paging through a result set is optional. If it does support paging (not just <a href="#limit">Limiting the Size of a Result Set</a>), then in each result set it returns, the responding entity MUST include &lt;first/&gt; and &lt;last/&gt; elements that specify the unique ID (UID) for the first and last items in the page. If there is only one item in the page the first and last UIDs MUST be the same. If there are no items in the page then the &lt;first/&gt; and &lt;last/&gt; elements MUST NOT be included.</p>
+    <p class="" style="">The responding entity may generate these UIDs in any way, as long as the UIDs are unique in the context of all possible members of the full result set. Each UID MAY be based on part of the content of its associated item, as shown below, or on an internal table index. Another possible method is to serialize the XML of the item and then hash it to generate the UID. Note: The requesting entity MUST treat all UIDs as opaque.</p>
+    <p class="" style="">The responding entity MUST also include the number of items in the full set (which MAY be approximate) encapsulated in a &lt;count/&gt; element.</p>
+    <p class="" style="">The &lt;first/&gt; element MUST include an 'index' attribute. This integer specifies the position within the full set (which MAY be approximate) of the first item in the page. If that item is the first in the full set then the index MUST be '0'. If the last item in the page is the last item in the full set then the index MUST equal the specified count minus the number of items in the page.</p>
+    <p class="caption">Example 6. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The requesting entity can then ask for the next page in the result set by including in its request the UID of the <span style="font-style: italic">last</span> item from the previous page (encapsulated in an &lt;after/&gt; element), and the maximum number of items to return. Note: if no &lt;after/&gt; element is specified then the UID defaults to "before the first item in the result set".</p>
+    <p class="caption">Example 7. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">first</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">follows</span> the item that the requesting entity indicated it has already received:</p>
+    <p class="caption">Example 8. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It may sometimes be necessary to return an empty <span style="font-style: italic">page</span> to the requesting entity. For example, with dynamic result sets, the responding entity MAY delete some items from the full result set between requests. Note: If there are no items in the <span style="font-style: italic">full</span> result set then the responding entity MUST return a response that adheres to the definition of the wrapper protocol (see <a href="#count">Getting the Item Count</a>).</p>
+    <p class="caption">Example 9. Returning an Empty Page</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page80'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;790&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="backwards">Paging Backwards Through a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the previous page in a result set by including in its request the UID of the <span style="font-style: italic">first</span> item from the page that has already been received (encapsulated in a &lt;before/&gt; element), and the maximum number of items to return.</p>
+    <p class="caption">Example 10. Requesting the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before&gt;peter@pixyland.org&lt;/before&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">last</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">preceeds</span> the item that the requesting entity indicated it has already received:</p>
+    <p class="caption">Example 11. Returning the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="notfound">Page Not Found</a>
+</h3>
+    <p class="" style="">The responding entity MUST reply with an 'item-not-found' error if <span style="font-style: italic">all</span> the following circumstances apply:</p>
+    <ol start="" type="">
+      <li>The item specified by the requesting entity via the UID in the &lt;after/&gt; or &lt;before/&gt; element no longer exists (it was deleted after the previous page was sent)</li>
+      <li>The UID itself cannot be used to derive directly the next item within the set (e.g. the alphabetical or numerical order of the UIDs do not specify the order of the items)</li>
+      <li>The responding entity does not remember the position of the deleted item within the full list. (Even if the responding entity bothers to remember the position of each deleted item, it will typically be necessary to expire that 'state' after an implementation-specific period of time.)</li>
+    </ol>
+    <p class="caption">Example 12. Returning a Page-not-Found Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="last">Requesting the Last Page in a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the last page in a result set by including in its request an empty &lt;before/&gt; element, and the maximum number of items to return.</p>
+    <p class="caption">Example 13. Requesting the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.7 <a name="jump">Retrieving a Page Out of Order</a>
+</h3>
+    <p class="" style="">The requesting entity MAY choose not to retrieve pages from the result set in order. (For example, when its user drags the user interface slider to a radically new position within a very large result set.)</p>
+    <p class="" style="">If the UID before the start (or after the end) of a desired result set page is not known, then the requesting entity MAY request the page that <span style="font-style: italic">starts</span> at a particular index within the result set by including in its request the index of the <span style="font-style: italic">first</span> item (encapsulated in an &lt;index/&gt; element), and the maximum number of items to return.</p>
+    <p class="caption">Example 14. Requesting a Result Page by Index</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;index&gt;10&lt;/index&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity MUST derive the first UID from the specified index (the method used MAY be approximate), before returning the requested result set page in the normal way. Note: The 'index' attribute of the &lt;first/&gt; element MUST be the same as the index specified in the request. If the index specified by the requesting entity is greater than or equal to the number of items in the full set then the responding entity MUST return an empty page (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+    <p class="caption">Example 15. Returning a Result Page at an Index</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set management in the context of <span style="font-weight: bold">Jabber Search.</span>. Therefore in the following examples we show the use of result set management in the context of <span style="font-weight: bold">Service Discovery</span>. A future version of this document may also include examples from <span style="font-weight: bold">Publish-Subscribe</span> and <span style="font-weight: bold">Message Archiving</span> and other XMPP protocol extensions.</p>
+  <p class="caption">Example 16. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 17. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;150&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 18. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 19. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apache@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;acc3594e844c77696f7a7ba9367ae324b6b958ad&lt;/first&gt;
+      &lt;last&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/last&gt;
+      &lt;count&gt;150&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 20. Requesting a Page Beginning After the Last Item Received</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;after&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set management, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 21. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 22. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set management extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set management, it MUST ignore the extension.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set management protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace and <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260578">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260629">7</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='after' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='before' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='count' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='first' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='index' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='last' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='count' type='xs:int'/&gt;
+
+  &lt;xs:element name='first'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='index' type='xs:int' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Olivier Goffart, Jon Perlow and Andrew Plotkin for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250898">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2250921">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250945">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250964">4</a>. JEP-0136: Message Archiving &lt;<a href="http://www.jabber.org/jeps/jep-0136.html">http://www.jabber.org/jeps/jep-0136.html</a>&gt;.</p>
+<p><a name="nt-id2250984">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2260578">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260629">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2006-08-24)</h4>
+<div class="indent">
+<p class="" style="">Added 'before' and 'first' elements, specified how to return an empty page and how to request the last page, removed reverse order sets, added out-of-order page access.</p> (ip)
+    </div>
+<h4>Version 0.9 (2006-08-23)</h4>
+<div class="indent">
+<p class="" style="">Eliminated static result sets, justified expanded and clarified dynamic result sets, added page-not-found error, described when minimal state is necessary, added reverse order sets.</p> (ip)
+    </div>
+<h4>Version 0.8 (2006-08-22)</h4>
+<div class="indent">
+<p class="" style="">Added optional method for handling dynamic result sets.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-08-10)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.11.html
+++ b/content/xep-0059-0.11.html
@@ -1,0 +1,657 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Management">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-25">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Management</h1>
+<p>This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.11<br>
+            Last Updated: 2006-08-25<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Management%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Management (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.2.  <a href="#forwards">Paging Forwards Through a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#backwards">Paging Backwards Through a Result Set</a>
+</dt>
+<dt>2.4.  <a href="#notfound">Page Not Found</a>
+</dt>
+<dt>2.5.  <a href="#last">Requesting the Last Page in a Result Set</a>
+</dt>
+<dt>2.6.  <a href="#jump">Retrieving a Page Out of Order</a>
+</dt>
+<dt>2.7.  <a href="#count">Getting the Item Count</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250950">1</a>], <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250974">2</a>], <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250996">3</a>], <span class="ref" style="">Message Archiving</span>  [<a href="#nt-id2251012">4</a>], and perhaps other future XMPP extensions, it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2251036">5</a>] service). Thus it would be helpful to define an XMPP protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of a result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set (via XML character data of  the &lt;max/&gt; element):</p>
+    <p class="caption">Example 1. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 2. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="forwards">Paging Forwards Through a Result Set</a>
+</h3>
+    <p class="" style="">Note: The set of items that match a query MAY change over time, even during the time that a requesting entity pages through a result set (e.g., a set of chatrooms, since rooms can be created and destroyed at any time). The paging protocol outlined in this section is designed to make the following features <span style="font-style: italic">possible</span>:</p>
+    <ul>
+      <li>Each result page is up-to-date at the time it is sent (not just at the time the first page was sent).</li>
+      <li>No items will be omitted from pages not yet sent (even if, after earlier pages were sent, some of the items they contained were removed from the set).</li>
+      <li>When paging through the list in order, duplicate items are never received.</li>
+      <li>Responding entity maintains no state (or a single minimal state for all requestors containing the positions of all recently deleted items).</li>
+      <li>Rapid calculation of which items should appear on a requested page by responding entity (even for large result sets).</li>
+    </ul>
+    <p class="" style="">Note: If a responding entity implements dynamic result sets then receiving entities paging through the complete result set should be aware that it may not correspond to the result set as it existed at any one point in time.</p>
+    <p class="" style="">The request for the first page is the same as when <a href="#limit">Limiting the Size of a Result Set</a>:</p>
+    <p class="caption">Example 3. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Responding entity support for paging through a result set is optional. If it does support paging (not just <a href="#limit">Limiting the Size of a Result Set</a>), then in each result set it returns, the responding entity MUST include &lt;first/&gt; and &lt;last/&gt; elements that specify the unique ID (UID) for the first and last items in the page. If there is only one item in the page the first and last UIDs MUST be the same. If there are no items in the page then the &lt;first/&gt; and &lt;last/&gt; elements MUST NOT be included.</p>
+    <p class="" style="">The responding entity may generate these UIDs in any way, as long as the UIDs are unique in the context of all possible members of the full result set. Each UID MAY be based on part of the content of its associated item, as shown below, or on an internal table index. Another possible method is to serialize the XML of the item and then hash it to generate the UID. Note: The requesting entity MUST treat all UIDs as opaque.</p>
+    <p class="" style="">The responding entity SHOULD also include the number of items in the full set (which MAY be approximate) encapsulated in a &lt;count/&gt; element. The &lt;first/&gt; element SHOULD include an 'index' attribute. This integer specifies the position within the full set (which MAY be approximate) of the first item in the page. If that item is the first in the full set then the index MUST be '0'. If the last item in the page is the last item in the full set then the index MUST equal the specified count minus the number of items in the page.</p>
+    <p class="" style="">Note: The &lt;count/&gt; element and 'index' attribute enable important functionality for requesting entities (for example, a scroll-bar user-interface component). They MAY be omitted, but <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
+    <p class="caption">Example 4. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The requesting entity can then ask for the next page in the result set by including in its request the UID of the <span style="font-style: italic">last</span> item from the previous page (encapsulated in an &lt;after/&gt; element), and the maximum number of items to return. Note: if no &lt;after/&gt; element is specified then the UID defaults to "before the first item in the result set".</p>
+    <p class="caption">Example 5. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">first</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">follows</span> the item that the requesting entity indicated it has already received:</p>
+    <p class="caption">Example 6. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It may sometimes be necessary to return an empty <span style="font-style: italic">page</span> to the requesting entity. For example, with dynamic result sets the responding entity MAY delete some items from the full result set between requests. Another example occurs when the requesting entity specifies "0" for the maximum number items to return (see <a href="#count">Getting the Item Count</a>).</p>
+    <p class="caption">Example 7. Returning an Empty Page</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page80'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;790&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no items whatsoever in the <span style="font-style: italic">full</span> result set, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search", "http://jabber.org/protocol/disco#items", or "http://jabber.org/protocol/pubsub"). For both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity shall return an empty &lt;query/&gt; element; for <span style="font-weight: bold">JEP-0060</span>, that means the responding entity shall return an empty &lt;pubsub/&gt; element; for <span style="font-weight: bold">JEP-0136</span>, that means the responding entity shall return an empty &lt;list/&gt; or &lt;store/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="backwards">Paging Backwards Through a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the previous page in a result set by including in its request the UID of the <span style="font-style: italic">first</span> item from the page that has already been received (encapsulated in a &lt;before/&gt; element), and the maximum number of items to return.</p>
+    <p class="caption">Example 8. Requesting the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before&gt;peter@pixyland.org&lt;/before&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">last</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">preceeds</span> the item that the requesting entity indicated it has already received:</p>
+    <p class="caption">Example 9. Returning the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="notfound">Page Not Found</a>
+</h3>
+    <p class="" style="">The responding entity MUST reply with an 'item-not-found' error if <span style="font-style: italic">all</span> the following circumstances apply:</p>
+    <ol start="" type="">
+      <li>The item specified by the requesting entity via the UID in the &lt;after/&gt; or &lt;before/&gt; element no longer exists (it was deleted after the previous page was sent)</li>
+      <li>The UID itself cannot be used to derive directly the next item within the set (e.g. the alphabetical or numerical order of the UIDs do not specify the order of the items)</li>
+      <li>The responding entity does not remember the position of the deleted item within the full list. (Even if the responding entity bothers to remember the position of each deleted item, it will typically be necessary to expire that 'state' after an implementation-specific period of time.)</li>
+    </ol>
+    <p class="caption">Example 10. Returning a Page-not-Found Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="last">Requesting the Last Page in a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the last page in a result set by including in its request an empty &lt;before/&gt; element, and the maximum number of items to return.</p>
+    <p class="caption">Example 11. Requesting the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="jump">Retrieving a Page Out of Order</a>
+</h3>
+    <p class="" style="">The requesting entity MAY choose not to retrieve pages from the result set in order. (For example, when its user drags the user interface slider to a radically new position within a very large result set.)</p>
+    <p class="" style="">If the UID before the start (or after the end) of a desired result set page is not known, then the requesting entity MAY request the page that <span style="font-style: italic">starts</span> at a particular index within the result set by including in its request the index of the <span style="font-style: italic">first</span> item (encapsulated in an &lt;index/&gt; element), and the maximum number of items to return.</p>
+    <p class="" style="">Note: If the responding entity omitted the &lt;count/&gt; element from previous responses for this result set, then the requesting entity SHOULD assume that the responding entity does not support page retrieval by index for this result set (see error below).</p>
+    <p class="caption">Example 12. Requesting a Result Page by Index</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;index&gt;10&lt;/index&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity SHOULD derive the first UID from the specified index (the method used MAY be approximate). However, <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to do that with reasonably accuracy then the responding entity MAY return a &lt;feature-not-implemented/&gt; error. Otherwise, the requested result set page MUST be returned in the normal way.</p>
+    <p class="" style="">Note: The 'index' attribute of the &lt;first/&gt; element MUST be the same as the index specified in the request. If the index specified by the requesting entity is greater than or equal to the number of items in the full set then the responding entity MUST return an empty page (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+    <p class="caption">Example 13. Returning a Result Page at an Index</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Returning a Feature-not-Implemented Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;index&gt;10&lt;/index&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.7 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity simply specifies zero for the maximum size of the result set page:</p>
+    <p class="caption">Example 15. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;0&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 16. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The &lt;count/&gt; element MAY be omitted, but <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
+    <p class="" style="">Note: If there are no items in the <span style="font-style: italic">full</span> result set then the responding entity MUST return a response that adheres to the definition of the wrapper protocol (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set management in the context of <span style="font-weight: bold">Jabber Search.</span>. Therefore in the following examples we show the use of result set management in the context of <span style="font-weight: bold">Service Discovery</span>. A future version of this document may also include examples from <span style="font-weight: bold">Publish-Subscribe</span> and <span style="font-weight: bold">Message Archiving</span> and other XMPP protocol extensions.</p>
+  <p class="caption">Example 17. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 18. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apache@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;acc3594e844c77696f7a7ba9367ae324b6b958ad&lt;/first&gt;
+      &lt;last&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/last&gt;
+      &lt;count&gt;150&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 19. Requesting a Page Beginning After the Last Item Received</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;after&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set management, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 20. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 21. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set management extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set management, it MUST ignore the extension.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set management protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace and <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258662">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258714">7</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='after' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='before' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='count' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='first' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='index' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='last' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='first'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='index' type='xs:int' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Olivier Goffart, Jon Perlow, and Andrew Plotkin for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250950">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2250974">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250996">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251012">4</a>. JEP-0136: Message Archiving &lt;<a href="http://www.jabber.org/jeps/jep-0136.html">http://www.jabber.org/jeps/jep-0136.html</a>&gt;.</p>
+<p><a name="nt-id2251036">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2258662">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258714">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.11 (2006-08-25)</h4>
+<div class="indent">
+<p class="" style="">Made count and index optional, changed protocol for getting count, more clarifications and examples.</p> (ip)
+    </div>
+<h4>Version 0.10 (2006-08-24)</h4>
+<div class="indent">
+<p class="" style="">Added before and first elements, specified how to return an empty page and how to request the last page, removed reverse order sets, added out-of-order page access.</p> (ip)
+    </div>
+<h4>Version 0.9 (2006-08-23)</h4>
+<div class="indent">
+<p class="" style="">Eliminated static result sets, justified expanded and clarified dynamic result sets, added page-not-found error, described when minimal state is necessary, added reverse order sets.</p> (ip)
+    </div>
+<h4>Version 0.8 (2006-08-22)</h4>
+<div class="indent">
+<p class="" style="">Added optional method for handling dynamic result sets.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-08-10)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.12.html
+++ b/content/xep-0059-0.12.html
@@ -1,0 +1,671 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Management">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Description" content="This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-09-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Management</h1>
+<p>This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.12<br>
+            Last Updated: 2006-09-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Management%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Management (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.2.  <a href="#forwards">Paging Forwards Through a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#backwards">Paging Backwards Through a Result Set</a>
+</dt>
+<dt>2.4.  <a href="#notfound">Page Not Found</a>
+</dt>
+<dt>2.5.  <a href="#last">Requesting the Last Page in a Result Set</a>
+</dt>
+<dt>2.6.  <a href="#jump">Retrieving a Page Out of Order</a>
+</dt>
+<dt>2.7.  <a href="#count">Getting the Item Count</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250967">1</a>], <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250990">2</a>], <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250957">3</a>], <span class="ref" style="">Message Archiving</span>  [<a href="#nt-id2251030">4</a>], and perhaps other future XMPP extensions, it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2251053">5</a>] service). Thus it would be helpful to define an XMPP protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of a result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set (via the XML character data of the &lt;max/&gt; element):</p>
+    <p class="caption">Example 1. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 2. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="forwards">Paging Forwards Through a Result Set</a>
+</h3>
+    <p class="" style="">The set of items that match a query MAY change over time, even during the time that a requesting entity pages through a result set (e.g., a set of chatrooms, since rooms can be created and destroyed at any time). The paging protocol outlined in this section is designed to make the following features <span style="font-style: italic">possible</span>:</p>
+    <ul>
+      <li>Each result page is up-to-date at the time it is sent (not just at the time the first page was sent).</li>
+      <li>No items will be omitted from pages not yet sent (even if, after earlier pages were sent, some of the items they contained were removed from the set).</li>
+      <li>When paging through the list in order, duplicate items are never received.</li>
+      <li>Responding entity maintains no state (or a single minimal state for all requestors containing the positions of all recently deleted items).</li>
+      <li>Rapid calculation of which items should appear on a requested page by responding entity (even for large result sets).</li>
+    </ul>
+    <p class="" style="">Note: If a responding entity implements dynamic result sets then receiving entities paging through the complete result set should be aware that it may not correspond to the result set as it existed at any one point in time.</p>
+    <p class="" style="">The request for the first page is the same as when <a href="#limit">Limiting the Size of a Result Set</a>:</p>
+    <p class="caption">Example 3. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Responding entity support for paging through a result set is optional. If it does support paging (not just <a href="#limit">Limiting the Size of a Result Set</a>), then in each result set it returns, the responding entity MUST include &lt;first/&gt; and &lt;last/&gt; elements that specify the unique ID (UID) for the first and last items in the page. If there is only one item in the page, then the first and last UIDs MUST be the same. If there are no items in the page, then the &lt;first/&gt; and &lt;last/&gt; elements MUST NOT be included.</p>
+    <p class="" style="">The responding entity may generate these UIDs in any way, as long as the UIDs are unique in the context of all possible members of the full result set. Each UID MAY be based on part of the content of its associated item, as shown below, or on an internal table index. Another possible method is to serialize the XML of the item and then hash it to generate the UID. Note: The requesting entity MUST treat all UIDs as opaque.</p>
+    <p class="" style="">The responding entity SHOULD also include the number of items in the full set (which MAY be approximate) encapsulated in a &lt;count/&gt; element. The &lt;first/&gt; element SHOULD include an 'index' attribute. This integer specifies the position within the full set (which MAY be approximate) of the first item in the page. If that item is the first in the full set, then the index MUST be '0'. If the last item in the page is the last item in the full set, then the value of the &lt;first/&gt; element's 'index' attribute MUST be the specified count minus the number of items in the last page.</p>
+    <p class="" style="">Note: The &lt;count/&gt; element and 'index' attribute enable important functionality for requesting entities (for example, a scroll-bar user-interface component). They MAY be omitted, but <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
+    <p class="caption">Example 4. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The requesting entity can then ask for the next page in the result set by including in its request the UID of the <span style="font-style: italic">last</span> item from the previous page (encapsulated in an &lt;after/&gt; element), along with the maximum number of items to return. Note: If no &lt;after/&gt; element is specified, then the UID defaults to "the first item in the result set".</p>
+    <p class="caption">Example 5. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">first</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">follows</span> the item that the requesting entity indicated in the &lt;after/&gt; element:</p>
+    <p class="caption">Example 6. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It may sometimes be necessary to return an empty <span style="font-style: italic">page</span> to the requesting entity. For example, with dynamic result sets the responding entity MAY delete some items from the full result set between requests. Another example occurs when the requesting entity specifies "0" for the maximum number items to return (see <a href="#count">Getting the Item Count</a>).</p>
+    <p class="caption">Example 7. Returning an Empty Page</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page80'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;790&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no items whatsoever in the <span style="font-style: italic">full</span> result set, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search", "http://jabber.org/protocol/disco#items", or "http://jabber.org/protocol/pubsub"). For both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity shall return an empty &lt;query/&gt; element; for <span style="font-weight: bold">JEP-0060</span>, that means the responding entity shall return an empty &lt;pubsub/&gt; element; for <span style="font-weight: bold">JEP-0136</span>, that means the responding entity shall return an empty &lt;list/&gt; or &lt;store/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="backwards">Paging Backwards Through a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the previous page in a result set by including in its request the UID of the <span style="font-style: italic">first</span> item from the page that has already been received (encapsulated in a &lt;before/&gt; element), along with the maximum number of items to return. The &lt;before/&gt; element MAY include an 'index' attribute that is the same as the 'index' value from the &lt;first/&gt; element of the previous page.</p>
+    <p class="caption">Example 8. Requesting the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before index='10'&gt;peter@pixyland.org&lt;/before&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">last</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">preceeds</span> the item that the requesting entity indicated it has already received:</p>
+    <p class="caption">Example 9. Returning the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="notfound">Page Not Found</a>
+</h3>
+    <p class="" style="">The responding entity MUST reply with an 'item-not-found' error if <span style="font-style: italic">all</span> the following circumstances apply:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The item specified by the requesting entity via the UID in the &lt;after/&gt; or &lt;before/&gt; element no longer exists (it was deleted after the previous page was sent).</p></li>
+      <li><p class="" style="">The UID itself cannot be used to derive directly the next item within the set (e.g. the alphabetical or numerical order of the UIDs do not specify the order of the items).</p></li>
+      <li><p class="" style="">The responding entity does not remember the position of the deleted item within the full list. (Even if the responding entity bothers to remember the position of each deleted item, it will typically be necessary to expire that 'state' after an implementation-specific period of time.)</p></li>
+    </ol>
+    <p class="caption">Example 10. Returning a Page-Not-Found Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="last">Requesting the Last Page in a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the last page in a result set by including in its request an empty &lt;before/&gt; element, and the maximum number of items to return.</p>
+    <p class="caption">Example 11. Requesting the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="jump">Retrieving a Page Out of Order</a>
+</h3>
+    <p class="" style="">The requesting entity MAY choose not to retrieve pages from the result set in order. (For example, when its user drags the user interface slider to a radically new position within a very large result set.)</p>
+    <p class="" style="">If the UID before the start (or after the end) of a desired result set page is not known, then the requesting entity can request the page that <span style="font-style: italic">starts</span> at a particular index within the result set by including in its request an empty &lt;after/&gt; element whose 'index' attribute specifies the <span style="font-style: italic">first</span> item to be returned, as well as the maximum number of items to return.</p>
+    <p class="" style="">Note: If the responding entity omitted the &lt;count/&gt; element from previous responses for this result set, then the requesting entity SHOULD assume that the responding entity does not support page retrieval by index for this result set (see error below).</p>
+    <p class="caption">Example 12. Requesting a Result Page by Index</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after index='10'/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The 'index' attribute of the &lt;first/&gt; element MUST be the same as the index specified in the request. If the index specified by the requesting entity is greater than or equal to the number of items in the full set then the responding entity MUST return an empty page (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+    <p class="caption">Example 13. Returning a Result Page at an Index</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity SHOULD derive the first UID from the specified index (the method used MAY be approximate). However, <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to do that with reasonable accuracy then the responding entity MAY return a &lt;feature-not-implemented/&gt; error. Otherwise, the requested result set page MUST be returned in the normal way.</p>
+    <p class="caption">Example 14. Returning a Feature-not-Implemented Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;index&gt;10&lt;/index&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Similarly, the requesting entity can request the page prior to a particular index within the result set by including in its request an empty &lt;before/&gt; element whose 'index' attribute specifies the item after the <span style="font-style: italic">last</span> item to be returned, as well as the maximum number of items to return.</p>
+  </div>
+  <div class="indent">
+<h3>2.7 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity simply specifies zero for the maximum size of the result set page:</p>
+    <p class="caption">Example 15. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;0&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 16. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The &lt;count/&gt; element MAY be omitted, but <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
+    <p class="" style="">Note: If there are no items in the <span style="font-style: italic">full</span> result set then the responding entity MUST return a response that adheres to the definition of the wrapper protocol (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set management in the context of <span style="font-weight: bold">Jabber Search.</span>. Therefore in the following examples we show the use of result set management in the context of <span style="font-weight: bold">Service Discovery</span>. A future version of this document may also include examples from <span style="font-weight: bold">Publish-Subscribe</span> and <span style="font-weight: bold">Message Archiving</span> and other XMPP protocol extensions.</p>
+  <p class="caption">Example 17. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 18. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apache@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;acc3594e844c77696f7a7ba9367ae324b6b958ad&lt;/first&gt;
+      &lt;last&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/last&gt;
+      &lt;count&gt;150&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 19. Requesting a Page Beginning After the Last Item Received</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;after&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set management, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 20. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 21. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set management extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set management, it MUST ignore the extension.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set management protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace and <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259016">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259067">7</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='after' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='before' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='count' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='first' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='last' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='first'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='index' type='xs:int' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='before'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='index' type='xs:int' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Olivier Goffart, Jon Perlow, and Andrew Plotkin for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250967">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2250990">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250957">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251030">4</a>. JEP-0136: Message Archiving &lt;<a href="http://www.jabber.org/jeps/jep-0136.html">http://www.jabber.org/jeps/jep-0136.html</a>&gt;.</p>
+<p><a name="nt-id2251053">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259016">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259067">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.12 (2006-09-06)</h4>
+<div class="indent">
+<p class="" style="">Added index attribute to before element; removed index element (use after or before instead).</p> (psa/vm)
+    </div>
+<h4>Version 0.11 (2006-08-25)</h4>
+<div class="indent">
+<p class="" style="">Made count and index optional, changed protocol for getting count, more clarifications and examples.</p> (ip)
+    </div>
+<h4>Version 0.10 (2006-08-24)</h4>
+<div class="indent">
+<p class="" style="">Added before and first elements, specified how to return an empty page and how to request the last page, removed reverse order sets, added out-of-order page access.</p> (ip)
+    </div>
+<h4>Version 0.9 (2006-08-23)</h4>
+<div class="indent">
+<p class="" style="">Eliminated static result sets, justified expanded and clarified dynamic result sets, added page-not-found error, described when minimal state is necessary, added reverse order sets.</p> (ip)
+    </div>
+<h4>Version 0.8 (2006-08-22)</h4>
+<div class="indent">
+<p class="" style="">Added optional method for handling dynamic result sets.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-08-10)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.13.html
+++ b/content/xep-0059-0.13.html
@@ -1,0 +1,666 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Management">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Description" content="This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-09-07">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Management</h1>
+<p>This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.13<br>
+            Last Updated: 2006-09-07<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Management%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Management (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.2.  <a href="#forwards">Paging Forwards Through a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#backwards">Paging Backwards Through a Result Set</a>
+</dt>
+<dt>2.4.  <a href="#notfound">Page Not Found</a>
+</dt>
+<dt>2.5.  <a href="#last">Requesting the Last Page in a Result Set</a>
+</dt>
+<dt>2.6.  <a href="#jump">Retrieving a Page Out of Order</a>
+</dt>
+<dt>2.7.  <a href="#count">Getting the Item Count</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250990">1</a>], <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251048">2</a>], <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2251002">3</a>], <span class="ref" style="">Message Archiving</span>  [<a href="#nt-id2251024">4</a>], and perhaps other future XMPP extensions, it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257561">5</a>] service). Thus it would be helpful to define an XMPP protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of a result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set (via the XML character data of the &lt;max/&gt; element):</p>
+    <p class="caption">Example 1. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 2. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="forwards">Paging Forwards Through a Result Set</a>
+</h3>
+    <p class="" style="">The set of items that match a query MAY change over time, even during the time that a requesting entity pages through a result set (e.g., a set of chatrooms, since rooms can be created and destroyed at any time). The paging protocol outlined in this section is designed to make the following features <span style="font-style: italic">possible</span>:</p>
+    <ul>
+      <li>Each result page is up-to-date at the time it is sent (not just at the time the first page was sent).</li>
+      <li>No items will be omitted from pages not yet sent (even if, after earlier pages were sent, some of the items they contained were removed from the set).</li>
+      <li>When paging through the list in order, duplicate items are never received.</li>
+      <li>Responding entity maintains no state (or a single minimal state for all requestors containing the positions of all recently deleted items).</li>
+      <li>Rapid calculation of which items should appear on a requested page by responding entity (even for large result sets).</li>
+    </ul>
+    <p class="" style="">Note: If a responding entity implements dynamic result sets then receiving entities paging through the complete result set should be aware that it may not correspond to the result set as it existed at any one point in time.</p>
+    <p class="" style="">The request for the first page is the same as when <a href="#limit">Limiting the Size of a Result Set</a>:</p>
+    <p class="caption">Example 3. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Responding entity support for paging through a result set is optional. If it does support paging (not just <a href="#limit">Limiting the Size of a Result Set</a>), then in each result set it returns, the responding entity MUST include &lt;first/&gt; and &lt;last/&gt; elements that specify the unique ID (UID) for the first and last items in the page. If there is only one item in the page, then the first and last UIDs MUST be the same. If there are no items in the page, then the &lt;first/&gt; and &lt;last/&gt; elements MUST NOT be included.</p>
+    <p class="" style="">The responding entity may generate these UIDs in any way, as long as the UIDs are unique in the context of all possible members of the full result set. Each UID MAY be based on part of the content of its associated item, as shown below, or on an internal table index. Another possible method is to serialize the XML of the item and then hash it to generate the UID. Note: The requesting entity MUST treat all UIDs as opaque.</p>
+    <p class="" style="">The responding entity SHOULD also include the number of items in the full set (which MAY be approximate) encapsulated in a &lt;count/&gt; element. The &lt;first/&gt; element SHOULD include an 'index' attribute. This integer specifies the position within the full set (which MAY be approximate) of the first item in the page. If that item is the first in the full set, then the index MUST be '0'. If the last item in the page is the last item in the full set, then the value of the &lt;first/&gt; element's 'index' attribute MUST be the specified count minus the number of items in the last page.</p>
+    <p class="" style="">Note: The &lt;count/&gt; element and 'index' attribute enable important functionality for requesting entities (for example, a scroll-bar user-interface component). They MAY be omitted, but <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
+    <p class="caption">Example 4. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The requesting entity can then ask for the next page in the result set by including in its request the UID of the <span style="font-style: italic">last</span> item from the previous page (encapsulated in an &lt;after/&gt; element), along with the maximum number of items to return. Note: If no &lt;after/&gt; element is specified, then the UID defaults to "before the first item in the result set" (i.e., effectively an index of negative one).</p>
+    <p class="caption">Example 5. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">first</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">follows</span> the item that the requesting entity indicated in the &lt;after/&gt; element:</p>
+    <p class="caption">Example 6. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It may sometimes be necessary to return an empty <span style="font-style: italic">page</span> to the requesting entity. For example, with dynamic result sets the responding entity MAY delete some items from the full result set between requests. Another example occurs when the requesting entity specifies "0" for the maximum number items to return (see <a href="#count">Getting the Item Count</a>).</p>
+    <p class="caption">Example 7. Returning an Empty Page</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page80'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;790&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no items whatsoever in the <span style="font-style: italic">full</span> result set, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search", "http://jabber.org/protocol/disco#items", or "http://jabber.org/protocol/pubsub"). For both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity shall return an empty &lt;query/&gt; element; for <span style="font-weight: bold">JEP-0060</span>, that means the responding entity shall return an empty &lt;pubsub/&gt; element; for <span style="font-weight: bold">JEP-0136</span>, that means the responding entity shall return an empty &lt;list/&gt; or &lt;store/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="backwards">Paging Backwards Through a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the previous page in a result set by including in its request the UID of the <span style="font-style: italic">first</span> item from the page that has already been received (encapsulated in a &lt;before/&gt; element), along with the maximum number of items to return.</p>
+    <p class="caption">Example 8. Requesting the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before&gt;peter@pixyland.org&lt;/before&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">last</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">preceeds</span> the item that the requesting entity indicated it has already received:</p>
+    <p class="caption">Example 9. Returning the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="notfound">Page Not Found</a>
+</h3>
+    <p class="" style="">The responding entity MUST reply with an 'item-not-found' error if <span style="font-style: italic">all</span> the following circumstances apply:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The item specified by the requesting entity via the UID in the &lt;after/&gt; or &lt;before/&gt; element no longer exists (it was deleted after the previous page was sent).</p></li>
+      <li><p class="" style="">The UID itself cannot be used to derive directly the next item within the set (e.g. the alphabetical or numerical order of the UIDs do not specify the order of the items).</p></li>
+      <li><p class="" style="">The responding entity does not remember the position of the deleted item within the full list. (Even if the responding entity bothers to remember the position of each deleted item, it will typically be necessary to expire that 'state' after an implementation-specific period of time.)</p></li>
+    </ol>
+    <p class="caption">Example 10. Returning a Page-Not-Found Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="last">Requesting the Last Page in a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the last page in a result set by including in its request an empty &lt;before/&gt; element, and the maximum number of items to return.</p>
+    <p class="caption">Example 11. Requesting the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="jump">Retrieving a Page Out of Order</a>
+</h3>
+    <p class="" style="">The requesting entity MAY choose not to retrieve pages from the result set in order. (For example, when its user drags the user interface slider to a radically new position within a very large result set.)</p>
+    <p class="" style="">Only if the UID before the start (or after the end) of a desired result set page is not known, then the requesting entity MAY request the page that <span style="font-style: italic">starts</span> at a particular index within the result set. It does that by including in its request the index of the <span style="font-style: italic">first</span> item to be returned (encapsulated in an &lt;index/&gt; element), as well as the maximum number of items to return. Note: For reasons mentioned in <a href="#forwards">Paging Forwards Through a Result Set</a> requesting entities SHOULD, where possible, specify pages using a UID instead of an index.</p>
+    <p class="" style="">Note: If the responding entity omitted the &lt;count/&gt; element from previous responses for this result set, then the requesting entity SHOULD assume that the responding entity does not support page retrieval by index for this result set (see error below).</p>
+    <p class="caption">Example 12. Requesting a Result Page by Index</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;index&gt;10&lt;/index&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity SHOULD derive the first UID from the specified index (the method used MAY be approximate) before returning the requested result set page in the normal way. If the specified index was "0" then the responding entity SHOULD derive the UID that is the first in the full result set.</p>
+    <p class="" style="">Note: The 'index' attribute of the &lt;first/&gt; element MUST be the same as the index specified in the request. If the index specified by the requesting entity is greater than or equal to the number of items in the full set then the responding entity MUST return an empty page (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+    <p class="caption">Example 13. Returning a Result Page at an Index</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If it would be either impossible or exceptionally resource intensive for the responding entity to derive the first UID from the specified index with reasonable accuracy then the responding entity MAY return a &lt;feature-not-implemented/&gt; error.</p>
+    <p class="caption">Example 14. Returning a Feature-not-Implemented Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;index&gt;10&lt;/index&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.7 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity simply specifies zero for the maximum size of the result set page:</p>
+    <p class="caption">Example 15. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;0&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 16. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The &lt;count/&gt; element MAY be omitted, but <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
+    <p class="" style="">Note: If there are no items in the <span style="font-style: italic">full</span> result set then the responding entity MUST return a response that adheres to the definition of the wrapper protocol (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set management in the context of <span style="font-weight: bold">Jabber Search.</span>. Therefore in the following examples we show the use of result set management in the context of <span style="font-weight: bold">Service Discovery</span>. A future version of this document may also include examples from <span style="font-weight: bold">Publish-Subscribe</span> and <span style="font-weight: bold">Message Archiving</span> and other XMPP protocol extensions.</p>
+  <p class="caption">Example 17. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 18. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apache@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;acc3594e844c77696f7a7ba9367ae324b6b958ad&lt;/first&gt;
+      &lt;last&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/last&gt;
+      &lt;count&gt;150&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 19. Requesting a Page Beginning After the Last Item Received</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;after&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set management, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 20. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 21. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set management extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set management, it MUST ignore the extension.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set management protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace and <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259035">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259086">7</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='after' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='before' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='count' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='first' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='index' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='last' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='first'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='index' type='xs:int' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Olivier Goffart, Jon Perlow, and Andrew Plotkin for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250990">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2251048">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251002">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251024">4</a>. JEP-0136: Message Archiving &lt;<a href="http://www.jabber.org/jeps/jep-0136.html">http://www.jabber.org/jeps/jep-0136.html</a>&gt;.</p>
+<p><a name="nt-id2257561">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259035">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259086">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.13 (2006-09-07)</h4>
+<div class="indent">
+<p class="" style="">Reverted to v0.11 with slight wording changes.</p> (ip/psa)
+    </div>
+<h4>Version 0.12 (2006-09-06)</h4>
+<div class="indent">
+<p class="" style="">Added index attribute to before element; removed index element (use after or before instead).</p> (psa/vm)
+    </div>
+<h4>Version 0.11 (2006-08-25)</h4>
+<div class="indent">
+<p class="" style="">Made count and index optional, changed protocol for getting count, more clarifications and examples.</p> (ip)
+    </div>
+<h4>Version 0.10 (2006-08-24)</h4>
+<div class="indent">
+<p class="" style="">Added before and first elements, specified how to return an empty page and how to request the last page, removed reverse order sets, added out-of-order page access.</p> (ip)
+    </div>
+<h4>Version 0.9 (2006-08-23)</h4>
+<div class="indent">
+<p class="" style="">Eliminated static result sets, justified expanded and clarified dynamic result sets, added page-not-found error, described when minimal state is necessary, added reverse order sets.</p> (ip)
+    </div>
+<h4>Version 0.8 (2006-08-22)</h4>
+<div class="indent">
+<p class="" style="">Added optional method for handling dynamic result sets.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-08-10)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.14.html
+++ b/content/xep-0059-0.14.html
@@ -1,0 +1,670 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Management">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Description" content="This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-09-13">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Management</h1>
+<p>This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.14<br>
+            Last Updated: 2006-09-13<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Management%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Management (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#limit">Limiting the Number of Items</a>
+</dt>
+<dt>2.2.  <a href="#forwards">Paging Forwards Through a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#backwards">Paging Backwards Through a Result Set</a>
+</dt>
+<dt>2.4.  <a href="#notfound">Page Not Found</a>
+</dt>
+<dt>2.5.  <a href="#last">Requesting the Last Page in a Result Set</a>
+</dt>
+<dt>2.6.  <a href="#jump">Retrieving a Page Out of Order</a>
+</dt>
+<dt>2.7.  <a href="#count">Getting the Item Count</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2251064">1</a>], <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251032">2</a>], <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257554">3</a>], <span class="ref" style="">Message Archiving</span>  [<a href="#nt-id2257575">4</a>], and probably other future XMPP extensions, it is possible to receive large dynamic result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257595">5</a>] service). This XMPP protocol extension enables the following functionality for use by other XMPP protocols:</p>
+  <ol start="" type="">
+    <li>Limit the number of items returned.</li>
+    <li>Page forwards or backwards through a result set by retrieving the items in smaller subsets.</li>
+    <li>Discover the size of a result set without retrieving the items themselves.</li>
+    <li>Retrieve a page (subset) of items starting at any point in a result set.</li>
+  </ol>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="limit">Limiting the Number of Items</a>
+</h3>
+    <p class="" style="">In order to limit the number of items of a result set to be returned, the requesting entity specifies a request type of "set" and the maximum size of the desired subset (via the XML character data of the &lt;max/&gt; element):</p>
+    <p class="caption">Example 1. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the first items of the result set in order. The number of items is limited to the requested size:</p>
+    <p class="caption">Example 2. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="forwards">Paging Forwards Through a Result Set</a>
+</h3>
+    <p class="" style="">An entity often needs to retrieve a page of items adjacent to a page it has already received. For examples, when retrieving a complete result set in order page by page, or when a user 'scrolls' forwards one page.</p>
+    <p class="" style="">The set of items that match a query MAY change over time, even during the time that a requesting entity pages through the result set (e.g., a set of chatrooms, since rooms can be created and destroyed at any time). The paging protocol outlined in this section is designed so that entities MAY provide the following features:</p>
+    <ul>
+      <li>Each page of the result set is up-to-date at the time it is sent (not just at the time the first page was sent).</li>
+      <li>No items will be omitted from pages not yet sent (even if, after earlier pages were sent, some of the items they contained were removed from the set).</li>
+      <li>When paging through the list in order, duplicate items are never received.</li>
+      <li>The responding entity maintains no state (or a single minimal state for all requesting entities containing the positions of all recently deleted items).</li>
+      <li>Rapid calculation of which items should appear on a requested page by responding entity (even for large result sets).</li>
+    </ul>
+    <p class="" style="">Note: If a responding entity implements dynamic result sets then receiving entities paging through the complete result set should be aware that it may not correspond to the result set as it existed at any one point in time.</p>
+    <p class="" style="">The request for the first page is the same as when <a href="#limit">Limiting the Number of Items</a>:</p>
+    <p class="caption">Example 3. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Responding entity support for paging through a result set is optional. If it does support paging (not just <a href="#limit">Limiting the Number of Items</a>), then in each page it returns, the responding entity MUST include &lt;first/&gt; and &lt;last/&gt; elements that specify the unique ID (UID) for the first and last items in the page. If there is only one item in the page, then the first and last UIDs MUST be the same. If there are no items in the page, then the &lt;first/&gt; and &lt;last/&gt; elements MUST NOT be included.</p>
+    <p class="" style="">The responding entity may generate these UIDs in any way, as long as the UIDs are unique in the context of all possible members of the full result set. Each UID MAY be based on part of the content of its associated item, as shown below, or on an internal table index. Another possible method is to serialize the XML of the item and then hash it to generate the UID. Note: The requesting entity MUST treat all UIDs as opaque.</p>
+    <p class="" style="">The responding entity SHOULD also include the number of items in the full result set (which MAY be approximate) encapsulated in a &lt;count/&gt; element. The &lt;first/&gt; element SHOULD include an 'index' attribute. This integer specifies the position within the full set (which MAY be approximate) of the first item in the page. If that item is the first in the full set, then the index SHOULD be '0'. If the last item in the page is the last item in the full set, then the value of the &lt;first/&gt; element's 'index' attribute SHOULD be the specified count minus the number of items in the last page.</p>
+    <p class="" style="">Note: The &lt;count/&gt; element and 'index' attribute enable important functionality for requesting entities (for example, a scroll-bar user-interface component). They MAY be omitted, but <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
+    <p class="caption">Example 4. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The requesting entity can then ask for the next page in the result set by including in its request the UID of the <span style="font-style: italic">last</span> item from the previous page (encapsulated in an &lt;after/&gt; element), along with the maximum number of items to return. Note: If no &lt;after/&gt; element is specified, then the UID defaults to "before the first item in the result set" (i.e., effectively an index of negative one).</p>
+    <p class="caption">Example 5. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">first</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">follows</span> the item that the requesting entity indicated in the &lt;after/&gt; element:</p>
+    <p class="caption">Example 6. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">It may sometimes be necessary to return an empty <span style="font-style: italic">page</span> to the requesting entity. For example, with dynamic result sets the responding entity MAY delete some items from the full result set between requests. Another example occurs when the requesting entity specifies "0" for the maximum number items to return (see <a href="#count">Getting the Item Count</a>).</p>
+    <p class="caption">Example 7. Returning an Empty Page</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page80'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;790&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there are no items whatsoever in the <span style="font-style: italic">full</span> result set, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search", "http://jabber.org/protocol/disco#items", or "http://jabber.org/protocol/pubsub"). For both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity shall return an empty &lt;query/&gt; element; for <span style="font-weight: bold">JEP-0060</span>, that means the responding entity shall return an empty &lt;pubsub/&gt; element; for <span style="font-weight: bold">JEP-0136</span>, that means the responding entity shall return an empty &lt;list/&gt; or &lt;store/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="backwards">Paging Backwards Through a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the previous page in a result set by including in its request the UID of the <span style="font-style: italic">first</span> item from the page that has already been received (encapsulated in a &lt;before/&gt; element), along with the maximum number of items to return.</p>
+    <p class="caption">Example 8. Requesting the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before&gt;peter@pixyland.org&lt;/before&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The <span style="font-style: italic">last</span> item in the page returned by the responding entity MUST be the item that immediately <span style="font-style: italic">preceeds</span> the item that the requesting entity indicated it has already received:</p>
+    <p class="caption">Example 9. Returning the Previous Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='back1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;stpeter@jabber.org&lt;/first&gt;
+      &lt;last&gt;peterpan@neverland.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="notfound">Page Not Found</a>
+</h3>
+    <p class="" style="">The responding entity MUST reply with an 'item-not-found' error if <span style="font-style: italic">all</span> the following circumstances apply:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The item specified by the requesting entity via the UID in the &lt;after/&gt; or &lt;before/&gt; element no longer exists (it was deleted after the previous page was sent).</p></li>
+      <li><p class="" style="">The UID itself cannot be used to derive directly the next item within the set (e.g. the alphabetical or numerical order of the UIDs do not specify the order of the items).</p></li>
+      <li><p class="" style="">The responding entity does not remember the position of the deleted item within the full list. (Even if the responding entity bothers to remember the position of each deleted item, it will typically be necessary to expire that 'state' after an implementation-specific period of time.)</p></li>
+    </ol>
+    <p class="caption">Example 10. Returning a Page-Not-Found Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="last">Requesting the Last Page in a Result Set</a>
+</h3>
+    <p class="" style="">The requesting entity MAY ask for the last page in a result set by including in its request an empty &lt;before/&gt; element, and the maximum number of items to return.</p>
+    <p class="caption">Example 11. Requesting the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;before/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="jump">Retrieving a Page Out of Order</a>
+</h3>
+    <p class="" style="">The requesting entity MAY choose not to retrieve pages from the result set in order. (For example, when its user drags a user-interface slider to a radically new position within a very large result set.)</p>
+    <p class="" style="">Only if the UID before the start (or after the end) of a desired result set page is not known, then the requesting entity MAY request the page that <span style="font-style: italic">starts</span> at a particular index within the result set. It does that by including in its request the index of the <span style="font-style: italic">first</span> item to be returned (encapsulated in an &lt;index/&gt; element), as well as the maximum number of items to return. Note: For reasons mentioned in <a href="#forwards">Paging Forwards Through a Result Set</a> requesting entities SHOULD, where possible, specify pages using a UID instead of an index.</p>
+    <p class="" style="">Note: If the responding entity omitted the &lt;count/&gt; element from previous responses for this result set, then the requesting entity SHOULD assume that the responding entity does not support page retrieval by index for this result set (see error below).</p>
+    <p class="caption">Example 12. Requesting a Result Page by Index</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;index&gt;371&lt;/index&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity SHOULD derive the first UID from the specified index (the method used MAY be approximate) before returning the requested result set page in the normal way. If the specified index was "0" then the responding entity SHOULD derive the UID that is the first in the full result set.</p>
+    <p class="" style="">Note: The 'index' attribute of the &lt;first/&gt; element MUST be the same as the index specified in the request. If the index specified by the requesting entity is greater than or equal to the number of items in the full set then the responding entity MUST return an empty page (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+    <p class="caption">Example 13. Returning a Result Page at an Index</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='10'&gt;peter@pixyland.org&lt;/first&gt;
+      &lt;last&gt;peter@rabbit.lit&lt;/last&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If it would be either impossible or exceptionally resource intensive for the responding entity to derive the first UID from the specified index with reasonable accuracy then the responding entity MAY return a &lt;feature-not-implemented/&gt; error.</p>
+    <p class="caption">Example 14. Returning a Feature-not-Implemented Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='index10'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;index&gt;371&lt;/index&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.7 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity simply specifies zero for the maximum size of the result set page:</p>
+    <p class="caption">Example 15. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;nick&gt;Pete&lt;/nick&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;0&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise if determining the exact number of items would be resource-intensive:</p>
+    <p class="caption">Example 16. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;count&gt;800&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The &lt;count/&gt; element MAY be omitted, but <span style="font-style: italic">only</span> if it would be either impossible or exceptionally resource intensive to calculate reasonably accurate values.</p>
+    <p class="" style="">Note: If there are no items in the <span style="font-style: italic">full</span> result set then the responding entity MUST return a response that adheres to the definition of the wrapper protocol (see <a href="#forwards">Paging Forwards Through a Result Set</a>).</p>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set management in the context of <span style="font-weight: bold">Jabber Search</span>. In the following examples we show the use of this protocol in the context of <span style="font-weight: bold">Service Discovery</span>. <span style="font-weight: bold">JEP-0136</span> ("Message Archiving") includes more examples. A future version of this document may also include examples from <span style="font-weight: bold">Publish-Subscribe</span> and other XMPP protocol extensions.</p>
+  <p class="caption">Example 17. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 18. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apache@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;acc3594e844c77696f7a7ba9367ae324b6b958ad&lt;/first&gt;
+      &lt;last&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/last&gt;
+      &lt;count&gt;150&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 19. Requesting a Page Beginning After the Last Item Received</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;after&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set management, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 20. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 21. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">An entity SHOULD NOT include the result set management extensions defined in this document in its requests if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set management, it MUST ignore such extensions.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set management protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace, <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace, and <span style="font-weight: bold">JEP-0136</span> for the 'http://jabber.org/protocol/archive' namespace.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259080">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259132">7</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='after' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='before' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='count' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='first' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='index' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='last' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='first'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='index' type='xs:int' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Olivier Goffart, Jon Perlow, and Andrew Plotkin for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251064">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2251032">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257554">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257575">4</a>. JEP-0136: Message Archiving &lt;<a href="http://www.jabber.org/jeps/jep-0136.html">http://www.jabber.org/jeps/jep-0136.html</a>&gt;.</p>
+<p><a name="nt-id2257595">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259080">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259132">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.14 (2006-09-13)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology and corrected several examples.</p> (ip)
+    </div>
+<h4>Version 0.13 (2006-09-07)</h4>
+<div class="indent">
+<p class="" style="">Reverted to v0.11 with slight wording changes.</p> (ip/psa)
+    </div>
+<h4>Version 0.12 (2006-09-06)</h4>
+<div class="indent">
+<p class="" style="">Added index attribute to before element; removed index element (use after or before instead).</p> (psa/vm)
+    </div>
+<h4>Version 0.11 (2006-08-25)</h4>
+<div class="indent">
+<p class="" style="">Made count and index optional, changed protocol for getting count, more clarifications and examples.</p> (ip)
+    </div>
+<h4>Version 0.10 (2006-08-24)</h4>
+<div class="indent">
+<p class="" style="">Added before and first elements, specified how to return an empty page and how to request the last page, removed reverse order sets, added out-of-order page access.</p> (ip)
+    </div>
+<h4>Version 0.9 (2006-08-23)</h4>
+<div class="indent">
+<p class="" style="">Eliminated static result sets, justified expanded and clarified dynamic result sets, added page-not-found error, described when minimal state is necessary, added reverse order sets.</p> (ip)
+    </div>
+<h4>Version 0.8 (2006-08-22)</h4>
+<div class="indent">
+<p class="" style="">Added optional method for handling dynamic result sets.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-08-10)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.2.html
+++ b/content/xep-0059-0.2.html
@@ -1,0 +1,306 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Manipulation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Manipulation">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines an XMPP extension to enable more advanced search functionality.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Manipulation</h1>
+<p>This document defines an XMPP extension to enable more advanced search functionality.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0059<br>
+            Version: 0.2<br>
+            Last Updated: 2005-12-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Manipulation%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Manipulation (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jls@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#count">Getting the Item Count</a>
+</dt>
+<dt>2.2.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#page">Paging Through a Result Set</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>5.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>6.  <a href="#schema">Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In both <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251461">1</a>] and <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2251482">2</a>], it is possible to receive large result sets in response to information requests (e.g., a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2251506">3</a>] service or a user directory search on a common first name). Thus it would be helpful to define a protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of an actual result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity specifies a request type of "count":</p>
+    <p class="caption">Example 1. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count:</p>
+    <p class="caption">Example 2. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;866&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set:</p>
+    <p class="caption">Example 3. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 4. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="page">Paging Through a Result Set</a>
+</h3>
+    <p class="" style="">In order to page through a result set, the requesting entity specifies a request type of "set" as well as the item to start with (initially "0") as well as the maximum number of items to return:</p>
+    <p class="caption">Example 5. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the first page of the result set:</p>
+    <p class="caption">Example 6. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the requesting entity can then ask for the next page in the result set:</p>
+    <p class="caption">Example 7. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the first page of the result set:</p>
+    <p class="caption">Example 8. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;peterpan&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;prabbit&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">To be defined.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250770">4</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250824">5</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>6.
+       <a name="schema">Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='count' type='xs:string'/&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='1' maxOccurs='1'/&gt;
+        &lt;xs:element name='start' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251461">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251482">2</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2251506">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2250770">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2250824">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema. (psa)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">Initial version. (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.3.html
+++ b/content/xep-0059-0.3.html
@@ -1,0 +1,423 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Manipulation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Manipulation">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines an XMPP extension to enable more advanced search functionality.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Manipulation</h1>
+<p>This document defines an XMPP extension to enable more advanced search functionality.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0059<br>
+            Version: 0.3<br>
+            Last Updated: 2006-04-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Manipulation%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Manipulation (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#count">Getting the Item Count</a>
+</dt>
+<dt>2.2.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#page">Paging Through a Result Set</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In both <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250699">1</a>] and <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251010">2</a>], it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250858">3</a>] service). Thus it would be helpful to define a protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of an actual result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity specifies a request type of "count":</p>
+    <p class="caption">Example 1. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count:</p>
+    <p class="caption">Example 2. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;866&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set:</p>
+    <p class="caption">Example 3. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 4. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="page">Paging Through a Result Set</a>
+</h3>
+    <p class="" style="">In order to page through a result set, the requesting entity specifies a request type of "set" as well as the item to start with (initially "0") as well as the maximum number of items to return:</p>
+    <p class="caption">Example 5. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the first page of the result set:</p>
+    <p class="caption">Example 6. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the requesting entity can then ask for the next page in the result set:</p>
+    <p class="caption">Example 7. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the second page of the result set:</p>
+    <p class="caption">Example 8. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;peterpan&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;prabbit&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the result set contains the last items that meet the provided criteria, the responding entitity SHOULD include an empty &lt;end/&gt; element:</p>
+    <p class="caption">Example 9. Returning the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='lastpage'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    [the last items]
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+      &lt;end/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set manipulation in the context of <span style="font-weight: bold">JEP-0055: Jabber Search.</span>. Therefore in the following examples we show the use of result set manipulation in the context of <span style="font-weight: bold">JEP-0030: Service Discovery</span>.</p>
+  <p class="caption">Example 10. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 11. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;123&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 12. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 13. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apatche@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set manipulation, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 14. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 15. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set manipulation extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set manipulation, it MUST ignore the extension.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no known security issues related to this protocol.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257174">4</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257225">5</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='count' type='xs:string'/&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='1' maxOccurs='1'/&gt;
+        &lt;xs:element name='start' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='end' type='empty' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250699">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2251010">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250858">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257174">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257225">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.4.html
+++ b/content/xep-0059-0.4.html
@@ -1,0 +1,441 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Manipulation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Manipulation">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines an XMPP extension to enable more advanced search functionality.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Manipulation</h1>
+<p>This document defines an XMPP extension to enable more advanced search functionality.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0059<br>
+            Version: 0.4<br>
+            Last Updated: 2006-04-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Manipulation%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Manipulation (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#count">Getting the Item Count</a>
+</dt>
+<dt>2.2.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#page">Paging Through a Result Set</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>10.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In both <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250723">1</a>] and <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251035">2</a>], it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250872">3</a>] service). Thus it would be helpful to define a protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of an actual result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity specifies a request type of "count":</p>
+    <p class="caption">Example 1. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 2. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set:</p>
+    <p class="caption">Example 3. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 4. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="page">Paging Through a Result Set</a>
+</h3>
+    <p class="" style="">In order to page through a result set, the requesting entity specifies a request type of "set" as well as the item to start with (initially "0") as well as the maximum number of items to return:</p>
+    <p class="caption">Example 5. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the first page of the result set:</p>
+    <p class="caption">Example 6. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As shown in the previous example, the responding entity MAY include the item count with the first result set (or any future result set, although returning the count with the first result set is probably most helpful).</p>
+    <p class="" style="">Naturally, the requesting entity can then ask for the next page in the result set:</p>
+    <p class="caption">Example 7. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the second page of the result set:</p>
+    <p class="caption">Example 8. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;peterpan&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;prabbit&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the result set contains the last items that meet the provided criteria, the responding entitity SHOULD include an empty &lt;end/&gt; element:</p>
+    <p class="caption">Example 9. Returning the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='lastpage'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    [the last items]
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+      &lt;end/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set manipulation in the context of <span style="font-weight: bold">JEP-0055: Jabber Search.</span>. Therefore in the following examples we show the use of result set manipulation in the context of <span style="font-weight: bold">JEP-0030: Service Discovery</span>.</p>
+  <p class="caption">Example 10. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 11. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;150&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 12. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 13. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apatche@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set manipulation, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 14. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 15. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set manipulation extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set manipulation, it MUST ignore the extension.</p>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">If a search is performed over a live store (e.g., a list of chatrooms, where new rooms can be created while a search is ongoing), the number of items in the result set might change between between any two pages. One possible way to handle this is for the responding entity to send some state to the requesting entity in each response, which the requesting entity sends back with each subsequent request. Methods for doing so are currently out of scope but may addressed in a future version of this specification.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no known security issues related to this protocol.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257246">4</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257298">5</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='count' type='xs:string'/&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='1' maxOccurs='1'/&gt;
+        &lt;xs:element name='start' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='end' type='empty' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>10.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Valerie Mercier and Jon Perlow for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250723">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2251035">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250872">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257246">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257298">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.5.html
+++ b/content/xep-0059-0.5.html
@@ -1,0 +1,456 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Manipulation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Manipulation">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines an XMPP extension to enable more advanced search functionality.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-05-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Manipulation</h1>
+<p>This document defines an XMPP extension to enable more advanced search functionality.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.5<br>
+            Last Updated: 2006-05-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Manipulation%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Manipulation (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#count">Getting the Item Count</a>
+</dt>
+<dt>2.2.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#page">Paging Through a Result Set</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>10.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In both <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250768">1</a>] and <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250786">2</a>], it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250808">3</a>] service). Thus it would be helpful to define a protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of an actual result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity specifies a request type of "count":</p>
+    <p class="caption">Example 1. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 2. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no items match, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search" or "http://jabber.org/protocol/disco#items"); for both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity MUST return an empty &lt;query/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set:</p>
+    <p class="caption">Example 3. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 4. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="page">Paging Through a Result Set</a>
+</h3>
+    <p class="" style="">In order to page through a result set, the requesting entity specifies a request type of "set" as well as the item to start with (initially "0") as well as the maximum number of items to return:</p>
+    <p class="caption">Example 5. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the first page of the result set:</p>
+    <p class="caption">Example 6. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As shown in the previous example, the responding entity MAY include the item count with the first result set (or any future result set, although returning the count with the first result set is probably most helpful).</p>
+    <p class="" style="">Naturally, the requesting entity can then ask for the next page in the result set:</p>
+    <p class="caption">Example 7. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the second page of the result set:</p>
+    <p class="caption">Example 8. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;peterpan&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;prabbit&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the result set contains the last items that meet the provided criteria, the responding entitity SHOULD include an empty &lt;end/&gt; element:</p>
+    <p class="caption">Example 9. Returning the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='lastpage'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    [the last items]
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+      &lt;end/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set manipulation in the context of <span style="font-weight: bold">JEP-0055: Jabber Search.</span>. Therefore in the following examples we show the use of result set manipulation in the context of <span style="font-weight: bold">JEP-0030: Service Discovery</span>.</p>
+  <p class="caption">Example 10. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 11. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;150&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 12. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 13. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apatche@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set manipulation, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 14. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 15. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set manipulation extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set manipulation, it MUST ignore the extension.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set manipulation protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">If a search is performed over a live store (e.g., a list of chatrooms, where new rooms can be created while a search is ongoing), the number of items in the result set might change between between any two pages. One possible way to handle this is for the responding entity to send some state to the requesting entity in each response, which the requesting entity sends back with each subsequent request. Methods for doing so are currently out of scope but may addressed in a future version of this specification.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace and <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259831">4</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259882">5</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='count' type='xs:string'/&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='1' maxOccurs='1'/&gt;
+        &lt;xs:element name='start' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='end' type='empty' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>10.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jon Perlow for his feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250768">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2250786">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250808">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259831">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259882">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.7.html
+++ b/content/xep-0059-0.7.html
@@ -1,0 +1,466 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Management">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines an XMPP extension to enable entities to page through and otherwise manage the receipt of large result sets.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Management</h1>
+<p>This document defines an XMPP extension to enable entities to page through and otherwise manage the receipt of large result sets.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.6<br>
+            Last Updated: 2006-07-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Management%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Management (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#count">Getting the Item Count</a>
+</dt>
+<dt>2.2.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#page">Paging Through a Result Set</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>10.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250787">1</a>], <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250811">2</a>], <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250833">3</a>], and perhaps other future XMPP extensions, it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2251025">4</a>] service). Thus it would be helpful to define an XMPP protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of a result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity specifies a request type of "count":</p>
+    <p class="caption">Example 1. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 2. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no items match, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search", "http://jabber.org/protocol/disco#items", or "http://jabber.org/protocol/pubsub"). For both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity shall return an empty &lt;query/&gt; element; for <span style="font-weight: bold">JEP-0060</span>, that means the responding entity shall return an empty &lt;pubsub/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set:</p>
+    <p class="caption">Example 3. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 4. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="page">Paging Through a Result Set</a>
+</h3>
+    <p class="" style="">In order to page through a result set, the requesting entity specifies a request type of "set" as well as the item to start with (initially "0") as well as the maximum number of items to return:</p>
+    <p class="caption">Example 5. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the first page of the result set:</p>
+    <p class="caption">Example 6. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='pgmillard@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Millard&lt;/last&gt;
+      &lt;nick&gt;pgmillard&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;0&lt;/start&gt;
+    &lt;/set&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As shown in the previous example, the responding entity MAY include the item count with the first result set (or any future result set, although returning the count with the first result set is probably most helpful).</p>
+    <p class="" style="">Naturally, the requesting entity can then ask for the next page in the result set:</p>
+    <p class="caption">Example 7. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the second page of the result set:</p>
+    <p class="caption">Example 8. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;peterpan&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;prabbit&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the result set contains the last items that meet the provided criteria, the responding entitity SHOULD include an empty &lt;end/&gt; element:</p>
+    <p class="caption">Example 9. Returning the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='lastpage'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    [the last items]
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;start&gt;10&lt;/start&gt;
+      &lt;end/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set management in the context of <span style="font-weight: bold">JEP-0055: Jabber Search.</span>. Therefore in the following examples we show the use of result set management in the context of <span style="font-weight: bold">JEP-0030: Service Discovery</span>. A future version of this document may also include examples from <span style="font-weight: bold">JEP-0060: Publish-Subscribe</span>.</p>
+  <p class="caption">Example 10. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 11. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;150&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 12. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 13. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apatche@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set management, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 14. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 15. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set management extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set management, it MUST ignore the extension.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set management protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">The set of items that match a query may change over time, even during the time that a requesting entity pages through a result set (e.g., a set of chatrooms, since rooms can be created and destroyed at any time). A responding entity implementation could handle this state of affairs in one of two ways:</p>
+  <ol start="" type="">
+    <li><p class="" style="">Establish a "static" result set associated with the request and enable the requesting entity to page through that static result set. This has the benefit of never returning a duplicate item, but may not produce up-to-date results and may place an additional burden on the responding entity.</p></li>
+    <li><p class="" style="">Whenever the requesting entity requests another page, generate a new "dynamic" result set and return the appropriate page from that dynamic result set. This has the benefit of producing up-to-date results, but may return duplicate items.</p></li>
+  </ol>
+  <p class="" style="">An implementation may use either of these approaches.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace and <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259844">5</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259895">6</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='count' type='xs:string'/&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='1' maxOccurs='1'/&gt;
+        &lt;xs:element name='start' type='xs:int' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='end' type='empty' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>10.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jon Perlow for his feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250787">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2250811">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250833">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251025">4</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259844">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259895">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.8.html
+++ b/content/xep-0059-0.8.html
@@ -1,0 +1,529 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Management">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Management</h1>
+<p>This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.8<br>
+            Last Updated: 2006-08-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Management%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Management (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#count">Getting the Item Count</a>
+</dt>
+<dt>2.2.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#page">Paging Through a Result Set</a>
+</dt>
+<dt>2.4.  <a href="#dynamic">Handling Dynamic Result Sets</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250826">1</a>], <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250989">2</a>], <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2251011">3</a>], and perhaps other future XMPP extensions, it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2251031">4</a>] service). Thus it would be helpful to define an XMPP protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of a result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity specifies a request type of "count":</p>
+    <p class="caption">Example 1. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 2. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no items match, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search", "http://jabber.org/protocol/disco#items", or "http://jabber.org/protocol/pubsub"). For both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity shall return an empty &lt;query/&gt; element; for <span style="font-weight: bold">JEP-0060</span>, that means the responding entity shall return an empty &lt;pubsub/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set (via XML character data of  the &lt;max/&gt; element):</p>
+    <p class="caption">Example 3. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 4. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;petie&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="page">Paging Through a Result Set</a>
+</h3>
+    <p class="" style="">In order to page through a result set, the requesting entity specifies a request type of "set" as well as the item after which the page shall start (which defaults to "0") and the maximum number of items to return:</p>
+    <p class="caption">Example 5. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the first page of the result set:</p>
+    <p class="caption">Example 6. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;petie&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As shown in the previous example, the responding entity MAY include the item count with the first result set (or any future result set, although returning the count with the first result set is probably most helpful).</p>
+    <p class="" style="">Naturally, the requesting entity can then ask for the next page in the result set:</p>
+    <p class="caption">Example 7. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the second page of the result set:</p>
+    <p class="caption">Example 8. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;peterpan&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;prabbit&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the result set contains the last items that meet the provided criteria, the responding entitity SHOULD include an empty &lt;end/&gt; element:</p>
+    <p class="caption">Example 9. Returning the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='lastpage'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    [the last items]
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;end/&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="dynamic">Handling Dynamic Result Sets</a>
+</h3>
+    <p class="" style="">The set of items that match a query may change over time, even during the time that a requesting entity pages through a result set (e.g., a set of chatrooms, since rooms can be created and destroyed at any time). By following the method outlined in this section, a responding entity implementation can make it more likely that the requesting entity will receive up-to-date search results and not receive duplicate items. (Note: Support for this method is OPTIONAL.)</p>
+    <p class="" style="">First, in the result set it returns, the responding entity includes a &lt;last/&gt; element that specifies a unique ID (UID) for the last item in the result set. The responding entity can generate this UID in any way, as long as the ID is unique in the context of the full result set; one possible method, shown below, is to serialize the XML of the last item in the result set and then hash it according to the SHA-1 algorithm (see <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2259866">5</a>]).</p>
+    <p class="caption">Example 10. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apache@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;last&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/last&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity cares about receiving up-to-date results and not receiving duplicate items, it can then specify the UID of the last item as the XML character data of an &lt;after/&gt; element in its next request:</p>
+    <p class="caption">Example 11. Requesting a Page Beginning After the Last Item Received</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;after&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then MUST begin the next page in the result set with the item that follows the last item received by the requesting entity.</p>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set management in the context of <span style="font-weight: bold">JEP-0055: Jabber Search.</span>. Therefore in the following examples we show the use of result set management in the context of <span style="font-weight: bold">JEP-0030: Service Discovery</span>. A future version of this document may also include examples from <span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> and other XMPP protocol extensions.</p>
+  <p class="caption">Example 12. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 13. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;150&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 14. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 15. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apache@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;last&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/last&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 16. Requesting a Page Beginning After the Last Item Received</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;after&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set management, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 17. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 18. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set management extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set management, it MUST ignore the extension.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set management protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace and <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260171">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260222">7</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='count' type='xs:string'/&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='1' maxOccurs='1'/&gt;
+        &lt;xs:choice minOccurs='0' maxOccurs='1'/&gt;
+          &lt;xs:element name='last' type='xs:string'/&gt;
+          &lt;xs:element name='after' type='xs:string'/&gt;
+          &lt;xs:element name='end' type='empty'/&gt;
+        &lt;/xs:choice&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Ian Paterson, Jon Perlow, and Andrew Plotkin for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250826">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2250989">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251011">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251031">4</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259866">5</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2260171">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260222">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2006-08-22)</h4>
+<div class="indent">
+<p class="" style="">Added optional method for handling dynamic result sets.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-08-10)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0059-0.9.html
+++ b/content/xep-0059-0.9.html
@@ -1,0 +1,530 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0059: Result Set Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Result Set Management">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-23">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0059">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0059: Result Set Management</h1>
+<p>This document defines an XMPP protocol extension to enable entities to page through and otherwise manage the receipt of large result sets.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0059<br>
+            Version: 0.9<br>
+            Last Updated: 2006-08-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rsm<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Result%20Set%20Management%20(JEP-0059)">http://wiki.jabber.org/index.php/Result Set Management (JEP-0059)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jls@antepo.com">jls@antepo.com</a><br>
+        JID: 
+        <a href="xmpp:jlseguineau@im.antepo.com">jlseguineau@im.antepo.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#count">Getting the Item Count</a>
+</dt>
+<dt>2.2.  <a href="#limit">Limiting the Size of a Result Set</a>
+</dt>
+<dt>2.3.  <a href="#page">Paging Through a Result Set</a>
+</dt>
+<dt>2.4.  <a href="#reverse">Requesting a Result Set in Reverse Order</a>
+</dt>
+</dl>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dt>4.  <a href="#disco">Determining Support</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2250863">1</a>], <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250886">2</a>], <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250908">3</a>], <span class="ref" style="">Message Archiving</span>  [<a href="#nt-id2250928">4</a>], and perhaps other future XMPP extensions, it is possible to receive large result sets in response to information requests (e.g., a user directory search on a common first name or a service discovery items request sent to a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250949">5</a>] service). Thus it would be helpful to define an XMPP protocol extension that enables the following functionality:</p>
+  <ol start="" type="">
+    <li>Discover the size of a potential result set without retrieving the items themselves.</li>
+    <li>Limit the size of a result set.</li>
+    <li>Page through a result set by retrieving the items in smaller subsets.</li>
+  </ol>
+  <p class="" style="">This document defines just such a protocol extension.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="count">Getting the Item Count</a>
+</h3>
+    <p class="" style="">In order to get the item count of a result set without retrieving the items themselves, the requesting entity specifies a request type of "count":</p>
+    <p class="caption">Example 1. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns the item count, which MAY be approximate rather than precise (since determining the exact number of items may be resource-intensive):</p>
+    <p class="caption">Example 2. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='count1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no items match, the responding entity MUST return a response that adheres to the definition of the wrapper protocol (e.g., "jabber:iq:search", "http://jabber.org/protocol/disco#items", or "http://jabber.org/protocol/pubsub"). For both <span style="font-weight: bold">JEP-0055</span> and <span style="font-weight: bold">JEP-0030</span>, that means the responding entity shall return an empty &lt;query/&gt; element; for <span style="font-weight: bold">JEP-0060</span>, that means the responding entity shall return an empty &lt;pubsub/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="limit">Limiting the Size of a Result Set</a>
+</h3>
+    <p class="" style="">In order to limit the number of items to be returned in a result set, the requesting entity specifies a request type of "set" and the maximum size of the desired result set (via XML character data of  the &lt;max/&gt; element):</p>
+    <p class="caption">Example 3. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity then returns a result set limited to the requested size:</p>
+    <p class="caption">Example 4. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='limit1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;petie&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="page">Paging Through a Result Set</a>
+</h3>
+    <p class="" style="">Note: The set of items that match a query MAY change over time, even during the time that a requesting entity pages through a result set (e.g., a set of chatrooms, since rooms can be created and destroyed at any time). The paging protocol outlined in this section is designed to make the following features <span style="font-style: italic">possible</span>:  [<a href="#nt-id2259756">6</a>]</p>
+    <ul>
+      <li>Each result page is up-to-date at the time it is sent (not just at the time the first page was sent).</li>
+      <li>No items will be omitted from pages not yet sent (even if, after earlier pages were sent, some of the items they contained were removed from the set).</li>
+      <li>Duplicate items are never received.</li>
+      <li>Responding entity maintains no state (or a single minimal state for all requestors containing the positions of all recently deleted items).</li>
+      <li>Rapid calculation of which items should appear on a requested page by responding entity (even for large result sets).</li>
+    </ul>
+    <p class="" style="">The request for the first page is the same as when <a href="#limit">Limiting the Size of a Result Set</a>:</p>
+    <p class="caption">Example 5. Requesting the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Responding entity support for paging through a result set is optional. If it does support paging (not just <a href="#limit">Limiting the Size of a Result Set</a>), then in each result set it returns, the responding entity MUST include a &lt;last/&gt; element that specifies a unique ID (UID) for the <span style="font-style: italic">last</span> item in the page. The responding entity can generate this UID in any way, as long as the UID is unique in the context of all possible members of the full result set. The UID MAY be based on part of the content of the last item, as shown below, or on an internal table index. Another possible method is to serialize the XML of the last item in the result set and then hash it to generate the UID. Note: The requesting entity MUST treat all UIDs as opaque.</p>
+    <p class="caption">Example 6. Returning the First Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page1'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='stpeter@jabber.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Saint-Andre&lt;/last&gt;
+      &lt;nick&gt;stpeter&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peterpan@neverland.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;petie&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;last xmlns='http://jabber.org/protocol/rsm'&gt;peterpan@neverland.lit&lt;/last&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;800&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As shown in the previous example, the responding entity MAY include the item count with the first result set (or any future result set, although returning the count with the first result set is probably most helpful).</p>
+    <p class="" style="">The requesting entity can then ask for the next page in the result set by including in its request the UID of the last item from the previous page (encapsulated in an &lt;after/&gt; element), and the maximum number of items to return. Note: if no &lt;after/&gt; element is specified then the UID defaults to "before the first item in the result set".</p>
+    <p class="caption">Example 7. Requesting the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity MUST begin the next page in the result set with the item that <span style="font-style: italic">follows</span> the item that the requesting entity indicated it has already received:</p>
+    <p class="caption">Example 8. Returning the Second Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;item jid='peter@pixyland.org'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Pan&lt;/last&gt;
+      &lt;nick&gt;peterpan&lt;/nick&gt;
+    &lt;/item&gt;
+    .
+    [8 more items]
+    .
+    &lt;item jid='peter@rabbit.lit'&gt;
+      &lt;first&gt;Peter&lt;/first&gt;
+      &lt;last&gt;Rabbit&lt;/last&gt;
+      &lt;nick&gt;prabbit&lt;/nick&gt;
+    &lt;/item&gt;
+    &lt;last xmlns='http://jabber.org/protocol/rsm'&gt;'peter@rabbit.lit&lt;/last&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the result set contains the last items that meet the provided criteria, the responding entitity SHOULD include an empty &lt;end/&gt; element. In this case, it MAY omit the &lt;last/&gt; element:</p>
+    <p class="caption">Example 9. Returning the Last Page of a Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='lastpage'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    [the last items]
+    &lt;end xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The responding entity MUST reply with an 'item-not-found' error if <span style="font-style: italic">all</span> the following circumstances apply:</p>
+    <ol start="" type="">
+      <li>The item specified by the requesting entity via the UID in the &lt;after/&gt; element no longer exists (it was deleted after the previous page was sent)</li>
+      <li>The UID itself cannot be used to derive directly the next item within the set (e.g. the alphabetical or numerical order of the UIDs do not specify the order of the items)</li>
+      <li>The responding entity does not remember the position of the deleted item within the full list. (Even if the responding entity bothers to remember the position of each deleted item, it will typically be necessary to expire that 'state' after an implementation-specific period of time)</li>
+    </ol>
+    <p class="caption">Example 10. Returning a Page-not-Found Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='users.jabber.org' to='stpeter@jabber.org/roundabout' id='page2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;peterpan@neverland.lit&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="reverse">Requesting a Result Set in Reverse Order</a>
+</h3>
+    <p class="" style="">If the requesting entity wants to receive the items of a results set in reverse order then it MUST include an empty &lt;reverse/&gt; element in <span style="font-style: italic">every</span> page request.</p>
+    <p class="caption">Example 11. Requesting a Page from a Reverse Order Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='users.jabber.org' id='reverse2'&gt;
+  &lt;query xmlns='jabber:iq:search'&gt;
+    &lt;first&gt;Peter&lt;/first&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;reverse/&gt;
+      &lt;max&gt;10&lt;/max&gt;
+      &lt;after&gt;stpeter@heaven.com&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The foregoing examples show the use of result set management in the context of <span style="font-weight: bold">Jabber Search.</span>. Therefore in the following examples we show the use of result set management in the context of <span style="font-weight: bold">Service Discovery</span>. A future version of this document may also include examples from <span style="font-weight: bold">Publish-Subscribe</span> and <span style="font-weight: bold">Message Archiving</span> and other XMPP protocol extensions.</p>
+  <p class="caption">Example 12. Requesting the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 13. Returning the Item Count</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;count xmlns='http://jabber.org/protocol/rsm'&gt;150&lt;/count&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 14. Requesting a Limit to the Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 15. Returning a Limited Result Set</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='conference.jabber.org' to='stpeter@jabber.org/roundabout' id='ex2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='12@conference.jabber.org'/&gt;
+    &lt;item jid='adium@conference.jabber.org'/&gt;
+    &lt;item jid='airhitch@conference.jabber.org'/&gt;
+    &lt;item jid='alphaville@conference.jabber.org'/&gt;
+    &lt;item jid='apache@conference.jabber.org'/&gt;
+    &lt;item jid='argia@conference.jabber.org'/&gt;
+    &lt;item jid='armagetron@conference.jabber.org'/&gt;
+    &lt;item jid='atticroom123@conference.jabber.org'/&gt;
+    &lt;item jid='banquise@conference.jabber.org'/&gt;
+    &lt;item jid='bar_paradise@conference.jabber.org'/&gt;
+    &lt;item jid='beer@conference.jabber.org'/&gt;
+    &lt;item jid='blondie@conference.jabber.org'/&gt;
+    &lt;item jid='bpnops@conference.jabber.org'/&gt;
+    &lt;item jid='brasileiros@conference.jabber.org'/&gt;
+    &lt;item jid='bulgaria@conference.jabber.org'/&gt;
+    &lt;item jid='cantinalivre@conference.jabber.org'/&gt;
+    &lt;item jid='casablanca@conference.jabber.org'/&gt;
+    &lt;item jid='chinortpcrew@conference.jabber.org'/&gt;
+    &lt;item jid='coffeetalk@conference.jabber.org'/&gt;
+    &lt;item jid='council@conference.jabber.org'/&gt;
+    &lt;last xmlns='http://jabber.org/protocol/rsm'&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/last&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 16. Requesting a Page Beginning After the Last Item Received</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='stpeter@jabber.org/roundabout' to='conference.jabber.org' id='ex3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;20&lt;/max&gt;
+      &lt;after&gt;4da91d4b330112f683dddaebf93180b1bd25e95f&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="disco">Determining Support</a>
+</h2>
+  <p class="" style="">In order for a requesting entity to determine if a responding entity supports result set management, it SHOULD send a <span style="font-weight: bold">Service Discovery</span> information request to the responding entity:</p>
+  <p class="caption">Example 17. Requesting entity queries responding entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='stpeter@jabber.org/roundabout'
+    to='conference.jabber.org'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 18. Responding entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='conference.jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rsm'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">A requesting entity SHOULD NOT include result set management extensions if it does not have positive knowledge that the responding entity supports the protocol defined herein. If the responding entity does not understand result set management, it MUST ignore the extension.</p>
+  <p class="" style="">Note: Even if a responding entity understands the result set management protocol, its support for result set management in the context of any given using protocol is OPTIONAL (e.g., an implementation could support it in the context of the 'jabber:iq:search' namespace but not in the context of the 'http://jabber.org/protocol/disco#items' namespace). Currently the only way for a requesting entity to determine if a responding entity supports result set management in the context of a given using protocol is to include result set management extensions in its request. If the responding entity does not include result set management extensions in its response, then the requesting entity SHOULD NOT include such extensions in future requests wrapped by the using protocol namespace.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using ("wrapper") protocol, such as <span style="font-weight: bold">JEP-0030</span> for the 'http://jabber.org/protocol/disco#items' namespace and <span style="font-weight: bold">JEP-0055</span> for the 'jabber:iq:search' namespace.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260431">7</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260478">8</a>] shall include 'http://jabber.org/protocol/rsm' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rsm'
+    xmlns='http://jabber.org/protocol/rsm'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='count' type='xs:string'/&gt;
+
+  &lt;xs:element name='end' type='empty'/&gt;
+
+  &lt;xs:element name='last' type='xs:string'/&gt;
+
+  &lt;xs:element name='set'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='max' type='xs:int' minOccurs='1' maxOccurs='1'/&gt;
+        &lt;xs:element name='after' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element name='reverse' type='empty' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jon Perlow and Andrew Plotkin for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250863">1</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2250886">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250908">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250928">4</a>. JEP-0136: Message Archiving &lt;<a href="http://www.jabber.org/jeps/jep-0136.html">http://www.jabber.org/jeps/jep-0136.html</a>&gt;.</p>
+<p><a name="nt-id2250949">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259756">6</a>. If a responding entity implements dynamic result sets then receiving entities should be aware that the complete result set received may not correspond to the result set as it existed at any one point in time.</p>
+<p><a name="nt-id2260431">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260478">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2006-08-23)</h4>
+<div class="indent">
+<p class="" style="">Eliminated static result sets, justified expanded and clarified dynamic result sets, added page-not-found error, described when minimal state is necessary, added reverse order sets.</p> (ip)
+    </div>
+<h4>Version 0.8 (2006-08-22)</h4>
+<div class="indent">
+<p class="" style="">Added optional method for handling dynamic result sets.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-08-10)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated implementation note to clarify handling of result sets (static vs. dynamic).</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-05-02)</h4>
+<div class="indent">
+<p class="" style="">Clarified error handling, determination of support in the context of using protocols, and security considerations.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-04-24)</h4>
+<div class="indent">
+<p class="" style="">Specified that an item count may be approximate; specified that an item count may be returned with a page of results.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added &lt;end/&gt; element to specify last result set; added service discovery information; added more examples.</p> (psa/vm)
+    </div>
+<h4>Version 0.2 (2005-12-22)</h4>
+<div class="indent">
+<p class="" style="">Revived and renamed the JEP; modified syntax; added use case for getting number of items; defined XML schema.</p> (psa/vm)
+    </div>
+<h4>Version 0.1 (2002-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jls)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0060-1.6.html
+++ b/content/xep-0060-1.6.html
@@ -1,0 +1,3858 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0060: Publish-Subscribe</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Publish-Subscribe">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Description" content="This JEP defines a generic publish/subscribe framework for use by Jabber entities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-07-13">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0060">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0060: Publish-Subscribe</h1>
+<p>This JEP defines a generic publish/subscribe framework for use by Jabber entities.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0060<br>
+            Version: 1.6<br>
+            Last Updated: 2004-07-13<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004, JEP-0030, JEP-0068, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pubsub<br>
+        Schema for pubsub: &lt;<a href="http://jabber.org/protocol/pubsub/pubsub.xsd">http://jabber.org/protocol/pubsub/pubsub.xsd</a>&gt;<br>
+        Schema for pubsub#event: &lt;<a href="http://jabber.org/protocol/pubsub/event.xsd">http://jabber.org/protocol/pubsub/event.xsd</a>&gt;<br>
+        Schema for pubsub#owner: &lt;<a href="http://jabber.org/protocol/pubsub/owner.xsd">http://jabber.org/protocol/pubsub/owner.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Millard</h3>
+<p class="indent">
+        Email: pgmillard@jabber.org<br>
+        JID: pgmillard@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-pubsub">Publish-Subscribe Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#addressing">Addressing</a>
+</dt>
+<dt>5.  <a href="#events">Event Types</a>
+</dt>
+<dt>6.  <a href="#affiliations">Affiliations</a>
+</dt>
+<dt>7.  <a href="#substates">Subscription States</a>
+</dt>
+<dt>8.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#entity">Entity Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.1.  <a href="#disco-service">Discover Service Features</a>
+</dt>
+<dt>8.1.2.  <a href="#entity-create">Create a New Node</a>
+</dt>
+<dt>8.1.3.  <a href="#entity-publish">Publish an Item to a Node</a>
+</dt>
+<dt>8.1.4.  <a href="#entity-delete">Delete an Item from a Node</a>
+</dt>
+<dt>8.1.5.  <a href="#entity-subscribe">Subscribe to a Node</a>
+</dt>
+<dt>8.1.6.  <a href="#entity-approve">Approving and Denying Subscription Requests</a>
+</dt>
+<dt>8.1.7.  <a href="#entity-request">Request Current Affiliations</a>
+</dt>
+<dt>8.1.8.  <a href="#entity-unsub">Unsubscribe from a Node</a>
+</dt>
+<dt>8.1.9.  <a href="#entity-configure">Configure Subscription Options</a>
+</dt>
+<dt>8.1.10.  <a href="#entity-getitems">Get Items for a Node</a>
+</dt>
+<dt>8.1.11.  <a href="#entity-discovernodes">Discover Nodes</a>
+</dt>
+<dt>8.1.12.  <a href="#metadata">Discover Node Meta-Data</a>
+</dt>
+<dt>8.1.13.  <a href="#entity-discoveritems">Discover Items for a Node</a>
+</dt>
+</dl>
+<dt>8.2.  <a href="#owner">Owner Use Cases</a>
+</dt>
+<dl>
+<dt>8.2.1.  <a href="#owner-configure">Configure a Node</a>
+</dt>
+<dt>8.2.2.  <a href="#owner-default">Request Default Configuration Options</a>
+</dt>
+<dt>8.2.3.  <a href="#owner-delete">Delete a Node</a>
+</dt>
+<dt>8.2.4.  <a href="#owner-purge">Purge All Node Items</a>
+</dt>
+<dt>8.2.5.  <a href="#owner-modify">Modifying Entity Affiliations</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#collections">Collection Nodes</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#collections-subscribe">Subscribing to a Collection Node</a>
+</dt>
+<dt>9.2.  <a href="#collections-root">Root Collection Node</a>
+</dt>
+<dt>9.3.  <a href="#collections-createnodes">Creating New Collection Nodes</a>
+</dt>
+<dt>9.4.  <a href="#collections-createaffil">Creating Nodes Affiliated with a Collection</a>
+</dt>
+<dt>9.5.  <a href="#collections-notify">Generating Publish Notifications for Collections</a>
+</dt>
+</dl>
+<dt>10.  <a href="#errors">Error Conditions</a>
+</dt>
+<dt>11.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#impl-presence">Presence-Based Delivery of Events</a>
+</dt>
+<dt>11.2.  <a href="#impl-offline">Not Sending Events to Offline Storage</a>
+</dt>
+<dt>11.3.  <a href="#impl-uniqueness">Node and Item ID Uniqueness</a>
+</dt>
+<dt>11.4.  <a href="#impl-authorize">Authorizing Subscription Requests (Pending Subscribers)</a>
+</dt>
+<dt>11.5.  <a href="#impl-hierarchies">Handling Node Hierarchies</a>
+</dt>
+<dt>11.6.  <a href="#impl-message">Message Bodies</a>
+</dt>
+<dt>11.7.  <a href="#impl-multiple">Multiple Node Discovery</a>
+</dt>
+<dt>11.8.  <a href="#impl-association">Associating Events and Payloads with the Generating Entity</a>
+</dt>
+<dt>11.9.  <a href="#impl-leases">Implementing Time-Based Subscriptions (Leases)</a>
+</dt>
+<dt>11.10.  <a href="#impl-content">Implementing Content-Based Pubsub Systems</a>
+</dt>
+</dl>
+<dt>12.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>13.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>14.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+<dt>14.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>14.4.  <a href="#registrar-formtypes">Field Standardization</a>
+</dt>
+<dl>
+<dt>14.4.1.  <a href="#registrar-formtypes-auth">pubsub#subscribe_authorization FORM_TYPE</a>
+</dt>
+<dt>14.4.2.  <a href="#registrar-formtypes-options">pubsub#subscribe_options FORM_TYPE</a>
+</dt>
+<dt>14.4.3.  <a href="#registrar-formtypes-config">pubsub#node_config FORM_TYPE</a>
+</dt>
+<dt>14.4.4.  <a href="#registrar-formtypes-metadata">pubsub#meta-data FORM_TYPE</a>
+</dt>
+</dl>
+<dt>14.5.  <a href="#registrar-shim">SHIM Headers</a>
+</dt>
+</dl>
+<dt>15.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#schemas-pubsub">http://jabber.org/protocol/pubsub</a>
+</dt>
+<dt>15.2.  <a href="#schemas-event">http://jabber.org/protocol/pubsub#event</a>
+</dt>
+<dt>15.3.  <a href="#schemas-owner">http://jabber.org/protocol/pubsub#owner</a>
+</dt>
+<dt>15.4.  <a href="#schemas-error">http://jabber.org/protocol/pubsub#errors</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+        <p class="" style="">As Jabber technologies have matured, the need for a generic publish-subscribe (&quot;pubsub&quot;) mechanism has arisen in a number of problem spaces. These include (but are not limited to): news feeds and content syndacation, avatar management, shared bookmarks, auction and trading systems, online catalogs, workflow systems, network management systems, NNTP gateways, vCard/profile management, and weblogs.</p>
+        <p class="" style="">In all of these domains, it is desirable for data communication to follow the classic &quot;publish-subscribe&quot; or &quot;observer&quot; design pattern: a person or application publishes information, and an event notification or the data itself is broadcasted to all authorized subscribers. In general, the relationship between the publisher and subscriber is mediated by a service that receives publication requests, broadcasts event notifications and/or the data itself to subscribers, and enables privileged entities to manage lists of people or applications that are authorized to publish or subscribe. In most pubsub services, the focal point for publication and subscription is a &quot;topic&quot; or &quot;node&quot; to which publishers send data and from which subscribers receive notifications and/or data. Additionally, some nodes may also maintain a history of events and provide other services that supplement the pure pubsub model.</p>
+        <p class="" style="">This Jabber Enhancement Proposal defines a single, cohesive, generic protocol which all forms of pubsub can utilize. While compliant implementations are not required to implement all of the features defined herein, this JEP documents most usages that may be requested of a pubsub service.</p>
+    <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+      <div class="indent">
+<h3>2.1 <a name="terms-pubsub">Publish-Subscribe Terms</a>
+</h3>
+        <p class="" style="">The following terms are used throughout this document to refer to elements, objects, or actions that occur in the context of a pubsub service.</p>
+        <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+<td align="" colspan="" rowspan="">Address</td>
+<td align="" colspan="" rowspan="">(1) A JID as defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2602244">1</a>], or (2) the combination of a JID and a <span class="ref">Service Discovery</span>  [<a href="#nt-id2602266">2</a>] node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Entity</td>
+<td align="" colspan="" rowspan="">A JID-addressable Jabber entity (client, service, application, etc.).</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Event</td>
+<td align="" colspan="" rowspan="">A change in the state of a node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Instant Node</td>
+<td align="" colspan="" rowspan="">A node whose NodeID is automatically generated by a pubsub service.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Item</td>
+<td align="" colspan="" rowspan="">An XML fragment which is published to a node, thereby generating an event.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">ItemID</td>
+<td align="" colspan="" rowspan="">A unique identifier for an item in the contect of a specific node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Node</td>
+<td align="" colspan="" rowspan="">A virtual location to which information can be published and from which event notifications and/or payloads can be received (in other pubsub systems, this may be labelled a &quot;topic&quot;).</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Leaf</td>
+<td align="" colspan="" rowspan="">A type of node that contains published items only. It is NOT a container for other nodes.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Collection</td>
+<td align="" colspan="" rowspan="">A type of node that contains nodes and/or other collections but no published items. Collections provide the foundation entity to provide a means of representing hierarchial node structures.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">NodeID</td>
+<td align="" colspan="" rowspan="">The unique identifier for a node within the context of a pubsub service.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Notification</td>
+<td align="" colspan="" rowspan="">A message sent to a subscriber informing them of an event.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Outcast</td>
+<td align="" colspan="" rowspan="">An entity that is disallowed from subscribing or publishing to a node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Owner</td>
+<td align="" colspan="" rowspan="">The creator and manager of a node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Payload</td>
+<td align="" colspan="" rowspan="">The full data associated with an event (e.g., an RSS feed) rather than just the event itself.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Private</td>
+<td align="" colspan="" rowspan="">A node to which subscriptions are limited by means of a whitelist.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Public</td>
+<td align="" colspan="" rowspan="">A node to which any entity may subscribe.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Publisher</td>
+<td align="" colspan="" rowspan="">An entity that is allowed to publish items to a node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Pubsub Service</td>
+<td align="" colspan="" rowspan="">An XMPP server or component that adheres to the protocol defined herein.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Subscriber</td>
+<td align="" colspan="" rowspan="">An entity that is subscribed to a node.</td>
+</tr>
+        </table>
+      </div>
+    <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+        <p class="" style="">Requirements for a pubsub service can be driven by end-user needs as well as the needs of other components and services which can use the service. First, a pubsub service implemented using Jabber MUST provide the basic features which implement a pure publish-subscribe pattern:</p>
+        
+        <ul>
+            <li>A Jabber entity MUST be able to publish events to a service such that all subscribers receive notification of the event.</li>
+            <li>Entities MUST be allowed to be affiliated with a node. Allowable affiliations are owner, publisher, none, and outcast. Implementations MUST support affiliations of owner and none, and MAY support affiliations of outcast and publisher.</li>
+            <li>Entities MUST be allowed to query the pubsub service to determine what optional features of this specification the service implements. This query MUST use the Service Discovery protocol.</li>
+            <li>Entities MUST be allowed to query a node to determine the meta-data for that node. This query MUST use the Service Discovery protocol.</li>
+        </ul>
+
+        
+        <p class="" style="">Some of the possible uses of a Jabber-based pubsub service will require other features, but these features are not mandatory for compliance with this specification. However, if these features are implemented, they MUST follow the protocol described herein to be compliant. These features include:</p>
+        <ul>
+            <li>If configuration of nodes is allowed, a node owner SHOULD be able to configure a node.</li>
+            <li>If configuration of subscription options is allowed, a subscriber SHOULD be able to configure the subscription options.</li>
+            <li>A node owner SHOULD be able to specify who may subscribe to a node.</li>
+            <li>A node owner SHOULD be able to specify who may publish to a node.</li>
+            <li>A node MAY be configured to deliver the published payload inside the event notification.</li>
+            <li>A node MAY be configured to persist published items to some persistent storage mechanism.</li>
+            <li>A node MAY be configured to persist only a limited number of items.</li>
+            <li>A node MAY be configured to deliver the last published item after a subscription is granted.</li>
+            <li>A service MAY support collections.</li>
+        </ul>
+
+    <h2>4.
+       <a name="addressing">Addressing</a>
+</h2>
+      <p class="" style="">If a pubsub node is addressable, it MUST be addressable either as (1) a JID or as (1) the combination of a JID and a Service Discovery node.</p>
+      <p class="" style="">If a pubsub node is addressable as a JID, the NodeID MUST be the resource identifier, and MUST NOT be specified by the &quot;user&quot; portion (node identifier) of the JID (e.g. &quot;domain/NodeID&quot; and &quot;user@domain/NodeID&quot; are allowed; &quot;NodeID@domain&quot; is not allowed). JID addressing SHOULD be used when interacting with a pubsub node using a protocol that does not support the node attribute. For example, when a service makes it possible for entities to subscribe nodes via presence, it would address nodes as JIDs.</p>
+      <p class="" style="">If a pubsub node is addressable as a Service Discovery node, the NodeID MUST be the value of both the Service Discovery 'node' attribute and the pubsub 'node' attribute (i.e., for discovery purposes, a pubsub node is equivalent to a Service Discovery node). Note: A pubsub service MAY enable entities to discover pubsub nodes (and items associated with such nodes) via Service Discovery, but this is OPTIONAL.</p>
+    <h2>5.
+       <a name="events">Event Types</a>
+</h2>
+        <p class="" style="">The requirements listed above imply that there are two major dimensions along which we can measure events: persistent vs. transient, and pure notification vs. inclusion of payload. An implementation SHOULD enable an owner to configure a node along both of these dimensions.</p>
+        <p class="" style="">A pubsub service MUST validate publish requests against the configuration of the node along both of these dimensions. See the <a href="#entity-publish">publish use-case</a> for specific error conditions based on a publish versus event-type mismatch. In addition, whether an item must be provided by the publisher, and whether an item ID is provided by the publisher or generated by the pubsub service, depends on the type of event being published. We can summarize the relevant rules as follows:</p>
+        <p class="caption">Table 2: Event Types, Items, and Item IDs</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+<th colspan="" rowspan="">--&gt;</th>
+<th colspan="" rowspan="">Notification</th>
+<th colspan="" rowspan="">Payload</th>
+</tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan=""><span style="font-weight: bold">Persistent</span></td>
+            <td align="" colspan="" rowspan="">Publisher MUST include an item element, which MAY be empty or contain a payload; if item ID is not provided by publisher, it MUST be generated by pubsub service</td>
+            <td align="" colspan="" rowspan="">Publisher MUST include an item element that contains the payload; if item ID is not provided by publisher, it MUST be generated by pubsub service</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan=""><span style="font-weight: bold">Transient</span></td>
+            <td align="" colspan="" rowspan="">Publisher MUST NOT include an item element (therefore item ID is neither provided nor generated)</td>
+            <td align="" colspan="" rowspan="">Publisher MUST include an item element that contains the payload, but the item ID is OPTIONAL</td>
+          </tr>
+        </table>
+    <h2>6.
+       <a name="affiliations">Affiliations</a>
+</h2>
+        <p class="" style="">To manage permissions, the protocol defined herein uses a hierarchy of affiliations, similiar to those introduced in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2603039">3</a>].</p>
+        <p class="caption">Table 3: Affiliations and their Privileges</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+            <th colspan="" rowspan="">Affiliation</th>
+            <th colspan="" rowspan="">Subscribe</th>
+            <th colspan="" rowspan="">Publish Items</th>
+            <th colspan="" rowspan="">Purge Items</th>
+            <th colspan="" rowspan="">Configure Node</th>
+            <th colspan="" rowspan="">Delete Node</th>
+            <th colspan="" rowspan="">Delete Item</th>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Owner</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Publisher</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">Yes/No</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">None</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Outcast</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+		    <td align="" colspan="" rowspan="">No</td>
+          </tr>
+        </table>
+        <p class="" style="">Pubsub services MAY allow any publisher to delete any item once it has been published to that node instead of allowing only the original publisher to remove it (this is disoverable via the &quot;pubsub#delete-any&quot; feature. If a publisher is not allowed to delete an item, the service MUST bounce the request using a &lt;not-authorized/&gt; error.</p>
+        <p class="" style="">Any Jabber entity which is currently subscribed to a node may unsubscribe from a node. All other entities which attempt to unsubscribe from a node MUST receive a &lt;item-not-found/&gt; error in response.</p>
+        <p class="" style="">The ways in which an entity changes its affiliation with a node are well-defined. Typically, an owner action is required to make an affiliation state transition. Affiliation changes and their triggering actions are specified in the following table.</p>
+        <p class="caption">Table 4: Affiliation State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+            <th colspan="" rowspan="">--&gt;</th>
+            <th colspan="" rowspan="">Outcast</th>
+            <th colspan="" rowspan="">None</th>
+            <th colspan="" rowspan="">Publisher</th>
+            <th colspan="" rowspan="">Owner</th>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Outcast</td>
+            <td align="" colspan="" rowspan="">--</td>
+            <td align="" colspan="" rowspan="">Owner removes ban</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to publisher list</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">None</td>
+            <td align="" colspan="" rowspan="">Owner bans entity</td>
+            <td align="" colspan="" rowspan="">--</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to publisher list</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Publisher</td>
+            <td align="" colspan="" rowspan="">Owner bans entity</td>
+            <td align="" colspan="" rowspan="">Owner removes entity from publisher list</td>
+            <td align="" colspan="" rowspan="">--</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Owner</td>
+            <td align="" colspan="" rowspan="">n/a</td>
+            <td align="" colspan="" rowspan="">Owner resigns</td>
+            <td align="" colspan="" rowspan="">n/a</td>
+            <td align="" colspan="" rowspan="">--</td>
+          </tr>
+        </table>
+    <h2>7.
+       <a name="substates">Subscription States</a>
+</h2>
+        
+        <p class="" style="">
+        Subscriptions to a node may exist in several states.
+        </p>
+
+        <p class="caption">Table 5: Subscription States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+            <th colspan="" rowspan="">Subscription State</th>
+            <th colspan="" rowspan="">Description</th>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">None</td>
+            <td align="" colspan="" rowspan="">The node MUST NOT send event notifications or payloads to the Entity.</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">Pending</td>
+            <td align="" colspan="" rowspan="">An entity has requested to subscribe to a node and the request has not yet been approved by a node owner. The node MUST NOT send event notifications or payloads to the entity while it is in this state.</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">Unconfigured</td>
+            <td align="" colspan="" rowspan="">An entity has subscribed but its subscription options have not yet been configured. The node MAY send event notifications or payloads to the entity while it is in this state. The service MAY timeout unconfigured subscriptions.</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">Subscribed</td>
+            <td align="" colspan="" rowspan="">An entity is subscribed to a node. The node MUST send all event notifications (and, if configured, payloads) to the entity while it is in this state.</td>
+        </tr>
+        </table>
+
+    <h2>8.
+       <a name="usecases">Use Cases</a>
+</h2>
+        <p class="" style="">The following sections define the use cases and the protocol to be used by various actors in those use cases. The <a href="#impl">Implementation Notes</a> section below describes many important factors and business rules which all pubsub services MUST observe. (Note: the examples throughout assume the existence of a separate pubsub component and include any relevant 'from' addresses as stamped by a server or network edge.)</p>
+
+        
+        <div class="indent">
+<h3>8.1 <a name="entity">Entity Use Cases</a>
+</h3>
+
+            
+            <div class="indent">
+<h3>8.1.1 <a name="disco-service">Discover Service Features</a>
+</h3>
+                <p class="" style="">Pubub services MUST respond to feature queries using the Service Discovery protocol and scoped by the http://jabber.org/protocol/disco#info namespace. The disco#info result MUST indicate support for the features by using a feature element with the appropriate 'var' attribute. Throughout this document these features are noted, and have been registered with the Jabber Registrar as described in the <a href="registrar">Jabber Registrar Considerations</a> section of this document.</p>
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.2 <a name="entity-create">Create a New Node</a>
+</h3>
+                <p class="" style="">Implementations of pubsub SHOULD allow users and services to create new nodes, which other Jabber entities may then publish to or subscribe to (depending on permissions). However, implementations MAY disallow creation of nodes based on the identity of the entity trying to create the new node, or MAY disallow node creation altogether.</p>
+
+                <p class="" style="">Nodes are created based on a NodeID supplied by the node creator. The NodeID MAY have semantic meaning, but such meaning is not required. If the requested NodeID already exists, the pubsub service MUST respond with a &lt;conflict/&gt; error. If the pubsub service does not support node creation, or the requesting JID does not have authorization to create nodes, the pubsub service MUST respond with a &lt;feature-not-implemented/&gt; error.</p>
+                
+                <p class="" style="">Implementations SHOULD allow node creation requests to contain a node configuration request in the same IQ element. (See the <a href="#entity-configure">Configure Node</a> section below for more details.) If an entity wishes to accept the default configuration, it SHOULD include an empty &lt;configure/&gt; element in its node creation request.</p>
+
+                <p class="" style="">The NodeID requested in the create node request MAY be modified by the service depending on the node-configuration specified. For example, if the node configuration requests that the new node become associated with a <a href="#collection_create">collection node</a>, the service MAY create a node identifier which is not the same as the original ID requested. In this case, the service MUST return the modified NodeID in the IQ result, contained in a &lt;create/&gt; element whose 'node' attribute specifies the modified NodeID.</p>
+
+                <p class="" style="">Some implementations MAY choose to force entities to register with the pubsub service before allowing nodes to be created. In these cases, the service MUST respond to the create request with a &lt;registration-required/&gt; error if the entity is not registered.</p>
+
+                <p class="" style="">When a service successfully creates a node on behalf of the requesting entity, it MUST return an IQ result. If the node creation request did not specify a NodeID (i.e., the sender requested an &quot;instant node&quot; as described below), the service MUST specify the created NodeID in the IQ result. If the node creation request specified a NodeID but the service modified the NodeID before creating the node as described under the <a href="#collections">Collection Nodes</a> section of this document, the service MUST also specify the modified node in the IQ result. In all other cases, the service MUST NOT specify the NodeID in the IQ result (since the sender can determine which node was created by tracking the 'id' attribute that it provided in the IQ set).</p>
+
+                <p class="caption">Example 1. Entity requests a new node with default configuration.</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;create1&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+        &lt;create node=&quot;generic/pgm-mp3-player&quot;/&gt;
+        &lt;configure/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 2. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;create1&quot;/&gt;</pre></div>
+
+                <p class="caption">Example 3. Server replies with Conflict</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;create1&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+        &lt;create node=&quot;generic/pgm-mp3-player&quot;/&gt;
+    &lt;/pubsub&gt;
+    &lt;error code=&quot;409&quot; type=&quot;cancel&quot;&gt;
+      &lt;conflict xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 4. Server replies with Not Implemented</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;create1&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+        &lt;create node=&quot;generic/pgm-mp3-player&quot;/&gt;
+    &lt;/pubsub&gt;
+    &lt;error code=&quot;501&quot; type=&quot;cancel&quot;&gt;
+      &lt;feature-not-implemented xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 5. Server replies with Registration Required</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;create1&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+        &lt;create node=&quot;generic/pgm-mp3-player&quot;/&gt;
+    &lt;/pubsub&gt;
+    &lt;error code=&quot;407&quot; type=&quot;auth&quot;&gt;
+      &lt;registration-required xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="" style="">In some cases, the requesting entity may want the service to automatically generate a unique NodeID for the newly-created node, to which it may immediately publish; we can think of this as an &quot;instant node&quot;. To do this, the requesting entity MUST NOT include a NodeID in the request. If the user has permissions to create nodes, the pubsub service MUST create the node, generate a NodeID that is unique within the context of that pubsub service, and inform the user of success (including the NodeID). A service SHOULD support instant nodes; if it does not, it MUST return a &lt;not-acceptable/&gt; error.</p>
+                <p class="caption">Example 6. Client requests an instant node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;create2&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+        &lt;create/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 7. Server replies with success and generated NodeID</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;create2&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+       &lt;create
+         node=&quot;generic/25e3d37dabbab9541f7523321421edc5bfeb2dae&quot;/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+                <p class="caption">Example 8. Server does not support instant nodes</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;create2&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+       &lt;create/&gt;
+    &lt;/pubsub&gt;
+    &lt;error code=&quot;406&quot; type=&quot;modify&quot;&gt;
+      &lt;not-acceptable xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.3 <a name="entity-publish">Publish an Item to a Node</a>
+</h3>
+                <p class="" style="">Any entity which is allowed to publish to a node (i.e., a publisher or an owner) may do so at any time. When the pubsub service receives the request, all (approved and active) subscribers are notified of the event. The node configuration MUST specify whether or not the payload is to be delivered to the subscribers. If payloads are not delivered with the event notification, subscribers MAY request the published item via the protocol defined in the <a href="#entity-getitems">Get Items for a Node</a> section of this document.</p>
+                <p class="" style="">An item MUST NOT contain data defined by more than one namespace, with the exception of item meta-data as described below.</p>
+                <p class="" style="">When a publisher publishes a new item to a node, the service MUST validate that the publish request matches the <a href="#events">event type</a> node configuration. Specifically, if items are persistent, or payloads are delivered with event notifications, then the publish request MUST contain an item. If the node is configured for pure event notification, then the publish request MUST NOT contain an item. If a mismatch is detected, the service MUST bounce the packet with a &lt;bad-request/&gt; error.</p>
+                <p class="" style="">In order to facilitate authorization for item removal as shown in the <a href="#entity-delete">Delete an Item from a Node</a> section below, implementations which support persistent items SHOULD store the item (if the node is so configured) and maintain a record of the publisher.</p>
+                <p class="" style="">(Note: the following examples adhere to the payload format defined in <span class="ref">User Tune</span>  [<a href="#nt-id2604287">4</a>]).</p>
+                <p class="caption">Example 9. Entity publishes an item with an ItemID</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;publish1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;publish node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 10. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;publish1&quot;/&gt;</pre></div>
+
+                <p class="caption">Example 11. Entity is not authorized to publish to node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;publish1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;publish node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;401&quot; type=&quot;auth&quot;&gt;
+    &lt;not-authorized xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 12. Entity attempts to publish to a non-existent node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;publish1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;publish node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;404&quot; type=&quot;cancel&quot;&gt;
+    &lt;item-not-found xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="" style="">If the node is so configured, the subscribers will receive event notifications only.</p>
+                <p class="caption">Example 13. Subscribers receive event notifications only</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to=&quot;subscriber2&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+                <p class="" style="">If the node is so configured, the subscribers will receive both event notifications and payloads.</p>
+                <p class="caption">Example 14. Subscribers receive event notifications with payloads</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to=&quot;subscriber2&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+            <p class="" style="">Item identifiers are not mandatory and may not be necessary for many types of nodes. In these cases, when an item is published, it is put into the stack of items.</p>
+
+                <p class="caption">Example 15. Entity publishes an item without an ItemID</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;publish1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;publish node=&quot;generic/pgm-mp3-catalog&quot;&gt;
+      &lt;item&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 16. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;publish1&quot;/&gt;</pre></div>
+
+                <p class="" style="">If a publisher publishes an item and the ItemID matches that of an existing item, the pubsub service MUST overwrite the existing item and generate a new event notification.</p>
+
+                <p class="" style="">If a single entity is subscribed to a node multiple times, then the service SHOULD notate the event notification so that the entity can determine what subscription identifiers generated this event. If these notations are included, they MUST use the <span class="ref">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2595802">5</a>] protocol and SHOULD be included after the event notification information (i.e., as the last child of the &lt;message/&gt; stanza).</p>
+
+                <p class="caption">Example 17. Subscriber receives notated event notification</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name=&quot;pubsub#subid&quot;&gt;123-abc&lt;/header&gt;
+    &lt;header name=&quot;pubsub#subid&quot;&gt;004-yyy&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;</pre></div>
+
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.4 <a name="entity-delete">Delete an Item from a Node</a>
+</h3>
+            <p class="" style="">A service SHOULD allow publishers to delete items once they have been published to a node that supports persistent items. To delete an item, the publisher sends a retract request as shown in the follow examples. This request may fail because:</p>
+           <ul>
+           <li>The publisher is not authorized to delete the requested item (&lt;not-authorized/&gt; error).</li>
+           <li>The node does not exist (&lt;item-not-found/&gt; error).</li>
+           <li>The node does not support persistent items (&lt;not-allowed/&gt; error).</li>
+           <li>The service does not support the deletion of items (&lt;feature-not-implemented/&gt; error).</li>
+           </ul>
+
+                <p class="caption">Example 18. Entity deletes an item from a node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;deleteitem1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;retract node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 19. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;deleteitem1&quot;/&gt;</pre></div>
+
+                <p class="caption">Example 20. Publisher is not authorized to delete this item</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;deleteitem1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;retract node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;401&quot; type=&quot;auth&quot;&gt;
+    &lt;not-authorized xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 21. Publisher is trying to delete an item from a non-existent node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;deleteitem1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;retract node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;404&quot; type=&quot;cancel&quot;&gt;
+    &lt;item-not-found xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 22. Publisher is trying to delete an item from a node which does not support persistent items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;deleteitem1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;retract node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;405&quot; type=&quot;cancel&quot;&gt;
+    &lt;not-allowed xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 23. Service does not support deleting items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;deleteitem1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;retract node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;current&quot;/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;501&quot; type=&quot;cancel&quot;&gt;
+    &lt;feature-not-implemented xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+
+            <p class="" style="">If an implementation supports allowing subscribers to be notified of deleted items (and the node is configured for it), the service MUST use message notifications as shown below. The syntax is identical to publish notifications except that instead of &lt;item/&gt; elements, we have &lt;retract/&gt; elements.</p>
+
+                <p class="caption">Example 24. Subscribers are notified of deletion</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;retract id=&quot;current&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to=&quot;subscriber2&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;retract id=&quot;current&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+            </div>
+
+
+            
+            <div class="indent">
+<h3>8.1.5 <a name="entity-subscribe">Subscribe to a Node</a>
+</h3>
+            <p class="" style="">When a Jabber entity wishes to subscribe to a node, it sends an IQ request to the pubsub service. Depending on the configuration of the node, several things may happen. If the node has &quot;open&quot; subscriptions, the potential subscriber receives either a result or an error. If the node has been configured so that subscription requests must be approved by the node owner (or a designated approver), the pubsub service sends a message to the node owner requesting authorization, where the message contains a form that is structured in accordance with the <span class="ref">Data Forms</span>  [<a href="#nt-id2604978">6</a>] protocol. To approve the subscription request, the node owner MUST submit the form. To deny the request, the owner MUST cancel the form.</p>
+
+            <p class="" style="">Subscription requests to a node MUST contain a 'jid' attribute, which enables the subscriber to specify either a bare JID or a specific resource which should be used as the subscribed Jabber ID. Implementations MUST at a minimum check the bare JID requested against the 'from' attribute on the received packet to make sure that the requesting entity has the same identity as the JID which is being requested to be added to the subscriber list. (Naturally, JIDs of the form &lt;domain&gt; and &lt;domain/resource&gt; may subscribe as well.)</p>
+
+            <p class="" style="">Some implementations MAY allow a service-configured list of entities (Jabber IDs) which are excluded from this check. Those entities may be treated as trusted proxies which are allowed to subscribe on behalf of other users. In the same way, implementations may enable blacklisting of entities based on Jabber ID which are not allowed to perform specific operations.</p>
+
+            <p class="" style="">Services MAY allow entities to subscribe multiple times to the same node. This enables an entity to subscribe using different subscription options. If multiple subscriptions for the same JID is allowed, the service MUST use the 'subid' attribute to differentiate between subscriptions for the same entity. The SubID MUST be present on the entity element any time it is sent to the entity. If the service does not allow multiple subscriptions for the same entity and it receives an additional subscription request, the service MUST return the current subscription state (as if the subscription was just approved).</p>
+
+            <p class="" style="">If an entity attempts to subscribe with a JID that is not allowed (bare JIDs do not match, or the user does not have some kind of admin or proxy privilege as defined by the implementation), then the pubsub service MUST respond with a &lt;not-authorized/&gt; error.</p>
+
+            <p class="" style="">Commercial deployments may wish to allow subscribers to be linked to some kind of paying customer database. If the subscriber needs to provide payment in order to subscribe to the node (e.g., if the subscriber is not in the customer database or the customer's account is not paid up), the service SHOULD return a &lt;payment-required/&gt; error to the subscriber.</p>
+
+                <p class="caption">Example 25. Entity subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;sub1@foo.com/home&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;subscribe
+        node=&quot;generic/pgm-mp3-player&quot;
+        jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 26. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;entity node=&quot;generic/pgm-mp3-player&quot;
+            jid=&quot;sub1@foo.com&quot;
+            affiliation=&quot;none&quot;
+            subid=&quot;123-abc&quot;
+            subscription=&quot;subscribed&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+
+                <p class="caption">Example 27. Entity is not authorized to create a subscription</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;subscribe
+        node=&quot;generic/pgm-mp3-player&quot;
+        jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;401&quot; type=&quot;auth&quot;&gt;
+    &lt;not-authorized xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 28. Payment is required for a subscription</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;subscribe
+        node=&quot;generic/pgm-mp3-player&quot;
+        jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;402&quot; type=&quot;auth&quot;&gt;
+    &lt;payment-required xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 29. Server replies with node not found</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;subscribe
+        node=&quot;generic/pgm-mp3-player&quot;
+        jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;404&quot; type=&quot;cancel&quot;&gt;
+    &lt;item-not-found xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 30. Server replies with pending (owner must approve subscription request)</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;entity node=&quot;generic/pgm-mp3-player&quot;
+            jid=&quot;sub1@foo.com&quot;
+            affiliation=&quot;none&quot;
+            subid=&quot;123-abc&quot;
+            subscription=&quot;pending&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            <div class="indent">
+<h3>8.1.6 <a name="entity-approve">Approving and Denying Subscription Requests</a>
+</h3>
+            <p class="" style="">Pubsub services MAY send approval requests to the current approver (typically the node owner) at any time. As such, these are simple message stanzas which contain a Data Form. The node owner MAY also request the current pending subscriptions at any time. Implementations MUST use the <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2605206">7</a>] protocol to request the pending list. The command name (node attribute of the command element) MUST have a value of &quot;http://jabber.org/protocol/pubsub#get-pending&quot;. The command MUST take a single field argument with a 'var' attribute value of &quot;node&quot;. This field MUST contain the desired NodeID. The node field SHOULD be a list-single field which contains all of the NodeIDs for which the requestor has approval privileges.
+            </p>
+
+            <p class="" style="">If an entity which does not have sufficient permissions to approve subscription requests attempts to get the current pending list, the service MUST respond with a &lt;forbidden/&gt; error message. If the node requested in the node field does not exist, the service MUST respond with a &lt;item-not-found/&gt; error message.
+            </p>
+
+            <p class="" style="">When subscription approval messages are sent to the current approver (typically, the node owner), the form MUST contain a hidden field element which uses a 'var' attribute of FORM_TYPE, and a value of &quot;http://jabber.org/protocol/pubsub&quot; as specified in <span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2605169">8</a>]. This enables client applications to detect that this is a pubsub subscriber request, and, if desired, to use some non-standard jabber:x:data dialog. The form MUST contain a boolean field that has a 'var' attribute of &quot;pubsub#allow&quot; which is the field that designates whether or not to allow the subscription request. This field MUST be checked when the form is processed after submission to see if the subscription should be allowed or denied. If the approver cancels the Data Form, then the subscription request MUST remain in the pending list. The Data Form sent to the approver SHOULD include fields to show the node identifier, the subscription id (if applicable), and the JID of the pending subscriber.</p>
+
+            <p class="caption">Example 31. Owner requests pending subscription requests</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot; to=&quot;pubsub.jabber.org&quot; id=&quot;pending1&quot;&gt;
+    &lt;command xmlns=&quot;http://jabber.org/protocol/commands&quot;
+             node=&quot;http://jabber.org/protocol/pubsub#get-pending&quot;
+             action=&quot;execute&quot;/&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 32. Server responds with data form to be populated</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot; to=&quot;pubsub.jabber.org&quot; id=&quot;pending1&quot;&gt;
+    &lt;command xmlns=&quot;http://jabber.org/protocol/commands&quot;
+             sessionid=&quot;pubsub-get-pending:20031021T150901Z-600&quot;
+             node=&quot;http://jabber.org/protocol/pubsub#get-pending&quot;
+             status=&quot;executing&quot;
+             action=&quot;execute&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;form&quot;&gt;
+            &lt;field type=&quot;list-single&quot;
+                   var=&quot;pubsub#node&quot;&gt;
+                &lt;option&gt;&lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;&lt;/option&gt;
+                &lt;option&gt;&lt;value&gt;generic/pgm-geoloc&lt;/value&gt;&lt;/option&gt;
+                &lt;option&gt;&lt;value&gt;generic/pgm-avatar&lt;/value&gt;&lt;/option&gt;
+            &lt;/field&gt;
+        &lt;/x&gt;
+    &lt;/command&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 33. Server responds with forbidden</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot; from=&quot;pubsub.jabber.org&quot; id=&quot;pending2&quot;&gt;
+    &lt;error code=&quot;403&quot; type=&quot;cancel&quot;&gt;
+      &lt;forbidden xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 34. Server responds with node not found</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot; from=&quot;pubsub.jabber.org&quot; id=&quot;pending2&quot;&gt;
+    &lt;error code=&quot;404&quot;&gt;
+      &lt;item-not-found xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 35. Owner requests all pending subscription requests for a node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot; to=&quot;pubsub.jabber.org&quot; id=&quot;pending2&quot;&gt;
+    &lt;command xmlns=&quot;http://jabber.org/protocol/commands&quot;
+             sessionid=&quot;pubsub-get-pending:20031021T150901Z-600&quot;
+             node=&quot;http://jabber.org/protocol/pubsub#get-pending&quot;
+             action=&quot;execute&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;submit&quot;&gt;
+            &lt;field var=&quot;pubsub#node&quot;&gt;
+                &lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;
+            &lt;/field&gt;
+        &lt;/x&gt;
+    &lt;/command&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 36. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot; from=&quot;pubsub.jabber.org&quot; id=&quot;pending2&quot;/&gt;</pre></div>
+
+                <p class="caption">Example 37. Server sends authorization request to node owner</p>
+<div class="indent"><pre>
+&lt;message to=&quot;node-owner&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+    &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;form&quot;&gt;
+        &lt;title&gt;PubSub subscriber request&lt;/title&gt;
+        &lt;instructions&gt;
+          To approve this entity&amp;apos;s subscription request,
+          click the OK button. To deny the request, click the
+          cancel button.
+        &lt;/instructions&gt;
+        &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#subid&quot;
+               type=&quot;hidden&quot;&gt;
+            &lt;value&gt;123-abc&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#node&quot;
+               type=&quot;text-single&quot;
+               label=&quot;Node ID&quot;&gt;
+            &lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pusub#subscriber_jid&quot;
+               type=&quot;jid-single&quot;
+               label=&quot;Subscriber Address&quot;&gt;
+            &lt;value&gt;sub1@foo.com&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#allow&quot;
+               type=&quot;boolean&quot;
+               label=&quot;Allow this JID to subscribe to this pubsub node?&quot;&gt;
+            &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+    &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+
+            <p class="caption">Example 38. Owner approves subscription request</p>
+<div class="indent"><pre>
+&lt;message from=&quot;node-owner&quot; to=&quot;pubsub.jabber.org&quot;&gt;
+    &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;submit&quot;&gt;
+        &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+           &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#subid&quot;&gt;
+           &lt;value&gt;123-abc&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#node&quot;&gt;
+           &lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#subscriber_jid&quot;&gt;
+           &lt;value&gt;sub1@foo.com&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#allow&quot;&gt;
+            &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+    &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+
+            <p class="caption">Example 39. Owner denies subscription request</p>
+<div class="indent"><pre>
+&lt;message from=&quot;node-owner&quot; to=&quot;pubsub.jabber.org&quot;&gt;
+    &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;submit&quot;&gt;
+        &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+           &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#subid&quot;&gt;
+           &lt;value&gt;123-abc&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#node&quot;&gt;
+           &lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#subscriber_jid&quot;&gt;
+           &lt;value&gt;sub1@foo.com&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var=&quot;pubsub#allow&quot;&gt;
+            &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+    &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+
+
+            <p class="" style="">The service would then send a message with extended information in the 'jabber:x:data' namespace for all pending subscription requests, as shown above for a single pending subscription request.</p>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.7 <a name="entity-request">Request Current Affiliations</a>
+</h3>
+                <p class="" style="">Entities MUST be allowed to query the service to provide all of the current affiliations for all nodes within that service for that entity. The affiliations element is used to make the request. For each affiliation, an entity element is returned containing the NodeID, the JID which is affiliated (MAY include a resource, depending on how the JID subscribed), the affiliation, and the current subscription state. If subscription identifiers are supported by the service and the entity's subscription is not NONE or OUTCAST, the 'subid' attribute MUST be present as well as the 'jid' attribute.</p>
+
+                <p class="caption">Example 40. Entity requests all current affiliations</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;sub1@foo.com&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;allsubs&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;affiliations/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 41. Service replies with all current affiliations</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com&quot;
+    id=&quot;allsubs&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;affiliations&gt;
+      &lt;entity node=&quot;node1&quot;
+              jid=&quot;sub1@foo.com&quot;
+              affiliation=&quot;owner&quot;
+              subid=&quot;sub1&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+      &lt;entity node=&quot;node2&quot;
+              jid=&quot;sub1@foo.com&quot;
+              affiliation=&quot;publisher&quot;
+              subid=&quot;sub2&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+      &lt;entity node=&quot;node3&quot;
+              jid=&quot;sub1@foo.com/pda&quot;
+              affiliation=&quot;none&quot;
+              subid=&quot;sub3&quot;
+              subscription=&quot;unconfigured&quot;/&gt;
+      &lt;entity node=&quot;node4&quot;
+              jid=&quot;sub1@foo.com/work&quot;
+              affiliation=&quot;none&quot;
+              subid=&quot;sub4&quot;
+              subscription=&quot;pending&quot;/&gt;
+      &lt;entity node=&quot;node5&quot;
+              jid=&quot;sub1@foo.com&quot;
+              affiliation=&quot;outcast&quot;
+              subscription=&quot;none&quot;/&gt;
+      &lt;entity node=&quot;node6&quot;
+              jid=&quot;sub1@foo.com&quot;
+              affiliation=&quot;owner&quot;
+              subscription=&quot;none&quot;/&gt;
+    &lt;/affiliations&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.8 <a name="entity-unsub">Unsubscribe from a Node</a>
+</h3>
+            <p class="" style="">To unsubscribe from a node, the subscriber sends an appropriately-formatted IQ request to the node in question. If the unsubscribe is successful, an IQ result is sent back. If the requestor is not an existing subscriber, the pubsub service MUST return a &lt;not-authorized/&gt; error. If the node does not exist, the pubsub service MUST return a &lt;item-not-found/&gt; error. If a subscription identifier is associated with the subscription (ie, the service supports them), the unsubscribe request MUST include the appropriate 'subid' attribute. If the unsubscribe request includes a SubID that is not valid for the subscriber, the service MUST return a &lt;not-acceptable/&gt; error.</p>
+
+                <p class="caption">Example 42. Entity unsubscribes from a node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;sub1@foo.com&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;unsub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+     &lt;unsubscribe
+         node=&quot;generic/pgm-mp3-player&quot;
+         subid=&quot;123-abc&quot;
+         jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 43. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com&quot;
+    id=&quot;unsub1&quot;/&gt;
+</pre></div>
+
+                <p class="caption">Example 44. Requestor is not a subscriber</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com&quot;
+    id=&quot;unsub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+     &lt;unsubscribe
+         node=&quot;generic/pgm-mp3-player&quot;
+         subid=&quot;123-abc&quot;
+         jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;401&quot; type=&quot;auth&quot;&gt;
+    &lt;not-authorized xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;requestor-not-subscribed xmlns=&quot;http://jabber.org/protocol/pubsub#errors&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 45. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com&quot;
+    id=&quot;unsub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+     &lt;unsubscribe
+         node=&quot;generic/pgm-mp3-player&quot;
+         subid=&quot;123-abc&quot;
+         jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;404&quot; type=&quot;cancel&quot;&gt;
+    &lt;item-not-found xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+
+                <p class="caption">Example 46. Invalid subscription identifier</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com&quot;
+    id=&quot;unsub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+     &lt;unsubscribe
+         node=&quot;generic/pgm-mp3-player&quot;
+         subid=&quot;123-abc&quot;
+         jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;406&quot; type=&quot;modify&quot;&gt;
+    &lt;not-acceptable xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.9 <a name="entity-configure">Configure Subscription Options</a>
+</h3>
+            <p class="" style="">Implementations MAY allow subscribers to configure options for their own subscription. Implementations SHOULD use the <span style="font-weight: bold">Data Forms</span> protocol to accomplish this configuration. A subscriber requests the subscription options by using the &lt;options/&gt; element inside of an IQ stanza, to which the service MUST respond with either an error (detailed below) or a result element containing the options.</p>
+
+            <p class="" style="">If a service supports subscription options it MUST advertise that fact in the result to a disco#info query by including a feature whose 'var' attribute is &quot;pubsub#subscription-options&quot;. If a service supports subscription options, an entity MAY subscribe and provide the subscription options in the same stanza. In this case, the subscribe-options element MUST be a sibling of the subscribe element on the subscribe request. (If the service does not support subscription options, is MUST return a &lt;feature-not-implemented/&gt; error.)</p>
+
+            <p class="" style="">When requesting subscription options, the subscriber MUST specify both the NodeID of the node and the JID which is subscribed to the node. Services MUST validate that the entity making the request is authorized to set the subscription options for the subscribed entity. If the subscriber's JID is of the form &lt;user@host/resource&gt;, a services SHOULD perform this check by comparing the user@host part of the two JIDs to ensure that they match. If a subscription identifier is associated with the subscription, the 'subid' attribute MUST be present on the request in order for the service to differentiate subscriptions for the same entity.</p>
+
+            <p class="" style="">If a node supports subscription options, it MUST return a &lt;subscribe-options&gt; element inside the entity element in the result of the subscription request. The subscribe-options element MAY contain a &lt;required/&gt; child element if the subscriber MUST configure the subscription before receiving any notifications from that event. Services MAY timeout subscription requests if configuration is required and a configuration request is not submitted within a reasonable amount of time (which shall be determined by the service or node configuration). If the jabber:x:data &lt;required/&gt; element is not present, the subscription takes effect immediately and enables the entity to configure the subscription at any time.</p>
+
+            <p class="" style="">The following example shows some (but by no means all) of the possible configuration options which MAY be implemented in implementations. If an implementation implements these options using the <span style="font-weight: bold">Data Forms</span> protocol, that implementation MUST use the field variables that are registered with the Jabber Registrar in association with the 'http://jabber.org/protocol/pubsub' namespace (a preliminary representation of those field variables is shown below, but MUST NOT be construed as canonical, since the Jabber Registrar may standardize additional fields at a later date without changes to this JEP). An implementation MAY choose to specify different labels, values, and even field types, but must conform to the defined variable naming scheme.</p>
+
+            <p class="" style="">If nodes or services do not support subscriber options, then the response for an options request MUST be a &lt;feature-not-implemented/&gt; error. If a subscriber attempts to set an invalid group of options, the service MUST respond with a &lt;bad-request/&gt; error.
+            </p>
+
+                <p class="caption">Example 47. Entity subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;sub1@foo.com/home&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;subscribe
+        node=&quot;generic/pgm-mp3-player&quot;
+        jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 48. Server replies with success and indicates that subscription configuration is required</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;entity node=&quot;generic/pgm-mp3-player&quot;
+            jid=&quot;sub1@foo.com&quot;
+            affiliation=&quot;none&quot;
+            subid=&quot;123-abc&quot;
+            subscription=&quot;unconfigured&quot;&gt;
+      &lt;subscribe-options&gt;
+        &lt;required/&gt;
+      &lt;/subscribe-options&gt;
+    &lt;/entity&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 49. Subscriber requests subscription options form</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;sub1@foo.com/home&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;options1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;options
+        node=&quot;generic/pgm-mp3-player&quot;
+        subid=&quot;123-abc&quot;
+        jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 50. Server responds with Not Implemented (subscription options not supported)</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;options1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;options
+        node=&quot;generic/pgm-mp3-player&quot;
+        subid=&quot;123-abc&quot;
+        jid=&quot;sub1@foo.com&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;501&quot; type=&quot;cancel&quot;&gt;
+    &lt;feature-not-implemented xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;subscription-options-unavailable 
+        xmlns=&quot;http://jabber.org/protocol/pubsub#errors&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 51. Server responds with the options form</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;options1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;options node=&quot;generic/pgm-mp3-player&quot;
+             jid=&quot;sub1@foo.com&quot;
+             subid=&quot;123-abc&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot;&gt;
+          &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#digest&quot; type=&quot;boolean&quot;
+                 label=&quot;Receive digest notifications (approx. one per day)&quot;&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field
+              var=&quot;pubsub#show-values&quot;
+              type=&quot;list-multi&quot;
+              label=&quot;Select the presence types which are 
+                     allowed to receive notifications&quot;&gt;
+            &lt;option label=&quot;Want to Chat&quot;&gt;&lt;value&gt;chat&lt;/value&gt;&lt;/option&gt;
+            &lt;option label=&quot;Available&quot;&gt;&lt;value&gt;online&lt;/value&gt;&lt;/option&gt;
+            &lt;option label=&quot;Away&quot;&gt;&lt;value&gt;away&lt;/value&gt;&lt;/option&gt;
+            &lt;option label=&quot;Extended Away&quot;&gt;&lt;value&gt;xa&lt;/value&gt;&lt;/option&gt;
+            &lt;option label=&quot;Do Not Disturb&quot;&gt;&lt;value&gt;dnd&lt;/value&gt;&lt;/option&gt;
+            &lt;value&gt;chat&lt;/value&gt;
+            &lt;value&gt;online&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 52. Subscriber returns completed options form</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;sub1@foo.com/home&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;options2&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;options node=&quot;generic/pgm-mp3-player&quot;
+             jid=&quot;sub1@foo.com&quot;
+             subid=&quot;123-abc&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot;&gt;
+          &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#digest&quot; type=&quot;boolean&quot;&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+          &lt;field var=&quot;pubsub#show-values&quot; type=&quot;list-multi&quot;&gt;
+            &lt;value&gt;chat&lt;/value&gt;
+            &lt;value&gt;online&lt;/value&gt;
+            &lt;value&gt;away&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 53. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;options2&quot;/&gt;</pre></div>
+
+                <p class="caption">Example 54. Server responds with Bad Request for invalid options</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;sub1@foo.com/home&quot;
+    id=&quot;options2&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;options node=&quot;generic/pgm-mp3-player&quot;
+             subid=&quot;123-abc&quot;
+             jid=&quot;sub1@foo.com&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot;&gt;
+          &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#digest&quot; type=&quot;boolean&quot;&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+          &lt;field var=&quot;pubsub#show-values&quot; type=&quot;list-multi&quot;&gt;
+            &lt;value&gt;chat&lt;/value&gt;
+            &lt;value&gt;online&lt;/value&gt;
+            &lt;value&gt;away&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;400&quot; type=&quot;modify&quot;&gt;
+    &lt;bad-request xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;invalid-options xmlns=&quot;http://jabber.org/protocol/pubsub#errors&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.10 <a name="entity-getitems">Get Items for a Node</a>
+</h3>
+            <p class="" style="">Implementations of pubsub that choose to persist items MAY allow entities to request existing items from a node. Entities may wish to do this after successfully subscribing to a node in order to receive all the items that are in the publishing &quot;history&quot; for that node. When an entity requests items, the pubsub service SHOULD verify that the requesting entity has a subscription to the pubsub node. If a subscription identifier is associated with a specific subscription, the entity MUST append the 'subid' attribute to the items element when making the request (if it does not, the service SHOULD return a &lt;not-acceptable/&gt; error). This attribute allows the pubsub service to generate different sets of items based on the subscription options associated with a specific subscription.</p>
+            <p class="" style="">
+            Subscribers may also receive event notification without any payload information. In this case, the client may request the item that was published (using the ItemID) in order to retrieve the payload. When an entity requests items by ItemID, implementations MUST allow multiple items to be specified in the request. Implementations MAY also allow entities to request the most recent N items by using the 'max_items' attribute. When max_items is used, implementations SHOULD return the N most recent (as opposed to the N oldest) items.
+            </p>
+
+                <p class="caption">Example 55. Subscriber requests all active items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;items1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; subid=&quot;123-abc&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 56. Server sends items back</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;items1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; subid=&quot;123-abc&quot;&gt;
+      &lt;item id=&quot;item1&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id=&quot;item2&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Edward Gregson&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;Tuba Tones&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id=&quot;item3&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Walter Ross&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;The Tuba's Greatest Hits&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 57. Service does not support persistent items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;items1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; subid=&quot;123-abc&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;501&quot; type=&quot;cancel&quot;&gt;
+    &lt;feature-not-implemented xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;persistence-unavailable xmlns=&quot;http://jabber.org/protocol/pubsub#errors&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 58. Subscriber requests two most recent items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;items2&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; max_items=&quot;2&quot; subid=&quot;123-abc&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 59. Server returns two most recent items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;items2&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; subid=&quot;123-abc&quot;&gt;
+      &lt;item id=&quot;item2&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Edward Gregson&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;Tuba Tones&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id=&quot;item3&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Walter Ross&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;The Tuba's Greatest Hits&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 60. Subscriber requests specific items by ItemID</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;items3&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; subid=&quot;123-abc&quot;&gt;
+      &lt;item id=&quot;item1&quot;/&gt;
+      &lt;item id=&quot;item3&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 61. Server sends requested item(s)</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;items3&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; subid=&quot;123-abc&quot;&gt;
+      &lt;item id=&quot;item1&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id=&quot;item3&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Walter Ross&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;The Tuba's Greatest Hits&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 62. Subscriber requests last two items using max_items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;items4&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; max_items=&quot;2&quot; subid=&quot;123-abc&quot;&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 63. Server sends requested item(s)</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;items4&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot; subid=&quot;123-abc&quot;&gt;
+      &lt;item id=&quot;item2&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Edward Gregson&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;Tuba Tones&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id=&quot;item3&quot;&gt;
+        &lt;tune xmlns=&quot;http://jabber.org/protocol/tune&quot;&gt;
+          &lt;artist&gt;Walter Ross&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;The Tuba's Greatest Hits&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 64. Subscriber sends request without subid</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;items5&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 65. Subid required</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;items5&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;406&quot; type=&quot;modify&quot;&gt;
+    &lt;not-acceptable xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.11 <a name="entity-discovernodes">Discover Nodes</a>
+</h3>
+            <p class="" style="">A service MAY implement some kind of pubsub browsing mechanism which enables the user to discover various nodes. The user may then select nodes to which he or she is interested in subscribing. Entities SHOULD use the <span style="font-weight: bold">Service Discovery</span> protocol for node discovery, subject to the recommendations in JEP-0030 regarding large result sets (for which <span class="ref">Jabber Search</span>  [<a href="#nt-id2606262">9</a>] or some other protocol SHOULD be used). The examples show the protocol for possible results when using Service Discovery on a hierarchical pubsub service.</p>
+
+            <p class="caption">Example 66. A client discovers all first level nodes</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;nodes1&quot;&gt;
+    &lt;query xmlns=&quot;http://jabber.org/protocol/disco#items&quot;/&gt;
+&lt;/iq&gt;
+
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;nodes1&quot;&gt;
+    &lt;query xmlns=&quot;http://jabber.org/protocol/disco#items&quot;&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot;
+              node=&quot;generic&quot;
+              name=&quot;A place for generic nodes&quot;/&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot;
+              node=&quot;bar&quot;
+              name=&quot;A place for drinks&quot;/&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot;
+              node=&quot;fez&quot;
+              name=&quot;A place for hats&quot;/&gt;
+    &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 67. A client drills down to second level nodes</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;nodes2&quot;&gt;
+    &lt;query xmlns=&quot;http://jabber.org/protocol/disco#items&quot; node=&quot;generic&quot;/&gt;
+&lt;/iq&gt;
+
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;nodes2&quot;&gt;
+    &lt;query xmlns=&quot;http://jabber.org/protocol/disco#items&quot;
+           node=&quot;generic&quot;&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot;
+              node=&quot;generic/pgm-mp3-player&quot;/&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot;
+              node=&quot;generic/psa-mp3-player&quot;/&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot;
+              node=&quot;generic/slashdot-news&quot;/&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot;
+              node=&quot;generic/meerkat-news&quot;/&gt;
+    &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.12 <a name="metadata">Discover Node Meta-Data</a>
+</h3>
+                <p class="" style="">Pubsub services MUST allow entities to query individual nodes for the meta-data associated with that node. The Service Discovery protocol and <span class="ref">Service Discovery Extensions</span>  [<a href="#nt-id2606352">10</a>] MUST be used to discover meta-data about individual nodes. The disco#info results MUST include an identity with a category of pubsub and a type of either leaf or collection. If a specific node has an identity type of leaf, then it MUST contain individual items. If a specific node has an identity type of collection, then it MUST contain other nodes, and or collections. Nodes with an identity type of collection MUST NOT contain items.</p>
+
+                
+                <p class="" style="">Meta-data information SHOULD include a field which contains the namespace of the payload data. If this field is present, it MUST be identified with a field with a 'var' attribute of pubsub#type and SHOULD be a field type of hidden. Meta-data information MAY include a field which contains the location (URL) of an XSL transformation (see <span class="ref">XSL Transformations</span>  [<a href="#nt-id2606311">11</a>]) which can be applied to payload packets. This transform MUST generate a valid Data Form result that the client could then display using a generic Data Forms rendering engine in accordance with JEP-0004. If this default XSLT field is present, it MUST be idenitified using a field with a 'var' attribute of &quot;pubsub#payload_xslt&quot;.</p>
+
+                <p class="caption">Example 68. Entity Queries a node for meta-data</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot; to=&quot;pubsub.jabber.org&quot; from=&quot;entity1&quot; id=&quot;meta-1&quot;&gt;
+  &lt;query xmlns=&quot;http://jabber.org/protocol/disco#info&quot;
+         node=&quot;generic/pgm-mp3-player&quot;/&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 69. Service responds with meta-data</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot; from=&quot;pubsub.jabber.org&quot; to=&quot;entity1&quot;&gt;
+  &lt;query xmlns=&quot;http://jabber.org/protocol/disco#info&quot;
+         node=&quot;generic/pgm-mp3-player&quot;&gt;
+    &lt;identity category=&quot;pubsub&quot; type=&quot;leaf&quot;/&gt;
+    &lt;feature var=&quot;http://jabber.org/protocol/pubsub&quot;/&gt;
+    &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;result&quot;&gt;
+      &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+        &lt;value&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#type&quot; label=&quot;Payload type&quot;&gt;
+        &lt;value&gt;http://jabber.org/protocol/tune&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#payload_xslt&quot; label=&quot;Payload XSLT&quot;&gt;
+        &lt;value&gt;http://jabber.org/protocol/tune/payload.xslt&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#creator&quot; label=&quot;Node creator&quot;&gt;
+        &lt;value&gt;creator@jabber.org&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#creation_date&quot; label=&quot;Creation date&quot;&gt;
+        &lt;value&gt;2003-07-29T22:56Z&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#description&quot; label=&quot;A description of the node&quot;&gt;
+        &lt;value&gt;This node rocks!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#language&quot; label=&quot;Default language&quot;&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#publisher&quot; label=&quot;Publishers to this node&quot;&gt;
+        &lt;value&gt;pgm@jabber.org&lt;/value&gt;
+        &lt;value&gt;MaineBoy@jabber.org&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#title&quot; label=&quot;A name for the node&quot;&gt;
+        &lt;value&gt;This node has no name.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+
+                  <p class="" style="">Much of the meta-data provided about a node maps directly to selected <span class="ref">Dublin Core Metadata Initiative (DCMI)</span>  [<a href="#nt-id2606378">12</a>] meta-data attributes; specifically:</p>
+                  <p class="caption">Table 6: Dublin Core Metadata Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+                    <tr class="body">
+<th colspan="" rowspan="">Pubsub Field</th>
+<th colspan="" rowspan="">Dublin Core Metadata Attribute</th>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#creation_date</td>
+<td align="" colspan="" rowspan="">Date  [<a href="#nt-id2606454">13</a>]</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#creator</td>
+<td align="" colspan="" rowspan="">Creator</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#description</td>
+<td align="" colspan="" rowspan="">Description</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#language</td>
+<td align="" colspan="" rowspan="">Language</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#publisher</td>
+<td align="" colspan="" rowspan="">Publisher</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#title</td>
+<td align="" colspan="" rowspan="">Title</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#type</td>
+<td align="" colspan="" rowspan="">Type  [<a href="#nt-id2606573">14</a>]</td>
+</tr>
+                  </table>
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.13 <a name="entity-discoveritems">Discover Items for a Node</a>
+</h3>
+            <p class="" style="">To discover the published items which exist on the service for a specific node, an entity MAY send a disco#items request to the node itself, and each item will be returned as a Service Discovery &lt;item/&gt; element. The 'name' attribute of each Service Discovery item MUST contain its ItemID and the item MUST NOT possess a 'node' attribute. This ItemID MAY then be used to retrieve the actual node using the protocol defined in the <a href="#entity-getitems">Get Items for a Node</a> section of this document.
+            </p>
+
+            <p class="caption">Example 70. A client requests all of the items for a node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;items1&quot;&gt;
+    &lt;query xmlns=&quot;http://jabber.org/protocol/disco#items&quot;
+           node=&quot;generic/slashdot-news&quot; /&gt;
+&lt;/iq&gt;
+
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;items1&quot;&gt;
+    &lt;query xmlns=&quot;http://jabber.org/protocol/disco#items&quot;
+           node=&quot;generic/slashdot-news&quot;&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot; name=&quot;2003/03/06/1641229&quot;/&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot; name=&quot;2003/03/06/1629206&quot;/&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot; name=&quot;2003/03/06/1625222&quot;/&gt;
+        &lt;item jid=&quot;pubsub.jabber.org&quot; name=&quot;2003/03/06/1341209&quot;/&gt;
+    &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+            </div>
+
+        </div>
+
+        
+        <div class="indent">
+<h3>8.2 <a name="owner">Owner Use Cases</a>
+</h3>
+            <p class="" style="">Implementations MAY allow node owners to configure the various options for a specific node. Implementations SHOULD use the <span style="font-weight: bold">Data Forms</span> protocol to allow the node owner to accomplish the configuration.</p>
+            <p class="" style="">The following example shows SOME of the possible configuration options which MAY be implemented in some implementations. If an implementation implements these features using the <span style="font-weight: bold">Data Forms</span> protocol, that implementation MUST use the fields that are registered with the Jabber Registrar in association with the 'http://jabber.org/protocol/pubsub' namespace (a preliminary representation of those field variables is shown below, but MUST NOT be construed as canonical, since the Jabber Registrar may standardize additional fields at a later date without changes to this JEP). An implementation MAY choose to specify different labels, values, and even field types, but must conform to the defined variable naming scheme.</p>
+
+            
+            <div class="indent">
+<h3>8.2.1 <a name="owner-configure">Configure a Node</a>
+</h3>
+
+                <p class="" style="">After creating a new node, the node owner may want to modify the node configuration. The process for doing so is shown below.</p>
+
+                <p class="caption">Example 71. Owner requests configuration form</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;config1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub#owner&quot;&gt;
+    &lt;configure node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+                <p class="caption">Example 72. Server responds with configuration form</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;config1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub#owner&quot;&gt;
+    &lt;configure node=&quot;generic/pgm-mp3-player&quot;&gt;
+     &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;form&quot;&gt;
+      &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+        &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#deliver_payloads&quot; type=&quot;boolean&quot;
+             label=&quot;Deliver payloads with event notifications&quot;&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_config&quot; type=&quot;boolean&quot;
+             label=&quot;Notify subscribers when the node configuration changes&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_delete&quot; type=&quot;boolean&quot;
+             label=&quot;Notify subscribers when the node is deleted&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_retract&quot; type=&quot;boolean&quot;
+             label=&quot;Notify subscribers when items are removed from the node&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#persist_items&quot; type=&quot;boolean&quot;
+             label=&quot;Persist items to storage&quot;&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#max_items&quot; type=&quot;text-single&quot;
+             label=&quot;Max # of items to persist&quot;&gt;
+        &lt;value&gt;10&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#subscribe&quot; type=&quot;boolean&quot;
+             label=&quot;Whether to allow subscriptions&quot;&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#subscription_model&quot; type=&quot;list-single&quot;
+             label=&quot;Specify the subscriber model&quot;&gt;
+        &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;authorize&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;open&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#publish_model&quot; type=&quot;list-single&quot;
+             label=&quot;Specify the publisher model&quot;&gt;
+        &lt;option&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;subscribers&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;publishers&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#max_payload_size&quot; type=&quot;text-single&quot;
+             label=&quot;Max Payload size in bytes&quot;&gt;
+        &lt;value&gt;9216&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#send_item_subscribe&quot; type=&quot;boolean&quot;
+             label=&quot;Send items to new subscribers&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#presence_based_delivery&quot; type=&quot;boolean&quot;
+             label=&quot;Only deliver notifications to available users&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#current_approver&quot; type=&quot;list-single&quot;
+             label=&quot;Specify the current subscription approver&quot;&gt;
+        &lt;option&gt;&lt;value&gt;owner1@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;owner2@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;owner3@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;owner2@foo.com&lt;/value&gt;
+     &lt;/field&gt;
+     &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="" style="">If no configuration options are available (e.g., because node configuration is &quot;locked down&quot;), the service MUST return a &lt;feature-not-implemented/&gt; error to the owner.</p>
+
+                <p class="caption">Example 73. Node has no configuration options</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;config1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub#owner&quot;&gt;
+    &lt;configure node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;501&quot; type=&quot;cancel&quot;&gt;
+    &lt;feature-not-implemented xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;node-not-configurable xmlns=&quot;http://jabber.org/protocol/pubsub#errors&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="" style="">After receiving the configuration form, the owner SHOULD either submit a completed configuration form or cancel the configuration process, in which case the existing configuration MUST be applied.</p>
+
+                <p class="caption">Example 74. Owner submits node configuration form</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;config2&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub#owner&quot;&gt;
+    &lt;configure node=&quot;generic/pgm-mp3-player&quot;&gt;
+     &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;submit&quot;&gt;
+      &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+        &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#deliver_payloads&quot;&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#persist_items&quot;&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#max_items&quot;&gt;&lt;value&gt;10&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#subscription_allow&quot;&gt;&lt;value&gt;authorize&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#publish_model&quot;&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#send_item_subscribe&quot;&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#presence_based_delivery&quot;&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_config&quot;&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_delete&quot;&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_retract&quot;&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#max_payload_size&quot;&gt;&lt;value&gt;1028&lt;/value&gt;&lt;/field&gt;
+      &lt;field var=&quot;pubsub#current_approver&quot;&gt;&lt;value&gt;owner2@foo.com&lt;/value&gt;&lt;/field&gt;
+     &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 75. Owner cancels configuration process</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;config2&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub#owner&quot;&gt;
+    &lt;configure node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;cancel&quot;/&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="" style="">If the &quot;pubsub#notify_config&quot; option is set to &quot;1&quot; (yes), then the service MUST send a notification of configuration change to all subscribers. (A service SHOULD support this option for leaf nodes and MUST support it for <a href="#collection">Collection Nodes</a>.) If the node configuration is set to event notifications only, the notification MUST consist of an empty &lt;item/&gt; element whose 'id' attribute is set to a value of &quot;configuration&quot;; if the node configuration is set to full payloads, the &lt;item/&gt; element MUST in addition contain the node configuration as represented via the <span style="font-weight: bold">Data Forms</span> protocol.</p>
+
+            <p class="caption">Example 76. Service sends configuration change notification (event notification only)</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;configuration&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+            <p class="caption">Example 77. Service sends configuration change notification (full payload)</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;item id=&quot;configuration&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;result&quot;&gt;
+          &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#deliver_payloads&quot;
+                 label=&quot;Deliver payloads with event notifications&quot;&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#notify_config&quot;
+                 label=&quot;Notify subscribers when the node configuration changes&quot;&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#notify_delete&quot;
+                 label=&quot;Notify subscribers when the node is deleted&quot;&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#notify_retract&quot;
+                 label=&quot;Notify subscribers when items are removed from the node&quot;&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#persist_items&quot;
+                 label=&quot;Persist items to storage&quot;&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#max_items&quot;
+                 label=&quot;Max # of items to persist&quot;&gt;
+            &lt;value&gt;10&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#subscribe&quot;
+                 label=&quot;Whether to allow subscriptions&quot;&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#subscription_model&quot;
+                 label=&quot;Specify the subscriber model&quot;&gt;
+            &lt;value&gt;open&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#publish_model&quot;
+                 label=&quot;Specify the publisher model&quot;&gt;
+            &lt;value&gt;publishers&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#max_payload_size&quot;
+                 label=&quot;Max Payload size in bytes&quot;&gt;
+            &lt;value&gt;9216&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#send_item_subscribe&quot;
+                 label=&quot;Send items to new subscribers&quot;&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#presence_based_delivery&quot;
+                 label=&quot;Only deliver notifications to available users&quot;&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#current_approver&quot;
+                 label=&quot;Specify the current subscription approver&quot;&gt;
+            &lt;value&gt;owner2@foo.com&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+         </div>
+
+         <div class="indent">
+<h3>8.2.2 <a name="owner-default">Request Default Configuration Options</a>
+</h3>
+
+            <p class="" style="">Services MAY allow entities to create nodes and include configuration options in the same stanza as the node creation request. In these cases, the entity SHOULD first get the node options which can be used. To get the options, the entity MUST send a configure request to the service with no NodeID; in response, the service MUST return the default node options if it supports batching a node creation and configuration request.   [<a href="#nt-id2606966">15</a>] If the service does not support this feature, it MUST return a &lt;feature-not-implemented/&gt; error.</p>
+            <p class="" style="">Before deciding whether or not accept the default configuration during node creation, an entity may want to determine what the default node configuration settings are for the service.</p>
+
+            <p class="caption">Example 78. Entity requests default node configuration options</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    id=&quot;config3&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub#owner&quot;&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 79. Service responds with default node configuration options</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pgm@jabber.org&quot;
+    id=&quot;config3&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub#owner&quot;&gt;
+    &lt;configure&gt;
+     &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;form&quot;&gt;
+      &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+         &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#deliver_payloads&quot; type=&quot;boolean&quot;
+             label=&quot;Deliver payloads with event notifications&quot;&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_config&quot; type=&quot;boolean&quot;
+             label=&quot;Notify subscribers when the node configuration changes&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_delete&quot; type=&quot;boolean&quot;
+             label=&quot;Notify subscribers when the node is deleted&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#notify_retract&quot; type=&quot;boolean&quot;
+             label=&quot;Notify subscribers when items are removed from the node&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#persist_items&quot; type=&quot;boolean&quot;
+             label=&quot;Persist items to storage&quot;&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#max_items&quot; type=&quot;text-single&quot;
+             label=&quot;Max # of items to persist&quot;&gt;
+        &lt;value&gt;10&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#subscribe&quot; type=&quot;boolean&quot;
+             label=&quot;Whether to allow subscriptions&quot;&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#subscription_model&quot; type=&quot;list-single&quot;
+             label=&quot;Specify the subscriber model&quot;&gt;
+        &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;authorize&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;open&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#publish_model&quot; type=&quot;list-single&quot;
+             label=&quot;Specify the publisher model&quot;&gt;
+        &lt;option&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;subscribers&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;publishers&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#max_payload_size&quot; type=&quot;text-single&quot;
+             label=&quot;Max Payload size in bytes&quot;&gt;
+        &lt;value&gt;9216&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#send_item_subscribe&quot; type=&quot;boolean&quot;
+             label=&quot;Send items to new subscribers&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#presence_based_delivery&quot; type=&quot;boolean&quot;
+             label=&quot;Only deliver notifications to available users&quot;&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var=&quot;pubsub#current_approver&quot; type=&quot;list-single&quot;
+             label=&quot;Specify the current subscription approver&quot;&gt;
+        &lt;option&gt;&lt;value&gt;owner1@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;owner2@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;owner3@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;owner2@foo.com&lt;/value&gt;
+     &lt;/field&gt;
+     &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 80. Service does not support default options</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;config3&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub#owner&quot;&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;501&quot; type=&quot;cancel&quot;&gt;
+    &lt;feature-not-implemented xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+    &lt;node-not-configurable xmlns=&quot;http://jabber.org/protocol/pubsub#errors&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.2.3 <a name="owner-delete">Delete a Node</a>
+</h3>
+            <p class="" style="">Deleting a node removes the node from the implementation (and data store if applicable). If an implementation persists items, deleting a node MUST first have the same effect as purging all the items for the node (see the <a href="#owner-purge">Purge all node items</a> section below) before the node itself is deleted.</p>
+
+                <p class="caption">Example 81. Owner deletes a node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;delete1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;delete node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 82. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;delete1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;delete node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;404&quot; type=&quot;cancel&quot;&gt;
+    &lt;item-not-found xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 83. Entity is not an owner</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;delete1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;delete node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;401&quot; type=&quot;auth&quot;&gt;
+    &lt;not-authorized xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 84. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;delete1&quot;/&gt;</pre></div>
+
+                <p class="caption">Example 85. Subscribers are notified of node removal</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;delete node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to=&quot;subscriber2&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;delete node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.2.4 <a name="owner-purge">Purge All Node Items</a>
+</h3>
+            <p class="" style="">Purging a node is applicable only in an implementation which persists published items. The act of purging a node removes all items from the persistent store. If an implementation does not persist items, it MUST return a &lt;feature-not-implemented/&gt; error. If the entity requesting to purge the node is not a node owner, the implementation must return a &lt;not-authorized/&gt; error.</p>
+            <p class="" style="">If a node and/or service has been configured to notify subscribers on deletion of items, a purge request MUST send the same notifications as are sent when deleting items.</p>
+
+                <p class="caption">Example 86. Owner purges items from a node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;purge1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;purge node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 87. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;purge1&quot;/&gt;</pre></div>
+
+                <p class="caption">Example 88. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;purge1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;purge node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;404&quot; type=&quot;cancel&quot;&gt;
+    &lt;item-not-found xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 89. Entity is not an owner</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;purge1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;purge node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;401&quot; type=&quot;auth&quot;&gt;
+    &lt;not-authorized xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 90. Node is not configured for persistent items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;purge1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;purge node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;501&quot; type=&quot;cancel&quot;&gt;
+    &lt;feature-not-implemented xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.2.5 <a name="owner-modify">Modifying Entity Affiliations</a>
+</h3>
+            <p class="" style="">Entities will be affiliated with a node. The node owner may edit these affiliations using the pubsub namespace. The owner may get a list of all affiliated entities, and set affiliations for existing or new entities. Note that if the node is configured for open subscriptions and/or open publishers, then the service itself will also be modifying this list. Affiliations with a node SHOULD be handled and stored using the &quot;bare JID&quot; (user@host) of an entity rather than the &quot;full JID&quot; (user@host/resource).</p>
+            <p class="" style="">Implementations SHOULD allow owners to specify not only affiliations, but also subscriptions. If either the 'affiliation' attribute or the 'subscription' attribute is not specified in a modification request, then the value MUST NOT be changed.</p>
+
+                <p class="caption">Example 91. Owner requests all affiliated entities</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;ent1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;entities node=&quot;generic/pgm-mp3-player&quot;/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 92. Server responds with entity items</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;ent1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;entities node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;entity jid=&quot;pgm@jabber.org&quot;
+              affiliation=&quot;owner&quot;
+              subscription=&quot;none&quot;/&gt;
+      &lt;entity jid=&quot;bar@baz.com&quot;
+              affiliation=&quot;publisher&quot;
+              subscription=&quot;none&quot;/&gt;
+      &lt;entity jid=&quot;bar2@baz.com&quot;
+              affiliation=&quot;publisher&quot;
+              subid=&quot;sub1&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+      &lt;entity jid=&quot;bar3@baz.com&quot;
+              affiliation=&quot;publisher&quot;
+              subid=&quot;sub2&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+      &lt;entity jid=&quot;sub1@foo.com&quot;
+              affiliation=&quot;none&quot;
+              subid=&quot;sub3&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+      &lt;entity jid=&quot;sub2@foo.com&quot;
+              affiliation=&quot;none&quot;
+              subid=&quot;sub4&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+      &lt;entity jid=&quot;sub3@foo.com&quot;
+              affiliation=&quot;none&quot;
+              subid=&quot;sub5&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+      &lt;entity jid=&quot;p1@bar.com&quot;
+              affiliation=&quot;none&quot;
+              subid=&quot;sub6&quot;
+              subscription=&quot;pending&quot;/&gt;
+      &lt;entity jid=&quot;p2@bar.com&quot;
+              affiliation=&quot;none&quot;
+              subid=&quot;sub7&quot;
+              subscription=&quot;pending&quot;/&gt;
+      &lt;entity jid=&quot;out1@foo.com&quot;
+              affiliation=&quot;outcast&quot;
+              subscription=&quot;none&quot;/&gt;
+      &lt;entity jid=&quot;out2@foo.com&quot;
+              affiliation=&quot;outcast&quot;
+              subscription=&quot;none&quot;/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 93. Owner sets affiliations for publishers</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;ent2&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;entities node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;entity jid=&quot;abc@bar.com&quot;
+              affiliation=&quot;publisher&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 94. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;ent2&quot;/&gt;</pre></div>
+
+                <p class="" style="">The owner MAY change multiple affiliations in a single request. If one of the entity elements specified is invalid, the service SHOULD return an IQ error with the invalid entries. The following example shows an entity attempting to make another owner an outcast (pgm@jabber.org). This implementation of pubsub does not allow that operation, so it returns that item, and the error for that item. Note that the affiliation sent back is the original un-altered affiliation.
+                </p>
+                <p class="" style="">The state chart at the beginning of this document is a MUST-IMPLEMENT set of rules for checking possible state transitions. Implementations MAY enforce other (more strict) rules. When errors occur during a modification request for multiple entities, the pubsub service MUST return any entity element(s) which caused the error. Returned entities which failed to be modified MUST include the existing 'affiliation' and 'subscription' attributes. An error element containing the error code and a brief description of the error MUST also be included as a child element of the entity which failed. Any entity elements which are not returned in an IQ error case MUST be treated as successful modifications.
+                </p>
+
+                <p class="caption">Example 95. Owner sets affiliation for multiple entities</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;ent3&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;entities node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;entity jid=&quot;bar@baz.com&quot;
+              affiliation=&quot;publisher&quot;
+              subscription=&quot;none&quot;/&gt;
+      &lt;entity jid=&quot;bar2@baz.com&quot;
+              affiliation=&quot;publisher&quot;
+              subscription=&quot;none&quot;/&gt;
+      &lt;entity jid=&quot;bar3@baz.com&quot;
+              affiliation=&quot;publisher&quot;
+              subid=&quot;sub2&quot;
+              subscription=&quot;subscribed&quot;/&gt;
+      &lt;entity jid=&quot;pgm@jabber.org&quot;
+              affiliation=&quot;outcast&quot;
+              subscription=&quot;none&quot;/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 96. Server responds with an error</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;error&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;ent3&quot;/&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;entities node=&quot;generic/pgm-mp3-player&quot;&gt;
+      &lt;entity jid=&quot;pgm@jabber.org&quot;
+              affiliation=&quot;owner&quot;
+              subscription=&quot;none&quot;/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+  &lt;error code=&quot;401&quot; type=&quot;auth&quot;&gt;
+    &lt;not-authorized xmlns=&quot;urn:ietf:params:xml:ns:xmpp-stanzas&quot;/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+
+            </div>
+        </div>
+    <h2>9.
+       <a name="collections">Collection Nodes</a>
+</h2>
+        <p class="" style="">A pubsub service MAY support collection nodes as well as leaf nodes. Collections enable nodes to be grouped together in any way including a hierarchy. Collections MUST contain only &quot;leaf&quot; nodes and/or other collections. Collections MUST NOT contain published items, since only &quot;leaf&quot; nodes contain items. If collections are supported, then the service MUST advertise that fact in its disco#info responses by including a feature of &quot;pubsub#collections&quot;.</p>
+
+        <p class="" style="">Pubsub services that implement collections SHOULD allow entities to subscribe to collection nodes. Subscriptions to collection nodes MUST be configured via the protocol specified in the <a href="#usecases">Use Cases</a> section of this document. Subscription options for collection nodes MUST include a subscription type field which enables the subscriber to configure the subscription either as a subscription for items or as a subscription for nodes. This subscription option MUST use the registered field name of &quot;pubsub#subscription_type&quot; as defined in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document. If the subscription type specified on a subscription to a collection node is &quot;items&quot;, the subscriber MUST be notified whenever an item is published to any node contained in the collection, where such a node may be a direct &quot;child&quot; of the collection node, or a child (to any depth) of a sub-collection of the collection node to which the subscriber has subscribed.</p>
+
+        <div class="indent">
+<h3>9.1 <a name="collections-subscribe">Subscribing to a Collection Node</a>
+</h3>
+        
+        <p class="" style="">When subscribing to a collection node, a service MUST allow the subscriber to specify whether it wants to receive notifications only from first-level children of the collection or from all descendents. For subscriptions of type &quot;nodes&quot;, this enables the subscriber to be informed only when a new node is added in the specific collection to which it has subscribed, or to be informed whenever a node is added anywhere in the node &quot;tree&quot; that begins at the level of the collection to which it has subscribed. A similar distinction applies to subscriptions of type &quot;items&quot;. The name for this configuration option is &quot;pubsub#subscription_depth&quot;.</p>
+
+        <p class="caption">Example 97. Entity subscribes to a collection node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;sub1@foo.com/home&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;subscribe jid=&quot;sub1@foo.com&quot;/&gt;
+    &lt;options jid=&quot;sub1@foo.com&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot;&gt;
+          &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#subscription_type&quot;&gt;
+            &lt;value&gt;items&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#subscription_depth&quot;&gt;
+            &lt;value&gt;all&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+   &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+        <p class="" style="">The subscriber will now receive item notifications from nodes at any depth within this collection.</p>
+
+        </div>
+
+        <div class="indent">
+<h3>9.2 <a name="collections-root">Root Collection Node</a>
+</h3>
+
+        <p class="" style="">Pubsub services that implement collections SHOULD support a root collection. This collection MUST include all nodes in the entire pubsub service and shall be identified by the lack of a node identifier (i.e., the address of the pubsub service itself, such as &quot;pubsub.shakespeare.lit&quot;). Subscribing to this node with a subscription of type &quot;nodes&quot; enables an entity to be notified whenever a new node is created in the entire pubsub system.</p>
+
+        <p class="caption">Example 98. Entity subscribes to the root collection node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;sub1@foo.com/home&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;sub1&quot;&gt;
+  &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+    &lt;subscribe jid=&quot;sub1@foo.com&quot;/&gt;
+    &lt;options jid=&quot;sub1@foo.com&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot;&gt;
+          &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#subscription_type&quot;&gt;
+            &lt;value&gt;nodes&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#subscription_depth&quot;&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+   &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+        <p class="" style="">If an entity subscribes to a collection node with a subscription type of &quot;nodes&quot;, then the service MUST inform the subscriber whenever a new node is added to the collection. This is simply done by sending a notification where the 'id' attribute of the &lt;item/&gt; element specifies the NodeID of the new node. The notification event MUST also include the node meta-data specified in the section above, which is formatted using the <span style="font-weight: bold">Data Forms</span> protocol.</p>
+
+            <p class="caption">Example 99. Payload format for node subscriptions</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items&gt;
+      &lt;item id=&quot;new-node-id&quot;&gt;
+        &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;result&quot;&gt;
+          &lt;field var=&quot;FORM_TYPE&quot; type=&quot;hidden&quot;&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#creation_date&quot; label=&quot;Creation date&quot;&gt;
+            &lt;var&gt;2003-07-29T22:56Z&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#creator&quot; label=&quot;Node creator&quot;&gt;
+            &lt;var&gt;creator@jabber.org&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#description&quot; label=&quot;A description of the node&quot;&gt;
+            &lt;var&gt;This node rocks!&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#language&quot; label=&quot;Default language&quot;&gt;
+            &lt;var&gt;en&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#publisher&quot; label=&quot;Publishers to this node&quot;&gt;
+            &lt;var&gt;pgm@jabber.org&lt;/var&gt;
+            &lt;var&gt;MaineBoy@jabber.org&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#title&quot; label=&quot;A name for the node&quot;&gt;
+            &lt;var&gt;This node has no name.&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var=&quot;pubsub#type&quot; label=&quot;The type of node&quot;&gt;
+            &lt;var&gt;http://jabber.org/protocol/moods&lt;/var&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+        </div>
+
+        <div class="indent">
+<h3>9.3 <a name="collections-createnodes">Creating New Collection Nodes</a>
+</h3>
+            <p class="" style="">To create a new node which is a collection node, the node configuration protocol MUST be used in the node creation request. When a pubsub system supports collections, it MUST support node configuration via the Data Forms protocol as specified in the foregoing sections of this document. A field for node type MUST be included in the node configuration form, and it MUST have a 'var' attribute of &quot;pubsub#node_type&quot;. This field MUST have a type of list-single, where the two possible options are &quot;leaf&quot; (the default) and &quot;collection&quot;. If a service does not allow new collection nodes to be created, it MUST respond with a &lt;not-allowed/&gt; error. If the requesting entity has insufficient privileges to create new collections, the service MUST respond with a &lt;not-authorized/&gt; eror.</p>
+
+            <p class="caption">Example 100. Entity requests a new collection node</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;create1&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+        &lt;create node=&quot;test&quot;/&gt;
+        &lt;configure&gt;
+            &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;submit&quot;&gt;
+                &lt;field type=&quot;hidden&quot;
+                       var=&quot;FORM_TYPE&quot;&gt;
+                    &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+                &lt;/field&gt;
+                &lt;field var=&quot;pubsub#node_type&quot;&gt;
+                    &lt;value&gt;collection&lt;/value&gt;
+                &lt;/field&gt;
+            &lt;/x&gt;
+        &lt;/configure&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 101. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    to=&quot;pgm@jabber.org&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;create1&quot;/&gt;</pre></div>
+
+        </div>
+
+        <div class="indent">
+<h3>9.4 <a name="collections-createaffil">Creating Nodes Affiliated with a Collection</a>
+</h3>
+            <p class="" style="">To create a new node which is part of an existing collection, the node configuration protocol MUST be used in the node creation request. When a pubsub system supports collections, it MUST support node configuration via the Data Forms protocol as specified in the foregoing sections. A field for collections MUST be included in the node configuration form, and it MUST have a 'var' attribute of &quot;pubsub#collections&quot;. This field MUST have a Data Forms type of &quot;text-multi&quot;. </p>
+
+            <p class="caption">Example 102. Entity creates a new node related to a collection</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;set&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;pubsub.jabber.org&quot;
+    id=&quot;create1&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+        &lt;create node=&quot;foo&quot;/&gt;
+        &lt;configure&gt;
+            &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;submit&quot;&gt;
+                &lt;field var=&quot;pubsub#collections&quot;&gt;&lt;value&gt;test&lt;/value&gt;&lt;/field&gt;
+            &lt;/x&gt;
+        &lt;/configure&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 103. Server responds with actual new node identifier</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;result&quot;
+    to=&quot;pgm@jabber.org&quot;
+    from=&quot;pubsub.jabber.org&quot;
+    id=&quot;create1&quot;&gt;
+    &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+        &lt;create node=&quot;test/foo&quot;/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+        </div>
+
+        <div class="indent">
+<h3>9.5 <a name="collections-notify">Generating Publish Notifications for Collections</a>
+</h3>
+
+            <p class="" style="">If an item is published to a node which is also contained by a collection, and an entity is subscribed to that collection with a subscription type of items, then the notifications generated by the service MUST contain additional information. The items element contained in the notification message MUST have the node identifier of the collection that the entity originally subscribed to. The item element MUST ALSO contain a node identifier for the node which generated the notification.</p>
+
+                <p class="caption">Example 104. Subscribers receive notifications from a collection</p>
+<div class="indent"><pre>
+&lt;message to=&quot;subscriber1&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic&quot;&gt;
+      &lt;item node=&quot;generic/pgm-mp3-player&quot; id=&quot;current&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to=&quot;subscriber2&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic&quot;&gt;
+      &lt;item node=&quot;generic/pgm-mp3-player&quot; id=&quot;current&quot;/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+        </div>
+
+    <h2>10.
+       <a name="errors">Error Conditions</a>
+</h2>
+        <p class="" style="">
+        <p class="caption">Table 7: Error conditions and typical causes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+            <tr class="body">
+                <th colspan="" rowspan="">Condition</th>
+                <th colspan="" rowspan="">Description</th>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+                <td align="" colspan="" rowspan="">The node already exists. Some implementations may also use this error when publishing items with an ItemID that already exists. See implementation notes for ItemIDs below.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+                <td align="" colspan="" rowspan="">The operation being attempted on a node (or the system) is disabled because the service itself does not support the operation.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+                <td align="" colspan="" rowspan="">An entity is requesting an operation for a Jabber ID which it is not allowed to change. For example, a@jabber.org attempts to subscribe b@jabber.org to a specific node.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;item-not-found/&gt;</td>
+                <td align="" colspan="" rowspan="">The node specified for some operation does not exist.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+                <td align="" colspan="" rowspan="">An entity has attempted to perform an action which the service implements; however the sysadmin or the node owner has disabled the action for that specific service or node.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+                <td align="" colspan="" rowspan="">This error is produced when an entity tries to perform some action on a node, and that entity has insufficient privileges to perform the action.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;payment-required/&gt;</td>
+                <td align="" colspan="" rowspan="">This error would typically be used to indicate that a subscription for a pubsub node is based on some kind payment service. Payments would be done out-of-band using some agreed-upon method (not defined herein).</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;registration-required/&gt;</td>
+                <td align="" colspan="" rowspan="">Some implementations may require entities to register before node creation is allowed.</td>
+            </tr>
+        </table>
+        <p class="" style="">Note: Refer to <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2608627">16</a>] for information regarding error syntax.</p>
+    <h2>11.
+       <a name="impl">Implementation Notes</a>
+</h2>
+
+        <div class="indent">
+<h3>11.1 <a name="impl-presence">Presence-Based Delivery of Events</a>
+</h3>
+        <p class="" style="">Implementations of pubsub MAY deliver event notifications only when the subscriber is online. In these cases, the option may be a node configuration option as shown in the examples above. In addition, to facilitate this, the pubsub service needs to subscribe to the subscriber's presence and check the current presence information before sending any event notifications (as described in <span class="ref">XMPP IM</span>  [<a href="#nt-id2608586">17</a>]).
+        </p>
+        </div>
+
+        <div class="indent">
+<h3>11.2 <a name="impl-offline">Not Sending Events to Offline Storage</a>
+</h3>
+        <p class="" style="">Sending events to users of existing Jabber servers may force event notifications to be sent to offline storage for later delivery. This may not always be desirable. The possible ways of preventing this behavior include:</p>
+            <ul>
+            <li>Use presence-based subscription options as described above.</li>
+            <li>Use delivery semantics as defined by <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2608747">18</a>].</li>
+            <li>Specify a message type of &quot;headline&quot;, which in some existing server implementations will prevent offline storage.</li>
+            </ul>
+        </div>
+
+        <div class="indent">
+<h3>11.3 <a name="impl-uniqueness">Node and Item ID Uniqueness</a>
+</h3>
+        <p class="" style="">NodeIDs MUST be treated as unique identifiers within the context of a particular pubsub service.</p>
+        <p class="" style="">If item identifiers are used, they MUST be treated as unique within the scope of the node. NodeID + ItemID MUST be unique within a given service, and MUST specify a single published item to a single node. Multiple publishes to the same ItemID MAY result in behavior similar to that stated above for nodes (except that multiple items in a list MUST NOT have the same ItemID, since ItemIDs MUST be unique within the scope of a node).</p>
+        <p class="" style="">If a publisher publishes an item and the ItemID matches that of an existing item, the pubsub service MUST overwrite the existing item and generate a new event notification.</p>
+        </div>
+
+        <div class="indent">
+<h3>11.4 <a name="impl-authorize">Authorizing Subscription Requests (Pending Subscribers)</a>
+</h3>
+        <p class="" style="">Implementations may handle sending subscription requests to node owners differently. Possibilities include:
+        </p>
+            <ul>
+                <li>Send requests to multiple owners all the time (these may be stored to offline).</li>
+                <li>The service could subscribe to owner presence, and send only to the owners that are online.</li>
+                <li>The node configuration stores the current owner which is designated to approve subscription requests (this is shown in the configuration examples).</li>
+                <li>All owners vote on the new subscriber.</li>
+                <li>Any owner is allowed to veto the subscriber.</li>
+            </ul>
+          <p class="" style="">An implementation MAY use any of these methods, or some other method not defined herein.</p>
+        </div>
+
+        <div class="indent">
+<h3>11.5 <a name="impl-hierarchies">Handling Node Hierarchies</a>
+</h3>
+        <p class="" style="">NodeIDs MAY have semantic value in implementations of pubsub. If an implementation wishes node IDs to have hierarchical meaning (as is shown in the examples), that implementation MAY choose any naming scheme which is suitable to the hierarchy in question. Identifiers could use slashes, periods, or other special characters as the hierarchy separator.
+        </p>
+        </div>
+
+        <div class="indent">
+<h3>11.6 <a name="impl-message">Message Bodies</a>
+</h3>
+          <p class="" style="">The &lt;message/&gt; stanzas sent from a service to a subscriber for purposes of event notification SHOULD include a &lt;body/&gt; child whose textual CDATA informs the subscriber that the message contains an event notification (e.g., text such as &quot;This message contains an event notification&quot; would be appropriate). This enables &quot;graceful degradation&quot; in case the user's current client does not support pubsub.</p>
+        </div>
+
+        <div class="indent">
+<h3>11.7 <a name="impl-multiple">Multiple Node Discovery</a>
+</h3>
+          <p class="" style="">A user may publish information that adheres to a certain profile at multiple pubsub nodes, and a potential subscriber may want to discover all of these pubsub nodes. The user may make a list of pubsub nodes publicly available for querying even when the user is offline by using the Service Discovery mechanism for &quot;publishing&quot; items (see Section 4 of JEP-0030). The potential subscriber may then send a disco#items request to the user's bare JID (&lt;user@host&gt;), including the 'node' attribute set to the value of the namespace to which the desired information adheres. The user's server then returns a list of pubsub nodes that meet that criterion (with each pubsub node being a separate Service Discovery item). Here is an example:</p>
+          <p class="caption">Example 105. Discovering multiple nodes</p>
+<div class="indent"><pre>
+&lt;iq type=&quot;get&quot;
+    from=&quot;stpeter@jabber.org/home&quot;
+    to=&quot;pgm@jabber.org&quot;
+    id=&quot;multi-1&quot;/&gt;
+  &lt;query xmlns=&quot;http://jabber.org/protocol/disco#items&quot;
+         node=&quot;http://jabber.org/protocol/tune&quot;/&gt;
+&lt;/iq&gt;
+
+&lt;iq type=&quot;result&quot;
+    from=&quot;pgm@jabber.org&quot;
+    to=&quot;stpeter@jabber.org/home&quot;
+    id=&quot;multi-1&quot;/&gt;
+  &lt;query xmlns=&quot;http://jabber.org/protocol/disco#items&quot;
+         node=&quot;http://jabber.org/protocol/tune&quot;&gt;
+    &lt;item jid=&quot;pubsub.jabber.org&quot;
+          node=&quot;generic/pgm-mp3-player&quot;
+          name=&quot;Laptop MP3 Player&quot;/&gt;
+    &lt;item jid=&quot;thepub.pgmillard.com&quot;
+          node=&quot;cdplayer&quot;
+          name=&quot;CD Player @ Home&quot;/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+        </div>
+
+        <div class="indent">
+<h3>11.8 <a name="impl-association">Associating Events and Payloads with the Generating Entity</a>
+</h3>
+          <p class="" style="">In some contexts, it is valuable to provide an association between the event notification or payload and the entity to which the published information pertains. For example, in the context of a protocol such as <span class="ref">User Geolocation</span>  [<a href="#nt-id2609038">19</a>], the user may generate the geolocation information or the information may be generated by an automated service (e.g., a service offered by a mobile telephony provider), but in either case the information is <span style="font-style: italic">about</span> the user (specifically, his or her spatial location). In order to associate the information with the user in a manner more explicit than enforcing semantic meaning on the NodeID, the service MAY include 'replyto' or 'replyroom' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2608974">20</a>] protocol) with the &lt;message/&gt; or &lt;presence/&gt; stanzas that contain event notifications and payloads. An example is shown below:</p>
+          <p class="caption">Example 106. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='i1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='portia@merchantofvenice.lit'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+          </pre></div>
+        </div>
+
+        <div class="indent">
+<h3>11.9 <a name="impl-leases">Implementing Time-Based Subscriptions (Leases)</a>
+</h3>
+            <p class="" style="">In some systems it may be desirable to provide a leasing system on subscriptions to a node in order to expire old or stale subscriptions. This can be accomplished using this protocol by using the configurable subscription options, and implementations SHOULD use this method when providing this type of functionality. When an entity subscribes, a field could be sent back in the subscription options which has a 'var' attribute of pubsub#expire. This field MUST contain a date-time specified in <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2609144">21</a>]. When an entity wants to renew the lease, it simply gets the current subscription options, changes the value of the pubsub#expire field, and resubmits the new subscription options back to the service. If the new expire value exceeds the maximum value allowed for subscription leases then service MUST change the value of the field to be the current date/time plus the maximum allowed lease period.</p>
+        </div>
+
+        <div class="indent">
+<h3>11.10 <a name="impl-content">Implementing Content-Based Pubsub Systems</a>
+</h3>
+            <p class="" style="">Content-based pubsub services SHOULD make use of a variety of optional features.</p>
+            <ul>
+            <li>Content-based services SHOULD use subscription options to specify the filter to apply to a specific node to determine the content that should be pushed for each node.</li>
+            <li>Content-based services SHOULD allow entities to subscribe more than once to a single node. If this is allowed, the service MUST use the subscription identifier syntax as specified in this document.</li>
+            </ul>
+        </div>
+
+    <h2>12.
+       <a name="security">Security Considerations</a>
+</h2>
+        <p class="" style="">Because the data published to a pubsub node may contain sensitive information (e.g., a user's geolocation), node owners SHOULD exercise care in approving subscription requests. Security considerations regarding particular kinds of information are the responsbility of the using protocol.</p>
+        <p class="" style="">A service MUST NOT send event notifications or payloads to an entity, nor allow an entity to retrieve items published to a node, unless that entity is an authorized subscriber to the node.</p>
+        <p class="" style="">A service MUST NOT allow non-owners or other unauthorized entities to complete any actions defined under the <a href="#owner">Owner Use Cases</a> section above.</p>
+    <h2>13.
+       <a name="iana">IANA Considerations</a>
+</h2>
+        <p class="" style="">This JEP does not require interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2609295">22</a>].</p>
+    <h2>14.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+      <div class="indent">
+<h3>14.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+        <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2609249">23</a>] shall include the following namespaces in its registry of protocol namespaces:</p>
+        <ul>
+          <li>http://jabber.org/protocol/pubsub</li>
+          <li>http://jabber.org/protocol/pubsub#event</li>
+          <li>http://jabber.org/protocol/pubsub#owner</li>
+        </ul>
+      </div>
+
+      <div class="indent">
+<h3>14.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+        <p class="" style="">As a result of this JEP, the Jabber Registrar shall register a Service Discovery category of &quot;pubsub&quot;, as well as three specific Service Discovery types within that category:</p>
+        <p class="caption">Table 8: Service Discovery Types in Pubsub Category</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+            <td align="" colspan="" rowspan="">collection</td>
+            <td align="" colspan="" rowspan="">A pubsub node of the &quot;collection&quot; type.</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">leaf</td>
+            <td align="" colspan="" rowspan="">A pubsub node of the &quot;leaf&quot; type.</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">service</td>
+            <td align="" colspan="" rowspan="">A pubsub service that supports the functionality defined in JEP-0060. (Prior to version 1.15 of JEP-0060, this type was called &quot;generic&quot;.)</td>
+          </tr>
+        </table>
+        <p class="" style="">The registry submission is as follows:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;desc&gt;Services and nodes that adhere to JEP-0060.&lt;/desc&gt;
+  &lt;type&gt;
+    &lt;name&gt;collection&lt;/name&gt;
+    &lt;desc&gt;A pubsub node of the &quot;collection&quot; type.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+  &lt;type&gt;
+    &lt;name&gt;leaf&lt;/name&gt;
+    &lt;desc&gt;A pubsub node of the &quot;leaf&quot; type.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+  &lt;type&gt;
+    &lt;name&gt;service&lt;/name&gt;
+    &lt;desc&gt;A pubsub service that supports the functionality defined in JEP-0060.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+        </pre></div>
+        <p class="" style="">Future submissions to the Jabber Registrar may register additional types.</p>
+      </div>
+
+      <div class="indent">
+<h3>14.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+
+        <p class="" style="">As a result of this JEP, the Jabber Registrar shall register Service Discovery features that may be returned by pubsub services. The following table defines the initial set of such features. (Future submissions to the Jabber Registrar may register additional features.)</p>
+
+        <p class="caption">Table 9: Service Discovery Features</p>
+<table border="1" cellpadding="3" cellspacing="0">
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#collections</td>
+                <td align="" colspan="" rowspan="">Collection nodes are supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#config-node</td>
+                <td align="" colspan="" rowspan="">Configuration of node options is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#create-nodes</td>
+                <td align="" colspan="" rowspan="">Creation of nodes is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#delete-any</td>
+                <td align="" colspan="" rowspan="">Any publisher may delete an item (not only the originating publisher).</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#instant-nodes</td>
+                <td align="" colspan="" rowspan="">Creation of instant nodes is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#item-ids</td>
+                <td align="" colspan="" rowspan="">Publishers may specify item identifiers.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#leased-subscription</td>
+                <td align="" colspan="" rowspan="">Time-based subscriptions are supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#meta-data</td>
+                <td align="" colspan="" rowspan="">Node meta-data is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#multi-subscribe</td>
+                <td align="" colspan="" rowspan="">A single entity may subscribe to a node multiple times.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#outcast-affiliation</td>
+                <td align="" colspan="" rowspan="">The outcast affiliation is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#persistent-items</td>
+                <td align="" colspan="" rowspan="">Persistent items are supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#presence-notifications</td>
+                <td align="" colspan="" rowspan="">Presence-based delivery of event notifications is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#publisher-affiliation</td>
+                <td align="" colspan="" rowspan="">The publisher affiliation is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#retrieve-items</td>
+                <td align="" colspan="" rowspan="">Item retrieval is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#subscription-options</td>
+                <td align="" colspan="" rowspan="">Configuration of subscription options is supported.</td>
+</tr>
+        </table>
+        <p class="" style="">The registry submission is as follows:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;feature var='http://jabber.org/protocol/pubsub#collections'&gt;
+  &lt;desc&gt;Collection nodes are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#config-node'&gt;
+  &lt;desc&gt;Configuration of node options is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#create-nodes'&gt;
+  &lt;desc&gt;Creation of nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#delete-any'&gt;
+  &lt;desc&gt;Any publisher may delete an item (not only the originating publisher).&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#instant-nodes'&gt;
+  &lt;desc&gt;Creation of instant nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#item-ids'&gt;
+  &lt;desc&gt;Publishers may specify item identifiers.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#leased-subscription'&gt;
+  &lt;desc&gt;Time-based subscriptions are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#meta-data'&gt;
+  &lt;desc&gt;Node meta-data is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#multi-subscribe'&gt;
+  &lt;desc&gt;A single entity may subscribe to a node multiple times.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#outcast-affiliation'&gt;
+  &lt;desc&gt;The outcast affiliation is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#persistent-items'&gt;
+  &lt;desc&gt;Persistent items are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#presence-notifications'&gt;
+  &lt;desc&gt;Presence-based delivery of event notifications is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#publisher-affiliation'&gt;
+  &lt;desc&gt;The publisher affiliation is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#retrieve-items'&gt;
+  &lt;desc&gt;Item retrieval is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+&lt;feature var='http://jabber.org/protocol/pubsub#subscription-options'&gt;
+  &lt;desc&gt;Configuration of subscription options is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/feature&gt;
+        </pre></div>
+      </div>
+
+
+
+      <div class="indent">
+<h3>14.4 <a name="registrar-formtypes">Field Standardization</a>
+</h3>
+        <p class="" style="">JEP-0068 defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. Within pubsub, there are four uses of such forms:</p>
+        <ol start="" type="">
+          <li>Authorization of subscriptions using the 'http://jabber.org/protocol/pubsub#subscribe_authorization' namespace</li>
+          <li>Configuration of subscription options using the 'http://jabber.org/protocol/pubsub#subscribe_options' namespace</li>
+          <li>Configuration of a node using the 'http://jabber.org/protocol/pubsub#node_config' namespace</li>
+          <li>Setting of meta-data information using the 'http://jabber.org/protocol/pubsub#meta-data' namespace</li>
+        </ol>
+        <p class="" style="">The registry submissions associated with these namespaces are defined below.</p>
+
+        <div class="indent">
+<h3>14.4.1 <a name="registrar-formtypes-auth">pubsub#subscribe_authorization FORM_TYPE</a>
+</h3>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling authorization of subscriptions to pubsub nodes&lt;/desc&gt;
+  &lt;field
+      var='pubsub#allow'
+      type='boolean'
+      label='Whether to allow the subscription'/&gt;
+  &lt;field
+      var='pubsub#node'
+      type='text-single'
+      label='The NodeID of the node'/&gt;
+  &lt;field
+      var='pubsub#subid'
+      type='text-single'
+      label='The SubID of the subscription'/&gt;
+  &lt;field
+      var='pubsub#subscriber_jid'
+      type='jid-single'
+      label='The address (JID) of the subscriber'/&gt;
+&lt;/form_type&gt;
+          </pre></div>
+        </div>
+        <div class="indent">
+<h3>14.4.2 <a name="registrar-formtypes-options">pubsub#subscribe_options FORM_TYPE</a>
+</h3>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling configuration of subscription options for pubsub nodes&lt;/desc&gt;
+  &lt;field
+      var='pubsub#digest'
+      type='boolean'
+      label='Whether a user wants to receive digests
+             (aggregations) of notifications or all
+             notifications individually'/&gt;
+  &lt;field
+      var='pubsub#digest'
+      type='boolean'
+      label='Whether a user wants to receive digests
+             (aggregations) of notifications or all
+             notifications individually'/&gt;
+  &lt;field
+      var='pubsub#show-values'
+      type='list-multi'
+      label='The presence states for which a user
+             wants to receive notifications'&gt;
+    &lt;option label='XMPP Show Value of Away'&gt;
+      &lt;value&gt;away&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of Chat'&gt;
+      &lt;value&gt;chat&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of DND (Do Not Disturb)'&gt;
+      &lt;value&gt;dnd&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Mere Availability in XMPP (No Show Value)'&gt;
+      &lt;value&gt;online&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of XA (Extended Away)'&gt;
+      &lt;value&gt;xa&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var=&quot;pubsub#subscription_type&quot;
+         type=&quot;list-single&quot;&gt;
+    &lt;option label='Receive notification of new items only'&gt;
+      &lt;value&gt;items&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Receive notification of new nodes only'&gt;
+      &lt;value&gt;nodes&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var=&quot;pubsub#subscription_depth&quot;
+         type=&quot;list-single&quot;&gt;
+    &lt;option label='Receive notification from direct child nodes only'&gt;
+      &lt;value&gt;1&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Receive notification from all descendent nodes'&gt;
+      &lt;value&gt;all&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;/field&gt;
+&lt;/form_type&gt;
+          </pre></div>
+        </div>
+        <div class="indent">
+<h3>14.4.3 <a name="registrar-formtypes-config">pubsub#node_config FORM_TYPE</a>
+</h3>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#node_config&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling configuration of pubsub nodes&lt;/desc&gt;
+  &lt;field var=&quot;pubsub#current_approver&quot;
+         type=&quot;list-single&quot;
+         label=&quot;The current subscription approver&quot;/&gt;
+  &lt;field var=&quot;pubsub#deliver_payloads&quot;
+         type=&quot;boolean&quot;
+         label=&quot;Whether to deliver payloads with event notifications&quot;/&gt;
+  &lt;field var=&quot;pubsub#max_items&quot;
+         type=&quot;text-single&quot;
+         label=&quot;The maximum number of items to persist&quot;/&gt;
+  &lt;field var=&quot;pubsub#max_payload_size&quot;
+         type=&quot;text-single&quot;
+         label=&quot;The maximum payload size in bytes&quot;/&gt;
+  &lt;field var=&quot;pubsub#node_type&quot;
+         type=&quot;list-single&quot;
+         label=&quot;The type of node (collection or leaf)&quot;&gt;
+    &lt;option label='Collection node (contains nodes and/or collections)'&gt;
+      &lt;value&gt;collection&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Leaf node (contains published items only)'&gt;
+      &lt;value&gt;leaf&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var=&quot;pubsub#notify_config&quot;
+         type=&quot;boolean&quot;
+         label=&quot;Whether to notify subscribers when the node configuration changes&quot;/&gt;
+  &lt;field var=&quot;pubsub#notify_delete&quot;
+         type=&quot;boolean&quot;
+         label=&quot;Whether to notify subscribers when the node is deleted&quot;/&gt;
+  &lt;field var=&quot;pubsub#notify_retract&quot;
+         type=&quot;boolean&quot;
+         label=&quot;Whether to notify subscribers when items are removed from the node&quot;/&gt;
+  &lt;field var=&quot;pubsub#persist_items&quot;
+         type=&quot;boolean&quot;
+         label=&quot;Whether to persist items to storage&quot;/&gt;
+  &lt;field var=&quot;pubsub#presence_based_delivery&quot;
+         type=&quot;boolean&quot;
+         label=&quot;Whether to deliver notifications to available users only&quot;/&gt;
+  &lt;field var=&quot;pubsub#publish_model&quot;
+         type=&quot;list-single&quot;
+         label=&quot;The publisher model&quot;&gt;
+    &lt;option label='Only publishers may publish'&gt;
+      &lt;value&gt;publishers&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Subscribers may publish'&gt;
+      &lt;value&gt;subscribers&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Anyone may publish'&gt;
+      &lt;value&gt;open&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var=&quot;pubsub#subscribe&quot; type=&quot;boolean&quot;
+         label=&quot;Whether to allow subscriptions&quot;&gt;
+    &lt;value&gt;1&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var=&quot;pubsub#subscription_model&quot;
+         type=&quot;list-single&quot;
+         label=&quot;The subscriber model&quot;&gt;
+    &lt;option label='Only those on a whitelist may subscribe'&gt;
+      &lt;value&gt;whitelist&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Subscription requests must be authorized'&gt;
+      &lt;value&gt;authorize&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Anyone may subscribe'&gt;
+      &lt;value&gt;open&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var=&quot;pubsub#send_item_subscribe&quot;
+         type=&quot;boolean&quot;
+         label=&quot;Whether to send items to new subscribers&quot;/&gt;
+&lt;/form_type&gt;
+          </pre></div>
+        </div>
+        <div class="indent">
+<h3>14.4.4 <a name="registrar-formtypes-metadata">pubsub#meta-data FORM_TYPE</a>
+</h3>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling setting of meta-data information about pubsub nodes&lt;/desc&gt;
+  &lt;field var=&quot;pubsub#creation_date&quot;
+         type='text-single'
+         label=&quot;The datetime when the node was created&quot;/&gt;
+  &lt;field var=&quot;pubsub#creator&quot;
+         type='jid-single'
+         label=&quot;The JID of the node creator&quot;/&gt;
+  &lt;field var=&quot;pubsub#description&quot;
+         type='text-single'
+         label=&quot;A description of the node&quot;/&gt;
+  &lt;field var=&quot;pubsub#language&quot;
+         type='text-single'
+         label=&quot;The default language of the node&quot;/&gt;
+  &lt;field var=&quot;pubsub#publisher&quot;
+         type='jid-multi'
+         label=&quot;The JIDs of those who may publish to this node&quot;/&gt;
+  &lt;field var=&quot;pubsub#title&quot;
+         type='text-single'
+         label=&quot;The name of the node&quot;/&gt;
+  &lt;field var=&quot;pubsub#type&quot;
+         type='text-single'
+         label=&quot;The type of node, usually specified by
+                the namespace of the payload (if any)&quot;/&gt;
+&lt;/form_type&gt;
+          </pre></div>
+        </div>
+      </div>
+      <div class="indent">
+<h3>14.5 <a name="registrar-shim">SHIM Headers</a>
+</h3>
+        <p class="" style="">The Jabber Registrar shall add &quot;pubsub#subid&quot; to its registry of SHIM headers (per JEP-0131). The registry submission is as follows:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;pubsub#subid&lt;/name&gt;
+  &lt;desc&gt;A subscription identifer within the pubsub protocol.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/header&gt;
+        </pre></div>
+        <p class="" style="">Future submissions to the Jabber Registrar may register additional SHIM headers that can be used in relation to the pubsub protocol.</p>
+      </div>
+    <h2>15.
+       <a name="schemas">XML Schemas</a>
+</h2>
+      <div class="indent">
+<h3>15.1 <a name="schemas-pubsub">http://jabber.org/protocol/pubsub</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub'
+    xmlns='http://jabber.org/protocol/pubsub'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import 
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='pubsub'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0'&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='create' minOccurs='0'/&gt;
+          &lt;xs:element ref='configure' minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='subscribe' minOccurs='0'/&gt;
+          &lt;xs:element ref='options' minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:choice minOccurs='0'&gt;
+          &lt;xs:element ref='affiliations'/&gt;
+          &lt;xs:element ref='delete'/&gt;
+          &lt;xs:element ref='entities'/&gt;
+          &lt;xs:element ref='entity'/&gt;
+          &lt;xs:element ref='items'/&gt;
+          &lt;xs:element ref='publish'/&gt;
+          &lt;xs:element ref='purge'/&gt;
+          &lt;xs:element ref='retract'/&gt;
+          &lt;xs:element ref='unsubscribe'/&gt;
+        &lt;/xs:choice&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='affiliations'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:element ref='entity' minOccurs='0' maxOccurs='unbounded'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='configure'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'
+                   xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='create'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='delete'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='entities'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='entity' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='entity'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='subscribe-options' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+            &lt;xs:enumeration value='publisher'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='subscription' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='pending'/&gt;
+            &lt;xs:enumeration value='subscribed'/&gt;
+            &lt;xs:enumeration value='unconfigured'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='items'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='max_items' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='options'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:any namespace='jabber:x:data'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='publish'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='purge'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='retract'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscribe-options'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='required' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscribe'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsubscribe'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+        </pre></div>
+      </div>
+
+      <div class="indent">
+<h3>15.2 <a name="schemas-event">http://jabber.org/protocol/pubsub#event</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#event'
+    xmlns='http://jabber.org/protocol/pubsub#event'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='event'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0'&gt;
+        &lt;xs:element ref='delete'/&gt;
+        &lt;xs:element ref='items'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='delete'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='items'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+        </pre></div>
+      </div>
+
+      <div class="indent">
+<h3>15.3 <a name="schemas-owner">http://jabber.org/protocol/pubsub#owner</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#owner'
+    xmlns='http://jabber.org/protocol/pubsub#owner'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import 
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='pubsub'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='configure'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='optional'/&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='get-pending'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='configure'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'
+                   xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+        </pre></div>
+      </div>
+
+      <div class="indent">
+<h3>15.4 <a name="schemas-error">http://jabber.org/protocol/pubsub#errors</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#errors'
+    xmlns='http://jabber.org/protocol/pubsub#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      This namespace is used for error reporting only, as
+      defined in JEP-0060: 
+      
+      http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='invalid-options' type='empty'/&gt;
+  &lt;xs:element name='node-not-configurable' type='empty'/&gt;
+  &lt;xs:element name='persistence-unavailable' type='empty'/&gt;
+  &lt;xs:element name='requestor-not-subscribed' type='empty'/&gt;
+  &lt;xs:element name='subscription-options-unavailable' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+        </pre></div>
+      </div>
+
+    <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602244">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602266">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603039">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604287">4</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595802">5</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604978">6</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605206">7</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605169">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606262">9</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606352">10</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606311">11</a>. XSL Transformations &lt;<a href="http://www.w3.org/TR/xslt/">http://www.w3.org/TR/xslt/</a>&gt;.</p>
+<p>
+<a name="nt-id2606378">12</a>. The Dublin Core Metadata Initiative (DCMI) is an organization dedicated to promoting the widespread adoption of interoperable metadata standards. For further information, see &lt;<a href="http://www.dublincore.org/">http://www.dublincore.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2606454">13</a>. The value SHOULD be a DateTime as defined in JEP-0082, and MUST conform to one of the profiles defined therein.</p>
+<p>
+<a name="nt-id2606573">14</a>. The pubsub type SHOULD be the namespace that defines the payload (such as 'http://jabber.org/protocol/tune') if appropriate.</p>
+<p>
+<a name="nt-id2606966">15</a>. A configure request with no NodeID must not be confused with a creation request with no NodeID; in response to the former, the service returns the default node options, whereas in response to the latter it creates an instant node.</p>
+<p>
+<a name="nt-id2608627">16</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2608586">17</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2608747">18</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2609038">19</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p>
+<a name="nt-id2608974">20</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2609144">21</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2609295">22</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2609249">23</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.6 (2004-07-13)</h4>
+<div class="indent">Added service discovery features for pubsub#meta-data, pubsub#request-affiliations, and pubsub#retrieve-items. Added pubsub#subscription_depth configuration option. Specified pubsub-specific error condition elements qualified by pubsub#errors namespace. (pgm/psa)
+    </div>
+<h4>Version 1.5 (2004-07-07)</h4>
+<div class="indent">Fixed typos. Added more details to the section on collections. Added paragraph to create node use case to allow the service to change the requested node-id to something which it creates. Added text about bouncing publish requests when the request does not match the event-type for that node. Added disco features for the jabber registrar. Changed affiliation verbiage to allow publishers to remove any item. Tweaked verbiage for create node, eliminated extra example. Fully defined Jabber Registrar submissions. Corrected schemas. (pgm/psa)
+    </div>
+<h4>Version 1.4 (2004-06-22)</h4>
+<div class="indent">Added subid syntax in a variety of places. Added more information about disco#info and disco#items support. Added more info about subscription options. Added collection information. Added implementation notes about subscription leases, and content-based pubsub services. (pgm)
+    </div>
+<h4>Version 1.3 (2004-04-25)</h4>
+<div class="indent">Editorial review; added one implementation note. (psa)
+    </div>
+<h4>Version 1.2 (2004-03-09)</h4>
+<div class="indent">Added XMPP error handling. (psa)
+    </div>
+<h4>Version 1.1 (2004-01-14)</h4>
+<div class="indent">Added Jabber Registrar Considerations subsection for Service Discovery category/type registration. (psa)
+    </div>
+<h4>Version 1.0 (2003-10-28)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.16 (2003-10-23)</h4>
+<div class="indent">Clarified JID addressing usage for nodes. Added specific MAY requirement for disco usage. Added sentence about implementations verifying that an entity has a subscription before getting the current items.
+             (pgm)
+    </div>
+<h4>Version 0.15 (2003-10-21)</h4>
+<div class="indent">Fixed invalid XML in examples for subscription deny/allow.
+             (pgm)
+    </div>
+<h4>Version 0.14 (2003-10-21)</h4>
+<div class="indent">Clarified restrictions on addressing nodes by JID. Added &quot;Approving and denying subscription requests&quot; section. Changed get-pending to use Ad-Hoc Commands. Changed semantics when sending in a form type='cancel' for pending subscriptions.
+             (pgm)
+    </div>
+<h4>Version 0.13 (2003-09-30)</h4>
+<div class="indent">Removed item as a possible child of subscribe and unsubscribe and pubsub in the schemas. Removed retract as a possible child of item in the pubsub#event schema. Added verbiage to requirements for addressing nodes either via JIDs or disco nodes.
+             (pgm)
+    </div>
+<h4>Version 0.12 (2003-08-13)</h4>
+<div class="indent">Defined public vs. private nodes; described how changes to existing nodes might trigger meta-node events (e.g., configuration changes); changed &lt;x/&gt; to &lt;event/&gt; for #events namespace; added meta-data about meta-nodes; fully defined Jabber Registrar considerations. (pgm, psa)
+    </div>
+<h4>Version 0.11 (2003-06-25)</h4>
+<div class="indent">Removed subscription notifications since they have inherent issues. Removed empty implementation note sub-section.
+             (pgm)
+    </div>
+<h4>Version 0.10 (2003-06-11)</h4>
+<div class="indent">Fixed error example when returning 501 from an items-get request. Added note about receiving subscription requests when an entity is already subscribed. Fixed some entity elements in various subscription examples. Many were missing the node attribute. Added subscription change notification verbiage and example. Added verbiage and example of subscription state notification being sent to the requesting entity. Added disco#items information for getting a list of item identifiers for a single node. Added verbiage for returning the current entity element when a curent subscriber attempts to subscribe again.
+             (pgm)
+    </div>
+<h4>Version 0.9 (2003-04-30)</h4>
+<div class="indent">Include JID attributes in the entity elements when receiving your affiliations. Changed error code 406 (which was wrong) to 404, which is correct. Changed many 405 errors to 401, and modified the error table to make it more implementable (rules are more concrete). Added subscribe-options element for indicating subscriptions may be configured. (pgm)
+    </div>
+<h4>Version 0.8 (2003-04-03)</h4>
+<div class="indent">Clarified the affiliations table and the semantics around subscribing and unsubscribing. Added protocol to get all of &quot;your&quot; affiliations in the service. Added protocol for services informing subscribers that configurable subscription options are available. Added protocol for obtaining existing node configuration settings and for batching configuration and node creation requests into a single stanza. Added meta-node implementation notes and specified the interaction with the Jabber Registrar and the &quot;meta&quot; NodeIDs. Added authorization notes to subscription options.
+             (pgm)
+    </div>
+<h4>Version 0.7 (2003-02-14)</h4>
+<div class="indent">Clarified requirements around what affiliations must be supported. Moved requirements about specifying entities which can subscribe and publish out of the MUSTs to MAYs. Changed SHOULD to MAY when talking about allowing entities to create nodes. Added ability to send configuration requests in the same stanza as a creation request.
+             (pgm)
+    </div>
+<h4>Version 0.6 (2003-02-06)</h4>
+<div class="indent">Added more details and an example about publishing without NodeID. Added more implementation notes about NodeIDs and persistent storage. (pgm)
+    </div>
+<h4>Version 0.5 (2003-01-22)</h4>
+<div class="indent">
+            Fixed header for delete item example. Added examples showing subscribers being notified of deleted items. Added examples for notification of node deletion, and configuration for node deletion. Added Subscriber option semantics and examples. Added examples for 402 and 407 errors on subscribe and create respectively. Added clarification about ItemID handling to impl notes.
+             (pgm)
+    </div>
+<h4>Version 0.4 (2003-01-21)</h4>
+<div class="indent">Clarified in-band and out-of-band configuration requirement. Added Delete Item privilege for all affiliations to the table. Added Delete item protocol for publishers and owners. Added 401 error case for subscribing to an illegal jid. Changed subscription request form. Added defaults to configuration form, and clarified role of the Jabber Registrar for the features show. Added text explaining the max_items attribute. Changed &quot;last items&quot; to &quot;most recent items&quot;. Removed default configuration acceptance -- owners should just cancel. Added the notify_retract configuration option. Clarified error handling for affiliation modifications.  (pgm)
+    </div>
+<h4>Version 0.3 (2003-01-20)</h4>
+<div class="indent">Added subscription attribute for entities. Removed subscriber from the affiliations table. Clarified configuration details. Clarified JabberID usages. Added Jabber Registrar Considerations. Added link to JEP-0068 about the FORM_TYPE element in subscription request notifications. Fixed some typos in examples. Added unsupported configuration namespace to example.  Added a default configuration example.  (pgm)
+    </div>
+<h4>Version 0.2 (2003-01-02)</h4>
+<div class="indent">Added numerous implementation notes; added get-pending action with regard to subscriptions; added error table; changed purge and delete to use IQ type='set'. (pgm)
+    </div>
+<h4>Version 0.1 (2002-11-19)</h4>
+<div class="indent">Initial version. (pgm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0060-1.7.html
+++ b/content/xep-0060-1.7.html
@@ -1,0 +1,4010 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0060: Publish-Subscribe</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Publish-Subscribe">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Ralph Meijer">
+<meta name="DC.Description" content="This JEP defines a generic publish/subscribe framework for use by Jabber entities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-03">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0060">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0060: Publish-Subscribe</h1>
+<p>This JEP defines a generic publish/subscribe framework for use by Jabber entities.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0060<br>
+            Version: 1.7<br>
+            Last Updated: 2005-03-03<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004, JEP-0030, JEP-0068, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pubsub<br>
+        XML Schema for pubsub: &lt;<a href="http://jabber.org/protocol/pubsub/pubsub.xsd">http://jabber.org/protocol/pubsub/pubsub.xsd</a>&gt;<br>
+        XML Schema for pubsub#event: &lt;<a href="http://jabber.org/protocol/pubsub/event.xsd">http://jabber.org/protocol/pubsub/event.xsd</a>&gt;<br>
+        XML Schema for pubsub#owner: &lt;<a href="http://jabber.org/protocol/pubsub/owner.xsd">http://jabber.org/protocol/pubsub/owner.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Publish-Subscribe%20(JEP-0060)">http://wiki.jabber.org/index.php/Publish-Subscribe (JEP-0060)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Millard</h3>
+<p class="indent">
+        See <a href="#authornote">Author Note</a><br></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Ralph Meijer</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ralphm@ik.nu">ralphm@ik.nu</a><br>
+        JID: 
+        <a href="xmpp:ralphm@ik.nu">ralphm@ik.nu</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-pubsub">Publish-Subscribe Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#addressing">Addressing</a>
+</dt>
+<dt>5.  <a href="#events">Event Types</a>
+</dt>
+<dt>6.  <a href="#affiliations">Affiliations</a>
+</dt>
+<dt>7.  <a href="#substates">Subscription States</a>
+</dt>
+<dt>8.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#entity">Entity Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.1.  <a href="#disco-service">Discover Service Features</a>
+</dt>
+<dt>8.1.2.  <a href="#entity-create">Create a New Node</a>
+</dt>
+<dt>8.1.3.  <a href="#entity-publish">Publish an Item to a Node</a>
+</dt>
+<dt>8.1.4.  <a href="#entity-delete">Delete an Item from a Node</a>
+</dt>
+<dt>8.1.5.  <a href="#entity-subscribe">Subscribe to a Node</a>
+</dt>
+<dt>8.1.6.  <a href="#entity-approve">Approving and Denying Subscription Requests</a>
+</dt>
+<dt>8.1.7.  <a href="#entity-retrieve">Retrieve Current Affiliations</a>
+</dt>
+<dt>8.1.8.  <a href="#entity-unsub">Unsubscribe from a Node</a>
+</dt>
+<dt>8.1.9.  <a href="#entity-configure">Configure Subscription Options</a>
+</dt>
+<dt>8.1.10.  <a href="#entity-getitems">Get Items for a Node</a>
+</dt>
+<dt>8.1.11.  <a href="#entity-discovernodes">Discover Nodes</a>
+</dt>
+<dt>8.1.12.  <a href="#entity-info-metadata">Discover Node Information and Meta-Data</a>
+</dt>
+<dt>8.1.13.  <a href="#entity-discoveritems">Discover Items for a Node</a>
+</dt>
+</dl>
+<dt>8.2.  <a href="#owner">Owner Use Cases</a>
+</dt>
+<dl>
+<dt>8.2.1.  <a href="#owner-configure">Configure a Node</a>
+</dt>
+<dt>8.2.2.  <a href="#owner-default">Request Default Configuration Options</a>
+</dt>
+<dt>8.2.3.  <a href="#owner-delete">Delete a Node</a>
+</dt>
+<dt>8.2.4.  <a href="#owner-purge">Purge All Node Items</a>
+</dt>
+<dt>8.2.5.  <a href="#owner-modify">Modifying Entity Affiliations</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#collections">Collection Nodes</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#collections-subscribe">Subscribing to a Collection Node</a>
+</dt>
+<dt>9.2.  <a href="#collections-root">Root Collection Node</a>
+</dt>
+<dt>9.3.  <a href="#collections-createnodes">Creating New Collection Nodes</a>
+</dt>
+<dt>9.4.  <a href="#collections-createaffil">Creating Nodes Affiliated with a Collection</a>
+</dt>
+<dt>9.5.  <a href="#collections-notify">Generating Publish Notifications for Collections</a>
+</dt>
+</dl>
+<dt>10.  <a href="#errors">Error Conditions</a>
+</dt>
+<dt>11.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#impl-presence">Presence-Based Delivery of Events</a>
+</dt>
+<dt>11.2.  <a href="#impl-offline">Not Sending Events to Offline Storage</a>
+</dt>
+<dt>11.3.  <a href="#impl-uniqueness">Node and Item ID Uniqueness</a>
+</dt>
+<dt>11.4.  <a href="#impl-authorize">Authorizing Subscription Requests (Pending Subscribers)</a>
+</dt>
+<dt>11.5.  <a href="#impl-hierarchies">Handling Node Hierarchies</a>
+</dt>
+<dt>11.6.  <a href="#impl-message">Message Bodies</a>
+</dt>
+<dt>11.7.  <a href="#impl-multiple">Multiple Node Discovery</a>
+</dt>
+<dt>11.8.  <a href="#impl-association">Associating Events and Payloads with the Generating Entity</a>
+</dt>
+<dt>11.9.  <a href="#impl-leases">Implementing Time-Based Subscriptions (Leases)</a>
+</dt>
+<dt>11.10.  <a href="#impl-content">Implementing Content-Based Pubsub Systems</a>
+</dt>
+</dl>
+<dt>12.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>13.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>14.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+<dt>14.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>14.4.  <a href="#registrar-formtypes">Field Standardization</a>
+</dt>
+<dl>
+<dt>14.4.1.  <a href="#registrar-formtypes-auth">pubsub#subscribe_authorization FORM_TYPE</a>
+</dt>
+<dt>14.4.2.  <a href="#registrar-formtypes-options">pubsub#subscribe_options FORM_TYPE</a>
+</dt>
+<dt>14.4.3.  <a href="#registrar-formtypes-config">pubsub#node_config FORM_TYPE</a>
+</dt>
+<dt>14.4.4.  <a href="#registrar-formtypes-metadata">pubsub#meta-data FORM_TYPE</a>
+</dt>
+</dl>
+<dt>14.5.  <a href="#registrar-shim">SHIM Headers</a>
+</dt>
+<dt>14.6.  <a href="#registrar-querytypes">URI Query Types</a>
+</dt>
+</dl>
+<dt>15.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#schemas-pubsub">http://jabber.org/protocol/pubsub</a>
+</dt>
+<dt>15.2.  <a href="#schemas-event">http://jabber.org/protocol/pubsub#event</a>
+</dt>
+<dt>15.3.  <a href="#schemas-owner">http://jabber.org/protocol/pubsub#owner</a>
+</dt>
+<dt>15.4.  <a href="#schemas-error">http://jabber.org/protocol/pubsub#errors</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+        <p class="" style="">As Jabber technologies have matured, the need for a generic publish-subscribe ("pubsub") mechanism has arisen in a number of problem spaces. These include (but are not limited to): news feeds and content syndacation, avatar management, shared bookmarks, auction and trading systems, online catalogs, workflow systems, network management systems, NNTP gateways, vCard/profile management, and weblogs.</p>
+        <p class="" style="">In all of these domains, it is desirable for data communication to follow the classic "publish-subscribe" or "observer" design pattern: a person or application publishes information, and an event notification or the data itself is broadcasted to all authorized subscribers. In general, the relationship between the publisher and subscriber is mediated by a service that receives publication requests, broadcasts event notifications and/or the data itself to subscribers, and enables privileged entities to manage lists of people or applications that are authorized to publish or subscribe. In most pubsub services, the focal point for publication and subscription is a "topic" or "node" to which publishers send data and from which subscribers receive notifications and/or data. Additionally, some nodes may also maintain a history of events and provide other services that supplement the pure pubsub model.</p>
+        <p class="" style="">This Jabber Enhancement Proposal defines a single, cohesive, generic protocol which all forms of pubsub can utilize. While compliant implementations are not required to implement all of the features defined herein, this JEP documents most usages that may be requested of a pubsub service.</p>
+    <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+      <div class="indent">
+<h3>2.1 <a name="terms-pubsub">Publish-Subscribe Terms</a>
+</h3>
+        <p class="" style="">The following terms are used throughout this document to refer to elements, objects, or actions that occur in the context of a pubsub service.</p>
+        <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+<td align="" colspan="" rowspan="">Address</td>
+<td align="" colspan="" rowspan="">(1) A JID as defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250282">1</a>], or (2) the combination of a JID and a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250306">2</a>] node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Entity</td>
+<td align="" colspan="" rowspan="">A JID-addressable Jabber entity (client, service, application, etc.).</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Event</td>
+<td align="" colspan="" rowspan="">A change in the state of a node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Instant Node</td>
+<td align="" colspan="" rowspan="">A node whose NodeID is automatically generated by a pubsub service.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Item</td>
+<td align="" colspan="" rowspan="">An XML fragment which is published to a node, thereby generating an event.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">ItemID</td>
+<td align="" colspan="" rowspan="">A unique identifier for an item in the contect of a specific node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Node</td>
+<td align="" colspan="" rowspan="">A virtual location to which information can be published and from which event notifications and/or payloads can be received (in other pubsub systems, this may be labelled a "topic").</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Leaf</td>
+<td align="" colspan="" rowspan="">A type of node that contains published items only. It is NOT a container for other nodes.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Collection</td>
+<td align="" colspan="" rowspan="">A type of node that contains nodes and/or other collections but no published items. Collections provide the foundation entity to provide a means of representing hierarchial node structures.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">NodeID</td>
+<td align="" colspan="" rowspan="">The unique identifier for a node within the context of a pubsub service.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Notification</td>
+<td align="" colspan="" rowspan="">A message sent to a subscriber informing them of an event.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Outcast</td>
+<td align="" colspan="" rowspan="">An entity that is disallowed from subscribing or publishing to a node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Owner</td>
+<td align="" colspan="" rowspan="">The creator and manager of a node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Payload</td>
+<td align="" colspan="" rowspan="">The full data associated with an event (e.g., an RSS feed) rather than just the event itself.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Private</td>
+<td align="" colspan="" rowspan="">A node to which subscriptions are limited by means of a whitelist.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Public</td>
+<td align="" colspan="" rowspan="">A node to which any entity may subscribe.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Publisher</td>
+<td align="" colspan="" rowspan="">An entity that is allowed to publish items to a node.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Pubsub Service</td>
+<td align="" colspan="" rowspan="">An XMPP server or component that adheres to the protocol defined herein.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">Subscriber</td>
+<td align="" colspan="" rowspan="">An entity that is subscribed to a node.</td>
+</tr>
+        </table>
+      </div>
+    <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+        <p class="" style="">Requirements for a pubsub service can be driven by end-user needs as well as the needs of other components and services which can use the service. First, a pubsub service implemented using Jabber MUST provide the basic features which implement a pure publish-subscribe pattern:</p>
+        
+        <ul>
+            <li>A Jabber entity MUST be able to publish events to a service such that all subscribers to a node receive notification of the event.</li>
+            <li>A Jabber entity MUST be allowed to be affiliated with a node. Allowable affiliations are owner, publisher, none, and outcast. Implementations MUST support affiliations of owner and none, and MAY support affiliations of outcast and publisher.</li>
+            <li>A Jabber entity MUST be allowed to query the pubsub service (or a specific node) to determine what optional features of this specification the service (or node) implements. This query MUST use the Service Discovery (disco#info) protocol.</li>
+            <li>A Jabber entity MUST be allowed to query a node to determine non-feature-related information about that node (e.g., the service discovery category+type). This query MUST use the Service Discovery (disco#info) protocol.</li>
+        </ul>
+
+        
+        <p class="" style="">Some of the possible uses of a Jabber-based pubsub service will require other features, but these features are not mandatory for compliance with this specification. However, if these features are implemented, they MUST follow the protocol described herein to be compliant. These features include:</p>
+        <ul>
+            <li>If configuration of nodes is allowed, a node owner SHOULD be able to configure a node.</li>
+            <li>If configuration of subscription options is allowed, a subscriber SHOULD be able to configure the subscription options.</li>
+            <li>A node owner SHOULD be able to specify who may subscribe to a node.</li>
+            <li>A node owner SHOULD be able to specify who may publish to a node.</li>
+            <li>A node MAY be configured to deliver the published payload inside the event notification.</li>
+            <li>A node MAY be configured to persist published items to some persistent storage mechanism.</li>
+            <li>A node MAY be configured to persist only a limited number of items.</li>
+            <li>A node MAY be configured to deliver the last published item after a subscription is granted.</li>
+            <li>A service MAY support collections.</li>
+            <li>A service or node MAY support extended service discovery information (meta-data).</li>
+        </ul>
+
+    <h2>4.
+       <a name="addressing">Addressing</a>
+</h2>
+      <p class="" style="">If a pubsub node is addressable, it MUST be addressable either as (1) a JID or as (1) the combination of a JID and a Service Discovery node.</p>
+      <p class="" style="">If a pubsub node is addressable as a JID, the NodeID MUST be the resource identifier, and MUST NOT be specified by the "user" portion (node identifier) of the JID (e.g. "domain/NodeID" and "user@domain/NodeID" are allowed; "NodeID@domain" is not allowed). JID addressing SHOULD be used when interacting with a pubsub node using a protocol that does not support the node attribute. For example, when a service makes it possible for entities to subscribe nodes via presence, it would address nodes as JIDs.</p>
+      <p class="" style="">If a pubsub node is addressable as a Service Discovery node, the NodeID MUST be the value of both the Service Discovery 'node' attribute and the pubsub 'node' attribute (i.e., for discovery purposes, a pubsub node is equivalent to a Service Discovery node). Note: A pubsub service MAY enable entities to discover pubsub nodes (and items associated with such nodes) via Service Discovery, but this is OPTIONAL.</p>
+    <h2>5.
+       <a name="events">Event Types</a>
+</h2>
+        <p class="" style="">The requirements listed above imply that there are two major dimensions along which we can measure events: persistent vs. transient, and pure notification vs. inclusion of payload. An implementation SHOULD enable an owner to configure a node along both of these dimensions.</p>
+        <p class="" style="">A pubsub service MUST validate publish requests against the configuration of the node along both of these dimensions. See the <a href="#entity-publish">publish use-case</a> for specific error conditions based on a publish versus event-type mismatch. In addition, whether an item must be provided by the publisher, and whether an item ID is provided by the publisher or generated by the pubsub service, depends on the type of event being published. We can summarize the relevant rules as follows:</p>
+        <p class="caption">Table 2: Event Types, Items, and Item IDs</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+<th colspan="" rowspan="">--&gt;</th>
+<th colspan="" rowspan="">Notification</th>
+<th colspan="" rowspan="">Payload</th>
+</tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan=""><span style="font-weight: bold">Persistent</span></td>
+            <td align="" colspan="" rowspan="">Publisher MUST include an item element, which MAY be empty or contain a payload; if item ID is not provided by publisher, it MUST be generated by pubsub service</td>
+            <td align="" colspan="" rowspan="">Publisher MUST include an item element that contains the payload; if item ID is not provided by publisher, it MUST be generated by pubsub service</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan=""><span style="font-weight: bold">Transient</span></td>
+            <td align="" colspan="" rowspan="">Publisher MUST NOT include an item element (therefore item ID is neither provided nor generated)</td>
+            <td align="" colspan="" rowspan="">Publisher MUST include an item element that contains the payload, but the item ID is OPTIONAL</td>
+          </tr>
+        </table>
+    <h2>6.
+       <a name="affiliations">Affiliations</a>
+</h2>
+        <p class="" style="">To manage permissions, the protocol defined herein uses a hierarchy of affiliations, similiar to those introduced in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250969">3</a>].</p>
+        <p class="caption">Table 3: Affiliations and their Privileges</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+            <th colspan="" rowspan="">Affiliation</th>
+            <th colspan="" rowspan="">Subscribe</th>
+            <th colspan="" rowspan="">Publish Items</th>
+            <th colspan="" rowspan="">Purge Items</th>
+            <th colspan="" rowspan="">Configure Node</th>
+            <th colspan="" rowspan="">Delete Node</th>
+            <th colspan="" rowspan="">Delete Item</th>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Owner</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Publisher</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">Yes/No</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">None</td>
+            <td align="" colspan="" rowspan="">Yes</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Outcast</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+            <td align="" colspan="" rowspan="">No</td>
+                    <td align="" colspan="" rowspan="">No</td>
+          </tr>
+        </table>
+        <p class="" style="">Pubsub services MAY allow any publisher to delete any item once it has been published to that node instead of allowing only the original publisher to remove it (this is disoverable via the "pubsub#delete-any" feature. If a publisher is not allowed to delete an item, the service MUST bounce the request using a &lt;not-authorized/&gt; error.</p>
+        <p class="" style="">Any Jabber entity which is currently subscribed to a node may unsubscribe from a node. All other entities which attempt to unsubscribe from a node MUST receive a &lt;item-not-found/&gt; error in response.</p>
+        <p class="" style="">The ways in which an entity changes its affiliation with a node are well-defined. Typically, an owner action is required to make an affiliation state transition. Affiliation changes and their triggering actions are specified in the following table.</p>
+        <p class="caption">Table 4: Affiliation State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+            <th colspan="" rowspan="">--&gt;</th>
+            <th colspan="" rowspan="">Outcast</th>
+            <th colspan="" rowspan="">None</th>
+            <th colspan="" rowspan="">Publisher</th>
+            <th colspan="" rowspan="">Owner</th>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Outcast</td>
+            <td align="" colspan="" rowspan="">--</td>
+            <td align="" colspan="" rowspan="">Owner removes ban</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to publisher list</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">None</td>
+            <td align="" colspan="" rowspan="">Owner bans entity</td>
+            <td align="" colspan="" rowspan="">--</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to publisher list</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Publisher</td>
+            <td align="" colspan="" rowspan="">Owner bans entity</td>
+            <td align="" colspan="" rowspan="">Owner removes entity from publisher list</td>
+            <td align="" colspan="" rowspan="">--</td>
+            <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Owner</td>
+            <td align="" colspan="" rowspan="">n/a</td>
+            <td align="" colspan="" rowspan="">Owner resigns</td>
+            <td align="" colspan="" rowspan="">n/a</td>
+            <td align="" colspan="" rowspan="">--</td>
+          </tr>
+        </table>
+    <h2>7.
+       <a name="substates">Subscription States</a>
+</h2>
+        
+        <p class="" style="">
+        Subscriptions to a node may exist in several states.
+        </p>
+
+        <p class="caption">Table 5: Subscription States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+            <th colspan="" rowspan="">Subscription State</th>
+            <th colspan="" rowspan="">Description</th>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">None</td>
+            <td align="" colspan="" rowspan="">The node MUST NOT send event notifications or payloads to the Entity.</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">Pending</td>
+            <td align="" colspan="" rowspan="">An entity has requested to subscribe to a node and the request has not yet been approved by a node owner. The node MUST NOT send event notifications or payloads to the entity while it is in this state.</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">Unconfigured</td>
+            <td align="" colspan="" rowspan="">An entity has subscribed but its subscription options have not yet been configured. The node MAY send event notifications or payloads to the entity while it is in this state. The service MAY timeout unconfigured subscriptions.</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">Subscribed</td>
+            <td align="" colspan="" rowspan="">An entity is subscribed to a node. The node MUST send all event notifications (and, if configured, payloads) to the entity while it is in this state.</td>
+        </tr>
+        </table>
+
+    <h2>8.
+       <a name="usecases">Use Cases</a>
+</h2>
+        <p class="" style="">The following sections define the use cases and the protocol to be used by various actors in those use cases. The <a href="#impl">Implementation Notes</a> section below describes many important factors and business rules which all pubsub services MUST observe. (Note: the examples throughout assume the existence of a separate pubsub component and include any relevant 'from' addresses as stamped by a server or network edge.)</p>
+
+        
+        <div class="indent">
+<h3>8.1 <a name="entity">Entity Use Cases</a>
+</h3>
+
+            
+            <div class="indent">
+<h3>8.1.1 <a name="disco-service">Discover Service Features</a>
+</h3>
+                <p class="" style="">Pubub services MUST respond to feature queries using the Service Discovery protocol and scoped by the http://jabber.org/protocol/disco#info namespace. The disco#info result MUST indicate support for the features by using a feature element with the appropriate 'var' attribute. Throughout this document these features are noted, and have been registered with the Jabber Registrar as described in the <a href="registrar">Jabber Registrar Considerations</a> section of this document.</p>
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.2 <a name="entity-create">Create a New Node</a>
+</h3>
+                <p class="" style="">Implementations of pubsub SHOULD allow users and services to create new nodes, which other Jabber entities may then publish to or subscribe to (depending on permissions). However, implementations MAY disallow creation of nodes based on the identity of the entity trying to create the new node, or MAY disallow node creation altogether.</p>
+
+                <p class="" style="">Nodes are created based on a NodeID supplied by the node creator. The NodeID MAY have semantic meaning, but such meaning is not required. If the requested NodeID already exists, the pubsub service MUST respond with a &lt;conflict/&gt; error. If the pubsub service does not support node creation, or the requesting JID does not have authorization to create nodes, the pubsub service MUST respond with a &lt;feature-not-implemented/&gt; error.</p>
+                
+                <p class="" style="">Implementations SHOULD allow node creation requests to contain a node configuration request in the same IQ element. (See the <a href="#owner-configure">Configure a Node</a> section below for more details.) If an entity wishes to accept the default configuration, it SHOULD include an empty &lt;configure/&gt; element in its node creation request.</p>
+
+                <p class="" style="">The NodeID requested in the create node request MAY be modified by the service depending on the node-configuration specified. For example, if the node configuration requests that the new node become associated with a <a href="#collection_create">collection node</a>, the service MAY create a node identifier which is not the same as the original ID requested. In this case, the service MUST return the modified NodeID in the IQ result, contained in a &lt;create/&gt; element whose 'node' attribute specifies the modified NodeID.</p>
+
+                <p class="" style="">Some implementations MAY choose to force entities to register with the pubsub service before allowing nodes to be created. In these cases, the service MUST respond to the create request with a &lt;registration-required/&gt; error if the entity is not registered.</p>
+
+                <p class="" style="">When a service successfully creates a node on behalf of the requesting entity, it MUST return an IQ result. If the node creation request did not specify a NodeID (i.e., the sender requested an "instant node" as described below), the service MUST specify the created NodeID in the IQ result. If the node creation request specified a NodeID but the service modified the NodeID before creating the node as described under the <a href="#collections">Collection Nodes</a> section of this document, the service MUST also specify the modified node in the IQ result. In all other cases, the service MUST NOT specify the NodeID in the IQ result (since the sender can determine which node was created by tracking the 'id' attribute that it provided in the IQ set).</p>
+
+                <p class="caption">Example 1. Entity requests a new node with default configuration.</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="create1"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+        &lt;create node="generic/pgm-mp3-player"/&gt;
+        &lt;configure/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 2. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="create1"/&gt;</pre></div>
+
+                <p class="caption">Example 3. Server replies with Conflict</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="create1"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+        &lt;create node="generic/pgm-mp3-player"/&gt;
+    &lt;/pubsub&gt;
+    &lt;error code="409" type="cancel"&gt;
+      &lt;conflict xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 4. Server replies with Not Implemented</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="create1"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+        &lt;create node="generic/pgm-mp3-player"/&gt;
+    &lt;/pubsub&gt;
+    &lt;error code="501" type="cancel"&gt;
+      &lt;feature-not-implemented xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 5. Server replies with Registration Required</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="create1"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+        &lt;create node="generic/pgm-mp3-player"/&gt;
+    &lt;/pubsub&gt;
+    &lt;error code="407" type="auth"&gt;
+      &lt;registration-required xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="" style="">In some cases, the requesting entity may want the service to automatically generate a unique NodeID for the newly-created node, to which it may immediately publish; we can think of this as an "instant node". To do this, the requesting entity MUST NOT include a NodeID in the request. If the user has permissions to create nodes, the pubsub service MUST create the node, generate a NodeID that is unique within the context of that pubsub service, and inform the user of success (including the NodeID). A service SHOULD support instant nodes; if it does not, it MUST return a &lt;not-acceptable/&gt; error.</p>
+                <p class="caption">Example 6. Client requests an instant node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="create2"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+        &lt;create/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 7. Server replies with success and generated NodeID</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="create2"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+       &lt;create
+         node="generic/25e3d37dabbab9541f7523321421edc5bfeb2dae"/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+                <p class="caption">Example 8. Server does not support instant nodes</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="create2"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+       &lt;create/&gt;
+    &lt;/pubsub&gt;
+    &lt;error code="406" type="modify"&gt;
+      &lt;not-acceptable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.3 <a name="entity-publish">Publish an Item to a Node</a>
+</h3>
+                <p class="" style="">Any entity which is allowed to publish to a node (i.e., a publisher or an owner) may do so at any time. When the pubsub service receives the request, all (approved and active) subscribers are notified of the event. The node configuration MUST specify whether or not the payload is to be delivered to the subscribers. If payloads are not delivered with the event notification, subscribers MAY request the published item via the protocol defined in the <a href="#entity-getitems">Get Items for a Node</a> section of this document.</p>
+                <p class="" style="">An item MUST NOT contain data defined by more than one namespace, with the exception of item meta-data as described below.</p>
+                <p class="" style="">When a publisher publishes a new item to a node, the service MUST validate that the publish request matches the <a href="#events">event type</a> node configuration. Specifically, if items are persistent, or payloads are delivered with event notifications, then the publish request MUST contain an item. If the node is configured for pure event notification, then the publish request MUST NOT contain an item. If a mismatch is detected, the service MUST bounce the packet with a &lt;bad-request/&gt; error.</p>
+                <p class="" style="">In order to facilitate authorization for item removal as shown in the <a href="#entity-delete">Delete an Item from a Node</a> section below, implementations which support persistent items SHOULD store the item (if the node is so configured) and maintain a record of the publisher.</p>
+                <p class="" style="">(Note: the following examples adhere to the payload format defined in <span class="ref" style="">User Tune</span>  [<a href="#nt-id2252087">4</a>]).</p>
+                <p class="caption">Example 9. Entity publishes an item with an ItemID</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="publish1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;publish node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 10. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="publish1"/&gt;</pre></div>
+
+                <p class="caption">Example 11. Entity is not authorized to publish to node</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="publish1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;publish node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="401" type="auth"&gt;
+    &lt;not-authorized xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 12. Entity attempts to publish to a non-existent node</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="publish1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;publish node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="404" type="cancel"&gt;
+    &lt;item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="" style="">If the node is so configured, the subscribers will receive event notifications only.</p>
+                <p class="caption">Example 13. Subscribers receive event notifications only</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to="subscriber2" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+                <p class="" style="">If the node is so configured, the subscribers will receive both event notifications and payloads.</p>
+                <p class="caption">Example 14. Subscribers receive event notifications with payloads</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to="subscriber2" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+            <p class="" style="">Item identifiers are not mandatory and may not be necessary for many types of nodes. In these cases, when an item is published, it is put into the stack of items.</p>
+
+                <p class="caption">Example 15. Entity publishes an item without an ItemID</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="publish1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;publish node="generic/pgm-mp3-catalog"&gt;
+      &lt;item&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 16. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="publish1"/&gt;</pre></div>
+
+                <p class="" style="">If a publisher publishes an item and the ItemID matches that of an existing item, the pubsub service MUST overwrite the existing item and generate a new event notification.</p>
+
+                <p class="" style="">If a single entity is subscribed to a node multiple times, then the service SHOULD notate the event notification so that the entity can determine what subscription identifiers generated this event. If these notations are included, they MUST use the <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2252264">5</a>] protocol and SHOULD be included after the event notification information (i.e., as the last child of the &lt;message/&gt; stanza).</p>
+
+                <p class="caption">Example 17. Subscriber receives notated event notification</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name="pubsub#subid"&gt;123-abc&lt;/header&gt;
+    &lt;header name="pubsub#subid"&gt;004-yyy&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;</pre></div>
+
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.4 <a name="entity-delete">Delete an Item from a Node</a>
+</h3>
+            <p class="" style="">A service SHOULD allow publishers to delete items once they have been published to a node that supports persistent items. To delete an item, the publisher sends a retract request as shown in the follow examples. This request may fail because:</p>
+           <ul>
+           <li>The publisher is not authorized to delete the requested item (&lt;not-authorized/&gt; error).</li>
+           <li>The node does not exist (&lt;item-not-found/&gt; error).</li>
+           <li>The node does not support persistent items (&lt;not-allowed/&gt; error).</li>
+           <li>The service does not support the deletion of items (&lt;feature-not-implemented/&gt; error).</li>
+           </ul>
+
+                <p class="caption">Example 18. Entity deletes an item from a node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="deleteitem1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;retract node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 19. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="deleteitem1"/&gt;</pre></div>
+
+                <p class="caption">Example 20. Publisher is not authorized to delete this item</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="deleteitem1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;retract node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="401" type="auth"&gt;
+    &lt;not-authorized xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 21. Publisher is trying to delete an item from a non-existent node</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="deleteitem1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;retract node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="404" type="cancel"&gt;
+    &lt;item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 22. Publisher is trying to delete an item from a node which does not support persistent items</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="deleteitem1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;retract node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="405" type="cancel"&gt;
+    &lt;not-allowed xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 23. Service does not support deleting items</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="deleteitem1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;retract node="generic/pgm-mp3-player"&gt;
+      &lt;item id="current"/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="501" type="cancel"&gt;
+    &lt;feature-not-implemented xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+
+            <p class="" style="">If an implementation supports allowing subscribers to be notified of deleted items (and the node is configured for it), the service MUST use message notifications as shown below. The syntax is identical to publish notifications except that instead of &lt;item/&gt; elements, we have &lt;retract/&gt; elements.</p>
+
+                <p class="caption">Example 24. Subscribers are notified of deletion</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;retract id="current"/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to="subscriber2" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;retract id="current"/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+            </div>
+
+
+            
+            <div class="indent">
+<h3>8.1.5 <a name="entity-subscribe">Subscribe to a Node</a>
+</h3>
+            <p class="" style="">When a Jabber entity wishes to subscribe to a node, it sends an IQ request to the pubsub service. Depending on the configuration of the node, several things may happen. If the node has "open" subscriptions, the potential subscriber receives either a result or an error. If the node has been configured so that subscription requests must be approved by the node owner (or a designated approver), the pubsub service sends a message to the node owner requesting authorization, where the message contains a form that is structured in accordance with the <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2252741">6</a>] protocol. To approve the subscription request, the node owner MUST submit the form. To deny the request, the owner MUST cancel the form.</p>
+
+            <p class="" style="">Subscription requests to a node MUST contain a 'jid' attribute, which enables the subscriber to specify either a bare JID or a specific resource which should be used as the subscribed Jabber ID. Implementations MUST at a minimum check the bare JID requested against the 'from' attribute on the received packet to make sure that the requesting entity has the same identity as the JID which is being requested to be added to the subscriber list. (Naturally, JIDs of the form &lt;domain&gt; and &lt;domain/resource&gt; may subscribe as well.)</p>
+
+            <p class="" style="">Some implementations MAY allow a service-configured list of entities (Jabber IDs) which are excluded from this check. Those entities may be treated as trusted proxies which are allowed to subscribe on behalf of other users. In the same way, implementations may enable blacklisting of entities based on Jabber ID which are not allowed to perform specific operations.</p>
+
+            <p class="" style="">Services MAY allow entities to subscribe multiple times to the same node. This enables an entity to subscribe using different subscription options. If multiple subscriptions for the same JID is allowed, the service MUST use the 'subid' attribute to differentiate between subscriptions for the same entity. The SubID MUST be present on the entity element any time it is sent to the entity. If the service does not allow multiple subscriptions for the same entity and it receives an additional subscription request, the service MUST return the current subscription state (as if the subscription was just approved).</p>
+
+            <p class="" style="">If an entity attempts to subscribe with a JID that is not allowed (bare JIDs do not match, or the user does not have some kind of admin or proxy privilege as defined by the implementation), then the pubsub service MUST respond with a &lt;not-authorized/&gt; error.</p>
+
+            <p class="" style="">Commercial deployments may wish to allow subscribers to be linked to some kind of paying customer database. If the subscriber needs to provide payment in order to subscribe to the node (e.g., if the subscriber is not in the customer database or the customer's account is not paid up), the service SHOULD return a &lt;payment-required/&gt; error to the subscriber.</p>
+
+                <p class="caption">Example 25. Entity subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="sub1@foo.com/home"
+    to="pubsub.jabber.org"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;subscribe
+        node="generic/pgm-mp3-player"
+        jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 26. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;entity node="generic/pgm-mp3-player"
+            jid="sub1@foo.com"
+            affiliation="none"
+            subid="123-abc"
+            subscription="subscribed"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+
+                <p class="caption">Example 27. Entity is not authorized to create a subscription</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;subscribe
+        node="generic/pgm-mp3-player"
+        jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="401" type="auth"&gt;
+    &lt;not-authorized xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 28. Payment is required for a subscription</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;subscribe
+        node="generic/pgm-mp3-player"
+        jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="402" type="auth"&gt;
+    &lt;payment-required xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 29. Server replies with node not found</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;subscribe
+        node="generic/pgm-mp3-player"
+        jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="404" type="cancel"&gt;
+    &lt;item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 30. Server replies with pending (owner must approve subscription request)</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;entity node="generic/pgm-mp3-player"
+            jid="sub1@foo.com"
+            affiliation="none"
+            subid="123-abc"
+            subscription="pending"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            <div class="indent">
+<h3>8.1.6 <a name="entity-approve">Approving and Denying Subscription Requests</a>
+</h3>
+            <p class="" style="">Pubsub services MAY send approval requests to the current approver (typically the node owner) at any time. As such, these are simple message stanzas which contain a Data Form. The node owner MAY also request the current pending subscriptions at any time. Implementations MUST use the <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2252941">7</a>] protocol to request the pending list. The command name (node attribute of the command element) MUST have a value of "http://jabber.org/protocol/pubsub#get-pending". The command MUST take a single field argument with a 'var' attribute value of "node". This field MUST contain the desired NodeID. The node field SHOULD be a list-single field which contains all of the NodeIDs for which the requestor has approval privileges.
+            </p>
+
+            <p class="" style="">If an entity which does not have sufficient permissions to approve subscription requests attempts to get the current pending list, the service MUST respond with a &lt;forbidden/&gt; error message. If the node requested in the node field does not exist, the service MUST respond with a &lt;item-not-found/&gt; error message.
+            </p>
+
+            <p class="" style="">When subscription approval messages are sent to the current approver (typically, the node owner), the form MUST contain a hidden field element which uses a 'var' attribute of FORM_TYPE, and a value of "http://jabber.org/protocol/pubsub" as specified in <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2252996">8</a>]. This enables client applications to detect that this is a pubsub subscriber request, and, if desired, to use some non-standard jabber:x:data dialog. The form MUST contain a boolean field that has a 'var' attribute of "pubsub#allow" which is the field that designates whether or not to allow the subscription request. This field MUST be checked when the form is processed after submission to see if the subscription should be allowed or denied. If the approver cancels the Data Form, then the subscription request MUST remain in the pending list. The Data Form sent to the approver SHOULD include fields to show the node identifier, the subscription id (if applicable), and the JID of the pending subscriber.</p>
+
+            <p class="caption">Example 31. Owner requests pending subscription requests</p>
+<div class="indent"><pre>
+&lt;iq type="set" to="pubsub.jabber.org" id="pending1"&gt;
+    &lt;command xmlns="http://jabber.org/protocol/commands"
+             node="http://jabber.org/protocol/pubsub#get-pending"
+             action="execute"/&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 32. Server responds with data form to be populated</p>
+<div class="indent"><pre>
+&lt;iq type="result" to="pubsub.jabber.org" id="pending1"&gt;
+    &lt;command xmlns="http://jabber.org/protocol/commands"
+             sessionid="pubsub-get-pending:20031021T150901Z-600"
+             node="http://jabber.org/protocol/pubsub#get-pending"
+             status="executing"
+             action="execute"&gt;
+        &lt;x xmlns="jabber:x:data" type="form"&gt;
+            &lt;field type="list-single"
+                   var="pubsub#node"&gt;
+                &lt;option&gt;&lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;&lt;/option&gt;
+                &lt;option&gt;&lt;value&gt;generic/pgm-geoloc&lt;/value&gt;&lt;/option&gt;
+                &lt;option&gt;&lt;value&gt;generic/pgm-avatar&lt;/value&gt;&lt;/option&gt;
+            &lt;/field&gt;
+        &lt;/x&gt;
+    &lt;/command&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 33. Server responds with forbidden</p>
+<div class="indent"><pre>
+&lt;iq type="error" from="pubsub.jabber.org" id="pending2"&gt;
+    &lt;error code="403" type="cancel"&gt;
+      &lt;forbidden xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 34. Server responds with node not found</p>
+<div class="indent"><pre>
+&lt;iq type="error" from="pubsub.jabber.org" id="pending2"&gt;
+    &lt;error code="404"&gt;
+      &lt;item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 35. Owner requests all pending subscription requests for a node</p>
+<div class="indent"><pre>
+&lt;iq type="set" to="pubsub.jabber.org" id="pending2"&gt;
+    &lt;command xmlns="http://jabber.org/protocol/commands"
+             sessionid="pubsub-get-pending:20031021T150901Z-600"
+             node="http://jabber.org/protocol/pubsub#get-pending"
+             action="execute"&gt;
+        &lt;x xmlns="jabber:x:data" type="submit"&gt;
+            &lt;field var="pubsub#node"&gt;
+                &lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;
+            &lt;/field&gt;
+        &lt;/x&gt;
+    &lt;/command&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 36. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq type="result" from="pubsub.jabber.org" id="pending2"/&gt;</pre></div>
+
+                <p class="caption">Example 37. Server sends authorization request to node owner</p>
+<div class="indent"><pre>
+&lt;message to="node-owner" from="pubsub.jabber.org"&gt;
+    &lt;x xmlns="jabber:x:data" type="form"&gt;
+        &lt;title&gt;PubSub subscriber request&lt;/title&gt;
+        &lt;instructions&gt;
+          To approve this entity&amp;apos;s subscription request,
+          click the OK button. To deny the request, click the
+          cancel button.
+        &lt;/instructions&gt;
+        &lt;field var="FORM_TYPE" type="hidden"&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#subid"
+               type="hidden"&gt;
+            &lt;value&gt;123-abc&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#node"
+               type="text-single"
+               label="Node ID"&gt;
+            &lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pusub#subscriber_jid"
+               type="jid-single"
+               label="Subscriber Address"&gt;
+            &lt;value&gt;sub1@foo.com&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#allow"
+               type="boolean"
+               label="Allow this JID to subscribe to this pubsub node?"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+    &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+
+            <p class="caption">Example 38. Owner approves subscription request</p>
+<div class="indent"><pre>
+&lt;message from="node-owner" to="pubsub.jabber.org"&gt;
+    &lt;x xmlns="jabber:x:data" type="submit"&gt;
+        &lt;field var="FORM_TYPE" type="hidden"&gt;
+           &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#subid"&gt;
+           &lt;value&gt;123-abc&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#node"&gt;
+           &lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#subscriber_jid"&gt;
+           &lt;value&gt;sub1@foo.com&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#allow"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+    &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+
+            <p class="caption">Example 39. Owner denies subscription request</p>
+<div class="indent"><pre>
+&lt;message from="node-owner" to="pubsub.jabber.org"&gt;
+    &lt;x xmlns="jabber:x:data" type="submit"&gt;
+        &lt;field var="FORM_TYPE" type="hidden"&gt;
+           &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#subid"&gt;
+           &lt;value&gt;123-abc&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#node"&gt;
+           &lt;value&gt;generic/pgm-mp3-player&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#subscriber_jid"&gt;
+           &lt;value&gt;sub1@foo.com&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#allow"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+    &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+
+
+            <p class="" style="">The service would then send a message with extended information in the 'jabber:x:data' namespace for all pending subscription requests, as shown above for a single pending subscription request.</p>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.7 <a name="entity-retrieve">Retrieve Current Affiliations</a>
+</h3>
+                <p class="" style="">Entities SHOULD be allowed to query the service to provide all of the current affiliations for all nodes within that service for that entity. The affiliations element is used to make the request. For each affiliation, an entity element is returned containing the NodeID, the JID which is affiliated (MAY include a resource, depending on how the JID subscribed), the affiliation, and the current subscription state. If subscription identifiers are supported by the service and the entity's subscription is not NONE or OUTCAST, the 'subid' attribute MUST be present as well as the 'jid' attribute.</p>
+
+                <p class="caption">Example 40. Entity requests all current affiliations</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="sub1@foo.com"
+    to="pubsub.jabber.org"
+    id="allsubs"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;affiliations/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 41. Service replies with all current affiliations</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com"
+    id="allsubs"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;affiliations&gt;
+      &lt;entity node="node1"
+              jid="sub1@foo.com"
+              affiliation="owner"
+              subid="sub1"
+              subscription="subscribed"/&gt;
+      &lt;entity node="node2"
+              jid="sub1@foo.com"
+              affiliation="publisher"
+              subid="sub2"
+              subscription="subscribed"/&gt;
+      &lt;entity node="node3"
+              jid="sub1@foo.com/pda"
+              affiliation="none"
+              subid="sub3"
+              subscription="unconfigured"/&gt;
+      &lt;entity node="node4"
+              jid="sub1@foo.com/work"
+              affiliation="none"
+              subid="sub4"
+              subscription="pending"/&gt;
+      &lt;entity node="node5"
+              jid="sub1@foo.com"
+              affiliation="outcast"
+              subscription="none"/&gt;
+      &lt;entity node="node6"
+              jid="sub1@foo.com"
+              affiliation="owner"
+              subscription="none"/&gt;
+    &lt;/affiliations&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.8 <a name="entity-unsub">Unsubscribe from a Node</a>
+</h3>
+            <p class="" style="">To unsubscribe from a node, the subscriber sends an appropriately-formatted IQ request to the node in question. If the unsubscribe is successful, an IQ result is sent back. If the value of the 'jid' attribute does not specify an existing subscriber, the pubsub service MUST return an error stanza, which SHOULD be &lt;unexpected-request/&gt; and which SHOULD also include a &lt;not-subscribed/&gt; child qualified by the 'http://jabber.org/protocol/pubsub#errors' namespace. If the requestor is not authorized to unsubscribe the specified JID, the service MUST return a &lt;not-authorized/&gt; error. If the node does not exist, the pubsub service MUST return a &lt;item-not-found/&gt; error. If a subscription identifier is associated with the subscription (ie, the service supports them), the unsubscribe request MUST include the appropriate 'subid' attribute. If the unsubscribe request includes a SubID but SubIDs are not supported for the node (or the subscriber did not subscribe using a SubID in the first place), then the service SHOULD ignore the SubID and simply unsubscribe the entity. If subscriber originally subscribed with a SubID but the unsubscribe request includes a SubID other that is not valid or current for the subscriber, the service MUST return a &lt;not-acceptable/&gt; error.</p>
+
+                <p class="caption">Example 42. Entity unsubscribes from a node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="sub1@foo.com"
+    to="pubsub.jabber.org"
+    id="unsub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+     &lt;unsubscribe
+         node="generic/pgm-mp3-player"
+         subid="123-abc"
+         jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 43. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com"
+    id="unsub1"/&gt;
+</pre></div>
+
+                <p class="caption">Example 44. Requestor is not a subscriber</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com"
+    id="unsub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+     &lt;unsubscribe
+         node="generic/pgm-mp3-player"
+         subid="123-abc"
+         jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="401" type="auth"&gt;
+    &lt;not-authorized xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;not-subscribed xmlns="http://jabber.org/protocol/pubsub#errors"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 45. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com"
+    id="unsub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+     &lt;unsubscribe
+         node="generic/pgm-mp3-player"
+         subid="123-abc"
+         jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="404" type="cancel"&gt;
+    &lt;item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+
+                <p class="caption">Example 46. Invalid subscription identifier</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com"
+    id="unsub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+     &lt;unsubscribe
+         node="generic/pgm-mp3-player"
+         subid="123-abc"
+         jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="406" type="modify"&gt;
+    &lt;not-acceptable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.9 <a name="entity-configure">Configure Subscription Options</a>
+</h3>
+            <p class="" style="">Implementations MAY allow subscribers to configure options for their own subscription. Implementations SHOULD use the <span style="font-weight: bold">Data Forms</span> protocol to accomplish this configuration. A subscriber requests the subscription options by using the &lt;options/&gt; element inside of an IQ stanza, to which the service MUST respond with either an error (detailed below) or a result element containing the options.</p>
+
+            <p class="" style="">If a service supports subscription options it MUST advertise that fact in the result to a disco#info query by including a feature whose 'var' attribute is "pubsub#subscription-options". If a service supports subscription options, an entity MAY subscribe and provide the subscription options in the same stanza. In this case, the subscribe-options element MUST be a sibling of the subscribe element on the subscribe request. (If the service does not support subscription options, is MUST return a &lt;feature-not-implemented/&gt; error.)</p>
+
+            <p class="" style="">When requesting subscription options, the subscriber MUST specify both the NodeID of the node and the JID which is subscribed to the node. Services MUST validate that the entity making the request is authorized to set the subscription options for the subscribed entity. If the subscriber's JID is of the form &lt;user@host/resource&gt;, a services SHOULD perform this check by comparing the user@host part of the two JIDs to ensure that they match. If a subscription identifier is associated with the subscription, the 'subid' attribute MUST be present on the request in order for the service to differentiate subscriptions for the same entity.</p>
+
+            <p class="" style="">If a node supports subscription options, it MUST return a &lt;subscribe-options&gt; element inside the entity element in the result of the subscription request. The subscribe-options element MAY contain a &lt;required/&gt; child element if the subscriber MUST configure the subscription before receiving any notifications from that event. Services MAY timeout subscription requests if configuration is required and a configuration request is not submitted within a reasonable amount of time (which shall be determined by the service or node configuration). If the jabber:x:data &lt;required/&gt; element is not present, the subscription takes effect immediately and enables the entity to configure the subscription at any time.</p>
+
+            <p class="" style="">The following example shows some (but by no means all) of the possible configuration options which MAY be implemented in implementations. If an implementation implements these options using the <span style="font-weight: bold">Data Forms</span> protocol, that implementation MUST use the field variables that are registered with the Jabber Registrar in association with the 'http://jabber.org/protocol/pubsub' namespace (a preliminary representation of those field variables is shown below, but MUST NOT be construed as canonical, since the Jabber Registrar may standardize additional fields at a later date without changes to this JEP). An implementation MAY choose to specify different labels, values, and even field types, but must conform to the defined variable naming scheme.</p>
+
+            <p class="" style="">If nodes or services do not support subscriber options, then the response for an options request MUST be a &lt;feature-not-implemented/&gt; error. If a subscriber attempts to set an invalid group of options, the service MUST respond with a &lt;bad-request/&gt; error.
+            </p>
+
+                <p class="caption">Example 47. Entity subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="sub1@foo.com/home"
+    to="pubsub.jabber.org"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;subscribe
+        node="generic/pgm-mp3-player"
+        jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 48. Server replies with success and indicates that subscription configuration is required</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;entity node="generic/pgm-mp3-player"
+            jid="sub1@foo.com"
+            affiliation="none"
+            subid="123-abc"
+            subscription="unconfigured"&gt;
+      &lt;subscribe-options&gt;
+        &lt;required/&gt;
+      &lt;/subscribe-options&gt;
+    &lt;/entity&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 49. Subscriber requests subscription options form</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="sub1@foo.com/home"
+    to="pubsub.jabber.org"
+    id="options1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;options
+        node="generic/pgm-mp3-player"
+        subid="123-abc"
+        jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 50. Server responds with Not Implemented (subscription options not supported)</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="options1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;options
+        node="generic/pgm-mp3-player"
+        subid="123-abc"
+        jid="sub1@foo.com"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="501" type="cancel"&gt;
+    &lt;feature-not-implemented xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;subscription-options-unavailable 
+        xmlns="http://jabber.org/protocol/pubsub#errors"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 51. Server responds with the options form</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="options1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;options node="generic/pgm-mp3-player"
+             jid="sub1@foo.com"
+             subid="123-abc"&gt;
+        &lt;x xmlns="jabber:x:data"&gt;
+          &lt;field var="FORM_TYPE" type="hidden"&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#digest" type="boolean"
+                 label="Receive digest notifications (approx. one per day)"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field
+              var="pubsub#show-values"
+              type="list-multi"
+              label="Select the presence types which are 
+                     allowed to receive notifications"&gt;
+            &lt;option label="Want to Chat"&gt;&lt;value&gt;chat&lt;/value&gt;&lt;/option&gt;
+            &lt;option label="Available"&gt;&lt;value&gt;online&lt;/value&gt;&lt;/option&gt;
+            &lt;option label="Away"&gt;&lt;value&gt;away&lt;/value&gt;&lt;/option&gt;
+            &lt;option label="Extended Away"&gt;&lt;value&gt;xa&lt;/value&gt;&lt;/option&gt;
+            &lt;option label="Do Not Disturb"&gt;&lt;value&gt;dnd&lt;/value&gt;&lt;/option&gt;
+            &lt;value&gt;chat&lt;/value&gt;
+            &lt;value&gt;online&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 52. Subscriber returns completed options form</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="sub1@foo.com/home"
+    to="pubsub.jabber.org"
+    id="options2"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;options node="generic/pgm-mp3-player"
+             jid="sub1@foo.com"
+             subid="123-abc"&gt;
+        &lt;x xmlns="jabber:x:data"&gt;
+          &lt;field var="FORM_TYPE" type="hidden"&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#digest" type="boolean"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+          &lt;field var="pubsub#show-values" type="list-multi"&gt;
+            &lt;value&gt;chat&lt;/value&gt;
+            &lt;value&gt;online&lt;/value&gt;
+            &lt;value&gt;away&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 53. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="options2"/&gt;</pre></div>
+
+                <p class="caption">Example 54. Server responds with Bad Request for invalid options</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="sub1@foo.com/home"
+    id="options2"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;options node="generic/pgm-mp3-player"
+             subid="123-abc"
+             jid="sub1@foo.com"&gt;
+        &lt;x xmlns="jabber:x:data"&gt;
+          &lt;field var="FORM_TYPE" type="hidden"&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#digest" type="boolean"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+          &lt;field var="pubsub#show-values" type="list-multi"&gt;
+            &lt;value&gt;chat&lt;/value&gt;
+            &lt;value&gt;online&lt;/value&gt;
+            &lt;value&gt;away&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="400" type="modify"&gt;
+    &lt;bad-request xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;invalid-options xmlns="http://jabber.org/protocol/pubsub#errors"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.10 <a name="entity-getitems">Get Items for a Node</a>
+</h3>
+            <p class="" style="">Implementations of pubsub that choose to persist items MAY allow entities to request existing items from a node. Entities may wish to do this after successfully subscribing to a node in order to receive all the items that are in the publishing "history" for that node. When an entity requests items, the pubsub service SHOULD verify that the requesting entity has a subscription to the pubsub node. If a subscription identifier is associated with a specific subscription, the entity MUST append the 'subid' attribute to the items element when making the request (if it does not, the service SHOULD return a &lt;not-acceptable/&gt; error). This attribute allows the pubsub service to generate different sets of items based on the subscription options associated with a specific subscription.</p>
+            <p class="" style="">
+            Subscribers may also receive event notification without any payload information. In this case, the client may request the item that was published (using the ItemID) in order to retrieve the payload. When an entity requests items by ItemID, implementations MUST allow multiple items to be specified in the request. Implementations MAY also allow entities to request the most recent N items by using the 'max_items' attribute. When max_items is used, implementations SHOULD return the N most recent (as opposed to the N oldest) items.
+            </p>
+
+                <p class="caption">Example 55. Subscriber requests all active items</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="items1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player" subid="123-abc"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 56. Server sends items back</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    id="items1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player" subid="123-abc"&gt;
+      &lt;item id="item1"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id="item2"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Edward Gregson&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;Tuba Tones&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id="item3"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Walter Ross&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;The Tuba's Greatest Hits&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 57. Service does not support persistent items</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="items1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player" subid="123-abc"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="501" type="cancel"&gt;
+    &lt;feature-not-implemented xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;persistence-unavailable xmlns="http://jabber.org/protocol/pubsub#errors"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 58. Subscriber requests two most recent items</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="items2"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player" max_items="2" subid="123-abc"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 59. Server returns two most recent items</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    id="items2"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player" subid="123-abc"&gt;
+      &lt;item id="item2"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Edward Gregson&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;Tuba Tones&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id="item3"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Walter Ross&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;The Tuba's Greatest Hits&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 60. Subscriber requests specific items by ItemID</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="items3"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player" subid="123-abc"&gt;
+      &lt;item id="item1"/&gt;
+      &lt;item id="item3"/&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 61. Server sends requested item(s)</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    id="items3"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player" subid="123-abc"&gt;
+      &lt;item id="item1"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+      &lt;item id="item3"&gt;
+        &lt;tune xmlns="http://jabber.org/protocol/tune"&gt;
+          &lt;artist&gt;Walter Ross&lt;/artist&gt;
+          &lt;title&gt;Tuba Concerto&lt;/title&gt;
+          &lt;source&gt;The Tuba's Greatest Hits&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 62. Subscriber sends request without subid</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="items5"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 63. Subid required</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="items5"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;items node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="406" type="modify"&gt;
+    &lt;not-acceptable xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.11 <a name="entity-discovernodes">Discover Nodes</a>
+</h3>
+            <p class="" style="">A service MAY implement some kind of pubsub browsing mechanism which enables the user to discover various nodes. The user may then select nodes to which he or she is interested in subscribing. Entities SHOULD use the <span style="font-weight: bold">Service Discovery</span> protocol for node discovery, subject to the recommendations in JEP-0030 regarding large result sets (for which <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2253954">9</a>] or some other protocol SHOULD be used). The examples show the protocol for possible results when using Service Discovery on a hierarchical pubsub service.</p>
+
+            <p class="caption">Example 64. A client discovers all first level nodes</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="nodes1"&gt;
+    &lt;query xmlns="http://jabber.org/protocol/disco#items"/&gt;
+&lt;/iq&gt;
+
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="nodes1"&gt;
+    &lt;query xmlns="http://jabber.org/protocol/disco#items"&gt;
+        &lt;item jid="pubsub.jabber.org"
+              node="generic"
+              name="A place for generic nodes"/&gt;
+        &lt;item jid="pubsub.jabber.org"
+              node="bar"
+              name="A place for drinks"/&gt;
+        &lt;item jid="pubsub.jabber.org"
+              node="fez"
+              name="A place for hats"/&gt;
+    &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 65. A client drills down to second level nodes</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="nodes2"&gt;
+    &lt;query xmlns="http://jabber.org/protocol/disco#items" node="generic"/&gt;
+&lt;/iq&gt;
+
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="nodes2"&gt;
+    &lt;query xmlns="http://jabber.org/protocol/disco#items"
+           node="generic"&gt;
+        &lt;item jid="pubsub.jabber.org"
+              node="generic/pgm-mp3-player"/&gt;
+        &lt;item jid="pubsub.jabber.org"
+              node="generic/psa-mp3-player"/&gt;
+        &lt;item jid="pubsub.jabber.org"
+              node="generic/slashdot-news"/&gt;
+        &lt;item jid="pubsub.jabber.org"
+              node="generic/meerkat-news"/&gt;
+    &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.12 <a name="entity-info-metadata">Discover Node Information and Meta-Data</a>
+</h3>
+                <p class="" style="">A pubsub service MUST allow entities to query individual nodes for the information associated with that node. The Service Discovery protocol MUST be used to discover this information. The disco#info results MUST include an identity with a category of pubsub and a type of either leaf or collection. If a specific node has an identity type of leaf, then it MUST contain individual items. If a specific node has an identity type of collection, then it MUST contain other nodes and/or collections but MUST NOT contain items.</p>
+                <p class="" style="">The disco#info result MAY include detailed metadata about the node, encapsulated in the <span style="font-weight: bold">Data Forms</span> (JEP-0004) format as described in <span class="ref" style="">Service Discovery Extensions</span>  [<a href="#nt-id2254052">10</a>], where the data form context is specified by including a FORM_TYPE of "http://jabber.org/protocol/pubsub#meta-data" in accordance with JEP-0068. If meta-data is provided, it SHOULD include values for all configured options as well as "automatic" information such as the node creation date, a list of publishers, and the like.</p>
+
+                <p class="caption">Example 66. Entity Queries a node for information and meta-data</p>
+<div class="indent"><pre>
+&lt;iq type="get" to="pubsub.jabber.org" from="entity1" id="meta-1"&gt;
+  &lt;query xmlns="http://jabber.org/protocol/disco#info"
+         node="generic/pgm-mp3-player"/&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 67. Service responds with information and meta-data</p>
+<div class="indent"><pre>
+&lt;iq type="result" from="pubsub.jabber.org" to="entity1"&gt;
+  &lt;query xmlns="http://jabber.org/protocol/disco#info"
+         node="generic/pgm-mp3-player"&gt;
+    &lt;identity category="pubsub" type="leaf"/&gt;
+    &lt;feature var="http://jabber.org/protocol/pubsub"/&gt;
+    &lt;x xmlns="jabber:x:data" type="result"&gt;
+      &lt;field var="FORM_TYPE" type="hidden"&gt;
+        &lt;value&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#type" label="Payload type"&gt;
+        &lt;value&gt;http://jabber.org/protocol/tune&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#payload_xslt" label="Payload XSLT"&gt;
+        &lt;value&gt;http://jabber.org/protocol/tune/payload.xslt&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#creator" label="Node creator"&gt;
+        &lt;value&gt;creator@jabber.org&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#creation_date" label="Creation date"&gt;
+        &lt;value&gt;2003-07-29T22:56Z&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#description" label="A description of the node"&gt;
+        &lt;value&gt;This node rocks!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#language" label="Default language"&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#publisher" label="Publishers to this node"&gt;
+        &lt;value&gt;pgm@jabber.org&lt;/value&gt;
+        &lt;value&gt;MaineBoy@jabber.org&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#title" label="A name for the node"&gt;
+        &lt;value&gt;This node has no name.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+
+                  <p class="" style="">Much of the meta-data provided about a node maps directly to selected <span class="ref" style="">Dublin Core Metadata Initiative (DCMI)</span>  [<a href="#nt-id2254108">11</a>] meta-data attributes; specifically:</p>
+                  <p class="caption">Table 6: Dublin Core Metadata Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+                    <tr class="body">
+<th colspan="" rowspan="">Pubsub Field</th>
+<th colspan="" rowspan="">Dublin Core Metadata Attribute</th>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#creation_date</td>
+<td align="" colspan="" rowspan="">Date  [<a href="#nt-id2254169">12</a>]</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#creator</td>
+<td align="" colspan="" rowspan="">Creator</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#description</td>
+<td align="" colspan="" rowspan="">Description</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#language</td>
+<td align="" colspan="" rowspan="">Language</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#publisher</td>
+<td align="" colspan="" rowspan="">Publisher</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#title</td>
+<td align="" colspan="" rowspan="">Title</td>
+</tr>
+                    <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#type</td>
+<td align="" colspan="" rowspan="">Type  [<a href="#nt-id2254270">13</a>]</td>
+</tr>
+                  </table>
+            </div>
+
+            
+            <div class="indent">
+<h3>8.1.13 <a name="entity-discoveritems">Discover Items for a Node</a>
+</h3>
+            <p class="" style="">To discover the published items which exist on the service for a specific node, an entity MAY send a disco#items request to the node itself, and each item will be returned as a Service Discovery &lt;item/&gt; element. The 'name' attribute of each Service Discovery item MUST contain its ItemID and the item MUST NOT possess a 'node' attribute. This ItemID MAY then be used to retrieve the actual node using the protocol defined in the <a href="#entity-getitems">Get Items for a Node</a> section of this document.
+            </p>
+
+            <p class="caption">Example 68. A client requests all of the items for a node</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="items1"&gt;
+    &lt;query xmlns="http://jabber.org/protocol/disco#items"
+           node="generic/slashdot-news" /&gt;
+&lt;/iq&gt;
+
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="items1"&gt;
+    &lt;query xmlns="http://jabber.org/protocol/disco#items"
+           node="generic/slashdot-news"&gt;
+        &lt;item jid="pubsub.jabber.org" name="2003/03/06/1641229"/&gt;
+        &lt;item jid="pubsub.jabber.org" name="2003/03/06/1629206"/&gt;
+        &lt;item jid="pubsub.jabber.org" name="2003/03/06/1625222"/&gt;
+        &lt;item jid="pubsub.jabber.org" name="2003/03/06/1341209"/&gt;
+    &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+            </div>
+
+        </div>
+
+        
+        <div class="indent">
+<h3>8.2 <a name="owner">Owner Use Cases</a>
+</h3>
+            <p class="" style="">Implementations MAY allow node owners to configure the various options for a specific node. Implementations SHOULD use the <span style="font-weight: bold">Data Forms</span> protocol to allow the node owner to accomplish the configuration.</p>
+            <p class="" style="">The following example shows SOME of the possible configuration options which MAY be implemented in some implementations. If an implementation implements these features using the <span style="font-weight: bold">Data Forms</span> protocol, that implementation MUST use the fields that are registered with the Jabber Registrar in association with the 'http://jabber.org/protocol/pubsub' namespace (a preliminary representation of those field variables is shown below, but MUST NOT be construed as canonical, since the Jabber Registrar may standardize additional fields at a later date without changes to this JEP). An implementation MAY choose to specify different labels, values, and even field types, but must conform to the defined variable naming scheme.</p>
+
+            
+            <div class="indent">
+<h3>8.2.1 <a name="owner-configure">Configure a Node</a>
+</h3>
+
+                <p class="" style="">After creating a new node, the node owner may want to modify the node configuration. The process for doing so is shown below.</p>
+
+                <p class="caption">Example 69. Owner requests configuration form</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="config1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+                <p class="caption">Example 70. Server responds with configuration form</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    id="config1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure node="generic/pgm-mp3-player"&gt;
+      &lt;x xmlns="jabber:x:data" type="form"&gt;
+        &lt;field var="FORM_TYPE" type="hidden"&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#deliver_payloads" type="boolean"
+               label="Deliver payloads with event notifications"&gt;
+          &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#notify_config" type="boolean"
+               label="Notify subscribers when the node configuration changes"&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#notify_delete" type="boolean"
+               label="Notify subscribers when the node is deleted"&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#notify_retract" type="boolean"
+               label="Notify subscribers when items are removed from the node"&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#persist_items" type="boolean"
+               label="Persist items to storage"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#max_items" type="text-single"
+               label="Max # of items to persist"&gt;
+          &lt;value&gt;10&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#subscribe" type="boolean"
+               label="Whether to allow subscriptions"&gt;
+          &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#subscription_model" type="list-single"
+               label="Specify the subscriber model"&gt;
+          &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;authorize&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+          &lt;value&gt;open&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#publish_model" type="list-single"
+               label="Specify the publisher model"&gt;
+          &lt;option&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;subscribers&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+          &lt;value&gt;publishers&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#max_payload_size" type="text-single"
+               label="Max Payload size in bytes"&gt;
+          &lt;value&gt;9216&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#send_item_subscribe" type="boolean"
+               label="Send items to new subscribers"&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#presence_based_delivery" type="boolean"
+               label="Only deliver notifications to available users"&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#current_approver" type="list-single"
+               label="Specify the current subscription approver"&gt;
+          &lt;option&gt;&lt;value&gt;owner1@foo.com&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;owner2@foo.com&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;owner3@foo.com&lt;/value&gt;&lt;/option&gt;
+          &lt;value&gt;owner2@foo.com&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#type" type="text-single"
+               label="Specify the type of payload data to be provided at this node"/&gt;
+        &lt;field var="pubsub#payload_xslt" type="text-single"
+	       label="Payload XSLT"/&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="" style="">If no configuration options are available (e.g., because node configuration is "locked down"), the service MUST return a &lt;feature-not-implemented/&gt; error to the owner.</p>
+
+                <p class="caption">Example 71. Node has no configuration options</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="config1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="501" type="cancel"&gt;
+    &lt;feature-not-implemented xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;node-not-configurable xmlns="http://jabber.org/protocol/pubsub#errors"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="" style="">After receiving the configuration form, the owner SHOULD either submit a completed configuration form or cancel the configuration process, in which case the existing configuration MUST be applied.</p>
+
+                <p class="caption">Example 72. Owner submits node configuration form</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="config2"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure node="generic/pgm-mp3-player"&gt;
+      &lt;x xmlns="jabber:x:data" type="submit"&gt;
+        &lt;field var="FORM_TYPE" type="hidden"&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var="pubsub#deliver_payloads"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#persist_items"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#max_items"&gt;&lt;value&gt;10&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#subscription_allow"&gt;&lt;value&gt;authorize&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#publish_model"&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#send_item_subscribe"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#presence_based_delivery"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#notify_config"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#notify_delete"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#notify_retract"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#max_payload_size"&gt;&lt;value&gt;1028&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#current_approver"&gt;&lt;value&gt;owner2@foo.com&lt;/value&gt;&lt;/field&gt;
+        &lt;field var="pubsub#type"&gt;http://jabber.org/protocol/tune&lt;/field&gt;
+        &lt;field var="pubsub#payload_xslt"&gt;
+	  &lt;value&gt;http://jabber.org/protocol/tune/payload.xslt&lt;/value&gt;
+	&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 73. Owner cancels configuration process</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="config2"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure node="generic/pgm-mp3-player"&gt;
+      &lt;x xmlns="jabber:x:data" type="cancel"/&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="" style="">If the "pubsub#notify_config" option is set to "1" (yes), then the service MUST send a notification of configuration change to all subscribers. (A service SHOULD support this option for leaf nodes and MUST support it for <a href="#collection">Collection Nodes</a>.) If the node configuration is set to event notifications only, the notification MUST consist of an empty &lt;item/&gt; element whose 'id' attribute is set to a value of "configuration"; if the node configuration is set to full payloads, the &lt;item/&gt; element MUST in addition contain the node configuration as represented via the <span style="font-weight: bold">Data Forms</span> protocol.</p>
+
+            <p class="caption">Example 74. Service sends configuration change notification (event notification only)</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;item id="configuration"/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+            <p class="caption">Example 75. Service sends configuration change notification (full payload)</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic/pgm-mp3-player"&gt;
+      &lt;item id="configuration"&gt;
+        &lt;x xmlns="jabber:x:data" type="result"&gt;
+          &lt;field var="FORM_TYPE" type="hidden"&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#deliver_payloads"
+                 label="Deliver payloads with event notifications"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#notify_config"
+                 label="Notify subscribers when the node configuration changes"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#notify_delete"
+                 label="Notify subscribers when the node is deleted"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#notify_retract"
+                 label="Notify subscribers when items are removed from the node"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#persist_items"
+                 label="Persist items to storage"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#max_items"
+                 label="Max # of items to persist"&gt;
+            &lt;value&gt;10&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#subscribe"
+                 label="Whether to allow subscriptions"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#subscription_model"
+                 label="Specify the subscriber model"&gt;
+            &lt;value&gt;open&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#publish_model"
+                 label="Specify the publisher model"&gt;
+            &lt;value&gt;publishers&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#max_payload_size"
+                 label="Max Payload size in bytes"&gt;
+            &lt;value&gt;9216&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#send_item_subscribe"
+                 label="Send items to new subscribers"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#presence_based_delivery"
+                 label="Only deliver notifications to available users"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#current_approver"
+                 label="Specify the current subscription approver"&gt;
+            &lt;value&gt;owner2@foo.com&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#type"
+                 label="Specify the type of payload data to be provided at this node"&gt;
+            &lt;value&gt;http://jabber.org/protocol/tune&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#payload_xslt" label="Payload XSLT"&gt;
+            &lt;value&gt;http://jabber.org/protocol/tune/payload.xslt&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+         </div>
+
+         <div class="indent">
+<h3>8.2.2 <a name="owner-default">Request Default Configuration Options</a>
+</h3>
+
+            <p class="" style="">Services MAY allow entities to create nodes and include configuration options in the same stanza as the node creation request. In these cases, the entity SHOULD first get the node options which can be used. To get the options, the entity MUST send a configure request to the service with no NodeID; in response, the service MUST return the default node options if it supports batching a node creation and configuration request.   [<a href="#nt-id2254628">14</a>] If the service does not support this feature, it MUST return a &lt;feature-not-implemented/&gt; error in response to the configure request with no NodeID. If the feature is not implemented but the requesting entity does not first check to determine if it is implemented but instead simply sends a create-node request that includes configuration options, the service SHOULD ignore the configuration part of the request and proceed as if it had not been included.</p>
+            <p class="" style="">Before deciding whether or not accept the default configuration during node creation, an entity may want to determine what the default node configuration settings are for the service.</p>
+
+            <p class="caption">Example 76. Entity requests default configuration options for leaf nodes</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    id="config3"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure type="leaf"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 77. Service responds with default configuration options for leaf nodes</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pgm@jabber.org"
+    id="config3"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure type="leaf"&gt;
+     &lt;x xmlns="jabber:x:data" type="form"&gt;
+      &lt;field var="FORM_TYPE" type="hidden"&gt;
+         &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#deliver_payloads" type="boolean"
+             label="Deliver payloads with event notifications"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#notify_config" type="boolean"
+             label="Notify subscribers when the node configuration changes"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#notify_delete" type="boolean"
+             label="Notify subscribers when the node is deleted"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#notify_retract" type="boolean"
+             label="Notify subscribers when items are removed from the node"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#persist_items" type="boolean"
+             label="Persist items to storage"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#max_items" type="text-single"
+             label="Max # of items to persist"&gt;
+        &lt;value&gt;10&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#subscribe" type="boolean"
+             label="Whether to allow subscriptions"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#subscription_model" type="list-single"
+             label="Specify the subscriber model"&gt;
+        &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;authorize&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;open&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#publish_model" type="list-single"
+             label="Specify the publisher model"&gt;
+        &lt;option&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;subscribers&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;publishers&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#max_payload_size" type="text-single"
+             label="Max Payload size in bytes"&gt;
+        &lt;value&gt;9216&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#send_item_subscribe" type="boolean"
+             label="Send items to new subscribers"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#presence_based_delivery" type="boolean"
+             label="Only deliver notifications to available users"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pubsub#current_approver" type="list-single"
+             label="Specify the current subscription approver"&gt;
+        &lt;option&gt;&lt;value&gt;owner1@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;owner2@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;owner3@foo.com&lt;/value&gt;&lt;/option&gt;
+        &lt;value&gt;owner2@foo.com&lt;/value&gt;
+     &lt;/field&gt;
+     &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 78. Service does not support default options</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="config3"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="501" type="cancel"&gt;
+    &lt;feature-not-implemented xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+    &lt;node-not-configurable xmlns="http://jabber.org/protocol/pubsub#errors"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+	      <p class="" style="">The default configuration options may be different for a collection node vs. a leaf node. In order to specifically request the default configuration options for a collection nodes, an entity MUST specify a type of "collection" in the request (since the default value for the 'type' attribute is "leaf"):</p>
+
+              <p class="caption">Example 79. Entity requests default configuration options for leaf nodes</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    id="config4"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub#owner"&gt;
+    &lt;configure type="collection"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.2.3 <a name="owner-delete">Delete a Node</a>
+</h3>
+            <p class="" style="">Deleting a node removes the node from the implementation (and data store if applicable). If an implementation persists items, deleting a node MUST first have the same effect as purging all the items for the node (see the <a href="#owner-purge">Purge all node items</a> section below) before the node itself is deleted.</p>
+
+                <p class="caption">Example 80. Owner deletes a node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="delete1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;delete node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 81. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="delete1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;delete node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="404" type="cancel"&gt;
+    &lt;item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 82. Entity is not an owner</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="delete1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;delete node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="401" type="auth"&gt;
+    &lt;not-authorized xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 83. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    id="delete1"/&gt;</pre></div>
+
+                <p class="caption">Example 84. Subscribers are notified of node removal</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;delete node="generic/pgm-mp3-player"/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to="subscriber2" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;delete node="generic/pgm-mp3-player"/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.2.4 <a name="owner-purge">Purge All Node Items</a>
+</h3>
+            <p class="" style="">Purging a node is applicable only in an implementation which persists published items. The act of purging a node removes all items from the persistent store. If an implementation does not persist items, it MUST return a &lt;feature-not-implemented/&gt; error. If the entity requesting to purge the node is not a node owner, the implementation must return a &lt;not-authorized/&gt; error.</p>
+            <p class="" style="">If a node and/or service has been configured to notify subscribers on deletion of items, a purge request MUST NOT result in sending the same notifications as are sent when deleting items (since purging a node with many persisted items could result in a huge number of notifications); instead, the node MUST send a single notification to each subscriber, containing an empty &lt;purge/&gt; child element.</p>
+
+                <p class="caption">Example 85. Owner purges items from a node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="purge1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;purge node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 86. Server replies with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    id="purge1"/&gt;</pre></div>
+
+                <p class="caption">Example 87. Subscribers are notified of node purge</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;purge node="generic/pgm-mp3-player"/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to="subscriber2" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;purge node="generic/pgm-mp3-player"/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+                <p class="caption">Example 88. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="purge1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;purge node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="404" type="cancel"&gt;
+    &lt;item-not-found xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 89. Entity is not an owner</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="purge1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;purge node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="401" type="auth"&gt;
+    &lt;not-authorized xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 90. Node is not configured for persistent items</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="purge1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;purge node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="501" type="cancel"&gt;
+    &lt;feature-not-implemented xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+            </div>
+
+            
+            <div class="indent">
+<h3>8.2.5 <a name="owner-modify">Modifying Entity Affiliations</a>
+</h3>
+            <p class="" style="">Entities will be affiliated with a node. The node owner may edit these affiliations using the pubsub namespace. The owner may get a list of all affiliated entities, and set affiliations for existing or new entities. Note that if the node is configured for open subscriptions and/or open publishers, then the service itself will also be modifying this list. Affiliations with a node SHOULD be handled and stored using the "bare JID" (user@host) of an entity rather than the "full JID" (user@host/resource).</p>
+            <p class="" style="">Implementations SHOULD allow owners to specify not only affiliations, but also subscriptions. If either the 'affiliation' attribute or the 'subscription' attribute is not specified in a modification request, then the value MUST NOT be changed.</p>
+
+                <p class="caption">Example 91. Owner requests all affiliated entities</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="ent1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;entities node="generic/pgm-mp3-player"/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 92. Server responds with entity items</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    to="pgm@jabber.org"
+    id="ent1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;entities node="generic/pgm-mp3-player"&gt;
+      &lt;entity jid="pgm@jabber.org"
+              affiliation="owner"
+              subscription="none"/&gt;
+      &lt;entity jid="bar@baz.com"
+              affiliation="publisher"
+              subscription="none"/&gt;
+      &lt;entity jid="bar2@baz.com"
+              affiliation="publisher"
+              subid="sub1"
+              subscription="subscribed"/&gt;
+      &lt;entity jid="bar3@baz.com"
+              affiliation="publisher"
+              subid="sub2"
+              subscription="subscribed"/&gt;
+      &lt;entity jid="sub1@foo.com"
+              affiliation="none"
+              subid="sub3"
+              subscription="subscribed"/&gt;
+      &lt;entity jid="sub2@foo.com"
+              affiliation="none"
+              subid="sub4"
+              subscription="subscribed"/&gt;
+      &lt;entity jid="sub3@foo.com"
+              affiliation="none"
+              subid="sub5"
+              subscription="subscribed"/&gt;
+      &lt;entity jid="p1@bar.com"
+              affiliation="none"
+              subid="sub6"
+              subscription="pending"/&gt;
+      &lt;entity jid="p2@bar.com"
+              affiliation="none"
+              subid="sub7"
+              subscription="pending"/&gt;
+      &lt;entity jid="out1@foo.com"
+              affiliation="outcast"
+              subscription="none"/&gt;
+      &lt;entity jid="out2@foo.com"
+              affiliation="outcast"
+              subscription="none"/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 93. Owner sets affiliations for publishers</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="ent2"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;entities node="generic/pgm-mp3-player"&gt;
+      &lt;entity jid="abc@bar.com"
+              affiliation="publisher"
+              subscription="subscribed"/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 94. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    from="pubsub.jabber.org"
+    id="ent2"/&gt;</pre></div>
+
+                <p class="" style="">The owner MAY change multiple affiliations in a single request. If one of the entity elements specified is invalid, the service SHOULD return an IQ error with the invalid entries. The following example shows an entity attempting to make another owner an outcast (pgm@jabber.org). This implementation of pubsub does not allow that operation, so it returns that item, and the error for that item. Note that the affiliation sent back is the original un-altered affiliation.
+                </p>
+                <p class="" style="">The state chart at the beginning of this document is a MUST-IMPLEMENT set of rules for checking possible state transitions. Implementations MAY enforce other (more strict) rules. When errors occur during a modification request for multiple entities, the pubsub service MUST return any entity element(s) which caused the error. Returned entities which failed to be modified MUST include the existing 'affiliation' and 'subscription' attributes. An error element containing the error code and a brief description of the error MUST also be included as a child element of the entity which failed. Any entity elements which are not returned in an IQ error case MUST be treated as successful modifications.
+                </p>
+
+                <p class="caption">Example 95. Owner sets affiliation for multiple entities</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="ent3"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;entities node="generic/pgm-mp3-player"&gt;
+      &lt;entity jid="bar@baz.com"
+              affiliation="publisher"
+              subscription="none"/&gt;
+      &lt;entity jid="bar2@baz.com"
+              affiliation="publisher"
+              subscription="none"/&gt;
+      &lt;entity jid="bar3@baz.com"
+              affiliation="publisher"
+              subid="sub2"
+              subscription="subscribed"/&gt;
+      &lt;entity jid="pgm@jabber.org"
+              affiliation="outcast"
+              subscription="none"/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+                <p class="caption">Example 96. Server responds with an error</p>
+<div class="indent"><pre>
+&lt;iq type="error"
+    from="pubsub.jabber.org"
+    id="ent3"/&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;entities node="generic/pgm-mp3-player"&gt;
+      &lt;entity jid="pgm@jabber.org"
+              affiliation="owner"
+              subscription="none"/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+  &lt;error code="401" type="auth"&gt;
+    &lt;not-authorized xmlns="urn:ietf:params:xml:ns:xmpp-stanzas"/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;</pre></div>
+
+
+            </div>
+        </div>
+    <h2>9.
+       <a name="collections">Collection Nodes</a>
+</h2>
+        <p class="" style="">A pubsub service MAY support collection nodes as well as leaf nodes. Collections enable nodes to be grouped together in any way including a hierarchy. Collections MUST contain only "leaf" nodes and/or other collections. Collections MUST NOT contain published items, since only "leaf" nodes contain items. If collections are supported, then the service MUST advertise that fact in its disco#info responses by including a feature of "pubsub#collections".</p>
+
+        <p class="" style="">Pubsub services that implement collections SHOULD allow entities to subscribe to collection nodes. Subscriptions to collection nodes MUST be configured via the protocol specified in the <a href="#usecases">Use Cases</a> section of this document. Subscription options for collection nodes MUST include a subscription type field which enables the subscriber to configure the subscription either as a subscription for items or as a subscription for nodes. This subscription option MUST use the registered field name of "pubsub#subscription_type" as defined in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document. If the subscription type specified on a subscription to a collection node is "items", the subscriber MUST be notified whenever an item is published to any node contained in the collection, where such a node may be a direct "child" of the collection node, or a child (to any depth) of a sub-collection of the collection node to which the subscriber has subscribed.</p>
+
+        <div class="indent">
+<h3>9.1 <a name="collections-subscribe">Subscribing to a Collection Node</a>
+</h3>
+        
+        <p class="" style="">When subscribing to a collection node, a service MUST allow the subscriber to specify whether it wants to receive notifications only from first-level children of the collection or from all descendents. For subscriptions of type "nodes", this enables the subscriber to be informed only when a new node is added in the specific collection to which it has subscribed, or to be informed whenever a node is added anywhere in the node "tree" that begins at the level of the collection to which it has subscribed. A similar distinction applies to subscriptions of type "items". The name for this configuration option is "pubsub#subscription_depth".</p>
+
+        <p class="caption">Example 97. Entity subscribes to a collection node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="sub1@foo.com/home"
+    to="pubsub.jabber.org"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;subscribe jid="sub1@foo.com"/&gt;
+    &lt;options jid="sub1@foo.com"&gt;
+        &lt;x xmlns="jabber:x:data"&gt;
+          &lt;field var="FORM_TYPE" type="hidden"&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#subscription_type"&gt;
+            &lt;value&gt;items&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#subscription_depth"&gt;
+            &lt;value&gt;all&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+   &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+        <p class="" style="">The subscriber will now receive item notifications from nodes at any depth within this collection.</p>
+
+        </div>
+
+        <div class="indent">
+<h3>9.2 <a name="collections-root">Root Collection Node</a>
+</h3>
+
+        <p class="" style="">Pubsub services that implement collections SHOULD support a root collection. This collection MUST include all nodes in the entire pubsub service and shall be identified by the lack of a node identifier (i.e., the address of the pubsub service itself, such as "pubsub.shakespeare.lit"). Subscribing to this node with a subscription of type "nodes" enables an entity to be notified whenever a new node is created in the entire pubsub system.</p>
+
+        <p class="caption">Example 98. Entity subscribes to the root collection node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="sub1@foo.com/home"
+    to="pubsub.jabber.org"
+    id="sub1"&gt;
+  &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+    &lt;subscribe jid="sub1@foo.com"/&gt;
+    &lt;options jid="sub1@foo.com"&gt;
+        &lt;x xmlns="jabber:x:data"&gt;
+          &lt;field var="FORM_TYPE" type="hidden"&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#subscription_type"&gt;
+            &lt;value&gt;nodes&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#subscription_depth"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+   &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+        <p class="" style="">If an entity subscribes to a collection node with a subscription type of "nodes", then the service MUST inform the subscriber whenever a new node is added to the collection. This is simply done by sending a notification where the 'id' attribute of the &lt;item/&gt; element specifies the NodeID of the new node. The notification event MUST also include the node meta-data specified in the section above, which is formatted using the <span style="font-weight: bold">Data Forms</span> protocol.</p>
+
+            <p class="caption">Example 99. Payload format for node subscriptions</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items&gt;
+      &lt;item id="new-node-id"&gt;
+        &lt;x xmlns="jabber:x:data" type="result"&gt;
+          &lt;field var="FORM_TYPE" type="hidden"&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#creation_date" label="Creation date"&gt;
+            &lt;var&gt;2003-07-29T22:56Z&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#creator" label="Node creator"&gt;
+            &lt;var&gt;creator@jabber.org&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#description" label="A description of the node"&gt;
+            &lt;var&gt;This node rocks!&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#language" label="Default language"&gt;
+            &lt;var&gt;en&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#publisher" label="Publishers to this node"&gt;
+            &lt;var&gt;pgm@jabber.org&lt;/var&gt;
+            &lt;var&gt;MaineBoy@jabber.org&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#title" label="A name for the node"&gt;
+            &lt;var&gt;This node has no name.&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#type" label="The type of data provided at the node"&gt;
+            &lt;var&gt;http://jabber.org/protocol/moods&lt;/var&gt;
+          &lt;/field&gt;
+          &lt;field var="pubsub#payload_xslt" label="Payload XSLT"&gt;
+            &lt;value&gt;http://jabber.org/protocol/tune/payload.xslt&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+        </div>
+
+        <div class="indent">
+<h3>9.3 <a name="collections-createnodes">Creating New Collection Nodes</a>
+</h3>
+            <p class="" style="">To create a new node which is a collection node, the requesting entity MUST specify a type of "collection" when asking the service to create the node.  [<a href="#nt-id2255362">15</a>] If a service does not allow new collection nodes to be created, it MUST respond with a &lt;not-allowed/&gt; error. If the requesting entity has insufficient privileges to create new collections, the service MUST respond with a &lt;not-authorized/&gt; error.</p>
+
+            <p class="caption">Example 100. Entity requests a new collection node</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="create3"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+        &lt;create node="test"
+	        type="collection"/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 101. Server responds with success</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    to="pgm@jabber.org"
+    from="pubsub.jabber.org"
+    id="create3"/&gt;</pre></div>
+
+        </div>
+
+        <div class="indent">
+<h3>9.4 <a name="collections-createaffil">Creating Nodes Affiliated with a Collection</a>
+</h3>
+            <p class="" style="">To create a new node which is part of an existing collection, the node configuration protocol MUST be used in the node creation request. When a pubsub system supports collections, it MUST support node configuration via the Data Forms protocol as specified in the foregoing sections. A field for collections MUST be included in the node configuration form, and it MUST have a 'var' attribute of "pubsub#collections". This field MUST have a Data Forms type of "text-multi". </p>
+
+            <p class="caption">Example 102. Entity creates a new node related to a collection</p>
+<div class="indent"><pre>
+&lt;iq type="set"
+    from="pgm@jabber.org"
+    to="pubsub.jabber.org"
+    id="create4"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+        &lt;create node="foo"/&gt;
+        &lt;configure&gt;
+            &lt;x xmlns="jabber:x:data" type="submit"&gt;
+                &lt;field var="pubsub#collections"&gt;&lt;value&gt;test&lt;/value&gt;&lt;/field&gt;
+            &lt;/x&gt;
+        &lt;/configure&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+            <p class="caption">Example 103. Server responds with actual new node identifier</p>
+<div class="indent"><pre>
+&lt;iq type="result"
+    to="pgm@jabber.org"
+    from="pubsub.jabber.org"
+    id="create4"&gt;
+    &lt;pubsub xmlns="http://jabber.org/protocol/pubsub"&gt;
+        &lt;create node="test/foo"/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;</pre></div>
+
+        </div>
+
+        <div class="indent">
+<h3>9.5 <a name="collections-notify">Generating Publish Notifications for Collections</a>
+</h3>
+
+            <p class="" style="">If an item is published to a node which is also contained by a collection, and an entity is subscribed to that collection with a subscription type of items, then the notifications generated by the service MUST contain additional information. The items element contained in the notification message MUST have the node identifier of the collection that the entity originally subscribed to. The item element MUST ALSO contain a node identifier for the node which generated the notification.</p>
+
+                <p class="caption">Example 104. Subscribers receive notifications from a collection</p>
+<div class="indent"><pre>
+&lt;message to="subscriber1" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic"&gt;
+      &lt;item node="generic/pgm-mp3-player" id="current"/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to="subscriber2" from="pubsub.jabber.org"&gt;
+  &lt;event xmlns="http://jabber.org/protocol/pubsub#event"&gt;
+    &lt;items node="generic"&gt;
+      &lt;item node="generic/pgm-mp3-player" id="current"/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;</pre></div>
+
+        </div>
+
+    <h2>10.
+       <a name="errors">Error Conditions</a>
+</h2>
+        <p class="" style=""></p>
+        <p class="caption">Table 7: Error conditions and typical causes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+            <tr class="body">
+                <th colspan="" rowspan="">Condition</th>
+                <th colspan="" rowspan="">Description</th>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+                <td align="" colspan="" rowspan="">The node already exists. Some implementations may also use this error when publishing items with an ItemID that already exists. See implementation notes for ItemIDs below.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+                <td align="" colspan="" rowspan="">The operation being attempted on a node (or the system) is disabled because the service itself does not support the operation.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+                <td align="" colspan="" rowspan="">An entity is requesting an operation for a Jabber ID which it is not allowed to change (e.g., a@jabber.org attempts to subscribe b@jabber.org to a specific node) or the requesting entity has an affiliation of "outcast".</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;item-not-found/&gt;</td>
+                <td align="" colspan="" rowspan="">The node specified for some operation does not exist.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+                <td align="" colspan="" rowspan="">An entity has attempted to perform an action which the service implements; however the sysadmin or the node owner has disabled the action for that specific service or node.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+                <td align="" colspan="" rowspan="">This error is produced when an entity tries to perform some action on a node, and that entity has insufficient privileges to perform the action.</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;payment-required/&gt;</td>
+                <td align="" colspan="" rowspan="">This error would typically be used to indicate that a subscription for a pubsub node is based on some kind payment service. Payments would be done out-of-band using some agreed-upon method (not defined herein).</td>
+            </tr>
+            <tr class="body">
+                <td align="" colspan="" rowspan="">&lt;registration-required/&gt;</td>
+                <td align="" colspan="" rowspan="">Some implementations may require entities to register before node creation is allowed.</td>
+            </tr>
+        </table>
+        <p class="" style="">Note: Refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2255752">16</a>] for information regarding error syntax.</p>
+    <h2>11.
+       <a name="impl">Implementation Notes</a>
+</h2>
+
+        <div class="indent">
+<h3>11.1 <a name="impl-presence">Presence-Based Delivery of Events</a>
+</h3>
+        <p class="" style="">Implementations of pubsub MAY deliver event notifications only when the subscriber is online. In these cases, the option may be a node configuration option as shown in the examples above. In addition, to facilitate this, the pubsub service needs to subscribe to the subscriber's presence and check the current presence information before sending any event notifications (as described in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2255808">17</a>]).
+        </p>
+        </div>
+
+        <div class="indent">
+<h3>11.2 <a name="impl-offline">Not Sending Events to Offline Storage</a>
+</h3>
+        <p class="" style="">Sending events to users of existing Jabber servers may force event notifications to be sent to offline storage for later delivery. This may not always be desirable. The possible ways of preventing this behavior include:</p>
+            <ul>
+            <li>Use presence-based subscription options as described above.</li>
+            <li>Use delivery semantics as defined by <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255898">18</a>].</li>
+            <li>Specify a message type of "headline", which in some existing server implementations will prevent offline storage.</li>
+            </ul>
+        </div>
+
+        <div class="indent">
+<h3>11.3 <a name="impl-uniqueness">Node and Item ID Uniqueness</a>
+</h3>
+        <p class="" style="">NodeIDs MUST be treated as unique identifiers within the context of a particular pubsub service.</p>
+        <p class="" style="">If item identifiers are used, they MUST be treated as unique within the scope of the node. NodeID + ItemID MUST be unique within a given service, and MUST specify a single published item to a single node. Multiple publishes to the same ItemID MAY result in behavior similar to that stated above for nodes (except that multiple items in a list MUST NOT have the same ItemID, since ItemIDs MUST be unique within the scope of a node).</p>
+        <p class="" style="">If a publisher publishes an item and the ItemID matches that of an existing item, the pubsub service MUST overwrite the existing item and generate a new event notification.</p>
+        </div>
+
+        <div class="indent">
+<h3>11.4 <a name="impl-authorize">Authorizing Subscription Requests (Pending Subscribers)</a>
+</h3>
+        <p class="" style="">Implementations may handle sending subscription requests to node owners differently. Possibilities include:
+        </p>
+            <ul>
+                <li>Send requests to multiple owners all the time (these may be stored to offline).</li>
+                <li>The service could subscribe to owner presence, and send only to the owners that are online.</li>
+                <li>The node configuration stores the current owner which is designated to approve subscription requests (this is shown in the configuration examples).</li>
+                <li>All owners vote on the new subscriber.</li>
+                <li>Any owner is allowed to veto the subscriber.</li>
+            </ul>
+          <p class="" style="">An implementation MAY use any of these methods, or some other method not defined herein.</p>
+        </div>
+
+        <div class="indent">
+<h3>11.5 <a name="impl-hierarchies">Handling Node Hierarchies</a>
+</h3>
+        <p class="" style="">NodeIDs MAY have semantic value in implementations of pubsub. If an implementation wishes node IDs to have hierarchical meaning (as is shown in the examples), that implementation MAY choose any naming scheme which is suitable to the hierarchy in question. Identifiers could use slashes, periods, or other special characters as the hierarchy separator.
+        </p>
+        </div>
+
+        <div class="indent">
+<h3>11.6 <a name="impl-message">Message Bodies</a>
+</h3>
+          <p class="" style="">The &lt;message/&gt; stanzas sent from a service to a subscriber for purposes of event notification SHOULD include a &lt;body/&gt; child whose textual CDATA informs the subscriber that the message contains an event notification (e.g., text such as "This message contains an event notification" would be appropriate). This enables "graceful degradation" in case the user's current client does not support pubsub.</p>
+        </div>
+
+        <div class="indent">
+<h3>11.7 <a name="impl-multiple">Multiple Node Discovery</a>
+</h3>
+          <p class="" style="">A user may publish information that adheres to a certain profile at multiple pubsub nodes, and a potential subscriber may want to discover all of these pubsub nodes. The user may make a list of pubsub nodes publicly available for querying even when the user is offline by using the Service Discovery mechanism for "publishing" items (see Section 4 of JEP-0030). The potential subscriber may then send a disco#items request to the user's bare JID (&lt;user@host&gt;), including the 'node' attribute set to the value of the namespace to which the desired information adheres. The user's server then returns a list of pubsub nodes that meet that criterion (with each pubsub node being a separate Service Discovery item). Here is an example:</p>
+          <p class="caption">Example 105. Discovering multiple nodes</p>
+<div class="indent"><pre>
+&lt;iq type="get"
+    from="stpeter@jabber.org/home"
+    to="pgm@jabber.org"
+    id="multi-1"/&gt;
+  &lt;query xmlns="http://jabber.org/protocol/disco#items"
+         node="http://jabber.org/protocol/tune"/&gt;
+&lt;/iq&gt;
+
+&lt;iq type="result"
+    from="pgm@jabber.org"
+    to="stpeter@jabber.org/home"
+    id="multi-1"/&gt;
+  &lt;query xmlns="http://jabber.org/protocol/disco#items"
+         node="http://jabber.org/protocol/tune"&gt;
+    &lt;item jid="pubsub.jabber.org"
+          node="generic/pgm-mp3-player"
+          name="Laptop MP3 Player"/&gt;
+    &lt;item jid="thepub.pgmillard.com"
+          node="cdplayer"
+          name="CD Player @ Home"/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+        </div>
+
+        <div class="indent">
+<h3>11.8 <a name="impl-association">Associating Events and Payloads with the Generating Entity</a>
+</h3>
+          <p class="" style="">In some contexts, it is valuable to provide an association between the event notification or payload and the entity to which the published information pertains. For example, in the context of a protocol such as <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2256106">19</a>], the user may generate the geolocation information or the information may be generated by an automated service (e.g., a service offered by a mobile telephony provider), but in either case the information is <span style="font-style: italic">about</span> the user (specifically, his or her spatial location). In order to associate the information with the user in a manner more explicit than enforcing semantic meaning on the NodeID, the service MAY include 'replyto' or 'replyroom' data (as specified by the <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2256137">20</a>] protocol) with the &lt;message/&gt; or &lt;presence/&gt; stanzas that contain event notifications and payloads. An example is shown below:</p>
+          <p class="caption">Example 106. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='i1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='portia@merchantofvenice.lit'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+          </pre></div>
+        </div>
+
+        <div class="indent">
+<h3>11.9 <a name="impl-leases">Implementing Time-Based Subscriptions (Leases)</a>
+</h3>
+            <p class="" style="">In some systems it may be desirable to provide a leasing system on subscriptions to a node in order to expire old or stale subscriptions. This can be accomplished using this protocol by using the configurable subscription options, and implementations SHOULD use this method when providing this type of functionality. When an entity subscribes, a field could be sent back in the subscription options which has a 'var' attribute of pubsub#expire. This field MUST contain a date-time specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2256204">21</a>]. When an entity wants to renew the lease, it simply gets the current subscription options, changes the value of the pubsub#expire field, and resubmits the new subscription options back to the service. If the new expire value exceeds the maximum value allowed for subscription leases then service MUST change the value of the field to be the current date/time plus the maximum allowed lease period.</p>
+        </div>
+
+        <div class="indent">
+<h3>11.10 <a name="impl-content">Implementing Content-Based Pubsub Systems</a>
+</h3>
+            <p class="" style="">Content-based pubsub services SHOULD make use of a variety of optional features.</p>
+            <ul>
+            <li>Content-based services SHOULD use subscription options to specify the filter to apply to a specific node to determine the content that should be pushed for each node.</li>
+            <li>Content-based services SHOULD allow entities to subscribe more than once to a single node. If this is allowed, the service MUST use the subscription identifier syntax as specified in this document.</li>
+            </ul>
+        </div>
+
+    <h2>12.
+       <a name="security">Security Considerations</a>
+</h2>
+        <p class="" style="">Because the data published to a pubsub node may contain sensitive information (e.g., a user's geolocation), node owners SHOULD exercise care in approving subscription requests. Security considerations regarding particular kinds of information are the responsbility of the using protocol.</p>
+        <p class="" style="">A service MUST NOT send event notifications or payloads to an entity, nor allow an entity to retrieve items published to a node, unless that entity is an authorized subscriber to the node.</p>
+        <p class="" style="">A service MUST NOT allow non-owners or other unauthorized entities to complete any actions defined under the <a href="#owner">Owner Use Cases</a> section above.</p>
+    <h2>13.
+       <a name="iana">IANA Considerations</a>
+</h2>
+        <p class="" style="">This JEP does not require interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256338">22</a>].</p>
+    <h2>14.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+      <div class="indent">
+<h3>14.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+        <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256392">23</a>] shall include the following namespaces in its registry of protocol namespaces:</p>
+        <ul>
+          <li>http://jabber.org/protocol/pubsub</li>
+          <li>http://jabber.org/protocol/pubsub#event</li>
+          <li>http://jabber.org/protocol/pubsub#owner</li>
+        </ul>
+      </div>
+
+      <div class="indent">
+<h3>14.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+        <p class="" style="">As a result of this JEP, the Jabber Registrar shall register a Service Discovery category of "pubsub", as well as three specific Service Discovery types within that category:</p>
+        <p class="caption">Table 8: Service Discovery Types in Pubsub Category</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+            <td align="" colspan="" rowspan="">collection</td>
+            <td align="" colspan="" rowspan="">A pubsub node of the "collection" type.</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">leaf</td>
+            <td align="" colspan="" rowspan="">A pubsub node of the "leaf" type.</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">service</td>
+            <td align="" colspan="" rowspan="">A pubsub service that supports the functionality defined in JEP-0060. (Prior to version 1.15 of JEP-0060, this type was called "generic".)</td>
+          </tr>
+        </table>
+        <p class="" style="">The registry submission is as follows:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;desc&gt;Services and nodes that adhere to JEP-0060.&lt;/desc&gt;
+  &lt;type&gt;
+    &lt;name&gt;collection&lt;/name&gt;
+    &lt;desc&gt;A pubsub node of the "collection" type.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+  &lt;type&gt;
+    &lt;name&gt;leaf&lt;/name&gt;
+    &lt;desc&gt;A pubsub node of the "leaf" type.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+  &lt;type&gt;
+    &lt;name&gt;service&lt;/name&gt;
+    &lt;desc&gt;A pubsub service that supports the functionality defined in JEP-0060.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+        </pre></div>
+        <p class="" style="">Future submissions to the Jabber Registrar may register additional types.</p>
+      </div>
+
+      <div class="indent">
+<h3>14.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+
+        <p class="" style="">As a result of this JEP, the Jabber Registrar shall register Service Discovery features that may be returned by pubsub services. The following table defines the initial set of such features. (Future submissions to the Jabber Registrar may register additional features.)</p>
+
+        <p class="caption">Table 9: Service Discovery Features</p>
+<table border="1" cellpadding="3" cellspacing="0">
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#collections</td>
+                <td align="" colspan="" rowspan="">Collection nodes are supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#config-node</td>
+                <td align="" colspan="" rowspan="">Configuration of node options is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#create-nodes</td>
+                <td align="" colspan="" rowspan="">Creation of nodes is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#delete-any</td>
+                <td align="" colspan="" rowspan="">Any publisher may delete an item (not only the originating publisher).</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#delete-nodes</td>
+                <td align="" colspan="" rowspan="">Deletion of nodes is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#instant-nodes</td>
+                <td align="" colspan="" rowspan="">Creation of instant nodes is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#item-ids</td>
+                <td align="" colspan="" rowspan="">Publishers may specify item identifiers.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#leased-subscription</td>
+                <td align="" colspan="" rowspan="">Time-based subscriptions are supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#meta-data</td>
+                <td align="" colspan="" rowspan="">Node meta-data is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#multi-subscribe</td>
+                <td align="" colspan="" rowspan="">A single entity may subscribe to a node multiple times.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#outcast-affiliation</td>
+                <td align="" colspan="" rowspan="">The outcast affiliation is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#persistent-items</td>
+                <td align="" colspan="" rowspan="">Persistent items are supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#presence-notifications</td>
+                <td align="" colspan="" rowspan="">Presence-based delivery of event notifications is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#publisher-affiliation</td>
+                <td align="" colspan="" rowspan="">The publisher affiliation is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#purge-nodes</td>
+                <td align="" colspan="" rowspan="">Purging of nodes is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#retract-items</td>
+                <td align="" colspan="" rowspan="">Item retraction is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#retrieve-affiliations</td>
+                <td align="" colspan="" rowspan="">Retrieval of current affiliations is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#retrieve-items</td>
+                <td align="" colspan="" rowspan="">Item retrieval is supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#subscribe</td>
+                <td align="" colspan="" rowspan="">Subscribing and unsubscribing are supported.</td>
+</tr>
+            <tr class="body">
+<td align="" colspan="" rowspan="">http://jabber.org/protocol/pubsub#subscription-options</td>
+                <td align="" colspan="" rowspan="">Configuration of subscription options is supported.</td>
+</tr>
+        </table>
+        <p class="" style="">The registry submission is as follows:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#collections&lt;/name&gt;
+  &lt;desc&gt;Collection nodes are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#config-node&lt;/name&gt;
+  &lt;desc&gt;Configuration of node options is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#create-nodes&lt;/name&gt;
+  &lt;desc&gt;Creation of nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#delete-any&lt;/name&gt;
+  &lt;desc&gt;Any publisher may delete an item (not only the originating publisher).&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#delete-nodes&lt;/name&gt;
+  &lt;desc&gt;Deletion of nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#instant-nodes&lt;/name&gt;
+  &lt;desc&gt;Creation of instant nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#item-ids&lt;/name&gt;
+  &lt;desc&gt;Publishers may specify item identifiers.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#leased-subscription&lt;/name&gt;
+  &lt;desc&gt;Time-based subscriptions are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/name&gt;
+  &lt;desc&gt;Node meta-data is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#multi-subscribe&lt;/name&gt;
+  &lt;desc&gt;A single entity may subscribe to a node multiple times.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#outcast-affiliation&lt;/name&gt;
+  &lt;desc&gt;The outcast affiliation is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#persistent-items&lt;/name&gt;
+  &lt;desc&gt;Persistent items are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#presence-notifications&lt;/name&gt;
+  &lt;desc&gt;Presence-based delivery of event notifications is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#publisher-affiliation&lt;/name&gt;
+  &lt;desc&gt;The publisher affiliation is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#purge-nodes&lt;/name&gt;
+  &lt;desc&gt;Purging of nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#retract-items&lt;/name&gt;
+  &lt;desc&gt;Item retraction is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#retrieve-affiliations&lt;/name&gt;
+  &lt;desc&gt;Retrieval of current affiliations is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#retrieve-items&lt;/name&gt;
+  &lt;desc&gt;Item retrieval is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscribe&lt;/name&gt;
+  &lt;desc&gt;Subscribing and unsubscribing are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscription-options&lt;/name&gt;
+  &lt;desc&gt;Configuration of subscription options is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+        </pre></div>
+      </div>
+
+      <div class="indent">
+<h3>14.4 <a name="registrar-formtypes">Field Standardization</a>
+</h3>
+        <p class="" style="">JEP-0068 defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. Within pubsub, there are four uses of such forms:</p>
+        <ol start="" type="">
+          <li>Authorization of subscriptions using the 'http://jabber.org/protocol/pubsub#subscribe_authorization' namespace</li>
+          <li>Configuration of subscription options using the 'http://jabber.org/protocol/pubsub#subscribe_options' namespace</li>
+          <li>Configuration of a node using the 'http://jabber.org/protocol/pubsub#node_config' namespace</li>
+          <li>Setting of meta-data information using the 'http://jabber.org/protocol/pubsub#meta-data' namespace</li>
+        </ol>
+        <p class="" style="">The registry submissions associated with these namespaces are defined below.</p>
+
+        <div class="indent">
+<h3>14.4.1 <a name="registrar-formtypes-auth">pubsub#subscribe_authorization FORM_TYPE</a>
+</h3>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling authorization of subscriptions to pubsub nodes&lt;/desc&gt;
+  &lt;field
+      var='pubsub#allow'
+      type='boolean'
+      label='Whether to allow the subscription'/&gt;
+  &lt;field
+      var='pubsub#node'
+      type='text-single'
+      label='The NodeID of the node'/&gt;
+  &lt;field
+      var='pubsub#subid'
+      type='text-single'
+      label='The SubID of the subscription'/&gt;
+  &lt;field
+      var='pubsub#subscriber_jid'
+      type='jid-single'
+      label='The address (JID) of the subscriber'/&gt;
+&lt;/form_type&gt;
+          </pre></div>
+        </div>
+        <div class="indent">
+<h3>14.4.2 <a name="registrar-formtypes-options">pubsub#subscribe_options FORM_TYPE</a>
+</h3>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling configuration of subscription options for pubsub nodes&lt;/desc&gt;
+  &lt;field
+      var='pubsub#digest'
+      type='boolean'
+      label='Whether a user wants to receive digests
+             (aggregations) of notifications or all
+             notifications individually'/&gt;
+  &lt;field
+      var='pubsub#digest'
+      type='boolean'
+      label='Whether a user wants to receive digests
+             (aggregations) of notifications or all
+             notifications individually'/&gt;
+  &lt;field
+      var='pubsub#show-values'
+      type='list-multi'
+      label='The presence states for which a user
+             wants to receive notifications'&gt;
+    &lt;option label='XMPP Show Value of Away'&gt;
+      &lt;value&gt;away&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of Chat'&gt;
+      &lt;value&gt;chat&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of DND (Do Not Disturb)'&gt;
+      &lt;value&gt;dnd&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Mere Availability in XMPP (No Show Value)'&gt;
+      &lt;value&gt;online&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of XA (Extended Away)'&gt;
+      &lt;value&gt;xa&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var="pubsub#subscription_type"
+         type="list-single"&gt;
+    &lt;option label='Receive notification of new items only'&gt;
+      &lt;value&gt;items&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Receive notification of new nodes only'&gt;
+      &lt;value&gt;nodes&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var="pubsub#subscription_depth"
+         type="list-single"&gt;
+    &lt;option label='Receive notification from direct child nodes only'&gt;
+      &lt;value&gt;1&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Receive notification from all descendent nodes'&gt;
+      &lt;value&gt;all&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;/field&gt;
+&lt;/form_type&gt;
+          </pre></div>
+        </div>
+        <div class="indent">
+<h3>14.4.3 <a name="registrar-formtypes-config">pubsub#node_config FORM_TYPE</a>
+</h3>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#node_config&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling configuration of pubsub nodes&lt;/desc&gt;
+  &lt;field var="pubsub#collection"
+         type="boolean"
+         label="Whether or not the node is a collection"/&gt;
+  &lt;field var="pubsub#current_approver"
+         type="list-single"
+         label="The current subscription approver"/&gt;
+  &lt;field var="pubsub#deliver_payloads"
+         type="boolean"
+         label="Whether to deliver payloads with event notifications"/&gt;
+  &lt;field var="pubsub#max_items"
+         type="text-single"
+         label="The maximum number of items to persist"/&gt;
+  &lt;field var="pubsub#max_payload_size"
+         type="text-single"
+         label="The maximum payload size in bytes"/&gt;
+  &lt;field var="pubsub#node_type"
+         type="list-single"
+         label="The type of node (collection or leaf)"&gt;
+    &lt;option label='Collection node (contains nodes and/or collections)'&gt;
+      &lt;value&gt;collection&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Leaf node (contains published items only)'&gt;
+      &lt;value&gt;leaf&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var="pubsub#notify_config"
+         type="boolean"
+         label="Whether to notify subscribers when the node configuration changes"/&gt;
+  &lt;field var="pubsub#notify_delete"
+         type="boolean"
+         label="Whether to notify subscribers when the node is deleted"/&gt;
+  &lt;field var="pubsub#notify_retract"
+         type="boolean"
+         label="Whether to notify subscribers when items are removed from the node"/&gt;
+  &lt;field var="pubsub#persist_items"
+         type="boolean"
+         label="Whether to persist items to storage"/&gt;
+  &lt;field var="pubsub#presence_based_delivery"
+         type="boolean"
+         label="Whether to deliver notifications to available users only"/&gt;
+  &lt;field var="pubsub#publish_model"
+         type="list-single"
+         label="The publisher model"&gt;
+    &lt;option label='Only publishers may publish'&gt;
+      &lt;value&gt;publishers&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Subscribers may publish'&gt;
+      &lt;value&gt;subscribers&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Anyone may publish'&gt;
+      &lt;value&gt;open&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var="pubsub#subscribe" type="boolean"
+         label="Whether to allow subscriptions"&gt;
+    &lt;value&gt;1&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var="pubsub#subscription_model"
+         type="list-single"
+         label="The subscriber model"&gt;
+    &lt;option label='Only those on a whitelist may subscribe'&gt;
+      &lt;value&gt;whitelist&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Subscription requests must be authorized'&gt;
+      &lt;value&gt;authorize&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Anyone may subscribe'&gt;
+      &lt;value&gt;open&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var="pubsub#send_item_subscribe"
+         type="boolean"
+         label="Whether to send items to new subscribers"/&gt;
+  &lt;field var="pubsub#type"
+         type='text-single'
+         label="The type of node data, usually specified by
+                the namespace of the payload (if any); MAY
+                be list-single rather than text-single"/&gt;
+  &lt;field var="pubsub#payload_xslt" 
+	 type="text-single"
+         label="The URL of an XSL transformation which can be 
+	        applied to payload packets in order to generate 
+		a valid Data Forms result that the client could 
+		then display using a generic Data Forms rendering 
+		engine"/&gt;
+&lt;/form_type&gt;
+          </pre></div>
+        </div>
+        <div class="indent">
+<h3>14.4.4 <a name="registrar-formtypes-metadata">pubsub#meta-data FORM_TYPE</a>
+</h3>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling setting of meta-data information about pubsub nodes&lt;/desc&gt;
+  &lt;field var="pubsub#creation_date"
+         type='text-single'
+         label="The datetime when the node was created"/&gt;
+  &lt;field var="pubsub#creator"
+         type='jid-single'
+         label="The JID of the node creator"/&gt;
+  &lt;field var="pubsub#description"
+         type='text-single'
+         label="A description of the node"/&gt;
+  &lt;field var="pubsub#language"
+         type='text-single'
+         label="The default language of the node"/&gt;
+  &lt;field var="pubsub#publisher"
+         type='jid-multi'
+         label="The JIDs of those who may publish to this node"/&gt;
+  &lt;field var="pubsub#title"
+         type='text-single'
+         label="The name of the node"/&gt;
+&lt;/form_type&gt;
+          </pre></div>
+        </div>
+      </div>
+      <div class="indent">
+<h3>14.5 <a name="registrar-shim">SHIM Headers</a>
+</h3>
+        <p class="" style="">The Jabber Registrar shall add "pubsub#subid" to its registry of SHIM headers (per JEP-0131). The registry submission is as follows:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;pubsub#subid&lt;/name&gt;
+  &lt;desc&gt;A subscription identifer within the pubsub protocol.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/header&gt;
+        </pre></div>
+        <p class="" style="">Future submissions to the Jabber Registrar may register additional SHIM headers that can be used in relation to the pubsub protocol.</p>
+      </div>
+  <div class="indent">
+<h3>14.6 <a name="registrar-querytypes">URI Query Types</a>
+</h3>
+    <p class="" style="">As authorized by <span class="ref" style="">XMPP URI Query Components</span>  [<a href="#nt-id2257254">24</a>], the Jabber Registrar maintains a registry of queries and key-value pairs for use in XMPP URIs (see &lt;<a href="http://www.jabber.org/registrar/querytypes.html">http://www.jabber.org/registrar/querytypes.html</a>&gt;).</p>
+    <p class="" style="">The "pubsub" querytype is defined herein for interaction with pubsub services, with two keys: (1) "node" (to specify pubsub nodes) and (2) "action", whose defined values are "subscribe" and "unsubscribe".</p>
+    <p class="caption">Example 107. Pubsub Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=subscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 108. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 109. Pubsub Unsubscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=unsubscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 110. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following submission registers the "pubsub" querytype.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the pubsub node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+    </pre></div>
+  </div>
+    <h2>15.
+       <a name="schemas">XML Schemas</a>
+</h2>
+      <div class="indent">
+<h3>15.1 <a name="schemas-pubsub">http://jabber.org/protocol/pubsub</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub'
+    xmlns='http://jabber.org/protocol/pubsub'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import 
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='pubsub'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0'&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='create' minOccurs='0'/&gt;
+          &lt;xs:element ref='configure' minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='subscribe' minOccurs='0'/&gt;
+          &lt;xs:element ref='options' minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:choice minOccurs='0'&gt;
+          &lt;xs:element ref='affiliations'/&gt;
+          &lt;xs:element ref='delete'/&gt;
+          &lt;xs:element ref='entities'/&gt;
+          &lt;xs:element ref='entity'/&gt;
+          &lt;xs:element ref='items'/&gt;
+          &lt;xs:element ref='publish'/&gt;
+          &lt;xs:element ref='purge'/&gt;
+          &lt;xs:element ref='retract'/&gt;
+          &lt;xs:element ref='unsubscribe'/&gt;
+        &lt;/xs:choice&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='affiliations'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:element ref='entity' minOccurs='0' maxOccurs='unbounded'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='configure'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'
+                   xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='create'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='type' use='optional' default='leaf'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='collection'/&gt;
+                &lt;xs:enumeration value='leaf'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='delete'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='entities'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='entity' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='entity'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='subscribe-options' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='affiliation' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='outcast'/&gt;
+            &lt;xs:enumeration value='owner'/&gt;
+            &lt;xs:enumeration value='publisher'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='subscription' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='pending'/&gt;
+            &lt;xs:enumeration value='subscribed'/&gt;
+            &lt;xs:enumeration value='unconfigured'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='items'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='max_items' type='xs:positiveInteger' use='optional'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='options'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:any namespace='jabber:x:data'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='publish'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='purge'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='retract'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscribe-options'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='required' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscribe'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsubscribe'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+        </pre></div>
+      </div>
+
+      <div class="indent">
+<h3>15.2 <a name="schemas-event">http://jabber.org/protocol/pubsub#event</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#event'
+    xmlns='http://jabber.org/protocol/pubsub#event'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='event'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0'&gt;
+        &lt;xs:element ref='delete'/&gt;
+        &lt;xs:element ref='items'/&gt;
+        &lt;xs:element ref='purge'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='delete'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='items'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='purge'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+        </pre></div>
+      </div>
+
+      <div class="indent">
+<h3>15.3 <a name="schemas-owner">http://jabber.org/protocol/pubsub#owner</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#owner'
+    xmlns='http://jabber.org/protocol/pubsub#owner'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import 
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='pubsub'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='configure'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='optional'/&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='get-pending'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='configure'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'
+                   xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' use='optional'/&gt;
+      &lt;xs:attribute name='type' use='optional' default='leaf'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='collection'/&gt;
+            &lt;xs:enumeration value='leaf'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+        </pre></div>
+      </div>
+
+      <div class="indent">
+<h3>15.4 <a name="schemas-error">http://jabber.org/protocol/pubsub#errors</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#errors'
+    xmlns='http://jabber.org/protocol/pubsub#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      This namespace is used for error reporting only, as
+      defined in JEP-0060: 
+      
+      http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='invalid-options' type='empty'/&gt;
+  &lt;xs:element name='node-not-configurable' type='empty'/&gt;
+  &lt;xs:element name='persistence-unavailable' type='empty'/&gt;
+  &lt;xs:element name='not-subscribed' type='empty'/&gt;
+  &lt;xs:element name='subscription-options-unavailable' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+        </pre></div>
+      </div>
+
+    <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250282">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250306">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250969">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2252087">4</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2252264">5</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2252741">6</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2252941">7</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2252996">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2253954">9</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2254052">10</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p><a name="nt-id2254108">11</a>. The Dublin Core Metadata Initiative (DCMI) is an organization dedicated to promoting the widespread adoption of interoperable metadata standards. For further information, see &lt;<a href="http://www.dublincore.org/">http://www.dublincore.org/</a>&gt;.</p>
+<p><a name="nt-id2254169">12</a>. The value SHOULD be a DateTime as defined in JEP-0082, and MUST conform to one of the profiles defined therein.</p>
+<p><a name="nt-id2254270">13</a>. The pubsub type SHOULD be the namespace that defines the payload (such as 'http://jabber.org/protocol/tune') if appropriate.</p>
+<p><a name="nt-id2254628">14</a>. A configure request with no NodeID must not be confused with a creation request with no NodeID; in response to the former, the service returns the default node options, whereas in response to the latter it creates an instant node.</p>
+<p><a name="nt-id2255362">15</a>. Earlier versions of this JEP specified the use of the configuration protocol in the node creation request, containing a field for node type in the node configuration form whose 'var' attribute was "pubsub#node_type" and whose &lt;value/&gt; was "collection"; that protocol is now deprecated.</p>
+<p><a name="nt-id2255752">16</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2255808">17</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255898">18</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256106">19</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2256137">20</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2256204">21</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2256338">22</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256392">23</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2257254">24</a>. JEP-0147: XMPP URI Query Components &lt;<a href="http://www.jabber.org/jeps/jep-0147.html">http://www.jabber.org/jeps/jep-0147.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.7 (2005-03-03)</h4>
+<div class="indent">Reinstated pubsub#subscribe feature (deleted in error); added type attribute for the &lt;create/&gt; and &lt;configure/&gt; elements to differentiate between leaf nodes and collection nodes; in Section 8.1.7, changed affiliations retrieval support to SHOULD and added pubsub#retrieve-affiliations feature; in Section 8.1.10, removed two duplicate examples; in Section 8.1.12, clarified relationship between normal disco#info data and node meta-data (which uses a service discovery extension); in Section 8.2.4, specified that node purgation MUST result in one event notification, not a notification per item; in Section 8.1.8, further specified handling of SubIDs; clarified nature of the pubsub#type field; mentioned that the forbidden error should be returned in response to certain operations requested by an outcast; corrected datatype of max_items attribute from xs:string to xs:positiveInteger; corrected &lt;requestor-not-subscribed/&gt; error to &lt;not-subscribed/&gt; since the subsribed JID need not be that of the requestor; added service discovery features for more optional use cases: retracting items, purging nodes, deleting nodes; updated relevant registries. (psa/rm)
+    </div>
+<h4>Version 1.6 (2004-07-13)</h4>
+<div class="indent">Added service discovery features for pubsub#meta-data, and pubsub#retrieve-items. Added pubsub#subscription_depth configuration option. Specified pubsub-specific error condition elements qualified by pubsub#errors namespace. (pgm/psa)
+    </div>
+<h4>Version 1.5 (2004-07-07)</h4>
+<div class="indent">Fixed typos. Added more details to the section on collections. Added paragraph to create node use case to allow the service to change the requested node-id to something which it creates. Added text about bouncing publish requests when the request does not match the event-type for that node. Added disco features for the jabber registrar. Changed affiliation verbiage to allow publishers to remove any item. Tweaked verbiage for create node, eliminated extra example. Fully defined Jabber Registrar submissions. Corrected schemas. (pgm/psa)
+    </div>
+<h4>Version 1.4 (2004-06-22)</h4>
+<div class="indent">Added subid syntax in a variety of places. Added more information about disco#info and disco#items support. Added more info about subscription options. Added collection information. Added implementation notes about subscription leases, and content-based pubsub services. (pgm)
+    </div>
+<h4>Version 1.3 (2004-04-25)</h4>
+<div class="indent">Editorial review; added one implementation note. (psa)
+    </div>
+<h4>Version 1.2 (2004-03-09)</h4>
+<div class="indent">Added XMPP error handling. (psa)
+    </div>
+<h4>Version 1.1 (2004-01-14)</h4>
+<div class="indent">Added Jabber Registrar Considerations subsection for Service Discovery category/type registration. (psa)
+    </div>
+<h4>Version 1.0 (2003-10-28)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.16 (2003-10-23)</h4>
+<div class="indent">Clarified JID addressing usage for nodes. Added specific MAY requirement for disco usage. Added sentence about implementations verifying that an entity has a subscription before getting the current items.
+             (pgm)
+    </div>
+<h4>Version 0.15 (2003-10-21)</h4>
+<div class="indent">Fixed invalid XML in examples for subscription deny/allow.
+             (pgm)
+    </div>
+<h4>Version 0.14 (2003-10-21)</h4>
+<div class="indent">Clarified restrictions on addressing nodes by JID. Added "Approving and denying subscription requests" section. Changed get-pending to use Ad-Hoc Commands. Changed semantics when sending in a form type='cancel' for pending subscriptions.
+             (pgm)
+    </div>
+<h4>Version 0.13 (2003-09-30)</h4>
+<div class="indent">Removed item as a possible child of subscribe and unsubscribe and pubsub in the schemas. Removed retract as a possible child of item in the pubsub#event schema. Added verbiage to requirements for addressing nodes either via JIDs or disco nodes.
+             (pgm)
+    </div>
+<h4>Version 0.12 (2003-08-13)</h4>
+<div class="indent">Defined public vs. private nodes; described how changes to existing nodes might trigger meta-node events (e.g., configuration changes); changed &lt;x/&gt; to &lt;event/&gt; for #events namespace; added meta-data about meta-nodes; fully defined Jabber Registrar considerations. (pgm, psa)
+    </div>
+<h4>Version 0.11 (2003-06-25)</h4>
+<div class="indent">Removed subscription notifications since they have inherent issues. Removed empty implementation note sub-section.
+             (pgm)
+    </div>
+<h4>Version 0.10 (2003-06-11)</h4>
+<div class="indent">Fixed error example when returning 501 from an items-get request. Added note about receiving subscription requests when an entity is already subscribed. Fixed some entity elements in various subscription examples. Many were missing the node attribute. Added subscription change notification verbiage and example. Added verbiage and example of subscription state notification being sent to the requesting entity. Added disco#items information for getting a list of item identifiers for a single node. Added verbiage for returning the current entity element when a curent subscriber attempts to subscribe again.
+             (pgm)
+    </div>
+<h4>Version 0.9 (2003-04-30)</h4>
+<div class="indent">Include JID attributes in the entity elements when receiving your affiliations. Changed error code 406 (which was wrong) to 404, which is correct. Changed many 405 errors to 401, and modified the error table to make it more implementable (rules are more concrete). Added subscribe-options element for indicating subscriptions may be configured. (pgm)
+    </div>
+<h4>Version 0.8 (2003-04-03)</h4>
+<div class="indent">Clarified the affiliations table and the semantics around subscribing and unsubscribing. Added protocol to get all of "your" affiliations in the service. Added protocol for services informing subscribers that configurable subscription options are available. Added protocol for obtaining existing node configuration settings and for batching configuration and node creation requests into a single stanza. Added meta-node implementation notes and specified the interaction with the Jabber Registrar and the "meta" NodeIDs. Added authorization notes to subscription options.
+             (pgm)
+    </div>
+<h4>Version 0.7 (2003-02-14)</h4>
+<div class="indent">Clarified requirements around what affiliations must be supported. Moved requirements about specifying entities which can subscribe and publish out of the MUSTs to MAYs. Changed SHOULD to MAY when talking about allowing entities to create nodes. Added ability to send configuration requests in the same stanza as a creation request.
+             (pgm)
+    </div>
+<h4>Version 0.6 (2003-02-06)</h4>
+<div class="indent">Added more details and an example about publishing without NodeID. Added more implementation notes about NodeIDs and persistent storage. (pgm)
+    </div>
+<h4>Version 0.5 (2003-01-22)</h4>
+<div class="indent">
+            Fixed header for delete item example. Added examples showing subscribers being notified of deleted items. Added examples for notification of node deletion, and configuration for node deletion. Added Subscriber option semantics and examples. Added examples for 402 and 407 errors on subscribe and create respectively. Added clarification about ItemID handling to impl notes.
+             (pgm)
+    </div>
+<h4>Version 0.4 (2003-01-21)</h4>
+<div class="indent">Clarified in-band and out-of-band configuration requirement. Added Delete Item privilege for all affiliations to the table. Added Delete item protocol for publishers and owners. Added 401 error case for subscribing to an illegal jid. Changed subscription request form. Added defaults to configuration form, and clarified role of the Jabber Registrar for the features show. Added text explaining the max_items attribute. Changed "last items" to "most recent items". Removed default configuration acceptance -- owners should just cancel. Added the notify_retract configuration option. Clarified error handling for affiliation modifications.  (pgm)
+    </div>
+<h4>Version 0.3 (2003-01-20)</h4>
+<div class="indent">Added subscription attribute for entities. Removed subscriber from the affiliations table. Clarified configuration details. Clarified JabberID usages. Added Jabber Registrar Considerations. Added link to JEP-0068 about the FORM_TYPE element in subscription request notifications. Fixed some typos in examples. Added unsupported configuration namespace to example.  Added a default configuration example.  (pgm)
+    </div>
+<h4>Version 0.2 (2003-01-02)</h4>
+<div class="indent">Added numerous implementation notes; added get-pending action with regard to subscriptions; added error table; changed purge and delete to use IQ type='set'. (pgm)
+    </div>
+<h4>Version 0.1 (2002-11-19)</h4>
+<div class="indent">Initial version. (pgm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0060-1.8.html
+++ b/content/xep-0060-1.8.html
@@ -1,0 +1,7123 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0060: Publish-Subscribe</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Publish-Subscribe">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Ralph Meijer">
+<meta name="DC.Description" content="This document defines a publish-subscribe protocol for use on Jabber/XMPP networks.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-06-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0060">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0060: Publish-Subscribe</h1>
+<p>This document defines a publish-subscribe protocol for use on Jabber/XMPP networks.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Draft">Draft</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0060<br>
+            Version: 1.8<br>
+            Last Updated: 2006-06-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, JEP-0004, JEP-0030, JEP-0068, JEP-0082, JEP-0131<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pubsub<br>
+        XML Schema for pubsub namespace: &lt;<a href="http://jabber.org/protocol/pubsub/pubsub.xsd">http://jabber.org/protocol/pubsub/pubsub.xsd</a>&gt;<br>
+        XML Schema for pubsub#errors namespace: &lt;<a href="http://jabber.org/protocol/pubsub/errors.xsd">http://jabber.org/protocol/pubsub/errors.xsd</a>&gt;<br>
+        XML Schema for pubsub#event namespace: &lt;<a href="http://jabber.org/protocol/pubsub/event.xsd">http://jabber.org/protocol/pubsub/event.xsd</a>&gt;<br>
+        XML Schema for pubsub#owner namespace: &lt;<a href="http://jabber.org/protocol/pubsub/owner.xsd">http://jabber.org/protocol/pubsub/owner.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Publish-Subscribe%20(JEP-0060)">http://wiki.jabber.org/index.php/Publish-Subscribe (JEP-0060)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Millard</h3>
+<p class="indent">
+        See <a href="#authornote">Author Note</a><br></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Ralph Meijer</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ralphm@ik.nu">ralphm@ik.nu</a><br>
+        JID: 
+        <a href="xmpp:ralphm@ik.nu">ralphm@ik.nu</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dl>
+<dt>1.1.  <a href="#intro-overview">Overview</a>
+</dt>
+<dt>1.2.  <a href="#intro-example">Motivating Example</a>
+</dt>
+</dl>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#preliminaries">Preliminaries</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#affiliations">Affiliations</a>
+</dt>
+<dt>4.2.  <a href="#substates">Subscription States</a>
+</dt>
+<dt>4.3.  <a href="#events">Event Types</a>
+</dt>
+<dt>4.4.  <a href="#nodetypes">Node Types</a>
+</dt>
+<dt>4.5.  <a href="#accessmodels">Node Access Models</a>
+</dt>
+<dt>4.6.  <a href="#addressing">Addressing</a>
+</dt>
+<dl>
+<dt>4.6.1.  <a href="#addressing-jid">JID</a>
+</dt>
+<dt>4.6.2.  <a href="#addressing-jidnode">JID+NodeID</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#entity">Entity Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#entity-features">Discover Features</a>
+</dt>
+<dt>5.2.  <a href="#entity-nodes">Discover Nodes</a>
+</dt>
+<dt>5.3.  <a href="#entity-info">Discover Node Information</a>
+</dt>
+<dt>5.4.  <a href="#entity-metadata">Discover Node Meta-Data</a>
+</dt>
+<dt>5.5.  <a href="#entity-discoveritems">Discover Items for a Node</a>
+</dt>
+<dt>5.6.  <a href="#entity-subscriptions">Retrieve Subscriptions</a>
+</dt>
+<dt>5.7.  <a href="#entity-affiliations">Retrieve Affiliations</a>
+</dt>
+</dl>
+<dt>6.  <a href="#subscriber">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#subscriber-subscribe">Subscribe to a Node</a>
+</dt>
+<dt>6.2.  <a href="#subscriber-unsubscribe">Unsubscribe from a Node</a>
+</dt>
+<dt>6.3.  <a href="#subscriber-configure">Configure Subscription Options</a>
+</dt>
+<dt>6.4.  <a href="#subscriber-retrieve">Retrieve Items from a Node</a>
+</dt>
+</dl>
+<dt>7.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#publisher-publish">Publish an Item to a Node</a>
+</dt>
+<dt>7.2.  <a href="#publisher-delete">Delete an Item from a Node</a>
+</dt>
+</dl>
+<dt>8.  <a href="#owner">Owner Use Cases</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#owner-create">Create a Node</a>
+</dt>
+<dl>
+<dt>8.1.1.  <a href="#owner-create-general">General Considerations</a>
+</dt>
+<dt>8.1.2.  <a href="#owner-create-default">Create a Node With Default Configuration</a>
+</dt>
+<dt>8.1.3.  <a href="#owner-create-and-configure">Create and Configure a Node</a>
+</dt>
+</dl>
+<dt>8.2.  <a href="#owner-configure">Configure a Node</a>
+</dt>
+<dt>8.3.  <a href="#owner-default">Request Default Configuration Options</a>
+</dt>
+<dt>8.4.  <a href="#owner-delete">Delete a Node</a>
+</dt>
+<dt>8.5.  <a href="#owner-purge">Purge All Node Items</a>
+</dt>
+<dt>8.6.  <a href="#owner-subreq">Manage Subscription Requests</a>
+</dt>
+<dl><dt>8.6.1.  <a href="#owner-subreq-all">Request All Pending Subscription Requests</a>
+</dt></dl>
+<dt>8.7.  <a href="#owner-subscriptions">Manage Subscriptions</a>
+</dt>
+<dt>8.8.  <a href="#owner-affiliations">Manage Affiliations</a>
+</dt>
+</dl>
+<dt>9.  <a href="#collections">Collection Nodes</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#collections-subscribe">Subscribe to a Collection Node</a>
+</dt>
+<dt>9.2.  <a href="#collections-root">Root Collection Node</a>
+</dt>
+<dt>9.3.  <a href="#collections-createnode">Create a New Collection Node</a>
+</dt>
+<dt>9.4.  <a href="#collections-createassociated">Create a Node Associated with a Collection</a>
+</dt>
+<dt>9.5.  <a href="#collections-associate">Associate an Existing Node with a Collection</a>
+</dt>
+<dt>9.6.  <a href="#collections-disassociate">Disassociate a Node from a Collection</a>
+</dt>
+<dt>9.7.  <a href="#collections-notify">Generating Publish Notifications for Collections</a>
+</dt>
+</dl>
+<dt>10.  <a href="#features">Feature Summary</a>
+</dt>
+<dt>11.  <a href="#errors">Error Conditions</a>
+</dt>
+<dt>12.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#impl-recipients">Intended Recipients for Notifications</a>
+</dt>
+<dt>12.2.  <a href="#impl-bounce">Handling Notification-Related Errors</a>
+</dt>
+<dt>12.3.  <a href="#impl-presence">Presence-Based Delivery of Events</a>
+</dt>
+<dt>12.4.  <a href="#impl-offline">Not Routing Events to Offline Storage</a>
+</dt>
+<dt>12.5.  <a href="#impl-body">Including a Message Body</a>
+</dt>
+<dt>12.6.  <a href="#impl-uniqueness">Node ID and Item ID Uniqueness</a>
+</dt>
+<dt>12.7.  <a href="#impl-caching">Item Caching</a>
+</dt>
+<dt>12.8.  <a href="#impl-batch">Batch Processing</a>
+</dt>
+<dt>12.9.  <a href="#impl-autosubscribe">Auto-Subscribing Owners and Publishers</a>
+</dt>
+<dt>12.10.  <a href="#impl-authorize">Authorizing Subscription Requests (Pending Subscribers)</a>
+</dt>
+<dt>12.11.  <a href="#impl-subchange">Notification of Subscription State Changes</a>
+</dt>
+<dt>12.12.  <a href="#impl-semantics">NodeID Semantics</a>
+</dt>
+<dt>12.13.  <a href="#impl-multiple">Multiple Node Discovery</a>
+</dt>
+<dt>12.14.  <a href="#impl-shim">Inclusion of SHIM Headers</a>
+</dt>
+<dt>12.15.  <a href="#impl-association">Associating Events and Payloads with the Generating Entity</a>
+</dt>
+<dt>12.16.  <a href="#impl-chaining">Chaining</a>
+</dt>
+<dt>12.17.  <a href="#impl-leases">Time-Based Subscriptions (Leases)</a>
+</dt>
+<dt>12.18.  <a href="#impl-content">Content-Based Pubsub Systems</a>
+</dt>
+</dl>
+<dt>13.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dl><dt>13.1.  <a href="#i18n-formtypes">Field Labels</a>
+</dt></dl>
+<dt>14.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>15.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>16.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>16.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+<dt>16.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>16.4.  <a href="#registrar-formtypes">Field Standardization</a>
+</dt>
+<dl>
+<dt>16.4.1.  <a href="#registrar-formtypes-auth">pubsub#subscribe_authorization FORM_TYPE</a>
+</dt>
+<dt>16.4.2.  <a href="#registrar-formtypes-options">pubsub#subscribe_options FORM_TYPE</a>
+</dt>
+<dt>16.4.3.  <a href="#registrar-formtypes-config">pubsub#node_config FORM_TYPE</a>
+</dt>
+<dt>16.4.4.  <a href="#registrar-formtypes-metadata">pubsub#meta-data FORM_TYPE</a>
+</dt>
+</dl>
+<dt>16.5.  <a href="#registrar-shim">SHIM Headers</a>
+</dt>
+<dt>16.6.  <a href="#registrar-querytypes">URI Query Types</a>
+</dt>
+</dl>
+<dt>17.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>17.1.  <a href="#schemas-pubsub">http://jabber.org/protocol/pubsub</a>
+</dt>
+<dt>17.2.  <a href="#schemas-error">http://jabber.org/protocol/pubsub#errors</a>
+</dt>
+<dt>17.3.  <a href="#schemas-event">http://jabber.org/protocol/pubsub#event</a>
+</dt>
+<dt>17.4.  <a href="#schemas-owner">http://jabber.org/protocol/pubsub#owner</a>
+</dt>
+</dl>
+<dt>18.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt>19.  <a href="#authornote">Author Note</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <div class="indent">
+<h3>1.1 <a name="intro-overview">Overview</a>
+</h3>
+    <p class="" style="">As Jabber/XMPP technologies have matured, the need for a generic publish-subscribe ("pubsub") mechanism has arisen in a number of problem spaces. These include (but are not limited to): news feeds and content syndication, extended presence, avatar management, shared bookmarks, auction and trading systems, online catalogs, workflow systems, network management systems, NNTP gateways, profile management, and event notification.</p>
+    <p class="" style="">In all of these domains, it is desirable for data communication to follow the classic "publish-subscribe" or "observer" design pattern: a person or application publishes information, and an event notification or the data itself is broadcasted to all authorized subscribers. In general, the relationship between the publisher and subscriber is mediated by a service that receives publication requests, broadcasts event notifications and/or the data itself to subscribers, and enables privileged entities to manage lists of people or applications that are authorized to publish or subscribe. In most pubsub services, the focal point for publication and subscription is a "topic" or "node" to which publishers send data and from which subscribers receive notifications and/or data. Additionally, some nodes may also maintain a history of events and provide other services that supplement the pure pubsub model.</p>
+    <p class="" style="">This document defines a single, cohesive, generic protocol which all forms of pubsub can utilize. While compliant implementations are not required to implement all of the features defined herein, this document addresses most usages that may be requested of a pubsub service. Other specifications may define subsets of publish-subscribe for use in specialized contexts, but such profiles are out of scope for this document.</p>
+  </div>
+  <div class="indent">
+<h3>1.2 <a name="intro-example">Motivating Example</a>
+</h3>
+    <p class="" style="">In order to motivate the discussion, we provide a simple, introductory example of a pubsub protocol flow.</p>
+    <p class="" style="">Perhaps the most popular application of pubsub-like functionality is content syndication, which has become familiar from the RSS and Atom (<span class="ref" style="">RFC 4287</span>  [<a href="#nt-id2260047">1</a>]) feeds associated with weblogs, news sites, and other frequently-updated information available on the Internet. Consider the example of a weblog published by one of the Shakespearean characters typical of Jabber/XMPP protocol documentation. When this character authors a new weblog entry, his blogging software publishes the entry to a pubsub node hosted at a pubsub service:</p>
+    <p class="caption">Example 1. Publisher Publishes a New Weblog Entry</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/blogbot'
+    to='pubsub.shakespeare.lit'
+    id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Service Notifies Subscribers</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... ENTRY ...
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='bernardo@denmark.lit' id='bar'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... ENTRY ...
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='horatio@denmark.lit' id='baz'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... ENTRY ...
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='marcellus@denmark.lit' id='fez'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... ENTRY ...
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">Naturally, many other protocol flows may be required in order to enable publication of items to a node (e.g., the publisher first needs to create the node and subscribers need to sign up for notifications). These protocol flows are fully described in the remainder of this document.</p>
+    <p class="" style="">An even simpler example is that of a transient node that sends only notifications, which is the pure pubsub model:</p>
+    <p class="caption">Example 3. A Transient Notification</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='elsinore/doorbell'/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="" style="">The following terms are used throughout this document to refer to elements, objects, or actions that occur in the context of a pubsub service. (Note: Some of these terms are specified in greater detail within the body of this document.)</p>
+  <p class="caption">Table 1: Publish-Subscribe Terms</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+<td align="" colspan="" rowspan="">Authorize Access Model</td>
+<td align="" colspan="" rowspan="">A node access model under which an entity can subscribe only through having a subscription request approved by a node owner (subscription requests are accepted but only provisionally) and only subscribers may retrieve items.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Address</td>
+<td align="" colspan="" rowspan="">(1) A JID as defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2260219">2</a>], or (2) the combination of a JID and a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260243">3</a>] node.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Collection Node</td>
+<td align="" colspan="" rowspan="">A type of node that contains nodes and/or other collections but no published items. Collections make it possible to represent hierarchial node structures.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Entity</td>
+<td align="" colspan="" rowspan="">A JID-addressable Jabber entity (client, service, application, etc.).</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Event</td>
+<td align="" colspan="" rowspan="">A change in the state of a node.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Instant Node</td>
+<td align="" colspan="" rowspan="">A node whose NodeID is automatically generated by a pubsub service.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Item</td>
+<td align="" colspan="" rowspan="">An XML fragment which is published to a node, thereby generating an event.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">ItemID</td>
+<td align="" colspan="" rowspan="">A unique identifier for an item in the context of a specific node.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Leaf Node</td>
+<td align="" colspan="" rowspan="">A type of node that contains published items only. It is NOT a container for other nodes.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Node</td>
+<td align="" colspan="" rowspan="">A virtual location to which information can be published and from which event notifications and/or payloads can be received (in other pubsub systems, this may be labelled a "topic").</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">NodeID</td>
+<td align="" colspan="" rowspan="">The unique identifier for a node within the context of a pubsub service. The NodeID is either supplied by the node creator or generated by the pubsub service (if the node creator requests an Instant Node). The NodeID MAY have semantic meaning, but such meaning is OPTIONAL.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Notification</td>
+<td align="" colspan="" rowspan="">A message sent to a subscriber informing them of an event.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Outcast</td>
+<td align="" colspan="" rowspan="">An entity that is disallowed from subscribing or publishing to a node.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Owner</td>
+<td align="" colspan="" rowspan="">The manager of a node, of which there may be more than one; often but not necessarily the node creator.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Payload</td>
+<td align="" colspan="" rowspan="">The full data associated with an event rather than just the event notification itself.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Open Access Model</td>
+<td align="" colspan="" rowspan="">A node access model under which any entity may subscribe and retrieve items without approval.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Personal Eventing</td>
+<td align="" colspan="" rowspan="">A simplified subset of Publish-Subscribe for use in the context of instant messaging and presence applications, whereby each IM user's JID is a virtual pubsub service; for details, see <span class="ref" style="">Personal Eventing via Pubsub</span>  [<a href="#nt-id2260518">4</a>].</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Presence Access Model</td>
+<td align="" colspan="" rowspan="">A node access model under which any entity that is subscribed to the owner's presence with a subscription of type "from" or "both" (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2260565">5</a>]) may subscribe to the node and retrieve items from the node; this access model applies mainly to instant messaging systems.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Publisher</td>
+<td align="" colspan="" rowspan="">An entity that is allowed to publish items to a node.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Pubsub Service</td>
+<td align="" colspan="" rowspan="">An XMPP server or component that adheres to the protocol defined herein.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Roster Access Model</td>
+<td align="" colspan="" rowspan="">A node access model under which any entity that is subscribed to the owner's presence and in the specified roster group(s) may subscribe to the node and retrieve items from the node; this access model applies mainly to instant messaging systems.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Subscriber</td>
+<td align="" colspan="" rowspan="">An entity that is subscribed to a node.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Whitelist Access Model</td>
+<td align="" colspan="" rowspan="">A node access model under which an entity can subscribe only through being added by a node owner (subscription requests are rejected) and only subscribers may retrieve items.</td>
+</tr>
+  </table>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">Requirements for a pubsub service can be driven by end-user needs as well as the needs of other components and services which can use the service. First, a pubsub service implemented using Jabber MUST provide the basic features which implement a pure publish-subscribe pattern:</p>
+        
+  <ul>
+    <li>An entity MUST be able to publish events to a service such that all subscribers to a node receive notification of the event.</li>
+    <li>An entity MUST be allowed to be affiliated with a node. Allowable affiliations are owner, publisher, none, and outcast. Implementations MUST support affiliations of owner and none, and MAY support affiliations of outcast and publisher.</li>
+    <li>An entity MUST be allowed to query the pubsub service (or a specific node) to determine what optional features of this specification the service (or node) implements. This query MUST use the Service Discovery (disco#info) protocol.</li>
+    <li>An entity MUST be allowed to query a node to determine non-feature-related information about that node (e.g., the service discovery category+type). This query MUST use the Service Discovery (disco#info) protocol.</li>
+  </ul>
+
+        
+  <p class="" style="">Some of the possible uses of a Jabber-based pubsub service will require other features, but these features are OPTIONAL and therefore not mandatory for compliance with this specification. However, if these features are implemented, they MUST adhere to the protocol described herein in to be compliant. These features include:</p>
+  <ul>
+    <li>A service MAY cache the last item published to a node (even if that node is not configured to persist items) and, if it does so, SHOULD send that item (or notification thereof) to entities that subscribe to the node; however, specific profiles of the generic publish-subscribe protocol MAY define more stringent requirements regarding this is"cache-last-item" feature.</li>
+    <li>A node owner SHOULD be able to specify who may subscribe to a node.</li>
+    <li>A node owner SHOULD be able to specify who may publish to a node.</li>
+    <li>A node MAY be configured to deliver the published payload inside the event notification.</li>
+    <li>A node MAY be configured to persist published items to some persistent storage mechanism.</li>
+    <li>A node MAY be configured to persist only a limited number of items.</li>
+    <li>A service MAY support collections.</li>
+    <li>A service or node MAY support extended service discovery information (meta-data).</li>
+  </ul>
+
+<h2>4.
+       <a name="preliminaries">Preliminaries</a>
+</h2>
+
+  <div class="indent">
+<h3>4.1 <a name="affiliations">Affiliations</a>
+</h3>
+    <p class="" style="">To manage permissions, the protocol defined herein uses a hierarchy of affiliations, similiar to those introduced in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2260816">6</a>].</p>
+    <p class="" style="">Support for the "owner" and "none" affiliations is REQUIRED. Support for all other affiliations is RECOMMENDED. Particular kinds of pubsub services MAY enforce additional requirements.</p>
+    <p class="caption">Table 2: Affiliations and their Privileges</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Affiliation</th>
+        <th colspan="" rowspan="">Subscribe</th>
+        <th colspan="" rowspan="">Publish Items</th>
+        <th colspan="" rowspan="">Purge Items</th>
+        <th colspan="" rowspan="">Configure Node</th>
+        <th colspan="" rowspan="">Delete Node</th>
+        <th colspan="" rowspan="">Delete Item</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Owner</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Publisher</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">Yes/No *</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">None</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Outcast</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">No</td>
+      </tr>
+    </table>
+    <p class="" style="">* Note: A service MAY allow any publisher to delete any item once it has been published to that node instead of allowing only the original publisher to remove it (this is disoverable via the "pubsub#delete-any" feature).</p>
+    <p class="" style="">The ways in which an entity changes its affiliation with a node are well-defined. Typically, an owner action is required to make an affiliation state transition. Affiliation changes and their triggering actions are specified in the following table.</p>
+    <p class="caption">Table 3: Affiliation State Chart</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">--&gt;</th>
+        <th colspan="" rowspan="">Outcast</th>
+        <th colspan="" rowspan="">None</th>
+        <th colspan="" rowspan="">Publisher</th>
+        <th colspan="" rowspan="">Owner</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Outcast</td>
+        <td align="" colspan="" rowspan="">--</td>
+        <td align="" colspan="" rowspan="">Owner removes ban</td>
+        <td align="" colspan="" rowspan="">Owner adds entity to publisher list</td>
+        <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">None</td>
+        <td align="" colspan="" rowspan="">Owner bans entity</td>
+        <td align="" colspan="" rowspan="">--</td>
+        <td align="" colspan="" rowspan="">Owner adds entity to publisher list</td>
+        <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Publisher</td>
+        <td align="" colspan="" rowspan="">Owner bans entity</td>
+        <td align="" colspan="" rowspan="">Owner removes entity from publisher list</td>
+        <td align="" colspan="" rowspan="">--</td>
+        <td align="" colspan="" rowspan="">Owner adds entity to owner list</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Owner</td>
+        <td align="" colspan="" rowspan="">n/a</td>
+        <td align="" colspan="" rowspan="">Owner resigns</td>
+        <td align="" colspan="" rowspan="">n/a</td>
+        <td align="" colspan="" rowspan="">--</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="indent">
+<h3>4.2 <a name="substates">Subscription States</a>
+</h3>
+    <p class="" style="">Subscriptions to a node may exist in several states.</p>
+    <p class="caption">Table 4: Subscription States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Subscription State</th>
+        <th colspan="" rowspan="">Description</th>
+        </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">None</td>
+        <td align="" colspan="" rowspan="">The node MUST NOT send event notifications or payloads to the Entity.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Pending</td>
+        <td align="" colspan="" rowspan="">An entity has requested to subscribe to a node and the request has not yet been approved by a node owner. The node MUST NOT send event notifications or payloads to the entity while it is in this state.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Unconfigured</td>
+        <td align="" colspan="" rowspan="">An entity has subscribed but its subscription options have not yet been configured. The node MAY send event notifications or payloads to the entity while it is in this state. The service MAY timeout unconfigured subscriptions.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Subscribed</td>
+        <td align="" colspan="" rowspan="">An entity is subscribed to a node. The node MUST send all event notifications (and, if configured, payloads) to the entity while it is in this state.</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="indent">
+<h3>4.3 <a name="events">Event Types</a>
+</h3>
+    <p class="" style="">The requirements for the publish-subscribe protocol imply that there are two major dimensions along which we can measure events: persistent vs. transient, and pure notification vs. inclusion of payload. An implementation SHOULD enable an owner to configure a node along both of these dimensions.</p>
+    <p class="" style="">No matter whether a node is configured for persistent or transient events, a service MAY cache the last item published to the node and send that item to new subscribers (see the <a href="impl-caching">Item Caching</a> section of this document).</p>
+    <p class="" style="">A pubsub service MUST validate publish requests against the configuration of the node along both of these dimensions (see the <a href="#publisher-publish">Publish An Item to a Node</a> section of this document for the relevant error conditions).</p>
+    <p class="" style="">Whether an item must be provided by the publisher, and whether an item ID is provided by the publisher or generated by the pubsub service, depends on the type of event being published. We can summarize the relevant rules as follows:</p>
+    <p class="caption">Table 5: Event Types, Items, and Item IDs</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">--&gt;</th>
+<th colspan="" rowspan="">Notification</th>
+<th colspan="" rowspan="">Payload</th>
+</tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan=""><span style="font-weight: bold">Persistent</span></td>
+        <td align="" colspan="" rowspan="">Publisher MUST include an &lt;item/&gt; element, which MAY be empty or contain a payload; if item ID is not provided by publisher, it MUST be generated by pubsub service</td>
+        <td align="" colspan="" rowspan="">Publisher MUST include an &lt;item/&gt; element that contains the payload; if item ID is not provided by publisher, it MUST be generated by pubsub service</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan=""><span style="font-weight: bold">Transient</span></td>
+        <td align="" colspan="" rowspan="">Publisher MUST NOT include an &lt;item/&gt; element (therefore item ID is neither provided nor generated) but the notification will include an empty &lt;items/&gt; element</td>
+        <td align="" colspan="" rowspan="">Publisher MUST include an &lt;item/&gt; element that contains the payload, but the item ID is OPTIONAL</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="indent">
+<h3>4.4 <a name="nodetypes">Node Types</a>
+</h3>
+    <p class="" style="">There are two types of nodes:</p>
+    <p class="caption">Table 6: Node Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Node Type</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Leaf</td>
+        <td align="" colspan="" rowspan="">A node that contains published items only. It is NOT a container for other nodes. This is the most common node type.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Collection</td>
+        <td align="" colspan="" rowspan="">A node that contains nodes and/or other collections but no published items. Collections make it possible to represent hierarchial node structures.</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="indent">
+<h3>4.5 <a name="accessmodels">Node Access Models</a>
+</h3>
+    <p class="" style="">In order to make node creation simpler for clients, we define the following node access models (in order of openness):</p>
+    <p class="caption">Table 7: Node Access Models</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Access Model</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Open</td>
+        <td align="" colspan="" rowspan="">Any entity may subscribe to the node (i.e., without the necessity for subscription approval) and any entity may retrieve items from the node (i.e., without being subscribed); this SHOULD be the default access model for generic pubsub services.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Presence</td>
+        <td align="" colspan="" rowspan="">Any entity with a subscription of type "from" or "both" may subscribe to the node and retrieve items from the node; this access model applies mainly to instant messaging systems (see <span style="font-weight: bold">RFC 3921</span>).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Roster</td>
+        <td align="" colspan="" rowspan="">Any entity in the specified roster group(s) may subscribe to the node and retrieve items from the node; this access model applies mainly to instant messaging systems (see <span style="font-weight: bold">RFC 3921</span>).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Authorize</td>
+        <td align="" colspan="" rowspan="">The node owner must approve all subscription requests, and only subscribers may retrieve items from the node.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Whitelist</td>
+        <td align="" colspan="" rowspan="">An entity may be subscribed only through being added to a whitelist by the node owner (unsolicited subscription requests are rejected), and only subscribers may retrieve items from the node. In effect, the default affiliation is outcast. The node owner MUST automatically be on the whitelist. In order to add entities to the whitelist, the node owner SHOULD use the protocol specified in the <a href="#owner-affiliations">Manage Affiliated Entities</a> section of this document.</td>
+      </tr>
+    </table>
+    <p class="" style="">A generic publish-subscribe implementation SHOULD support all of the defined access models, although specialized publish-subscribe implementations MAY support only a subset of the access models. Which access models are provided in a particular deployment is a matter of service provisioning (e.g., some restricted deployments may wish to lock down permissions so that only the "authorize" and "whitelist" access models are provided, or even only the "whitelist" access model).</p>
+    <p class="" style="">In order for a node creator or owner to specify the access model (see the <a href="#owner-create">Create a Node With Default Configuration</a> and <a href="#owner-configure">Configure a Node</a> sections of this document), the 'pubsub#access_model' configuration field is used.</p>
+  </div>
+
+  <div class="indent">
+<h3>4.6 <a name="addressing">Addressing</a>
+</h3>
+    <p class="" style="">If a pubsub node is addressable, it MUST be addressable either (1) as a JID or (2) as the combination of a JID and a node.  [<a href="#nt-id2261969">7</a>]</p>
+    <div class="indent">
+<h3>4.6.1 <a name="addressing-jid">JID</a>
+</h3>
+      <p class="" style="">If a pubsub node is addressable as a JID, the NodeID MUST be the resource identifier, and MUST NOT be specified by the "user" portion (node identifier) of the JID (e.g. "domain.tld/NodeID" and "user@domain.tld/NodeID" are allowed; "NodeID@domain.tld" is not allowed). JID addressing SHOULD be used when interacting with a pubsub node using a protocol that does not support the node attribute. For example, when a service makes it possible for entities to subscribe to nodes via presence, it would address nodes as JIDs. If a pubsub node is addressable as a JID, the pubsub service MUST ensure that the NodeID conforms to the Resourceprep profile of Stringprep as described in <span style="font-weight: bold">RFC 3920</span>.</p>
+      <p class="" style="">Consider the following example, in which the pubsub service is located at the hostname pubsub.shakespeare.lit.</p>
+      <p class="caption">Example 4. Node addressed as domain.tld/NodeID</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit/news announcements'&gt;
+  ...
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Now consider the following example, in which the pubsub service is located at pubsub@shakespeare.lit.</p>
+      <p class="caption">Example 5. Node addressed as user@domain.tld/NodeID</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub@shakespeare.lit/news announcements'&gt;
+  ...
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.6.2 <a name="addressing-jidnode">JID+NodeID</a>
+</h3>
+      <p class="" style="">If a pubsub node is addressable as a JID plus node, the NodeID MUST be the value of both the Service Discovery 'node' attribute and the pubsub 'node' attribute; i.e., for discovery purposes, a pubsub node is equivalent to a Service Discovery node. If a pubsub node is addressable as a JID plus node, the pubsub service SHOULD ensure that the NodeID conforms to the Resourceprep profile of Stringprep as described in <span style="font-weight: bold">RFC 3920</span>.</p>
+      <p class="" style="">Consider the following example, in which the (virtual) pubsub service is located at hamlet@denmark.lit.</p>
+      <p class="caption">Example 6. Node addressed as JID+NodeID</p>
+<div class="indent"><pre>
+&lt;iq to='hamlet@denmark.lit'&gt;
+  &lt;query node='princely_musings'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>5.
+       <a name="entity">Entity Use Cases</a>
+</h2>
+  <p class="" style="">This section defines the use cases for and protocols to be used by any entity that wishes to interact with a publish-subscribe service, mainly focused on Service Discovery use cases.</p>
+
+  <div class="indent">
+<h3>5.1 <a name="entity-features">Discover Features</a>
+</h3>
+    <p class="" style="">A service MUST respond to service discovery information requests qualified by the 'http://jabber.org/protocol/disco#info' namespace. The "disco#info" result returned by a pubsub service MUST indicate the identity of the service and indicate which pubsub features are supported.</p>
+    <p class="caption">Example 7. Entity Queries Pubsub Service Regarding Supported Features</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='feature1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Pubsub Service Returns Set of Supported Features</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='feature1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='service'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The possible pubsub features are noted throughout this document and have been registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document. For information regarding which features are required, recommended, and optional, see the <a href="#features">Feature Summary</a> section of this document.</p>
+  </div>
+
+  <div class="indent">
+<h3>5.2 <a name="entity-nodes">Discover Nodes</a>
+</h3>
+    <p class="" style="">If a service implements a hierarchy of nodes (by means of <a href="#collections">Collection Nodes</a>), it MUST also enable entities to discover the nodes in that hierarchy by means of the <span style="font-weight: bold">Service Discovery</span> protocol, subject to the recommendations in <span style="font-weight: bold">JEP-0030</span> regarding large result sets (for which <span class="ref" style="">Jabber Search</span>  [<a href="#nt-id2262221">8</a>] or some other protocol SHOULD be used). The following examples show the use of service discovery in discovering the nodes available at a hierarchical pubsub service.</p>
+    <p class="" style="">Note: Node hierarchies and collection nodes are OPTIONAL. For details, refer to the <a href="#impl-semantics">NodeID Semantics</a> and <a href="#collections">Collection Nodes</a> sections of this document.</p>
+    <p class="" style="">In the first example, an entity sends a service discovery items ("disco#items") request to the root node (i.e., the service itself), which is a <a href="#collections">Collection Node</a>:</p>
+    <p class="caption">Example 9. Entity requests all first-level nodes</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='nodes1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 10. Service returns all first-level nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='nodes1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='blogs'
+          name='Weblog updates'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='news'
+          name='News and announcements'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">In the second example, an entity sends a disco#items request to one of the first-level nodes, which is also a collection node:</p>
+    <p class="caption">Example 11. Entity requests second-level nodes</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='nodes2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='blogs'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service returns second-level nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='nodes2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='blogs'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='princely_musings'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='kingly_ravings'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='starcrossed_stories'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='moorish_meanderings'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a node is a leaf node rather than a collection node and items have been published to the node, the service MAY return one &lt;item/&gt; element for each published item as described in the <a href="#entity-discoveritems">Discover Items for a Node</a> section of this document, however such items MUST NOT include a 'node' attribute (since they are published items, not nodes).</p>
+  </div>
+
+  <div class="indent">
+<h3>5.3 <a name="entity-info">Discover Node Information</a>
+</h3>
+    <p class="" style="">A pubsub service MUST allow entities to query individual nodes for the information associated with that node. The Service Discovery protocol MUST be used to discover this information. The "disco#info" result MUST include an identity with a category of "pubsub" and a type of either "leaf" or "collection".</p>
+    <p class="" style="">Note: If a node has an identity type of "leaf", then it MUST NOT contain other nodes or collections (only items); if a node has an identity type of "collection", then it MUST NOT contain items (only other nodes or collections).</p>
+    <p class="caption">Example 13. Entity queries collection node for information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='info2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='blogs'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Service responds with identity of pubsub/collection</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='meta1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='blogs'&gt;
+    ...
+    &lt;identity category='pubsub' type='collection'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 15. Entity queries leaf node for information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='princely_musings'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service responds with identity of pubsub/collection</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;identity category='pubsub' type='leaf'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="entity-metadata">Discover Node Meta-Data</a>
+</h3>
+    <p class="" style="">The "disco#info" result MAY include detailed meta-data about the node, encapsulated in the <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2262448">9</a>] format as described in <span class="ref" style="">Service Discovery Extensions</span>  [<a href="#nt-id2262472">10</a>], where the data form context is specified by including a FORM_TYPE of "http://jabber.org/protocol/pubsub#meta-data" in accordance with <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2262497">11</a>]. If meta-data is provided, it SHOULD include values for all configured options as well as "automatic" information such as the node creation date, a list of publishers, and the like.</p>
+    <p class="caption">Example 17. Entity queries a node for information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='meta1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='princely_musings'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 18. Service responds with information and meta-data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='meta1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='princely_musings'/&gt;
+    &lt;identity category='pubsub' type='leaf'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#type' label='Payload type'&gt;
+        &lt;value&gt;http://www.w3.org/2005/Atom&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#creator' label='Node creator'&gt;
+        &lt;value&gt;hamlet@denmark.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#creation_date' label='Creation date'&gt;
+        &lt;value&gt;2003-07-29T22:56Z&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#title' label='A short name for the node'&gt;
+        &lt;value&gt;Princely Musings (Atom)&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#description' label='A description of the node'&gt;
+        &lt;value&gt;Updates for Hamlet&amp;apos;s Princely Musings weblog.&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#language' label='Default language'&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#contact' label='People to contact with questions'&gt;
+        &lt;value&gt;bard@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#owner' label='Node owners'&gt;
+        &lt;value&gt;hamlet@denmark.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#publisher' label='Publishers to this node'&gt;
+        &lt;value&gt;hamlet@denmark.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pubsub#num_subscribers' label='Number of subscribers to this node'&gt;
+        &lt;value&gt;1066&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Node meta-data can be set in many ways. Some of it is based on node configuration (e.g., the owner's JID) whereas some of it may be dynamic (e.g., the number of subscribers). Any static information to be provided in the node meta-data SHOULD be provided as fields in the node configuration form.</p>
+    <p class="" style="">Much of the meta-data provided about a node maps directly to selected <span class="ref" style="">Dublin Core Metadata Initiative (DCMI)</span>  [<a href="#nt-id2262536">12</a>] meta-data attributes; specifically:</p>
+    <p class="caption">Table 8: Dublin Core Meta-Data Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Pubsub Field</th>
+<th colspan="" rowspan="">Dublin Core Meta-Data Attribute</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#creation_date</td>
+<td align="" colspan="" rowspan="">Date  [<a href="#nt-id2250505">13</a>]</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#creator</td>
+<td align="" colspan="" rowspan="">Creator</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#description</td>
+<td align="" colspan="" rowspan="">Description</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#language</td>
+<td align="" colspan="" rowspan="">Language</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#publisher</td>
+<td align="" colspan="" rowspan="">Publisher</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#title</td>
+<td align="" colspan="" rowspan="">Title</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">pubsub#type</td>
+<td align="" colspan="" rowspan="">Type  [<a href="#nt-id2250608">14</a>]</td>
+</tr>
+    </table>
+  </div>
+
+  <div class="indent">
+<h3>5.5 <a name="entity-discoveritems">Discover Items for a Node</a>
+</h3>
+    <p class="" style="">To discover the published items which exist on the service for a specific node, an entity MAY send a "disco#items" request to the node itself, and the service MAY return each item as a Service Discovery &lt;item/&gt; element. The 'name' attribute of each Service Discovery item MUST contain its ItemID and the item MUST NOT possess a 'node' attribute. This ItemID MAY then be used to retrieve the item using the protocol defined in the <a href="#subscriber-retrieve">Retrieve Items from a Node</a> section of this document.</p>
+    <p class="caption">Example 19. Entity requests all of the items for a node</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='princely_musings'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='princely_musings'&gt;
+    &lt;item jid='pubsub.shakespeare.lit' name='368866411b877c30064a5f62b917cffe'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit' name='3300659945416e274474e469a1f0154c'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit' name='4e30f35051b7b8b42abe083742187228'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit' name='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>5.6 <a name="entity-subscriptions">Retrieve Subscriptions</a>
+</h3>
+    <p class="" style="">A service SHOULD allow an entity to query the service to retrieve its subscriptions for all nodes at the service. In order to make the request, the requesting entity MUST send an IQ-get whose &lt;pubsub/&gt; child contains an empty &lt;subscriptions/&gt; element with no attributes.</p>
+    <p class="caption">Example 20. Entity requests all current subscriptions</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='subscriptions1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscriptions/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service returns a list of subscriptions, it MUST return all subscriptions for all JIDs that match the bare JID (&lt;node@domain.tld&gt;) portion of the 'from' attribute on the request.</p>
+    <p class="" style="">For each subscription, a &lt;subscription/&gt; element is returned specifying the NodeID, the JID that is affiliated (which MAY include a resource, depending on how the entity subscribed), and the current subscription state. If subscription identifiers are supported by the service, the 'subid' attribute MUST be present as well.</p>
+    <p class="caption">Example 21. Service returns all current subscriptions</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit'
+    id='subscriptions1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscriptions&gt;
+      &lt;subscription node='node1' jid='francisco@denmark.lit' subscription='subscribed'/&gt;
+      &lt;subscription node='node2' jid='francisco@denmark.lit' subscription='subscribed'/&gt;
+      &lt;subscription node='node5' jid='francisco@denmark.lit' subscription='unconfigured'/&gt;
+      &lt;subscription node='node6' jid='francisco@denmark.lit' subscription='pending'/&gt;
+    &lt;/subscriptions&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the subscriptions retrieval request might fail:</p>
+    <ol start="" type="">
+      <li>The requesting entity has no subscriptions.</li>
+      <li>Subscriptions retrieval is not supported.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the requesting entity has no subscriptions, the pubsub service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 22. No subscriptions</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='subscriptions1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscriptions/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service does not support subscriptions retrieval, the service MUST respond with a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "retrieve-subscriptions".</p>
+    <p class="caption">Example 23. Subscriptions retrieval not supported</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='subscriptions1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscriptions/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='retrieve-subscriptions'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="entity-affiliations">Retrieve Affiliations</a>
+</h3>
+    <p class="" style="">A service SHOULD allow an entity to query the service to retrieve its affiliations for all nodes at the service. In order to make the request, the requesting entity includes an empty &lt;affiliations/&gt; element with no attributes.</p>
+    <p class="caption">Example 24. Entity requests all current affiliations</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='affil1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;affiliations/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service returns a list of affiliations, it MUST return all affiliations for all JIDs that match the bare JID (&lt;node@domain.tld&gt;) portion of the 'from' attribute on the request.</p>
+    <p class="" style="">For each affiliation, an &lt;affiliation/&gt; element is returned containing the NodeID and the affiliation state (owner, publisher, or outcast).</p>
+    <p class="caption">Example 25. Service replies with all current affiliations</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit'
+    id='affil1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;affiliations&gt;
+      &lt;affiliation node='node1' affiliation='owner'/&gt;
+      &lt;affiliation node='node2' affiliation='publisher'/&gt;
+      &lt;affiliation node='node5' affiliation='outcast'/&gt;
+      &lt;affiliation node='node6' affiliation='owner'/&gt;
+    &lt;/affiliations&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the affiliations retrieval request might fail:</p>
+    <ol start="" type="">
+      <li>The requesting entity has no affiliations.</li>
+      <li>Affiliations retrieval is not supported.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the requesting entity has no affiliations, the pubsub service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 26. No affiliations</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='affil1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;affiliations/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service does not support affiliations retrieval, the service MUST respond with a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "retrieve-affiliations".</p>
+    <p class="caption">Example 27. Affiliations retrieval not supported</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='affil1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;affiliations/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='retrieve-affiliations'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="subscriber">Subscriber Use Cases</a>
+</h2>
+
+  <p class="" style="">This section defines the use cases for and protocols to be used by potential and actual subscribers. (Note: The <a href="#impl">Implementation Notes</a> section of this document describes many important factors and business rules which a pubsub service MUST observe. In addition, the examples throughout assume the existence of a separate pubsub component and include any relevant 'from' addresses as stamped by a server or network edge.)</p>
+
+  <div class="indent">
+<h3>6.1 <a name="subscriber-subscribe">Subscribe to a Node</a>
+</h3>
+    <p class="" style="">When a Jabber entity wishes to subscribe to a node, it sends a subscription request to the pubsub service. The subscription request is an IQ-set where the &lt;pubsub/&gt; element contains one and only one &lt;subscribe/&gt; element. The &lt;subscribe/&gt; element MUST possess a 'node' attribute specifying the node to which the entity wishes to subscribe. The &lt;subscribe/&gt; element MUST also possess a 'jid' attribute specifying the exact XMPP address to be used as the subscribed JID -- often a bare JID (&lt;node@domain.tld&gt;) or full JID (&lt;node@domain.tld/resource&gt;), although JIDs of the form &lt;domain.tld&gt; or &lt;domain.tld/resource&gt; may subscribe as well.</p>
+    <p class="" style="">If the specified JID is a bare JID or full JID, the service MUST at a minimum check the bare JID portion against the bare JID portion of the 'from' attribute on the received IQ request to make sure that the requesting entity has the same identity as the JID which is being requested to be added to the subscriber list. However, some implementations MAY enable the service administrator to configure a list of entities that are excluded from this check; those entities may be considered "trusted proxies" that are allowed to subscribe on behalf of other entities. In the same way, implementations MAY enable blacklisting of entities that are not allowed to perform specific operations (such as subscribing or creating nodes).</p>
+    <p class="" style="">A service MAY allow entities to subscribe multiple times to the same node. This enables an entity to subscribe using different subscription options. If multiple subscriptions for the same JID are allowed, the service MUST use the 'subid' attribute to differentiate between subscriptions for the same entity (therefore the SubID MUST be unique for each node+JID combination and the SubID MUST be present on the entity element any time it is sent to the subscriber). It is NOT RECOMMENDED for clients to generate SubIDs, since collisions might result; therefore a service SHOULD generate the SubID on behalf of the subscriber and MAY overwrite SubIDs if they are provided by subscribers. If the service does not allow multiple subscriptions for the same entity and it receives an additional subscription request, the service MUST return the current subscription state (as if the subscription was just approved).</p>
+    <p class="" style="">Here is an example of a subscription request.</p>
+    <p class="caption">Example 28. Entity subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the subscription request is successfully processed, the server MUST inform the requesting entity that it is now subscribed (which MAY include a service-generated SubID).</p>
+    <p class="caption">Example 29. Service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription
+        node='princely_musings'
+        jid='francisco@denmark.lit'
+        subid='ba49252aaa4f5d320c24d3766f0bdcade78c78d3'
+        subscription='subscribed'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MAY also send the last published item to the new subscriber. The message containing this item SHOULD be stamped with extended information qualified by the 'jabber:x:delay' namespace (see <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2263463">15</a>]) to indicate it is are sent with delayed delivery. (Note that in this example the message notification is sent to the bare JID since that is the subscribed JID.)</p>
+    <p class="caption">Example 30. Service sends last published item</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the subscription request might fail:</p>
+    <ol start="" type="">
+      <li>The bare JID portions of the JIDs do not match.</li>
+      <li>The node has an access model of "presence" and the requesting entity is not subscribed to the owner's presence.</li>
+      <li>The node has an access model of "roster" and the requesting entity is not in one of the authorized roster groups.</li>
+      <li>The node has an access model of "whitelist" and the requesting entity is not on the whitelist.</li>
+      <li>The service requires payment for subscriptions to the node.</li>
+      <li>The requesting entity is anonymous and the service does not allow anonymous entities to subscribe.</li>
+      <li>The requesting entity has a pending subscription.</li>
+      <li>The requesting entity is blocked from subscribing (e.g., because having an affiliation of outcast).</li>
+      <li>The node does not support subscriptions.</li>
+      <li>The node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the bare JID portions of the JIDs do not match as described above and the requesting entity does not have some kind of admin or proxy privilege as defined by the implementation, the service MUST return a &lt;bad-request/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;invalid-jid/&gt;.</p>
+    <p class="caption">Example 31. JIDs do not match</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='bernardo@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-jid xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">For nodes with an access model of "presence", if the requesting entity is not subscribed to the owner's presence then the pubsub service MUST respond with a &lt;not-authorized/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;presence-subscription-required/&gt;.</p>
+    <p class="caption">Example 32. Entity is not authorized to create a subscription (presence subscription required)</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;presence-subscription-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">For nodes with an access model of "roster", if the requesting entity is not in one of the authorized roster groups then the pubsub service MUST respond with a &lt;not-authorized/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;not-in-roster-group/&gt;.</p>
+    <p class="caption">Example 33. Entity is not authorized to create a subscription (not in roster group)</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;not-in-roster-group xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">For nodes with a node access model of "whitelist", if the requesting entity is not on the whitelist then the service MUST return a &lt;not-allowed/&gt; error, which SHOULD include a pubsub-specific error condition of &lt;closed-node/&gt;.</p>
+    <p class="caption">Example 34. Node has whitelist access model</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;closed-node xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Commercial deployments may wish to link subscribers to a database of paying customers. If the subscriber needs to provide payment in order to subscribe to the node (e.g., if the subscriber is not in the customer database or the customer's account is not paid up), the service SHOULD return a &lt;payment-required/&gt; error to the subscriber.</p>
+    <p class="caption">Example 35. Payment is required for a subscription</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;payment-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Some XMPP servers may allow authentication using SASL ANONYMOUS; however, because the resulting entity is unstable (the assigned JID may not be owned by the same principal in a persistent manner), a service MAY prevent anonymous entities from subscribing to nodes and SHOULD use service discovery to determine if an entity has an identity of "account/anonymous". If a requesting entity is anonymous but the service does not allow anonymous entities to subscribe, the service SHOULD return a &lt;forbidden/&gt; error to the subscriber.</p>
+    <p class="caption">Example 36. Requesting entity is anonymous</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='anonymous@denmark.lit/foo'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='anonymous@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity has a pending subscription, the service MUST return a &lt;not-authorized/&gt; error to the subscriber, which SHOULD include a pubsub-specific error condition of &lt;not-subscribed/&gt;.</p>
+    <p class="caption">Example 37. Requesting entity has pending subscription</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;pending-subscription xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity is blocked from subscribing (e.g., because having an affiliation of outcast), the service MUST return a &lt;forbidden/&gt; error to the subscriber.</p>
+    <p class="caption">Example 38. Requesting entity is blocked</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not allow entities to subscribe, the service SHOULD return a &lt;feature-not-implemented/&gt; error to the subscriber, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "subscribe".</p>
+    <p class="caption">Example 39. Subscribing not supported</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='subscribe'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not exist, the service SHOULD return an &lt;item-not-found/&gt; error to the subscriber.</p>
+    <p class="caption">Example 40. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">For nodes with an access model of "authorize", subscription requests MUST be approved by one of the node owners; therefore the pubsub service sends a message to the node owner(s) requesting authorization (see the <a href="#owner-subreq">Manage Subscription Requests</a> section of this document). Because the subscription request may or may not be approved, the service MUST return a pending notification to the subscriber.</p>
+    <p class="caption">Example 41. Service replies with pending</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription
+        node='princely_musings'
+        jid='francisco@denmark.lit'
+        subscription='pending'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the entity must configure its subscription options (see the <a href="#subscriber-configure">Configure Subscription Options</a> section of this document) before receiving notifications, the service MUST so inform the entity. It SHOULD do so by returning an IQ-result to the requesting entity with a notation that configuration of subscription options is required.</p>
+    <p class="caption">Example 42. Service replies with success and indicates that subscription configuration is required</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription
+        node='princely_musings'
+        jid='francisco@denmark.lit'
+        subscription='unconfigured'&gt;
+      &lt;subscribe-options&gt;
+        &lt;required/&gt;
+      &lt;/subscribe-options&gt;
+    &lt;/subscription&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The node shall include the &lt;required/&gt; child element only if the subscriber must configure the subscription before receiving any notifications. A service MAY time out subscription requests if configuration is required and a configuration request is not submitted within a reasonable amount of time (which shall be determined by the service or node configuration).</p>
+    <p class="" style="">Alternatively, if the service is unable to create the subscription without simultaneous configuration, the service MAY return a &lt;not-acceptable/&gt; error, which SHOULD include a pubsub-specific error condition of &lt;configuration-required/&gt;.</p>
+    <p class="caption">Example 43. Service returns error specifying that subscription configuration is required</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+&lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#deliver'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#digest'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#include_body'&gt;&lt;value&gt;false&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#show-values'&gt;
+          &lt;value&gt;chat&lt;/value&gt;
+          &lt;value&gt;online&lt;/value&gt;
+          &lt;value&gt;away&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/options&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;configuration-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;required/&gt; element is not included and no error is returned, the subscription takes effect immediately and the entity may configure the subscription at any time (the service MAY indicate that subscription options are supported by including an empty &lt;subscribe-options/&gt; element in the IQ-result, as shown in the following example).</p>
+    <p class="caption">Example 44. Service replies with success and indicates that subscription options are supported but not required</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription
+        node='princely_musings'
+        jid='francisco@denmark.lit'
+        subscription='unconfigured'&gt;
+      &lt;subscribe-options/&gt;
+    &lt;/subscription&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>6.2 <a name="subscriber-unsubscribe">Unsubscribe from a Node</a>
+</h3>
+    <p class="" style="">To unsubscribe from a node, the subscriber sends an IQ-set whose &lt;pubsub/&gt; child contains an &lt;unsubscribe/&gt; element that specifies the node and the subscribed JID.</p>
+    <p class="caption">Example 45. Entity unsubscribes from a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='unsub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+     &lt;unsubscribe
+         node='princely_musings'
+         jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the request can be successfully processed, the service MUST return an IQ result.</p>
+    <p class="caption">Example 46. Service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='unsub1'/&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the unsubscribe request might fail:</p>
+    <ol start="" type="">
+      <li>The requesting entity has multiple subscriptions to the node but does not specify a subscription ID.</li>
+      <li>The request does not specify an existing subscriber.</li>
+      <li>The requesting entity does not have sufficient privileges to unsubscribe the specified JID.</li>
+      <li>The node does not exist.</li>
+      <li>The request specifies a subscription ID that is not valid or current.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the requesting entity has multiple subscriptions to the node but does not specify a subscription ID, the service MUST return a &lt;bad-request/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;subid-required/&gt;.</p>
+    <p class="caption">Example 47. Entity did not specify SubID</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='unsub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+     &lt;unsubscribe node='princely_musings' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;subid-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the value of the 'jid' attribute does not specify an existing subscriber, the pubsub service MUST return an error stanza, which SHOULD be &lt;unexpected-request/&gt; and which SHOULD also include a pubsub-specific error condition of &lt;not-subscribed/&gt;.</p>
+    <p class="caption">Example 48. Requesting entity is not a subscriber</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='unsub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+     &lt;unsubscribe node='princely_musings' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;unexpected-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;not-subscribed xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity is prohibited from unsubscribing the specified JID, the service MUST return a &lt;forbidden/&gt; error. The service MUST validate that the entity making the request is authorized to unsubscribe the entity. If the subscriber's JID is of the form &lt;node@domain.tld/resource&gt;, a service MUST perform this check by comparing the &lt;node@domain.tld&gt; part of the two JIDs to ensure that they match. If the bare JID portions of the JIDs do not match and the requesting entity is not authorized to unsubscribe the JID (e.g., because it is not a service-wide admin or authorized proxy), the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 49. Requesting entity is prohibited from unsubscribing entity</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='unsub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+     &lt;unsubscribe
+         node='princely_musings'
+         jid='bard@shakespeare.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not exist, the pubsub service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 50. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='unsub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+     &lt;unsubscribe
+         node='princely_musings'
+         jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a subscription identifier is associated with the subscription, the unsubscribe request MUST include an appropriate 'subid' attribute. If the unsubscribe request includes a SubID but SubIDs are not supported for the node (or the subscriber did not subscribe using a SubID in the first place), the service SHOULD ignore the SubID and simply unsubscribe the entity. If the subscriber originally subscribed with a SubID but the unsubscribe request includes a SubID that is not valid or current for the subscriber, the service MUST return a &lt;not-acceptable/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;invalid-subid/&gt;.</p>
+    <p class="caption">Example 51. Invalid subscription identifier</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='unsub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+     &lt;unsubscribe
+         node='princely_musings'
+         subid='ba49252aaa4f5d320c24d3766f0bdcade78c78d3'
+         jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-subid xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="subscriber-configure">Configure Subscription Options</a>
+</h3>
+    <p class="" style="">Implementations MAY allow subscribers to configure subscription options. Implementations SHOULD use the <span style="font-weight: bold">Data Forms</span> protocol to accomplish this configuration (however, an out-of-band mechanism such as a web interface could be offered as well).</p>
+    <p class="" style="">If a service supports subscription options it MUST advertise that fact in its response to a "disco#info" query by including a feature whose 'var' attribute is "pubsub#subscription-options".</p>
+    <p class="caption">Example 52. Pubsub service indicates support for subscription options</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='feature1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/pubsub#subscription-options'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A subscriber requests the subscription options by including an &lt;options/&gt; element inside an IQ-get stanza.</p>
+    <p class="caption">Example 53. Subscriber requests subscription options form</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='options1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the request can be successfully processed, the service MUST respond with the options.</p>
+    <p class="caption">Example 54. Service responds with the options form</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='options1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#deliver' type='boolean'
+               label='Enable delivery?'&gt;
+          &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#digest' type='boolean'
+               label='Receive digest notifications (approx. one per day)?'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#include_body' type='boolean'
+               label='Receive message body in addition to payload?'&gt;
+          &lt;value&gt;false&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field
+            var='pubsub#show-values'
+            type='list-multi'
+            label='Select the presence types which are
+                   allowed to receive notifications'&gt;
+          &lt;option label='Want to Chat'&gt;&lt;value&gt;chat&lt;/value&gt;&lt;/option&gt;
+          &lt;option label='Available'&gt;&lt;value&gt;online&lt;/value&gt;&lt;/option&gt;
+          &lt;option label='Away'&gt;&lt;value&gt;away&lt;/value&gt;&lt;/option&gt;
+          &lt;option label='Extended Away'&gt;&lt;value&gt;xa&lt;/value&gt;&lt;/option&gt;
+          &lt;option label='Do Not Disturb'&gt;&lt;value&gt;dnd&lt;/value&gt;&lt;/option&gt;
+          &lt;value&gt;chat&lt;/value&gt;
+          &lt;value&gt;online&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The foregoing example shows some (but by no means all) of the possible configuration options that MAY be provided. If an implementation provides these options using the <span style="font-weight: bold">Data Forms</span> protocol, it MUST use the field variables that are registered with the Jabber Registrar in association with the 'http://jabber.org/protocol/pubsub' namespace (a preliminary representation of those field variables is shown above and in the <a href="#registrar-formtypes-options">pubsub#subscribe_options FORM_TYPE</a> section of this document, but MUST NOT be construed as canonical since the Jabber Registrar may standardize additional fields at a later date without changes to this document).</p>
+    <p class="" style="">Note: Many of the relevant data form fields are of type "boolean" and MUST be handled accordingly.  [<a href="#nt-id2262874">16</a>]</p>
+    <p class="" style="">There are several reasons why the options request might fail:</p>
+    <ol start="" type="">
+      <li>The requesting entity does not have sufficient privileges to modify subscription options for the specified JID.</li>
+      <li>The requesting entity (or specified subscriber) is not subscribed.</li>
+      <li>The request does not specify both the NodeID and the subscriber's JID.</li>
+      <li>The request does not specify a subscription ID but one is required.</li>
+      <li>The request specifies a subscription ID that is not valid or current.</li>
+      <li>Subscription options are not supported.</li>
+      <li>The node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">When requesting subscription options, the subscriber MUST specify the JID that is subscribed to the node and SHOULD specify a node (if no node is specified, the service MUST assume that the requesting entity wishes to request subscription options for its subscription to the root collection node; see the <a href="#collections-root">Root Collection Node</a> section of this document for details).</p>
+    <p class="" style="">The service MUST validate that the entity making the request is authorized to set the subscription options for the subscribed entity. If the subscriber's JID is of the form &lt;node@domain.tld/resource&gt;, a service MUST perform this check by comparing the &lt;node@domain.tld&gt; part of the two JIDs to ensure that they match. If the bare JID portions of the JIDs do not match and the requesting entity is not authorized to modify subscription options for the JID (e.g., because it is not a service-wide admin or authorized proxy), the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 55. Requesting entity does not have sufficient privileges to modify subscription options</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='bernardo@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity (or specified subscriber, if different) is not subscribed, the service MUST return an &lt;unexpected-request/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;not-subscribed/&gt;.</p>
+    <p class="caption">Example 56. No such subscriber</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='options1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;unexpected-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;not-subscribed xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the subscriber does not specify a JID, the service MUST return a &lt;bad-request/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;jid-required/&gt;.</p>
+    <p class="caption">Example 57. Subscriber JID not specified</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='options1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;jid-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a subscription identifier is associated with the subscription, the 'subid' attribute MUST be present on the request in order for the service to differentiate subscriptions for the same entity. If the 'subid' is required but not provided, the service MUST return a &lt;bad-request/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;subid-required/&gt;.</p>
+    <p class="caption">Example 58. SubID required</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;subid-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a subscription identifier is associated with the subscription but the request includes a SubID that is not valid or current for the subscriber, the service MUST return a &lt;not-acceptable/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;invalid-subid/&gt;.</p>
+    <p class="caption">Example 59. Invalid subscription identifier</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='unsub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+     &lt;unsubscribe
+         node='princely_musings'
+         subid='991d7fd1616fd041015064133cd097a10030819e'
+         jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-subid xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node or service does not support subscription options, the service MUST respond with a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "subscription-options".</p>
+    <p class="caption">Example 60. Subscription options not supported</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='options1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='subscription-options'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not exist, the pubsub service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 61. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='options1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">After receiving the configuration form, the requesting entity SHOULD submit the form in order to update the entity's subscription options for that node.</p>
+    <p class="caption">Example 62. Subscriber submits completed options form</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='options2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'&gt;
+        &lt;x xmlns='jabber:x:data' type='submit'&gt;
+          &lt;field var='FORM_TYPE' type='hidden'&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var='pubsub#deliver'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+          &lt;field var='pubsub#digest'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+          &lt;field var='pubsub#include_body'&gt;&lt;value&gt;false&lt;/value&gt;&lt;/field&gt;
+          &lt;field var='pubsub#show-values'&gt;
+            &lt;value&gt;chat&lt;/value&gt;
+            &lt;value&gt;online&lt;/value&gt;
+            &lt;value&gt;away&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service can successfully process the submission, it MUST respond with success.</p>
+    <p class="caption">Example 63. Service responds with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='options2'/&gt;
+    </pre></div>
+    <p class="" style="">If the subscriber attempts to set an invalid group of options, the service MUST respond with a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 64. Service responds with Bad Request for invalid options</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='options2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'&gt;
+      &lt;x xmlns='jabber:x:data'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#deliver'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#digest'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#include_body'&gt;&lt;value&gt;false&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#show-values'&gt;
+          &lt;value&gt;chat&lt;/value&gt;
+          &lt;value&gt;online&lt;/value&gt;
+          &lt;value&gt;away&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/options&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-options xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The other errors already mentioned for getting subscription options also apply to setting subscription options.</p>
+    <p class="" style="">As noted, if a service supports subscription options, an entity MAY subscribe and provide the subscription options in the same stanza.</p>
+    <p class="" style="">Note: The &lt;options/&gt; element MUST follow the &lt;subscribe/&gt; element and MUST NOT possess a 'node' attribute or 'jid' attribute, since the value of the &lt;subscribe/&gt; element's 'node' attribute specifies the desired NodeID and the value of the &lt;subscribe/&gt; element's 'jid' attribute specifies the subscriber's JID; if any of these rules are violated, the service MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 65. Entity subscribes to node and sets configuration options</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='princely_musings' jid='francisco@denmark.lit'/&gt;
+    &lt;options&gt;
+      &lt;x xmlns='jabber:x:data'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#deliver'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#digest'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#include_body'&gt;&lt;value&gt;false&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#show-values'&gt;
+          &lt;value&gt;chat&lt;/value&gt;
+          &lt;value&gt;online&lt;/value&gt;
+          &lt;value&gt;away&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="subscriber-retrieve">Retrieve Items from a Node</a>
+</h3>
+    <p class="" style="">Implementations of pubsub that choose to persist items MAY allow entities to request existing items from a node (e.g., an entity may wish to do this after successfully subscribing in order to receive all the items in the publishing history for the node). The service MUST conform to the node's access model in determining whether to return items to the entity that requests them. Specifically:</p>
+    <ul>
+      <li><p class="" style="">If the access model is "open", the service SHOULD allow any entity (whether or not it is subscribed) to retrieve items.</p></li>
+      <li><p class="" style="">If the access model is "presence", the service SHOULD allow any entity that is subscribed to the owner's presence to retrieve items.</p></li>
+      <li><p class="" style="">If the access model is "roster", the service SHOULD allow any entity that is subscribed to the owner's presence and contained in the relevant roster group(s) to retrieve items.</p></li>
+      <li><p class="" style="">If the access model is "authorize" or "whitelist", the service MUST allow only subscribed entities to retrieve items.</p></li>
+    </ul>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements for the foregoing access models is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the node owner to retrieve items from a node and SHOULD always allow a publisher to do so.)</p>
+    <p class="" style="">The subscriber may request all items by specifying only the Node ID without restrictions.</p>
+    <p class="caption">Example 66. Subscriber requests all items</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service then SHOULD return all items published to the node, although it MAY truncate the result set if a large number of items has been published.</p>
+    <p class="caption">Example 67. Service returns all items</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='368866411b877c30064a5f62b917cffe'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;The Uses of This World&lt;/title&gt;
+          &lt;summary&gt;
+O, that this too too solid flesh would melt
+Thaw and resolve itself into a dew!
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32396&lt;/id&gt;
+          &lt;published&gt;2003-12-12T17:47:23Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-12T17:47:23Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+      &lt;item id='3300659945416e274474e469a1f0154c'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Ghostly Encounters&lt;/title&gt;
+          &lt;summary&gt;
+O all you host of heaven! O earth! what else?
+And shall I couple hell? O, fie! Hold, hold, my heart;
+And you, my sinews, grow not instant old,
+But bear me stiffly up. Remember thee!
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32396&lt;/id&gt;
+          &lt;published&gt;2003-12-12T23:21:34Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-12T23:21:34Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+      &lt;item id='4e30f35051b7b8b42abe083742187228'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Alone&lt;/title&gt;
+          &lt;summary&gt;
+Now I am alone.
+O, what a rogue and peasant slave am I!
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32396&lt;/id&gt;
+          &lt;published&gt;2003-12-13T11:09:53Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T11:09:53Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Even if the service or node does not support persistent items, it MAY return the last published item.</p>
+    <p class="caption">Example 68. Service returns last published item</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the items retrieval request might fail:</p>
+    <ol start="" type="">
+      <li>The requesting entity has multiple subscriptions to the node but does not specify a subscription ID.</li>
+      <li>The requesting entity is subscribed but specifies an invalid subscription ID.</li>
+      <li>The node does not return items to unsubscribed entities and the requesting entity is not subscribed.</li>
+      <li>The service or node does not support persistent items and does not return the last published item.</li>
+      <li>The service or node does not support item retrieval.</li>
+      <li>The node has an access model of "presence" and the requesting entity is not subscribed to the owner's presence.</li>
+      <li>The node has an access model of "roster" and the requesting entity is not in one of the authorized roster groups.</li>
+      <li>The node has an access model of "whitelist" and the requesting entity is not on the whitelist.</li>
+      <li>The service or node requires payment for item retrieval.</li>
+      <li>The requesting entity is blocked from retrieving items from the node (e.g., because having an affiliation of outcast).</li>
+      <li>The node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the requesting entity has multiple subscriptions to the node but does not specify a subscription ID, the service MUST return a &lt;bad-request/&gt; error to the subscriber, which SHOULD also include a pubsub-specific error condition of &lt;subid-required/&gt;.</p>
+    <p class="caption">Example 69. Entity did not specify SubID</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;subid-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity is subscribed but specifies an invalid subscription ID, the service MUST return a &lt;not-acceptable/&gt; error to the subscriber, which SHOULD also include a pubsub-specific error condition of &lt;invalid-subid/&gt;.</p>
+    <p class="caption">Example 70. Entity specified invalid SubID</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-subid xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not return items to unsubscribed entities and the requesting entity is not subscribed (which includes having a pending subscription), the service MUST return a &lt;not-authorized/&gt; error to the subscriber, which SHOULD also include a pubsub-specific error condition of &lt;not-subscribed/&gt;.</p>
+    <p class="caption">Example 71. Entity is not subscribed</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;not-subscribed xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service or node does not support persistent items and does not return the last published item, the service MUST return a &lt;feature-not-implemented/&gt; error to the subscriber, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "persistent-items".</p>
+    <p class="caption">Example 72. Persistent items not supported</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='persistent-items'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service or node does not support item retrieval (e.g., because the node is a collection node), the service MUST return a &lt;feature-not-implemented/&gt; error to the subscriber, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "retrieve-items".</p>
+    <p class="caption">Example 73. Item retrieval not supported</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='retrieve-items'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">For nodes with an access model of "presence", if the requesting entity is not subscribed to the owner's presence then the pubsub service MUST respond with a &lt;not-authorized/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;presence-subscription-required/&gt;.</p>
+    <p class="caption">Example 74. Entity is not authorized to retrieve items (presence subscription required)</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;presence-subscription-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">For nodes with an access model of "roster", if the requesting entity is not in one of the authorized roster groups then the pubsub service MUST respond with a &lt;not-authorized/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;not-in-roster-group/&gt;.</p>
+    <p class="caption">Example 75. Entity is not authorized to retrieve items (not in roster group)</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;not-in-roster-group xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">For nodes with a node access model of "whitelist", if the requesting entity is not on the whitelist then the service MUST return a &lt;not-allowed/&gt; error, which SHOULD include a pubsub-specific error condition of &lt;closed-node/&gt;.</p>
+    <p class="caption">Example 76. Node has whitelist access model</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;closed-node xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Commercial deployments may wish to link subscribers to a database of paying customers. If the subscriber needs to provide payment in order to retrieve items from the node (e.g., if the subscriber is not in the customer database or the customer's account is not paid up), the service SHOULD return a &lt;payment-required/&gt; error to the subscriber.</p>
+    <p class="caption">Example 77. Payment is required to retrieve items</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;payment-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity is blocked from subscribing (e.g., because having an affiliation of outcast), the service MUST return a &lt;forbidden/&gt; error to the subscriber.</p>
+    <p class="caption">Example 78. Requesting entity is blocked</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not exist, the service SHOULD return an &lt;item-not-found/&gt; error to the subscriber.</p>
+    <p class="caption">Example 79. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MAY allow entities to request the most recent N items by using the 'max_items' attribute. When max_items is used, implementations SHOULD return the N most recent (as opposed to the N oldest) items. (Note: A future version of this specification may recommend the use of <span class="ref" style="">Result Set Manipulation</span>  [<a href="#nt-id2265656">17</a>] instead of the 'max_items' attribute.)</p>
+    <p class="caption">Example 80. Subscriber requests two most recent items</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='items2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings' max_items='2'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 81. Service returns two most recent items</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='items2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='4e30f35051b7b8b42abe083742187228'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Alone&lt;/title&gt;
+          &lt;summary&gt;
+Now I am alone.
+O, what a rogue and peasant slave am I!
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32396&lt;/id&gt;
+          &lt;published&gt;2003-12-13T11:09:53Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T11:09:53Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MAY return event notifications without payloads (e.g., to conserve bandwidth). If so, the client MAY request a specific item (using the ItemID) in order to retrieve the payload. When an entity requests items by ItemID, implementations MUST allow multiple items to be specified in the request.</p>
+    <p class="caption">Example 82. Subscriber requests specific items by ItemID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='items3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='368866411b877c30064a5f62b917cffe'/&gt;
+      &lt;item id='4e30f35051b7b8b42abe083742187228'/&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Service sends requested item(s)</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    id='items3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='368866411b877c30064a5f62b917cffe'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;The Uses of This World&lt;/title&gt;
+          &lt;summary&gt;
+O, that this too too solid flesh would melt
+Thaw and resolve itself into a dew!
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32396&lt;/id&gt;
+          &lt;published&gt;2003-12-12T17:47:23Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-12T17:47:23Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+      &lt;item id='4e30f35051b7b8b42abe083742187228'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Alone&lt;/title&gt;
+          &lt;summary&gt;
+Now I am alone.
+O, what a rogue and peasant slave am I!
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32396&lt;/id&gt;
+          &lt;published&gt;2003-12-13T11:09:53Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T11:09:53Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a subscription identifier is associated with a specific subscription, the service MUST require it so that it can generate different sets of items based on the subscription options associated with a specific subscription. Therefore the entity MUST include the 'subid' attribute with the items element when making the request; if it does not, the service MUST return a &lt;not-acceptable/&gt; error, which SHOULD include a pubsub-specific error condition of &lt;subid-required/&gt;.</p>
+    <p class="caption">Example 84. Subscriber sends request without SubID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='items5'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 85. SubID required</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='items5'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;subid-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+<h2>7.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="publisher-publish">Publish an Item to a Node</a>
+</h3>
+    <p class="" style="">Any entity which is allowed to publish items to a node (i.e., a publisher or an owner) may do so at any time by sending an IQ-set to the service containing a pubsub element with a &lt;publish/&gt; child; the &lt;publish/&gt; element MUST possess a 'node' attribute and depending on the node configuration MAY contain no &lt;item/&gt; elements, one &lt;item/&gt; element, or (for <a href="#impl-batch">Batch Processing</a>) more than one &lt;item/&gt; element.</p>
+    <p class="" style="">Note: It is not necessary for a publication request to include a payload or even an &lt;item/&gt; element in order to trigger a notification. For example, the result of publishing to a transient, notification-only node will be a notification that does not include even an &lt;item/&gt; element (as shown in the <a href="#intro-example">Motivating Example</a> section of this document). However, for the sake of convenience we refer to the act of publication as "publishing an item" (rather than, say, "triggering a notification") even though a publication request will not always contain an &lt;item/&gt; element.</p>
+    <p class="caption">Example 86. Publisher publishes an item with an ItemID</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/blogbot'
+    to='pubsub.shakespeare.lit'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the pubsub service can successfully process the request, it MUST inform the publisher of success.</p>
+    <p class="caption">Example 87. Service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/blogbot'
+    id='publish1'/&gt;
+    </pre></div>
+    <p class="" style="">If the pubsub service can successfully process the request, it MUST send then one &lt;message/&gt; stanza containing a pubsub event notification to each approved subscriber. Each &lt;message/&gt; stanza generated by a pubsub service SHOULD possess an 'id' attribute with a unique value so that the service can properly track any notification-related errors that may occur (see the <a href="impl-errors">Handling Notification-Related Errors</a> section of this document).</p>
+    <p class="" style="">Depending on the node configuration, the event notification either will or will not contain the payload, as shown in the following examples.</p>
+    <p class="" style="">If the node is configured to include payloads, the subscribers will receive payloads with the event notifications.</p>
+    <p class="caption">Example 88. Subscribers receive event notifications with payloads</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='bernardo@denmark.lit' id='bar'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='horatio@denmark.lit' id='baz'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='marcellus@denmark.lit' id='fez'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Soliloquy&lt;/title&gt;
+          &lt;summary&gt;
+To be, or not to be: that is the question:
+Whether 'tis nobler in the mind to suffer
+The slings and arrows of outrageous fortune,
+Or to take arms against a sea of troubles,
+And by opposing end them?
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32397&lt;/id&gt;
+          &lt;published&gt;2003-12-13T18:30:02Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T18:30:02Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If the node is configured to not include payloads, the subscribers will receive event notifications only. (If payloads are not included, subscribers may request the published item via the protocol defined in the <a href="#subscriber-retrieve">Retrieve Items from a Node</a> section of this document.)</p>
+    <p class="caption">Example 89. Subscribers receive event notifications only</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='bernardo@denmark.lit' id='bar'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='horatio@denmark.lit' id='baz'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='marcellus@denmark.lit' id='fez'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a single entity is subscribed to a node multiple times, the service SHOULD notate the event notification so that the entity can determine which subscription identifier(s) generated this event. If these notations are included, they MUST use the <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2265961">18</a>] format and SHOULD be included after the event notification information (i.e., as the last child of the &lt;message/&gt; stanza).</p>
+    <p class="caption">Example 90. Subscriber receives notated event notification</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='pubsub#subid'&gt;123-abc&lt;/header&gt;
+    &lt;header name='pubsub#subid'&gt;004-yyy&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the publish request might fail:</p>
+    <ol start="" type="">
+      <li>The requesting entity does not have sufficient privileges to publish.</li>
+      <li>The node does not support item publication.</li>
+      <li>The node does not exist.</li>
+      <li>The payload size exceeds a service-defined limit.</li>
+      <li>The item contains more than one payload element or the namespace of the root payload element does not match the configured namespace for the node.</li>
+      <li>The request does not match the node configuration.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">Note: If a publisher publishes an item with an Item ID and the ItemID matches that of an existing item, the pubsub service MUST NOT fail the publication but instead MUST overwrite the existing item and generate a new event notification (i.e., re-publication is equivalent to modification).</p>
+    <p class="" style="">If the requesting entity does not have sufficient privileges to publish, the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 91. Entity does not have sufficient privileges to publish to node</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... PAYLOAD ...
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not support item publication (because it is a <a href="collections">Collection Node</a>), the service MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "publish".</p>
+    <p class="caption">Example 92. Node does not support item publication</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... PAYLOAD ...
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='publish'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity attempts to publish an item to a node that does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 93. Entity attempts to publish to a non-existent node</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... PAYLOAD ...
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the payload size exceeds a service-defined limit, the service MUST return a &lt;not-acceptable/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;payload-too-big/&gt;.</p>
+    <p class="caption">Example 94. Entity attempts to publish very large payload</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... HUGE PAYLOAD ...
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;payload-too-big xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;item/&gt; element contains more than one payload element or the namespace of the root payload element does not match the configured namespace for the node, the service MUST bounce the request with a &lt;bad-request/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;invalid-payload/&gt;.</p>
+    <p class="caption">Example 95. Entity attempts to publish item with multiple payload elements or namespace does not match</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ... INVALID PAYLOAD ...
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-payload xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the request does not conform to the configured <a href="#events">event type</a> for the node, the service MAY bounce the request with a &lt;bad-request/&gt; error, which SHOULD also include a pubsub-specific error condition. The following rules apply:</p>
+    <ul>
+      <li>If the event type is persistent (either notification or payload) and the publisher does not specify an ItemID, the service MUST generate the ItemID and MUST NOT bounce the publication request.</li>
+      <li>If the event type is persistent (either notification or payload) and the publisher does not include an item, the service MUST bounce the publication request with a &lt;bad-request/&gt; error and a pubsub-specific error condition of &lt;item-required/&gt;.</li>
+      <li>If the event type is payload (either persistent or transient) and the publisher does not include a payload, the service SHOULD bounce the publication request with a &lt;bad-request/&gt; error and a pubsub-specific error condition of &lt;payload-required/&gt;.</li>
+      <li>If the event type is notification + transient and the publisher provides an item, the service MUST bounce the publication request with a &lt;bad-request/&gt; error and a pubsub-specific error condition of &lt;item-forbidden/&gt;.</li>
+    </ul>
+    <p class="" style="">Examples of these errors are shown below.</p>
+    <p class="caption">Example 96. Publisher attempts to publish to persistent node with no item</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;item-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 97. Publisher attempts to publish to payload node with no payload</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;payload-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 98. Publisher attempts to publish to transient notification node with item</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;item-forbidden xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Finally, in order to facilitate authorization for item removal as described in the <a href="#publisher-delete">Delete an Item from a Node</a> section of this document, implementations that support persistent items SHOULD store the item (if the node is so configured) and maintain a record of the publisher.</p>
+  </div>
+
+  <div class="indent">
+<h3>7.2 <a name="publisher-delete">Delete an Item from a Node</a>
+</h3>
+    <p class="" style="">A service SHOULD allow a publisher to delete an item once it has been published to a node that supports persistent items. To delete an item, the publisher sends a retract request as shown in the following examples. The &lt;retract/&gt; element MUST possess a 'node' attribute, MAY possess a 'notify' attribute, and SHOULD contain one &lt;item/&gt; element (but MAY contain more than one &lt;item/&gt; element for <a href="#impl-batch">Batch Processing</a> of item retractions); the &lt;item/&gt; element MUST be empty and MUST possess an 'id' attribute.</p>
+    <p class="caption">Example 99. Entity deletes an item from a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='retract1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;retract node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 100. Service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='retract1'/&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the item retraction request might fail:</p>
+    <ol start="" type="">
+      <li>The publisher does not have sufficient privileges to delete the requested item.</li>
+      <li>The node or item does not exist.</li>
+      <li>The request does not specify a node.</li>
+      <li>The request does not include an &lt;item/&gt; element or the &lt;item/&gt; element does not specify an ItemID.</li>
+      <li>The node does not support persistent items.</li>
+      <li>The service does not support the deletion of items.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the requesting entity does not have sufficient privileges to delete the item, the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 101. Requesting entity does not have sufficient privileges</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='retract1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;retract node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node or item does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 102. Non-existent node or item</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='retract1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;retract node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the request does not specify a node, the service MUST return a &lt;bad-request/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;node-required/&gt;.</p>
+    <p class="caption">Example 103. Request does not specify a node</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='retract1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;retract/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;node-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the request does not include an &lt;item/&gt; element or the &lt;item/&gt; element does not specify an ItemID, the service MUST return a &lt;bad-request/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;item-required/&gt;.</p>
+    <p class="caption">Example 104. Request does not specify an item</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='retract1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;retract node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;item-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not support persistent items (e.g., because it is a collection node or a transient node that does not deliver payloads), the service MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "persistent-items".</p>
+    <p class="caption">Example 105. Node does not support persistent items</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='retract1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;retract node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='persistent-items'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service does not support item deletion, it MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "delete-nodes".</p>
+    <p class="caption">Example 106. Service does not support item deletion</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='retract1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;retract node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='delete-nodes'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If none of the foregoing errors occurred, then the service MUST delete the item.</p>
+    <p class="" style="">If none of the foregoing errors occurred and the &lt;retract/&gt; element included a 'notify' attribute with a value of "true" or "1"  [<a href="#nt-id2266699">19</a>], then the service MUST delete the item and MUST send message notifications to all subscribers as shown below. The syntax is identical to publish notifications except that instead of an &lt;item/&gt; element, the notification includes a &lt;retract/&gt; element.</p>
+    <p class="caption">Example 107. Subscribers are notified of deletion</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;retract id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='bernardo@denmark.lit' id='bar'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;retract id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a single entity is subscribed to the node multiple times, the service SHOULD notate the notification of item deletion so that the entity can determine which subscription identifier(s) generated this event. As above, if these notations are included, they MUST use the <span style="font-weight: bold">Stanza Headers and Internet Metadata (SHIM)</span> protocol and SHOULD be included after the event notification information (i.e., as the last child of the &lt;message/&gt; stanza).</p>
+    <p class="caption">Example 108. Subscriber receives notated event notification</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='bernardo@denmark.lit' id='bar'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;retract id='ae890ac52d0df67ed7cfdf51b644e901'/&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='pubsub#subid'&gt;123-abc&lt;/header&gt;
+    &lt;header name='pubsub#subid'&gt;004-yyy&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+<h2>8.
+       <a name="owner">Owner Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="owner-create">Create a Node</a>
+</h3>
+    <div class="indent">
+<h3>8.1.1 <a name="owner-create-general">General Considerations</a>
+</h3>
+      <p class="" style="">A service SHOULD allow entities to create new nodes. However, a service MAY disallow creation of nodes based on the identity of the requesting entity, or MAY disallow node creation altogether (e.g., reserving that privilege to a service-wide administrator).</p>
+      <p class="" style="">There are two ways to create a node:</p>
+      <ol start="" type="">
+        <li>Create a node with default configuration for the specified node type.</li>
+        <li>Create and configure a node simultaneously.</li>
+      </ol>
+      <p class="" style="">These methods, along with method-specific error conditions, are explained more fully in the following sections.</p>
+      <p class="" style="">In addition to method-specific error conditions, there are several general reasons why the node creation request might fail:</p>
+      <ul>
+        <li>The service does not support node creation.</li>
+        <li>Only entities that are registered with the service are allowed to create nodes but the requesting entity is not registered.</li>
+        <li>The requesting entity does not have sufficient privileges to create nodes.</li>
+        <li>The requested NodeID already exists.</li>
+        <li>The request did not include a NodeID and "instant nodes" are not supported.</li>
+      </ul>
+      <p class="" style="">These general error cases are described more fully below.</p>
+      <p class="" style="">If the service does not support node creation, it MUST respond with a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "create-nodes".</p>
+      <p class="caption">Example 109. Service does not support node creation</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='princely_musings'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='create-nodes'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If only entities that are registered with the service may create nodes but the requesting entity has not yet registered, the service MUST respond with a &lt;registration-required/&gt; error.</p>
+      <p class="caption">Example 110. Service requires registration</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create1'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;create node='princely_musings'/&gt;
+      &lt;configure/&gt;
+    &lt;/pubsub&gt;
+    &lt;error type='auth'&gt;
+      &lt;registration-required xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the requesting entity does not have sufficient privileges to create nodes, the service MUST respond with a &lt;forbidden/&gt; error.</p>
+      <p class="caption">Example 111. Requesting entity is prohibited from creating nodes</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='princely_musings'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the requested NodeID already exists, the service MUST respond with a &lt;conflict/&gt; error.</p>
+      <p class="caption">Example 112. NodeID already exists</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='princely_musings'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the node creator does not specify a NodeID but the service does not support instant nodes, the service MUST return a &lt;not-acceptable/&gt; error, which SHOULD include a pubsub-specific error condition of &lt;nodeid-required/&gt;.</p>
+      <p class="caption">Example 113. Service does not support instant nodes</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create2'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;create/&gt;
+      &lt;configure/&gt;
+    &lt;/pubsub&gt;
+    &lt;error type='modify'&gt;
+      &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;nodeid-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the node creator does not specify a NodeID but the service supports instant nodes, the service SHOULD generate a NodeID that is unique within the context of the service on behalf of the node creator.</p>
+      <p class="caption">Example 114. Entity requests an instant node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='create2'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;create/&gt;
+      &lt;configure/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If no error occurs, the pubsub service SHOULD create the node, generate a NodeID that is unique within the context of that service, and inform the user of success (including the NodeID in the response).</p>
+      <p class="caption">Example 115. Service replies with success and generated NodeID</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create2'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;create node='25e3d37dabbab9541f7523321421edc5bfeb2dae'/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Note: When a service successfully creates a node on behalf of the requesting entity, it MUST return an IQ result. If the node creation request did not specify a NodeID and the service supports creation of instant nodes, the service MUST specify the created NodeID in the IQ result. Similarly, if the node creation request specified a NodeID but the service modified the NodeID before creating the node as described in the <a href="#collections">Collection Nodes</a> section of this document, the service MUST also specify the modified node in the IQ result. In all other cases, the service MUST NOT specify the NodeID in the IQ result (since the node creator can determine which node was created by tracking the 'id' attribute that it specified for the IQ-set).</p>
+    </div>
+    <div class="indent">
+<h3>8.1.2 <a name="owner-create-default">Create a Node With Default Configuration</a>
+</h3>
+      <p class="" style="">As explained above, each node type has its own default configuration. By asking the service to create a node with default configuration, the node creator accepts the default configuration. If the service allows node configuration, the owner may reconfigure the node after creating the node (as described in the <a href="#owner-configure">Configure a Node</a> section of this document). In addition, a service MAY allow entities to determine the default configuration options for a given node type before creating a node (as described in the <a href="#owner-default">Request Default Configurations</a> section of this document).</p>
+      <p class="" style="">In order to create a node with default configuration, the node creator MUST include an empty &lt;configure/&gt; child element in the creation request. The node creator MAY specify values for the 'pubsub#node_type' and 'pubsub#access_model' configuration fields or MAY accept the defaults, which are "leaf" for the 'pubsub#node_type' field and the value represented by the 'pubsub#access_model' field (i.e., "authorize", "open", "presence", "roster", or "whitelist").</p>
+      <p class="" style="">In the following example, the node creator requests a leaf node (the default type) with an open access model (assumed to be the default type for this service).</p>
+      <p class="caption">Example 116. Entity requests leaf node with (default) open access model</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='create1'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;create node='princely_musings'/&gt;
+      &lt;configure/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">In order to request an access model other than the default for the service, the node creator MUST include a Data Form in the node creation request that specifies a non-default value for the 'pubsub#node_type' field.</p>
+      <p class="caption">Example 117. Entity requests leaf node with non-default access model</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='create2'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;create node='princely_musings'/&gt;
+      &lt;configure&gt;
+        &lt;x xmlns='jabber:x:data' type='submit'&gt;
+          &lt;field var='FORM_TYPE' type='hidden'&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var='pubsub#access_model'&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/configure&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the access model is supported and none of the general or method-specific errors has occurred, the service SHOULD create the node and inform the requesting entity of success.</p>
+      <p class="caption">Example 118. Service informs requesting entity of success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create1'/&gt;
+      </pre></div>
+      <p class="" style="">If service does not support the specified access model, it MUST return a &lt;not-acceptable/&gt; error, which SHOULD include a pubsub-specific error condition of &lt;unsupported-access-model/&gt;.</p>
+      <p class="caption">Example 119. Service does not support specified access model</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create2'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;create node='princely_musings'/&gt;
+      &lt;configure&gt;
+        &lt;x xmlns='jabber:x:data' type='submit'&gt;
+          &lt;field var='FORM_TYPE' type='hidden'&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var='pubsub#access_model'&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/configure&gt;
+    &lt;/pubsub&gt;
+    &lt;error type='auth'&gt;
+      &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;unsupported-access-model xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+    &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">(For error handling if the service does not support the specified node type, see the <a href="#collections">Collection Node</a> section of this document.)</p>
+    </div>
+    <div class="indent">
+<h3>8.1.3 <a name="owner-create-and-configure">Create and Configure a Node</a>
+</h3>
+      <p class="" style="">If an implementation allows node configuration (see the <a href="#owner-configure">Configure a Node</a> section of this document), it SHOULD allow node creation requests to contain the desired node configuration in the node creation request.</p>
+      <p class="" style="">Note: The &lt;configure/&gt; element MUST follow the &lt;create/&gt; element and MUST NOT possess a 'node' attribute, since the value of the &lt;create/&gt; element's 'node' attribute specifies the desired NodeID; if any of these rules are violated, the service MUST return a &lt;bad-request/&gt; error.</p>
+      <p class="caption">Example 120. Entity requests a new node with non-default configuration.</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='princely_musings'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#title'&gt;&lt;value&gt;Princely Musings (Atom)&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#deliver_payloads'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#persist_items'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#max_items'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;&lt;value&gt;open&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#publish_model'&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#send_item_subscribe'&gt;&lt;value&gt;false&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#presence_based_delivery'&gt;&lt;value&gt;false&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_config'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_delete'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_retract'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#max_payload_size'&gt;&lt;value&gt;1028&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#type'&gt;&lt;value&gt;http://www.w3.org/2005/Atom&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#body_xslt'&gt;
+          &lt;value&gt;http://jabxslt.jabberstudio.org/atom_body.xslt&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 121. Service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='create1'/&gt;
+      </pre></div>
+      <p class="" style="">If a service supports this "create-and-configure" feature, it MUST advertise that fact by returning a feature of "http://jabber.org/protocol/pubsub#create-and-configure" in response to service discovery information requests. If the create-and-configure option is not supported but the requesting entity sends such a request anyway, the service SHOULD ignore the configuration part of the request and proceed as if it had not been included.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="owner-configure">Configure a Node</a>
+</h3>
+    <p class="" style="">After creating a new node, the node owner may want to modify the node configuration. The process for doing so is shown below.</p>
+    <p class="caption">Example 122. Owner requests configuration form</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The following example shows some of the possible configuration options that MAY be provided. If an implementation implements these features using the <span style="font-weight: bold">Data Forms</span> protocol, that implementation MUST use the fields that are registered with the Jabber Registrar in association with the 'http://jabber.org/protocol/pubsub' namespace (a preliminary representation of those field variables is shown below and in the <a href="#registrar-formtypes-confi">pubsub#node_config FORM_TYPE</a> section of this document, but MUST NOT be construed as canonical, since the Jabber Registrar may standardize additional fields at a later date without changes to this document). An implementation MAY choose to specify different labels, values, and even field types, but MUST conform to the defined variable naming scheme.</p>
+    <p class="caption">Example 123. Service responds with configuration form</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#title' type='text-single'
+               label='A friendly name for the node'/&gt;
+        &lt;field var='pubsub#deliver_payloads' type='boolean'
+               label='Deliver payloads with event notifications'&gt;
+          &lt;value&gt;true&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#notify_config' type='boolean'
+               label='Notify subscribers when the node configuration changes'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#notify_delete' type='boolean'
+               label='Notify subscribers when the node is deleted'&gt;
+          &lt;value&gt;false&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#notify_retract' type='boolean'
+               label='Notify subscribers when items are removed from the node'&gt;
+          &lt;value&gt;false&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#persist_items' type='boolean'
+               label='Persist items to storage'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#max_items' type='text-single'
+               label='Max # of items to persist'&gt;
+          &lt;value&gt;10&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscribe' type='boolean'
+               label='Whether to allow subscriptions'&gt;
+          &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model' type='list-single'
+               label='Specify the subscriber model'&gt;
+          &lt;option&gt;&lt;value&gt;authorize&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+          &lt;value&gt;open&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed' type='list-multi'
+               label='Roster groups allowed to subscribe'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;courtiers&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;servants&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;enemies&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#publish_model' type='list-single'
+               label='Specify the publisher model'&gt;
+          &lt;option&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;subscribers&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+          &lt;value&gt;publishers&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#max_payload_size' type='text-single'
+               label='Max Payload size in bytes'&gt;
+          &lt;value&gt;1028&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#send_item_subscribe' type='boolean'
+               label='Send items to new subscribers'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#presence_based_delivery' type='boolean'
+               label='Deliver notifications only to available users'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#type' type='text-single'
+               label='Specify the type of payload data to be provided at this node'&gt;
+          &lt;value&gt;http://www.w3.org/2005/Atom&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#dataform_xslt' type='text-single'
+               label='Payload XSLT'/&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the node configuration request might fail:</p>
+    <ol start="" type="">
+      <li>The service does not support node configuration.</li>
+      <li>The requesting entity does not have sufficient privileges to configure the node.</li>
+      <li>The request did not specify a node.</li>
+      <li>The node has no configuration options.</li>
+      <li>The specified node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the service does not support node configuration, the service MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "config-node".</p>
+    <p class="caption">Example 124. Service does not support node configuration</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='config-node'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity does not have sufficient privileges to configure the node, the service MUST respond with a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 125. Requesting entity is prohibited from configuring this node</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the request did not specify a node, the service SHOULD return a &lt;bad-request/&gt; error. It is possible that by not including a NodeID, the requesting entity is asking to configure the root node; however, if the requesting entity is not a service-level admin, it makes sense to return &lt;bad-request/&gt; instead of &lt;forbidden/&gt;.</p>
+    <p class="caption">Example 126. Request did not specify a node</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;nodeid-required xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no configuration options are available (e.g., because node configuration is "locked down"), the service MUST return a &lt;not-allowed/&gt; error to the owner.</p>
+    <p class="caption">Example 127. Node has no configuration options</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 128. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">After receiving the configuration form, the owner SHOULD submit a completed configuration form.</p>
+    <p class="caption">Example 129. Owner submits node configuration form</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='config2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#title'&gt;&lt;value&gt;Princely Musings (Atom)&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#deliver_payloads'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#persist_items'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#max_items'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;&lt;value&gt;open&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#publish_model'&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#send_item_subscribe'&gt;&lt;value&gt;false&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#presence_based_delivery'&gt;&lt;value&gt;false&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_config'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_delete'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_retract'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#max_payload_size'&gt;&lt;value&gt;1028&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#type'&gt;&lt;value&gt;http://www.w3.org/2005/Atom&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#body_xslt'&gt;
+          &lt;value&gt;http://jabxslt.jabberstudio.org/atom_body.xslt&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 130. Service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='config2'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the owner MAY cancel the configuration process, in which case the existing configuration MUST be applied.</p>
+    <p class="caption">Example 131. Owner cancels configuration process</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='config2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'&gt;
+      &lt;x xmlns='jabber:x:data' type='cancel'/&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested node configuration change cannot be processed (e.g., because the node owner has attempted to change the configuration so that there are no node owners), the service MUST return a &lt;not-acceptable/&gt; error to the owner.</p>
+    <p class="caption">Example 132. Configuration change cannot be processed</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='config2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the "pubsub#notify_config" option is set to true, the service MUST send a notification of configuration change to all subscribers. (A service SHOULD support this option for leaf nodes and MUST support it for <a href="#collection">Collection Nodes</a>.) If the node configuration is set to event notifications only, the notification MUST consist of an empty &lt;configuration/&gt; element whose 'node' attribute is set to the NodeID of the node; if the node configuration is set to full payloads, the &lt;configuration/&gt; element MUST in addition contain the node configuration as represented via the <span style="font-weight: bold">Data Forms</span> protocol.</p>
+    <p class="caption">Example 133. Service sends configuration change notification (event notification only)</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;configuration node='princely_musings'/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 134. Service sends configuration change notification (full payload)</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;configuration node='princely_musings'&gt;
+      &lt;x xmlns='jabber:x:data' type='result'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#title'&gt;&lt;value&gt;Princely Musings (Atom)&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#deliver_payloads'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_config'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_delete'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#notify_retract'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#persist_items'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#max_items'&gt;&lt;value&gt;10&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#subscribe'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;&lt;value&gt;open&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#publish_model'&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#max_payload_size'&gt;&lt;value&gt;9216&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#send_item_subscribe'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#presence_based_delivery'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#type'&gt;&lt;value&gt;http://www.w3.org/2005/Atom&lt;/value&gt;&lt;/field&gt;
+        &lt;field var='pubsub#body_xslt'&gt;
+          &lt;value&gt;http://jabxslt.jabberstudio.org/atom_body.xslt&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configuration&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="owner-default">Request Default Configuration Options</a>
+</h3>
+    <p class="" style="">A service MAY allow entities to determine the default node configuration for new nodes created on the service, in order to help entities determine whether they want to perform create-and-configure as previously described. To get the options, the entity MUST send an empty &lt;default/&gt; element to the service with no NodeID; in response, the service SHOULD return the default node options.</p>
+    <p class="caption">Example 135. Entity requests default configuration options</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='def1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;default/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 136. Service responds with default configuration options</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='hamlet@denmark.lit/elsinore'
+    id='def1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;default&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+           &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#title' type='text-single'
+               label='A friendly name for the node'/&gt;
+        &lt;field var='pubsub#deliver_payloads' type='boolean'
+             label='Deliver payloads with event notifications'&gt;
+          &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#notify_config' type='boolean'
+               label='Notify subscribers when the node configuration changes'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#notify_delete' type='boolean'
+               label='Notify subscribers when the node is deleted'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#notify_retract' type='boolean'
+               label='Notify subscribers when items are removed from the node'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#persist_items' type='boolean'
+               label='Persist items to storage'&gt;
+          &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#max_items' type='text-single'
+               label='Max # of items to persist'&gt;
+          &lt;value&gt;10&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscribe' type='boolean'
+               label='Whether to allow subscriptions'&gt;
+          &lt;value&gt;1&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model' type='list-single'
+               label='Specify the subscriber model'&gt;
+          &lt;option&gt;&lt;value&gt;authorize&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+          &lt;value&gt;open&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed' type='list-multi'
+               label='Roster groups allowed to subscribe'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;courtiers&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;servants&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;enemies&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#publish_model' type='list-single'
+               label='Specify the publisher model'&gt;
+          &lt;option&gt;&lt;value&gt;publishers&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;subscribers&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+          &lt;value&gt;publishers&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#max_payload_size' type='text-single'
+               label='Max payload size in bytes'&gt;
+          &lt;value&gt;9216&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#send_item_subscribe' type='boolean'
+               label='Send items to new subscribers'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#presence_based_delivery' type='boolean'
+               label='Only deliver notifications to available users'&gt;
+          &lt;value&gt;0&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/default&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the default node configuration options request might fail:</p>
+    <ol start="" type="">
+      <li>The service does not support node configuration.</li>
+      <li>The service does not support retrieval of default node configuration.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the service does not support node configuration, it MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "config-node".</p>
+    <p class="caption">Example 137. Service does not support node configuration</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='def1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;default/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='config-node'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service does not support retrieval of default node configuration options, it MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "retrieve-default".</p>
+    <p class="caption">Example 138. Service does not support retrieval of default configuration options</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='def1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;default/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='retrieve-default'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The default configuration options may be different for a collection node vs. a leaf node. In order to specifically request the default configuration options for collection nodes, an entity MUST include a Data Form with a 'pubsub#node_type' field whose value is "collection" in the request (since the default value for the 'pubsub#node_type' field is "leaf").</p>
+    <p class="caption">Example 139. Entity requests default configuration options for collection nodes</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='hamlet@denmark.lit/elsinore'
+    id='def2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;default&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#node_type'&gt;&lt;value&gt;collection&lt;/value&gt;&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/default&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service does not support collection nodes, it MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "collections".</p>
+    <p class="caption">Example 140. Service does not support collection nodes</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='def2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;default&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#node_type'&gt;&lt;value&gt;collection&lt;/value&gt;&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/default&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='collections'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="owner-delete">Delete a Node</a>
+</h3>
+    <p class="" style="">If a service supports node creation, it MUST support node deletion. If an implementation persists items, it MUST remove all items from persistent storage before the node itself is deleted.</p>
+    <p class="" style="">In order to delete a node, a node owner MUST send a node deletion request, consisting of a &lt;delete/&gt; element whose 'node' attribute specifies the NodeID of the node to be deleted.</p>
+    <p class="caption">Example 141. Owner deletes a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='delete1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;delete node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no error occurs, the service MUST inform the owner of success.</p>
+    <p class="caption">Example 142. Service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    id='delete1'/&gt;
+    </pre></div>
+    <p class="" style="">In addition, the service MUST also send notification of node deletion to all subscribers (which SHOULD include pending and unconfigured subscriptions).</p>
+    <p class="caption">Example 143. Subscribers are notified of node deletion</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;delete node='princely_musings'/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='bernardo@denmark.lit' id='bar'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;delete node='princely_musings'/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">There are several reasons why the node deletion request might fail:</p>
+    <ol start="" type="">
+      <li>The requesting entity does not have sufficient privileges to delete the node.</li>
+      <li>The node is the root collection node, which cannot be deleted.</li>
+      <li>The specified node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the requesting entity does not have sufficient privileges to delete the node (e.g., is not an owner), the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 144. Entity is not an owner</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='delete1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;delete node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity attempts to delete the root collection node, the service MUST return a &lt;not-allowed/&gt; error.</p>
+    <p class="caption">Example 145. Node is the root</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='delete1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;delete/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity attempts to delete a node that does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 146. Owner attempts to delete a non-existent node</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='delete1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;delete node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the deleted node is a <a href="#collections">Collection Node</a>, the implementation MAY associate the "orphaned" leaf nodes with the root collection node or associate them with no collection node.</p>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="owner-purge">Purge All Node Items</a>
+</h3>
+    <p class="" style="">If a service persists published items, it MAY enable node owners to purge the node of all published items (thus removing all items from the persistent store, with the exception of the last published item, which MAY be cached). In order to purge a node of all items, a node owner MUST send a node purge request, consisting of a &lt;purge/&gt; element whose 'node' attribute specifies the NodeID of the node to be purged.</p>
+    <p class="caption">Example 147. Owner purges all items from a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;purge node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no error occurs, the service MUST purge the node and inform the owner of success.</p>
+    <p class="caption">Example 148. Service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    id='purge1'/&gt;
+    </pre></div>
+    <p class="" style="">If the node or service has been configured to notify subscribers on deletion of items, a purge request MUST NOT result in sending the same notifications as are sent when deleting items (since purging a node with many persisted items could result in a large number of notifications); instead, the node MUST send a single notification to each subscriber, containing an empty &lt;purge/&gt; child element.</p>
+    <p class="caption">Example 149. Subscribers are notified of node purge</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;purge node='princely_musings'/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='pubsub.shakespeare.lit' to='bernardo@denmark.lit' id='bar'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;purge node='princely_musings'/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">There are several reasons why the node purge request might fail:</p>
+    <ol start="" type="">
+      <li>The node or service does not support node purging.</li>
+      <li>The requesting entity does not have sufficient privileges to purge the node.</li>
+      <li>The node is not configured to persist items.</li>
+      <li>The specified node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the node or service does not support node purging, it MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "purge-nodes".</p>
+    <p class="caption">Example 150. Service does not support node purging</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;purge node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='purge-nodes'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity does not have sufficient privileges to purge the node (e.g., because it is not a node owner), the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 151. Entity is not an owner</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;purge node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service or node does not persist items (e.g., because the node is a collection node), it MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "persistent-items".</p>
+    <p class="caption">Example 152. Node is not configured for persistent items</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;purge node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='persistent-items'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 153. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;purge node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>8.6 <a name="owner-subreq">Manage Subscription Requests</a>
+</h3>
+    <p class="" style="">A service MAY send subscription approval requests to the node owner(s) at any time. An approval request consists of a message stanza containing a Data Form scoped by the "http://jabber.org/protocol/pubsub#subscribe_authorization" FORM_TYPE. The form MUST contain a boolean field that has a 'var' attribute of "pubsub#allow", which is the field that designates whether or not to allow the subscription request. The form SHOULD include fields that specify the node identifier, the subscription id (if applicable), and the JID of the pending subscriber. The message MAY include a &lt;body/&gt; element that contains natural-language text explaining that the message contains a pending subscription form.</p>
+    <p class="caption">Example 154. Service sends authorization request to node owner</p>
+<div class="indent"><pre>
+&lt;message to='hamlet@denmark.lit' from='pubsub.shakespeare.lit' id='approve1'&gt;
+  &lt;x xmlns='jabber:x:data' type='form'&gt;
+    &lt;title&gt;PubSub subscriber request&lt;/title&gt;
+    &lt;instructions&gt;
+      To approve this entity&amp;apos;s subscription request,
+      click the OK button. To deny the request, click the
+      cancel button.
+    &lt;/instructions&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;
+      &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#subid' type='hidden'&gt;&lt;value&gt;123-abc&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='pubsub#node' type='text-single' label='Node ID'&gt;
+      &lt;value&gt;princely_musings&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pusub#subscriber_jid' type='jid-single' label='Subscriber Address'&gt;
+      &lt;value&gt;horatio@denmark.lit&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#allow' type='boolean'
+           label='Allow this JID to subscribe to this pubsub node?'&gt;
+      &lt;value&gt;false&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In order to approve the request, the owner shall submit the form and set the "pubsub#allow" field to a value of "1" or "true"; for tracking purposes the message MUST reflect the 'id' attribute originally provided.</p>
+    <p class="caption">Example 155. Owner approves subscription request</p>
+<div class="indent"><pre>
+&lt;message from='hamlet@denmark.lit/elsinore' to='pubsub.shakespeare.lit' id='approve1'&gt;
+  &lt;x xmlns='jabber:x:data' type='submit'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;
+      &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#subid'&gt;
+      &lt;value&gt;123-abc&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#node'&gt;
+      &lt;value&gt;princely_musings&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#subscriber_jid'&gt;
+      &lt;value&gt;horatio@denmark.lit&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#allow'&gt;
+       &lt;value&gt;true&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The service then SHOULD send notification to the approved subscriber (see the <a href="#impl-subchange">Notification of Subscription State Changes</a> section of this document).</p>
+    <p class="caption">Example 156. Subscription approval notification</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.shakespeare.lit'
+    to='horatio@denmark.lit'
+    id='approvalnotify1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription node='princely_musings' jid='horatio@denmark.lit' subscription='subscribed'/&gt;
+  &lt;/pubsub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In order to deny the request, the owner shall submit the form and set the "pubsub#allow" field to a value of "0" or "false"; as above, the message MUST reflect the 'id' attribute originally provided.</p>
+    <p class="caption">Example 157. Owner denies subscription request</p>
+<div class="indent"><pre>
+&lt;message from='hamlet@denmark.lit/elsinore' to='pubsub.shakespeare.lit' id='approve1'&gt;
+  &lt;x xmlns='jabber:x:data' type='submit'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;
+       &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#subid'&gt;
+       &lt;value&gt;123-abc&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#node'&gt;
+      &lt;value&gt;princely_musings&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#subscriber_jid'&gt;
+       &lt;value&gt;horatio@denmark.lit&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;field var='pubsub#allow'&gt;
+        &lt;value&gt;false&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The service then SHOULD send notification to the denied subscriber (see the <a href="#impl-subchange">Notification of Subscription State Changes</a> section of this document).</p>
+    <p class="caption">Example 158. Subscription cancellation / denial notification</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.shakespeare.lit'
+    to='horatio@denmark.lit'
+    id='unsubnotify1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription node='princely_musings' jid='horatio@denmark.lit' subscription='none'/&gt;
+  &lt;/pubsub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In order to cancel the form submission, the owner shall reply with the form's 'type' attribute set to "cancel".</p>
+    <p class="caption">Example 159. Owner cancels form submission</p>
+<div class="indent"><pre>
+&lt;message from='hamlet@denmark.lit/elsinore' to='pubsub.shakespeare.lit' id='approve1'&gt;
+  &lt;x xmlns='jabber:x:data' type='cancel'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;
+      &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The service MUST check the "pubsub#allow" field to see if the subscription should be allowed or denied. If the owner cancels the Data Form, then the subscription request MUST remain in the pending state.</p>
+    <div class="indent">
+<h3>8.6.1 <a name="owner-subreq-all">Request All Pending Subscription Requests</a>
+</h3>
+      <p class="" style="">A service MAY allow owners to request all the current pending subscription requests for all of their nodes at the service. Implementations MUST use the <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2268695">20</a>] protocol to provide this functionality. The command name ('node' attribute of the command element) MUST have a value of "http://jabber.org/protocol/pubsub#get-pending".</p>
+      <p class="caption">Example 160. Owner requests pending subscription requests</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='pending1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/pubsub#get-pending'
+           action='execute'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If no error occurs, the service SHOULD return a data form for managing subscription requests, which MUST contain a single field with a 'var' attribute value of "node" whose &lt;option/&gt; elements specify the nodes for which the requesting entity has subscription approval privileges (as an optimization, the service MAY specify only the nodes that have subscription requests pending).</p>
+      <p class="caption">Example 161. Service responds with data form to be populated</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='pending1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           sessionid='pubsub-get-pending:20031021T150901Z-600'
+           node='http://jabber.org/protocol/pubsub#get-pending'
+           status='executing'
+           action='execute'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='list-single' var='pubsub#node'&gt;
+        &lt;option&gt;&lt;value&gt;princely_musings&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;news_from_elsinore&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">There are several reasons why the pending subscription approval request might fail:</p>
+      <ol start="" type="">
+        <li>The service does not support the ad-hoc commands protocol.</li>
+        <li>The service supports ad-hoc commands but does not support the "get-pending" feature.</li>
+        <li>The requesting entity does not have sufficient privileges to approve subscription requests.</li>
+        <li>The specified node does not exist.</li>
+      </ol>
+      <p class="" style="">These error cases are described more fully below.</p>
+      <p class="" style="">If the service does not support the ad-hoc commands protocol, it MUST respond with a &lt;service-unavailable/&gt; error.</p>
+      <p class="caption">Example 162. Service responds with node not found</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='pending1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/pubsub#get-pending'
+           action='execute'/&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the service does not support the "get-pending" feature, it MUST respond with a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "get-pending".</p>
+      <p class="caption">Example 163. Service responds with node not found</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='pending1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/pubsub#get-pending'
+           action='execute'/&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='get-pending'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the requesting entity does not have sufficient privileges to approve subscription requests, the service MUST respond with a &lt;forbidden/&gt; error.</p>
+      <p class="caption">Example 164. Entity does not have sufficient privileges to approve subscription requests</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='pending1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/pubsub#get-pending'
+           action='execute'/&gt;
+  &lt;error type='cancel'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested node does not exist, the service MUST respond with an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 165. Service responds with node not found</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='pending1'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/pubsub#get-pending'
+           action='execute'/&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Upon receiving the data form for managing subscription requests, the owner then MAY request pending subscription approval requests for a given node.</p>
+      <p class="caption">Example 166. Owner requests all pending subscription requests for a node</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='pubsub.shakespeare.lit' id='pending2'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           sessionid='pubsub-get-pending:20031021T150901Z-600'
+           node='http://jabber.org/protocol/pubsub#get-pending'
+           action='execute'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='pubsub#node'&gt;
+        &lt;value&gt;princely_musings&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If no error occurs, the service shall respond with success.</p>
+      <p class="caption">Example 167. Service responds with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='pending2'/&gt;
+    </pre></div>
+      <p class="" style="">The service shall then send one subscription approval message for each pending subscription request, as shown above for a single pending subscription request.</p>
+      <p class="" style="">Note: A service SHOULD conform to its affiliation policies in maintaining the list of pending subscriptions. In particular, if the affiliation of an entity with a pending subscription is modified to owner or publisher, the service SHOULD automatically approve the subscription request and remove the entity's previous request from the pending list. Similarly, if the affiliation of an entity with a pending subscription is modified to outcast, the service SHOULD automatically reject the subscription request and remove the entity's previous request from the pending list.</p>
+      <p class="" style="">If an entity's subscription request is denied, the service SHOULD send a &lt;message/&gt; to the entity, where the message conforms to the format described in the <a href="#impl-unsub">Notification of Subscription Denial or Cancellation</a> section of this document.</p>
+    </div>
+  </div>
+
+  <div class="indent">
+<h3>8.7 <a name="owner-subscriptions">Manage Subscriptions</a>
+</h3>
+    <p class="" style="">A service MAY allow a node owner to edit the list of subscriptions associated with a given node and to set subscriptions for new entities (for nodes of type "whitelist", this enables the node owner to add subscribers); if so, it MUST advertise support for the "pubsub#manage-subscriptions" feature.</p>
+    <p class="" style="">In order to request a list of all subscriptions, a node owner MUST send a subscriptions request, consisting of a &lt;subscriptions/&gt; element whose 'node' attribute specifies the NodeID of the relevant node.</p>
+    <p class="caption">Example 168. Owner requests all subscriptions</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='subman1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;subscriptions node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no error occurs, the service MUST return the list of subscriptions for entities whose subscription state is "subscribed" or "unconfigured" (it MUST NOT return entities whose subscription state is "none" and SHOULD NOT return entities whose subscription state is "pending"). The result MAY specify multiple &lt;subscription/&gt; elements for the same entity (JID), but each element MUST possess a distinct value of the 'subid' attribute (as shown below).</p>
+    <p class="caption">Example 169. Service returns list of subscriptions</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='subman1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;subscriptions node='princely_musings'&gt;
+      &lt;subscription jid='hamlet@denmark.lit' subscription='subscribed'/&gt;
+      &lt;subscription jid='polonius@denmark.lit' subscription='unconfigured'/&gt;
+      &lt;subscription jid='bernardo@denmark.lit' subscription='subscribed' subid='123-abc'/&gt;
+      &lt;subscription jid='bernardo@denmark.lit' subscription='subscribed' subid='004-yyy'/&gt;
+    &lt;/subscriptions&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the manage subscriptions request might fail:</p>
+    <ol start="" type="">
+      <li>The service does not support subscription management.</li>
+      <li>The requesting entity does not have sufficient privileges to manage subscriptions.</li>
+      <li>The specified node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If an implementation does not support subscription management, it MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "manage-subscriptions".</p>
+    <p class="caption">Example 170. Node or service does not support subscription management</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;subscriptions node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='manage-subscriptions'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity is not a node owner, the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 171. Entity is not an owner</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='subman1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;subscriptions node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 172. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;subscriptions node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Upon receiving the subscriptions list, the node owner MAY modify subscription states. The owner MUST send only modified subscription states (i.e., a "delta"), not the complete list. (Note: If the 'subscription' attribute is not specified in a modification request, then the value MUST NOT be changed.)</p>
+    <p class="caption">Example 173. Owner modifies subscriptions</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='subman2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;subscriptions node='princely_musings'/&gt;
+      &lt;subscription jid='bard@shakespeare.lit' subscription='subscribed'/&gt;
+    &lt;/subscriptions&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 174. Service responds with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    id='subman2'/&gt;
+    </pre></div>
+    <p class="" style="">In order to remove an entity from the subscriptions list, the owner MUST set the value of the 'subscription' attribute to "none" and the service MUST remove that entity from the subscriptions list and not return it in response to future list requests.</p>
+    <p class="" style="">The owner MAY change multiple subscriptions in a single request. If one of the entity elements specified is invalid, the service MUST return an IQ error (which SHOULD be &lt;not-acceptable/&gt;) with the invalid entries, where the subscription returned is the original, un-altered subscription.</p>
+    <p class="caption">Example 175. Owner sets subscription for multiple entities</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='subman3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;subscriptions node='princely_musings'&gt;
+      &lt;subscription jid='polonius@denmark.lit' subscription='none'/&gt;
+      &lt;subscription jid='bard@shakespeare.lit' subscription='subscribed'/&gt;
+    &lt;/subscriptions&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 176. Service responds with an error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='subman3'/&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;subscriptions node='princely_musings'&gt;
+      &lt;subscription jid='bard@shakespeare.lit' subscription='subscribed'/&gt;
+    &lt;/subscriptions&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If errors occur during a modification request for multiple entities, the pubsub service MUST return any &lt;subscription/&gt; element(s) which caused the error. Returned entities which failed to be modified MUST include the existing 'subscription' attribute. Any entity elements which are not returned in an IQ error case MUST be treated as successful modifications. The owner MAY specify multiple &lt;subscription/&gt; elements for the same entity, but each element MUST possess a distinct value of the 'subid' attribute.</p>
+    <p class="" style="">An implementation SHOULD send notification to an entity whose subscription has changed (see the <a href="#impl-subchange">Notification of Subscription State Changes</a> section of this document).</p>
+    <p class="caption">Example 177. Service sends notification of subscription change</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='polonius@denmark.lit'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription node='princely_musings' jid='polonius@denmark.lit' subscription='none'/&gt;
+  &lt;/pubsub&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>8.8 <a name="owner-affiliations">Manage Affiliations</a>
+</h3>
+    <p class="" style="">A service MAY allow a node owner to edit the affiliations of entities associated with a given node and to set affiliations for new entities; if so, it MUST advertise support for the "pubsub#modify-affiliations" feature.</p>
+    <p class="" style="">In order to request a list of all affiliated entities, a node owner MUST send an affiliations request, consisting of an &lt;affiliations/&gt; element whose 'node' attribute specifies the NodeID of the relevant node.</p>
+    <p class="caption">Example 178. Owner requests all affiliated entities</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='ent1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;affiliations node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no error occurs, the service MUST return the list of entities whose affiliation is "owner", "publisher", or "outcast" (it MUST NOT return entities whose affiliation is "none").</p>
+    <p class="caption">Example 179. Service returns list of affiliated entities</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='ent1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;affiliations node='princely_musings'&gt;
+      &lt;affiliation jid='hamlet@denmark.lit' affiliation='owner'/&gt;
+      &lt;affiliation jid='polonius@denmark.lit' affiliation='outcast'/&gt;
+    &lt;/affiliations&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several reasons why the affiliated entities request might fail:</p>
+    <ol start="" type="">
+      <li>The service does not support modification of affiliations.</li>
+      <li>The requesting entity does not have sufficient privileges to modify affiliations.</li>
+      <li>The specified node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If an implementation does not support modification of affiliations, it MUST return a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "modify-affiliations".</p>
+    <p class="caption">Example 180. Node or service does not support affiliation management</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;affiliations node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='modify-affiliations'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity is not a node owner, the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 181. Entity is not an owner</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='ent1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;affiliations node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the node does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 182. Node does not exist</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;affiliations node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Upon receiving the affiliations list, the node owner MAY modify affiliations. The owner MUST send only modified affiliations (i.e., a "delta"), not the complete list. (Note: If the 'affiliation' attribute is not specified in a modification request, then the value MUST NOT be changed.)</p>
+    <p class="caption">Example 183. Owner modifies affiliations</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='ent2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;affiliations node='princely_musings'/&gt;
+      &lt;affiliation jid='hamlet@denmark.lit' affiliation='owner'/&gt;
+      &lt;affiliation jid='polonius@denmark.lit' affiliation='none'/&gt;
+      &lt;affiliation jid='bard@shakespeare.lit' affiliation='publisher'/&gt;
+    &lt;/affiliations&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 184. Service responds with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    id='ent2'/&gt;
+    </pre></div>
+    <p class="" style="">In order to remove an entity from the affiliations list, the owner MUST set the value of the 'affiliation' attribute to "none" and the service MUST remove that entity from the affiliations list and not return it in response to future list requests.</p>
+    <p class="" style="">The owner MAY change multiple affiliations in a single request. If one of the entity elements specified is invalid, the service MUST return an IQ error (which SHOULD be &lt;not-acceptable/&gt;) with the invalid entries, where the affiliation returned is the original, un-altered affiliation.</p>
+    <p class="" style="">The following example shows an entity attempting to make the owner something other than an affiliation of "owner", an action which MUST NOT be allowed if there is only one owner.</p>
+    <p class="caption">Example 185. Owner sets affiliation for multiple entities</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='ent3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;affiliations node='princely_musings'&gt;
+      &lt;affiliation jid='hamlet@denmark.lit' affiliation='none'/&gt;
+      &lt;affiliation jid='polonius@denmark.lit' affiliation='none'/&gt;
+      &lt;affiliation jid='bard@shakespeare.lit' affiliation='publisher'/&gt;
+    &lt;/affiliations&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 186. Service responds with an error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='ent3'/&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;affiliations node='princely_musings'&gt;
+      &lt;affiliation jid='hamlet@denmark.lit' affiliation='owner'/&gt;
+    &lt;/affiliations&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The state chart at the beginning of this document is a MUST-IMPLEMENT set of rules for checking possible state transitions. Implementations MAY enforce other (more strict) rules. If errors occur during a modification request for multiple entities, the pubsub service MUST return any &lt;affiliate/&gt; element(s) which caused the error. Returned entities which failed to be modified MUST include the existing 'affiliation' attribute. Any entity elements which are not returned in an IQ error case MUST be treated as successful modifications. The owner MUST NOT specify multiple &lt;affiliate/&gt; elements for the same entity; otherwise the service MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="" style="">An implementation MAY send a message to an entity whose affiliation has changed, which MAY contain a &lt;body/&gt; element specifying natural-language text regarding the affiliation change and which SHOULD contain the modified affiliation data.</p>
+    <p class="caption">Example 187. Service sends notification of affiliation change</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='polonius@denmark.lit'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;affiliations node='princely_musings'&gt;
+      &lt;affilation jid='polonius@denmark.lit' affiliation='none'/&gt;
+    &lt;/affiliations&gt;
+  &lt;/pubsub&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="collections">Collection Nodes</a>
+</h2>
+
+  <p class="" style="">A pubsub service MAY support collection nodes as well as leaf nodes. Collections enable nodes to be grouped together in any way, including hierarchies and directed acyclic graphs. Collections MUST contain only leaf nodes and/or other collections. Collections MUST NOT contain published items, since only leaf nodes are allowed to contain items (therefore a collection MUST NOT support the "publish" feature or related features such as "persistent-items"). If collections are supported, a service MUST advertise that fact in its "disco#info" responses by including a feature of "pubsub#collections" and MUST support service discovery of child nodes as described in the <a href="entity-nodes">Discover Nodes</a> section of this document.</p>
+
+  <div class="indent">
+<h3>9.1 <a name="collections-subscribe">Subscribe to a Collection Node</a>
+</h3>
+    <p class="" style="">A service that implements collection nodes SHOULD allow entities to subscribe to collection nodes (subject to access models and local security policies).</p>
+    <p class="" style="">In addition to the subscription configuration options already defined, there are two subscription configuration options specific to collection nodes:</p>
+    <ul>
+      <li>
+        <p class="" style=""><span style="font-weight: bold">pubsub#subscription_type</span></p>
+        <p class="" style="">This subscription option enables the subscriber to subscribe either to items or to nodes.</p>
+        <p class="" style="">If the subscription type is "items", the subscriber shall be notified whenever any node contained in the collection generates a notification (e.g., when an item is published or deleted), as modified by the value of the "pubsub#subscription_depth" option.</p>
+        <p class="" style="">If the subscription type is "nodes", the subscriber shall be notified whenever a new node is added to the collection, as modified by the value of the "pubsub#subscription_depth" option.</p>
+        <p class="" style="">The default value of this subscription option MUST be "nodes".</p>
+      </li>
+      <li>
+        <p class="" style=""><span style="font-weight: bold">pubsub#subscription_depth</span></p>
+        <p class="" style="">This subscription option enables the subscriber to specify whether it wants to receive notifications only from first-level children of the collection (a value of "1") or from all descendents (a value of "all").</p>
+        <p class="" style="">For subscriptions of type "items", this enables the subscriber to be informed only when an item is published to a leaf node that is a direct child of the collection node to which it has subscribed, or to be informed whenever an item is published to any leaf node in the "tree" that begins at the level of the collection to which it has subscribed.</p>
+        <p class="" style="">For subscriptions of type "nodes", this enables the subscriber to be informed only when a new node is added in the specific collection to which it has subscribed, or to be informed whenever a node is added anywhere in the "tree" that begins at the level of the collection to which it has subscribed.</p>
+        <p class="" style="">The default value of this subscription option MUST be "1".</p>
+      </li>
+    </ul>
+    <p class="" style="">In order to subscribe to a collection node, an entity MUST send a subscription request to the node; the subscription request MAY include subscription options, but this is not strictly necessary (especially if the entity does not wish to override the default settings for the "pubsub#subscription_type" and "pubsub#subscription_depth" options).</p>
+    <p class="caption">Example 188. Entity subscribes to a collection node (no configuration)</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='collsub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe jid='francisco@denmark.lit'
+               node='blogs'/&gt;
+   &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The subscriber will now receive notification of new first-level nodes created within the "blogs" collection.</p>
+    <p class="caption">Example 189. Entity subscribes to a collection node (with configuration)</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='collsub2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe jid='francisco@denmark.lit'
+               node='blogs'/&gt;
+    &lt;options&gt;
+      &lt;x xmlns='jabber:x:data'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_type'&gt;
+          &lt;value&gt;items&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_depth'&gt;
+          &lt;value&gt;all&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+   &lt;/options&gt;
+ &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The subscriber will now receive item notifications from nodes at any depth within the "blogs" collection.</p>
+    <p class="" style="">Depending on the nature of the node "tree", a subscription type of "items" and depth of "all" may result in an extremely large number of notifications. Therefore, a service MAY disallow such a combination of subscription options, in which case it MUST return a &lt;not-allowed/&gt; error to the requesting entity.</p>
+    <p class="" style="">A service MAY allow an entity to subscribe to a collection node in two ways, once with a subscription of type "nodes" (to receive notification of any new nodes added to the collection or the entire tree) and one or more times with a subscription of type "items" (to receive all items published within the tree). However, a service SHOULD NOT allow an entity to subscribe twice to a collection node (once with a subscription depth of "1" and once with a subscription depth of "all") for the same subscription type, since two such subscriptions are unnecessary (a depth of "all" includes by definition a depth of "1"); in this case the service MUST return a &lt;conflict/&gt; error to the requesting entity.</p>
+  </div>
+
+  <div class="indent">
+<h3>9.2 <a name="collections-root">Root Collection Node</a>
+</h3>
+    <p class="" style="">A service that implements collections SHOULD support a root collection. The root collection shall be identified by the lack of a node identifier (i.e., the address of the pubsub service itself, such as "pubsub.shakespeare.lit").</p>
+    <p class="" style="">Subscribing to this node with a subscription of type "nodes" and a depth of "1" enables an entity to be notified whenever a new first-level node is created at the pubsub service. Subscribing to this node with a subscription of type "nodes" and a depth of "all" enables an entity to be notified whenever a new node is created anywhere at the pubsub service.</p>
+    <p class="caption">Example 190. Entity subscribes to the root collection node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='root1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe jid='francisco@denmark.lit'/&gt;
+ &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">In order to send notification of new nodes, the service shall send an event that contains a &lt;collection/&gt; element that in turns contains a &lt;node/&gt; element whose 'id' attribute specifies the NodeID of the new node.</p>
+    <p class="caption">Example 191. Notification of new node</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='francisco@denmark.lit'
+         id='newnode1'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;collection&gt;
+      &lt;node id='new-node-id'&gt;
+    &lt;/collection&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The notification event MAY also include the node meta-data, formatted using the <span style="font-weight: bold">Data Forms</span> protocol.</p>
+    <p class="caption">Example 192. Notification of new node</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='francisco@denmark.lit'
+         id='newnode2'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;collection&gt;
+      &lt;node id='new-node-id'&gt;
+        &lt;x xmlns='jabber:x:data' type='result'&gt;
+          &lt;field var='FORM_TYPE' type='hidden'&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var='pubsub#creation_date'&gt;&lt;var&gt;2003-07-29T22:56Z&lt;/var&gt;&lt;/field&gt;
+          &lt;field var='pubsub#creator'&gt;&lt;var&gt;hamlet@denmark.lit&lt;/var&gt;&lt;/field&gt;
+          &lt;field var='pubsub#description'&gt;&lt;var&gt;Atom feed for my blog.&lt;/var&gt;&lt;/field&gt;
+          &lt;field var='pubsub#language'&gt;&lt;var&gt;en&lt;/var&gt;&lt;/field&gt;
+          &lt;field var='pubsub#contact'&gt;&lt;value&gt;bard@shakespeare.lit&lt;/value&gt;&lt;/field&gt;
+          &lt;field var='pubsub#owner'&gt;&lt;value&gt;hamlet@denmark.lit&lt;/value&gt;&lt;/field&gt;
+          &lt;field var='pubsub#title'&gt;&lt;var&gt;Princely Musings (Atom).&lt;/var&gt;&lt;/field&gt;
+          &lt;field var='pubsub#type'&gt;&lt;value&gt;http://www.w3.org/2005/Atom&lt;/value&gt;&lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/node&gt;
+    &lt;/collection&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>9.3 <a name="collections-createnode">Create a New Collection Node</a>
+</h3>
+    <p class="" style="">To create a new collection node, the requesting entity MUST include a Data Form containing a 'pubsub#node_type' field whose &lt;value/&gt; is "collection".</p>
+    <p class="caption">Example 193. Entity requests a new collection node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bard@shakespeare.lit/globe'
+    to='pubsub.shakespeare.lit'
+    id='create3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='announcements'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#node_type'&gt;&lt;value&gt;collection&lt;/value&gt;&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 194. Service responds with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='bard@shakespeare.lit/globe'
+    id='create3'/&gt;
+    </pre></div>
+    <p class="" style="">In addition to the errors already defined for leaf node creation, there are several reasons why the collection node creation request might fail:</p>
+    <ol start="" type="">
+      <li>The service does not support collection nodes.</li>
+      <li>The service does not support creation of collection nodes.</li>
+      <li>The requesting entity does not have sufficient privileges to create collection nodes.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">If the service does not support collection nodes, it MUST respond with a &lt;feature-not-implemented/&gt; error, specifying a pubsub-specific error condition of &lt;unsupported/&gt; and a feature of "collections".</p>
+    <p class="caption">Example 195. Service does not support collection nodes</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported xmlns='http://jabber.org/protocol/pubsub#errors'
+                 feature='collections'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the service supports collection nodes but does not allow new collection nodes to be created, it MUST respond with a &lt;not-allowed/&gt; error.</p>
+    <p class="caption">Example 196. Service does not allow creation of collection nodes</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity has insufficient privileges to create new collections, the service MUST respond with a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 197. Requesting entity has insufficient privileges to create collection nodes</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='config1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A service MAY offer some node configuration options that are specific to collection nodes and not provided in configuration forms related to leaf nodes. The following are RECOMMENDED:</p>
+    <ul>
+      <li>pubsub#children_association_policy -- the policy regarding who may associate child nodes with the collection (values: all, owner, whitelist).</li>
+      <li>pubsub#children_association_whitelist -- the whitelist of entities that may associate child nodes with the collection.</li>
+      <li>pubsub#children_max -- the maximum number of child nodes that may be associated with a collection.</li>
+    </ul>
+  </div>
+
+  <div class="indent">
+<h3>9.4 <a name="collections-createassociated">Create a Node Associated with a Collection</a>
+</h3>
+    <p class="" style="">To create a new node and associate it with an existing collection, the node configuration protocol MUST be used in the node creation request (see the <a href="#owner-create-and-configure">Create and Configure a Node</a> section of this document). In order to specify the associated collection(s), the form MUST include a 'pubsub#collection' field.</p>
+    <p class="" style="">Note: Inclusion of the node configuration form is not necessary if the node is being created as a first-level child of the root collection node, since every such child is automatically affiliated with the root collection node (if any).</p>
+    <p class="" style="">Note: For the protocol used to associate an existing node with a collection, refer to the <a href="#collections-associate">Associate an Existing Node with a Collection</a> section of this document.</p>
+    <p class="caption">Example 198. Entity creates a new node associated with a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bard@shakespeare.lit/globe'
+    to='pubsub.shakespeare.lit'
+    id='create4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='plays'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='pubsub#collection'&gt;&lt;value&gt;announcements&lt;/value&gt;&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service then creates the node and associates it with the collection.</p>
+    <p class="" style="">Note: If the node is a collection node and the requesting entity wishes to request the default configuration, the requesting entity MUST include <span style="font-style: italic">only</span> the "pubsub#collection" and "pubsub#node_type" fields in the configuration form.</p>
+    <p class="" style="">There are several reasons why the request might fail:</p>
+    <ol start="" type="">
+      <li>The request specified more than one collection node, but the service allows a node to be associated with only one collection node.</li>
+      <li>The requesting entity does not have sufficient privileges to associate a node with the specified collection node.</li>
+      <li>No additional nodes can be associated with the collection node.</li>
+      <li>The specified collection node is actually a leaf node.</li>
+      <li>The specified collection node does not exist.</li>
+    </ol>
+    <p class="" style="">These error cases are described more fully below.</p>
+    <p class="" style="">An implementation MAY allow a node to be associated with more than one collection node and therefore MAY specify a type of "text-multi" for the "pubsub#collection" field. However, in order to reduce the complexity of implementation, it is RECOMMENDED to allow only one parent collection node for each node and therefore it is RECOMMENDED to specify a type of "text-single" for the "pubsub#collection" field. If a service supports associating a node with multiple collections, it MUST advertise support for the "multi-collection" feature (if that feature is not advertised, entities SHOULD assume that the service allows a node to be associated with only one collection). If the request specifies more than one collection node but the service allows a node to be associated with only one collection node, the service MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 199. Too many collection nodes</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='bard@shakespeare.lit/globe'
+    id='create4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='plays'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='pubsub#collection'&gt;
+          &lt;value&gt;announcements&lt;/value&gt;
+          &lt;value&gt;news&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#node_type'&gt;
+          &lt;value&gt;collection&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity does not have sufficient privileges to associate a node with the specified collection node, the service MUST return a &lt;forbidden/&gt; error.</p>
+    <p class="caption">Example 200. Insufficient privileges</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='bard@shakespeare.lit/globe'
+    id='create4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='plays'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='pubsub#collection'&gt;&lt;value&gt;announcements&lt;/value&gt;&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If no additional nodes can be associated with the collection node because a configurable limit of associated nodes has been reached, the service MUST return a &lt;conflict/&gt; error, which SHOULD also include a pubsub-specific error condition of &lt;max-nodes-exceeded/&gt;.</p>
+    <p class="caption">Example 201. Associated node limit reached</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='bard@shakespeare.lit/globe'
+    id='create4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='plays'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='pubsub#collection'&gt;&lt;value&gt;announcements&lt;/value&gt;&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;max-nodes-exceeded xmlns='http://jabber.org/protocol/pubsub#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the specified collection node is actually a leaf node, the service MUST return an &lt;not-allowed/&gt; error.</p>
+    <p class="caption">Example 202. Collection node is actually a leaf node</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='bard@shakespeare.lit/globe'
+    id='create4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='plays'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='pubsub#collection'&gt;&lt;value&gt;announcements&lt;/value&gt;&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the specified collection node does not exist, the service MUST return an &lt;item-not-found/&gt; error.</p>
+    <p class="caption">Example 203. No such collection node</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='pubsub.shakespeare.lit'
+    to='bard@shakespeare.lit/globe'
+    id='create4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='plays'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='pubsub#collection'&gt;&lt;value&gt;announcements&lt;/value&gt;&lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+  &lt;error type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>9.5 <a name="collections-associate">Associate an Existing Node with a Collection</a>
+</h3>
+    <p class="" style="">Although a node can be associated with a collection when it is created (as described above), it can also be associated with a collection after it has been created. This can be done in two ways:</p>
+    <ul>
+      <li>By modifying the node's "pubsub#collection" configuration field.</li>
+      <li>By modifying the collection node's "pubsub#children" configuration field.</li>
+    </ul>
+    <p class="" style="">These methods are described below.</p>
+    <p class="" style="">In order to modify the (child) node's "pubsub#collection" configuration field, the owner of the node shall submit a request to edit the node's configuration, receive a configuration form from the service, and then submit a modified configuration form:</p>
+    <p class="caption">Example 204. Node owner modifies node configuration</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='associate1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+        &lt;field var='pubsub#collection'&gt;&lt;value&gt;blogs&lt;/value&gt;&lt;/field&gt;
+        ...
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">In order to modify the (parent) node's "pubsub#children" configuration field, the owner of the node shall submit a request to edit the node's configuration, receive a configuration form from the service, and then submit a modified configuration form:</p>
+    <p class="caption">Example 205. Node owner modifies node configuration</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bard@shakespeare.lit/globe'
+    to='pubsub.shakespeare.lit'
+    id='associate2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='blogs'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+        &lt;field var='pubsub#children'&gt;
+          &lt;value&gt;princely_musings&lt;/value&gt;
+          &lt;value&gt;kingly_ravings&lt;/value&gt;
+          &lt;value&gt;starcrossed_stories&lt;/value&gt;
+          &lt;value&gt;moorish_meanderings&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>9.6 <a name="collections-disassociate">Disassociate a Node from a Collection</a>
+</h3>
+    <p class="" style="">A node can be disassociated from a collection after it has been associated (whether at creation time or afterward). This can be done in two ways:</p>
+    <ul>
+      <li>By modifying the node's "pubsub#collection" configuration field.</li>
+      <li>By modifying the collection node's "pubsub#children" configuration field.</li>
+    </ul>
+    <p class="" style="">These methods are described below.</p>
+    <p class="" style="">In order to modify the (child) node's "pubsub#collection" configuration field, the owner of the node shall submit a request to edit the node's configuration, receive a configuration form from the service, and then submit a modified configuration form:</p>
+    <p class="caption">Example 206. Node owner modifies node configuration</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='hamlet@denmark.lit/elsinore'
+    to='pubsub.shakespeare.lit'
+    id='associate1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='princely_musings'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+        &lt;field var='pubsub#collection'&gt;&lt;value&gt;&lt;/value&gt;&lt;/field&gt;
+        ...
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: To disassociate the node from all collection nodes, the node owner MUST submit an empty &lt;value/&gt; element within the 'pubsub#collection' field as shown in the foregoing example.</p>
+    <p class="" style="">In order to modify the (parent) node's "pubsub#children" configuration field, the owner of the node shall submit a request to edit the node's configuration, receive a configuration form from the service, and then submit a modified configuration form:</p>
+    <p class="caption">Example 207. Node owner modifies node configuration</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bard@shakespeare.lit/globe'
+    to='pubsub.shakespeare.lit'
+    id='associate2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub#owner'&gt;
+    &lt;configure node='blogs'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+        &lt;field var='pubsub#children'&gt;
+          &lt;value&gt;kingly_ravings&lt;/value&gt;
+          &lt;value&gt;starcrossed_stories&lt;/value&gt;
+          &lt;value&gt;moorish_meanderings&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a node is disassociated from a collection node and a new association is not formed, the implementation MAY associate the node with the root collection node or associate it with no collection node.</p>
+    <p class="" style="">Note: The combination of associating and disassociating a node with a collection can be used to move a node from one collection to another.</p>
+  </div>
+
+  <div class="indent">
+<h3>9.7 <a name="collections-notify">Generating Publish Notifications for Collections</a>
+</h3>
+    <p class="" style="">If an item is published to a node which is also includeed by a collection, and an entity is subscribed to that collection with a subscription type of "items", then the notifications generated by the service MUST contain additional information. The &lt;items/&gt; element contained in the notification message MUST specify the node identifier of the node that generated the notification (not the collection) and the &lt;item/&gt; element MUST contain a SHIM header that specifies the node identifier of the collection.</p>
+    <p class="caption">Example 208. Subscribers receive notifications from a collection</p>
+<div class="indent"><pre>
+&lt;message to='francisco@denmark.lit' from='pubsub.shakespeare.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ...
+        &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+          &lt;header name='pubsub#collection'&gt;blogs&lt;/header&gt;
+        &lt;/headers&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message to='bernardo@denmark.lit' from='pubsub.shakespeare.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='ae890ac52d0df67ed7cfdf51b644e901'&gt;
+        ...
+        &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+          &lt;header name='pubsub#collection'&gt;blogs&lt;/header&gt;
+        &lt;/headers&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="features">Feature Summary</a>
+</h2>
+  <p class="" style="">This section summarizes the features described herein, specifies the appropriate requirements level for each feature (REQUIRED, RECOMMENDED, or OPTIONAL), and provides cross-references to the section of this document in which each feature is described.</p>
+  <p class="" style="">Note: The feature names are all of the form "http://jabber.org/protocol/pubsub#name", where "name" is the text specified in the first column below.</p>
+  <p class="caption">Table 9: Service Discovery Features</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Description</th>
+      <th colspan="" rowspan="">Support</th>
+      <th colspan="" rowspan="">Section</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">collections</td>
+      <td align="" colspan="" rowspan="">Collection nodes are supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#collections">Collection Nodes</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">config-node</td>
+      <td align="" colspan="" rowspan="">Configuration of node options is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-configure">Configure a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">create-and-configure</td>
+      <td align="" colspan="" rowspan="">Simultaneous creation and configuration of nodes is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-create-and-configure">Create and Configure a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">create-nodes</td>
+      <td align="" colspan="" rowspan="">Creation of nodes is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-create">Create a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">delete-any</td>
+      <td align="" colspan="" rowspan="">Any publisher may delete an item (not only the originating publisher).</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#publisher-delete">Delete an Item from a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">delete-nodes</td>
+      <td align="" colspan="" rowspan="">Deletion of nodes is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-delete">Delete a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">get-pending</td>
+      <td align="" colspan="" rowspan="">Retrieval of pending subscription approvals is supported.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-subreq">Manage Subscription Requests</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">instant-nodes</td>
+      <td align="" colspan="" rowspan="">Creation of instant nodes is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-create">Create a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">item-ids</td>
+      <td align="" colspan="" rowspan="">Publishers may specify item identifiers.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""> </td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">leased-subscription</td>
+      <td align="" colspan="" rowspan="">Time-based subscriptions are supported.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#impl-leases">Time-Based Subscriptions (Leases)</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">manage-subscriptions</td>
+      <td align="" colspan="" rowspan="">Node owners may manage subscriptions.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-subscriptions">Manage Subscribers</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">meta-data</td>
+      <td align="" colspan="" rowspan="">Node meta-data is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""> </td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">modify-affiliations</td>
+      <td align="" colspan="" rowspan="">Node owners may modify affiliations.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-affiliations">Manage Affiliations</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">multi-collection</td>
+      <td align="" colspan="" rowspan="">A single leaf node may be associated with multiple collections.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan="">
+<a href="#collections-createassociated">Create a Node Associated with a Collection</a> and <a href="#collections-associate">Associate an Existing Node with a Collection</a>
+</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">multi-subscribe</td>
+      <td align="" colspan="" rowspan="">A single entity may subscribe to a node multiple times.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""> </td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">outcast-affiliation</td>
+      <td align="" colspan="" rowspan="">The outcast affiliation is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#affiliations">Affiliations</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">persistent-items</td>
+      <td align="" colspan="" rowspan="">Persistent items are supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""> </td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">presence-notifications</td>
+      <td align="" colspan="" rowspan="">Presence-based delivery of event notifications is supported.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""> </td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">publish</td>
+      <td align="" colspan="" rowspan="">Publishing items is supported (note: not valid for collection nodes).</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+      <td align="" colspan="" rowspan=""><a href="#publisher-publish">Publish an Item to a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">publisher-affiliation</td>
+      <td align="" colspan="" rowspan="">The publisher affiliation is supported.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""> </td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">purge-nodes</td>
+      <td align="" colspan="" rowspan="">Purging of nodes is supported.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-purge">Purge All Node Items</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">retract-items</td>
+      <td align="" colspan="" rowspan="">Item retraction is supported.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#publisher-delete">Delete an Item from a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">retrieve-affiliations</td>
+      <td align="" colspan="" rowspan="">Retrieval of current affiliations is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#publisher-affiliations">Retrieve Affiliations</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">retrieve-default</td>
+      <td align="" colspan="" rowspan="">Retrieval of default node configuration is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#owner-default">Request Default Configuration Options</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">retrieve-items</td>
+      <td align="" colspan="" rowspan="">Item retrieval is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#subscriber-retrieve">Retrieve Items from a Node</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">retrieve-subscriptions</td>
+      <td align="" colspan="" rowspan="">Retrieval of current subscriptions is supported.</td>
+      <td align="" colspan="" rowspan="">RECOMMENDED</td>
+      <td align="" colspan="" rowspan=""><a href="#subscriber-subscriptions">Retrieve Subscriptions</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">subscribe</td>
+      <td align="" colspan="" rowspan="">Subscribing and unsubscribing are supported.</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+      <td align="" colspan="" rowspan="">
+<a href="#subscriber-subscribe">Subscribe to a Node</a> and <a href="#subscriber-unsubscribe">Unsubscribe from a Node</a>
+</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">subscription-options</td>
+      <td align="" colspan="" rowspan="">Configuration of subscription options is supported.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#subscriber-configure">Configure Subscription Options</a></td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">subscription-notifications</td>
+      <td align="" colspan="" rowspan="">Notification of subscription state changes is supported.</td>
+      <td align="" colspan="" rowspan="">OPTIONAL</td>
+      <td align="" colspan="" rowspan=""><a href="#impl-subchange">Notification of Subscription State Changes</a></td>
+    </tr>
+  </table>
+<h2>11.
+       <a name="errors">Error Conditions</a>
+</h2>
+  <p class="caption">Table 10: Error conditions and typical causes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The node already exists.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The operation being attempted on a node (or the system) has failed because the service or node does not support the operation; the error SHOULD also specify which feature is unsupported.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">An entity does not have sufficient privileges to perform the action, is requesting an operation for another Jabber ID (e.g., francisco@denmark.lit attempts to subscribe bernardo@denmark.lit to a node), or the requesting entity has an affiliation of "outcast".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;item-not-found/&gt;</td>
+      <td align="" colspan="" rowspan="">The node or item specified for some operation does not exist.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">An entity has attempted to perform an action which the service implements; however the service-wide admin or the node owner has disabled the action for that service or node.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+      <td align="" colspan="" rowspan="">An entity has attempted to subscribe to or retrieve items from a node but is not authorized to see the account owner's presence, is not in the appropriate roster group, or is not on the whitelist for subscriptions.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;payment-required/&gt;</td>
+      <td align="" colspan="" rowspan="">Subscriptions and item retrieval are based on some kind payment service. Payments would be done out-of-band using some agreed-upon method (not defined herein).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;registration-required/&gt;</td>
+      <td align="" colspan="" rowspan="">Entities are required to register before node creation is allowed.</td>
+    </tr>
+  </table>
+  <p class="" style="">Note: Refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2272163">21</a>] for more information regarding error syntax.</p>
+<h2>12.
+       <a name="impl">Implementation Notes</a>
+</h2>
+
+  <div class="indent">
+<h3>12.1 <a name="impl-recipients">Intended Recipients for Notifications</a>
+</h3>
+    <p class="" style="">When a pubsub service generates notifications, it MUST adhere to the delivery rules implicit in the subscription option configuration for each subscriber. In particular, the 'to' address SHOULD be that of the subscribed JID only. The service SHOULD NOT attempt to guess at the most available resource associated with the subscribed JID (e.g., in the context of instant messaging systems).</p>
+  </div>
+
+  <div class="indent">
+<h3>12.2 <a name="impl-bounce">Handling Notification-Related Errors</a>
+</h3>
+    <p class="" style="">As noted above, a pubsub service SHOULD ensure that the &lt;message/&gt; stanza for each event notification it generates possesses an 'id' attribute with a unique value. (This notification ID is not to be confused with either the node ID or the item ID.) This ID MUST be unique within the context of the pubsub service in order to ensure proper tracking of any delivery-related errors.</p>
+    <p class="" style="">Exactly how a service shall handle delivery-related errors is a matter of implementation. In general, such handling is effectively similar to the bounce processing performed by other message delivery systems, such as mail transfer agents and mailing list software. The following are some suggested guidelines regarding the handling of XMPP-specific error conditions in relation to pubsub event notifications (see <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">JEP-0086</span> regarding XMPP error condition semantics):</p>
+    <ul>
+      <li>If the XMPP error is of type "cancel" (e.g., &lt;item-not-found/&gt;), or the error condition is &lt;gone/&gt;, the pubsub service SHOULD terminate the subscription of the entity to that node and MAY terminate the subscription of that entity to all nodes hosted at the service.</li>
+      <li>If the XMPP error is of type "auth" (e.g., &lt;registration-required/&gt;) or "wait" (e.g., &lt;remote-server-timeout/&gt;), or the error condition is &lt;bad-request/&gt;, &lt;redirect/&gt;, or &lt;not-acceptable/&gt;, the pubsub service SHOULD increment a bounce counter for that entity and MAY attempt to resend the event notification after some configurable amount of time. The service MAY terminate the subscription of the entity to that node if the bounce counter has reached some configurable limit.</li>
+    </ul>
+  </div>
+
+  <div class="indent">
+<h3>12.3 <a name="impl-presence">Presence-Based Delivery of Events</a>
+</h3>
+    <p class="" style="">Implementations of pubsub MAY deliver event notifications only when the subscriber is online. In these cases, the option may be a node configuration option as shown in the examples above. To facilitate this, the pubsub service needs to subscribe to the subscriber's presence and check the subscriber's current presence information before sending any event notifications (as described in <span style="font-weight: bold">RFC 3921</span>). Presence subscriptions MUST be based on the subscribed JID.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.4 <a name="impl-offline">Not Routing Events to Offline Storage</a>
+</h3>
+    <p class="" style="">Sending events to users of existing Jabber servers may force event notifications to be routed to offline storage for later delivery (as described in <span class="ref" style="">Best Practices for Handling Offline Messages</span>  [<a href="#nt-id2272341">22</a>]). This may not always be desirable. The possible ways of preventing this behavior include:</p>
+    <ul>
+      <li>Use presence-based subscription options as described above.</li>
+      <li>Use delivery semantics as defined by <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2272372">23</a>].</li>
+      <li>Specify a message type of "headline", which in most existing server implementations will prevent offline storage.</li>
+    </ul>
+  </div>
+
+  <div class="indent">
+<h3>12.5 <a name="impl-body">Including a Message Body</a>
+</h3>
+    <p class="" style="">If a service understands the semantics for a particular payload type and an entity's subscription is so configured (via the "pubsub#include_body" option), the service SHOULD include an appropriate XMPP &lt;body/&gt; child element along with the payloads it sends in event notifications for a given node, where the body's XML character data summarizes or represents the information contained in the payload (this enables clients that do not understand the payload format to present the appropriate information to an end user). For example, the Atom &lt;summary/&gt; element (see <span style="font-weight: bold">RFC 4287</span>) could be mapped to the XMPP &lt;body/&gt; element. A service MUST NOT provide the "pubsub#include_body" subscription option for a node if it does not have a defined way to transform part or all of the payload format into a sensible message body. A node owner MAY define an XSLT for transforming the payload format into a message body, via the "pubsub#body_xslt" node configuration option.</p>
+    <p class="" style="">If the service does not understand the semantics for a particular payload type, it MAY include a &lt;body/&gt; child whose XML character data informs the subscriber that the message contains an event notification (e.g., text such as "This message contains an event notification" would be appropriate).</p>
+  </div>
+
+  <div class="indent">
+<h3>12.6 <a name="impl-uniqueness">Node ID and Item ID Uniqueness</a>
+</h3>
+    <p class="" style="">NodeIDs MUST be treated as unique identifiers within the context of a particular pubsub service.</p>
+    <p class="" style="">If item identifiers are used, they MUST be treated as unique within the scope of the node. The combination of the NodeID + ItemID MUST be unique within a given service, and MUST specify a single published item at a single node.</p>
+    <p class="" style="">If a publisher publishes an item and the ItemID matches that of an existing item, the pubsub service MUST overwrite the existing item and generate a new event notification.</p>
+    <p class="" style="">Because it is possible for a node's configuration to change such that ItemIDs are required (e.g., a change from transient to persistent), a service SHOULD use ItemIDs for internal tracking purposes even if it does not include them with the notifications it generates prior to the configuration change.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.7 <a name="impl-caching">Item Caching</a>
+</h3>
+    <p class="" style="">A service MAY cache the last item published to a node, even if the node is configured for transient publication (i.e., configured to not persist items). The last published item SHOULD be sent to new subscribers upon successful processing of a subscription request or approval by a node owner.</p>
+    <p class="" style="">Note: If a publisher requests <a href="#impl-batch">Batch Processing</a> of item publications, the concept of "last published item" is undefined; therefore, if information coherence is needed, a publisher SHOULD publish items in separate requests rather than in batch mode.</p>
+    <p class="" style="">Note: Particular profiles of the generic publish-subscribe protocol MAY define more stringent requirements regarding the "cache-last-item" feature.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.8 <a name="impl-batch">Batch Processing</a>
+</h3>
+    <p class="" style="">A publisher MAY include multiple &lt;item/&gt; elements in a publish request and MAY include multiple &lt;item/&gt; elements in a retract request. This results in "batch processing" of publications or retractions. If the service cannot process any one of the items to be published or retracted, the entire batch MUST fail. Also note that batch publication renders the concept of "last published item" problematic; therefore, if information coherence is needed, a publisher SHOULD publish items in separate requests rather than in batch mode.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.9 <a name="impl-autosubscribe">Auto-Subscribing Owners and Publishers</a>
+</h3>
+    <p class="" style="">A service MUST allow owners and publishers to subscribe to a node, and to retrieve items from a node even if they are not subscribed. A service MAY auto-subscribe owners and publishers if they are not already subscribed, in which case it SHOULD generate a subscription ID if necessary for the subscription and SHOULD send a notification of successful subscription as described in the <a href="#impl-subchange">Notification of Subscription State Changes</a> section of this document.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.10 <a name="impl-authorize">Authorizing Subscription Requests (Pending Subscribers)</a>
+</h3>
+    <p class="" style="">How subscription requests are sent to node owners is a matter of implementation. Possibilities include:</p>
+    <ul>
+      <li>Send requests to all owners (these may be placed in offline storage as described in <span style="font-weight: bold">JEP-0160</span>) and first approval wins.</li>
+      <li>The service could subscribe to owner presence, and send only to the owners that are online.</li>
+      <li>All owners vote on the new subscriber.</li>
+      <li>Any owner is allowed to veto the subscriber.</li>
+    </ul>
+    <p class="" style="">An implementation MAY use any of these methods, or some other method not defined herein.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.11 <a name="impl-subchange">Notification of Subscription State Changes</a>
+</h3>
+    <p class="" style="">Various actions and events may result in changes to a subscription state:</p>
+    <ul>
+      <li><p class="" style="">Approval or denial of a subscription request as described in the <a href="#owner-subreq">Manage Subscription Requests</a> use case</p></li>
+      <li>
+<p class="" style="">Cancellation of an existing subscription, for which many "triggers" are possible:</p>
+        <ul>
+          <li>The entity simply unsubscribes from the node</li>
+          <li>The node is of type "presence" and the underlying presence subscription is cancelled</li>
+          <li>The node is of type "roster" and the entity is moved to an unauthorized roster group</li>
+        </ul>
+      </li>
+    </ul>
+    <p class="" style="">When a subscription state change occurs, a service SHOULD send a message to the (new, former, or denied) subscriber informing it of the change, where the message contains an &lt;event/&gt; element with a single &lt;subscription/&gt; child that specifies the node, JID, and subscription state. The notification MAY contain a &lt;body/&gt; element specifying natural-language text regarding the subscription change. Examples are shown below.</p>
+    <p class="caption">Example 209. Subscription approval notification</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.shakespeare.lit'
+    to='horatio@denmark.lit'
+    id='approvalnotify1'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;subscription node='princely_musings' jid='horatio@denmark.lit' subscription='subscribed'/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 210. Subscription cancellation / denial notification</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.shakespeare.lit'
+    to='horatio@denmark.lit'
+    id='unsubnotify1'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;subscription node='princely_musings' jid='horatio@denmark.lit' subscription='none'/&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the service has knowledge of the (former or denied) subscriber's presence, it SHOULD send the message to all of the subscriber's resources; if not, it MUST send the message to the subscriber's affiliated JID.</p>
+    <p class="" style="">If a service or node supports this feature, it MUST return a feature of "subscription-notifications" in its response to service discovery information requests.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.12 <a name="impl-semantics">NodeID Semantics</a>
+</h3>
+    <p class="" style="">NodeIDs MAY have semantic meaning in particular profiles, implementations, or deployments of pubsub. However, it is STRONGLY RECOMMENDED that such semantic meaning not be used to encapsulate the hierarchical structure of nodes; instead, node hierarchy SHOULD be encapsulated using collections and their associated child nodes.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.13 <a name="impl-multiple">Multiple Node Discovery</a>
+</h3>
+    <p class="" style="">A user may publish information that adheres to a certain profile at multiple pubsub nodes, and a potential subscriber may want to discover all of these pubsub nodes. The user may make a list of pubsub nodes publicly available for querying even when the user is offline by using the Service Discovery mechanism for "publishing" items (see Section 4 of <span style="font-weight: bold">JEP-0030</span>). The potential subscriber may then send a "disco#items" request to the user's bare JID (&lt;user@host&gt;), including the 'node' attribute set to the value of the namespace to which the desired information adheres. The user's server then returns a list of pubsub nodes that meet that criterion (with each pubsub node being a separate Service Discovery item). Here is an example.</p>
+    <p class="caption">Example 211. Discovering multiple nodes</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='hamlet@denmark.lit'
+    id='multi-1'/&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://www.w3.org/2005/Atom'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='hamlet@denmark.lit'
+    to='francisco@denmark.lit/barracks'
+    id='multi-1'/&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://www.w3.org/2005/Atom'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='princely_musings'
+          name='Princely Musings (Atom)'/&gt;
+    &lt;item jid='thepub.denmark.lit'
+          node='feed-o-rama'
+          name='Backup feed'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, a user may be registered with a server that offers personal eventing services, in which case the user will have one node per namespace as described in <span style="font-weight: bold">JEP-0163</span>.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.14 <a name="impl-shim">Inclusion of SHIM Headers</a>
+</h3>
+    <p class="" style="">When SubIDs are used, <span style="font-weight: bold">Stanza Headers and Internet Metadata (SHIM)</span> headers are to be included in order to differentiate notifications sent regarding a particular subscription. The relevant use cases and scenarios are:</p>
+    <ul>
+      <li>Sending notifications regarding newly-published items as described in the <a href="#publisher-publish">Publish an Item to a Node</a> use case.</li>
+      <li>Sending notifications regarding deleted items as described in the <a href="#publisher-delete">Delete an Item from a Node</a> use case.</li>
+    </ul>
+    <p class="" style="">The SHIM headers are generated by the node to which the subscriber has a subscription, which may be either a leaf node or a collection node.</p>
+    <p class="" style="">SHIM headers are not to be included when the content does not differ based on subscription ID, e.g., when a node sends notification of a configuration change to the node itself, notification that the node has been purged, or notification that the node has been deleted.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.15 <a name="impl-association">Associating Events and Payloads with the Generating Entity</a>
+</h3>
+    <p class="" style="">An implementation MAY enable the node configuration to specify an association between the event notification and the entity to which the published information pertains, but such a feature is OPTIONAL. Here are some possible examples:</p>
+    <ul>
+      <li>In the context of a geolocation notification service using <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2272978">24</a>], the user may generate the geolocation information or the information may be generated by an automated service (e.g., a service offered by a mobile telephony provider), but in either case the information is <span style="font-style: italic">about</span> the user's geolocation and therefore all replies should go to the user (who is probably the node owner).</li>
+      <li>In the context of a group weblog, different users might publish to the weblog and replies might go to the publisher of an entry rather than to the weblog owner.</li>
+      <li>In the context of an integrated pubsub and multi-user chat system, the node owner might be the room owner but all replies need to be sent to the room rather than to the owner.</li>
+    </ul>
+    <p class="" style="">Therefore we define three node configuration options:</p>
+    <ul>
+      <li>pubsub#itemreply -- the per-item policy for replies (the value is "owner" or "publisher").</li>
+      <li>pubsub#replyto -- the specific user JID(s) to which replies should be sent.</li>
+      <li>pubsub#replyroom -- the multi-user chat room to which replies should be sent.</li>
+    </ul>
+    <p class="" style="">A node owner MUST NOT define more than one of these options.</p>
+    <p class="" style="">An example is shown below.</p>
+    <p class="caption">Example 212. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='i1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='portia@merchantofvenice.lit'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, if a service implements the personal eventing subset of this protocol, the virtual pubsub service is the account owner's bare JID and notifications are sent from that JID; for details, refer to <span style="font-weight: bold">JEP-0163</span>.</p>
+  </div>
+
+  <div class="indent">
+<h3>12.16 <a name="impl-chaining">Chaining</a>
+</h3>
+    <p class="" style="">The word "chaining" refers to the practice of subscribing one node to another node. For instance, consider a scenario in which the node &lt;pubsub@example.net/NewsBroadcaster&gt; wants to distribute information received from the node "NewsFeed" at &lt;pubsub.example.com&gt;. While it is theoretically possible for &lt;pubsub@example.net/NewsBroadcaster&gt; to directly subscribe to the NewsFeed node (since the former node is directly addressable as a JID), implementations MUST NOT chain nodes in this fashion. Instead, implementations MUST subscribe from the address of the pubsub service rather than the node (in the example shown here, the subscription would be sent from &lt;pubsub@example.net&gt; rather than &lt;pubsub@example.net/NewsBroadcaster&gt;).</p>
+
+  </div>
+
+  <div class="indent">
+<h3>12.17 <a name="impl-leases">Time-Based Subscriptions (Leases)</a>
+</h3>
+    <p class="" style="">In some systems it may be desirable to provide a subscription "leasing" feature in order to expire old or stale subscriptions. Leases can be implemented using configurable subscription options; specifically, when an entity subscribes, the service would require configuration of subscription options and the configuration form would contain a field of "pubsub#expire". This field MUST contain a dateTime (as specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2273171">25</a>]).</p>
+    <p class="" style="">The leasing process is shown below.</p>
+    <p class="caption">Example 213. Leasing process</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='lease1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='lease1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription
+        node='princely_musings'
+        jid='francisco@denmark.lit'
+        subscription='unconfigured'&gt;
+      &lt;subscribe-options&gt;
+        &lt;required/&gt;
+      &lt;/subscribe-options&gt;
+    &lt;/subscription&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='lease2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='lease2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+        &lt;field var='pubsub#expire' type='text-single'
+               label='Requested lease period'/&gt;
+        ...
+      &lt;/x&gt;
+    &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='lease3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'&gt;
+        &lt;x xmlns='jabber:x:data' type='submit'&gt;
+          &lt;field var='FORM_TYPE' type='hidden'&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          ...
+          &lt;field var='pubsub#expire'&gt;&lt;value&gt;2006-02-28T11:59Z&lt;/value&gt;&lt;/field&gt;
+          ...
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='lease3'/&gt;
+    </pre></div>
+    <p class="" style="">The service MAY send a message to the subscriber when the lease is almost over (e.g., 24 hours before the end of the lease term). This SHOULD be done by sending a &lt;message/&gt; containing an empty pubsub &lt;event/&gt; element and a SHIM header named "pubsub#expire".</p>
+    <p class="caption">Example 214. Service notifies subscriber of impending lease end</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='francisco@denmark.lit/barracks'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='pubsub#expire'&gt;2006-02-28T23:59Z&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When the subscriber wants to renew the lease, it would get the current subscription options, change the value of the "pubsub#expire" field, and submit the new subscription options back to the service. If the new expire value exceeds the maximum value allowed for subscription leases, the service MUST change the value of the field to be the current date/time plus the maximum allowed lease period.</p>
+    <p class="caption">Example 215. Renewing a lease</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='renew1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='renew1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+        &lt;field var='pubsub#expire' type='text-single'
+               label='Requested lease period'/&gt;
+        ...
+      &lt;/x&gt;
+    &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='pubsub.shakespeare.lit'
+    id='renew2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings' jid='francisco@denmark.lit'&gt;
+        &lt;x xmlns='jabber:x:data' type='submit'&gt;
+          &lt;field var='FORM_TYPE' type='hidden'&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          ...
+          &lt;field var='pubsub#expire'&gt;&lt;value&gt;2006-03-31T23:59Z&lt;/value&gt;&lt;/field&gt;
+          ...
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='francisco@denmark.lit/barracks'
+    id='renew2'/&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>12.18 <a name="impl-content">Content-Based Pubsub Systems</a>
+</h3>
+    <p class="" style="">A service MAY enable entities to subscribe to nodes and apply a filter to notifications (e.g., keyword matching such as "send me all news entries from Slashdot that match the term 'Jabber'"). Such a content-based service SHOULD allow an entity to subscribe more than once to the same node and, if so, MUST use subscription identifiers (SubIDs) to distinguish between multiple subscriptions. In order to prevent collisions, a service that supports content-based subscriptions using SubIDs SHOULD generate SubIDs on behalf of subscribers rather than allowing subscribers to set their own SubIDs.  [<a href="#nt-id2273282">26</a>]</p>
+    <p class="" style="">Content-based services SHOULD use subscription options to specify the filter(s) to be applied. Because there many possible filtering mechanisms (many of which may be application-specific), this JEP does not define any such method. However, filtering mechanisms may be defined in separate specifications.</p>
+    <p class="" style="">A fictional example of the subscription options configuration process for content-based pubsub is shown below.</p>
+    <p class="caption">Example 216. A content-based subscription</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='marcellus@denmark.lit/castle'
+    to='pubsub.shakespeare.lit'
+    id='filter1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe
+        node='princely_musings'
+        jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='marcellus@denmark.lit/castle'
+    id='filter1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription
+        node='princely_musings'
+        jid='marcellus@denmark.lit'
+        subid='991d7fd1616fd041015064133cd097a10030819e'
+        subscription='unconfigured'&gt;
+      &lt;subscribe-options&gt;
+        &lt;required/&gt;
+      &lt;/subscribe-options&gt;
+    &lt;/subscription&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='get'
+    from='marcellus@denmark.lit/castle'
+    to='pubsub.shakespeare.lit'
+    id='filter2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings'
+             jid='marcellus@denmark.lit'
+             subid='991d7fd1616fd041015064133cd097a10030819e'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='marcellus@denmark.lit/castle'
+    id='filter2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings'
+             jid='marcellus@denmark.lit'
+             subid='991d7fd1616fd041015064133cd097a10030819e'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        ...
+        &lt;field var='http://shakespeare.lit/search#keyword'
+               type='text-single'
+               label='Keyword to match'/&gt;
+        ...
+      &lt;/x&gt;
+    &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set'
+    from='marcellus@denmark.lit/castle'
+    to='pubsub.shakespeare.lit'
+    id='filter3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;options node='princely_musings'
+             jid='marcellus@denmark.lit'
+             subid='991d7fd1616fd041015064133cd097a10030819e'&gt;
+        &lt;x xmlns='jabber:x:data' type='submit'&gt;
+          &lt;field var='FORM_TYPE' type='hidden'&gt;
+            &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+          &lt;/field&gt;
+          ...
+          &lt;field var='http://shakespeare.lit/search#keyword'&gt;&lt;value&gt;peasant&lt;/value&gt;&lt;/field&gt;
+          ...
+        &lt;/x&gt;
+     &lt;/options&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='marcellus@denmark.lit/castle'
+    id='filter3'/&gt;
+    </pre></div>
+    <p class="" style="">The subscriber will then be notified about events that match the keyword.</p>
+    <p class="caption">Example 217. Event notification for matched keyword</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='marcellus@denmark.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='princely_musings'&gt;
+      &lt;item id='4e30f35051b7b8b42abe083742187228'&gt;
+        &lt;entry xmlns='http://www.w3.org/2005/Atom'&gt;
+          &lt;title&gt;Alone&lt;/title&gt;
+          &lt;summary&gt;
+Now I am alone.
+O, what a rogue and peasant slave am I!
+          &lt;/summary&gt;
+          &lt;link rel='alternate' type='text/html'
+                href='http://denmark.lit/2003/12/13/atom03'/&gt;
+          &lt;id&gt;tag:denmark.lit,2003:entry-32396&lt;/id&gt;
+          &lt;published&gt;2003-12-13T11:09:53Z&lt;/published&gt;
+          &lt;updated&gt;2003-12-13T11:09:53Z&lt;/updated&gt;
+        &lt;/entry&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='pubsub#subid'&gt;991d7fd1616fd041015064133cd097a10030819e&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>13.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="i18n-formtypes">Field Labels</a>
+</h3>
+    <p class="" style="">The Data Forms shown in this specification include English-language labels for various fields; implementations that will display such forms to human users SHOULD provide localized label text for fields that are defined for the registered FORM_TYPEs.</p>
+  </div>
+<h2>14.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Because the data published to a pubsub node may contain sensitive information (e.g., a user's geolocation), node owners SHOULD exercise care in approving subscription requests. Security considerations regarding particular kinds of information are the responsbility of the using protocol.</p>
+  <p class="" style="">A service MUST NOT allow non-owners or other unauthorized entities to complete any actions defined under the <a href="#owner">Owner Use Cases</a> section of this document.</p>
+  <p class="" style="">A service MUST adhere to the defined access model in determining whether to send event notifications or payloads to an entity, or allow an entity to retrieve items from a node. A service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>15.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP does not require interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2273538">27</a>].</p>
+<h2>16.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+
+  <div class="indent">
+<h3>16.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2273589">28</a>] includes the following namespaces in its registry of protocol namespaces (see &lt;<a href="http://www.jabber.org/registrar/namespaces.html">http://www.jabber.org/registrar/namespaces.html</a>&gt;):</p>
+    <ul>
+      <li>http://jabber.org/protocol/pubsub</li>
+      <li>http://jabber.org/protocol/pubsub#errors</li>
+      <li>http://jabber.org/protocol/pubsub#event</li>
+      <li>http://jabber.org/protocol/pubsub#owner</li>
+    </ul>
+  </div>
+
+  <div class="indent">
+<h3>16.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-categories.html">http://www.jabber.org/registrar/disco-categories.html</a>&gt;), as well as three specific types within that category:</p>
+    <p class="caption">Table 11: Service Discovery Types in Pubsub Category</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <td align="" colspan="" rowspan="">collection</td>
+        <td align="" colspan="" rowspan="">A pubsub node of the "collection" type.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">leaf</td>
+        <td align="" colspan="" rowspan="">A pubsub node of the "leaf" type.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">service</td>
+        <td align="" colspan="" rowspan="">A pubsub service that supports the functionality defined in JEP-0060.  [<a href="#nt-id2273717">29</a>]</td>
+      </tr>
+    </table>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;desc&gt;Services and nodes that adhere to JEP-0060.&lt;/desc&gt;
+  &lt;type&gt;
+    &lt;name&gt;collection&lt;/name&gt;
+    &lt;desc&gt;A pubsub node of the "collection" type.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+  &lt;type&gt;
+    &lt;name&gt;leaf&lt;/name&gt;
+    &lt;desc&gt;A pubsub node of the "leaf" type.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+  &lt;type&gt;
+    &lt;name&gt;service&lt;/name&gt;
+    &lt;desc&gt;A pubsub service that supports the functionality defined in JEP-0060.&lt;/desc&gt;
+    &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+    <p class="" style="">Future submissions to the Jabber Registrar may register additional types.</p>
+  </div>
+
+  <div class="indent">
+<h3>16.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar maintains a registry of service discovery features (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;), which includes a number of features that may be returned by pubsub services. The following registry submission has been provided to the Jabber Registrar for that purpose.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#collections&lt;/name&gt;
+  &lt;desc&gt;Collection nodes are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#config-node&lt;/name&gt;
+  &lt;desc&gt;Configuration of node options is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#create-and-configure&lt;/name&gt;
+  &lt;desc&gt;Simultaneous creation and configuration of nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#create-nodes&lt;/name&gt;
+  &lt;desc&gt;Creation of nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#delete-any&lt;/name&gt;
+  &lt;desc&gt;Any publisher may delete an item (not only the originating publisher).&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#delete-nodes&lt;/name&gt;
+  &lt;desc&gt;Deletion of nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#get-pending&lt;/name&gt;
+  &lt;desc&gt;Retrieval of pending subscription approvals is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#instant-nodes&lt;/name&gt;
+  &lt;desc&gt;Creation of instant nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#item-ids&lt;/name&gt;
+  &lt;desc&gt;Publishers may specify item identifiers.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#leased-subscription&lt;/name&gt;
+  &lt;desc&gt;Time-based subscriptions are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/name&gt;
+  &lt;desc&gt;Node meta-data is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#manage-subscription&lt;/name&gt;
+  &lt;desc&gt;Node owners may manage subscriptions.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#modify-affiliations&lt;/name&gt;
+  &lt;desc&gt;Node owners may modify affiliations.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#multi-collection&lt;/name&gt;
+  &lt;desc&gt;A single leaf node may be associated with multiple collections.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#multi-subscribe&lt;/name&gt;
+  &lt;desc&gt;A single entity may subscribe to a node multiple times.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#outcast-affiliation&lt;/name&gt;
+  &lt;desc&gt;The outcast affiliation is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#persistent-items&lt;/name&gt;
+  &lt;desc&gt;Persistent items are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#presence-notifications&lt;/name&gt;
+  &lt;desc&gt;Presence-based delivery of event notifications is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#publish&lt;/name&gt;
+  &lt;desc&gt;Publishing items is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#publisher-affiliation&lt;/name&gt;
+  &lt;desc&gt;The publisher affiliation is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#purge-nodes&lt;/name&gt;
+  &lt;desc&gt;Purging of nodes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#retract-items&lt;/name&gt;
+  &lt;desc&gt;Item retraction is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#retrieve-affiliations&lt;/name&gt;
+  &lt;desc&gt;Retrieval of current affiliations is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#retrieve-default&lt;/name&gt;
+  &lt;desc&gt;Retrieval of default node configuration is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#retrieve-items&lt;/name&gt;
+  &lt;desc&gt;Item retrieval is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#retrieve-subscriptions&lt;/name&gt;
+  &lt;desc&gt;Retrieval of current subscriptions is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscribe&lt;/name&gt;
+  &lt;desc&gt;Subscribing and unsubscribing are supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscription-options&lt;/name&gt;
+  &lt;desc&gt;Configuration of subscription options is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscription-notifications&lt;/name&gt;
+  &lt;desc&gt;Notification of subscription state changes is supported.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>16.4 <a name="registrar-formtypes">Field Standardization</a>
+</h3>
+    <p class="" style="">JEP-0068 defines a process for standardizing the fields used within Data Forms scoped by a particular namespace, and the Jabber Registrar maintains a registry of such FORM_TYPES (see &lt;<a href="http://www.jabber.org/registrar/formtypes.html">http://www.jabber.org/registrar/formtypes.html</a>&gt;). Within pubsub, there are four uses of such forms:</p>
+    <ol start="" type="">
+      <li>Authorization of subscriptions using the 'http://jabber.org/protocol/pubsub#subscribe_authorization' namespace.</li>
+      <li>Configuration of subscription options using the 'http://jabber.org/protocol/pubsub#subscribe_options' namespace.</li>
+      <li>Configuration of a node using the 'http://jabber.org/protocol/pubsub#node_config' namespace.</li>
+      <li>Setting of meta-data information using the 'http://jabber.org/protocol/pubsub#meta-data' namespace.</li>
+    </ol>
+    <p class="" style="">The registry submissions associated with these namespaces are defined below.</p>
+    <p class="" style="">Note: There is no requirement that configuration fields need to be registered with the Jabber Registrar. However, as specified in Section 3.4 of <span style="font-weight: bold">JEP-0068</span>, names of custom (unregistered) fields MUST begin with the characters "x-" if the form itself is scoped by a registered FORM_TYPE.</p>
+
+    <div class="indent">
+<h3>16.4.1 <a name="registrar-formtypes-auth">pubsub#subscribe_authorization FORM_TYPE</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscribe_authorization&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling authorization of subscriptions to pubsub nodes&lt;/desc&gt;
+  &lt;field
+      var='pubsub#allow'
+      type='boolean'
+      label='Whether to allow the subscription'/&gt;
+  &lt;field
+      var='pubsub#subid'
+      type='text-single'
+      label='The SubID of the subscription'/&gt;
+  &lt;field
+      var='pubsub#node'
+      type='text-single'
+      label='The NodeID of the relevant node'/&gt;
+  &lt;field
+      var='pubsub#subscriber_jid'
+      type='jid-single'
+      label='The address (JID) of the subscriber'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>16.4.2 <a name="registrar-formtypes-options">pubsub#subscribe_options FORM_TYPE</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling configuration of subscription options for pubsub nodes&lt;/desc&gt;
+  &lt;field
+      var='pubsub#deliver'
+      type='boolean'
+      label='Whether an entity wants to receive
+             or disable notifications'/&gt;
+  &lt;field
+      var='pubsub#digest'
+      type='boolean'
+      label='Whether an entity wants to receive digests
+             (aggregations) of notifications or all
+             notifications individually'/&gt;
+  &lt;field var='pubsub#digest_frequency'
+         type='text-single'
+         label='The minimum number of milliseconds between
+                sending any two notification digests'/&gt;
+  &lt;field
+      var='pubsub#expire'
+      type='text-single'
+      label='The DateTime at which a leased subscription
+             will end or has ended'/&gt;
+  &lt;field
+      var='pubsub#include_body'
+      type='boolean'
+      label='Whether an entity wants to receive an XMPP
+             message body in addition to the payload
+             format'/&gt;
+  &lt;field
+      var='pubsub#show-values'
+      type='list-multi'
+      label='The presence states for which an entity
+             wants to receive notifications'&gt;
+    &lt;option label='XMPP Show Value of Away'&gt;
+      &lt;value&gt;away&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of Chat'&gt;
+      &lt;value&gt;chat&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of DND (Do Not Disturb)'&gt;
+      &lt;value&gt;dnd&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Mere Availability in XMPP (No Show Value)'&gt;
+      &lt;value&gt;online&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='XMPP Show Value of XA (Extended Away)'&gt;
+      &lt;value&gt;xa&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var='pubsub#subscription_type'
+         type='list-single'&gt;
+    &lt;option label='Receive notification of new items only'&gt;
+      &lt;value&gt;items&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Receive notification of new nodes only'&gt;
+      &lt;value&gt;nodes&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var='pubsub#subscription_depth'
+         type='list-single'&gt;
+    &lt;option label='Receive notification from direct child nodes only'&gt;
+      &lt;value&gt;1&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Receive notification from all descendent nodes'&gt;
+      &lt;value&gt;all&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>16.4.3 <a name="registrar-formtypes-config">pubsub#node_config FORM_TYPE</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#node_config&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling configuration of pubsub nodes&lt;/desc&gt;
+  &lt;field var='pubsub#access_model'
+         type='list-single'
+         label='Who may subscribe and retrieve items'&gt;
+    &lt;option label='Subscription requests must be approved and only subscribers may retrieve items'&gt;
+      &lt;value&gt;authorize&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Anyone may subscribe and retrieve items'&gt;
+      &lt;value&gt;open&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Anyone with a presence subscription of both or from may subscribe and retrieve items'&gt;
+      &lt;value&gt;presence&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Anyone in the specified roster group(s) may subscribe and retrieve items'&gt;
+      &lt;value&gt;roster&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Only those on a whitelist may subscribe and retrieve items'&gt;
+      &lt;value&gt;whitelist&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var='pubsub#body_xslt'
+         type='text-single'
+         label='The URL of an XSL transformation which can be
+                applied to payloads in order to generate an
+                appropriate message body element.'/&gt;
+  &lt;field var='pubsub#collection'
+         type='text-single'
+         label='The collection with which a node is affiliated'/&gt;
+  &lt;field var='pubsub#dataform_xslt'
+         type='text-single'
+         label='The URL of an XSL transformation which can be
+                applied to the payload format in order to generate
+                a valid Data Forms result that the client could
+                display using a generic Data Forms rendering
+                engine'/&gt;
+  &lt;field var='pubsub#deliver_payloads'
+         type='boolean'
+         label='Whether to deliver payloads with event notifications'/&gt;
+  &lt;field var='pubsub#itemreply'
+         type='list-single'
+         label='Whether owners or publisher should receive replies to items'&gt;
+    &lt;option label='Statically specify a replyto of the node owner(s)'&gt;
+      &lt;value&gt;owner&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Dynamically specify a replyto of the item publisher'&gt;
+      &lt;value&gt;publisher&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var='pubsub#children_association_policy'
+         type='list-single'
+         label='Who may associate leaf nodes with a collection'&gt;
+    &lt;option label='Anyone may associate leaf nodes with the collection'&gt;
+      &lt;value&gt;all&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Only collection node owners may associate leaf nodes with the collection'&gt;
+      &lt;value&gt;owners&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Only those on a whitelist may associate leaf nodes with the collection'&gt;
+      &lt;value&gt;whitelist&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var='pubsub#children_association_whitelist'
+         type='jid-multi'
+         label='The list of JIDs that may associated leaf nodes with a collection'/&gt;
+  &lt;field var='pubsub#children'
+         type='text-multi'
+         label='The child nodes (leaf or collection) associated with a collection'/&gt;
+  &lt;field var='pubsub#children_max'
+         type='text-single'
+         label='The maximum number of child nodes that can be associated with a collection'/&gt;
+  &lt;field var='pubsub#max_items'
+         type='text-single'
+         label='The maximum number of items to persist'/&gt;
+  &lt;field var='pubsub#max_payload_size'
+         type='text-single'
+         label='The maximum payload size in bytes'/&gt;
+  &lt;field var='pubsub#node_type'
+         type='list-single'
+         label='Whether the node is a leaf (default) or a collection'&gt;
+    &lt;option label='The node is a leaf node (default)'&gt;
+      &lt;value&gt;leaf&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='The node is a collection node'&gt;
+      &lt;value&gt;collection&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var='pubsub#notify_config'
+         type='boolean'
+         label='Whether to notify subscribers when the node configuration changes'/&gt;
+  &lt;field var='pubsub#notify_delete'
+         type='boolean'
+         label='Whether to notify subscribers when the node is deleted'/&gt;
+  &lt;field var='pubsub#notify_retract'
+         type='boolean'
+         label='Whether to notify subscribers when items are removed from the node'/&gt;
+  &lt;field var='pubsub#persist_items'
+         type='boolean'
+         label='Whether to persist items to storage'/&gt;
+  &lt;field var='pubsub#presence_based_delivery'
+         type='boolean'
+         label='Whether to deliver notifications to available users only'/&gt;
+  &lt;field var='pubsub#publish_model'
+         type='list-single'
+         label='The publisher model'&gt;
+    &lt;option label='Only publishers may publish'&gt;
+      &lt;value&gt;publishers&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Subscribers may publish'&gt;
+      &lt;value&gt;subscribers&lt;/value&gt;
+    &lt;/option&gt;
+    &lt;option label='Anyone may publish'&gt;
+      &lt;value&gt;open&lt;/value&gt;
+    &lt;/option&gt;
+  &lt;/field&gt;
+  &lt;field var='pubsub#replyroom'
+         type='jid-multi'
+         label='The specific multi-user chat rooms to specify for replyroom'/&gt;
+  &lt;field var='pubsub#replyto'
+         type='jid-multi'
+         label='The specific JID(s) to specify for replyto'/&gt;
+  &lt;field var='pubsub#roster_groups_allowed'
+         type='list-multi'
+         label='The roster group(s) allowed to subscribe and retrieve items'/&gt;
+  &lt;field var='pubsub#send_item_subscribe'
+         type='boolean'
+         label='Whether to send items to new subscribers'/&gt;
+  &lt;field var='pubsub#subscribe' type='boolean'
+         label='Whether to allow subscriptions'&gt;
+    &lt;value&gt;1&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='pubsub#title'
+         type='text-single'
+         label='A friendly name for the node'/&gt;
+  &lt;field var='pubsub#type'
+         type='text-single'
+         label='The type of node data, usually specified by
+                the namespace of the payload (if any); MAY
+                be list-single rather than text-single'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>16.4.4 <a name="registrar-formtypes-metadata">pubsub#meta-data FORM_TYPE</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/pubsub#meta-data&lt;/name&gt;
+  &lt;jep&gt;JEP-0060&lt;/jep&gt;
+  &lt;desc&gt;Forms enabling setting of meta-data information about pubsub nodes&lt;/desc&gt;
+  &lt;field var='pubsub#contact'
+         type='jid-multi'
+         label='The JIDs of those to contact with questions'/&gt;
+  &lt;field var='pubsub#creation_date'
+         type='text-single'
+         label='The datetime when the node was created'/&gt;
+  &lt;field var='pubsub#creator'
+         type='jid-single'
+         label='The JID of the node creator'/&gt;
+  &lt;field var='pubsub#description'
+         type='text-single'
+         label='A description of the node'/&gt;
+  &lt;field var='pubsub#language'
+         type='text-single'
+         label='The default language of the node'/&gt;
+  &lt;field var='pubsub#num_subscribers'
+         type='text-single'
+         label='The number of subscribers to the node'/&gt;
+  &lt;field var='pubsub#owner'
+         type='jid-multi'
+         label='The JIDs of those with an affiliation of owner'/&gt;
+  &lt;field var='pubsub#publisher'
+         type='jid-multi'
+         label='The JIDs of those with an affiliation of publisher'/&gt;
+  &lt;field var='pubsub#title'
+         type='text-single'
+         label='The name of the node'/&gt;
+  &lt;field var='pubsub#type'
+         type='text-single'
+         label='Payload type'/&gt;
+  &lt;/field&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>16.5 <a name="registrar-shim">SHIM Headers</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes "pubsub#collection", "pubsub#expire", and "pubsub#subid" in its registry of SHIM headers (see &lt;<a href="http://www.jabber.org/registrar/shim.html">http://www.jabber.org/registrar/shim.html</a>&gt;). The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;pubsub#collection&lt;/name&gt;
+  &lt;desc&gt;The collection via which a notification was received from the originating node.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/header&gt;
+&lt;header&gt;
+  &lt;name&gt;pubsub#expire&lt;/name&gt;
+  &lt;desc&gt;The DateTime at which a pubsub leased subscription will end or has ended.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/header&gt;
+&lt;header&gt;
+  &lt;name&gt;pubsub#subid&lt;/name&gt;
+  &lt;desc&gt;A subscription identifer within the pubsub protocol.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+&lt;/header&gt;
+    </pre></div>
+    <p class="" style="">Future submissions to the Jabber Registrar may register additional SHIM headers that can be used in relation to the pubsub protocol, and such submission may occur without updating this specification.</p>
+  </div>
+  <div class="indent">
+<h3>16.6 <a name="registrar-querytypes">URI Query Types</a>
+</h3>
+    <p class="" style="">As authorized by <span class="ref" style="">XMPP URI Query Components</span>  [<a href="#nt-id2274251">30</a>], the Jabber Registrar maintains a registry of queries and key-value pairs for use in XMPP URIs (see &lt;<a href="http://www.jabber.org/registrar/querytypes.html">http://www.jabber.org/registrar/querytypes.html</a>&gt;).</p>
+    <p class="" style="">The "pubsub" querytype is defined herein for interaction with pubsub services, with two keys: (1) "action" (whose defined values are "subscribe" and "unsubscribe") and (2) "node" (to specify a pubsub node).</p>
+    <p class="caption">Example 218. Pubsub Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=subscribe;node=princely_musings
+    </pre></div>
+    <p class="caption">Example 219. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 220. Pubsub Unsubscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=unsubscribe;node=princely_musings
+    </pre></div>
+    <p class="caption">Example 221. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='princely_musings'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following submission registers the "pubsub" querytype.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0060&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the pubsub node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+    </pre></div>
+  </div>
+<h2>17.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>17.1 <a name="schemas-pubsub">http://jabber.org/protocol/pubsub</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub'
+    xmlns='http://jabber.org/protocol/pubsub'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='pubsub'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='create'/&gt;
+          &lt;xs:element ref='configure' minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='subscribe' minOccurs='0'/&gt;
+          &lt;xs:element ref='options' minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:choice minOccurs='0'&gt;
+          &lt;xs:element ref='affiliations'/&gt;
+          &lt;xs:element ref='items'/&gt;
+          &lt;xs:element ref='publish'/&gt;
+          &lt;xs:element ref='retract'/&gt;
+          &lt;xs:element ref='subscription'/&gt;
+          &lt;xs:element ref='subscriptions'/&gt;
+          &lt;xs:element ref='unsubscribe'/&gt;
+        &lt;/xs:choice&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='affiliations'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='affiliation' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='affiliation'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='affiliation' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='outcast'/&gt;
+                &lt;xs:enumeration value='owner'/&gt;
+                &lt;xs:enumeration value='publisher'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='configure'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='create'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='items'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='max_items' type='xs:positiveInteger' use='optional'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='subid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='options'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:any namespace='jabber:x:data'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='subid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='publish'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='retract'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='notify' type='xs:boolean' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscribe-options'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='required' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscribe'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscriptions'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:element ref='subscription' minOccurs='0' maxOccurs='unbounded'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscription'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='subscribe-options' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='subid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='subscription' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='none'/&gt;
+            &lt;xs:enumeration value='pending'/&gt;
+            &lt;xs:enumeration value='subscribed'/&gt;
+            &lt;xs:enumeration value='unconfigured'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsubscribe'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='subid' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>17.2 <a name="schemas-error">http://jabber.org/protocol/pubsub#errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#errors'
+    xmlns='http://jabber.org/protocol/pubsub#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      This namespace is used for error reporting only, as
+      defined in JEP-0060:
+
+      http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='closed-node' type='empty'/&gt;
+  &lt;xs:element name='configuration-required' type='empty'/&gt;
+  &lt;xs:element name='invalid-jid' type='empty'/&gt;
+  &lt;xs:element name='invalid-options' type='empty'/&gt;
+  &lt;xs:element name='invalid-payload' type='empty'/&gt;
+  &lt;xs:element name='invalid-subid' type='empty'/&gt;
+  &lt;xs:element name='item-forbidden' type='empty'/&gt;
+  &lt;xs:element name='item-required' type='empty'/&gt;
+  &lt;xs:element name='jid-required' type='empty'/&gt;
+  &lt;xs:element name='max-nodes-exceeded' type='empty'/&gt;
+  &lt;xs:element name='nodeid-required' type='empty'/&gt;
+  &lt;xs:element name='not-in-roster-group' type='empty'/&gt;
+  &lt;xs:element name='not-subscribed' type='empty'/&gt;
+  &lt;xs:element name='payload-too-big' type='empty'/&gt;
+  &lt;xs:element name='payload-required' type='empty'/&gt;
+  &lt;xs:element name='pending-subscription' type='empty'/&gt;
+  &lt;xs:element name='presence-subscription-required' type='empty'/&gt;
+  &lt;xs:element name='subid-required' type='empty'/&gt;
+  &lt;xs:element name='unsupported'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='feature' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='collections'/&gt;
+                &lt;xs:enumeration value='config-node'/&gt;
+                &lt;xs:enumeration value='create-and-configure'/&gt;
+                &lt;xs:enumeration value='create-nodes'/&gt;
+                &lt;xs:enumeration value='delete-any'/&gt;
+                &lt;xs:enumeration value='delete-nodes'/&gt;
+                &lt;xs:enumeration value='get-pending'/&gt;
+                &lt;xs:enumeration value='instant-nodes'/&gt;
+                &lt;xs:enumeration value='item-ids'/&gt;
+                &lt;xs:enumeration value='leased-subscription'/&gt;
+                &lt;xs:enumeration value='manage-subscriptions'/&gt;
+                &lt;xs:enumeration value='meta-data'/&gt;
+                &lt;xs:enumeration value='modify-affiliations'/&gt;
+                &lt;xs:enumeration value='multi-collection'/&gt;
+                &lt;xs:enumeration value='multi-subscribe'/&gt;
+                &lt;xs:enumeration value='outcast-affiliation'/&gt;
+                &lt;xs:enumeration value='persistent-items'/&gt;
+                &lt;xs:enumeration value='presence-notifications'/&gt;
+                &lt;xs:enumeration value='publish'/&gt;
+                &lt;xs:enumeration value='publisher-affiliation'/&gt;
+                &lt;xs:enumeration value='purge-nodes'/&gt;
+                &lt;xs:enumeration value='retract-items'/&gt;
+                &lt;xs:enumeration value='retrieve-affiliations'/&gt;
+                &lt;xs:enumeration value='retrieve-default'/&gt;
+                &lt;xs:enumeration value='retrieve-items'/&gt;
+                &lt;xs:enumeration value='retrieve-subscriptions'/&gt;
+                &lt;xs:enumeration value='subscribe'/&gt;
+                &lt;xs:enumeration value='subscription-options'/&gt;
+                &lt;xs:enumeration value='subscription-notifications'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  &lt;xs:element name='unsupported-access-model' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>17.3 <a name="schemas-event">http://jabber.org/protocol/pubsub#event</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#event'
+    xmlns='http://jabber.org/protocol/pubsub#event'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='event'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0'&gt;
+        &lt;xs:element ref='collection'/&gt;
+        &lt;xs:element ref='configuration'/&gt;
+        &lt;xs:element ref='delete'/&gt;
+        &lt;xs:element ref='items'/&gt;
+        &lt;xs:element ref='purge'/&gt;
+        &lt;xs:element ref='subscription'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='collection'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='1'&gt;
+        &lt;xs:element ref='node'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='configuration'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0' xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='delete'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='items'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='retract' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0'&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='node'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='purge'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='retract'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscription'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='subid' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='subscription' use='optional'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='none'/&gt;
+                &lt;xs:enumeration value='pending'/&gt;
+                &lt;xs:enumeration value='subscribed'/&gt;
+                &lt;xs:enumeration value='unconfigured'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>17.4 <a name="schemas-owner">http://jabber.org/protocol/pubsub#owner</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubsub#owner'
+    xmlns='http://jabber.org/protocol/pubsub#owner'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0060: http://www.jabber.org/jeps/jep-0060.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+
+  &lt;xs:element name='pubsub'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='affiliations'/&gt;
+        &lt;xs:element ref='configure'/&gt;
+        &lt;xs:element ref='delete'/&gt;
+        &lt;xs:element ref='purge'/&gt;
+        &lt;xs:element ref='subscriptions'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='affiliations'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='affiliation' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='affiliation'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='affiliation' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='none'/&gt;
+                &lt;xs:enumeration value='outcast'/&gt;
+                &lt;xs:enumeration value='owner'/&gt;
+                &lt;xs:enumeration value='publisher'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='configure'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='node' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='default'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='delete'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='purge'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscriptions'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='subscription' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subscription'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='subscription' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='none'/&gt;
+                &lt;xs:enumeration value='pending'/&gt;
+                &lt;xs:enumeration value='subscribed'/&gt;
+                &lt;xs:enumeration value='unconfigured'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+
+<h2>18.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Bob Wyman, Gaston Dombiak, and Matt Tucker for their feedback.</p>
+<h2>19.
+       <a name="authornote">Author Note</a>
+</h2>
+  <p class="" style="">Peter Millard, primary author of this specification from version 0.1 through version 1.7, died on April 26, 2006. The remaining co-authors are indebted to him for his many years of work on publish-subscribe technologies.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2260047">1</a>. RFC 4287: The Atom Syndication Format &lt;<a href="http://www.ietf.org/rfc/rfc4287.txt">http://www.ietf.org/rfc/rfc4287.txt</a>&gt;.</p>
+<p><a name="nt-id2260219">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2260243">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260518">4</a>. JEP-0163: Personal Eventing via Pubsub &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2260565">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2260816">6</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2261969">7</a>. These nodes are equivalent to those used in <span style="font-weight: bold">JEP-0030: Service Discovery</span>.</p>
+<p><a name="nt-id2262221">8</a>. JEP-0055: Jabber Search &lt;<a href="http://www.jabber.org/jeps/jep-0055.html">http://www.jabber.org/jeps/jep-0055.html</a>&gt;.</p>
+<p><a name="nt-id2262448">9</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2262472">10</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p><a name="nt-id2262497">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2262536">12</a>. The Dublin Core Metadata Initiative (DCMI) is an organization dedicated to promoting the widespread adoption of interoperable metadata standards. For further information, see &lt;<a href="http://www.dublincore.org/">http://www.dublincore.org/</a>&gt;.</p>
+<p><a name="nt-id2250505">13</a>. The value SHOULD be a DateTime as defined in <span style="font-weight: bold">JEP-0082</span>, and MUST conform to one of the profiles defined therein.</p>
+<p><a name="nt-id2250608">14</a>. The pubsub type SHOULD be the namespace that defines the payload (such as 'http://www.w3.org/2005/Atom'), if payloads are supported.</p>
+<p><a name="nt-id2263463">15</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2262874">16</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2265656">17</a>. JEP-0059: Result Set Manipulation &lt;<a href="http://www.jabber.org/jeps/jep-0059.html">http://www.jabber.org/jeps/jep-0059.html</a>&gt;.</p>
+<p><a name="nt-id2265961">18</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2266699">19</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2268695">20</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2272163">21</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2272341">22</a>. JEP-0160: Best Practices for Handling Offline Messages &lt;<a href="http://www.jabber.org/jeps/jep-0160.html">http://www.jabber.org/jeps/jep-0160.html</a>&gt;.</p>
+<p><a name="nt-id2272372">23</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2272978">24</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2273171">25</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2273282">26</a>. Another way to implement content-based subscriptions is to host one node per keyword or other filter; however, this is likely to require an extremely large number of nodes.</p>
+<p><a name="nt-id2273538">27</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2273589">28</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2273717">29</a>. Prior to version 1.5 of JEP-0060, this type was called "generic".</p>
+<p><a name="nt-id2274251">30</a>. JEP-0147: XMPP URI Query Components &lt;<a href="http://www.jabber.org/jeps/jep-0147.html">http://www.jabber.org/jeps/jep-0147.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.8 (2006-06-27)</h4>
+<div class="indent">
+      <ul>
+        <li>Defined five access models: open, presence, roster, authorize, and whitelist</li>
+        <li>Renamed pubsub#subscription_model feature to pubsub#access_model</li>
+        <li>Separated affiliations retrieval from subscriptions retrieval</li>
+        <li>Removed subscription information from affiliations management</li>
+        <li>Changed &lt;entity/&gt; element to &lt;subscription/&gt; element in response to subscription request</li>
+        <li>Clarified batch processing of item publication and item deletion</li>
+        <li>Added basic example to introduction</li>
+        <li>More fully specified node creation flows</li>
+        <li>More fully specified recommended behavior for caching last published item, including use of jabber:x:delay protocol</li>
+        <li>Specified that semantic meaning of NodeIDs must not be used to encapsulate hierarchy</li>
+        <li>More fully specified error conditions</li>
+        <li>Changed some feature-related conditions to &lt;unsupported/&gt; plus feature attribute</li>
+        <li>Changed some error conditions from &lt;not-authorized/&gt; to &lt;forbidden/&gt;</li>
+        <li>Harmonized error conditions for unsubscribe if entity is not subscribed (unexpected-request rather than not-found)</li>
+        <li>Further defined error conditions related to item publication</li>
+        <li>Specified structure of &lt;affiliations/&gt;, &lt;delete/&gt;, &lt;purge/&gt;, and &lt;subscriptions/&gt; elements qualified by pubsub#owner namespace</li>
+        <li>Changed retrieval of default configuration options to use &lt;default/&gt; element, not &lt;configure/&gt; element</li>
+        <li>Allowed caching of last published item</li>
+        <li>Added pubsub#deliver subscription option</li>
+        <li>Added meta-data fields for pubsub#owners and pubsub#contact</li>
+        <li>Changed element for retrieval of default node configuration options from &lt;configure/&gt; to &lt;default/&gt; to prevent ambiguity related to configuration of root collection node</li>
+        <li>Specified pubsub#node_type configuration field</li>
+        <li>Specified pubsub#collection SHIM header</li>
+        <li>Specified conformance with Resourceprep for nodes addressable as JIDs</li>
+        <li>Added pubsub#modify-affiliations feature</li>
+        <li>Added pubsub#digest_frequency field to subscribe_options FORM_TYPE</li>
+        <li>Added pubsub#roster_groups_allowed field to node_config FORM_TYPE</li>
+        <li>More clearly specified the requirements level (MUST, SHOULD, MAY) for each service discovery feature</li>
+        <li>Defined pubsub#include_body subscription option and the pubsub#body_xslt node configuration option to transform payload format into an XMPP message body, and clarified rules for inclusion of message bodies</li>
+        <li>Clarified nature of collections and association of a node to a collection</li>
+        <li>Specified that simultaneous subscriptions of type nodes and items are allowed to collection nodes</li>
+        <li>Added examples and further explanation of time-based and content-based subscriptions</li>
+        <li>Added Internationalization Considerations</li>
+        <li>Clarified terminology</li>
+        <li>Corrected and updated the schemas</li>
+      </ul>
+     (psa)
+    </div>
+<h4>Version 1.7 (2005-03-03)</h4>
+<div class="indent">
+      <ul>
+        <li>Reinstated pubsub#subscribe feature (deleted in error)</li>
+        <li>Added type attribute for the &lt;create/&gt; and &lt;configure/&gt; elements to differentiate between leaf nodes and collection nodes</li>
+        <li>In Section 8.1.7, changed affiliations retrieval support to SHOULD and added pubsub#retrieve-affiliations feature</li>
+        <li>In Section 8.1.10, removed two duplicate examples</li>
+        <li>In Section 8.1.12, clarified relationship between normal disco#info data and node meta-data (which uses a service discovery extension)</li>
+        <li>In Section 8.2.4, specified that node purgation MUST result in one event notification, not a notification per item</li>
+        <li>In Section 8.1.8, further specified handling of SubIDs</li>
+        <li>Clarified nature of the pubsub#type field</li>
+        <li>Mentioned that the forbidden error should be returned in response to certain operations requested by an outcast</li>
+        <li>Corrected datatype of max_items attribute from xs:string to xs:positiveInteger</li>
+        <li>Corrected &lt;requesting-entity-not-subscribed/&gt; error to &lt;not-subscribed/&gt; since the subscribed JID need not be that of the requesting entity</li>
+        <li>Added service discovery features for more optional use cases: retracting items, purging nodes, deleting nodes</li>
+        <li>Updated relevant registries</li>
+      </ul>
+     (psa/rm)
+    </div>
+<h4>Version 1.6 (2004-07-13)</h4>
+<div class="indent">
+<p class="" style="">Added service discovery features for pubsub#meta-data, and pubsub#retrieve-items. Added pubsub#subscription_depth configuration option. Specified pubsub-specific error condition elements qualified by pubsub#errors namespace.</p> (pgm/psa)
+    </div>
+<h4>Version 1.5 (2004-07-07)</h4>
+<div class="indent">
+<p class="" style="">Fixed typos. Added more details to the section on collections. Added paragraph to create node use case to allow the service to change the requested node-id to something which it creates. Added text about bouncing publish requests when the request does not match the event-type for that node. Added disco features for the jabber registrar. Changed affiliation verbiage to allow publishers to remove any item. Tweaked verbiage for create node, eliminated extra example. Fully defined Jabber Registrar submissions. Corrected schemas.</p> (pgm/psa)
+    </div>
+<h4>Version 1.4 (2004-06-22)</h4>
+<div class="indent">
+<p class="" style="">Added subid syntax in a variety of places. Added more information about disco#info and disco#items support. Added more info about subscription options. Added collection information. Added implementation notes about subscription leases, and content-based pubsub services.</p> (pgm)
+    </div>
+<h4>Version 1.3 (2004-04-25)</h4>
+<div class="indent">
+<p class="" style="">Editorial review; added one implementation note.</p> (psa)
+    </div>
+<h4>Version 1.2 (2004-03-09)</h4>
+<div class="indent">
+<p class="" style="">Added XMPP error handling.</p> (psa)
+    </div>
+<h4>Version 1.1 (2004-01-14)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar Considerations subsection for Service Discovery category/type registration.</p> (psa)
+    </div>
+<h4>Version 1.0 (2003-10-28)</h4>
+<div class="indent">
+<p class="" style="">Per a vote of the Jabber Council, advanced status to Draft.</p> (psa)
+    </div>
+<h4>Version 0.16 (2003-10-23)</h4>
+<div class="indent">
+<p class="" style="">Clarified JID addressing usage for nodes. Added specific MAY requirement for disco usage. Added sentence about implementations verifying that an entity has a subscription before getting the current items.</p> (pgm)
+    </div>
+<h4>Version 0.15 (2003-10-21)</h4>
+<div class="indent">
+<p class="" style="">Fixed invalid XML in examples for subscription deny/allow.</p> (pgm)
+    </div>
+<h4>Version 0.14 (2003-10-21)</h4>
+<div class="indent">
+<p class="" style="">Clarified restrictions on addressing nodes by JID. Added section on Approving and Denying Subscription Requests. Changed get-pending to use Ad-Hoc Commands. Changed semantics when sending in a form type='cancel' for pending subscriptions.</p> (pgm)
+    </div>
+<h4>Version 0.13 (2003-09-30)</h4>
+<div class="indent">
+<p class="" style="">Removed item as a possible child of subscribe and unsubscribe and pubsub in the schemas. Removed retract as a possible child of item in the pubsub#event schema. Added verbiage to requirements for addressing nodes either via JIDs or disco nodes.</p> (pgm)
+    </div>
+<h4>Version 0.12 (2003-08-13)</h4>
+<div class="indent">
+<p class="" style="">Defined public vs. private nodes; described how changes to existing nodes might trigger meta-node events (e.g., configuration changes); changed &lt;x/&gt; to &lt;event/&gt; for #events namespace; added meta-data about meta-nodes; fully defined Jabber Registrar considerations.</p> (pgm/psa)
+    </div>
+<h4>Version 0.11 (2003-06-25)</h4>
+<div class="indent">
+<p class="" style="">Removed subscription notifications since they have inherent issues. Removed empty implementation note sub-section.</p> (pgm)
+    </div>
+<h4>Version 0.10 (2003-06-11)</h4>
+<div class="indent">
+<p class="" style="">Fixed error example when returning 501 from an items-get request. Added note about receiving subscription requests when an entity is already subscribed. Fixed some entity elements in various subscription examples. Many were missing the node attribute. Added subscription change notification verbiage and example. Added verbiage and example of subscription state notification being sent to the requesting entity. Added disco#items information for getting a list of item identifiers for a single node. Added verbiage for returning the current entity element when a curent subscriber attempts to subscribe again.</p> (pgm)
+    </div>
+<h4>Version 0.9 (2003-04-30)</h4>
+<div class="indent">
+<p class="" style="">Include JID attributes in the entity elements when receiving your affiliations. Changed error code 406 (which was wrong) to 404, which is correct. Changed many 405 errors to 401, and modified the error table to make it more implementable (rules are more concrete). Added subscribe-options element for indicating subscriptions may be configured.</p> (pgm)
+    </div>
+<h4>Version 0.8 (2003-04-03)</h4>
+<div class="indent">
+<p class="" style="">Clarified the affiliations table and the semantics around subscribing and unsubscribing. Added protocol to get all of your affiliations in the service. Added protocol for services informing subscribers that configurable subscription options are available. Added protocol for obtaining existing node configuration settings and for concatenating configuration and node creation requests into a single stanza. Added meta-node implementation notes and specified the interaction with the Jabber Registrar and the meta NodeIDs. Added authorization notes to subscription options.</p> (pgm)
+    </div>
+<h4>Version 0.7 (2003-02-14)</h4>
+<div class="indent">
+<p class="" style="">Clarified requirements around what affiliations must be supported. Moved requirements about specifying entities which can subscribe and publish out of the MUSTs to MAYs. Changed SHOULD to MAY when talking about allowing entities to create nodes. Added ability to send configuration requests in the same stanza as a creation request.</p> (pgm)
+    </div>
+<h4>Version 0.6 (2003-02-06)</h4>
+<div class="indent">
+<p class="" style="">Added more details and an example about publishing without NodeID. Added more implementation notes about NodeIDs and persistent storage.</p> (pgm)
+    </div>
+<h4>Version 0.5 (2003-01-22)</h4>
+<div class="indent">
+<p class="" style="">Fixed header for delete item example. Added examples showing subscribers being notified of deleted items. Added examples for notification of node deletion, and configuration for node deletion. Added Subscriber option semantics and examples. Added examples for 402 and 407 errors on subscribe and create respectively. Added clarification about ItemID handling to impl notes.</p> (pgm)
+    </div>
+<h4>Version 0.4 (2003-01-21)</h4>
+<div class="indent">
+<p class="" style="">Clarified in-band and out-of-band configuration requirement. Added Delete Item privilege for all affiliations to the table. Added Delete item protocol for publishers and owners. Added 401 error case for subscribing to an illegal jid. Changed subscription request form. Added defaults to configuration form, and clarified role of the Jabber Registrar for the features show. Added text explaining the max_items attribute. Changed "last items" to "most recent items". Removed default configuration acceptance -- owners should just cancel. Added the notify_retract configuration option. Clarified error handling for affiliation modifications. </p> (pgm)
+    </div>
+<h4>Version 0.3 (2003-01-20)</h4>
+<div class="indent">
+<p class="" style="">Added subscription attribute for entities. Removed subscriber from the affiliations table. Clarified configuration details. Clarified JabberID usages. Added Jabber Registrar Considerations. Added link to JEP-0068 about the FORM_TYPE element in subscription request notifications. Fixed some typos in examples. Added unsupported configuration namespace to example.  Added a default configuration example. </p> (pgm)
+    </div>
+<h4>Version 0.2 (2003-01-02)</h4>
+<div class="indent">
+<p class="" style="">Added numerous implementation notes; added get-pending action with regard to subscriptions; added error table; changed purge and delete to use IQ type='set'.</p> (pgm)
+    </div>
+<h4>Version 0.1 (2002-11-19)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (pgm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0065-1.5.html
+++ b/content/xep-0065-1.5.html
@@ -1,0 +1,916 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0065: SOCKS5 Bytestreams</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOCKS5 Bytestreams">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for establishing a bytestream between any two Jabber entities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-06-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0065">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0065: SOCKS5 Bytestreams</h1>
+<p>This JEP defines a protocol for establishing a bytestream between any two Jabber entities.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0065<br>
+            Version: 1.5<br>
+            Last Updated: 2004-06-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: bytestreams<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/bytestreams/bytestreams.xsd">http://jabber.org/protocol/bytestreams/bytestreams.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#terms-conformance">Conformance Terms</a>
+</dt>
+<dt>2.2.  <a href="#terms-arch">Architectural Terms</a>
+</dt>
+</dl>
+<dt>3.  <a href="#narrative">Narrative</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#narr-direct">Direct Connection</a>
+</dt>
+<dt>3.2.  <a href="#narr-direct">Mediated Connection</a>
+</dt>
+</dl>
+<dt>4.  <a href="#proto">Protocol</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#proto-disco">Initiator Queries Target Regarding Bytestreams Support</a>
+</dt>
+<dt>4.2.  <a href="#proto-proxies">Initiator Queries Server For Proxies</a>
+</dt>
+<dt>4.3.  <a href="#proto-proxyinfo">Initiator Queries Proxy to Find Out if it is a Proxy</a>
+</dt>
+<dt>4.4.  <a href="#proto-address">Initiator Discovers Network Address of StreamHost</a>
+</dt>
+<dt>4.5.  <a href="#proto-inform">Initiator Informs Target of StreamHosts</a>
+</dt>
+<dt>4.6.  <a href="#proto-establish">Target Establishes SOCKS5 Connection with StreamHost</a>
+</dt>
+<dt>4.7.  <a href="#proto-ack">Target Acknowledges SOCKS5 Connection</a>
+</dt>
+<dt>4.8.  <a href="#proto-initiator">Initiator Establishes SOCKS5 Connection with StreamHost</a>
+</dt>
+<dt>4.9.  <a href="#proto-activation">Activation of Bytestream</a>
+</dt>
+</dl>
+<dt>5.  <a href="#usecase">Formal Use Case</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#usecase-primary">Primary Flow</a>
+</dt>
+<dt>5.2.  <a href="#usecase-alternate">Alternate Flows</a>
+</dt>
+</dl>
+<dt>6.  <a href="#desc">Formal Description</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#desc-query">&lt;query/&gt; Element</a>
+</dt>
+<dt>6.2.  <a href="#desc-streamhost">&lt;streamhost/&gt; Element</a>
+</dt>
+<dt>6.3.  <a href="#desc-streamhost-used">&lt;streamhost-used/&gt; Element</a>
+</dt>
+<dt>6.4.  <a href="#desc-activate">&lt;activate/&gt; Element</a>
+</dt>
+</dl>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#impl-streamhost">StreamHost Requirements</a>
+</dt>
+<dt>7.2.  <a href="#impl-socks5">SOCKS5 Parameter Mapping</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">It is widely recognized within the Jabber community that it would be valuable to have a generic protocol for streaming binary data between any two entities on the network. The main application for such a bytestreaming technology would be file transfer, for which there are currently a number of incompatible protocols (resulting in a lack of interoperability). However, other applications are possible, which is why it is important to develop a generic protocol rather than one that is specialized for a particular application such as file transfer. This JEP proposes a protocol that meets the following conditions:</p>
+  <ul>
+    <li>Bytestreams are established over standard TCP sockets</li>
+    <li>Sockets may be direct (peer-to-peer) or mediated (established through a bytestreaming service)</li>
+    <li>Where possible, standard wire protocols are used</li>
+  </ul>
+  <p class="" style="">Specifically, this JEP proposes that the Jabber community make use of the SOCKS 5 protocol, which is an IETF-approved, IPv6-ready technology for bytestreams. (Note: because this proposal uses a subset of the SOCKS5 protocol that is specially adapted for Jabber bytestreams, existing SOCKS5 proxies CANNOT be used to implement this proposal.)</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-conformance">Conformance Terms</a>
+</h3>
+    <p>The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in <span class="ref">RFC 2119</span>  [<a href="#nt-id2594590">1</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="terms-arch">Architectural Terms</a>
+</h3>
+    <p class="caption">Table 1: Glossary of Entities</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+<th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Initiator</td>
+        <td align="" colspan="" rowspan="">A Jabber Entity that wishes to establish a bytestream with another Entity</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Target</td>
+        <td align="" colspan="" rowspan="">The Entity with which the Initiator is attempting to establish a bytestream</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Proxy</td>
+        <td align="" colspan="" rowspan="">A Jabber entity which is not NAT/Firewalled and is willing to be a middleman for the bytestream between the Initiator and the Target</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">StreamHost</td>
+        <td align="" colspan="" rowspan="">The system that the Target connects to and that is &quot;hosting&quot; the bytestream -- may be either the Initiator or a Proxy</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">StreamID</td>
+        <td align="" colspan="" rowspan="">A relatively unique Stream ID for this connection; this is generated by the Initiator for tracking purposes and MUST be less than 128 characters in length</td>
+      </tr>
+    </table>
+  </div>
+<h2>3.
+       <a name="narrative">Narrative</a>
+</h2>
+  <p class="" style="">There are two scenarios addressed by this protocol:</p>
+  <ol start="" type="">
+    <li>direct connection (i.e., the StreamHost is the Initiator)</li>
+    <li>mediated connection (i.e., the StreamHost is a Proxy)</li>
+  </ol>
+  <p class="" style="">The &quot;happy paths&quot; for these scenarios are described separately below for ease of understanding. A full description of these scenarios is captured in the Formal Use Case.</p>
+  <div class="indent">
+<h3>3.1 <a name="narr-direct">Direct Connection</a>
+</h3>
+    <p class="" style="">Direct connection is the simpler case. In this situation, the StreamHost is the Initiator (StreamHost/Initiator), which means that the Initiator knows the network address of the StreamHost and knows when to activate the bytestream. The process for establishing bytestreams in this case is as follows:</p>
+    <ol start="" type="">
+      <li><p class="" style="">Initiator sends IQ-set to Target specifying the full JID and network address of StreamHost/Initiator as well as the StreamID (SID) of the proposed bytestream.</p></li>
+      <li><p class="" style="">Target opens a TCP socket to the specified network address.</p></li>
+      <li><p class="" style="">Target requests connection via SOCKS5, with the DST.ADDR and DST.PORT parameters set to the values defined below.</p></li>
+      <li><p class="" style="">StreamHost/Initiator sends acknowledgement of successful connection to Target via SOCKS5.</p></li>
+      <li><p class="" style="">Target sends IQ-result to Initiator, preserving the 'id' of the initial IQ-set.</p></li>
+      <li><p class="" style="">StreamHost/Initiator activates the bytestream.</p></li>
+      <li><p class="" style="">Initiator and Target may begin using the bytestream.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="narr-direct">Mediated Connection</a>
+</h3>
+    <p class="" style="">Mediated connection is slightly more complicated. In this situation, the StreamHost is not the Initiator but a Proxy, which means that the Initiator must discover the network address of the StreamHost before sending the initial IQ-set, must negotiate a connection with the StreamHost in the same way that the Target does, and must request that the StreamHost activate the bytestream before it can be used. The process for establishing bytestreams in this case is as follows:</p>
+    <ol start="" type="">
+      <li><p class="" style="">Initiator discovers the network address of StreamHost in-band. [optional]</p></li>
+      <li><p class="" style="">Initiator sends IQ-set to Target specifying the full JID and network address of StreamHost as well as the StreamID (SID) of the proposed bytestream.</p></li>
+      <li><p class="" style="">Target opens a TCP socket to the selected StreamHost.</p></li>
+      <li><p class="" style="">Target establishes connection via SOCKS5, with the DST.ADDR and DST.PORT parameters set to the values defined below.</p></li>
+      <li><p class="" style="">StreamHost sends acknowledgement of successful connection to Target via SOCKS5.</p></li>
+      <li><p class="" style="">Target sends IQ-result to Initiator, preserving the 'id' of the initial IQ-set.</p></li>
+      <li><p class="" style="">Initiator opens a TCP socket at the StreamHost.</p></li>
+      <li><p class="" style="">Initiator establishes connection via SOCKS5, with the DST.ADDR and DST.PORT parameters set to the values defined below.</p></li>
+      <li><p class="" style="">StreamHost sends acknowledgement of successful connection to Initiator via SOCKS5.</p></li>
+      <li><p class="" style="">Initiator sends IQ-set to StreamHost requesting that StreamHost activate the bytestream associated with the StreamID.</p></li>
+      <li><p class="" style="">StreamHost activates the bytestream. (Data is now relayed between the two SOCKS5 connections by the proxy)</p></li>
+      <li><p class="" style="">StreamHost sends IQ-result to Initiator acknowledging that the bytestream has been activated (or specifying an error).</p></li>
+      <li><p class="" style="">Initiator and Target may begin using the bytestream.</p></li>
+    </ol>
+  </div>
+<h2>4.
+       <a name="proto">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="proto-disco">Initiator Queries Target Regarding Bytestreams Support</a>
+</h3>
+    <p class="" style="">Before attempting to initiate a bytestream, the Initiator may want to know if the Target supports the bytestream protocol. It may do so using <span class="ref">Service Discovery</span>  [<a href="#nt-id2595081">2</a>] as follows:</p>
+    <p class="caption">Example 1. Initiator Sends Service Discovery Request to Target</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='get' 
+    from='initiator@host1/foo' 
+    to='target@host2/bar' 
+    id='hello'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the Target's client supports bytestreams, it MUST answer to that effect in the service discovery result.</p>
+    <p class="caption">Example 2. Target Replies to Service Discovery Request</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='result' 
+    from='target@host2/bar' 
+    to='initiator@host1/foo' 
+    id='hello'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity 
+        category='proxy'
+        type='bytestreams'
+        name='SOCKS5 Bytestreams Service'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/bytestreams'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="proto-proxies">Initiator Queries Server For Proxies</a>
+</h3>
+    <p class="" style="">Before attempting to initiate a bytestream, the Initiator needs to find a proxy. It may do so using Service Discovery as follows:</p>
+    <p class="caption">Example 3. Initiator Sends Service Discovery Request to Server</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='get' 
+    from='initiator@host1/foo'
+    to='host1' 
+    id='server_items'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server will return all of the known JIDs in its disco list.</p>
+    <p class="caption">Example 4. Server Replies to Service Discovery Request</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='result' 
+    from='host1' 
+    to='initiator@host1/foo' 
+    id='server_items'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='proxy.host3' name='Bytestreams Proxy'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="proto-proxyinfo">Initiator Queries Proxy to Find Out if it is a Proxy</a>
+</h3>
+    <p class="" style="">For each item in the disco#items result, the client must ask them if they are a bytestreams proxy.  It may do so using Service Discovery as follows:</p>
+    <p class="caption">Example 5. Initiator Sends Service Discovery Request to Proxy</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='get' 
+    from='initiator@host1/foo'
+    to='proxy.host3' 
+    id='proxy_info'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The proxy will return its information.  The client should look in each identity to see if it contains an indentity in the category &quot;proxy&quot; and type &quot;bytestreams&quot;.</p>
+    <p class="caption">Example 6. Server Replies to Service Discovery Request</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='result' 
+    from='proxy.host3' 
+    to='initiator@host1/foo' 
+    id='proxy_info'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;identity category='proxy'
+              type='bytestreams'
+              name='SOCKS5 Bytestreams Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="proto-address">Initiator Discovers Network Address of StreamHost</a>
+</h3>
+    <p class="" style="">If the StreamHost is a Proxy, the Initiator must first request the full network address used for bytestreaming (obviously this is not required if the StreamHost is the Initiator). This is done by sending an IQ-get to the proxy in the bytestreams namespace, as follows:</p>
+    <p class="caption">Example 7. Initiator Requests Network Address from Proxy</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='get' 
+    from='initiator@host1/foo' 
+    to='proxy.host3' 
+    id='discover'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/bytestreams'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;streamhost/&gt; element containing network address MUST include the following attributes:</p>
+    <ul>
+      <li>
+<span style="font-weight: bold">jid</span> = the JID of the StreamHost for communications over Jabber</li>
+    </ul>
+    <p class="" style="">In addition, the &lt;streamhost/&gt; element MUST include:</p>
+    <p class="" style="">EITHER</p>
+    <ul>
+      <li>
+<span style="font-weight: bold">host</span> = the hostname or IP address of the StreamHost for SOCKS5 communications over TCP</li>
+      <li>
+<span style="font-weight: bold">port</span> = a port associated with the hostname or IP address for
+        SOCKS5 communications over TCP</li>
+    </ul>
+    <p class="" style="">OR</p>
+    <ul>
+      <li>
+<span style="font-weight: bold">zeroconf</span> = a zeroconf identifier to which an entity may connect</li>
+    </ul>
+    <p class="" style="">If included, the zeroconf  [<a href="#nt-id2595284">3</a>] service identifier and protocol name SHOULD be &quot;_jabber.bytestreams&quot;.</p>
+    <p class="caption">Example 8. Proxy Informs Initiator of Network Address</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='result' 
+    from='proxy.host3' 
+    to='initiator@host1/foo' 
+    id='discover'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/bytestreams'&gt;
+    &lt;streamhost 
+        jid='proxy.host3' 
+        host='24.24.24.1' 
+        zeroconf='_jabber.bytestreams'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the Initiator does not have permissions to initiate bytestreams on the Proxy for whatever reason (e.g., a proxy implementation may enable administrators to ban JIDs or domains from using the Proxy), the Proxy MUST return a &quot;Forbidden&quot; error to the Initiator (for information about error syntax, refer to <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2595431">4</a>]):</p>
+    <p class="caption">Example 9. Proxy Returns Error to Initiator</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='initiator@host1/foo' 
+    to='proxy.host3' 
+    id='discover'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/bytestreams'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the Proxy is unable to act as a StreamHost, the Proxy SHOULD return a &quot;Not Allowed&quot; error to the Initiator:</p>
+    <p class="caption">Example 10. Proxy Returns Error to Initiator</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='initiator@host1/foo' 
+    to='proxy.host3' 
+    id='discover'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/bytestreams'/&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="proto-inform">Initiator Informs Target of StreamHosts</a>
+</h3>
+    <p class="" style="">In order to establish a bytestream between the Initiator and the Target, the Initiator must provide network address information for the StreamHost(s) to the Target. This happens in-band via a single IQ-set, which must contain the following information:</p>
+    <ul>
+      <li>The network address of at least one StreamHost to which the Target may attempt to connect</li>
+      <li>The Stream ID for this connection</li>
+    </ul>
+    <p class="" style="">The protocol format is shown below.</p>  
+    <p class="caption">Example 11. Initiation of Interaction</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='set' 
+    from='initiator@host1/foo' 
+    to='target@host2/bar' 
+    id='initiate'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/bytestreams' sid='mySID'&gt;
+    &lt;streamhost 
+        jid='initiator@host1/foo' 
+        host='192.168.4.1' 
+        port='5086'/&gt;
+    &lt;streamhost 
+        jid='proxy.host3' 
+        host='24.24.24.1' 
+        zeroconf='_jabber.bytestreams'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the Target is unwilling to accept the bytestream, it MUST return a &quot;Not Acceptable&quot; error to the Initiator.</p>
+    <p class="caption">Example 12. Target Refuses Bytestream</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='target@host2/bar' 
+    to='initiator@host1/foo' 
+    id='initiate'&gt;
+  &lt;error code='406' type='auth'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="proto-establish">Target Establishes SOCKS5 Connection with StreamHost</a>
+</h3>
+    <p class="" style="">If the Target is willing to accept the bytestream, it MUST attempt to open a standard TCP socket on the network address of the StreamHost communicated by the Initiator. If the Initiator provides more than one StreamHost, the Target SHOULD try to connect to them in the order they occur.</p>
+    <p class="" style="">If the Target tries but is unable to connect to any of the StreamHosts and it does not wish to attempt a connection from its side, it MUST return a &quot;Not Found&quot; error to the Initiator.</p>
+    <p class="caption">Example 13. Target Is Unable to Connect to Any StreamHost and Wishes to End Transaction</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='target@host2/bar' 
+    to='initiator@host1/foo' 
+    id='initiate'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the Target is able to open a TCP socket on a StreamHost, it MUST utilize the SOCKS5 protocol specified in <span class="ref">RFC 1928</span>  [<a href="#nt-id2595635">5</a>] to establish the connection with the StreamHost. In accordance with the SOCKS5 RFC, the Target MAY have to authenticate in order to use the proxy. However, any authentication required is beyond the scope of this JEP. Once the Target has successfully authenticated with the Proxy (even anonymously), it SHOULD make a CONNECT request to a host named: SHA1(SID + Initiator JID + Target JID), port 0, where the SHA1 hashing algorithm is specified by <span class="ref">RFC 3174</span>  [<a href="#nt-id2595566">6</a>]. The JIDs provided MUST be full JIDs (i.e., &lt;user@host/resource&gt;); furthermore, in order to ensure proper results, the appropriate stringprep profiles (as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2595594">7</a>]) MUST be applied to the JIDs before application of the SHA1 hashing algorithm.</p>
+    <p class="caption">Example 14. Target Connects to StreamHost</p>
+<div class="indent"><pre>
+CMD = X'01'
+ATYP = X'03'
+DST.ADDR = SHA1 Hash of: (SID + Initiator JID + Target JID)
+DST.PORT = 0
+    </pre></div>
+    <p class="caption">Example 15. StreamHost Acknowledges Connection</p>
+<div class="indent"><pre>
+STATUS = X'00'
+    </pre></div>
+
+  </div>
+
+  <div class="indent">
+<h3>4.7 <a name="proto-ack">Target Acknowledges SOCKS5 Connection</a>
+</h3>
+    <p class="" style="">After the Target has authenticated with the StreamHost, it MUST send an IQ-result to the Inititator indicating which StreamHost was used.</p>
+    <p class="caption">Example 16. Target Notifies Initiator of Connection</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='result' 
+    from='target@host2/bar' 
+    to='initiator@host1/foo' 
+    id='initiate'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/bytestreams'&gt;
+    &lt;streamhost-used jid='proxy.host3'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">At this point, the Initiator knows which StreamHost was used by
+      the Target.</p>
+  </div>
+
+  <div class="indent">
+<h3>4.8 <a name="proto-initiator">Initiator Establishes SOCKS5 Connection with StreamHost</a>
+</h3>
+    <p class="" style="">If the StreamHost used is a Proxy, the Initiator MUST
+    authenticate and establish a connection with the StreamHost before
+    requesting that the StreamHost activate bytestream. The Initiator
+    will establish a connection to the SOCKS5 proxy in the same way
+    the Target did, passing the same value for the CONNECT request.
+    </p>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="proto-activation">Activation of Bytestream</a>
+</h3>
+    <p class="" style="">In order for the bytestream to be used, it MUST first be
+    activated by the StreamHost. If the StreamHost is the Initiator,
+    this is straightforward and does not require any in-band
+    protocol. However, if the StreamHost is a Proxy, the Initiator
+    MUST send an in-band request to the StreamHost. This is done by
+    sending an IQ-set to the Proxy.</p>
+    <p class="caption">Example 17. Initiator Requests Activation of Bytestream</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='set' 
+    from='initiator@host1/foo' 
+    to='proxy.host3' 
+    id='activate'&gt;
+  &lt;query xmlns='http://.jabber.org/protocol/bytestreams' sid='mySID'&gt;
+    &lt;activate&gt;target@host2/bar&lt;/activate&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note that the &lt;activate&gt; element encapsulates the Target's full JID. Using this information, with the SID and from address on the packet, the Proxy can activate the stream  by hashing the SID + Initiator JID + Target JID. This provides a reasonable level of trust that the activation request came from the Initiator.</p>
+    <p class="" style="">If the Proxy can fulfill the request, it MUST then respond to the Initiator with an IQ-result.</p>
+    <p class="caption">Example 18. Proxy Informs Initiator of Activation</p>
+<div class="indent"><pre>
+&lt;iq 
+    type='result' 
+    from='proxy.host3' 
+    to='initiator@host1/foo' 
+    id='activate'/&gt;
+    </pre></div>
+    <p class="" style="">The Proxy MUST then send acknowledgement of the connection to the Target.</p>
+    <p class="caption">Example 19. StreamHost Acknowledges Connection to Target</p>
+<div class="indent"><pre>
+STATUS = X'00'
+    </pre></div>
+    <p class="" style="">If the Proxy cannot fulfill the request, it MUST return an IQ-error to the Initiator; the following conditions are defined:</p>
+    <ul>
+      <li>&quot;Not Found&quot; error if the from address does not match that of the Initiator's full JID</li>
+      <li>&quot;Not Allowed&quot; error if only one party (either Initiator or Recipient, but not both) is connected to the Proxy</li>
+      <li>&quot;Internal Server Error&quot; error if the proxy cannot activate the bytestream because of some internal malfunction</li>
+    </ul>
+  </div>
+<h2>5.
+       <a name="usecase">Formal Use Case</a>
+</h2>
+  <p class="" style="">This is a formal representation of the narrative information provided above. The primary actor is the Initiator and the goal is to establish a bytestream between the Initiator and the Target. (Note: &quot;UCE&quot; stands for &quot;Use Case Ends&quot; (success is assumed unless otherwise specified) and &quot;P&quot; stands for &quot;Primary Flow&quot;, and &quot;A&quot; stands for &quot;Alternate Flow&quot;.)</p>
+  <div class="indent">
+<h3>5.1 <a name="usecase-primary">Primary Flow</a>
+</h3>
+    <ol start="" type="">
+      <li>Initiator wishes to establish a bytestream with Target</li>
+      <li>Initiator sends an IQ-set to Target specifying a StreamID and the network addresses of one or more StreamHosts [A1]</li>
+      <li>Target wishes to establish a bytestream with Initiator [A2]</li>
+      <li>Target requests TCP connection with a StreamHost [A3]</li>
+      <li>Target receives TCP acknowledgement from StreamHost [A4]</li>
+      <li>Target provides authentication credentials to StreamHost via SOCKS5</li>
+      <li>Target receives acknowledgement of authentication with StreamHost via SOCKS5 [A5]</li>
+      <li>Target requests connection with StreamHost via SOCKS5</li>
+      <li>Target sends IQ-result to Initiator announcing successful connection to StreamHost [A6]</li>
+      <li>Target receives acknowledgement of successful connection with StreamHost via SOCKS5 [A7]</li>
+      <li>Use Case Ends (bytestream is established and ready for use)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="usecase-alternate">Alternate Flows</a>
+</h3>
+
+    <p class="" style="">
+<span style="font-weight: bold">A1.</span> Initiator does not know the full network address of a StreamHost (i.e., Proxy)</p>
+    <ol start="" type="">
+      <li>Initiator sends IQ-get to Proxy</li>
+      <li>Initiator receives IQ-result from Proxy containing network address [A9][A10]</li>
+      <li>Return to P2</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A2.</span> Target does not wish to establish a bytestream with Initiator</p>
+    <ol start="" type="">
+      <li>Initiator receives &quot;Not Acceptable&quot; error from Target</li>
+      <li>UCE unsuccessfully</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A3.</span> No more StreamHosts in list (Target is unable to reach any of the provided StreamHosts)</p>
+    <ol start="" type="">
+      <li>Target returns &quot;Remote Server Error&quot; error to Initiator</li>
+      <li>UCE unsuccessfully</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A4.</span> Target cannot reach StreamHost</p>
+    <ol start="" type="">
+      <li>Return to P4</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A5.</span> Target authentication with StreamHost fails</p>
+    <ol start="" type="">
+      <li>Return to P4</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A6.</span> Proxy is unwilling to act as a StreamHost for Initiator</p>
+    <ol start="" type="">
+      <li>Initiator receives &quot;Forbidden&quot; error from Proxy</li>
+      <li>Return to P2</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A7.</span> Proxy is unable to act as a StreamHost for Initiator</p>
+    <ol start="" type="">
+      <li>Initiator receives &quot;Not Allowed&quot; error from Proxy</li>
+      <li>Return to P2</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A8.</span> Target connects to a Proxy</p>
+    <ol start="" type="">
+      <li>Initiator reaches Proxy [A9]</li>
+      <li>Target receives TCP acknowledgement from StreamHost [A9]</li>
+      <li>Initiator authenticates with Proxy via SOCKS5</li>
+      <li>Initiator receives acknowledgement of authentication with Proxy via SOCKS5 [A10]</li>
+      <li>Initiator requests connection with Proxy via SOCKS5</li>
+      <li>Initiator receives acknowledgement of successful connection with Proxy via SOCKS5 [A11]</li>
+      <li>Initiator sends IQ-set to Proxy requesting activation of bytestream</li>
+      <li>Initiator receives IQ-result from Proxy acknowledging activation of bytestream [A12]</li>
+      <li>Return to P9</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A9.</span> Initiator is unable to reach Proxy</p>
+    <ol start="" type="">
+      <li>UCE unsuccessfully</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A10.</span> Initiator is unable to authenticate with Proxy</p>
+    <ol start="" type="">
+      <li>UCE unsuccessfully</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A11.</span> Initiator is unable to connect to Proxy</p>
+    <ol start="" type="">
+      <li>UCE unsuccessfully</li>
+    </ol>
+
+    <p class="" style="">
+<span style="font-weight: bold">A12.</span> Proxy is unable to activate bytestream</p>
+    <ol start="" type="">
+      <li>Initiator receives &quot;Internal Server Error&quot; error from Proxy</li>
+      <li>UCE unsuccessfully</li>
+    </ol>
+
+  </div>
+<h2>6.
+       <a name="desc">Formal Description</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="desc-query">&lt;query/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;query/&gt; element is the container for all in-band communications. This element MUST be in the namespace &quot;http://jabber.org/protocol/bytestreams&quot;. This element has a single attribute for the stream session identifier, and contains multiple &lt;streamhost/&gt; elements, a single &lt;streamhost-used/&gt; element, or a single &lt;activate/&gt; element.</p>
+    <p class="" style="">The &quot;sid&quot; specifies the bytestream session identifier. This attribute MUST be present. The value of this attribute is any character data.</p>
+    <p class="" style="">The &lt;streamhost/&gt; element conveys the network connection information. At least one instance MUST be present in the initial IQ-set from the Initiator to the Target. If multiple instances of this element are present, each one MUST be a separate host/port combination.</p>
+    <p class="" style="">The &lt;streamhost-used/&gt; element transports the out-of-band token. It MUST be present in the IQ-set from the Target to the Initiator, and there MUST be only one instance.</p>
+    <p class="" style="">The &lt;activate/&gt; element is used to request activation of a unidirectional or bidirectional bytestream. It MUST be present in the IQ-set sent from the Initiator to the StreamHost after the Initiator receives an IQ-result from the Target, and there MUST be only one instance.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="desc-streamhost">&lt;streamhost/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;streamhost/&gt; element contains the bytestream connection information. This element has attributes for the StreamHost's JID, network host/address, and network port. This element MUST NOT contain any content nodes.</p>
+    <p class="" style="">The &quot;jid&quot; attribute specifies the StreamHost's JID. This attribute MUST be present, and MUST be a valid JID for use with an &lt;iq/&gt;.</p>
+    <p class="" style="">The &quot;host&quot; attribute specifies the host to connect to. This attribute MUST be present. The value MUST be either a resolvable domain name or the &quot;dotted decimal&quot; IP address (e.g. &quot;1.2.3.4&quot;).</p>
+    <p class="" style="">The &quot;port&quot; attribute specifies the port to connect to. This attribute MAY be present. The value MUST be a valid port number in decimal form.</p>
+    <p class="" style="">The &quot;zeroconf&quot; attribute specifies the zero-configuration service available for bytestreaming. This attribute SHOULD be present. The value SHOULD be '_jabber.bytestreams'.</p>
+    <p class="" style="">When communicating the available hosts, the Initiator MUST include EITHER the host and port OR the zeroconf information.</p>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="desc-streamhost-used">&lt;streamhost-used/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;streamhost-used/&gt; element indicates the StreamHost connected to. This element has a single attribute for the JID of the StreamHost to which the Target connected. This element MUST NOT contain any content node.</p>
+    <p class="" style="">The &quot;jid&quot; attribute specifies the full JID of the StreamHost. This attribute MUST be present, and MUST be a valid JID for use with an &lt;iq/&gt;.</p>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="desc-activate">&lt;activate/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;activate/&gt; element is a flag to trigger a Proxy to complete a connection.</p> 
+  </div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-streamhost">StreamHost Requirements</a>
+</h3>
+    <p class="" style="">A StreamHost SHOULD (but is not required to) do the following:</p>
+    <ol start="" type="">
+      <li>Allow bi-directional bytestreaming between the Initiator and Target.</li>
+      <li>Allow only one Target to connect to a bytestream (i.e., disallow multicasting).</li>
+      <li>Track sessions based on a combination of the StreamID and the Initiator's full JID, thus allowing an Initiator to create more than one simultaneous session.</li>
+      <li>Ignore but not drop any bytes sent before the bytestream is activated.</li>
+      <li>Prefer to use zero-configuration IP networking if supported.</li>
+    </ol>
+    <p class="" style="">In addition, a StreamHost MAY ignore the DST.ADDR and DST.PORT parameters if desired.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="impl-socks5">SOCKS5 Parameter Mapping</a>
+</h3>
+    <p class="" style="">To facilitate the usage of SOCKS5, command parameters MUST be mapped to the appropriate values. Parameters not specified in the table below SHOULD be used as defined in RFC 1928.</p>
+    <p class="caption">Table 2: Request/Parameter Mapping</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Parameter</th>
+<th colspan="" rowspan="">Value</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">CMD</td>
+<td align="" colspan="" rowspan="">1 (CONNECT)</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">ATYP</td>
+<td align="" colspan="" rowspan="">1 (IP V4), 3 (DOMAINNAME), or 4 (IP V6)</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">DST.ADDR</td>
+<td align="" colspan="" rowspan="">SHA1 Hash of: (SID + Initiator JID + Target JID)</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">DST.PORT</td>
+<td align="" colspan="" rowspan="">0</td>
+</tr>
+    </table>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This proposal does not include a method for securing or encrypting SOCKS5 bytetreams. If such security is desired, it MUST be negotiated over the bytestream (once established) using standard protocols such as SSL or TLS. Negotiation of such security methods is outside the scope of this JEP.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2596959">8</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The 'http://jabber.org/protocol/bytestreams' namespace is registered in the protocol namespaces registry maintained by the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2596909">9</a>].</p> 
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall add the &quot;proxy&quot; category and associated &quot;bytestreams&quot; type to the Service Discovery registry. The submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+  &lt;category&gt;
+    &lt;name&gt;proxy&lt;/name&gt;
+    &lt;desc&gt;Proxy servers or services&lt;/desc&gt;
+    &lt;type&gt;
+      &lt;name&gt;bytestreams&lt;/name&gt;
+      &lt;desc&gt;A proxy for SOCKS5 bytestreams&lt;/desc&gt;
+      &lt;doc&gt;JEP-0065&lt;/doc&gt;
+    &lt;/type&gt;
+  &lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/bytestreams'
+    xmlns='http://jabber.org/protocol/bytestreams'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0065: http://www.jabber.org/jeps/jep-0065.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='streamhost' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='streamhost-used' minOccurs='0'/&gt;
+        &lt;xs:element name='activate' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='streamhost'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='host' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='srvid' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='port' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='streamhost-used' type='xs:string'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2594590">1</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595081">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595284">3</a>. Zeroconf is a set of protocols that enable IP networking without the need for configuration. For further information, refer to &lt;<a href="http://www.zeroconf.org/">http://www.zeroconf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2595431">4</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595635">5</a>. RFC 1928: SOCKS Protocol Version 5 &lt;<a href="http://www.ietf.org/rfc/rfc1928.txt">http://www.ietf.org/rfc/rfc1928.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595566">6</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595594">7</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596959">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596909">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.5 (2004-06-29)</h4>
+<div class="indent">Added requirement to apply stringprep profiles before SHA1 hashing; added reference to RFC 3174. (psa)
+    </div>
+<h4>Version 1.4 (2004-06-28)</h4>
+<div class="indent">Cleaned up narratives to reflect current practices and removed unnecessary authentication references; fixed mismatch SOCKS5 parameter table values. (ds)
+    </div>
+<h4>Version 1.3 (2003-09-24)</h4>
+<div class="indent">Added disco#info &lt;identity/&gt; and corresponding Jabber Registrar submission; added XMPP error handling. (psa)
+    </div>
+<h4>Version 1.2 (2003-07-15)</h4>
+<div class="indent">Removed SIDs from the result queries, you should key off the IQ 'id' attribute instead. Added the disco exchange for finding available proxies. (rwe)
+    </div>
+<h4>Version 1.1 (2003-07-09)</h4>
+<div class="indent">Changed srvid to zeroconf; cleaned up use cases; updated the schema. (ds)
+    </div>
+<h4>Version 1.0 (2003-04-21)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.7 (2003-03-04)</h4>
+<div class="indent">Clarified that this proposal uses an adaptation of the SOCKS5 protocol, not the full protocol; replaced DTD with schema; added security considerations. (psa)
+    </div>
+<h4>Version 0.6 (2003-01-27)</h4>
+<div class="indent">Added service discovery example; added 'srvid' attribute to streamhost element and required inclusion of either 'srvid' or 'port' attribute; improved the algorithms for generating SOCKS5 UNAME and PASSWD parameters; specified that the DST.ADDR and DST.PORT parameters may be ignored; removed references to connected/disconnected notification, bidirectional bytestreams, and multiple targets; updated implementation notes. (psa/ds)
+    </div>
+<h4>Version 0.5 (2002-12-20)</h4>
+<div class="indent">Specified option of &quot;reversing the connection&quot; (Target becomes Initiator); added more error cases; resurrected and cleaned up formal use case. (psa)
+    </div>
+<h4>Version 0.4 (2002-12-19)</h4>
+<div class="indent">Added section on connected/disconnected notifications sent from Proxy to Initiator; cleaned up several examples; specified more error conditions; clarified the formal descriptions; added implementation notes and future considerations. (psa, mm)
+    </div>
+<h4>Version 0.3 (2002-12-17)</h4>
+<div class="indent">Added lots of detail to the narrative and protocol. (psa)
+    </div>
+<h4>Version 0.2 (2002-12-16)</h4>
+<div class="indent">Added SOCKS info. (ds)
+    </div>
+<h4>Version 0.1 (2002-12-13)</h4>
+<div class="indent">Initial version. (ds)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0066-1.2.html
+++ b/content/xep-0066-1.2.html
@@ -1,0 +1,378 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0066: Out of Band Data</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Out of Band Data">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides canonical documentation of the 'jabber:iq:oob' and 'jabber:x:oob' namespaces currently in use within the Jabber community.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0066">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0066: Out of Band Data</h1>
+<p>This JEP provides canonical documentation of the 'jabber:iq:oob' and 'jabber:x:oob' namespaces currently in use within the Jabber community.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in wide use within the Jabber community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; therefore it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0066<br>
+            Version: 1.3<br>
+            Last Updated: 2004-10-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: oob<br>
+        Schema for jabber:iq:oob: &lt;<a href="http://jabber.org/protocol/oob/iq-oob.xsd">http://jabber.org/protocol/oob/iq-oob.xsd</a>&gt;<br>
+        Schema for jabber:x:oob: &lt;<a href="http://jabber.org/protocol/oob/x-oob.xsd">http://jabber.org/protocol/oob/x-oob.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#iq-oob">jabber:iq:oob</a>
+</dt>
+<dt>3.  <a href="#x-oob">jabber:x:oob</a>
+</dt>
+<dt>4.  <a href="#nonhttp">Use With Non-HTTP URI Schemes</a>
+</dt>
+<dt>5.  <a href="#si">Integration With Stream Initiation</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>9.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schemas-iq">jabber:iq:oob</a>
+</dt>
+<dt>9.2.  <a href="#schemas-x">jabber:x:oob</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP documents the original mechanisms for out-of-band (OOB) data transfer as codified in the 'jabber:iq:oob' and 'jabber:x:oob' namespaces. This JEP is informational only and does not purport to recommend a Jabber standard.</p>
+<h2>2.
+       <a name="iq-oob">jabber:iq:oob</a>
+</h2>
+  <p class="" style="">The intent of the 'jabber:iq:oob' was to provide a &quot;least common denominator&quot; mechanism for basic file transfers in the early days of the Jabber open-source projects. The more advanced mechanisms defined in <span class="ref">File Transfer</span>  [<a href="#nt-id2596237">1</a>] SHOULD be used, although the 'jabber:iq:oob' namespace can be included as one option during the file transfer negotiation since many older clients do not yet support other file transfer options such as those defined in <span class="ref">SOCKS5 Bytestreams</span>  [<a href="#nt-id2596242">2</a>] and <span class="ref">In-Band Bytestreams</span>  [<a href="#nt-id2596167">3</a>].</p>
+  <p class="" style="">To initiate an out-of-band file transfer with an intended recipient using the 'jabber:iq:oob' namespace (whether or not negotiated via JEP-0096), the sending application sends an &lt;iq/&gt; of type 'set' to the recipient containing a &lt;query/&gt; child element qualified by the 'jabber:iq:oob' namespace; the &lt;query/&gt; MUST in turn contain a &lt;url/&gt; child specifying the URL of the file to be transferred, and MAY contain an optional &lt;desc/&gt; child describing the file. This usage is shown in the following example.</p>
+    <p class="caption">Example 1. Sender Initiates Request-Response</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='MaineBoy@jabber.org/home'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The expected result is for the recipient to retrieve the file via an HTTP GET request and to then inform the sender of successful receipt of the file. The receiving application MUST NOT send the IQ result until it has retrieved the complete file (e.g., it MUST NOT send the IQ result if it has merely attempted to retrieve the file or the URL provided seems to be valid):</p>
+    <p class="caption">Example 2. Recipient Informs Sender of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'/&gt;
+    </pre></div>
+    <p class="" style="">If the recipient attempts to retrieve the file but is unable to do so, the receiving application MUST return an &lt;iq/&gt; of type 'error' to the sender specifying a Not Found condition:</p>
+    <p class="caption">Example 3. Recipient Informs Sender of Failure</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the recipient rejects the request outright, the receiving application MUST return an &lt;iq/&gt; of type 'error' to the sender specifying a Not Acceptable condition:</p>
+    <p class="caption">Example 4. Recipient Rejects Request</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>3.
+       <a name="x-oob">jabber:x:oob</a>
+</h2>
+  <p class="" style="">The 'jabber:x:oob' namespace was not intended for use in file transfers, since the lack of a request-response semantic prevents the recipient from programatically confirming receipt of the file or communicating errors (if these features are needed, an application should use the 'jabber:iq:oob' namespace and/or the stream initiation profile defined in JEP-0096). However, the 'jabber:x:oob' namespace is useful for communicating a URL to other users or applications. This is done by including an &lt;x/&gt; child element qualified by the 'jabber:x:oob' namespace in either a &lt;message/&gt; and &lt;presence/&gt; stanza; the &lt;x/&gt; child MUST contain a &lt;url/&gt; child specifying the URL of the resource, and MAY contain an optional &lt;desc/&gt; child describing the resource.</p>
+    <p class="caption">Example 5. Sender Communicates a URI</p>
+<div class="indent"><pre>
+&lt;message from='stpeter@jabber.org/work'
+         to='MaineBoy@jabber.org/home'&gt;
+  &lt;body&gt;Yeah, but do you have a license to Jabber?&lt;/body&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Another creative usage of the 'jabber:x:oob' namespace is including a URI when logging off (perhaps pointing to a weblog entry):</p>
+    <p class="caption">Example 6. Including a URI with Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'&gt;
+  &lt;status&gt;
+    &lt;x xmlns='jabber:x:oob'&gt;
+      &lt;url&gt;http://www.saint-andre.com/blog/2002-06.html#2002-06-30T22:46&lt;/url&gt;
+    &lt;/x&gt;
+  &lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+<h2>4.
+       <a name="nonhttp">Use With Non-HTTP URI Schemes</a>
+</h2>
+  <p class="" style="">The value of the &lt;url/&gt; element is not limited to URIs that conform to the http: URI scheme (as specified by <span class="ref">RFC 2616</span>  [<a href="#nt-id2601986">4</a>]). For example, file transfers could also be effected using ftp: URIs as (specified by <span class="ref">RFC 959</span>  [<a href="#nt-id2601919">5</a>]). Going further afield, several existing Jabber clients use the callto: URI scheme to initiate voice conferencing via NetMeeting or GnomeMeeting. Other out-of-band communications could be initiated in a similar way via URI schemes such as sip: (as specified by <span class="ref">RFC 3261</span>  [<a href="#nt-id2601942">6</a>]). All of these usages are allowed by the existing OOB namespaces, as long as the value of the &lt;url/&gt; element is a valid URI (as specified by <span class="ref">RFC 2396</span>  [<a href="#nt-id2601966">7</a>]).</p>
+<h2>5.
+       <a name="si">Integration With Stream Initiation</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p>
+  <p class="" style="">
+<span class="ref">Stream Initiation</span>  [<a href="#nt-id2602106">8</a>] defines methods for negotiating content streams between any two entities, and JEP-0096 defines a profile of stream initiation for file transfer. Although the use of jabber:iq:oob is not recommended by JEP-0096, it could be offered as one option (e.g., a fallback if SOCKS5 Bytestreams and In-Band Bytestreams are not available). If so, the value of the feature negotiation option MUST be &quot;jabber:iq:oob&quot; and the &lt;query/&gt; element within the &lt;iq/&gt; stanza qualified by the 'jabber:iq:oob' namespace MUST possess a 'sid' attribute whose value is the StreamID negotiated by stream initiation.</p>
+  <p class="" style="">A sample protocol flow is shown below.</p>
+  <p class="caption">Example 7. Stream Initiation Offer</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' 
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/chamber'
+    id='offer1'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='test.txt'
+          size='1022'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;jabber:iq:oob&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+    
+  </pre></div>
+  <p class="caption">Example 8. Stream Initiation Result</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' 
+    from='juliet@capulet.com/chamber'&gt;
+    to='romeo@montague.net/orchard'
+    id='offer1'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si'
+      id='a0'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='stream-method'&gt;
+          &lt;value&gt;jabber:iq:oob&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+    
+  </pre></div>
+  <p class="caption">Example 9. Sender Initiates Request-Response</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/chamber'&gt;
+    id='send1'&gt;
+  &lt;query xmlns='jabber:iq:oob'
+         sid='a0'&gt;
+    &lt;url&gt;http://www.shakespeare.lit/files/letter.txt&lt;/url&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 10. Recipient Informs Sender of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com/chamber'&gt;
+    to='romeo@montague.net/orchard'
+    id='send1'/&gt;
+  </pre></div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">As with any mechanism that communicates a URI, care must be taken by the receiving application to ensure that the resource retrieved does not contain harmful or malicious data (e.g., a virus-infected file).</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602258">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'jabber:iq:oob' and 'jabber:x:oob' namespaces are included in the protocol namespaces registry maintained by the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602201">10</a>].</p>
+<h2>9.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schemas-iq">jabber:iq:oob</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:oob'
+    xmlns='jabber:iq:oob'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0066: http://www.jabber.org/jeps/jep-0066.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='url' type='xs:string' minOccurs='1'/&gt;
+        &lt;xs:element name='desc' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schemas-x">jabber:x:oob</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:x:oob'
+    xmlns='jabber:x:oob'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0066: http://www.jabber.org/jeps/jep-0066.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='url' type='xs:string' minOccurs='1'/&gt;
+        &lt;xs:element name='desc' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596237">1</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596242">2</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596167">3</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601986">4</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601919">5</a>. RFC 959: File Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0959.txt">http://www.ietf.org/rfc/rfc0959.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601942">6</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601966">7</a>. RFC 2396: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc2396.txt">http://www.ietf.org/rfc/rfc2396.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602106">8</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602258">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602201">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.3 (2004-10-12)</h4>
+<div class="indent">Added section on integration with stream initiation (JEP-0095); added sid attribute to jabber:iq:oob schema. (psa)
+    </div>
+<h4>Version 1.2 (2004-04-13)</h4>
+<div class="indent">Clarified that IQ use is for basic file transfer whereas message and presence use is for communication of URIs; added presence example; added references to file transfer JEPs as well as related open issue. (psa)
+    </div>
+<h4>Version 1.1 (2004-02-10)</h4>
+<div class="indent">Editorial adjustments and clarifications; added references to relevant RFCs. (psa)
+    </div>
+<h4>Version 1.0 (2003-10-08)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Active. (psa)
+    </div>
+<h4>Version 0.3 (2003-06-22)</h4>
+<div class="indent">Made several small editorial changes; added XML schemas. (psa)
+    </div>
+<h4>Version 0.2 (2003-01-08)</h4>
+<div class="indent">Added information about non-HTTP URIs. (psa)
+    </div>
+<h4>Version 0.1 (2002-12-16)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0066-1.3.html
+++ b/content/xep-0066-1.3.html
@@ -1,0 +1,372 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0066: Out of Band Data</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Out of Band Data">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides canonical documentation of the jabber:iq:oob and jabber:x:oob namespaces currently in use within the Jabber community.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0066">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0066: Out of Band Data</h1>
+<p>This JEP provides canonical documentation of the jabber:iq:oob and jabber:x:oob namespaces currently in use within the Jabber community.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in use within the Jabber/XMPP community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; however, it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0066<br>
+            Version: 1.3<br>
+            Last Updated: 2004-10-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: oob<br>
+        Schema for jabber:iq:oob: &lt;<a href="http://jabber.org/protocol/oob/iq-oob.xsd">http://jabber.org/protocol/oob/iq-oob.xsd</a>&gt;<br>
+        Schema for jabber:x:oob: &lt;<a href="http://jabber.org/protocol/oob/x-oob.xsd">http://jabber.org/protocol/oob/x-oob.xsd</a>&gt;<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Out%20of%20Band%20Data%20(JEP-0066)">http://wiki.jabber.org/index.php/Out of Band Data (JEP-0066)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#iq-oob">jabber:iq:oob</a>
+</dt>
+<dt>3.  <a href="#x-oob">jabber:x:oob</a>
+</dt>
+<dt>4.  <a href="#nonhttp">Use With Non-HTTP URI Schemes</a>
+</dt>
+<dt>5.  <a href="#si">Integration With Stream Initiation</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>9.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schemas-iq">jabber:iq:oob</a>
+</dt>
+<dt>9.2.  <a href="#schemas-x">jabber:x:oob</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP documents the original mechanisms for out-of-band (OOB) data transfer as codified in the 'jabber:iq:oob' and 'jabber:x:oob' namespaces. This JEP is informational only and does not purport to recommend a Jabber standard.</p>
+<h2>2.
+       <a name="iq-oob">jabber:iq:oob</a>
+</h2>
+  <p class="" style="">The intent of the 'jabber:iq:oob' was to provide a "least common denominator" mechanism for basic file transfers in the early days of the Jabber open-source projects. The more advanced mechanisms defined in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2250543">1</a>] SHOULD be used, although the 'jabber:iq:oob' namespace can be included as one option during the file transfer negotiation since many older clients do not yet support other file transfer options such as those defined in <span class="ref" style="">SOCKS5 Bytestreams</span>  [<a href="#nt-id2250573">2</a>] and <span class="ref" style="">In-Band Bytestreams</span>  [<a href="#nt-id2250590">3</a>].</p>
+  <p class="" style="">To initiate an out-of-band file transfer with an intended recipient using the 'jabber:iq:oob' namespace (whether or not negotiated via JEP-0096), the sending application sends an &lt;iq/&gt; of type 'set' to the recipient containing a &lt;query/&gt; child element qualified by the 'jabber:iq:oob' namespace; the &lt;query/&gt; MUST in turn contain a &lt;url/&gt; child specifying the URL of the file to be transferred, and MAY contain an optional &lt;desc/&gt; child describing the file. This usage is shown in the following example.</p>
+    <p class="caption">Example 1. Sender Initiates Request-Response</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='MaineBoy@jabber.org/home'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The expected result is for the recipient to retrieve the file via an HTTP GET request and to then inform the sender of successful receipt of the file. The receiving application MUST NOT send the IQ result until it has retrieved the complete file (e.g., it MUST NOT send the IQ result if it has merely attempted to retrieve the file or the URL provided seems to be valid):</p>
+    <p class="caption">Example 2. Recipient Informs Sender of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'/&gt;
+    </pre></div>
+    <p class="" style="">If the recipient attempts to retrieve the file but is unable to do so, the receiving application MUST return an &lt;iq/&gt; of type 'error' to the sender specifying a Not Found condition:</p>
+    <p class="caption">Example 3. Recipient Informs Sender of Failure</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the recipient rejects the request outright, the receiving application MUST return an &lt;iq/&gt; of type 'error' to the sender specifying a Not Acceptable condition:</p>
+    <p class="caption">Example 4. Recipient Rejects Request</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>3.
+       <a name="x-oob">jabber:x:oob</a>
+</h2>
+  <p class="" style="">The 'jabber:x:oob' namespace was not intended for use in file transfers, since the lack of a request-response semantic prevents the recipient from programatically confirming receipt of the file or communicating errors (if these features are needed, an application should use the 'jabber:iq:oob' namespace and/or the stream initiation profile defined in JEP-0096). However, the 'jabber:x:oob' namespace is useful for communicating a URL to other users or applications. This is done by including an &lt;x/&gt; child element qualified by the 'jabber:x:oob' namespace in either a &lt;message/&gt; and &lt;presence/&gt; stanza; the &lt;x/&gt; child MUST contain a &lt;url/&gt; child specifying the URL of the resource, and MAY contain an optional &lt;desc/&gt; child describing the resource.</p>
+    <p class="caption">Example 5. Sender Communicates a URI</p>
+<div class="indent"><pre>
+&lt;message from='stpeter@jabber.org/work'
+         to='MaineBoy@jabber.org/home'&gt;
+  &lt;body&gt;Yeah, but do you have a license to Jabber?&lt;/body&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Another creative usage of the 'jabber:x:oob' namespace is including a URI when logging off (perhaps pointing to a weblog entry):</p>
+    <p class="caption">Example 6. Including a URI with Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'&gt;
+  &lt;status&gt;
+    &lt;x xmlns='jabber:x:oob'&gt;
+      &lt;url&gt;http://www.saint-andre.com/blog/2002-06.html#2002-06-30T22:46&lt;/url&gt;
+    &lt;/x&gt;
+  &lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+<h2>4.
+       <a name="nonhttp">Use With Non-HTTP URI Schemes</a>
+</h2>
+  <p class="" style="">The value of the &lt;url/&gt; element is not limited to URIs that conform to the http: URI scheme (as specified by <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250766">4</a>]). For example, file transfers could also be effected using ftp: URIs as (specified by <span class="ref" style="">RFC 959</span>  [<a href="#nt-id2256232">5</a>]). Going further afield, several existing Jabber clients use the callto: URI scheme to initiate voice conferencing via NetMeeting or GnomeMeeting. Other out-of-band communications could be initiated in a similar way via URI schemes such as sip: (as specified by <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2256263">6</a>]). All of these usages are allowed by the existing OOB namespaces, as long as the value of the &lt;url/&gt; element is a valid URI (as specified by <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256284">7</a>]).</p>
+<h2>5.
+       <a name="si">Integration With Stream Initiation</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p>
+  <p class="" style=""><span class="ref" style="">Stream Initiation</span>  [<a href="#nt-id2256325">8</a>] defines methods for negotiating content streams between any two entities, and JEP-0096 defines a profile of stream initiation for file transfer. Although the use of jabber:iq:oob is not recommended by JEP-0096, it could be offered as one option (e.g., a fallback if SOCKS5 Bytestreams and In-Band Bytestreams are not available). If so, the value of the feature negotiation option MUST be "jabber:iq:oob" and the &lt;query/&gt; element within the &lt;iq/&gt; stanza qualified by the 'jabber:iq:oob' namespace MUST possess a 'sid' attribute whose value is the StreamID negotiated by stream initiation.</p>
+  <p class="" style="">A sample protocol flow is shown below.</p>
+  <p class="caption">Example 7. Stream Initiation Offer</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' 
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/chamber'
+    id='offer1'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='test.txt'
+          size='1022'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;jabber:iq:oob&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+    
+  </pre></div>
+  <p class="caption">Example 8. Stream Initiation Result</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' 
+    from='juliet@capulet.com/chamber'&gt;
+    to='romeo@montague.net/orchard'
+    id='offer1'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si'
+      id='a0'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='stream-method'&gt;
+          &lt;value&gt;jabber:iq:oob&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+    
+  </pre></div>
+  <p class="caption">Example 9. Sender Initiates Request-Response</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/chamber'&gt;
+    id='send1'&gt;
+  &lt;query xmlns='jabber:iq:oob'
+         sid='a0'&gt;
+    &lt;url&gt;http://www.shakespeare.lit/files/letter.txt&lt;/url&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 10. Recipient Informs Sender of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com/chamber'&gt;
+    to='romeo@montague.net/orchard'
+    id='send1'/&gt;
+  </pre></div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">As with any mechanism that communicates a URI, care must be taken by the receiving application to ensure that the resource retrieved does not contain harmful or malicious data (e.g., a virus-infected file).</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256475">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'jabber:iq:oob' and 'jabber:x:oob' namespaces are included in the protocol namespaces registry maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256515">10</a>].</p>
+<h2>9.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schemas-iq">jabber:iq:oob</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:oob'
+    xmlns='jabber:iq:oob'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0066: http://www.jabber.org/jeps/jep-0066.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='url' type='xs:string' minOccurs='1'/&gt;
+        &lt;xs:element name='desc' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schemas-x">jabber:x:oob</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:x:oob'
+    xmlns='jabber:x:oob'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0066: http://www.jabber.org/jeps/jep-0066.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='url' type='xs:string' minOccurs='1'/&gt;
+        &lt;xs:element name='desc' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250543">1</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2250573">2</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p><a name="nt-id2250590">3</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p><a name="nt-id2250766">4</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2256232">5</a>. RFC 959: File Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0959.txt">http://www.ietf.org/rfc/rfc0959.txt</a>&gt;.</p>
+<p><a name="nt-id2256263">6</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256284">7</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2256325">8</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p><a name="nt-id2256475">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256515">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.3 (2004-10-18)</h4>
+<div class="indent">Added non-normative section on integration with stream initiation (JEP-0095); added optional sid attribute to jabber:iq:oob schema. (psa)
+    </div>
+<h4>Version 1.2 (2004-04-13)</h4>
+<div class="indent">Clarified that IQ use is for basic file transfer whereas message and presence use is for communication of URIs; added presence example; added references to file transfer JEPs as well as related open issue. (psa)
+    </div>
+<h4>Version 1.1 (2004-02-10)</h4>
+<div class="indent">Editorial adjustments and clarifications; added references to relevant RFCs. (psa)
+    </div>
+<h4>Version 1.0 (2003-10-08)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Active. (psa)
+    </div>
+<h4>Version 0.3 (2003-06-22)</h4>
+<div class="indent">Made several small editorial changes; added XML schemas. (psa)
+    </div>
+<h4>Version 0.2 (2003-01-08)</h4>
+<div class="indent">Added information about non-HTTP URIs. (psa)
+    </div>
+<h4>Version 0.1 (2002-12-16)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0066-1.4.html
+++ b/content/xep-0066-1.4.html
@@ -1,0 +1,364 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0066: Out of Band Data</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Out of Band Data">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides canonical documentation of the jabber:iq:oob and jabber:x:oob namespaces currently in use within the Jabber community.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0066">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0066: Out of Band Data</h1>
+<p>This JEP provides canonical documentation of the jabber:iq:oob and jabber:x:oob namespaces currently in use within the Jabber community.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in use within the Jabber/XMPP community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; however, it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0066<br>
+            Version: 1.4<br>
+            Last Updated: 2006-01-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: oob<br>
+        Schema for jabber:iq:oob: &lt;<a href="http://jabber.org/protocol/oob/iq-oob.xsd">http://jabber.org/protocol/oob/iq-oob.xsd</a>&gt;<br>
+        Schema for jabber:x:oob: &lt;<a href="http://jabber.org/protocol/oob/x-oob.xsd">http://jabber.org/protocol/oob/x-oob.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Out%20of%20Band%20Data%20(JEP-0066)">http://wiki.jabber.org/index.php/Out of Band Data (JEP-0066)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#iq-oob">jabber:iq:oob</a>
+</dt>
+<dt>3.  <a href="#x-oob">jabber:x:oob</a>
+</dt>
+<dt>4.  <a href="#nonhttp">Use With Non-HTTP URI Schemes</a>
+</dt>
+<dt>5.  <a href="#si">Integration With Stream Initiation</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>9.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schemas-iq">jabber:iq:oob</a>
+</dt>
+<dt>9.2.  <a href="#schemas-x">jabber:x:oob</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP documents the original mechanisms for out-of-band (OOB) data transfer as codified in the 'jabber:iq:oob' and 'jabber:x:oob' namespaces. This JEP is informational only and does not purport to recommend a Jabber standard.</p>
+<h2>2.
+       <a name="iq-oob">jabber:iq:oob</a>
+</h2>
+  <p class="" style="">The intent of the 'jabber:iq:oob' was to provide a "least common denominator" mechanism for basic file transfers in the early days of the Jabber open-source projects. The more advanced mechanisms defined in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2250581">1</a>] SHOULD be used, although the 'jabber:iq:oob' namespace can be included as one option during the file transfer negotiation since many older clients do not yet support other file transfer options such as those defined in <span class="ref" style="">SOCKS5 Bytestreams</span>  [<a href="#nt-id2250611">2</a>] and <span class="ref" style="">In-Band Bytestreams</span>  [<a href="#nt-id2250630">3</a>].</p>
+  <p class="" style="">To initiate an out-of-band file transfer with an intended recipient using the 'jabber:iq:oob' namespace (whether or not negotiated via JEP-0096), the sending application sends an &lt;iq/&gt; of type 'set' to the recipient containing a &lt;query/&gt; child element qualified by the 'jabber:iq:oob' namespace; the &lt;query/&gt; MUST in turn contain a &lt;url/&gt; child specifying the URL of the file to be transferred, and MAY contain an optional &lt;desc/&gt; child describing the file. This usage is shown in the following example.</p>
+    <p class="caption">Example 1. Sender Initiates Request-Response</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='MaineBoy@jabber.org/home'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The expected result is for the recipient to retrieve the file via an HTTP GET request and to then inform the sender of successful receipt of the file. The receiving application MUST NOT send the IQ result until it has retrieved the complete file (e.g., it MUST NOT send the IQ result if it has merely attempted to retrieve the file or the URL provided seems to be valid):</p>
+    <p class="caption">Example 2. Recipient Informs Sender of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'/&gt;
+    </pre></div>
+    <p class="" style="">If the recipient attempts to retrieve the file but is unable to do so, the receiving application MUST return an &lt;iq/&gt; of type 'error' to the sender specifying a Not Found condition:</p>
+    <p class="caption">Example 3. Recipient Informs Sender of Failure</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the recipient rejects the request outright, the receiving application MUST return an &lt;iq/&gt; of type 'error' to the sender specifying a Not Acceptable condition:</p>
+    <p class="caption">Example 4. Recipient Rejects Request</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='MaineBoy@jabber.org/home'
+    to='stpeter@jabber.org/work'
+    id='oob1'&gt;
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+    &lt;desc&gt;A license to Jabber!&lt;/desc&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>3.
+       <a name="x-oob">jabber:x:oob</a>
+</h2>
+  <p class="" style="">The 'jabber:x:oob' namespace was not intended for use in file transfers, since the lack of a request-response semantic prevents the recipient from programatically confirming receipt of the file or communicating errors (if these features are needed, an application should use the 'jabber:iq:oob' namespace and/or the stream initiation profile defined in JEP-0096). However, the 'jabber:x:oob' namespace is useful for communicating a URL to other users or applications. This is done by including an &lt;x/&gt; child element qualified by the 'jabber:x:oob' namespace in either a &lt;message/&gt; and &lt;presence/&gt; stanza; the &lt;x/&gt; child MUST contain a &lt;url/&gt; child specifying the URL of the resource, and MAY contain an optional &lt;desc/&gt; child describing the resource.</p>
+    <p class="caption">Example 5. Sender Communicates a URI</p>
+<div class="indent"><pre>
+&lt;message from='stpeter@jabber.org/work'
+         to='MaineBoy@jabber.org/home'&gt;
+  &lt;body&gt;Yeah, but do you have a license to Jabber?&lt;/body&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;http://www.jabber.org/images/psa-license.jpg&lt;/url&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+<h2>4.
+       <a name="nonhttp">Use With Non-HTTP URI Schemes</a>
+</h2>
+  <p class="" style="">The value of the &lt;url/&gt; element is not limited to URIs that conform to the http: URI scheme (as specified by <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250759">4</a>]). For example, file transfers could also be effected using ftp: URIs as (specified by <span class="ref" style="">RFC 959</span>  [<a href="#nt-id2256442">5</a>]). Going further afield, several existing Jabber clients use the callto: URI scheme to initiate voice conferencing via NetMeeting or GnomeMeeting. Other out-of-band communications could be initiated in a similar way via URI schemes such as sip: (as specified by <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2256465">6</a>]). All of these usages are allowed by the existing OOB namespaces, as long as the value of the &lt;url/&gt; element is a valid URI (as specified by <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256488">7</a>]).</p>
+<h2>5.
+       <a name="si">Integration With Stream Initiation</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p>
+  <p class="" style=""><span class="ref" style="">Stream Initiation</span>  [<a href="#nt-id2256528">8</a>] defines methods for negotiating content streams between any two entities, and JEP-0096 defines a profile of stream initiation for file transfer. Although the use of jabber:iq:oob is not recommended by JEP-0096, it could be offered as one option (e.g., a fallback if SOCKS5 Bytestreams and In-Band Bytestreams are not available). If so, the value of the feature negotiation option MUST be "jabber:iq:oob" and the &lt;query/&gt; element within the &lt;iq/&gt; stanza qualified by the 'jabber:iq:oob' namespace MUST possess a 'sid' attribute whose value is the StreamID negotiated by stream initiation.</p>
+  <p class="" style="">A sample protocol flow is shown below.</p>
+  <p class="caption">Example 6. Stream Initiation Offer</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' 
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/chamber'
+    id='offer1'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='test.txt'
+          size='1022'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;jabber:iq:oob&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+    
+  </pre></div>
+  <p class="caption">Example 7. Stream Initiation Result</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' 
+    from='juliet@capulet.com/chamber'&gt;
+    to='romeo@montague.net/orchard'
+    id='offer1'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si'
+      id='a0'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='stream-method'&gt;
+          &lt;value&gt;jabber:iq:oob&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+    
+  </pre></div>
+  <p class="caption">Example 8. Sender Initiates Request-Response</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/chamber'&gt;
+    id='send1'&gt;
+  &lt;query xmlns='jabber:iq:oob'
+         sid='a0'&gt;
+    &lt;url&gt;http://www.shakespeare.lit/files/letter.txt&lt;/url&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 9. Recipient Informs Sender of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com/chamber'&gt;
+    to='romeo@montague.net/orchard'
+    id='send1'/&gt;
+  </pre></div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">As with any mechanism that communicates a URI, care must be taken by the receiving application to ensure that the resource retrieved does not contain harmful or malicious data (e.g., a virus-infected file).</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256679">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'jabber:iq:oob' and 'jabber:x:oob' namespaces are included in the protocol namespaces registry maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256719">10</a>].</p>
+<h2>9.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schemas-iq">jabber:iq:oob</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:oob'
+    xmlns='jabber:iq:oob'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0066: http://www.jabber.org/jeps/jep-0066.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='url' type='xs:string' minOccurs='1'/&gt;
+        &lt;xs:element name='desc' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schemas-x">jabber:x:oob</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:x:oob'
+    xmlns='jabber:x:oob'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0066: http://www.jabber.org/jeps/jep-0066.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='url' type='xs:string' minOccurs='1'/&gt;
+        &lt;xs:element name='desc' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250581">1</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2250611">2</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p><a name="nt-id2250630">3</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p><a name="nt-id2250759">4</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2256442">5</a>. RFC 959: File Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0959.txt">http://www.ietf.org/rfc/rfc0959.txt</a>&gt;.</p>
+<p><a name="nt-id2256465">6</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256488">7</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2256528">8</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p><a name="nt-id2256679">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256719">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.4 (2006-01-11)</h4>
+<div class="indent">Removed example of including URL in presence stanza. (psa)
+    </div>
+<h4>Version 1.3 (2004-10-18)</h4>
+<div class="indent">Added non-normative section on integration with stream initiation (JEP-0095); added optional sid attribute to jabber:iq:oob schema. (psa)
+    </div>
+<h4>Version 1.2 (2004-04-13)</h4>
+<div class="indent">Clarified that IQ use is for basic file transfer whereas message and presence use is for communication of URIs; added presence example; added references to file transfer JEPs as well as related open issue. (psa)
+    </div>
+<h4>Version 1.1 (2004-02-10)</h4>
+<div class="indent">Editorial adjustments and clarifications; added references to relevant RFCs. (psa)
+    </div>
+<h4>Version 1.0 (2003-10-08)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Active. (psa)
+    </div>
+<h4>Version 0.3 (2003-06-22)</h4>
+<div class="indent">Made several small editorial changes; added XML schemas. (psa)
+    </div>
+<h4>Version 0.2 (2003-01-08)</h4>
+<div class="indent">Added information about non-HTTP URIs. (psa)
+    </div>
+<h4>Version 0.1 (2002-12-16)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0070-0.10.html
+++ b/content/xep-0070-0.10.html
@@ -1,0 +1,523 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0070: Verifying HTTP Requests via XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Verifying HTTP Requests via XMPP">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a protocol that enables verification of an HTTP request via XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0070">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0070: Verifying HTTP Requests via XMPP</h1>
+<p>This document defines a protocol that enables verification of an HTTP request via XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0070<br>
+            Version: 0.10<br>
+            Last Updated: 2005-12-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2616, RFC 2617, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: http-auth<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Verifying%20HTTP%20Requests%20via%20XMPP%20(JEP-0070)">http://wiki.jabber.org/index.php/Verifying HTTP Requests via XMPP (JEP-0070)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt>
+<dt>2.2.  <a href="#terms-entities">Entities</a>
+</dt>
+</dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecase">Use Case</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#http-request">HTTP Client Sends Request via HTTP</a>
+</dt>
+<dt>4.2.  <a href="#http-response">HTTP Server Returns Authenticate Response via HTTP</a>
+</dt>
+<dt>4.3.  <a href="#http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#http-authz-basic">Basic Access Authentication Scheme</a>
+</dt>
+<dt>4.3.2.  <a href="#http-authz-digest">Digest Access Authentication Scheme</a>
+</dt>
+<dt>4.3.3.  <a href="#http-authz-add">Additional Authentication Schemes</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#http-process">HTPP Server Processes Request</a>
+</dt>
+<dt>4.5.  <a href="#xmpp-request">XMPP Server Requests Confirmation via XMPP</a>
+</dt>
+<dt>4.6.  <a href="#xmpp-confirm">XMPP Client Confirms Request via XMPP</a>
+</dt>
+<dt>4.7.  <a href="#http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>5.1.  <a href="#impl-methods">Interaction of HTTP methods</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#security-association">Association of Request</a>
+</dt>
+<dt>6.2.  <a href="#security-channel">Channel Encryption</a>
+</dt>
+<dt>6.3.  <a href="#security-e2e">End-to-End Encryption</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">HTTP (see <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250966">1</a>]) is a nearly-ubiquitous mechanism for the publication and retrieval of information over the Internet. Sometimes it is appropriate for an HTTP Server to allow access to that information only if the HTTP Client first provides authentication credentials. While there exist several standardized HTTP authentication schemes (see <span class="ref" style="">RFC 2617</span>  [<a href="#nt-id2250797">2</a>]), it may be useful in some applications to enforce verification of an HTTP request by requiring an XMPP entity (normally an IM user) to confirm that it made the request. This request verification can be combined with native HTTP authentication to provide a stronger association between the request and a particular user, as well as to take advantage of the strong user authentication provided in XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250834">3</a>]).</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+    <p class="" style="">This document inherits terminology about the HyperText Transfer Protocol from <span style="font-weight: bold">RFC 2616</span> and <span style="font-weight: bold">RFC 2617</span>.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="terms-entities">Entities</a>
+</h3>
+    <p class="caption">Table 1: Terms for Entities Described Herein</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+    </table>
+    <p class="" style="">Note well that an XMPP Client can simultaneously be an HTTP Client (or vice-versa), and that an XMPP Server can simultaneously be an HTTP Server (or vice-versa). However, for the purposes of this discussion, we assume that these entities are logically if not physically separate and distinct.</p>
+  </div>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The motivations for this document are to:</p>
+  <ul>
+    <li>Use an existing XMPP connection to associate an HTTP request with an XMPP entity.</li>
+    <li>Require confirmation of the request by the XMPP entity before allowing access.</li>
+    <li>Ensure that the HTTP request was generated by the principal controlling the XMPP entity.</li>
+  </ul>
+<h2>4.
+       <a name="usecase">Use Case</a>
+</h2>
+  <p class="" style="">The process flow for this protocol is as follows:</p>
+  <ol start="" type="">
+    <li>HTTP Client requests object via HTTP.</li>
+    <li>HTTP Server sends Authenticate Response via HTTP.</li>
+    <li>HTTP Client sends Authorization Request via HTTP (E1).</li>
+    <li>HTPP Server processes request and forwards it to XMPP Server.</li>
+    <li>XMPP Server requests confirmation via XMPP (E2).</li>
+    <li>XMPP Client confirms request via XMPP.</li>
+    <li>XMPP Server delivers confirmation to HTTP Server.</li>
+    <li>HTTP Server allows HTTP Client to access object (E3).</li>
+  </ol>
+  <p class="" style="">Error cases:</p>
+  <ul>
+    <li>E1: HTTP Client does not understand the presented authentication scheme.</li>
+    <li>E2: HTTP Server does not recognize or understand the request.</li>
+    <li>E3: HTTP Server denies access.</li>
+  </ul>
+  <p class="" style="">This process flow is described in more detail in the following sections.</p>
+  <div class="indent">
+<h3>4.1 <a name="http-request">HTTP Client Sends Request via HTTP</a>
+</h3>
+    <p class="" style="">Let us stipulate that an XMPP user (say, &lt;juliet@capulet.com&gt;) learns of an HTTP URL (e.g., &lt;https://files.shakespeare.lit:9345/missive.html&gt;). The user then attempts to retrieve the URL using her HTTP Client, which opens a TCP connection to the appropriate port of the host and sends an HTTP request as defined in <span style="font-weight: bold">RFC 2616</span>. The request method MAY be any valid HTTP request method, including user-defined methods.</p>
+    <p class="" style="">An example is provided below:</p>
+    <p class="caption">Example 1. HTTP Client Makes Request (No Credentials)</p>
+<div class="indent"><pre>
+GET https://files.shakespeare.lit:9345/missive.html HTTP/1.1
+    </pre></div>
+    <p class="" style="">In order to avoid a round trip, the initial request MAY contain HTTP authorization credentials as described below.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="http-response">HTTP Server Returns Authenticate Response via HTTP</a>
+</h3>
+    <p class="" style="">If the user did not provide authorization credentials in the initial request, the HTTP Server then MUST respond with a (401) Authenticate response as defined in <span style="font-weight: bold">RFC 2616</span>. The response MUST contain an HTTP 401 error and one WWW-Authenticate header for each authentication scheme recognized by the HTTP Server. In order to provide verification via XMPP, at least one of these headers MUST specify a realm of "xmpp" (case-sensitive).</p>
+    <p class="caption">Example 2. HTTP Server Returns Authenticate Response</p>
+<div class="indent"><pre>
+401 Unauthorized HTTP/1.1
+WWW-Authenticate: Basic realm="xmpp"
+WWW-Authenticate: Digest realm="xmpp", 
+                  domain="files.shakespeare.lit", 
+                  stale=false, 
+                  nonce="ec2cc00f21f71acd35ab9be057970609", 
+                  qop="auth", 
+                  algorithm="MD5"
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</h3>
+    <p class="" style="">The HTTP Client responds with an Authorization Request as defined in <span style="font-weight: bold">RFC 2616</span>. The following rules apply:</p>
+    <ol start="" type="">
+      <li>The request MUST include the Jabber Identifier (JID) of the user making the request. This SHOULD be the full JID (&lt;user@host/resource&gt;) of a client that supports the protocol defined herein, although it MAY be the user's bare JID (&lt;user@host&gt;) instead.</li>
+      <li>The request MUST include a transaction identifier for the request. This identifier MUST be unique within the context of the HTTP Client's interaction with the HTTP Server. If the HTTP request is generated by the XMPP Client (e.g., because the HTTP URL was discovered via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2256614">4</a>]) then the transaction identifier SHOULD be generated by the client; if not, the transaction identifier SHOULD be provided by the human user who controls the HTTP Client.</li>
+    </ol>
+    <p class="" style="">The Authorization Request process is described in the following subsections.</p>
+    <div class="indent">
+<h3>4.3.1 <a name="http-authz-basic">Basic Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">The Basic Access Authentication scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of a userid and password, separated by a ':' character and then encoded using Base64. When the realm is "xmpp", the profile defined herein further specifies that the userid MUST be a valid JID as described above, that the password entity MUST be a transaction identifier as described above, that any character in the JID or transaction identifier that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256680">5</a>] prior to Base64 encoding, and that Base64 encoding MUST adhere to Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256703">6</a>].</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> for specification of the syntax of the Basic Access Authentication scheme; that information is not duplicated here.)</p>
+      <p class="caption">Example 3. HTTP Client Makes Basic Authorization Request</p>
+<div class="indent"><pre>
+Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="http-authz-digest">Digest Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">The Digest Access Authentication scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of the MD5 checksum of the username, the password, a nonce value provided in the challenge, the HTTP method, and the requested URL. When the realm is "xmpp", the profile defined herein further specifies that prior to creating the MD5 checksum the username MUST be a valid JID as described above, that the password MUST be a transaction identifier as described above, and that any character in the JID or transaction identifier that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span style="font-weight: bold">RFC 3986</span>.</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> for specification of the syntax of the Digest Access Authentication scheme; that information is not duplicated here.)</p>
+      <p class="caption">Example 4. HTTP Client Makes Digest Authorization Request</p>
+<div class="indent"><pre>
+Authorization: Digest username="juliet@capulet.com",
+               realm="xmpp",
+               nonce="ec2cc00f21f71acd35ab9be057970609", 
+               uri="missive.html",
+               qop=auth,
+               nc=00000001,
+               cnonce="0a4f113b",
+               response="6629fae49393a05397450978507c4ef1",
+               opaque="5ccc069c403ebaf9f0171e9517f40e41" 
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.3 <a name="http-authz-add">Additional Authentication Schemes</a>
+</h3>
+      <p class="" style="">The HTTP Server MAY offer any other valid authentication scheme, instead of or in addition to the Basic and Digest schemes mentioned above, as long as the scheme makes it possible to specify a userid (JID) and transaction identifier as described above. However, it is RECOMMENDED to implement both the Basic and Digest authentication schemes.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="http-process">HTPP Server Processes Request</a>
+</h3>
+    <p class="" style="">Once the HTTP Client has communicated the JID and transaction identifier to the HTTP Server, the HTTP Server MUST verify that the JID is authorized to access the HTTP resource. This may involve JID-level or domain-level access checks, or (depending on local service policies) potentially no access checks at all if only verification is required.</p>
+    <p class="" style="">If the JID is authorized to access the HTTP resource, the HTTP Server MUST pass the URL, method, JID, and transaction identifier to the XMPP Server for confirmation. Exactly how this is done is up to the implementation. It is RECOMMENDED for the HTTP Server to connect to the XMPP Server as a trusted server component and to itself generate the confirmation request as described below.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="xmpp-request">XMPP Server Requests Confirmation via XMPP</a>
+</h3>
+    <p class="" style="">Upon receiving the JID and transaction identifier from the HTTP Server, the XMPP Server MUST send a confirmation request (via XMPP) to the XMPP Client (or route the confirmation request generated by the HTTP Server acting as a trusted XMPP server component).</p>
+    <p class="" style="">The confirmation request shall consist of an empty &lt;confirm/&gt; element qualified by the ''http://jabber.org/protocol/http-auth' namespace. This element MUST possess a 'method' attribute whose value is the method of the HTTP request, MUST possess a 'url' attribute whose value is the full HTTP URL that was requested, and MUST possess an 'id' attribute whose value is the transaction identifier provided in the HTTP Authorization Request.</p>
+    <p class="" style="">If the JID provided was a full JID, the confirmation request SHOULD be sent in an &lt;iq/&gt; stanza of type "get" whose 'to' attribute is set to the full JID, but MAY be sent in a &lt;message/&gt; stanza.</p>
+    <p class="" style="">If the JID provided was a bare JID, the confirmation request MUST be sent in a &lt;message/&gt; stanza whose 'to' attribute is set to the bare JID; this enables delivery to the "most available" resource for the user (however "most available" is determined by the XMPP Server). The &lt;message/&gt; stanza SHOULD include a &lt;thread/&gt; element for tracking purposes and MAY include a &lt;body/&gt; element that provides human-readable information or instructions.</p>
+    <p class="caption">Example 5. Confirmation Request Sent via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='files.shakespeare.lit' 
+    to='juliet@capulet.com/balcony' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Confirmation Request Sent via Message</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='files.shakespeare.lit' 
+         to='juliet@capulet.com'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;body&gt;
+    Someone (maybe you) has requested the file 
+    https://files.shakespeare.lit:9345/missive.html.
+    If you wish to confirm the request, please reply
+    to this message by typing "OK". If not, please 
+    reply with "No".
+  &lt;/body&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="xmpp-confirm">XMPP Client Confirms Request via XMPP</a>
+</h3>
+    <p class="" style="">If the confirmation request was provided via an &lt;iq/&gt; stanza, the XMPP Client MUST respond to the request by sending an &lt;iq/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;iq/&gt; response stanza MUST be of type "result" and MAY contain the original &lt;confirm/&gt; child element (although this is not necessary since the XMPP 'id' attribute can be used for tracking purposes):</p>
+    <p class="caption">Example 7. XMPP Client Confirms Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'/&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;iq/&gt; response stanza MUST be of type "error", MAY contain the original &lt;confirm/&gt; child element (although this is not necessary since the XMPP 'id' attribute can be used for tracking purposes), and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 8. XMPP Client Denies Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the confirmation request was provided via a &lt;message/&gt; stanza and the &lt;message/&gt; contains a human-readable &lt;body/&gt; or does not contain a &lt;body/&gt; but the XMPP Client understands the 'http://jabber.org/protocol/http-auth' namespace, the XMPP Client SHOULD respond to the request by sending a &lt;message/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;message/&gt; response stanza SHOULD be of type "normal", MUST mirror the &lt;thread/&gt; ID (if provided by the XMPP Server), and MUST contain the original &lt;confirm/&gt; child element:</p>
+    <p class="caption">Example 9. XMPP Client Confirms Request via Message</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;message/&gt; response stanza MUST be of type "error", MUST mirror the &lt;thread/&gt; ID (if provided by the XMPP Server), MUST contain the original &lt;confirm/&gt; child element, and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 10. XMPP Client Denies Request via Message</p>
+<div class="indent"><pre>
+&lt;message type='error' 
+         from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</h3>
+    <p class="" style="">Once the XMPP Client has successfully confirmed the request, the XMPP Server forwards that confirmation to the HTTP Server, which allows access:</p>
+    <p class="caption">Example 11. HTTP Server Allows Access to Object</p>
+<div class="indent"><pre>
+200 OK HTTP/1.1
+Content-Type: text/html
+Content-Length: 3032
+
+...
+    </pre></div>
+    <p class="" style="">If the XMPP Client denied the request, the HTTP Server MUST return a Forbidden error:</p>
+    <p class="caption">Example 12. HTTP Server Denies Access to Object</p>
+<div class="indent"><pre>
+403 Forbidden HTTP/1.1
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="impl-methods">Interaction of HTTP methods</a>
+</h3>
+    <p class="" style="">For the HEAD and OPTIONS methods, the credentials SHOULD be usable for a subsequent request from the same entity. This enables an entity to both determine support for the mechanism defined herein and start the authentication process.</p>
+    <p class="" style="">For the POST and PUT methods (or any method containing a message body), clients MUST send all data with each request (if needed, the client should obtain credentials with a previous HEAD or OPTIONS method).</p>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="security-association">Association of Request</a>
+</h3>
+    <p class="" style="">In order to associate the HTTP request with the XMPP confirmation, a transaction identifier MUST be provided by the user in the HTTP Authorization Request, then passed unchanged to the XMPP Client as the value of the &lt;confirm/&gt; element's 'id' attribute. If the XMPP Client generated the HTTP request, it MUST check the transaction identifier against the requests it has made to verify that the request has not yet been confirmed. If the XMPP Client did not generate the HTTP request, it MUST present the transaction identifier to the user for confirmation. If the XMPP Client or User confirms the request, the XMPP Client MUST then return a confirmation to the XMPP Server for delivery to the HTTP Server.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="security-channel">Channel Encryption</a>
+</h3>
+    <p class="" style="">To reduce the likelihood of man-in-the-middle attacks, channel encryption SHOULD be used for both the XMPP channel and the HTTP channel. In particular:</p>
+    <ol start="" type="">
+      <li>The channel used for HTTP requests and responses SHOULD be encrypted via SSL (secure HTTP via https: URLs) or TLS (<span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2257387">7</a>]).</li>
+      <li>If the standard binding of XMPP to TCP is used, TLS SHOULD be negotiated for the XMPP channel in accordance with <span style="font-weight: bold">RFC 3920</span>.</li>
+      <li>If a binding of XMPP to HTTP is used (e.g., as specified in <span style="font-weight: bold">JEP-0124</span>), exchanges between the XMPP Client and XMPP Server (connection manager) SHOULD be sent over a channel that is encrypted using SSL or TLS.</li>
+    </ol> 
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="security-e2e">End-to-End Encryption</a>
+</h3>
+    <p class="" style="">For added security, the XMPP Server and XMPP Client may wish to communicate using end-to-end encryption. Methods for doing so are outside the scope of this proposal.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257466">8</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257504">9</a>] shall include "http://jabber.org/protocol/http-auth" in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/http-auth'
+    xmlns='http://jabber.org/protocol/http-auth'
+    elementFormDefault='qualified'&gt;
+  
+  &lt;xs:element name='confirm'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='id' use='required' type='xs:string'/&gt;
+          &lt;xs:attribute name='method' use='required' type='xs:NCName'/&gt;
+          &lt;xs:attribute name='url' use='required' type='xs:anyURI'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250966">1</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2250797">2</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p><a name="nt-id2250834">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256614">4</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2256680">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2256703">6</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2257387">7</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2257466">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257504">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2005-12-01)</h4>
+<div class="indent">Corrected several errors in the text. (psa)
+    </div>
+<h4>Version 0.9 (2005-11-09)</h4>
+<div class="indent">Changed use of transaction identifier from SHOULD to MUST; removed x-xmpp-auth scheme; clarified requirements, business rules, and confirm element syntax; added several more examples; more clearly specified how HTTP server communicates with XMPP server; updated schema and security considerations. (psa)
+    </div>
+<h4>Version 0.8 (2005-10-19)</h4>
+<div class="indent">Changed use of transaction identifier from MAY to SHOULD; updated and clarified security considerations. (psa)
+    </div>
+<h4>Version 0.7 (2005-10-11)</h4>
+<div class="indent">Added more HTTP examples to illustrate process flow; updated IANA considerations and security considerations. (psa)
+    </div>
+<h4>Version 0.6 (2005-07-21)</h4>
+<div class="indent">Updated references; clarified several points in the text; rewrote introduction. (psa)
+    </div>
+<h4>Version 0.5 (2004-04-27)</h4>
+<div class="indent">Added optional id attribute in order to track requests, described in new implementation note. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-14)</h4>
+<div class="indent">Incorporated results of IRL and IM discussions: simplified the flow; added x-xmpp-auth authentication scheme. (psa/dss/jh)
+    </div>
+<h4>Version 0.3 (2003-06-27)</h4>
+<div class="indent">Removed hashing requirements; added/clarified JID fields in HTTP headers; added XML Schema; added XMPP error conditions; added more descriptions for confirm and accept tokens; fixed discrepancies in examples. (lw)
+    </div>
+<h4>Version 0.2 (2003-06-26)</h4>
+<div class="indent">Updated to reflect feedback received (moved to using standard HTTP authentication headers; included token-authority JID in HTTP header; removed example involving deprecated JEP). (lw)
+    </div>
+<h4>Version 0.1 (2003-01-31)</h4>
+<div class="indent">Initial draft. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0070-0.5.html
+++ b/content/xep-0070-0.5.html
@@ -1,0 +1,473 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0070: Authenticating HTTP Requests via Jabber</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Authenticating HTTP Requests via Jabber">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol that enables verification of an HTTP request via Jabber.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-04-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0070">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0070: Authenticating HTTP Requests via Jabber</h1>
+<p>This JEP defines a protocol that enables verification of an HTTP request via Jabber.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0070<br>
+            Version: 0.5<br>
+            Last Updated: 2004-04-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2616, RFC 2617, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: http-auth<br>
+</p>
+<h2>Author Information</h2>
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt>
+<dt>2.2.  <a href="#terms-entities">Entities</a>
+</dt>
+</dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecase">Use Case</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#http-request">HTTP Client Sends Request via HTTP</a>
+</dt>
+<dt>4.2.  <a href="#http-response">HTTP Server Sends WWW-Authenticate Response via HTTP</a>
+</dt>
+<dt>4.3.  <a href="#http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#http-authz-basic">Basic Access Authorization Scheme</a>
+</dt>
+<dt>4.3.2.  <a href="#http-authz-digest">Digest Access Authorization Scheme</a>
+</dt>
+<dt>4.3.3.  <a href="#http-authz-xmpp">x-xmpp-auth Access Authorization Scheme</a>
+</dt>
+<dt>4.3.4.  <a href="#intro">Additional Authorization Schemes</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#intro">Jabber Server Requests Confirmation via XMPP</a>
+</dt>
+<dt>4.5.  <a href="#xmpp-verify">Jabber Client Verifies Request via XMPP</a>
+</dt>
+<dt>4.6.  <a href="#http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#impl-methods">Interaction of HTTP methods</a>
+</dt>
+<dt>5.2.  <a href="#impl-tracking">Tracking requests</a>
+</dt>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#security-connection">Connection Trust</a>
+</dt>
+<dt>6.2.  <a href="#security-e2e">End-to-End Encryption</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">HTTP is a nearly-ubiquitous mechanism for the publication of information. This includes current mechanisms used to share &quot;out-of-band&quot; information in Jabber applications (see <span class="ref">Out-of-Band Data</span>  [<a href="#nt-id2596340">1</a>]).</p>
+  <p class="" style="">In many cases, some form of authentication between the HTTP request and the Jabber entity making the request is desired or required (e.g., to require acknowledgement of the request in Jabber band to take advantage of the user authentication provided therein). To accomplish this, an HTTP authentication scheme is proposed to tie together the Jabber and HTTP communications. This JEP describes the processes and structure for such an HTTP authentication scheme.</p>
+  <p class="" style="">Additionally, web-based, Jabber-aware applications may wish to utilize known information about a JID, without prompting the user for yet another username/password combination (the first being provided through their Jabber client). An automated or &quot;single-signon&quot; login facility would be preferable in this case.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+    <p class="" style="">This JEP inherits terminology about the HyperText Transfer Protocol from <span class="ref">RFC 2616</span>  [<a href="#nt-id2596305">2</a>] and <span class="ref">RFC 2617</span>  [<a href="#nt-id2596319">3</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="terms-entities">Entities</a>
+</h3>
+    <p class="caption">Table 1: Terms for Entities Described Herein</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Jabber Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Jabber Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+    </table>
+    <p class="" style="">Note well that a Jabber Client can simultaneously be an HTTP Client (or vice-versa), and that a Jabber Server can simultaneously be an HTTP Server (or vice-versa); in fact the latter usually will be the case in order to provide a bridge between HTTP and XMPP communications. However, for the purposes of this discussion, we assume that these entities are logically if not physically separate and distinct.</p>
+  </div>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The motivations for this JEP are:</p>
+  <ul>
+    <li>To provide a minimal, explicit association between a Jabber entity and an HTTP URL.</li>
+    <li>To provide a &quot;good enough&quot; level of assurance that the HTTP request was generated by the principal controlling the Jabber entity.</li>
+  </ul>
+<h2>4.
+       <a name="usecase">Use Case</a>
+</h2>
+  <p class="" style="">The process flow for this protocol is as follows:</p>
+  <ol start="" type="">
+    <li>HTTP Client requests object via HTTP.</li>
+    <li>HTTP Server sends WWW-Authenticate Response via HTTP.</li>
+    <li>HTTP Client sends Authorization Request via HTTP (E1).</li>
+    <li>Jabber Server requests confirmation via XMPP (E2).</li>
+    <li>Jabber Client confirms request via XMPP.</li>
+    <li>HTTP Server allows HTTP Client to access object (E3).</li>
+  </ol>
+  <p class="" style="">Error cases:</p>
+  <ul>
+    <li>E1: HTTP Client does not understand the presented authorization scheme.</li>
+    <li>E2: HTTP Server does not recognize or understand the request.</li>
+    <li>E3: HTTP Server denies access.</li>
+  </ul>
+  <p class="" style="">This process flow is described in more detail in the following sections.</p>
+  <div class="indent">
+<h3>4.1 <a name="http-request">HTTP Client Sends Request via HTTP</a>
+</h3>
+    <p class="" style="">Let us stipulate that a user (say, &lt;juliet@capulet.com&gt;) learns of a URL (e.g., &lt;http://files.shakespeare.lit:9345/missive.html&gt;). The user then attempts to retrieve the URL using her HTTP Client, which opens a TCP connection to the appropriate port of the host and sends an HTTP request as defined in RFC 2616. The request method MAY be any valid HTTP request method, including user-defined methods. In addition, the initial request MAY contain authorization credentials (as described below) in order to avoid a round trip.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="http-response">HTTP Server Sends WWW-Authenticate Response via HTTP</a>
+</h3>
+    <p class="" style="">If the user did not provide authorization credentials in the initial request, the HTTP Server then responds with a WWW-Authenticate response as defined in RFC 2616. The response MUST contain an HTTP 401 error and a comma-separated list of authorization schemes recognized by the HTTP Server, which SHOULD include the &quot;x-xmpp-auth&quot; method. Authentication schemes that do not include usernames SHOULD NOT be offered by the HTTP Server if the &quot;x-xmpp-auth&quot; scheme is offered. The WWW-Authenticate response SHOULD also include a realm of &quot;xmpp&quot; (case-sensitive).</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</h3>
+    <p class="" style="">The HTTP Client responds with an Authorization Request as defined in RFC 2616. The request MUST include the Jabber Identifier (JID) of the user making the request, preferably a full JID (&lt;user@host/resource&gt;), although a bare JID (&lt;user@host&gt;) may also be provided. Descriptions of the syntax for doing so are provided in the following subsections; however, the reader must refer to the appropriate RFCs for full details regarding authentication schemes other than &quot;x-xmpp-auth&quot;, since they are not defined herein.</p>
+    <div class="indent">
+<h3>4.3.1 <a name="http-authz-basic">Basic Access Authorization Scheme</a>
+</h3>
+      <p class="" style="">The Basic Access Authorization scheme is defined in RFC 2617. This scheme specifies that the authorization information shall consist of a userid and password, separated by a ':' character and then encoded using Base64. The profile defined herein further specifies that the userid MUST be a valid JID as described above, that the password entity SHOULD be empty, that Base64 encoding MUST adhere to Section 3 of <span class="ref">RFC 3548</span>  [<a href="#nt-id2602449">4</a>], and that any non-US-ASCII characters MUST be transformed into US-ASCII (in accordance with standard UTF-8 transformations) prior to encoding as Base64. Refer to RFC 2617 for information regarding the syntax of the Basic Access Authorization scheme.</p>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="http-authz-digest">Digest Access Authorization Scheme</a>
+</h3>
+      <p class="" style="">The Digest Access Authorization scheme is defined in RFC 2617. This scheme specifies that the authorization information shall consist of the MD5 checksum of the username, the password, a nonce value provided in the challenge, the HTTP method, and the requested URI. The profile defined herein further specifies that the the username MUST be a valid JID as described above, that the password SHOULD be empty, and that any UTF-8 characters MUST be escaped into %HEXHEX formats prior to creating the MD5 checksum. Refer to RFC 2617 for information regarding the syntax of the Digest Access Authorization scheme.</p>
+    </div>
+    <div class="indent">
+<h3>4.3.3 <a name="http-authz-xmpp">x-xmpp-auth Access Authorization Scheme</a>
+</h3>
+      <p class="" style="">This section defines the HTTP authentication scheme. This scheme is included mainly to provide a &quot;trap door&quot; for web-based Jabber clients, so that they can intercept a page load, see that the &quot;x-xmpp-auth&quot; mechanism is offered, and pass the user's JID directly back to the server.</p>
+      <p class="" style="">RFC 2616 details the general syntax for headers, and the meaning of error codes, while Section 1 of RFC 2617 details the framework of an authentication scheme; that information is not duplicated here.</p>
+      <p class="" style="">The &quot;x-xmpp-auth&quot; scheme challenge provides the &quot;realm&quot; (as required by RFC 2617). The realm MUST be &quot;xmpp&quot; (case-sensitive).</p>
+      <p class="" style="">The &quot;x-xmpp-auth&quot; scheme credentials MUST provide the full or bare JID of the entity that can confirm the request. The JID MUST be provided as a quoted-string.</p>
+      <p class="" style="">The enhanced BNF for the &quot;x-xmpp-auth&quot; Access Authorization scheme is as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+x-xmpp-auth-challenge   := &quot;x-xmpp-auth&quot; 1*SP &quot;realm&quot; &quot;=&quot; &quot;xmpp&quot;&gt;
+x-xmpp-auth-credentials := &quot;x-xmpp-auth&quot; 1*SP &quot;jid&quot; &quot;=&quot; \
+                            &lt;quoted-string&gt;
+jid                     := XMPP address as specified in XMPP-CORE
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.4 <a name="intro">Additional Authorization Schemes</a>
+</h3>
+      <p class="" style="">The HTTP Server MAY offer any other valid authorization scheme, instead of or in addition to the Basic and Digest schemes mentioned above.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="intro">Jabber Server Requests Confirmation via XMPP</a>
+</h3>
+    <p class="" style="">Once the HTTP Client has communicated the full JID or bare JID to the HTTP Server, the Jabber Server sends a confirmation request (via XMPP) to the Jabber Client. If the JID provided was a full JID, the confirmation request SHOULD be sent in an &lt;iq/&gt; stanza of type &quot;get&quot; whose 'to' attribute is set to the full JID, but MAY be sent in a &lt;message/&gt; stanza. If the JID provided was a bare JID, the confirmation request MUST be sent in a &lt;message/&gt; stanza whose 'to' attribute is set to the bare JID; this enables delivery to the &quot;most available&quot; resource for the user (however &quot;most available&quot; is determined by the Jabber Server).</p>
+    <p class="caption">Example 1. Confirmation Request Sent via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='files.shakespeare.lit' 
+    to='juliet@capulet.com/balcony' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Confirmation Request Sent via Message</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='files.shakespeare.lit' 
+         to='juliet@capulet.com'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;body&gt;
+    Someone (maybe you) has requested the file 
+    http://files.shakespeare.lit:9345/missive.html.
+    If you wish to confirm the request, please reply
+    to this message by typing &quot;OK&quot;. If not, please 
+    reply with &quot;No&quot;.
+  &lt;/body&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The &lt;confirm/&gt; element MUST possess both a 'url' attribute and a 'method' attribute; the value of the 'url' attribute MUST be the full path of the HTTP object requested and the value of the 'method' attribute MUST be a valid HTTP method.</p>
+    <p class="" style="">In addition, the &lt;confirm/&gt; element MAY possess an 'id' attribute; see the <a href="#impl">Implementation Notes</a> for details.</p>
+    <p class="" style="">If provided, the &lt;thread/&gt; element and its XML character data value MUST be mirrored in any message reply.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="xmpp-verify">Jabber Client Verifies Request via XMPP</a>
+</h3>
+    <p class="" style="">If the confirmation request was provided via an &lt;iq/&gt; stanza, the Jabber Client MUST respond to the request by sending an &lt;iq/&gt; stanza back to the Jabber Server. If the user wishes to confirm the request, the Jabber Client MUST reply; the &lt;iq/&gt; response stanza MUST be of type &quot;result&quot; and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 3. Jabber Client Confirms Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'/&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the Jabber Client MUST reply; the &lt;iq/&gt; response stanza MUST be of type &quot;error&quot;, MAY contain the original &lt;confirm/&gt; child element (although this is not required), and MUST specify an error, which SHOULD be &quot;Not Authorized&quot;:</p>
+    <p class="caption">Example 4. Jabber Client Denies Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the confirmation request was provided via a &lt;message/&gt; stanza, the Jabber Client SHOULD respond to the request by sending a &lt;message/&gt; stanza back to the Jabber Server. If the user wishes to confirm the request, the Jabber Client MUST reply; the &lt;message/&gt; response stanza SHOULD be of type &quot;normal&quot;, SHOULD mirror the &lt;thread/&gt; ID (if provided), and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 5. Jabber Client Confirms Request via Message</p>
+<div class="indent"><pre>
+&lt;message type='get' 
+         from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;body&gt;OK&lt;/body&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the Jabber Client MUST reply; the &lt;message/&gt; response stanza MUST be of type &quot;error&quot;, SHOULD mirror the &lt;thread/&gt; ID (if provided), MAY (but is NOT REQUIRED to) contain the original &lt;confirm/&gt; child element, and MUST specify an error, which SHOULD be &quot;Not Authorized&quot;:</p>
+    <p class="caption">Example 6. Jabber Client Denies Request via Message</p>
+<div class="indent"><pre>
+&lt;message type='error' 
+         from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;body&gt;No&lt;/body&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</h3>
+    <p class="" style="">Once the Jabber Client has successfully confirmed the request, the HTTP Server allows access:</p>
+    <p class="caption">Example 7. HTTP Server Allows Access to Object</p>
+<div class="indent"><pre>
+200 OK HTTP/1.1
+Content-Type: text/html
+Content-Length: 3032
+
+...
+    </pre></div>
+    <p class="" style="">If the Jabber Client denied the request, the HTTP Server MUST return a Forbidden error:</p>
+    <p class="caption">Example 8. HTTP Server Denies Access to Object</p>
+<div class="indent"><pre>
+403 Forbidden HTTP/1.1
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="impl-methods">Interaction of HTTP methods</a>
+</h3>
+    <p class="" style="">For the HEAD and OPTIONS methods, the credentials SHOULD be usable for a subsequent request from the same entity. This would allow for an entity to both determine support for this mechanism and start the authentication process.</p>
+    <p class="" style="">For the POST and PUT methods (or any method containing a message body), clients MUST send all data with each request; the HTTP server is under no obligation to assume that the client will fail. This is especially true since the client can obtain credentials with a previous HEAD or OPTIONS method.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="impl-tracking">Tracking requests</a>
+</h3>
+    <p class="" style="">As noted above and as specified in the schema, the &lt;confirm/&gt; element MAY possess an 'id' attribute. If included, this attribute SHOULD be used to track requests between the HTTP client and the XMPP client; to ensure proper tracking, the ID SHOULD be generated by the HTTP client (or provided by the end user) and included as the value of the password entity within the basic or digest authentication scheme, then passed unchanged to the XMPP client as the value of the &lt;confirm/&gt; element's 'id' attribute.</p>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="security-connection">Connection Trust</a>
+</h3>
+    <p class="" style="">The authentication mechanism is still vulnerable to man-in-the-middle attacks.  It may be less vulnerable than HTTP &quot;basic&quot; or &quot;digest&quot; authentication, in that it utilizes an outside connection for a significant amount of the negotiation. This outside channel may be more trusted than the initial HTTP connection can be.</p>
+    <p class="" style="">Additionally, this authentication scheme can be used with Secure HTTP (HTTPS) and <span class="ref">RFC 2817</span>  [<a href="#nt-id2603207">5</a>]. In this case, the authentication scheme is used to associate the connection to the involved JIDs, and relies on SSL/TLS to authenticate the connection.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="security-e2e">End-to-End Encryption</a>
+</h3>
+    <p class="" style="">For added security, the Jabber Server and Jabber Client may wish to communicate using end-to-end encryption. Methods for doing so are outside the scope of this proposal.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The HTTP authentication scheme &quot;x-xmpp-auth&quot; may be registered with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603176">6</a>], although this is not strictly necessary.</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603333">7</a>] shall add the 'http://jabber.org/protocol/http-auth' namespace to its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/http-auth'
+    xmlns='http://jabber.org/protocol/http-auth'
+    elementFormDefault='qualified'&gt;
+  
+  &lt;xs:element name='confirm'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='id' use='optional' type='xs:string'/&gt;
+          &lt;xs:attribute name='method' use='required' type='xs:NCName'/&gt;
+          &lt;xs:attribute name='url' use='required' type='xs:anyURI'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596340">1</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596305">2</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596319">3</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602449">4</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603207">5</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603176">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603333">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2004-04-27)</h4>
+<div class="indent">Added optional id attribute in order to track requests, described in new implementation note. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-14)</h4>
+<div class="indent">Incorporated results of IRL and IM discussions: simplified the flow; added &quot;x-xmpp-auth&quot; mechanism. (psa)
+    </div>
+<h4>Version 0.3 (2003-06-27)</h4>
+<div class="indent">Removed hashing requirements; added/clarified JID fields in HTTP headers; added XML Schema; added XMPP error conditions; added more descriptions for &quot;confirm&quot; and &quot;accept&quot; tokens; fixed discrepancies in examples. (lw)
+    </div>
+<h4>Version 0.2 (2003-06-26)</h4>
+<div class="indent">Updated to reflect user feedback (moved to using standard HTTP authentication headers; included token-authority JID in HTTP header; removed example involving deprecated JEP). (lw)
+    </div>
+<h4>Version 0.1 (2003-01-31)</h4>
+<div class="indent">Initial draft. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0070-0.6.html
+++ b/content/xep-0070-0.6.html
@@ -1,0 +1,474 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0070: Authenticating HTTP Requests via XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Authenticating HTTP Requests via XMPP">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol that enables verification of an HTTP request via XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0070">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0070: Authenticating HTTP Requests via XMPP</h1>
+<p>This JEP defines a protocol that enables verification of an HTTP request via XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0070<br>
+            Version: 0.6<br>
+            Last Updated: 2005-07-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2616, RFC 2617, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: http-auth<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt>
+<dt>2.2.  <a href="#terms-entities">Entities</a>
+</dt>
+</dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecase">Use Case</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#http-request">HTTP Client Sends Request via HTTP</a>
+</dt>
+<dt>4.2.  <a href="#http-response">HTTP Server Sends WWW-Authenticate Response via HTTP</a>
+</dt>
+<dt>4.3.  <a href="#http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#http-authz-basic">Basic Access Authorization Scheme</a>
+</dt>
+<dt>4.3.2.  <a href="#http-authz-digest">Digest Access Authorization Scheme</a>
+</dt>
+<dt>4.3.3.  <a href="#http-authz-xmpp">x-xmpp-auth Access Authorization Scheme</a>
+</dt>
+<dt>4.3.4.  <a href="#intro">Additional Authorization Schemes</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#intro">XMPP Server Requests Confirmation via XMPP</a>
+</dt>
+<dt>4.5.  <a href="#xmpp-verify">XMPP Client Verifies Request via XMPP</a>
+</dt>
+<dt>4.6.  <a href="#http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#impl-methods">Interaction of HTTP methods</a>
+</dt>
+<dt>5.2.  <a href="#impl-tracking">Tracking requests</a>
+</dt>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#security-connection">Connection Trust</a>
+</dt>
+<dt>6.2.  <a href="#security-e2e">End-to-End Encryption</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">HTTP (see <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2251403">1</a>]) is a nearly-ubiquitous mechanism for the publication of information. Sometimes it is appropriate for an HTTP Server to allow access to that information only if the HTTP Client first provides authentication credentials. While there exist several standardized HTTP authentication mechanisms (see <span class="ref" style="">RFC 2617</span>  [<a href="#nt-id2251433">2</a>]), it may be useful in some applications to authenticate an HTTP request by requiring an XMPP entity (normally an IM user) to affirm that it made the request -- for example, to take advantage of the strong user authentication provided in XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251456">3</a>]).</p>
+  <p class="" style="">Additionally, web-based, XMPP-aware applications may wish to utilize known information about a JID when making HTTP requests, without prompting the user for yet another username/password combination (the first being provided through their XMPP Client), thus resulting in automated login or "single-sign-on" functionality.</p>
+  <p class="" style="">Therefore, this JEP specifies the processes and structure for an authentication scheme that enables authentication of HTTP requests via XMPP.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+    <p class="" style="">This JEP inherits terminology about the HyperText Transfer Protocol from <span style="font-weight: bold">RFC 2616</span> and <span style="font-weight: bold">RFC 2617</span>.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="terms-entities">Entities</a>
+</h3>
+    <p class="caption">Table 1: Terms for Entities Described Herein</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+    </table>
+    <p class="" style="">Note well that a XMPP Client can simultaneously be an HTTP Client (or vice-versa), and that a XMPP Server can simultaneously be an HTTP Server (or vice-versa). However, for the purposes of this discussion, we assume that these entities are logically if not physically separate and distinct.</p>
+  </div>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The motivations for this JEP are:</p>
+  <ul>
+    <li>To provide a minimal, explicit association between an XMPP entity and a request sent to an HTTP URL.</li>
+    <li>To provide a "good enough" level of assurance that the HTTP request was generated by the principal controlling the XMPP entity.</li>
+  </ul>
+<h2>4.
+       <a name="usecase">Use Case</a>
+</h2>
+  <p class="" style="">The process flow for this protocol is as follows:</p>
+  <ol start="" type="">
+    <li>HTTP Client requests object via HTTP.</li>
+    <li>HTTP Server sends WWW-Authenticate Response via HTTP.</li>
+    <li>HTTP Client sends Authorization Request via HTTP (E1).</li>
+    <li>XMPP Server requests confirmation via XMPP (E2).</li>
+    <li>XMPP Client confirms request via XMPP.</li>
+    <li>HTTP Server allows HTTP Client to access object (E3).</li>
+  </ol>
+  <p class="" style="">Error cases:</p>
+  <ul>
+    <li>E1: HTTP Client does not understand the presented authorization scheme.</li>
+    <li>E2: HTTP Server does not recognize or understand the request.</li>
+    <li>E3: HTTP Server denies access.</li>
+  </ul>
+  <p class="" style="">This process flow is described in more detail in the following sections.</p>
+  <div class="indent">
+<h3>4.1 <a name="http-request">HTTP Client Sends Request via HTTP</a>
+</h3>
+    <p class="" style="">Let us stipulate that a user (say, &lt;juliet@capulet.com&gt;) learns of a URL (e.g., &lt;http://files.shakespeare.lit:9345/missive.html&gt;). The user then attempts to retrieve the URL using her HTTP Client, which opens a TCP connection to the appropriate port of the host and sends an HTTP request as defined in <span style="font-weight: bold">RFC 2616</span>. The request method MAY be any valid HTTP request method, including user-defined methods. In addition, the initial request MAY contain authorization credentials (as described below) in order to avoid a round trip.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="http-response">HTTP Server Sends WWW-Authenticate Response via HTTP</a>
+</h3>
+    <p class="" style="">If the user did not provide authorization credentials in the initial request, the HTTP Server then responds with a WWW-Authenticate response as defined in <span style="font-weight: bold">RFC 2616</span>. The response MUST contain an HTTP 401 error and a comma-separated list of authorization schemes recognized by the HTTP Server, which SHOULD include the "x-xmpp-auth" method. Authentication schemes that do not include usernames SHOULD NOT be offered by the HTTP Server if the "x-xmpp-auth" scheme is offered. The WWW-Authenticate response SHOULD also include a realm of "xmpp" (case-sensitive).</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</h3>
+    <p class="" style="">The HTTP Client responds with an Authorization Request as defined in <span style="font-weight: bold">RFC 2616</span>. The request MUST include the Jabber Identifier (JID) of the user making the request, preferably a full JID (&lt;user@host/resource&gt;), although a bare JID (&lt;user@host&gt;) may also be provided. The Authentication Request process is described in the following subsections.</p>
+    <div class="indent">
+<h3>4.3.1 <a name="http-authz-basic">Basic Access Authorization Scheme</a>
+</h3>
+      <p class="" style="">The Basic Access Authorization scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of a userid and password, separated by a ':' character and then encoded using Base64. The profile defined herein further specifies that the userid MUST be a valid JID as described above, that the password entity SHOULD be empty, that Base64 encoding MUST adhere to Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256104">4</a>], and that any character that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256127">5</a>].</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> regarding the syntax of the Basic Access Authorization scheme; that information is not duplicated here.)</p>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="http-authz-digest">Digest Access Authorization Scheme</a>
+</h3>
+      <p class="" style="">The Digest Access Authorization scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of the MD5 checksum of the username, the password, a nonce value provided in the challenge, the HTTP method, and the requested URI. The profile defined herein further specifies that prior to creating the MD5 checksum the username MUST be a valid JID as described above, that the password SHOULD be empty, and that any character that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span style="font-weight: bold">RFC 3986</span>.</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> regarding the syntax of the Digest Access Authorization scheme; that information is not duplicated here.)</p>
+    </div>
+    <div class="indent">
+<h3>4.3.3 <a name="http-authz-xmpp">x-xmpp-auth Access Authorization Scheme</a>
+</h3>
+      <p class="" style="">This section defines the "x-xmpp-auth" HTTP authentication scheme. This scheme is included mainly to provide a "trap door" for web-based XMPP clients, so that they can intercept a page load, see that the "x-xmpp-auth" mechanism is offered, and pass the user's JID directly back to the server.</p>
+      <p class="" style="">The "x-xmpp-auth" scheme challenge provides the realm (as required by <span style="font-weight: bold">RFC 2617</span>), which MUST be "xmpp" (case-sensitive).</p>
+      <p class="" style="">The "x-xmpp-auth" scheme credentials MUST provide the full or bare JID of the entity that can confirm the request. The JID MUST be provided as a quoted-string.</p>
+      <p class="" style="">The enhanced BNF for the "x-xmpp-auth" Access Authorization scheme is as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+x-xmpp-auth-challenge   := "x-xmpp-auth" 1*SP "realm" "=" "xmpp"
+x-xmpp-auth-credentials := "x-xmpp-auth" 1*SP "jid" "=" \
+                            &lt;quoted-string&gt;
+jid                     := XMPP address as specified in RFC 3920
+      </pre></div>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2616</span> regarding header syntax and the meaning of error codes, and to Section 1 of <span style="font-weight: bold">RFC 2617</span> regarding the framework of an authentication scheme; that information is not duplicated here.)</p>
+    </div>
+    <div class="indent">
+<h3>4.3.4 <a name="intro">Additional Authorization Schemes</a>
+</h3>
+      <p class="" style="">The HTTP Server MAY offer any other valid authorization scheme, instead of or in addition to the Basic and Digest schemes mentioned above.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="intro">XMPP Server Requests Confirmation via XMPP</a>
+</h3>
+    <p class="" style="">Once the HTTP Client has communicated the full JID or bare JID to the HTTP Server, the XMPP Server sends a confirmation request (via XMPP) to the XMPP Client.</p>
+    <p class="" style="">If the JID provided was a full JID, the confirmation request SHOULD be sent in an &lt;iq/&gt; stanza of type "get" whose 'to' attribute is set to the full JID, but MAY be sent in a &lt;message/&gt; stanza.</p>
+    <p class="" style="">If the JID provided was a bare JID, the confirmation request MUST be sent in a &lt;message/&gt; stanza whose 'to' attribute is set to the bare JID; this enables delivery to the "most available" resource for the user (however "most available" is determined by the XMPP Server). The &lt;message/&gt; stanza MAY include a &lt;body/&gt; element that provides human-readable information or instructions.</p>
+    <p class="caption">Example 1. Confirmation Request Sent via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='files.shakespeare.lit' 
+    to='juliet@capulet.com/balcony' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Confirmation Request Sent via Message</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='files.shakespeare.lit' 
+         to='juliet@capulet.com'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;body&gt;
+    Someone (maybe you) has requested the file 
+    http://files.shakespeare.lit:9345/missive.html.
+    If you wish to confirm the request, please reply
+    to this message by typing "OK". If not, please 
+    reply with "No".
+  &lt;/body&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The &lt;confirm/&gt; element MUST possess both a 'url' attribute and a 'method' attribute; the value of the 'url' attribute MUST be the full path of the HTTP object requested and the value of the 'method' attribute MUST be a valid HTTP method.</p>
+    <p class="" style="">In addition, the &lt;confirm/&gt; element MAY possess an 'id' attribute; see the <a href="#impl">Implementation Notes</a> for details.</p>
+    <p class="" style="">If provided, the &lt;thread/&gt; element and its XML character data value MUST be mirrored in any message reply.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="xmpp-verify">XMPP Client Verifies Request via XMPP</a>
+</h3>
+    <p class="" style="">If the confirmation request was provided via an &lt;iq/&gt; stanza, the XMPP Client MUST respond to the request by sending an &lt;iq/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;iq/&gt; response stanza MUST be of type "result" and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 3. XMPP Client Confirms Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'/&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;iq/&gt; response stanza MUST be of type "error", MAY contain the original &lt;confirm/&gt; child element (although this is not required), and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 4. XMPP Client Denies Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the confirmation request was provided via a &lt;message/&gt; stanza, the XMPP Client SHOULD respond to the request by sending a &lt;message/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;message/&gt; response stanza SHOULD be of type "normal", MUST mirror the &lt;thread/&gt; ID (if provided), and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 5. XMPP Client Confirms Request via Message</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;message/&gt; response stanza MUST be of type "error", SHOULD mirror the &lt;thread/&gt; ID (if provided), MAY (but is not required to) contain the original &lt;confirm/&gt; child element, and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 6. XMPP Client Denies Request via Message</p>
+<div class="indent"><pre>
+&lt;message type='error' 
+         from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</h3>
+    <p class="" style="">Once the XMPP Client has successfully confirmed the request, the HTTP Server allows access:</p>
+    <p class="caption">Example 7. HTTP Server Allows Access to Object</p>
+<div class="indent"><pre>
+200 OK HTTP/1.1
+Content-Type: text/html
+Content-Length: 3032
+
+...
+    </pre></div>
+    <p class="" style="">If the XMPP Client denied the request, the HTTP Server MUST return a Forbidden error:</p>
+    <p class="caption">Example 8. HTTP Server Denies Access to Object</p>
+<div class="indent"><pre>
+403 Forbidden HTTP/1.1
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="impl-methods">Interaction of HTTP methods</a>
+</h3>
+    <p class="" style="">For the HEAD and OPTIONS methods, the credentials SHOULD be usable for a subsequent request from the same entity. This would enable an entity to both determine support for this mechanism and start the authentication process.</p>
+    <p class="" style="">For the POST and PUT methods (or any method containing a message body), clients MUST send all data with each request; the HTTP server is under no obligation to assume that the client will fail. This is especially true since the client can obtain credentials with a previous HEAD or OPTIONS method.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="impl-tracking">Tracking requests</a>
+</h3>
+    <p class="" style="">As noted above and as specified in the schema, the &lt;confirm/&gt; element MAY possess an 'id' attribute. If included, this attribute SHOULD be used to track requests between the HTTP Client and the XMPP Client; to ensure proper tracking, the ID SHOULD be generated by the HTTP Client (or provided by the end user) and included as the value of the password entity within the basic or digest authentication scheme, then passed unchanged to the XMPP Client as the value of the &lt;confirm/&gt; element's 'id' attribute.</p>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="security-connection">Connection Trust</a>
+</h3>
+    <p class="" style="">The authentication mechanism is still vulnerable to man-in-the-middle attacks.  It may be less vulnerable than HTTP basic or digest authentication, in that it utilizes an outside connection for a significant amount of the negotiation. This outside channel may be more trusted than the initial HTTP connection can be.</p>
+    <p class="" style="">Additionally, this authentication scheme can be used with Secure HTTP (HTTPS) and <span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2256690">6</a>]. In this case, the authentication scheme is used to associate the connection to the involved JIDs, and relies on SSL/TLS to authenticate the connection.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="security-e2e">End-to-End Encryption</a>
+</h3>
+    <p class="" style="">For added security, the XMPP Server and XMPP Client may wish to communicate using end-to-end encryption. Methods for doing so are outside the scope of this proposal.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The HTTP authentication scheme "x-xmpp-auth" may be registered with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256754">7</a>], although this is not strictly necessary.</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256840">8</a>] shall include "http://jabber.org/protocol/http-auth" in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/http-auth'
+    xmlns='http://jabber.org/protocol/http-auth'
+    elementFormDefault='qualified'&gt;
+  
+  &lt;xs:element name='confirm'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='id' use='optional' type='xs:string'/&gt;
+          &lt;xs:attribute name='method' use='required' type='xs:NCName'/&gt;
+          &lt;xs:attribute name='url' use='required' type='xs:anyURI'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251403">1</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2251433">2</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p><a name="nt-id2251456">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256104">4</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256127">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2256690">6</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2256754">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256840">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-07-21)</h4>
+<div class="indent">Updated references; clarified several points in the text; rewrote introduction. (psa)
+    </div>
+<h4>Version 0.5 (2004-04-27)</h4>
+<div class="indent">Added optional id attribute in order to track requests, described in new implementation note. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-14)</h4>
+<div class="indent">Incorporated results of IRL and IM discussions: simplified the flow; added "x-xmpp-auth" mechanism. (psa)
+    </div>
+<h4>Version 0.3 (2003-06-27)</h4>
+<div class="indent">Removed hashing requirements; added/clarified JID fields in HTTP headers; added XML Schema; added XMPP error conditions; added more descriptions for "confirm" and "accept" tokens; fixed discrepancies in examples. (lw)
+    </div>
+<h4>Version 0.2 (2003-06-26)</h4>
+<div class="indent">Updated to reflect user feedback (moved to using standard HTTP authentication headers; included token-authority JID in HTTP header; removed example involving deprecated JEP). (lw)
+    </div>
+<h4>Version 0.1 (2003-01-31)</h4>
+<div class="indent">Initial draft. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0070-0.7.html
+++ b/content/xep-0070-0.7.html
@@ -1,0 +1,495 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0070: Authenticating HTTP Requests via XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Authenticating HTTP Requests via XMPP">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol that enables verification of an HTTP request via XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0070">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0070: Authenticating HTTP Requests via XMPP</h1>
+<p>This JEP defines a protocol that enables verification of an HTTP request via XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0070<br>
+            Version: 0.7<br>
+            Last Updated: 2005-10-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2616, RFC 2617, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: http-auth<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt>
+<dt>2.2.  <a href="#terms-entities">Entities</a>
+</dt>
+</dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecase">Use Case</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#http-request">HTTP Client Sends Request via HTTP</a>
+</dt>
+<dt>4.2.  <a href="#http-response">HTTP Server Sends Authenticate Response via HTTP</a>
+</dt>
+<dt>4.3.  <a href="#http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#http-authz-basic">Basic Access Authentication Scheme</a>
+</dt>
+<dt>4.3.2.  <a href="#http-authz-digest">Digest Access Authentication Scheme</a>
+</dt>
+<dt>4.3.3.  <a href="#http-authz-xmpp">x-xmpp-auth Access Authentication Scheme</a>
+</dt>
+<dt>4.3.4.  <a href="#intro">Additional Authentication Schemes</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#intro">XMPP Server Requests Confirmation via XMPP</a>
+</dt>
+<dt>4.5.  <a href="#xmpp-verify">XMPP Client Verifies Request via XMPP</a>
+</dt>
+<dt>4.6.  <a href="#http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#impl-methods">Interaction of HTTP methods</a>
+</dt>
+<dt>5.2.  <a href="#impl-tracking">Tracking requests</a>
+</dt>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#security-connection">Connection Trust</a>
+</dt>
+<dt>6.2.  <a href="#security-e2e">End-to-End Encryption</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">HTTP (see <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250479">1</a>]) is a nearly-ubiquitous mechanism for the publication of information. Sometimes it is appropriate for an HTTP Server to allow access to that information only if the HTTP Client first provides authentication credentials. While there exist several standardized HTTP authentication schemes (see <span class="ref" style="">RFC 2617</span>  [<a href="#nt-id2250645">2</a>]), it may be useful in some applications to authenticate an HTTP request by requiring an XMPP entity (normally an IM user) to affirm that it made the request -- for example, to take advantage of the strong user authentication provided in XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250669">3</a>]).</p>
+  <p class="" style="">Additionally, web-based, XMPP-aware applications may wish to utilize known information about a JID when making HTTP requests, without prompting the user for yet another username/password combination (the first being provided through their XMPP Client), thus resulting in automated login or "single-sign-on" functionality.</p>
+  <p class="" style="">Therefore, this JEP specifies the processes and structure for an authentication scheme that enables authentication of HTTP requests via XMPP.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+    <p class="" style="">This JEP inherits terminology about the HyperText Transfer Protocol from <span style="font-weight: bold">RFC 2616</span> and <span style="font-weight: bold">RFC 2617</span>.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="terms-entities">Entities</a>
+</h3>
+    <p class="caption">Table 1: Terms for Entities Described Herein</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+    </table>
+    <p class="" style="">Note well that a XMPP Client can simultaneously be an HTTP Client (or vice-versa), and that a XMPP Server can simultaneously be an HTTP Server (or vice-versa). However, for the purposes of this discussion, we assume that these entities are logically if not physically separate and distinct.</p>
+  </div>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The motivations for this JEP are:</p>
+  <ul>
+    <li>To provide a minimal, explicit association between an XMPP entity and a request sent to an HTTP URL.</li>
+    <li>To provide a "good enough" level of assurance that the HTTP request was generated by the principal controlling the XMPP entity.</li>
+  </ul>
+<h2>4.
+       <a name="usecase">Use Case</a>
+</h2>
+  <p class="" style="">The process flow for this protocol is as follows:</p>
+  <ol start="" type="">
+    <li>HTTP Client requests object via HTTP.</li>
+    <li>HTTP Server sends Authenticate Response via HTTP.</li>
+    <li>HTTP Client sends Authorization Request via HTTP (E1).</li>
+    <li>XMPP Server requests confirmation via XMPP (E2).</li>
+    <li>XMPP Client confirms request via XMPP.</li>
+    <li>HTTP Server allows HTTP Client to access object (E3).</li>
+  </ol>
+  <p class="" style="">Error cases:</p>
+  <ul>
+    <li>E1: HTTP Client does not understand the presented authentication scheme.</li>
+    <li>E2: HTTP Server does not recognize or understand the request.</li>
+    <li>E3: HTTP Server denies access.</li>
+  </ul>
+  <p class="" style="">This process flow is described in more detail in the following sections.</p>
+  <div class="indent">
+<h3>4.1 <a name="http-request">HTTP Client Sends Request via HTTP</a>
+</h3>
+    <p class="" style="">Let us stipulate that a user (say, &lt;juliet@capulet.com&gt;) learns of a URL (e.g., &lt;http://files.shakespeare.lit:9345/missive.html&gt;). The user then attempts to retrieve the URL using her HTTP Client, which opens a TCP connection to the appropriate port of the host and sends an HTTP request as defined in <span style="font-weight: bold">RFC 2616</span>. The request method MAY be any valid HTTP request method, including user-defined methods. In addition, the initial request MAY contain authorization credentials (as described below) in order to avoid a round trip. An example is provided below:</p>
+    <p class="caption">Example 1. HTTP Client Makes Request (No Credentials)</p>
+<div class="indent"><pre>
+GET missive.html HTTP/1.1
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="http-response">HTTP Server Sends Authenticate Response via HTTP</a>
+</h3>
+    <p class="" style="">If the user did not provide authorization credentials in the initial request, the HTTP Server then responds with a (401) Authenticate response as defined in <span style="font-weight: bold">RFC 2616</span>. The response MUST contain an HTTP 401 error and one WWW-Authenticate header for each authentication scheme recognized by the HTTP Server (these headers SHOULD include a header for the "x-xmpp-auth" scheme). Authentication schemes that do not include usernames SHOULD NOT be offered by the HTTP Server if the "x-xmpp-auth" scheme is offered. The Authenticate response SHOULD also include a realm of "xmpp" (case-sensitive).</p>
+    <p class="caption">Example 2. HTTP Server Allows Access to Object</p>
+<div class="indent"><pre>
+401 Unauthorized HTTP/1.1
+WWW-Authenticate: Basic realm="xmpp"
+WWW-Authenticate: Digest realm="xmpp", domain="shakespeare.lit", stale=false, \
+                  nonce="ec2cc00f21f71acd35ab9be057970609", qop="auth", algorithm="MD5"
+WWW-Authenticate: x-xmpp-auth realm="xmpp"
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</h3>
+    <p class="" style="">The HTTP Client responds with an Authorization Request as defined in <span style="font-weight: bold">RFC 2616</span>. The request MUST include the Jabber Identifier (JID) of the user making the request, preferably a full JID (&lt;user@host/resource&gt;), although a bare JID (&lt;user@host&gt;) may also be provided. The Authentication Request process is described in the following subsections.</p>
+    <div class="indent">
+<h3>4.3.1 <a name="http-authz-basic">Basic Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">The Basic Access Authentication scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of a userid and password, separated by a ':' character and then encoded using Base64. The profile defined herein further specifies that the userid MUST be a valid JID as described above, that the password entity SHOULD be empty, that Base64 encoding MUST adhere to Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256304">4</a>], and that any character that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256327">5</a>].</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> regarding the syntax of the Basic Access Authentication scheme; that information is not duplicated here.)</p>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="http-authz-digest">Digest Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">The Digest Access Authentication scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of the MD5 checksum of the username, the password, a nonce value provided in the challenge, the HTTP method, and the requested URI. The profile defined herein further specifies that prior to creating the MD5 checksum the username MUST be a valid JID as described above, that the password SHOULD be empty, and that any character that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span style="font-weight: bold">RFC 3986</span>.</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> regarding the syntax of the Digest Access Authentication scheme; that information is not duplicated here.)</p>
+    </div>
+    <div class="indent">
+<h3>4.3.3 <a name="http-authz-xmpp">x-xmpp-auth Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">This section defines the "x-xmpp-auth" HTTP authentication scheme. This scheme is included mainly to provide a "trap door" for web-based XMPP clients, so that they can intercept a page load, see that the "x-xmpp-auth" authentication scheme is offered, and pass the user's JID directly back to the server.</p>
+      <p class="" style="">The "x-xmpp-auth" scheme challenge provides the realm (as required by <span style="font-weight: bold">RFC 2617</span>), which MUST be "xmpp" (case-sensitive).</p>
+      <p class="" style="">The "x-xmpp-auth" scheme credentials MUST provide the full or bare JID of the entity that can confirm the request. The JID MUST be provided as a quoted-string.</p>
+      <p class="" style="">The enhanced BNF for the "x-xmpp-auth" Access Authentication scheme is as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+x-xmpp-auth-challenge   := "x-xmpp-auth" 1*SP "realm" "=" "xmpp"
+x-xmpp-auth-credentials := "x-xmpp-auth" 1*SP "jid" "=" \
+                            &lt;quoted-string&gt;
+jid                     := XMPP address as specified in RFC 3920
+      </pre></div>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2616</span> regarding header syntax and the meaning of error codes, and to Section 1 of <span style="font-weight: bold">RFC 2617</span> regarding the framework of an authentication scheme; that information is not duplicated here.)</p>
+      <p class="caption">Example 3. HTTP Client Sends x-xmpp-auth Authorization Request</p>
+<div class="indent"><pre>
+GET missive.html HTTP/1.1
+Authorization: x-xmpp-auth jid="juliet@capulet.com/balcony"
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.4 <a name="intro">Additional Authentication Schemes</a>
+</h3>
+      <p class="" style="">The HTTP Server MAY offer any other valid authentication scheme, instead of or in addition to the Basic and Digest schemes mentioned above.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="intro">XMPP Server Requests Confirmation via XMPP</a>
+</h3>
+    <p class="" style="">Once the HTTP Client has communicated the full JID or bare JID to the HTTP Server, the XMPP Server sends a confirmation request (via XMPP) to the XMPP Client.</p>
+    <p class="" style="">If the JID provided was a full JID, the confirmation request SHOULD be sent in an &lt;iq/&gt; stanza of type "get" whose 'to' attribute is set to the full JID, but MAY be sent in a &lt;message/&gt; stanza.</p>
+    <p class="" style="">If the JID provided was a bare JID, the confirmation request MUST be sent in a &lt;message/&gt; stanza whose 'to' attribute is set to the bare JID; this enables delivery to the "most available" resource for the user (however "most available" is determined by the XMPP Server). The &lt;message/&gt; stanza MAY include a &lt;body/&gt; element that provides human-readable information or instructions.</p>
+    <p class="caption">Example 4. Confirmation Request Sent via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='files.shakespeare.lit' 
+    to='juliet@capulet.com/balcony' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Confirmation Request Sent via Message</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='files.shakespeare.lit' 
+         to='juliet@capulet.com'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;body&gt;
+    Someone (maybe you) has requested the file 
+    http://files.shakespeare.lit:9345/missive.html.
+    If you wish to confirm the request, please reply
+    to this message by typing "OK". If not, please 
+    reply with "No".
+  &lt;/body&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The &lt;confirm/&gt; element MUST possess both a 'url' attribute and a 'method' attribute; the value of the 'url' attribute MUST be the full path of the HTTP object requested and the value of the 'method' attribute MUST be a valid HTTP method.</p>
+    <p class="" style="">In addition, the &lt;confirm/&gt; element MAY possess an 'id' attribute; see the <a href="#impl">Implementation Notes</a> for details.</p>
+    <p class="" style="">If provided, the &lt;thread/&gt; element and its XML character data value MUST be mirrored in any message reply.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="xmpp-verify">XMPP Client Verifies Request via XMPP</a>
+</h3>
+    <p class="" style="">If the confirmation request was provided via an &lt;iq/&gt; stanza, the XMPP Client MUST respond to the request by sending an &lt;iq/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;iq/&gt; response stanza MUST be of type "result" and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 6. XMPP Client Confirms Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'/&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;iq/&gt; response stanza MUST be of type "error", MAY contain the original &lt;confirm/&gt; child element (although this is not required), and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 7. XMPP Client Denies Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the confirmation request was provided via a &lt;message/&gt; stanza, the XMPP Client SHOULD respond to the request by sending a &lt;message/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;message/&gt; response stanza SHOULD be of type "normal", MUST mirror the &lt;thread/&gt; ID (if provided), and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 8. XMPP Client Confirms Request via Message</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;message/&gt; response stanza MUST be of type "error", SHOULD mirror the &lt;thread/&gt; ID (if provided), MAY (but is not required to) contain the original &lt;confirm/&gt; child element, and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 9. XMPP Client Denies Request via Message</p>
+<div class="indent"><pre>
+&lt;message type='error' 
+         from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</h3>
+    <p class="" style="">Once the XMPP Client has successfully confirmed the request, the HTTP Server allows access:</p>
+    <p class="caption">Example 10. HTTP Server Allows Access to Object</p>
+<div class="indent"><pre>
+200 OK HTTP/1.1
+Content-Type: text/html
+Content-Length: 3032
+
+...
+    </pre></div>
+    <p class="" style="">If the XMPP Client denied the request, the HTTP Server MUST return a Forbidden error:</p>
+    <p class="caption">Example 11. HTTP Server Denies Access to Object</p>
+<div class="indent"><pre>
+403 Forbidden HTTP/1.1
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="impl-methods">Interaction of HTTP methods</a>
+</h3>
+    <p class="" style="">For the HEAD and OPTIONS methods, the credentials SHOULD be usable for a subsequent request from the same entity. This enables an entity to both determine support for the mechanism defined herein and start the authentication process.</p>
+    <p class="" style="">For the POST and PUT methods (or any method containing a message body), clients MUST send all data with each request; the HTTP server is under no obligation to assume that the client will fail. This is especially true since the client can obtain credentials with a previous HEAD or OPTIONS method.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="impl-tracking">Tracking requests</a>
+</h3>
+    <p class="" style="">As noted above and as specified in the schema, the &lt;confirm/&gt; element MAY possess an 'id' attribute. If included, this attribute SHOULD be used to track requests between the HTTP Client and the XMPP Client; to ensure proper tracking, the ID SHOULD be generated by the HTTP Client (or provided by the end user) and included as the value of the password entity within the basic or digest authentication scheme, then passed unchanged to the XMPP Client as the value of the &lt;confirm/&gt; element's 'id' attribute.</p>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="security-connection">Connection Trust</a>
+</h3>
+    <p class="" style="">The "x-xmpp-auth" Access Authentication scheme is still vulnerable to man-in-the-middle attacks. However, it may be less vulnerable than HTTP Basic authentication or Digest authentication, in that it utilizes an outside connection for a significant amount of the negotiation. This outside channel may be more trusted than the initial HTTP connection can be, given the existence of strong authentication (via SASL) in XMPP.</p>
+    <p class="" style="">Section 4.6 of <span style="font-weight: bold">RFC 2617</span> specifies that if an HTTP server returns multiple challenges with a 401 (Authenticate) response, an HTTP client must use the strongest authentication scheme it understands. For the purposes of this JEP, an HTTP client MUST consider the "x-xmpp-auth" scheme to be stronger than the HTTP Basic scheme and SHOULD consider the "x-xmpp-auth" scheme to be stronger than the HTTP Digest scheme.</p>
+    <p class="" style="">Additionally, the "x-xmpp-auth" Access Authentication scheme can be used with Secure HTTP (HTTPS) and <span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2256823">6</a>]. In this case, the authentication scheme is used to associate the HTTP request to the relevant JID and relies on SSL/TLS to ensure the privacy and data integrity of the HTTP connection.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="security-e2e">End-to-End Encryption</a>
+</h3>
+    <p class="" style="">For added security, the XMPP Server and XMPP Client may wish to communicate using end-to-end encryption. Methods for doing so are outside the scope of this proposal.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">If and when the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257124">7</a>] establishes a registry for HTTP authentication schemes, the "x-xmpp-auth" scheme may be registered there.</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257170">8</a>] shall include "http://jabber.org/protocol/http-auth" in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/http-auth'
+    xmlns='http://jabber.org/protocol/http-auth'
+    elementFormDefault='qualified'&gt;
+  
+  &lt;xs:element name='confirm'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='id' use='optional' type='xs:string'/&gt;
+          &lt;xs:attribute name='method' use='required' type='xs:NCName'/&gt;
+          &lt;xs:attribute name='url' use='required' type='xs:anyURI'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250479">1</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2250645">2</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p><a name="nt-id2250669">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256304">4</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256327">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2256823">6</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2257124">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257170">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2005-10-11)</h4>
+<div class="indent">Added more HTTP examples to illustrate process flow; updated IANA considerations and security considerations. (psa)
+    </div>
+<h4>Version 0.6 (2005-07-21)</h4>
+<div class="indent">Updated references; clarified several points in the text; rewrote introduction. (psa)
+    </div>
+<h4>Version 0.5 (2004-04-27)</h4>
+<div class="indent">Added optional id attribute in order to track requests, described in new implementation note. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-14)</h4>
+<div class="indent">Incorporated results of IRL and IM discussions: simplified the flow; added x-xmpp-auth authentication scheme. (psa/dss/jh)
+    </div>
+<h4>Version 0.3 (2003-06-27)</h4>
+<div class="indent">Removed hashing requirements; added/clarified JID fields in HTTP headers; added XML Schema; added XMPP error conditions; added more descriptions for confirm and accept tokens; fixed discrepancies in examples. (lw)
+    </div>
+<h4>Version 0.2 (2003-06-26)</h4>
+<div class="indent">Updated to reflect feedback received (moved to using standard HTTP authentication headers; included token-authority JID in HTTP header; removed example involving deprecated JEP). (lw)
+    </div>
+<h4>Version 0.1 (2003-01-31)</h4>
+<div class="indent">Initial draft. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0070-0.8.html
+++ b/content/xep-0070-0.8.html
@@ -1,0 +1,515 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0070: Authenticating HTTP Requests via XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Authenticating HTTP Requests via XMPP">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a protocol that enables verification of an HTTP request via XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0070">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0070: Authenticating HTTP Requests via XMPP</h1>
+<p>This document defines a protocol that enables verification of an HTTP request via XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0070<br>
+            Version: 0.8<br>
+            Last Updated: 2005-10-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2616, RFC 2617, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: http-auth<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Authenticating%20HTTP%20Requests%20via%20XMPP%20(JEP-0070)">http://wiki.jabber.org/index.php/Authenticating HTTP Requests via XMPP (JEP-0070)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt>
+<dt>2.2.  <a href="#terms-entities">Entities</a>
+</dt>
+</dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecase">Use Case</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#http-request">HTTP Client Sends Request via HTTP</a>
+</dt>
+<dt>4.2.  <a href="#http-response">HTTP Server Sends Authenticate Response via HTTP</a>
+</dt>
+<dt>4.3.  <a href="#http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#http-authz-basic">Basic Access Authentication Scheme</a>
+</dt>
+<dt>4.3.2.  <a href="#http-authz-digest">Digest Access Authentication Scheme</a>
+</dt>
+<dt>4.3.3.  <a href="#http-authz-xmpp">x-xmpp-auth Access Authentication Scheme</a>
+</dt>
+<dt>4.3.4.  <a href="#intro">Additional Authentication Schemes</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#intro">XMPP Server Requests Confirmation via XMPP</a>
+</dt>
+<dt>4.5.  <a href="#xmpp-verify">XMPP Client Verifies Request via XMPP</a>
+</dt>
+<dt>4.6.  <a href="#http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>5.1.  <a href="#impl-methods">Interaction of HTTP methods</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#security-trust">Connection Trust</a>
+</dt>
+<dt>6.2.  <a href="#security-strength">Strength of Authentication Schemes</a>
+</dt>
+<dt>6.3.  <a href="#security-channel">Channel Encryption</a>
+</dt>
+<dt>6.4.  <a href="#security-e2e">End-to-End Encryption</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">HTTP (see <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250590">1</a>]) is a nearly-ubiquitous mechanism for the publication of information. Sometimes it is appropriate for an HTTP Server to allow access to that information only if the HTTP Client first provides authentication credentials. While there exist several standardized HTTP authentication schemes (see <span class="ref" style="">RFC 2617</span>  [<a href="#nt-id2250756">2</a>]), it may be useful in some applications to authenticate an HTTP request by requiring an XMPP entity (normally an IM user) to affirm that it made the request -- for example, to take advantage of the strong user authentication provided in XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250793">3</a>]).</p>
+  <p class="" style="">Additionally, web-based, XMPP-aware applications may wish to utilize known information about a JID when making HTTP requests, without prompting the user for yet another username/password combination (the first being provided through their XMPP Client), thus resulting in automated login or "single-sign-on" functionality.</p>
+  <p class="" style="">Therefore, this document specifies the processes and structure for an authentication scheme that enables authentication of HTTP requests via XMPP.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+    <p class="" style="">This document inherits terminology about the HyperText Transfer Protocol from <span style="font-weight: bold">RFC 2616</span> and <span style="font-weight: bold">RFC 2617</span>.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="terms-entities">Entities</a>
+</h3>
+    <p class="caption">Table 1: Terms for Entities Described Herein</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+    </table>
+    <p class="" style="">Note well that a XMPP Client can simultaneously be an HTTP Client (or vice-versa), and that a XMPP Server can simultaneously be an HTTP Server (or vice-versa). However, for the purposes of this discussion, we assume that these entities are logically if not physically separate and distinct.</p>
+  </div>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The motivations for this document are:</p>
+  <ul>
+    <li>To provide a minimal, explicit association between an XMPP entity and a request sent to an HTTP URL.</li>
+    <li>To provide a "good enough" level of assurance that the HTTP request was generated by the principal controlling the XMPP entity.</li>
+  </ul>
+<h2>4.
+       <a name="usecase">Use Case</a>
+</h2>
+  <p class="" style="">The process flow for this protocol is as follows:</p>
+  <ol start="" type="">
+    <li>HTTP Client requests object via HTTP.</li>
+    <li>HTTP Server sends Authenticate Response via HTTP.</li>
+    <li>HTTP Client sends Authorization Request via HTTP (E1).</li>
+    <li>XMPP Server requests confirmation via XMPP (E2).</li>
+    <li>XMPP Client confirms request via XMPP.</li>
+    <li>HTTP Server allows HTTP Client to access object (E3).</li>
+  </ol>
+  <p class="" style="">Error cases:</p>
+  <ul>
+    <li>E1: HTTP Client does not understand the presented authentication scheme.</li>
+    <li>E2: HTTP Server does not recognize or understand the request.</li>
+    <li>E3: HTTP Server denies access.</li>
+  </ul>
+  <p class="" style="">This process flow is described in more detail in the following sections.</p>
+  <div class="indent">
+<h3>4.1 <a name="http-request">HTTP Client Sends Request via HTTP</a>
+</h3>
+    <p class="" style="">Let us stipulate that a user (say, &lt;juliet@capulet.com&gt;) learns of a URL (e.g., &lt;http://files.shakespeare.lit:9345/missive.html&gt;). The user then attempts to retrieve the URL using her HTTP Client, which opens a TCP connection to the appropriate port of the host and sends an HTTP request as defined in <span style="font-weight: bold">RFC 2616</span>. The request method MAY be any valid HTTP request method, including user-defined methods. In addition, the initial request MAY contain authorization credentials (as described below) in order to avoid a round trip. An example is provided below:</p>
+    <p class="caption">Example 1. HTTP Client Makes Request (No Credentials)</p>
+<div class="indent"><pre>
+GET missive.html HTTP/1.1
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="http-response">HTTP Server Sends Authenticate Response via HTTP</a>
+</h3>
+    <p class="" style="">If the user did not provide authorization credentials in the initial request, the HTTP Server then responds with a (401) Authenticate response as defined in <span style="font-weight: bold">RFC 2616</span>. The response MUST contain an HTTP 401 error and one WWW-Authenticate header for each authentication scheme recognized by the HTTP Server (these headers SHOULD include a header for the "x-xmpp-auth" scheme). Authentication schemes that do not include usernames SHOULD NOT be offered by the HTTP Server if the "x-xmpp-auth" scheme is offered. The Authenticate response SHOULD also include a realm of "xmpp" (case-sensitive).</p>
+    <p class="caption">Example 2. HTTP Server Allows Access to Object</p>
+<div class="indent"><pre>
+401 Unauthorized HTTP/1.1
+WWW-Authenticate: Basic realm="xmpp"
+WWW-Authenticate: Digest realm="xmpp", domain="shakespeare.lit", stale=false, \
+                  nonce="ec2cc00f21f71acd35ab9be057970609", qop="auth", algorithm="MD5"
+WWW-Authenticate: x-xmpp-auth realm="xmpp"
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</h3>
+    <p class="" style="">The HTTP Client responds with an Authorization Request as defined in <span style="font-weight: bold">RFC 2616</span>. The request MUST include the Jabber Identifier (JID) of the user making the request, preferably a full JID (&lt;user@host/resource&gt;), although a bare JID (&lt;user@host&gt;) may also be provided. The Authentication Request process is described in the following subsections.</p>
+    <div class="indent">
+<h3>4.3.1 <a name="http-authz-basic">Basic Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">The Basic Access Authentication scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of a userid and password, separated by a ':' character and then encoded using Base64. The profile defined herein further specifies that the userid MUST be a valid JID as described above, that the password entity SHOULD be a unique identifier for the transation (generated by the HTTP Client or end user), that Base64 encoding MUST adhere to Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256511">4</a>], and that any character that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256534">5</a>].</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> regarding the syntax of the Basic Access Authentication scheme; that information is not duplicated here.)</p>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="http-authz-digest">Digest Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">The Digest Access Authentication scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of the MD5 checksum of the username, the password, a nonce value provided in the challenge, the HTTP method, and the requested URI. The profile defined herein further specifies that prior to creating the MD5 checksum the username MUST be a valid JID as described above, that the password SHOULD be a unique identifier for the transation (generated by the HTTP Client or end user), and that any character that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span style="font-weight: bold">RFC 3986</span>.</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> regarding the syntax of the Digest Access Authentication scheme; that information is not duplicated here.)</p>
+    </div>
+    <div class="indent">
+<h3>4.3.3 <a name="http-authz-xmpp">x-xmpp-auth Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">This section defines the "x-xmpp-auth" HTTP authentication scheme. This scheme is included mainly to provide a "trap door" for web-based XMPP clients (e.g., XMPP clients that communicate via the <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2256622">6</a>] rather than the TCP binding specified in <span style="font-weight: bold">RFC 3920</span>), so that they can intercept a page load, see that the "x-xmpp-auth" authentication scheme is offered, and pass the user's JID directly back to the connection manager or proxy.</p>
+      <p class="" style="">The "x-xmpp-auth" scheme challenge provides the realm (as required by <span style="font-weight: bold">RFC 2617</span>), which MUST be "xmpp" (case-sensitive).</p>
+      <p class="" style="">The "x-xmpp-auth" scheme credentials MUST provide the full or bare JID of the entity that can confirm the request. The JID MUST be provided as a quoted-string.</p>
+      <p class="" style="">The enhanced BNF for the "x-xmpp-auth" Access Authentication scheme is as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+x-xmpp-auth-challenge   := "x-xmpp-auth" 1*SP "realm" "=" "xmpp"
+x-xmpp-auth-credentials := "x-xmpp-auth" 1*SP "jid" "=" \
+                            &lt;quoted-string&gt;
+jid                     := XMPP address as specified in RFC 3920
+      </pre></div>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2616</span> regarding header syntax and the meaning of error codes, and to Section 1 of <span style="font-weight: bold">RFC 2617</span> regarding the framework of an authentication scheme; that information is not duplicated here.)</p>
+      <p class="caption">Example 3. HTTP Client Sends x-xmpp-auth Authorization Request</p>
+<div class="indent"><pre>
+GET missive.html HTTP/1.1
+Authorization: x-xmpp-auth jid="juliet@capulet.com/balcony"
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.4 <a name="intro">Additional Authentication Schemes</a>
+</h3>
+      <p class="" style="">The HTTP Server MAY offer any other valid authentication scheme, instead of or in addition to the Basic and Digest schemes mentioned above.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="intro">XMPP Server Requests Confirmation via XMPP</a>
+</h3>
+    <p class="" style="">Once the HTTP Client has communicated the full JID or bare JID to the HTTP Server, the XMPP Server sends a confirmation request (via XMPP) to the XMPP Client.</p>
+    <p class="" style="">If the JID provided was a full JID, the confirmation request SHOULD be sent in an &lt;iq/&gt; stanza of type "get" whose 'to' attribute is set to the full JID, but MAY be sent in a &lt;message/&gt; stanza.</p>
+    <p class="" style="">If the JID provided was a bare JID, the confirmation request MUST be sent in a &lt;message/&gt; stanza whose 'to' attribute is set to the bare JID; this enables delivery to the "most available" resource for the user (however "most available" is determined by the XMPP Server). The &lt;message/&gt; stanza MAY include a &lt;body/&gt; element that provides human-readable information or instructions.</p>
+    <p class="" style="">If the HTTP Client included a unique transaction identifier as the password entity via the Basic Access Authentication or Digest Access Authentication scheme, that ID MUST be provided as the value of the &lt;confirm/&gt; element's 'id' attribute.</p>
+    <p class="caption">Example 4. Confirmation Request Sent via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='files.shakespeare.lit' 
+    to='juliet@capulet.com/balcony' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           id='transaction-identifier'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Confirmation Request Sent via Message</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='files.shakespeare.lit' 
+         to='juliet@capulet.com'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;body&gt;
+    Someone (maybe you) has requested the file 
+    http://files.shakespeare.lit:9345/missive.html.
+    If you wish to confirm the request, please reply
+    to this message by typing "OK". If not, please 
+    reply with "No".
+  &lt;/body&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           id='transaction-identifier'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The &lt;confirm/&gt; element MUST possess both a 'url' attribute and a 'method' attribute; the value of the 'url' attribute MUST be the full path of the HTTP object requested and the value of the 'method' attribute MUST be a valid HTTP method.</p>
+    <p class="" style="">In addition, the &lt;confirm/&gt; element MAY possess an 'id' attribute; see the <a href="#impl">Implementation Notes</a> for details.</p>
+    <p class="" style="">If provided, the &lt;thread/&gt; element and its XML character data value MUST be mirrored in any message reply.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="xmpp-verify">XMPP Client Verifies Request via XMPP</a>
+</h3>
+    <p class="" style="">If the confirmation request was provided via an &lt;iq/&gt; stanza, the XMPP Client MUST respond to the request by sending an &lt;iq/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;iq/&gt; response stanza MUST be of type "result" and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 6. XMPP Client Confirms Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'/&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;iq/&gt; response stanza MUST be of type "error", MAY contain the original &lt;confirm/&gt; child element (although this is not required), and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 7. XMPP Client Denies Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           id='transaction-identifier'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the confirmation request was provided via a &lt;message/&gt; stanza, the XMPP Client SHOULD respond to the request by sending a &lt;message/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;message/&gt; response stanza SHOULD be of type "normal", MUST mirror the &lt;thread/&gt; ID (if provided), and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 8. XMPP Client Confirms Request via Message</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           id='transaction-identifier'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;message/&gt; response stanza MUST be of type "error", SHOULD mirror the &lt;thread/&gt; ID (if provided), MAY (but is not required to) contain the original &lt;confirm/&gt; child element, and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 9. XMPP Client Denies Request via Message</p>
+<div class="indent"><pre>
+&lt;message type='error' 
+         from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           method='GET'
+           url='http://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</h3>
+    <p class="" style="">Once the XMPP Client has successfully confirmed the request, the HTTP Server allows access:</p>
+    <p class="caption">Example 10. HTTP Server Allows Access to Object</p>
+<div class="indent"><pre>
+200 OK HTTP/1.1
+Content-Type: text/html
+Content-Length: 3032
+
+...
+    </pre></div>
+    <p class="" style="">If the XMPP Client denied the request, the HTTP Server MUST return a Forbidden error:</p>
+    <p class="caption">Example 11. HTTP Server Denies Access to Object</p>
+<div class="indent"><pre>
+403 Forbidden HTTP/1.1
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="impl-methods">Interaction of HTTP methods</a>
+</h3>
+    <p class="" style="">For the HEAD and OPTIONS methods, the credentials SHOULD be usable for a subsequent request from the same entity. This enables an entity to both determine support for the mechanism defined herein and start the authentication process.</p>
+    <p class="" style="">For the POST and PUT methods (or any method containing a message body), clients MUST send all data with each request; the HTTP server is under no obligation to assume that the client will fail. This is especially true since the client can obtain credentials with a previous HEAD or OPTIONS method.</p>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="security-trust">Connection Trust</a>
+</h3>
+    <p class="" style="">Confirmation of HTTP requests via XMPP is still vulnerable to man-in-the-middle attacks. However, it may be less vulnerable than pure HTTP authentication, since it utilizes an outside connection for a significant amount of the negotiation. This outside channel may be more trusted than a pure HTTP connection can be, given the existence of strong authentication (via SASL) in XMPP.</p>
+    <p class="" style="">In order to provide a stronger connection between the HTTP request and the XMPP confirmation, a transaction identifier SHOULD be provided if the HTTP Basic Access Authentication or Digest Access Authentication scheme is used, then passed unchanged to the XMPP Client as the value of the &lt;confirm/&gt; element's 'id' attribute.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="security-strength">Strength of Authentication Schemes</a>
+</h3>
+    <p class="" style="">Section 4.6 of <span style="font-weight: bold">RFC 2617</span> specifies that if an HTTP server returns multiple challenges with a 401 (Authenticate) response, an HTTP client must use the strongest authentication scheme it understands. For the purposes of this document, an HTTP client MUST consider the "x-xmpp-auth" scheme to be stronger than the HTTP Basic scheme and SHOULD consider the HTTP Digest scheme to be stronger than the "x-xmpp-auth" scheme.</p>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="security-channel">Channel Encryption</a>
+</h3>
+    <p class="" style="">To reduce the likelihood of man-in-the-middle attacks, channel encryption SHOULD be used for both the XMPP channel and the HTTP channel. In particular:</p>
+    <ul>
+      <li>The channel used for HTTP requests and responses SHOULD be encrypted via SSL (secure HTTP via https: URIs) or TLS (<span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2257179">7</a>]).</li>
+      <li>If the standard binding of XMPP to TCP is used, TLS SHOULD be negotiated for the XMPP channel in accordance with <span style="font-weight: bold">RFC 3920</span>.</li>
+      <li>If a binding of XMPP to HTTP is used (e.g., as specified in <span style="font-weight: bold">JEP-0124</span>), exchanges between the XMPP Client and XMPP Server (connection manager) SHOULD be sent over a channel that is encrypted using SSL or TLS.</li>
+    </ul> 
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="security-e2e">End-to-End Encryption</a>
+</h3>
+    <p class="" style="">For added security, the XMPP Server and XMPP Client may wish to communicate using end-to-end encryption. Methods for doing so are outside the scope of this proposal.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">If the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257259">8</a>] establishes a registry for HTTP authentication schemes, the "x-xmpp-auth" scheme may be registered there.</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257300">9</a>] shall include "http://jabber.org/protocol/http-auth" in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/http-auth'
+    xmlns='http://jabber.org/protocol/http-auth'
+    elementFormDefault='qualified'&gt;
+  
+  &lt;xs:element name='confirm'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='id' use='optional' type='xs:string'/&gt;
+          &lt;xs:attribute name='method' use='required' type='xs:NCName'/&gt;
+          &lt;xs:attribute name='url' use='required' type='xs:anyURI'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250590">1</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2250756">2</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p><a name="nt-id2250793">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256511">4</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256534">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2256622">6</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2257179">7</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2257259">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257300">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2005-10-19)</h4>
+<div class="indent">Changed use of transaction identifier from MAY to SHOULD; updated and clarified security considerations. (psa)
+    </div>
+<h4>Version 0.7 (2005-10-11)</h4>
+<div class="indent">Added more HTTP examples to illustrate process flow; updated IANA considerations and security considerations. (psa)
+    </div>
+<h4>Version 0.6 (2005-07-21)</h4>
+<div class="indent">Updated references; clarified several points in the text; rewrote introduction. (psa)
+    </div>
+<h4>Version 0.5 (2004-04-27)</h4>
+<div class="indent">Added optional id attribute in order to track requests, described in new implementation note. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-14)</h4>
+<div class="indent">Incorporated results of IRL and IM discussions: simplified the flow; added x-xmpp-auth authentication scheme. (psa/dss/jh)
+    </div>
+<h4>Version 0.3 (2003-06-27)</h4>
+<div class="indent">Removed hashing requirements; added/clarified JID fields in HTTP headers; added XML Schema; added XMPP error conditions; added more descriptions for confirm and accept tokens; fixed discrepancies in examples. (lw)
+    </div>
+<h4>Version 0.2 (2003-06-26)</h4>
+<div class="indent">Updated to reflect feedback received (moved to using standard HTTP authentication headers; included token-authority JID in HTTP header; removed example involving deprecated JEP). (lw)
+    </div>
+<h4>Version 0.1 (2003-01-31)</h4>
+<div class="indent">Initial draft. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0070-0.9.html
+++ b/content/xep-0070-0.9.html
@@ -1,0 +1,527 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0070: Verifying HTTP Requests via XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Verifying HTTP Requests via XMPP">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a protocol that enables verification of an HTTP request via XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0070">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0070: Verifying HTTP Requests via XMPP</h1>
+<p>This document defines a protocol that enables verification of an HTTP request via XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0070<br>
+            Version: 0.9<br>
+            Last Updated: 2005-11-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2616, RFC 2617, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: http-auth<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Verifying%20HTTP%20Requests%20via%20XMPP%20(JEP-0070)">http://wiki.jabber.org/index.php/Verifying HTTP Requests via XMPP (JEP-0070)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt>
+<dt>2.2.  <a href="#terms-entities">Entities</a>
+</dt>
+</dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecase">Use Case</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#http-request">HTTP Client Sends Request via HTTP</a>
+</dt>
+<dt>4.2.  <a href="#http-response">HTTP Server Sends Authenticate Response via HTTP</a>
+</dt>
+<dt>4.3.  <a href="#http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#http-authz-basic">Basic Access Authentication Scheme</a>
+</dt>
+<dt>4.3.2.  <a href="#http-authz-digest">Digest Access Authentication Scheme</a>
+</dt>
+<dt>4.3.3.  <a href="#http-authz-add">Additional Authentication Schemes</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#http-process">HTPP Server Processes Request</a>
+</dt>
+<dt>4.5.  <a href="#xmpp-request">XMPP Server Requests Confirmation via XMPP</a>
+</dt>
+<dt>4.6.  <a href="#xmpp-confirm">XMPP Client Confirms Request via XMPP</a>
+</dt>
+<dt>4.7.  <a href="#http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>5.1.  <a href="#impl-methods">Interaction of HTTP methods</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#security-association">Association of Request</a>
+</dt>
+<dt>6.2.  <a href="#security-strength">Strength of Authentication Schemes</a>
+</dt>
+<dt>6.3.  <a href="#security-channel">Channel Encryption</a>
+</dt>
+<dt>6.4.  <a href="#security-e2e">End-to-End Encryption</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">HTTP (see <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250774">1</a>]) is a nearly-ubiquitous mechanism for the publication and retrieval of information over the Internet. Sometimes it is appropriate for an HTTP Server to allow access to that information only if the HTTP Client first provides authentication credentials. While there exist several standardized HTTP authentication schemes (see <span class="ref" style="">RFC 2617</span>  [<a href="#nt-id2250974">2</a>]), it may be useful in some applications to enforce verification of an HTTP request by requiring an XMPP entity (normally an IM user) to confirm that it made the request. This request verification can be combined with native HTTP authentication to provide a stronger association between the request and a particular user, as well as to take advantage of the strong user authentication provided in XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250822">3</a>]).</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+    <p class="" style="">This document inherits terminology about the HyperText Transfer Protocol from <span style="font-weight: bold">RFC 2616</span> and <span style="font-weight: bold">RFC 2617</span>.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="terms-entities">Entities</a>
+</h3>
+    <p class="caption">Table 1: Terms for Entities Described Herein</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HTTP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the HyperText Transfer Protocol (HTTP)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Client</td>
+        <td align="" colspan="" rowspan="">A client that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">XMPP Server</td>
+        <td align="" colspan="" rowspan="">A server that implements the Extensible Messaging and Presence Protocol (XMPP) or its antecedents</td>
+      </tr>
+    </table>
+    <p class="" style="">Note well that an XMPP Client can simultaneously be an HTTP Client (or vice-versa), and that an XMPP Server can simultaneously be an HTTP Server (or vice-versa). However, for the purposes of this discussion, we assume that these entities are logically if not physically separate and distinct.</p>
+  </div>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The motivations for this document are to:</p>
+  <ul>
+    <li>Use an existing XMPP connection to associate an HTTP request with an XMPP entity.</li>
+    <li>Require confirmation of the request by the XMPP entity before allowing access.</li>
+    <li>Ensure that the HTTP request was generated by the principal controlling the XMPP entity.</li>
+  </ul>
+<h2>4.
+       <a name="usecase">Use Case</a>
+</h2>
+  <p class="" style="">The process flow for this protocol is as follows:</p>
+  <ol start="" type="">
+    <li>HTTP Client requests object via HTTP.</li>
+    <li>HTTP Server sends Authenticate Response via HTTP.</li>
+    <li>HTTP Client sends Authorization Request via HTTP (E1).</li>
+    <li>HTPP Server processes request and forwards it to XMPP Server.</li>
+    <li>XMPP Server requests confirmation via XMPP (E2).</li>
+    <li>XMPP Client confirms request via XMPP.</li>
+    <li>XMPP Server delivers confirmation to HTTP Server.</li>
+    <li>HTTP Server allows HTTP Client to access object (E3).</li>
+  </ol>
+  <p class="" style="">Error cases:</p>
+  <ul>
+    <li>E1: HTTP Client does not understand the presented authentication scheme.</li>
+    <li>E2: HTTP Server does not recognize or understand the request.</li>
+    <li>E3: HTTP Server denies access.</li>
+  </ul>
+  <p class="" style="">This process flow is described in more detail in the following sections.</p>
+  <div class="indent">
+<h3>4.1 <a name="http-request">HTTP Client Sends Request via HTTP</a>
+</h3>
+    <p class="" style="">Let us stipulate that an XMPP user (say, &lt;juliet@capulet.com&gt;) learns of an HTTP URL (e.g., &lt;https://files.shakespeare.lit:9345/missive.html&gt;). The user then attempts to retrieve the URL using her HTTP Client, which opens a TCP connection to the appropriate port of the host and sends an HTTP request as defined in <span style="font-weight: bold">RFC 2616</span>. The request method MAY be any valid HTTP request method, including user-defined methods.</p>
+    <p class="" style="">An example is provided below:</p>
+    <p class="caption">Example 1. HTTP Client Makes Request (No Credentials)</p>
+<div class="indent"><pre>
+GET https://files.shakespeare.lit:9345/missive.html HTTP/1.1
+    </pre></div>
+    <p class="" style="">In order to avoid a round trip, the initial request MAY contain an HTTP Authorization as described below.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="http-response">HTTP Server Sends Authenticate Response via HTTP</a>
+</h3>
+    <p class="" style="">If the user did not provide authorization credentials in the initial request, the HTTP Server then MUST respond with a (401) Authenticate response as defined in <span style="font-weight: bold">RFC 2616</span>. The response MUST contain an HTTP 401 error and one WWW-Authenticate header for each authentication scheme recognized by the HTTP Server. In order to provide authentication via XMPP, at least one of these headers MUST specify a realm of "xmpp" (case-sensitive).</p>
+    <p class="caption">Example 2. HTTP Server Returns Autnenticate Response</p>
+<div class="indent"><pre>
+401 Unauthorized HTTP/1.1
+WWW-Authenticate: Basic realm="xmpp"
+WWW-Authenticate: Digest realm="xmpp", 
+                  domain="files.shakespeare.lit", 
+                  stale=false, 
+                  nonce="ec2cc00f21f71acd35ab9be057970609", 
+                  qop="auth", 
+                  algorithm="MD5"
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="http-authz">HTTP Client Sends Authorization Request via HTTP</a>
+</h3>
+    <p class="" style="">The HTTP Client responds with an Authorization Request as defined in <span style="font-weight: bold">RFC 2616</span>. The following rules apply:</p>
+    <ol start="" type="">
+      <li>The request MUST include the Jabber Identifier (JID) of the user making the request. This SHOULD be the full JID (&lt;user@host/resource&gt;) of a client that supports the protocol defined herein, although it MAY be the user's bare JID (&lt;user@host&gt;) instead.</li>
+      <li>The request MUST include a transaction identifier for the request. This identifier MUST be unique within the context of the HTTP Client's interaction with the HTTP Server. If the HTTP request is generated by the XMPP Client (e.g., because the HTTP URL was discovered via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2256589">4</a>]) tyhen the transaction identifier SHOULD be generated by the client; if not, the transaction identifier SHOULD be provided by the human user who controls the HTTP Client.</li>
+    </ol>
+    <p class="" style="">The Authorization Request process is described in the following subsections.</p>
+    <div class="indent">
+<h3>4.3.1 <a name="http-authz-basic">Basic Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">The Basic Access Authentication scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of a userid and password, separated by a ':' character and then encoded using Base64. When the realm is "xmpp", the profile defined herein further specifies that the userid MUST be a valid JID as described above, that the password entity MUST be a transaction identifier as described above, that Base64 encoding MUST adhere to Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256652">5</a>], and that any character that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256678">6</a>].</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> for specification of the syntax of the Basic Access Authentication scheme; that information is not duplicated here.)</p>
+      <p class="caption">Example 3. HTTP Client Makes Basic Authorization Request</p>
+<div class="indent"><pre>
+Authorization: Basic QWxhZGRpbjpvcGVuIHNlc2FtZQ==
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="http-authz-digest">Digest Access Authentication Scheme</a>
+</h3>
+      <p class="" style="">The Digest Access Authentication scheme is defined in <span style="font-weight: bold">RFC 2617</span>. This scheme specifies that the authorization information shall consist of the MD5 checksum of the username, the password, a nonce value provided in the challenge, the HTTP method, and the requested URI. When the realm is "xmpp", the profile defined herein further specifies that prior to creating the MD5 checksum the username MUST be a valid JID as described above, that the password MUST be a transaction identifier as described above, and that any character that is outside the range of the US-ASCII coded character set MUST be transformed into a percent-encoded octet as specified in Section 2.1 of <span style="font-weight: bold">RFC 3986</span>.</p>
+      <p class="" style="">(Refer to <span style="font-weight: bold">RFC 2617</span> for specification of the syntax of the Digest Access Authentication scheme; that information is not duplicated here.)</p>
+      <p class="caption">Example 4. HTTP Client Makes Digest Authorization Request</p>
+<div class="indent"><pre>
+Authorization: Digest username="juliet@capulet.com",
+               realm="xmpp",
+               nonce="ec2cc00f21f71acd35ab9be057970609", 
+               uri="missive.html",
+               qop=auth,
+               nc=00000001,
+               cnonce="0a4f113b",
+               response="6629fae49393a05397450978507c4ef1",
+               opaque="5ccc069c403ebaf9f0171e9517f40e41" 
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.3 <a name="http-authz-add">Additional Authentication Schemes</a>
+</h3>
+      <p class="" style="">The HTTP Server MAY offer any other valid authentication scheme, instead of or in addition to the Basic and Digest schemes mentioned above, as long as the scheme makes it possible to specify a userid (JID) and transaction identifier as described above. However, it is RECOMMENDED to implement both the Basic and Digest authentication schemes.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="http-process">HTPP Server Processes Request</a>
+</h3>
+    <p class="" style="">Once the HTTP Client has communicated the JID and transaction identifier to the HTTP Server, the HTTP Server MUST verify that the JID is authorized to access the HTTP resource. This may involve JID-level or domain-level access checks, or (depending on local service policies) potentially no access checks at all if only verification is required.</p>
+    <p class="" style="">If the JID is authorized to access the HTTP resource, the HTTP Server MUST pass the JID and transaction identifier to the XMPP Server for confirmation. Exactly how this is done is up to the implementation. The most likely scenario is for the HTTP Server to connect to the XMPP Server as a trusted server component, although it would also be possible for the XMPP Server to provide an HTTP interface.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="xmpp-request">XMPP Server Requests Confirmation via XMPP</a>
+</h3>
+    <p class="" style="">Upon receiving the JID and transaction identifier from the HTTP Server, the XMPP Server MUST send a confirmation request (via XMPP) to the XMPP Client.</p>
+    <p class="" style="">The confirmation request shall consist of an empty &lt;confirm/&gt; element qualified by the ''http://jabber.org/protocol/http-auth' namespace. This element MUST possess a 'method' attribute whose value is the method of the HTTP request, MUST possess a 'url' attribute whose value is the full HTTP URL that was requested, and MUST possess an 'id' attribute whose value is the transaction identifier provided in the HTTP Authorization Request.</p>
+    <p class="" style="">If the JID provided was a full JID, the confirmation request SHOULD be sent in an &lt;iq/&gt; stanza of type "get" whose 'to' attribute is set to the full JID, but MAY be sent in a &lt;message/&gt; stanza.</p>
+    <p class="" style="">If the JID provided was a bare JID, the confirmation request MUST be sent in a &lt;message/&gt; stanza whose 'to' attribute is set to the bare JID; this enables delivery to the "most available" resource for the user (however "most available" is determined by the XMPP Server). The &lt;message/&gt; stanza MAY include a &lt;body/&gt; element that provides human-readable information or instructions.</p>
+    <p class="caption">Example 5. Confirmation Request Sent via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='files.shakespeare.lit' 
+    to='juliet@capulet.com/balcony' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Confirmation Request Sent via Message</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='files.shakespeare.lit' 
+         to='juliet@capulet.com'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;body&gt;
+    Someone (maybe you) has requested the file 
+    https://files.shakespeare.lit:9345/missive.html.
+    If you wish to confirm the request, please reply
+    to this message by typing "OK". If not, please 
+    reply with "No".
+  &lt;/body&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="xmpp-confirm">XMPP Client Confirms Request via XMPP</a>
+</h3>
+    <p class="" style="">If the confirmation request was provided via an &lt;iq/&gt; stanza, the XMPP Client MUST respond to the request by sending an &lt;iq/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;iq/&gt; response stanza MUST be of type "result" and MAY contain the original &lt;confirm/&gt; child element (although this is not necessary since the XMPP 'id' attribute can be used for tracking purposes):</p>
+    <p class="caption">Example 7. XMPP Client Confirms Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'/&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;iq/&gt; response stanza MUST be of type "error", MAY contain the original &lt;confirm/&gt; child element (although this is not necessary since the XMPP 'id' attribute can be used for tracking purposes), and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 8. XMPP Client Denies Request via IQ</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    from='juliet@capulet.com/balcony' 
+    to='files.shakespeare.lit' 
+    id='ha000'&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the confirmation request was provided via a &lt;message/&gt; stanza and the &lt;message/&gt; contains a human-readable &lt;body/&gt; or does not contain a &lt;body/&gt; but the XMPP Client understands the 'http://jabber.org/protocol/http-auth' namespace, the XMPP Client SHOULD respond to the request by sending a &lt;message/&gt; stanza back to the XMPP Server. If the user wishes to confirm the request, the &lt;message/&gt; response stanza SHOULD be of type "normal", MUST mirror the &lt;thread/&gt; ID (if provided by the XMPP Server), and MAY contain the original &lt;confirm/&gt; child element (although this is not required):</p>
+    <p class="caption">Example 9. XMPP Client Confirms Request via Message</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the user wishes to deny the request, the &lt;message/&gt; response stanza MUST be of type "error", MUST mirror the &lt;thread/&gt; ID (if provided by the XMPP Server), MAY (but is not required to) contain the original &lt;confirm/&gt; child element, and MUST specify an error, which SHOULD be &lt;not-authorized/&gt;:</p>
+    <p class="caption">Example 10. XMPP Client Denies Request via Message</p>
+<div class="indent"><pre>
+&lt;message type='error' 
+         from='juliet@capulet.com/balcony'
+         to='files.shakespeare.lit'&gt;
+  &lt;thread&gt;e0ffe42b28561960c6b12b944a092794b9683a38&lt;/thread&gt;
+  &lt;confirm xmlns='http://jabber.org/protocol/http-auth'
+           id='transaction-identifier'
+           method='GET'
+           url='https://files.shakespeare.lit:9345/missive.html'/&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="http-access">HTTP Server Allows HTTP Client to Access Object</a>
+</h3>
+    <p class="" style="">Once the XMPP Client has successfully confirmed the request, the XMPP Server forwards that confirmation to the HTTP Server, which allows access:</p>
+    <p class="caption">Example 11. HTTP Server Allows Access to Object</p>
+<div class="indent"><pre>
+200 OK HTTP/1.1
+Content-Type: text/html
+Content-Length: 3032
+
+...
+    </pre></div>
+    <p class="" style="">If the XMPP Client denied the request, the HTTP Server MUST return a Forbidden error:</p>
+    <p class="caption">Example 12. HTTP Server Denies Access to Object</p>
+<div class="indent"><pre>
+403 Forbidden HTTP/1.1
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="impl-methods">Interaction of HTTP methods</a>
+</h3>
+    <p class="" style="">For the HEAD and OPTIONS methods, the credentials SHOULD be usable for a subsequent request from the same entity. This enables an entity to both determine support for the mechanism defined herein and start the authentication process.</p>
+    <p class="" style="">For the POST and PUT methods (or any method containing a message body), clients MUST send all data with each request; the HTTP server is under no obligation to assume that the client will fail. This is especially true since the client can obtain credentials with a previous HEAD or OPTIONS method.</p>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="security-association">Association of Request</a>
+</h3>
+    <p class="" style="">In order to associate the HTTP request with the XMPP confirmation, a transaction identifier MUST be provided by the user in the HTTP Authorization Request, then passed unchanged to the XMPP Client as the value of the &lt;confirm/&gt; element's 'id' attribute. If the XMPP Client generated the HTTP request, it MUST check the transaction identifier against the requests it has made to verify that the request has not yet been confirmed. If the XMPP Client did not generate the HTTP request, it MUST present the transaction identifier to the user for confirmation. If the XMPP Client or User confirms the request, the XMPP Client MUST then return a confirmation to the XMPP Server for delivery to the HTTP Server.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="security-strength">Strength of Authentication Schemes</a>
+</h3>
+    <p class="" style="">Section 4.6 of <span style="font-weight: bold">RFC 2617</span> specifies that if an HTTP server returns multiple challenges with a 401 (Authenticate) response, an HTTP client must use the strongest authentication scheme it understands. For the purposes of this document, an HTTP client MUST consider the HTTP Digest scheme to be stronger than the HTTP Basic scheme.</p>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="security-channel">Channel Encryption</a>
+</h3>
+    <p class="" style="">To reduce the likelihood of man-in-the-middle attacks, channel encryption SHOULD be used for both the XMPP channel and the HTTP channel. In particular:</p>
+    <ol start="" type="">
+      <li>The channel used for HTTP requests and responses SHOULD be encrypted via SSL (secure HTTP via https: URIs) or TLS (<span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2257383">7</a>]).</li>
+      <li>If the standard binding of XMPP to TCP is used, TLS SHOULD be negotiated for the XMPP channel in accordance with <span style="font-weight: bold">RFC 3920</span>.</li>
+      <li>If a binding of XMPP to HTTP is used (e.g., as specified in <span style="font-weight: bold">JEP-0124</span>), exchanges between the XMPP Client and XMPP Server (connection manager) SHOULD be sent over a channel that is encrypted using SSL or TLS.</li>
+    </ol> 
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="security-e2e">End-to-End Encryption</a>
+</h3>
+    <p class="" style="">For added security, the XMPP Server and XMPP Client may wish to communicate using end-to-end encryption. Methods for doing so are outside the scope of this proposal.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257463">8</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257501">9</a>] shall include "http://jabber.org/protocol/http-auth" in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/http-auth'
+    xmlns='http://jabber.org/protocol/http-auth'
+    elementFormDefault='qualified'&gt;
+  
+  &lt;xs:element name='confirm'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='id' use='required' type='xs:string'/&gt;
+          &lt;xs:attribute name='method' use='required' type='xs:NCName'/&gt;
+          &lt;xs:attribute name='url' use='required' type='xs:anyURI'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250774">1</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2250974">2</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p><a name="nt-id2250822">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256589">4</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2256652">5</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256678">6</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2257383">7</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2257463">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257501">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2005-11-09)</h4>
+<div class="indent">Changed use of transaction identifier from SHOULD to MUST; removed x-xmpp-auth scheme; clarified requirements, business rules, and confirm element syntax; added several more examples; more clearly specified how HTTP server communicates with XMPP server; updated schema and security considerations. (psa)
+    </div>
+<h4>Version 0.8 (2005-10-19)</h4>
+<div class="indent">Changed use of transaction identifier from MAY to SHOULD; updated and clarified security considerations. (psa)
+    </div>
+<h4>Version 0.7 (2005-10-11)</h4>
+<div class="indent">Added more HTTP examples to illustrate process flow; updated IANA considerations and security considerations. (psa)
+    </div>
+<h4>Version 0.6 (2005-07-21)</h4>
+<div class="indent">Updated references; clarified several points in the text; rewrote introduction. (psa)
+    </div>
+<h4>Version 0.5 (2004-04-27)</h4>
+<div class="indent">Added optional id attribute in order to track requests, described in new implementation note. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-14)</h4>
+<div class="indent">Incorporated results of IRL and IM discussions: simplified the flow; added x-xmpp-auth authentication scheme. (psa/dss/jh)
+    </div>
+<h4>Version 0.3 (2003-06-27)</h4>
+<div class="indent">Removed hashing requirements; added/clarified JID fields in HTTP headers; added XML Schema; added XMPP error conditions; added more descriptions for confirm and accept tokens; fixed discrepancies in examples. (lw)
+    </div>
+<h4>Version 0.2 (2003-06-26)</h4>
+<div class="indent">Updated to reflect feedback received (moved to using standard HTTP authentication headers; included token-authority JID in HTTP header; removed example involving deprecated JEP). (lw)
+    </div>
+<h4>Version 0.1 (2003-01-31)</h4>
+<div class="indent">Initial draft. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0071-1.0.html
+++ b/content/xep-0071-1.0.html
@@ -1,0 +1,1500 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0071: XHTML-IM</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XHTML-IM">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines an XHTML 1.0 Integration Set for use in exchanging instant messages that contain lightweight text markup.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0071">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0071: XHTML-IM</h1>
+<p>This JEP defines an XHTML 1.0 Integration Set for use in exchanging instant messages that contain lightweight text markup.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0071<br>
+            Version: 1.0<br>
+            Last Updated: 2004-09-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, XHTML 1.0, Modularization of XHTML, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: xhtml-im<br>
+        Schema for wrapper namespace: &lt;<a href="http://jabber.org/protocol/xhtml-im/xhtml-im-wrapper.xsd">http://jabber.org/protocol/xhtml-im/xhtml-im-wrapper.xsd</a>&gt;<br>
+        Schema for schema driver: &lt;<a href="http://jabber.org/protocol/xhtml-im/xhtml-im-driver.xsd">http://jabber.org/protocol/xhtml-im/xhtml-im-driver.xsd</a>&gt;<br>
+        Schema for content model: &lt;<a href="http://jabber.org/protocol/xhtml-im/xhtml-im-model.xsd">http://jabber.org/protocol/xhtml-im/xhtml-im-model.xsd</a>&gt;<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/XHTML-IM%20(JEP-0071)">http://wiki.jabber.org/index.php/XHTML-IM (JEP-0071)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#tech">Choice of Technology</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dt>5.  <a href="#wrapper">Wrapper Element</a>
+</dt>
+<dt>6.  <a href="#def">XHTML-IM Integration Set</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#def-structure">Structure Module Definition</a>
+</dt>
+<dt>6.2.  <a href="#def-text">Text Module Definition</a>
+</dt>
+<dt>6.3.  <a href="#def-hypertext">Hypertext Module Definition</a>
+</dt>
+<dt>6.4.  <a href="#def-list">List Module Definition</a>
+</dt>
+<dt>6.5.  <a href="#def-image">Image Module Definition</a>
+</dt>
+<dt>6.6.  <a href="#def-style">Style Attribute Module Definition</a>
+</dt>
+</dl>
+<dt>7.  <a href="#profile">Recommended Profile</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#profile-structure">Structure Module Profile</a>
+</dt>
+<dt>7.2.  <a href="#profile-text">Text Module Profile</a>
+</dt>
+<dt>7.3.  <a href="#profile-hypertext">Hypertext Module Profile</a>
+</dt>
+<dt>7.4.  <a href="#profile-list">List Module Profile</a>
+</dt>
+<dt>7.5.  <a href="#profile-image">Image Module Profile</a>
+</dt>
+<dt>7.6.  <a href="#profile-style">Style Attribute Module Profile</a>
+</dt>
+<dl><dt>7.6.1.  <a href="#profile-style-properties">Recommended Style Properties</a>
+</dt></dl>
+<dt>7.7.  <a href="#profile-attributes">Recommended Attributes</a>
+</dt>
+<dl>
+<dt>7.7.1.  <a href="#profile-attributes-common">Common Attributes</a>
+</dt>
+<dt>7.7.2.  <a href="#profile-attributes-special">Specialized Attributes</a>
+</dt>
+<dt>7.7.3.  <a href="#profile-attributes-other">Other Attributes</a>
+</dt>
+</dl>
+<dt>7.8.  <a href="#profile-summary">Summary of Recommendations</a>
+</dt>
+</dl>
+<dt>8.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>9.  <a href="#examples">Examples</a>
+</dt>
+<dt>10.  <a href="#discovery">Discovering Support for XHTML-IM</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#discovery-explicit">Explicit Discovery</a>
+</dt>
+<dt>10.2.  <a href="#discovery-implicit">Implicit Discovery</a>
+</dt>
+</dl>
+<dt>11.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>12.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#w3c-doctype">Document Type Name</a>
+</dt>
+<dt>12.2.  <a href="#w3c-conformance">User Agent Conformance</a>
+</dt>
+<dt>12.3.  <a href="#w3c-modularization">XHTML Modularization</a>
+</dt>
+<dt>12.4.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>12.5.  <a href="#w3c-versions">XHTML Versioning</a>
+</dt>
+</dl>
+<dt>13.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>14.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>15.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#schemas-wrapper">XHTML-IM Wrapper</a>
+</dt>
+<dt>15.2.  <a href="#schemas-driver">XHTML-IM Schema Driver</a>
+</dt>
+<dt>15.3.  <a href="#schemas-model">XHTML-IM Content Model</a>
+</dt>
+</dl>
+<dt>16.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines methods for exchanging instant messages that contain lightweight text markup. In the context of this JEP, "lightweight text markup" is to be understood as a combination of minimal structural elements and presentational styles that can easily be rendered on a wide variety of devices without requiring a full rich-text rendering engine such as a web browser. Examples of lightweight text markup include basic text blocks (e.g., paragraphs), lists, hyperlinks, image references, and font styles (e.g., sizes and colors).</p>
+<h2>2.
+       <a name="tech">Choice of Technology</a>
+</h2>
+  <p class="" style="">In the past, there have existed several incompatible methods within the Jabber community for exchanging instant messages that contain lightweight text markup. The most notable such methods have included derivatives of <span class="ref" style="">XHTML 1.0</span>  [<a href="#nt-id2256237">1</a>] as well as of <span class="ref" style="">Rich Text Format (RTF)</span>  [<a href="#nt-id2256258">2</a>].</p>
+  <p class="" style="">Although it is sometimes easier for client developers to implement RTF support (this is especially true on certain Microsoft Windows operating systems), there are several reasons (consistent with the <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2256288">3</a>]) for the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2256310">4</a>] to avoid the use of RTF in developing a protocol for lightweight text markup. Specifically:</p>
+  <ol start="1" type="1">
+    <li>RTF is not a structured vocabulary derived from SGML (as is <span class="ref" style="">HTML 4.0</span>  [<a href="#nt-id2256344">5</a>]) or, more relevantly, from XML (as is XHTML 1.0).</li>
+    <li>RTF is under the control of the Microsoft Corporation and thus is not an open standard maintained by a recognized standards development organization; therefore the JSF is unable to contribute to or influence its development if necessary, and any protocol the JSF developed using RTF would introduce unwanted dependencies.</li>
+  </ol>
+  <p class="" style="">Conversely, there are several reasons to prefer XHTML for lightweight text markup:</p>
+  <ol start="1" type="1">
+    <li>XHTML is a structured format that is defined as an application of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2256391">6</a>], making it especially appropriate for sending over Jabber/XMPP, which is at root a technology for streaming XML (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2256414">7</a>]).</li>
+    <li>XHTML is an open standard developed by the <span class="ref" style="">World Wide Web Consortium (W3C)</span>  [<a href="#nt-id2256441">8</a>], a recognized standards development organization.</li>
+  </ol>
+  <p class="" style="">Therefore, this JEP defines support for lightweight text markup in the form of an XMPP extension that encapsulates content defined by an XHTML 1.0 Integration Set that we label "XHTML-IM". The remainder of this JEP discusses lightweight text markup in terms of XHTML 1.0 only and does not further consider RTF or other technologies.</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">HTML was originally designed for authoring and presenting stuctured documents on the World Wide Web, and was subsequently extended to handle more advanced functionality such as image maps and interactive forms. However, the requirements for publishing documents (or developing transactional websites) for presentation by dedicated XHTML clients on traditional computers or small-screen devices are fundamentally different from the requirements for lightweight text markup of instant messages; for this reason, only a reduced set of XHTML features is needed for XHTML-IM. In particular:</p>
+  <ol start="1" type="1">
+    <li><p class="" style="">IM clients are not XHTML clients: their primary purpose is not to read pre-existing XHTML documents, but to read <span style="font-style: italic">and generate</span> relatively large numbers of fairly small instant messages.</p></li>
+    <li><p class="" style="">The underlying context for XHTML content in Jabber/XMPP instant messaging is provided not by a full XHTML document, but by an XML stream, and specifically by a message stanza within that stream. Thus the &lt;head/&gt; element and all its children are unnecessary. Only the &lt;body/&gt; element and some of its children are appropriate for use in instant messaging.</p></li>
+    <li><p class="" style="">The XHTML content that is read by one's IM client is normally generated on the fly by one's conversation partner (or, to be precise, by his or her IM client). Thus there is an inherent limit to the sophistication of the XHTML markup involved. Even in normal XHTML documents, fairly basic structural and rendering elements such as definition lists, abbreviations, addresses, and computer input handling (e.g., &lt;kbd/&gt; and &lt;var/&gt;) are relatively rare. There is little or no foreseeable need for such elements within the context of instant messaging.</p></li>
+    <li><p class="" style="">The foregoing is doubly true of more advanced markup such as tables, frames, and forms (however, there exists an XMPP extension that provides an instant messaging equivalent of the latter, as defined in <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2256572">9</a>]).</p></li>
+    <li><p class="" style="">Although ad-hoc styles are useful for messaging (by means of the 'style' attribute), full support for <span class="ref" style="">Cascading Style Sheets</span>  [<a href="#nt-id2256602">10</a>] (defined by the &lt;style/&gt; element or a standalone .css file, and implemented via the 'class' attribute) would be overkill since many CSS1 properties (e.g., box, classification, and text properties) were developed especially for sophisticated page layout.</p></li>
+    <li><p class="" style="">Background images, audio, animated text, layers, applets, scripts, and other multimedia content types are unnecessary, especially given the existence of XMPP extensions such as <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256645">11</a>].</p></li>
+    <li><p class="" style="">Content transformations such as those defined by <span class="ref" style="">XSL Transformations</span>  [<a href="#nt-id2256675">12</a>] must not be necessary in order for an instant messaging application to present lightweight text markup to an end user.</p></li>
+  </ol>
+  <p class="" style="">As explained below, some of these requirements are addressed by the definition of the XHTML-IM Integration Set itself, while others are addressed by a recommended "profile" for that Integration Set in the context of instant messaging applications.</p>
+<h2>4.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">This document defines an adaptation of XHTML 1.0 (specifically, an XHTML 1.0 Integration Set) that makes it possible to provide lightweight text markup of instant messages (mainly for Jabber/XMPP instant messages, although the Integration Set defined herein could be used by other protocols). This pattern is familiar from email, wherein the HTML-formatted version of the message supplements but does not supersede the text-only version of the message.  [<a href="#nt-id2256715">13</a>]</p>
+  <p class="" style="">In Jabber/XMPP communications, the meaning (as opposed to markup) of the message MUST always be represented as best as possible in the normal &lt;body/&gt; child element or elements of the &lt;message/&gt; stanza qualified by the 'jabber:client' (or 'jabber:server') namespace. Lightweight text markup is then provided within an &lt;html/&gt; element qualified by the 'http://jabber.org/protocol/xhtml-im' namespace.  [<a href="#nt-id2256728">14</a>] However, this &lt;html/&gt; element is used solely as a "wrapper" for the XHTML content itself, which content is encapsulated via one or more &lt;body/&gt; elements qualified by the 'http://www.w3.org/1999/xhtml' namespace, along with appropriate child elements thereof.</p>
+  <p class="" style="">The following example illustrates this approach.</p>
+  <p class="caption">Example 1. A simple example</p>
+<div class="indent"><pre>
+&lt;message&gt;
+  &lt;body&gt;hi!&lt;/body&gt;
+  &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt;
+    &lt;body xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p style='font-weight:bold'&gt;hi!&lt;/p&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Technically speaking, there are three aspects to the approach taken herein:</p>
+  <ol start="1" type="1">
+    <li>Definition of the &lt;html/&gt; "wrapper" element, which functions as an XMPP extension within XMPP &lt;message/&gt; stanzas.</li>
+    <li>Definition of the XHTML-IM Integration Set itself in terms of supported XHTML 1.0 modules, using the concepts defined in <span class="ref" style="">Modularization of XHTML</span>  [<a href="#nt-id2256822">15</a>].</li>
+    <li>A recommended "profile" regarding the specific XHTML 1.0 elements and attributes to be supported from each XHTML 1.0 module.</li>
+  </ol>
+  <p class="" style="">These three aspects are defined in the three document sections that follow.</p>
+<h2>5.
+       <a name="wrapper">Wrapper Element</a>
+</h2>
+  <p class="" style="">The root element for including XHTML content within XMPP stanzas is &lt;html/&gt;. This element is qualified by the 'http://jabber.org/protocol/xhtml-im' namespace. From the perspective of XMPP, it functions as an XMPP extension element; from the perspective of XHTML, it functions as a wrapper for XHTML 1.0 content qualified by the 'http://www.w3.org/1999/xhtml' namespace. Such XHTML content MUST be contained in one or more &lt;body/&gt; elements qualified by the 'http://www.w3.org/1999/xhtml' namespace and MUST conform to the XHTML-IM Integration Set defined in the following section. If more than one &lt;body/&gt; element is included in the &lt;html/&gt; wrapper element, each &lt;body/&gt; element MUST possess an 'xml:lang' attribute with a distinct value, where the value of that attribute MUST adhere to the rules defined in <span class="ref" style="">RFC 3066</span>  [<a href="#nt-id2256889">16</a>]. A formal definition of the &lt;html/&gt; element is provided in the <a href="#schemas-wrapper">XHTML-IM Wrapper Schema</a>.</p>
+  <p class="" style="">Note: The XHTML &lt;body/&gt; element is not to be confused with the XMPP &lt;body/&gt; element, which is a child of a &lt;message/&gt; stanza and is qualified by the 'jabber:client' or 'jabber:server' namespace as described in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256935">17</a>]. The &lt;html/&gt; wrapper element is intended for inclusion only as a direct child element of the XMPP &lt;message/&gt; stanza and only in order to specify a marked-up version of the message &lt;body/&gt; element or elements, but MAY be included elsewhere in accordance with the "extended namespace" rules defined in the <span style="font-weight: bold">XMPP IM</span> specification.</p>
+  <p class="" style="">Until and unless (1) additional integration sets are defined and (2) mechanisms are specified for discovering or negotiating which integration sets are supported, the XHTML markup contained within the &lt;html/&gt; wrapper element MUST NOT include elements and attributes that are not part of the XHTML-IM Integration Set defined in the following section, and any such elements and attributes MUST be ignored if received (where the meaning of "ignore" is defined by the conformance requirements of <span style="font-weight: bold">Modularization of XHTML</span>, as summarized in the <a href="#w3c-conformance">User Agent Conformance</a> section of this document).</p>
+<h2>6.
+       <a name="def">XHTML-IM Integration Set</a>
+</h2>
+  <p class="" style="">This section defines an XHTML 1.0 Integration Set for use in the context of instant messaging. Given its intended usage, we label it "XHTML-IM".</p>
+  <p class="" style=""><span style="font-weight: bold">Modularization of XHTML</span> provides the ability to formally define subsets of XHTML 1.0 via the concept of "modularization" (which may be familiar from <span class="ref" style="">XHTML Basic</span>  [<a href="#nt-id2257038">18</a>]). Many of the defined modules are not necessary or useful in the context of instant messaging, and in the context of Jabber/XMPP instant messaging specifically some modules have been superseded by well-defined XMPP extensions. This JEP specifies that XHTML-IM shall be based on the following XHTML 1.0 modules:</p>
+  <ul>
+    <li>Core Modules
+      <ul>
+        <li>Structure Module</li>
+        <li>Text Module</li>
+        <li>Hypertext Module</li>
+        <li>List Module</li>
+      </ul>
+    </li>
+    <li>Image Module</li>
+    <li>Style Attribute Module</li>
+  </ul>
+  <p class="" style=""><span style="font-weight: bold">Modularization of XHTML</span> defines many additional modules, such as Table Modules, Form Modules, Object Modules, and Frame Modules. None of these modules is part of the XHTML-IM Integration Set. If support for such modules is desired, it MUST be defined in a separate and distinct integration set.</p>
+  <div class="indent">
+<h3>6.1 <a name="def-structure">Structure Module Definition</a>
+</h3>
+    <p class="" style="">The Structure Module is defined as including the following elements and attributes:  [<a href="#nt-id2257101">19</a>]</p>
+    <p class="caption">Table 1: Defined Structure Module Elements and Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Attributes</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;body/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;head/&gt;</td>
+<td align="" colspan="" rowspan="">profile</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;html/&gt;</td>
+<td align="" colspan="" rowspan="">version</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;title/&gt;</td>
+<td align="" colspan="" rowspan=""></td>
+</tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="def-text">Text Module Definition</a>
+</h3>
+    <p class="" style="">The Text Module is defined as including the following elements and attributes:</p>
+    <p class="caption">Table 2: Defined Text Module Elements and Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Attributes</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;abbr/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;acronym/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;address/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;blockquote/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style; cite</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;br/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;cite/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;code/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;dfn/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;div/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;em/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;h1/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;h2/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;h3/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;h4/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;h5/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;h6/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;kbd/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;p/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;pre/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;q/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style; cite</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;samp/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;span/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;strong/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;var/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="def-hypertext">Hypertext Module Definition</a>
+</h3>
+    <p class="" style="">The Hypertext Module is defined as including the &lt;a/&gt; element only:</p> 
+    <p class="caption">Table 3: Defined Hypertext Module Elements and Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Attributes</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style; accesskey, charset, href, hreflang, rel, rev, tabindex, type</td>
+</tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="def-list">List Module Definition</a>
+</h3>
+    <p class="" style="">The List Module is defined as including the following elements and attributes:</p>
+    <p class="caption">Table 4: Defined List Module Elements and Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Attributes</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;dl/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;dt/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;dd/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;ol/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;ul/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;li/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style</td>
+</tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="def-image">Image Module Definition</a>
+</h3>
+    <p class="" style="">The Image Module is defined as including the &lt;img/&gt; element only:</p>
+    <p class="caption">Table 5: Defined Image Module Elements and Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Attributes</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;img/&gt;</td>
+<td align="" colspan="" rowspan="">class, id, title; style; alt, height, longdesc, src, width</td>
+</tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="def-style">Style Attribute Module Definition</a>
+</h3>
+    <p class="" style="">The Style Attribute Module is defined as including the style attribute only, as included in the preceding definition tables.</p>
+  </div>
+<h2>7.
+       <a name="profile">Recommended Profile</a>
+</h2>
+  <p class="" style="">Even within the restricted set of modules specified as defining the XHTML-IM Integration Set (see preceding section), some elements and attributes are inappropriate or unnecessary for the purpose of instant messaging; although such elements and attributes MAY be included in accordance with the XHTML-IM Integration Set, further recommended restrictions regarding which elements and attributes to include in XHTML content are specified below.</p>
+  <div class="indent">
+<h3>7.1 <a name="profile-structure">Structure Module Profile</a>
+</h3>
+    <p class="" style="">The intent of the protocol defined herein is to support lightweight text markup of XMPP message bodies only. Therefore the &lt;head/&gt;, &lt;html/&gt;, and &lt;title/&gt; elements are NOT RECOMMENDED to be generated by a compliant implementation, and SHOULD be ignored if received (where the meaning of "ignore" is defined by the conformance requirements of <span style="font-weight: bold">Modularization of XHTML</span>, as summarized in the <a href="#w3c-conformance">User Agent Conformance</a> section of this document). However, the &lt;body/&gt; element is REQUIRED, since it is the root element for all XHTM content.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="profile-text">Text Module Profile</a>
+</h3>
+    <p class="" style="">Not all of the Text Module elements are appropriate in the context of instant messaging, since the XHTML content that one views is generated by one's conversation partner in what is often a rapid-fire conversation thread. Only the following elements are RECOMMENDED in XHTML-IM:</p>
+    <ul>
+      <li>&lt;br/&gt;</li>
+      <li>&lt;div/&gt;</li>
+      <li>&lt;p/&gt;</li>
+      <li>&lt;span/&gt;</li>
+    </ul>
+    <p class="" style="">The other Text Module elements SHOULD NOT be generated by a compliant implementation, and MAY be ignored if received (where the meaning of "ignore" is defined by the conformance requirements of <span style="font-weight: bold">Modularization of XHTML</span>, as summarized in the <a href="#w3c-conformance">User Agent Conformance</a> section of this document).</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="profile-hypertext">Hypertext Module Profile</a>
+</h3>
+    <p class="" style="">The only recommended attributes of the &lt;a/&gt; element are specified in th <a href="#profile-attributes">Recommended Attributes</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="profile-list">List Module Profile</a>
+</h3>
+    <p class="" style="">Because it is unlikely that an instant messaging user would generate a definition list, only ordered and unordered lists are RECOMMENDED. Definition lists SHOULD NOT be generated by a compliant implementation, and MAY be ignored if received (where the meaning of "ignore" is defined by the conformance requirements of <span style="font-weight: bold">Modularization of XHTML</span>, as summarized in the <a href="#w3c-conformance">User Agent Conformance</a> section of this document).</p>
+  </div>
+  <div class="indent">
+<h3>7.5 <a name="profile-image">Image Module Profile</a>
+</h3>
+    <p class="" style="">The only recommended attributes of the &lt;img/&gt; element are specified in the <a href="#profile-attributes">Recommended Attributes</a> section of this document. In addition, for security reasons or because of display constraints, a compliant client MAY choose to display 'alt' text only, not the image itself.</p>
+  </div>
+  <div class="indent">
+<h3>7.6 <a name="profile-style">Style Attribute Module Profile</a>
+</h3>
+    <p class="" style="">This module MUST be supported in XHTML-IM if possible; although clients written for certain platforms (e.g., console clients, mobile phones, and handheld computers) or for certain classes of users (e.g., text-to-speech clients) may not be able to support all of the recommended styles directly, they SHOULD attempt to emulate or translate the defined style properties into text or other presentation styles that are appropriate for the platform or user base in question.</p> 
+    <p class="" style="">A full list of recommended style properties is provided below.</p>
+    <div class="indent">
+<h3>7.6.1 <a name="profile-style-properties">Recommended Style Properties</a>
+</h3>
+      <p class="" style=""><span style="font-weight: bold">CSS1</span> defines 42 "atomic" style properties (which are categorized into font, color and background, text, box, and classification properties) as well as 11 "shorthand" properties ("font", "background", "margin", "padding", "border-width", "border-top", "border-right", "border-bottom", "border-left", "border", and "list-style"). Many of these properties are not appropriate for use in text-based instant messaging, for one or more of the following reasons:</p>
+      <ol start="1" type="1">
+        <li>The property applies to or depends on the inclusion of images other than those handled by the XHTML Image Module (e.g., the "background-image", "background-repeat", "background-attachment", "background-position", and "list-style-image"  properties).</li>
+        <li>The property is intended for advanced document layout (e.g., the "line-height" property and most of the box properties, with the exception of "margin-left", which is useful for indenting text, and "margin-right", which can be useful when dealing with images).</li>
+        <li>The property is unnecessary since it can be emulated via user input or recommended XHTML stuctural elements (e.g., the "text-transform" property can be emulated by the user's keystrokes or use of the caps lock key)</li>
+        <li>The property is otherwise unlikely to ever be used in the context of rapid-fire conversations (e.g., the "font-variant", "word-spacing", "letter-spacing", and "list-style-position" properties).</li>
+        <li>The property is a shorthand property but some of the properties it includes are not appropriate for instant messaging applications according to the foregoing considerations (in fact this applies to all of the shorthand properties).</li>
+      </ol>
+      <p class="" style="">Unfortunately, <span style="font-weight: bold">CSS1</span> does not include mechanisms for defining profiles thereof (as does XHTML 1.0 in the form of XHTML Modularization). While there exist reduced sets of CSS2, these introduce more complexity than is desirable in the context of XHTML-IM. Therefore we simply provide a list of recommended CSS1 style properties.</p>
+      <p class="" style="">XHTML-IM stipulates that only the following style properties are RECOMMENDED:</p>
+      <ul>
+        <li>background-color</li>
+        <li>color</li>
+        <li>font-family</li>
+        <li>font-size</li>
+        <li>font-style</li>
+        <li>font-weight</li>
+        <li>margin-left</li>
+        <li>margin-right</li>
+        <li>text-align</li>
+        <li>text-decoration</li>
+      </ul>
+      <p class="" style="">Although a compliant implementation MAY generate or process other style properties defined in CSS1, such behavior is NOT RECOMMENDED by this JEP.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>7.7 <a name="profile-attributes">Recommended Attributes</a>
+</h3>
+    <div class="indent">
+<h3>7.7.1 <a name="profile-attributes-common">Common Attributes</a>
+</h3>
+      <p class="" style="">Section 5.1 of <span style="font-weight: bold">Modularization of XHTML</span> describes several "common" attribute collections: a "Core" collection ('class', 'id', 'title'), an "I18N" collection ('xml:lang', not shown below since it is implied in XML), an "Events" collection (not included in the XHTML-IM Integration Set because the Intrinsic Events Module is not selected), and a "Style" collection ('style'). The following table summarizes the recommended profile of these common attributes within the XHTML 1.0 content itself:</p>
+      <p class="caption">Table 6: Recommended Usage of Common Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+<th colspan="" rowspan="">Attribute</th>
+<th colspan="" rowspan="">Usage</th>
+<th colspan="" rowspan="">Reason</th>
+</tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">class</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+          <td align="" colspan="" rowspan="">External stylesheets (which 'class' would reference) are not recommended.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">id</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+          <td align="" colspan="" rowspan="">Internal links and message fragments are not recommended in IM content, nor are external stylesheets (which also make use of the 'id' attribute).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">title</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+          <td align="" colspan="" rowspan="">Granting of titles to elements in IM content seems unnecessary.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">style</td>
+          <td align="" colspan="" rowspan="">REQUIRED</td>
+          <td align="" colspan="" rowspan="">The 'style' attribute is required since it is the vehicle for presentational styles.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">xml:lang</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+          <td align="" colspan="" rowspan="">Differentiation of language identification should occur at the level of the &lt;body/&gt; element only.</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>7.7.2 <a name="profile-attributes-special">Specialized Attributes</a>
+</h3>
+      <p class="" style="">Beyond the "common" attributes, certain elements within the modules selected for the XHTML-IM Integration Set are allowed to possess other attributes, such as eight attributes for the &lt;a/&gt; element and five attributes for the &lt;img/&gt; element. The recommended profile for such attributes is provided in the following table:</p>
+      <p class="caption">Table 7: Recommended Usage of Specialized Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+<th colspan="" rowspan="">Element Scope</th>
+<th colspan="" rowspan="">Attribute</th>
+<th colspan="" rowspan="">Usage</th>
+</tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+          <td align="" colspan="" rowspan="">accesskey</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+          <td align="" colspan="" rowspan="">charset</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+          <td align="" colspan="" rowspan="">href</td>
+          <td align="" colspan="" rowspan="">REQUIRED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+          <td align="" colspan="" rowspan="">hreflang</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+          <td align="" colspan="" rowspan="">rel</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+          <td align="" colspan="" rowspan="">rev</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+          <td align="" colspan="" rowspan="">tabindex</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+          <td align="" colspan="" rowspan="">type</td>
+          <td align="" colspan="" rowspan="">RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;img/&gt;</td>
+          <td align="" colspan="" rowspan="">alt</td>
+          <td align="" colspan="" rowspan="">REQUIRED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;img/&gt;</td>
+          <td align="" colspan="" rowspan="">height</td>
+          <td align="" colspan="" rowspan="">RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;img/&gt;</td>
+          <td align="" colspan="" rowspan="">longdesc</td>
+          <td align="" colspan="" rowspan="">NOT RECOMMENDED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;img/&gt;</td>
+          <td align="" colspan="" rowspan="">src</td>
+          <td align="" colspan="" rowspan="">REQUIRED</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&lt;img/&gt;</td>
+          <td align="" colspan="" rowspan="">width</td>
+          <td align="" colspan="" rowspan="">RECOMMENDED</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>7.7.3 <a name="profile-attributes-other">Other Attributes</a>
+</h3>
+      <p class="" style="">Other XHTML 1.0 attributes SHOULD NOT be generated by a compliant implementation, and SHOULD be ignored if received (where the meaning of "ignore" is defined by the conformance requirements of <span style="font-weight: bold">Modularization of XHTML</span>, as summarized in the <a href="#w3c-conformance">User Agent Conformance</a> section of this document).</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>7.8 <a name="profile-summary">Summary of Recommendations</a>
+</h3>
+    <p class="" style="">The following table summarizes the elements and attributes that are recommended within the XHTML-IM Integration Set.</p>
+    <p class="caption">Table 8: Recommended Elements and Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Attributes</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;a/&gt;</td>
+        <td align="" colspan="" rowspan="">href, style, type</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;body/&gt;</td>
+        <td align="" colspan="" rowspan="">style, xml:lang  [<a href="#nt-id2259002">20</a>]</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;br/&gt;</td>
+        <td align="" colspan="" rowspan="">-none-</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;img/&gt;</td>
+        <td align="" colspan="" rowspan="">alt, height, src, style, width</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;li/&gt;</td>
+        <td align="" colspan="" rowspan="">style</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;ol/&gt;</td>
+        <td align="" colspan="" rowspan="">style</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;p/&gt;</td>
+        <td align="" colspan="" rowspan="">style</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;span/&gt;</td>
+        <td align="" colspan="" rowspan="">style</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;ul/&gt;</td>
+        <td align="" colspan="" rowspan="">style</td>
+      </tr>
+    </table>
+    <p class="" style="">Any other elements and attributes defined in the XHTML 1.0 modules that are included in the XHTML-IM Integration Set SHOULD NOT be generated by a compliant implementation, and SHOULD be ignored if received (where the meaning of "ignore" is defined by the conformance requirements of <span style="font-weight: bold">Modularization of XHTML</span>, as summarized in the <a href="#w3c-conformance">User Agent Conformance</a> section of this document).</p>
+  </div>
+<h2>8.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <p class="" style="">The following rules apply to the generation and processing of XHTML content by Jabber clients or other XMPP entities.</p>
+  <ol start="1" type="1">
+    <li><p class="" style="">The sending client MUST ensure that, if XHTML content is sent, its meaning is the same as that of the plaintext version, and that the two versions differ only in markup rather than meaning.</p></li>
+    <li><p class="" style="">XHTML-IM is a reduced set of <span style="font-weight: bold">XHTML 1.0</span> and thus also of <span style="font-weight: bold">XML 1.0</span>. Therefore all opening tags MUST be completed by inclusion of an appropriate closing tag.</p></li>
+    <li><p class="" style=""><span style="font-weight: bold">XMPP Core</span> specifies that an XMPP &lt;message/&gt; MAY contain more than one &lt;body/&gt; child as long as each &lt;body/&gt; possesses an 'xml:lang' attribute with a distinct value. In order to ensure correct internationalization, if an XMPP &lt;message/&gt; stanza contains more than one &lt;body/&gt; child and is also sent as XHTML-IM, the &lt;html/&gt; element SHOULD also contain more than one &lt;body/&gt; child, with one such element for each &lt;body/&gt; child of the &lt;message/&gt; stanza (distinguished by an appropriate 'xml:lang' attribute).</p></li>
+    <li><p class="" style="">Section 11.1 of <span style="font-weight: bold">XMPP Core</span> stipulates that character entities other than the five general entities defined in Section 4.6 of the XML specification (i.e., &amp;lt;, &amp;gt;, &amp;amp;, &amp;apos;, and &amp;quot;) MUST NOT be sent over an XML stream. Therefore implementations of XHTML-IM MUST NOT include predefined XHTML 1.0 entities such as &amp;nbsp; -- instead, implementations MUST use the equivalent character references as specified in Section 4.1 of the XML specification (even in non-obvious places such as URIs that are included in the 'href' attribute).</p></li>
+    <li><p class="" style="">For elements and attributes qualified by the 'http://www.w3.org/1999/xhtml' namespace, user agent conformance is guided by the requirements defined in <span style="font-weight: bold">Modularization of XHTML</span>; for details, refer to the <a href="#w3c-conformance">User Agent Conformance</a> section of this document.</p></li>
+    <li><p class="" style="">The use of structural elements is NOT RECOMMENDED where presentational styles are desired, which is why very few structural elements are specified herein. Implementations SHOULD use appropriate 'style' attributes (e.g., &lt;span style='font-weight: bold'&gt;this is bold&lt;/span&gt; and &lt;p style='margin-left: 5%'&gt;this is indented&lt;/p&gt;) rather than XHTML structural elements (e.g., &lt;strong/&gt; and &lt;blockquote/&gt;) wherever possible.</p></li>
+    <li><p class="" style="">Nesting of block structural elements (&lt;p/&gt;) and list elements (&lt;dl/&gt;, &lt;ol/&gt;, &lt;ul/&gt;) is NOT RECOMMENDED, except within &lt;div/&gt; elements.</p></li>
+    <li><p class="" style="">It is RECOMMENDED for implementations to replace line breaks with the &lt;br/&gt; element and to replace significant whitepace with the appropriate number of non-breaking spaces (via the NO-BREAK SPACE character or its equivalent), where "significant whitespace" means whitespace makes some material difference (e.g., one or more spaces at the beginning of a line or more than one space anywhere else within a line), not "normal" whitespace separating words or punctuation.</p></li>
+  </ol>
+<h2>9.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The following examples provide an insight into the inclusion of XHTML content in XMPP &lt;message/&gt; stanzas but are by no means exhaustive or definitive.</p>
+  <p class="" style="">(Note: The examples may not render correctly in all web browsers, since not all web browsers comply fully with the XHTML 1.0 and CSS1 standards. Markup in the examples may include line breaks for readability. Example renderings are shown with a colored background to set them off from the rest of the text.)</p>
+  <p class="caption">Example 2. Bold, italic, font colors</p>
+<div class="indent"><pre>
+&lt;message&gt;
+  &lt;body&gt;OMG, I&amp;apos;m green with envy!&lt;/body&gt;
+  &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt;
+    &lt;body xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p style='font-size:large'&gt;
+        &lt;span style='font-style: italic'&gt;OMG&lt;/span&gt;, 
+        I&amp;apos;m &lt;span style='color:green'&gt;green&lt;/span&gt;
+        with &lt;span style='font-weight: bold'&gt;envy&lt;/span&gt;!
+      &lt;/p&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">This could be rendered as follows:</p>
+  <div class="example" style="">
+    <p class="" style="font-size: large"><span class="" style="font-style: italic">OMG</span>, I'm <span class="" style="color:green">green</span> with <span class="" style="font-weight: bold">envy</span>!</p>
+  </div>
+  <p class="caption">Example 3. Indentation</p>
+<div class="indent"><pre>
+&lt;message&gt;
+  &lt;body&gt;As Emerson said in his essay Self-Reliance:
+
+     &amp;quot;A foolish consistency is the hobgoblin of little minds.&amp;quot;
+  &lt;/body&gt;
+  &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt;
+    &lt;body xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p&gt;As Emerson said in his essay &lt;span style='font-style: italic'&gt;Self-Reliance&lt;/span&gt;:&lt;/p&gt;
+      &lt;p style='margin-left: 5%'&gt;
+        &amp;quot;A foolish consistency is the hobgoblin of little minds.&amp;quot;
+      &lt;/p&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">This could be rendered as follows:</p>
+  <div class="example" style="">
+    <p class="" style="">As Emerson said in his essay <span class="" style="font-style: italic">Self-Reliance</span>:</p>
+    <p class="" style="margin-left: 5%">
+      "A foolish consistency is the hobgoblin of little minds."
+    </p>
+  </div>
+  <p class="caption">Example 4. An image and a hyperlink</p>
+<div class="indent"><pre>
+&lt;message&gt;
+  &lt;body&gt;Hey, are you licensed to Jabber?
+
+  http://www.jabber.org/images/psa-license.jpg
+  &lt;/body&gt;
+  &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt;
+    &lt;body xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p&gt;Hey, are you licensed to &lt;a href='http://www.jabber.org/'&gt;Jabber&lt;/a&gt;?&lt;/p&gt;
+      &lt;p&gt;&lt;img src='http://www.jabber.org/images/psa-license.jpg'
+              alt='A License to Jabber'
+              height='261'
+              width='537'/&gt;&lt;/p&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">This could be rendered as follows:</p>
+  <div class="indent" style="">
+    <p class="" style="">Hey, are you licensed to <a href="http://www.jabber.org/">Jabber</a>?</p>
+    <p class="" style=""><img src="http://www.jabber.org/images/psa-license.jpg"></p>
+  </div>
+  <p class="" style="">Note the large size of the image. Including the 'height' and 'width' attributes is therefore quite friendly, since it gives the receiving application hints as to whether the image is too large to fit into the current interface (naturally, these are hints only and cannot necessarily be relied upon in determining the size of the image).</p>
+  <p class="" style="">Rendering the 'alt' value rather than the image would yield something like the following:</p>
+  <div class="example" style="">
+    <p class="" style="">Hey, are you licensed to <a href="http://www.jabber.org/">Jabber</a>?</p>
+    <p class="" style="">IMG: "A License to Jabber"</p>
+  </div>
+  <p class="caption">Example 5. Two lists</p>
+<div class="indent"><pre>
+&lt;message&gt;
+  &lt;body&gt;Here&amp;apos;s my .plan for today:
+  1. Add the following examples to JEP-0071:
+     - ordered and unordered lists
+     - more styles (e.g., indentation)
+  2. Kick back and relax
+  &lt;/body&gt;
+  &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt;
+    &lt;body xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p&gt;Here&amp;apos;s my .plan for today:&lt;/p&gt;
+      &lt;ol&gt;
+        &lt;li&gt;Add the following examples to JEP-0071:
+          &lt;ul&gt;
+            &lt;li&gt;ordered and unordered lists&lt;/li&gt;
+            &lt;li&gt;more styles (e.g., indentation)&lt;/li&gt;
+          &lt;/ul&gt;
+        &lt;/li&gt;
+        &lt;li&gt;Kick back and relax&lt;/li&gt;
+      &lt;/ol&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">This could be rendered as follows:</p>
+  <div class="example" style="">
+    <p class="" style="">Here's my .plan for today:</p>
+    <ol start="1" type="1">
+      <li>Add the following examples to JEP-0071:
+        <ul>
+          <li>ordered and unordered lists</li>
+          <li>more styles (e.g., indentation)</li>
+        </ul>
+      </li>
+      <li>Kick back and relax</li>
+    </ol>
+  </div>
+  <p class="caption">Example 6. Quoted text</p>
+<div class="indent"><pre>
+&lt;message&gt;
+  &lt;body&gt;
+You wrote:
+
+   I think we have consensus on the following:
+
+   1. Remove &lt;div/&gt;
+   2. Nesting is not recommended
+   3. Don't preserve whitespace
+
+   Yes, no, maybe?
+
+That seems fine to me.
+  &lt;/body&gt;
+  &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt;
+    &lt;body xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p&gt;You wrote:&lt;/p&gt;
+      &lt;div style='margin-left: 5%'&gt;
+        &lt;p&gt;I think we have consensus on the following:&lt;/p&gt;
+        &lt;ol&gt;
+          &lt;li&gt;Remove &amp;lt;div/&amp;gt;&lt;/li&gt;
+          &lt;li&gt;Nesting is not recommended&lt;/li&gt;
+          &lt;li&gt;Don't preserve whitespace&lt;/li&gt;
+        &lt;/ol&gt;
+        &lt;p&gt;Yes, no, maybe?&lt;/p&gt;
+      &lt;/div&gt;
+      &lt;p&gt;That seems fine to me.&lt;/p&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Although quoting received messages is relatively uncommon in IM, it does happen. This could be rendered as follows:</p>
+  <div class="example" style="">
+      <p class="" style="">You wrote:</p>
+      <div class="" style="margin-left: 5%">
+        <p class="" style="">I think we have consensus on the following:</p>
+        <ol start="" type="">
+          <li>Remove &lt;div/&gt;</li>
+          <li>Nesting is not recommended</li>
+          <li>Don't preserve whitespace</li>
+        </ol>
+        <p class="" style="">Yes, no, maybe?</p>
+      </div>
+      <p class="" style="">That seems fine to me.</p>
+  </div>
+  <p class="caption">Example 7. Multiple bodies</p>
+<div class="indent"><pre>
+&lt;message&gt;
+  &lt;body xml:lang='en-US'&gt;awesome!&lt;/body&gt;
+  &lt;body xml:lang='de-DE'&gt;ausgezeichnet!&lt;/body&gt;
+  &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt;
+    &lt;body xml:lang='en-US' xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p style='font-weight: bold'&gt;awesome!&lt;/p&gt;
+    &lt;/body&gt;
+    &lt;body xml:lang='de-DE' xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p style='font-weight: bold'&gt;ausgezeichnet!&lt;/p&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">How multiple bodies would best be rendered will depend on the user agent and relevant application. For example, a specialized Jabber client that is used in foreign language instruction might show two languages side by side, whereas a dedicated IM client might show content only in a human user's preferred language as captured in the client configuration.</p>
+  <p class="caption">Example 8. Unrecognized Elements and Attributes</p>
+<div class="indent"><pre>
+&lt;message&gt;
+  &lt;body&gt;
+    The XHTML user agent conformance requirements say to ignore
+    elements and attributes you don't understand, to wit:
+
+      4. If a user agent encounters an element it does 
+         not recognize, it must continue to process the 
+         children of that element. If the content is text, 
+         the text must be presented to the user.
+
+      5. If a user agent encounters an attribute it does 
+         not recognize, it must ignore the entire attribute 
+         specification (i.e., the attribute and its value).
+  &lt;/body&gt;
+  &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt;
+    &lt;body xmlns='http://www.w3.org/1999/xhtml'&gt;
+      &lt;p&gt;The &lt;acronym&gt;XHTML&lt;/acronym&gt; user agent conformance 
+         requirements say to ignore elements and attributes 
+         you don't understand, to wit:&lt;/p&gt;
+      &lt;ol type='1' start='4'&gt;
+        &lt;li&gt;&lt;p&gt;
+          If a user agent encounters an element it does 
+          not recognize, it must continue to process the 
+          children of that element. If the content is text,
+          the text must be presented to the user.
+        &lt;/p&gt;&lt;/li&gt;
+        &lt;li&gt;&lt;p&gt;
+          If a user agent encounters an attribute it does 
+          not recognize, it must ignore the entire attribute 
+          specification (i.e., the attribute and its value).
+        &lt;/p&gt;&lt;/li&gt;
+      &lt;/ol&gt;
+    &lt;/body&gt;
+  &lt;/html&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Let us assume that the recipient's user agent recognizes neither the &lt;acronym/&gt; element (which is discouraged in XHTML-IM) nor the 'type' and 'start' attributes of the &lt;ol/&gt; element (which, after all, were deprecated in HTML 4.0), and that it does not render nested elements (e.g., the &lt;p/&gt; elements within the &lt;li/&gt; elements); in this case, it could render the content as follows (note that the element value is shown as text and the attribute value is not rendered):</p>
+  <div class="example" style="">
+    <p class="" style="">The XHTML user agent conformance requirements say to ignore elements and attributes you don't understand, to wit:</p>
+    <ol start="" type="">
+      <li>If a user agent encounters an element it does not recognize, it must continue to process the children of that element. If the content is text, the text must be presented to the user.</li>
+      <li>If a user agent encounters an attribute it does not recognize, it must ignore the entire attribute specification (i.e., the attribute and its value).</li>
+    </ol>
+  </div>
+<h2>10.
+       <a name="discovery">Discovering Support for XHTML-IM</a>
+</h2>
+  <p class="" style="">This section describes methods for discovering whether a Jabber client or other XMPP entity supports the protocol defined herein.</p>
+  <div class="indent">
+<h3>10.1 <a name="discovery-explicit">Explicit Discovery</a>
+</h3>
+    <p class="" style="">The primary means of discovering support for XHTML-IM is <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260100">21</a>].</p>
+    <p class="caption">Example 9. Seeking to Discover XHTML-IM Support</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='juliet@shakespeare.lit/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the queried entity supports XHTML-IM, it MUST return a &lt;feature/&gt; element with a 'var' attribute set to a value of "http://jabber.org/protocol/xhtml-im" in the IQ result.</p>
+      <p class="caption">Example 10. Contact Returns Disco Info Results</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@shakespeare.lit/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/xhtml-im'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="discovery-implicit">Implicit Discovery</a>
+</h3>
+    <p class="" style="">A Jabber user's client MAY send XML &lt;message/&gt; stanzas containing XHTML-IM extensions without first discovering if the conversation partner's client supports XHTML-IM. If the user's client sends a message that includes XHTML-IM markup and the conversation partner's client replies to that message but does not include XHTML-IM markup, the user's client SHOULD NOT continue sending XHTML-IM markup.</p>
+  </div>
+<h2>11.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The exclusion of scripts, applets, and other multimedia elements reduces the risk of exposure to harmful or malicious objects caused by inclusion of XHTML content. In addition, because of security concerns related to images, an implementation MAY choose not to show images but instead show only the 'alt' text.</p>
+<h2>12.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The usage of XHTML 1.0 defined herein meets the requirements for XHTML 1.0 Integration Set document type conformance as defined in Section 3 ("Conformance Definition") of <span style="font-weight: bold">Modularization of XHTML</span>.</p>
+  <div class="indent">
+<h3>12.1 <a name="w3c-doctype">Document Type Name</a>
+</h3>
+    <p class="" style="">The Formal Public Identifier (FPI) for the XHTML-IM document type definition is:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+-//JSF//DTD Instant Messaging with XHTML//EN
+    </pre></div>
+    <p class="" style="">The fields of this FPI are as follows:</p>
+    <ol start="1" type="1">
+      <li>The leading field is "-", which indicates that this is a privately-defined resource.</li>
+      <li>The second field is "JSF" (an abbreviation for Jabber Software Foundation), which identifies the organization that maintains the named item.</li>
+      <li>The third field contains two constructs:
+        <ol start="1" type="1">
+          <li>The public text class is "DTD", which adheres to ISO 8879 Clause 10.2.2.1.</li>
+          <li>The public text description is "Instant Messaging with XHTML", which contains but does not begin with the string "XHTML" (as recommended for an XHTML 1.0 Integration Set).</li>
+        </ol>
+      </li>
+      <li>The fourth field is "EN", which identifies the language (English) in which the item is defined.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="w3c-conformance">User Agent Conformance</a>
+</h3>
+    <p class="" style="">A user agent that implements this specification MUST conform to Section 3.5 ("XHTML Family User Agent Conformance") of <span style="font-weight: bold">Modularization of XHTML</span>. Many of the requirements defined therein are already met by Jabber clients simply because they already include XML parsers.</p>
+    <p class="" style="">However, "ignore" has a special meaning in XHTML modularization (different from its meaning in XMPP). Specifically, criteria 4 through 6 of Section 3.5 of <span style="font-weight: bold">Modularization of XHTML</span> state:</p>
+    <ol start="4" type="1">
+      <li>
+        <p class="" style=""><span style="font-style: italic">W3C TEXT:</span> If a user agent encounters an element it does not recognize, it must continue to process the children of that element. If the content is text, the text must be presented to the user.</p>
+        <p class="" style=""><span style="font-style: italic">JSF COMMENT:</span> This behavior is different from that defined by <span style="font-weight: bold">XMPP Core</span>, and in the context of XHTML-IM implementations applies only to XML elements qualified by the 'http://www.w3.org/1999/xhtml' namespace as defined herein. This criterion MUST be applied to all XHTML 1.0 elements except those explicitly included in XHTML-IM as described in the <a href="#def">XHTML-IM Integration Set</a> and <a href="#profile">Recommended Profile</a> sections of this document. Therefore, an XHTML-IM implementation MUST process all XHTML 1.0 child elements of the XHTML-IM &lt;html/&gt; element even if such child elements are not included in the XHTML 1.0 Integration Set defined herein, and MUST present to the recipient the XML character data contained in such child elements.</p>
+      </li>
+      <li>
+        <p class="" style=""><span style="font-style: italic">W3C TEXT:</span> If a user agent encounters an attribute it does not recognize, it must ignore the entire attribute specification (i.e., the attribute and its value).</p>
+        <p class="" style=""><span style="font-style: italic">JSF COMMENT:</span> This criterion MUST be applied to all XHTML 1.0 attributes except those explicitly included in XHTML-IM as described in the <a href="#def">XHTML-IM Integration Set</a> and <a href="#profile">Recommended Profile</a> sections of this document. Therefore, an XHTML-IM implementation MUST ignore all attributes of elements qualified by the 'http://www.w3.org/1999/xhtml' namespace if such attributes are not explicitly included in the XHTML 1.0 Integration Set defined herein.</p>
+      </li>
+      <li>
+        <p class="" style=""><span style="font-style: italic">W3C TEXT:</span> If a user agent encounters an attribute value it doesn't recognize, it must use the default attribute value.</p>
+        <p class="" style=""><span style="font-style: italic">JSF COMMENT:</span> Since not one of the attributes included in XHTML-IM has a default value defined for it in <span style="font-weight: bold">XHTML 1.0</span>, in practice this criterion does not apply to XHTML-IM implementations.</p>
+      </li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>12.3 <a name="w3c-modularization">XHTML Modularization</a>
+</h3>
+    <p class="" style="">For information regarding XHTML modularization in XML schema for the XHTML 1.0 Integration Set defined in this specification, refer to the <a href="#schemas-driver">Schema Driver</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>12.4 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">The XHTML 1.0 Integration Set defined herein has been reviewed informally by an editor of the XHTML Modularization in XML Schema specification but has not undergone formal review by the W3C; before this specification proceeds to a status of Final within the Jabber Software Foundation's standards process, it should undergo a formal review through communication with the Hypertext Coordinating Group within the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>12.5 <a name="w3c-versions">XHTML Versioning</a>
+</h3>
+    <p class="" style="">The W3C is actively working on <span class="ref" style="">XHTML 2.0</span>  [<a href="#nt-id2260546">22</a>] and may produce additional versions of XHTML in the future. This specification addresses XHTML 1.0 only, but it may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating XHTML 2.0 content in XMPP.</p>
+  </div>
+<h2>13.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260593">23</a>].</p>
+<h2>14.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Draft, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260639">24</a>] shall add 'http://jabber.org/protocol/xhtml-im' to its registry of protocol namespaces.</p>
+  </div>
+<h2>15.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>15.1 <a name="schemas-wrapper">XHTML-IM Wrapper</a>
+</h3>
+    <p class="" style="">The following schema defines the XMPP extension element that serves as a wrapper for XHTML content.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xhtml='http://www.w3.org/1999/xhtml'
+    targetNamespace='http://jabber.org/protocol/xhtml-im'
+    xmlns='http://jabber.org/protocol/xhtml-im'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='http://www.w3.org/1999/xhtml'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+
+      This schema defines the &lt;html/&gt; element qualified by
+      the 'http://jabber.org/protocol/xhtml-im' namespace.
+      The only allowable child is a &lt;body/&gt; element qualified
+      by the 'http://www.w3.org/1999/xhtml' namespace. Refer 
+      to the XHTML-IM schema driver for the definition of the 
+      XHTML 1.0 Integration Set.
+
+      Full documentation of this Integration Set is contained in
+      "JEP-0071: XHTML-IM", a specification published by the
+      Jabber Software Foundation.
+
+         http://www.jabber.org/jeps/jep-0071.html
+
+    &lt;/xs:documentation&gt;
+    &lt;xs:documentation source="http://www.jabber.org/jeps/jep-0071.html"/&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='html'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='xhtml:body' 
+                    minOccurs='0' 
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>15.2 <a name="schemas-driver">XHTML-IM Schema Driver</a>
+</h3>
+    <p class="" style="">The following schema defines the modularization schema driver for XHTML-IM.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://www.w3.org/1999/xhtml'
+    xmlns='http://www.w3.org/1999/xhtml'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+
+      This is the XML Schema driver for XHTML-IM, an XHTML 1.0
+      Integration Set for use in exchanging marked-up instant
+      messages between entities that conform to the Extensible
+      Messaging and Presence Protocol (XMPP). This Integration
+      Set includes a subset of the modules defined for XHTML 1.0
+      but does not redefine any existing modules, nor does it
+      define any new modules. Specifically, it includes the
+      following modules only:
+
+         - Structure
+         - Text
+         - Hypertext
+         - List
+         - Image
+         - Style Attribute
+     
+      The Formal Public Identifier (FPI) for this Integration
+      Set is:
+
+         -//JSF//DTD Instant Messaging with XHTML//EN
+
+      Full documentation of this Integration Set is contained in
+      "JEP-0071: XHTML-IM", a specification published by the
+      Jabber Software Foundation, which is available at the
+      following URL:
+
+         http://www.jabber.org/jeps/jep-0071.html
+
+    &lt;/xs:documentation&gt;
+    &lt;xs:documentation source="http://www.jabber.org/jeps/jep-0071.html"/&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-blkphras-1.xsd"/&gt;
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-blkstruct-1.xsd"/&gt;
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-hypertext-1.xsd"/&gt;
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-image-1.xsd"/&gt;
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-inlphras-1.xsd"/&gt;
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-inlstruct-1.xsd"/&gt;
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-inlstyle-1.xsd"/&gt;
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-list-1.xsd"/&gt;
+  &lt;xs:include 
+      schemaLocation="http://www.w3.org/MarkUp/SCHEMA/xhtml-struct-1.xsd"/&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>15.3 <a name="schemas-model">XHTML-IM Content Model</a>
+</h3>
+    <p class="" style="">The following schema defines the content model for XHTML-IM.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version="1.0" encoding="UTF-8"?&gt;
+&lt;xs:schema xmlns:xs="http://www.w3.org/2001/XMLSchema"
+           targetNamespace="http://www.w3.org/1999/xhtml"
+           xmlns="http://www.w3.org/1999/xhtml"&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+
+      This is the XML Schema module of named XHTML 1.0 content models 
+      for XHTML-IM, an XHTML 1.0 Integration Set for use in exchanging 
+      marked-up instant messages between entities that conform to 
+      the Extensible Messaging and Presence Protocol (XMPP). This 
+      Integration Set includes a subset of the modules defined for 
+      XHTML 1.0 but does not redefine any existing modules, nor 
+      does it define any new modules. Specifically, it includes the 
+      following modules only:
+
+         - Structure
+         - Text
+         - Hypertext
+         - List
+         - Image
+         - Style Attribute
+     
+      Therefore XHTML-IM uses the following content models:
+
+          Block.mix;            Block-like elements, e.g., paragraphs
+          Flow.mix;             Any block or inline elements
+          Inline.mix;           Character-level elements
+          InlineNoAnchor.class; Anchor element
+          InlinePre.mix;        Pre element
+
+      XHTML-IM also uses the following Attribute Groups:
+
+           Core.extra.attrib
+           I18n.extra.attrib
+           Common.extra
+
+      Full documentation of this Integration Set is contained in
+      "JEP-0071: XHTML-IM", a specification published by the
+      Jabber Software Foundation.
+
+         http://www.jabber.org/jeps/jep-0071.html
+
+    &lt;/xs:documentation&gt;
+    &lt;xs:documentation source="http://www.jabber.org/jeps/jep-0071.html"/&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;!-- BEGIN ATTRIBUTE GROUPS --&gt;
+
+  &lt;xs:attributeGroup name="Core.extra.attrib"/&gt;
+  &lt;xs:attributeGroup name="I18n.extra.attrib"/&gt;
+  &lt;xs:attributeGroup name="Common.extra"&gt;
+    &lt;xs:attributeGroup ref="style.attrib"/&gt;
+  &lt;/xs:attributeGroup&gt;
+
+  &lt;!-- END ATTRIBUTE GROUPS --&gt;
+
+  &lt;!-- BEGIN HYPERTEXT MODULE "PRIMITIVES" --&gt;
+
+  &lt;xs:group name="Anchor.class"&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element ref="a"/&gt;
+    &lt;/xs:sequence&gt;
+  &lt;/xs:group&gt;
+
+  &lt;!-- END HYPERTEXT MODULE "PRIMITIVES" --&gt;
+
+  &lt;!-- BEGIN IMAGE MODULE "PRIMITIVES" --&gt;
+
+  &lt;xs:group name="Image.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:element ref="img"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;!-- END IMAGE MODULE "PRIMITIVES" --&gt;
+
+  &lt;!-- BEGIN LIST MODULE "PRIMITIVES" --&gt;
+
+  &lt;xs:group name="List.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:element ref="ul"/&gt;
+      &lt;xs:element ref="ol"/&gt;
+      &lt;xs:element ref="dl"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;!-- END LIST MODULE "PRIMITIVES" --&gt;
+
+  &lt;!-- BEGIN TEXT MODULE "PRIMITIVES" --&gt;
+
+  &lt;xs:group name="BlkPhras.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:element ref="address"/&gt;
+      &lt;xs:element ref="blockquote"/&gt;
+      &lt;xs:element ref="pre"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;xs:group name="BlkStruct.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:element ref="div"/&gt;
+      &lt;xs:element ref="p"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;xs:group name="Heading.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:element ref="h1"/&gt;
+      &lt;xs:element ref="h2"/&gt;
+      &lt;xs:element ref="h3"/&gt;
+      &lt;xs:element ref="h4"/&gt;
+      &lt;xs:element ref="h5"/&gt;
+      &lt;xs:element ref="h6"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;xs:group name="InlPhras.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:element ref="abbr"/&gt;
+      &lt;xs:element ref="acronym"/&gt;
+      &lt;xs:element ref="cite"/&gt;
+      &lt;xs:element ref="code"/&gt;
+      &lt;xs:element ref="dfn"/&gt;
+      &lt;xs:element ref="em"/&gt;
+      &lt;xs:element ref="kbd"/&gt;
+      &lt;xs:element ref="q"/&gt;
+      &lt;xs:element ref="samp"/&gt;
+      &lt;xs:element ref="strong"/&gt;
+      &lt;xs:element ref="var"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;xs:group name="InlStruct.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:element ref="br"/&gt;
+      &lt;xs:element ref="span"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;!-- END TEXT MODULE "PRIMITIVES" --&gt;
+
+  &lt;!-- BEGIN BLOCK COMBINATIONS --&gt;
+
+  &lt;xs:group name="Block.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:group ref="BlkPhras.class"/&gt;
+      &lt;xs:group ref="BlkStruct.class"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;!-- END BLOCK COMBINATIONS --&gt;
+
+  &lt;!-- BEGIN INLINE COMBINATIONS --&gt;
+
+  &lt;!-- Any inline content --&gt;
+  &lt;xs:group name="Inline.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:group ref="Anchor.class"/&gt;
+      &lt;xs:group ref="Image.class"/&gt;
+      &lt;xs:group ref="InlPhras.class"/&gt;
+      &lt;xs:group ref="InlStruct.class"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;!-- Inline content contained in a hyperlink --&gt;
+  &lt;xs:group name="InlNoAnchor.class"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:group ref="Image.class"/&gt;
+      &lt;xs:group ref="InlStruct.class"/&gt;
+      &lt;xs:group ref="InlPhras.class"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;!-- END INLINE COMBINATIONS --&gt;
+
+  &lt;!-- BEGIN TOP-LEVEL MIXES --&gt;
+
+  &lt;xs:group name="Block.mix"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:group ref="Block.class"/&gt;
+      &lt;xs:group ref="Heading.class"/&gt;
+      &lt;xs:group ref="List.class"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;xs:group name="Flow.mix"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:group ref="Block.class"/&gt;
+      &lt;xs:group ref="Heading.class"/&gt;
+      &lt;xs:group ref="Inline.class"/&gt;
+      &lt;xs:group ref="List.class"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;xs:group name="Inline.mix"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:group ref="Inline.class"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;xs:group name="InlNoAnchor.mix"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:group ref="InlNoAnchor.class"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;xs:group name="InlinePre.mix"&gt;
+    &lt;xs:choice&gt;
+      &lt;xs:group ref="Anchor.class"/&gt;
+      &lt;xs:group ref="InlPhras.class"/&gt;
+      &lt;xs:group ref="InlStruct.class"/&gt;
+    &lt;/xs:choice&gt;
+  &lt;/xs:group&gt;
+
+  &lt;!-- END TOP-LEVEL MIXES --&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>16.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">This specification formalizes and extends earlier work by Jeremie Miller and Julian Missig on XHTML formatting of Jabber messages. Many thanks to Shane McCarron for his assistance regarding XHTML modularization and conformance issues. Thanks also to contributors on the Standards-JIG list for their feedback and suggestions.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2256237">1</a>. XHTML 1.0 &lt;<a href="http://www.w3.org/TR/xhtml1">http://www.w3.org/TR/xhtml1</a>&gt;.</p>
+<p><a name="nt-id2256258">2</a>. Rich Text Format (RTF) Version 1.5 Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp">http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp</a>&gt;.</p>
+<p><a name="nt-id2256288">3</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2256310">4</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2256344">5</a>. HTML 4.0 &lt;<a href="http://www.w3.org/TR/REC-html40">http://www.w3.org/TR/REC-html40</a>&gt;.</p>
+<p><a name="nt-id2256391">6</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2256414">7</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256441">8</a>. The World Wide Web Consortium defines data formats and markup languages (such as HTML and XML) for use over the Internet. For further information, see &lt;<a href="http://www.w3.org/">http://www.w3.org/</a>&gt;.</p>
+<p><a name="nt-id2256572">9</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2256602">10</a>. Cascading Style Sheets, level 1 &lt;<a href="http://www.w3.org/TR/REC-CSS1">http://www.w3.org/TR/REC-CSS1</a>&gt;.</p>
+<p><a name="nt-id2256645">11</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256675">12</a>. XSL Transformations &lt;<a href="http://www.w3.org/TR/xslt/">http://www.w3.org/TR/xslt/</a>&gt;.</p>
+<p><a name="nt-id2256715">13</a>. The XHTML is merely an alternative version of the message body or bodies, and the semantic meaning is to be derived from the textual message body or bodies rather than the XHTML version.</p>
+<p><a name="nt-id2256728">14</a>. It might have been better to use an element name other than &lt;html/&gt; for the wrapper element; however, changing it would not be backwards-compatible with the older protocol and existing implementations.</p>
+<p><a name="nt-id2256822">15</a>. Modularization of XHTML &lt;<a href="http://www.w3.org/TR/2004/WD-xhtml-modularization-20040218/">http://www.w3.org/TR/2004/WD-xhtml-modularization-20040218/</a>&gt;.</p>
+<p><a name="nt-id2256889">16</a>. RFC 3066: Tags for the Identification of Languages &lt;<a href="http://www.ietf.org/rfc/rfc3066.txt">http://www.ietf.org/rfc/rfc3066.txt</a>&gt;.</p>
+<p><a name="nt-id2256935">17</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257038">18</a>. XHTML Basic &lt;<a href="http://www.w3.org/TR/xhtml-basic">http://www.w3.org/TR/xhtml-basic</a>&gt;.</p>
+<p><a name="nt-id2257101">19</a>. The 'style' attribute is specified herein where appropriate because the Style Attribute Module is included in the definition of the XHTML-IM Integration Set, whereas the event-related attributes (e.g., 'onclick') are not specified because the Implicit Events Module is not included.</p>
+<p><a name="nt-id2259002">20</a>. When contained within the &lt;html xmlns='http://jabber.org/protocol/xhtml-im'&gt; element, a &lt;body/&gt; element is qualified by the 'http://www.w3.org/1999/xhtml' namespace; naturally, this is a namespace declaration rather than an attribute per se, and therefore is not mentioned in the attribute enumeration.</p>
+<p><a name="nt-id2260100">21</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260546">22</a>. XHTML 2.0 &lt;<a href="http://www.w3.org/TR/xhtml2">http://www.w3.org/TR/xhtml2</a>&gt;.</p>
+<p><a name="nt-id2260593">23</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260639">24</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2004-09-29)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.19 (2004-09-27)</h4>
+<div class="indent">Per list discussion, removed recommendation to preserve whitespace in XHTML bodies (instead, use of &lt;br/&gt; and non-breaking spaces is recommended); noted that nesting of elements is not recommended except within &lt;div/&gt; elements; and switched from padding-left to margin-left for indentation. (psa)
+    </div>
+<h4>Version 0.18 (2004-09-15)</h4>
+<div class="indent">Added recommendation to preserve whitespace in XHTML bodies. (psa)
+    </div>
+<h4>Version 0.17 (2004-09-08)</h4>
+<div class="indent">Simplified the recommended profiles based on list discussion; changed the examples accordingly. (psa)
+    </div>
+<h4>Version 0.16 (2004-08-30)</h4>
+<div class="indent">Specified the scope of the proposal; clarified reasons for the choice of technology; clarified one business rule; corrected several typographical errors. (psa)
+    </div>
+<h4>Version 0.15 (2004-07-29)</h4>
+<div class="indent">Based on W3C feedback, added content model and refactored the text to ensure separation between the XHTML 1.0 Integration Set itself and the JSF's recommended profile of the Integration Set; also split the requirements out from the Concepts and Approach section, added several more examples, and showed renderings of the examples. (psa)
+    </div>
+<h4>Version 0.14 (2004-05-19)</h4>
+<div class="indent">Clarified relationship between wrapper element and XHTML content. (psa)
+    </div>
+<h4>Version 0.13 (2004-05-18)</h4>
+<div class="indent">Initial version of XHTML modularization. (psa)
+    </div>
+<h4>Version 0.12 (2004-03-10)</h4>
+<div class="indent">Clarified and corrected several points in the text; improved and added to the examples. (psa)
+    </div>
+<h4>Version 0.11 (2003-12-05)</h4>
+<div class="indent">Defined XHTML 1.0 Integration Set conformance; removed schema pending work on XHTML modularization with W3C. (psa)
+    </div>
+<h4>Version 0.10 (2003-11-25)</h4>
+<div class="indent">Cleaned up the schema; added W3C considerations. (psa)
+    </div>
+<h4>Version 0.9 (2003-09-30)</h4>
+<div class="indent">Changed status to Deferred pending discussion with the W3C regarding XHTML modularization. (psa)
+    </div>
+<h4>Version 0.8 (2003-09-16)</h4>
+<div class="indent">Changed MUST to SHOULD for support of the Style Attribute Module; clarified relationship of XHTML-IM schema to XHTML schema; slight text cleanup. (psa)
+    </div>
+<h4>Version 0.7 (2003-08-19)</h4>
+<div class="indent">Added the &lt;code/&gt; element. (psa)
+    </div>
+<h4>Version 0.6 (2003-06-24)</h4>
+<div class="indent">Made image support recommended (not mandatory); removed references to conversation threads; fixed some issues in the schema; made small editorial changes throughout. (psa)
+    </div>
+<h4>Version 0.5 (2003-04-29)</h4>
+<div class="indent">Fixed the schema, made several small editorial changes. (psa)
+    </div>
+<h4>Version 0.4 (2003-02-20)</h4>
+<div class="indent">Brought back several content-based elements; added preliminary schema. (psa)
+    </div>
+<h4>Version 0.3 (2003-02-19)</h4>
+<div class="indent">Defined the attributes and style properties required by this document. (psa)
+    </div>
+<h4>Version 0.2 (2003-02-17)</h4>
+<div class="indent">Described the requirements more fully; added additional restrictions above and beyond the standard XHTML 1.0 Modules; added disco examples. (psa)
+    </div>
+<h4>Version 0.1 (2003-02-16)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.10.html
+++ b/content/xep-0072-0.10.html
@@ -1,0 +1,1102 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-09-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.10<br>
+            Last Updated: 2005-09-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: soap<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>4.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>4.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>5.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>6.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>7.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>8.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>8.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>8.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>8.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>8.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>8.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>8.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>8.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>8.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>8.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>8.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>8.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>8.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>8.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>9.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>9.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>9.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>10.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>11.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>12.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>12.2.  <a href="#registrar-disco">Service Discovery Identity</a>
+</dt>
+</dl>
+<dt>13.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>14.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>15.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2251294">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous RPC-like calls. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251273">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2251276">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2250452">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250543">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP specification defines the concepts of "SOAP intermediary" and "ultimate SOAP receiver" (see Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). In general, this specification assumes that XMPP entities that support the SOAP XMPP Binding will be ultimate SOAP receivers, since SOAP intermediaries tend to be artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these issues are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255704">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. However, one final justification for SOAP intermediaries is to act as gateways between different transport mechanisms (e.g., between HTTP and SMTP), and XMPP entities may well be SOAP intermediaries for that reason. Therefore, is is RECOMMENDED for XMPP entities to advertise their identity as SOAP intermediaries or receivers using the <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255735">7</a>] identities specified in the <a href="#registrar-disco">Service Discovery Identity</a> section of this document and described in the <a href="#disco">Service Discovery</a> section of this document. For further details about gateways between XMPP and other SOAP bindings, refer to the <a href="#impl">Implementation Notes</a> section of this document.</p>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">Before initiating the exchange of SOAP over XMPP, an entity SHOULD complete service discovery using the protocol defined in <span style="font-weight: bold">JEP-0030</span> in order to determine if another entity supports the SOAP XMPP Binding. The following example shows how a requesting entity can query a responding entity regarding its identity and supported protocols.</p>
+  <p class="caption">Example 1. Requester sends service discovery request to responder</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server' 
+    id='disco1'
+    type='get'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the responding entity supports the SOAP XMPP Binding, it MUST include a feature of "http://jabber.org/protocol/soap" in its reply. The responding entity SHOULD also specify if it is a SOAP intermediary or an ultimate SOAP receiver by including an identity of "soap/intermediary" or "soap/receiver" (or, potentially, both).</p>
+  <p class="caption">Example 2. Responder sends service discovery reply to requester</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    to='requester@example.com/soap-client'
+    id='disco1'
+    type='result'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='soap' type='receiver'/&gt;
+    &lt;feature var='http://jabber.org/protocol/soap'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both RPC-like calls and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with SOAP child elements are used in order to ensure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas SHOULD be used for RPC calls and when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas SHOULD be used for asynchronous one-way communications and when either store and forward or message tracing is desired.</li>
+  </ol>
+  <p class="" style="">Examples of these approaches are provided below; for a formal definition, refer to the <a href="#binding">SOAP XMPP Binding</a> section of this document.</p>
+  <div class="indent">
+<h3>4.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2255906">8</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a unique SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://schemas.xmlsoap.org/soap/envelope' namespace.</p>
+    <p class="caption">Example 3. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. A SOAP response, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>4.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track SOAP messages and eventually associate errors or answers with the relative requests.</p>
+    <p class="caption">Example 5. A SOAP envelope carrying an RDF description of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@example.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>4.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP Binding maps these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; stanzas of type "error". This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and &lt;iq/&gt; error codes (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span> as well as <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256038">9</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">IQ Error Description</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 6. A SOAP response with error, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travel.example.com/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type "error" to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 7. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents, and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML as well as byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256465">10</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>6.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">SOAP provides several methods to transport binary data as attachments; the most common are:</p>
+  <p class="" style="">First, inserting a link to the file directly either into the XMPP message or IQ stanza (e.g, via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2256530">11</a>]) or into the SOAP envelope (e.g., via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2256556">12</a>]). This is a general method that can be used by XMPP clients if they are able to retrieve the file via HTTP (see <span style="font-weight: bold">JEP-0066</span>).</p>
+  <p class="" style="">Second, encoding SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP 1.2 Attachment Feature</span>  [<a href="#nt-id2256624">13</a>] (or, more recently, <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2256594">14</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2256632">15</a>]). This can work well for the HTTP and email bindings of SOAP but cannot be used directly by native XMPP entities since XML streams transport pure XML only and not MIME messages; consider the following example:</p>
+  <p class="caption">Example 8. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start="&lt;claim061400a.xml@claiming-it.com&gt;"
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+  </pre></div>
+  <p class="" style="">Third, using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span>  [<a href="#nt-id2256649">16</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2256691">17</a>]. These methods are just other transport protocols and most likely would needlessly complicate implementations of SOAP over XMPP.</p>
+  <p class="" style="">Therefore, to transport binary data between native XMPP entities when a URL cannot be provided using <span style="font-weight: bold">JEP-0066</span> or some similar mechanism, the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256737">18</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 9. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@example.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='1972-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If an XMPP entity also functions as a SOAP intermediary, it SHOULD use W3C-recommended protocols for transporting SOAP attachments over non-XMPP SOAP bindings (e.g., HTTP and SMTP) when communicating with non-XMPP entities (see also the <a href="#impl">Implementation Notes</a> section of this document).</p>
+<h2>7.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2256829">19</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward.</p>
+<p class="" style="">The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to 'rpc' for SOAP messages carried in &lt;iq/&gt; stanzas, and to 'document' for &lt;message/&gt; stanzas.</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref" style="">XMPP IRI</span>  [<a href="#nt-id2256899">20</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+</ol>
+<p class="" style="">The following is an example of a WSDL definition for an endpoint that supports the SOAP XMPP binding: a mythical service that translates Shakespearean English into selected modern languages and dialects.</p>
+<p class="caption">Example 10. Example of WSDL definition for a translation service that supports SOAP over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='ShakespeareTranslation' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'
+    xmlns:tns='http://shakespeare.lit/translation.wsdl'&gt;
+  
+  &lt;binding name='ShakespeareTranslationSoap' type='tns:TranslationPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+
+  &lt;service name='ShakespeareTranslationService'&gt;
+    &lt;documentation&gt;Translates Shakespearean text.&lt;/documentation&gt;
+    &lt;port name='TranslationPort' binding='tns:ShakespeareTranslationSoap'&gt;
+      &lt;soap:address location='xmpp:translation@shakespeare.lit'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256985">21</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256995">22</a>].</p>
+<h2>8.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2257027">23</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2257050">24</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2257073">25</a>]. (Additionaly, a binding to BEEP is described in <span style="font-weight: bold">RFC 3288</span>.) As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>8.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2257183">26</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2257208">27</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email (see the <a href="#impl">Implementation Notes</a> section of this document). Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>8.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>8.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encpasulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>8.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>8.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message B.example.orges Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>9.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the <a href="#binding">SOAP XMPP Binding</a> section of this document. The current section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2259448">28</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>9.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2259495">29</a>], the SOAP XMPP Binding defined herein should be reviewed informally by one or more appropriate experts from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2259517">30</a>] advances it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's XML Protocol Working Group.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1, this specification may be modified to address handling of SOAP messages that are encoded in XML 1.1.</p>
+  </div>
+<h2>10.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2259588">31</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2259604">32</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2259641">33</a>].</p>
+<h2>11.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259681">34</a>] is required as a result of this JEP.</p>
+<h2>12.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259728">35</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="registrar-disco">Service Discovery Identity</a>
+</h3>
+    <p class="" style="">As a result of this JEP, the Jabber Registrar shall register a Service Discovery category of "soap" and two specific Service Discovery types within that category: "intermediary" and "receiver" (corresponding to the "SOAP intermediary" and "ultimate SOAP receiver" definitions provided in Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;soap&lt;/name&gt;
+  &lt;desc&gt;Entities that support the SOAP XMPP Binding as defined in JEP-0072.&lt;/desc&gt;
+  &lt;type&gt;
+    &lt;name&gt;intermediary&lt;/name&gt;
+    &lt;desc&gt;A SOAP intermediary.&lt;/desc&gt;
+    &lt;doc&gt;SOAP Version 1.2 Part 1&lt;/doc&gt;
+  &lt;/type&gt;
+  &lt;type&gt;
+    &lt;name&gt;receiver&lt;/name&gt;
+    &lt;desc&gt;An ultimate SOAP receiver.&lt;/desc&gt;
+    &lt;doc&gt;SOAP Version 1.2 Part 1&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>13.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>14.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative and is not part of the SOAP over XMPP specification itself.</span></p> 
+  <p class="" style="">An XMPP entity that supports the SOAP XMPP binding could function as a "SOAP intermediary" that hands a SOAP message off to some other deployment for subsequent processing (HTTP, email, a specialized enterprise messaging platform, etc.) rather than functioning as the "ultimate SOAP receiver" for the message (as these terms are defined in Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). If the intended recipient functions as a SOAP intermediary, implementations should be aware that subsequent processing may alter the representation of SOAP messages. (Entities SHOULD advertise whether they are intermediaries or receivers as described in the <a href="#disco">Service Discovery</a> section of this document.)</p>
+  <p class="" style="">As an example, consider a component that functions as a gateway between XMPP-based and HTTP-based web services. Its purpose might be to mix HTTP and XMPP for web services and to invoke any web services already accessible through HTTP from XMPP clients.</p>
+  <p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+  <p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+  <ol start="" type="">
+    <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+    <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+    <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+    <li>a blank return path</li>
+  </ol>
+  <p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+  <p class="caption">Example 11. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forwawd&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+  </pre></div>
+  <p class="" style="">Generic XMPP routers that conform to <span style="font-weight: bold">RFC 3920</span> may also "store and forward" Jabber messages. This feature is usually called "offline message handling": the router makes a decision as to whether to deliver the message to the local intended recipient based on the recipient's presence, and if the recipient is offline when the router processes the message then it may store the message for delivery when the recipient next comes online (rather than returning an error to the sender). Although it is possible to write an XMPP router that directly supports the SOAP XMPP binding and implements the SOAP processing model, generic XMPP routers do not contain such support. Accordingly, generic XMPP routers will not forward an XMPP message to an alternate SOAP transport such as HTTP or SMTP, or provide other functions of a SOAP intermediary or ultimate receiver. When a generic XMPP router delivers a message to the intended recipient (whether immediately or as delayed in "offline storage") and the intended recipient supports the SOAP XMPP binding, SOAP processing is performed; such an intended recipient MAY act either as a SOAP intermediary or as an ultimate SOAP receiver.</p>
+<h2>15.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Many thanks to Noah Mendelsohn and Michael Mahan for their assistance regarding SOAP binding definitions and conformance issues.</p>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251294">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2251273">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251276">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2250452">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250543">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2255704">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255735">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255906">8</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2256038">9</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2256465">10</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256530">11</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2256556">12</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2256624">13</a>. SOAP 1.2 Attachment Feature &lt;<a href="http://www.w3.org/TR/soap12-af/">http://www.w3.org/TR/soap12-af/</a>&gt;.</p>
+<p><a name="nt-id2256594">14</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2256632">15</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2256649">16</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256691">17</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2256737">18</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256829">19</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2256899">20</a>. An Internationalized Resource Identifier (IRI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-00.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-00.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256985">21</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256995">22</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257027">23</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2257050">24</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2257073">25</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2257183">26</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2257208">27</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2259448">28</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2259495">29</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2259517">30</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2259588">31</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2259604">32</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2259641">33</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2259681">34</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259728">35</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2005-09-01)</h4>
+<div class="indent">Added information about service discovery. (psa)
+    </div>
+<h4>Version 0.9 (2005-08-17)</h4>
+<div class="indent">Added implementation note about XMPP routers based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.8 (2005-07-21)</h4>
+<div class="indent">Cleaned up WSDL definition. (psa)
+    </div>
+<h4>Version 0.7 (2005-06-30)</h4>
+<div class="indent">Clarified implementation notes and text on attachments. (psa/ff)
+    </div>
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.11.html
+++ b/content/xep-0072-0.11.html
@@ -1,0 +1,1098 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-09-07">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.11<br>
+            Last Updated: 2005-09-07<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: soap<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>4.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>4.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>5.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>6.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>7.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>8.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>8.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>8.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>8.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>8.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>8.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>8.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>8.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>8.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>8.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>8.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>8.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>8.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>8.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>9.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>9.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>9.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>10.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>11.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>12.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>12.2.  <a href="#registrar-disco">Service Discovery Identity</a>
+</dt>
+</dl>
+<dt>13.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>14.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>15.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2251433">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous request-response semantics. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250453">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2251458">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2250474">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250570">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP specification defines the concepts of "SOAP intermediary" and "ultimate SOAP receiver" (see Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). In general, this specification assumes that XMPP entities that support the SOAP XMPP Binding will be ultimate SOAP receivers, since SOAP intermediaries tend to be artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these issues are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255871">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. One final justification for SOAP intermediaries is to act as gateways between different transport mechanisms (e.g., between HTTP and SMTP), and XMPP entities may well be SOAP intermediaries for that reason. For further details about gateways between XMPP and other SOAP bindings, refer to the <a href="#impl">Implementation Notes</a> section of this document.</p>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">Before initiating the exchange of SOAP over XMPP, an entity SHOULD complete service discovery using the protocol defined in <span style="font-weight: bold">JEP-0030</span> in order to determine if another entity supports the SOAP XMPP Binding. The following example shows how a requesting entity can query a responding entity regarding its identity and supported protocols.</p>
+  <p class="caption">Example 1. Requester sends service discovery request to responder</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server' 
+    id='disco1'
+    type='get'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the responding entity supports the SOAP XMPP Binding, it MUST include a feature of "http://jabber.org/protocol/soap" in its reply and SHOULD specify a service discovery identity of "automation/soap".</p>
+  <p class="caption">Example 2. Responder sends service discovery reply to requester</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    to='requester@example.com/soap-client'
+    id='disco1'
+    type='result'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='automation' type='soap'/&gt;
+    &lt;feature var='http://jabber.org/protocol/soap'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both synchronous request-response exchanges and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with SOAP child elements are used in order to ensure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas SHOULD be used when more formal request-response semantics are needed or when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas SHOULD be used when less formal request-response semantics are acceptable or when store-and-forward ("offline message") delivery is needed (e.g., because the intended recipient may be temporarily unavailable).</li>
+  </ol>
+  <p class="" style="">Examples of these approaches are provided below; for a formal definition, refer to the <a href="#binding">SOAP XMPP Binding</a> section of this document.</p>
+  <div class="indent">
+<h3>4.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2256046">7</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://www.w3.org/2003/05/soap-envelope' namespace.</p>
+    <p class="caption">Example 3. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. A SOAP response inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>4.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track the XMPP messages and eventually associate errors or answers with the related requests (this is for tracking at the XMPP level, not the SOAP level).</p>
+    <p class="caption">Example 5. A SOAP envelope carrying an RDF description of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@example.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>4.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP Binding maps these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; and &lt;message/&gt; stanzas of type "error". This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and XMPP error conditions (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span> as well as <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256177">8</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error Codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">XMPP Error Condition</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 6. A SOAP response with error inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travel.example.com/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type "error" to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 7. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML as well as byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256469">9</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>6.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">There are several potential methods for transporting binary data as attachments:</p>
+  <p class="" style="">First, inserting a link to the file directly either into the SOAP envelope (e.g., via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2256533">10</a>]) or into the XMPP message or IQ stanza (e.g, via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2256559">11</a>]). This is a general method that can be used by XMPP clients if they are able to retrieve the file via HTTP (see <span style="font-weight: bold">JEP-0066</span>).</p>
+  <p class="" style="">Second, encoding SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP 1.2 Attachment Feature</span>  [<a href="#nt-id2256627">12</a>] (or, more recently, <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2256603">13</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2256634">14</a>]). This can work well for the HTTP and email bindings of SOAP but cannot be used directly by native XMPP entities since XML streams transport pure XML only and not MIME messages; consider the following example:</p>
+  <p class="caption">Example 8. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start="&lt;claim061400a.xml@claiming-it.com&gt;"
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+  </pre></div>
+  <p class="" style="">Third, using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span>  [<a href="#nt-id2256652">15</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2256694">16</a>]. These methods are just other transport protocols and most likely would needlessly complicate implementations of SOAP over XMPP.</p>
+  <p class="" style="">Therefore, to transport binary data between native XMPP entities when a URL cannot be provided using <span style="font-weight: bold">JEP-0066</span> or some similar mechanism, the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256739">17</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 9. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@example.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='2005-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If an XMPP entity also functions as a SOAP intermediary, it SHOULD use W3C-recommended protocols for transporting SOAP attachments over non-XMPP SOAP bindings (e.g., HTTP and SMTP) when communicating with non-XMPP entities (see also the <a href="#impl">Implementation Notes</a> section of this document).</p>
+<h2>7.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2256833">18</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward.</p>
+<p class="" style="">The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to "document".</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref" style="">XMPP IRI/URI</span>  [<a href="#nt-id2256903">19</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+</ol>
+<p class="" style="">The following is an example of a WSDL definition for an endpoint that supports the SOAP XMPP binding: a mythical service that translates Shakespearean English into selected modern languages and dialects.</p>
+<p class="caption">Example 10. Example of WSDL definition for a translation service that supports SOAP over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='ShakespeareTranslation' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'
+    xmlns:tns='http://shakespeare.lit/translation.wsdl'&gt;
+  
+  &lt;binding name='ShakespeareTranslationSoap' type='tns:TranslationPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+
+  &lt;service name='ShakespeareTranslationService'&gt;
+    &lt;documentation&gt;Translates Shakespearean text.&lt;/documentation&gt;
+    &lt;port name='TranslationPort' binding='tns:ShakespeareTranslationSoap'&gt;
+      &lt;soap:address location='xmpp:translation@shakespeare.lit'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256982">20</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257001">21</a>].</p>
+<h2>8.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2257025">22</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2257050">23</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2257080">24</a>]. (Additionaly, a binding to BEEP is described in <span style="font-weight: bold">RFC 3288</span>.) As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>8.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2257183">25</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2257209">26</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email (see the <a href="#impl">Implementation Notes</a> section of this document). Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>8.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>8.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encappsulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>8.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>8.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Becomes Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>9.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the <a href="#binding">SOAP XMPP Binding</a> section of this document. The current section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2259452">27</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>9.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2259499">28</a>], the SOAP XMPP Binding defined herein has been reviewed informally by one or more appropriate experts from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2259521">29</a>] advanced it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's <a href="http://www.w3.org/2000/xp/Group/">XML Protocol Working Group</a>. To that end, revised versions of this specification will be announced on the W3C's public xml-dist-app@w3.org mailing list.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1 or subsequent versions, this specification may be modified to address handling of SOAP messages that are encoded in versions other than XML 1.0.</p>
+  </div>
+<h2>10.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2259598">30</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2259616">31</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2259653">32</a>].</p>
+<h2>11.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259698">33</a>] is required as a result of this JEP.</p>
+<h2>12.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259742">34</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="registrar-disco">Service Discovery Identity</a>
+</h3>
+    <p class="" style="">As a result of this JEP, the Jabber Registrar shall register a Service Discovery type of "soap" within the "automation" category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;automation&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;soap&lt;/name&gt;
+    &lt;desc&gt;A SOAP receiver (either intermediate or ultimate).&lt;/desc&gt;
+    &lt;doc&gt;JEP-0072&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>13.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>14.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p> 
+  <p class="" style="">An XMPP entity that supports the SOAP XMPP binding could function as a "SOAP intermediary" that hands a SOAP message off to some other deployment for subsequent processing (HTTP, email, a specialized enterprise messaging platform, etc.) rather than functioning as the "ultimate SOAP receiver" for the message (as these terms are defined in Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). If the intended recipient functions as a SOAP intermediary, implementations should be aware that subsequent processing may alter the representation of SOAP messages.</p>
+  <p class="" style="">As an example, consider a component that functions as a gateway between XMPP-based and HTTP-based web services. Its purpose might be to mix HTTP and XMPP for web services and to invoke any web services already accessible through HTTP from XMPP clients.</p>
+  <p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+  <p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+  <ol start="" type="">
+    <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+    <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+    <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+    <li>a blank return path</li>
+  </ol>
+  <p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+  <p class="caption">Example 11. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forward&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+  </pre></div>
+  <p class="" style="">Generic XMPP routers that conform to <span style="font-weight: bold">RFC 3920</span> may also "store and forward" Jabber messages. This feature is usually called "offline message handling": the router makes a decision as to whether to deliver the message to the local intended recipient based on the recipient's presence, and if the recipient is offline when the router processes the message then it may store the message for delivery when the recipient next comes online (rather than returning an error to the sender). Although it is possible to write an XMPP router that directly supports the SOAP XMPP binding and implements the SOAP processing model, generic XMPP routers do not contain such support. Accordingly, generic XMPP routers will not forward an XMPP message to an alternate SOAP transport such as HTTP or SMTP, or provide other functions of a SOAP intermediary or ultimate receiver. When a generic XMPP router delivers a message to the intended recipient (whether immediately or as delayed in "offline storage") and the intended recipient supports the SOAP XMPP binding, SOAP processing is performed; such an intended recipient MAY act either as a SOAP intermediary or as an ultimate SOAP receiver.</p>
+<h2>15.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Many thanks to Noah Mendelsohn for his assistance regarding SOAP binding definitions and conformance issues. Thanks also to Michael Mahan and Rich Salz for their comments.</p>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251433">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2250453">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251458">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2250474">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250570">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2255871">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256046">7</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2256177">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2256469">9</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256533">10</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2256559">11</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2256627">12</a>. SOAP 1.2 Attachment Feature &lt;<a href="http://www.w3.org/TR/soap12-af/">http://www.w3.org/TR/soap12-af/</a>&gt;.</p>
+<p><a name="nt-id2256603">13</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2256634">14</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2256652">15</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256694">16</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2256739">17</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256833">18</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2256903">19</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256982">20</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257001">21</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257025">22</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2257050">23</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2257080">24</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2257183">25</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2257209">26</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2259452">27</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2259499">28</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2259521">29</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2259598">30</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2259616">31</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2259653">32</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2259698">33</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259742">34</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.11 (2005-09-07)</h4>
+<div class="indent">Modified service discovery category and type; made several other small text changes based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.10 (2005-09-01)</h4>
+<div class="indent">Added information about service discovery. (psa)
+    </div>
+<h4>Version 0.9 (2005-08-17)</h4>
+<div class="indent">Added implementation note about XMPP routers based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.8 (2005-07-21)</h4>
+<div class="indent">Cleaned up WSDL definition. (psa)
+    </div>
+<h4>Version 0.7 (2005-06-30)</h4>
+<div class="indent">Clarified implementation notes and text on attachments. (psa/ff)
+    </div>
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.12.html
+++ b/content/xep-0072-0.12.html
@@ -1,0 +1,1177 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.12<br>
+            Last Updated: 2005-10-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: soap<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/SOAP%20Over%20XMPP%20(JEP-0072)">http://wiki.jabber.org/index.php/SOAP Over XMPP (JEP-0072)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#uc">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>3.2.  <a href="#exchange">Exchanging SOAP Messages</a>
+</dt>
+<dl>
+<dt>3.2.1.  <a href="#exchange-iq">Exchanging SOAP Messages Using XMPP IQ Stanzas</a>
+</dt>
+<dt>3.2.2.  <a href="#exchange-message">Exchanging SOAP Messages Using XMPP Message Stanzas</a>
+</dt>
+</dl>
+<dt>3.3.  <a href="#attachments">Sending Attachments</a>
+</dt>
+<dt>3.4.  <a href="#wsdl">Specifying a WSDL Definition</a>
+</dt>
+</dl>
+<dt>4.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>4.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>4.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>4.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>4.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>4.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>4.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>4.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>4.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>4.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>4.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>4.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>4.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>4.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>5.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>5.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>5.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl><dt>7.1.  <a href="#bizrules-encoding">Encoding</a>
+</dt></dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Identity</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>12.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>13.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2250615">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous request-response semantics. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250637">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2250811">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2250657">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250750">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP specification defines the concepts of "SOAP intermediary" and "ultimate SOAP receiver" (see Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). In general, this specification assumes that XMPP entities that support the SOAP XMPP Binding will be ultimate SOAP receivers, since SOAP intermediaries tend to be artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these issues are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256246">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. One final justification for SOAP intermediaries is to act as gateways between different transport mechanisms (e.g., between HTTP and SMTP), and XMPP entities may well be SOAP intermediaries for that reason. For further details about gateways between XMPP and other SOAP bindings, refer to the <a href="#impl">Implementation Notes</a> section of this document.</p>
+<h2>3.
+       <a name="uc">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco">Discovering Support</a>
+</h3>
+    <p class="" style="">In order to determine whether a potential responding entity supports the SOAP XMPP Binding, a requesting entity SHOULD send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256304">7</a>] information request to the potential responding entity:</p>
+    <p class="caption">Example 1. Requester queries responder regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server' 
+    id='disco1'
+    type='get'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the responding entity supports the SOAP XMPP Binding and the requesting entity is not blocked from communicating with the responding entity, the responding entity MUST include a feature of "http://jabber.org/protocol/soap" in its reply and SHOULD specify a service discovery identity of "automation/soap".</p>
+    <p class="caption">Example 2. Responder replies regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    to='requester@example.com/soap-client'
+    id='disco1'
+    type='result'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='automation' type='soap'/&gt;
+    &lt;feature var='http://jabber.org/protocol/soap'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="exchange">Exchanging SOAP Messages</a>
+</h3>
+    <p class="" style="">When a requesting entity wants to interact with a responding entity via the SOAP XMPP Binding, it faces a fundamental choice: to use &lt;iq/&gt; stanzas or to use &lt;message/&gt; stanzas. The following guidelines may prove useful:</p>
+    <ol start="" type="">
+      <li>&lt;iq/&gt; stanzas SHOULD be used when more formal request-response semantics are needed or when an immediate answer is required.</li>
+      <li>&lt;message/&gt; stanzas SHOULD be used when less formal request-response semantics are acceptable or when store-and-forward ("offline message") delivery is needed (e.g., because the intended recipient may be temporarily unavailable).</li>
+    </ol>
+    <p class="" style="">Examples of both approaches are provided below, encapsulating the SOAP message examples (a travel reservation flow) to be found in <span class="ref" style="">SOAP Version 1.2 Part 0</span>  [<a href="#nt-id2256419">8</a>].</p>
+    <div class="indent">
+<h3>3.2.1 <a name="exchange-iq">Exchanging SOAP Messages Using XMPP IQ Stanzas</a>
+</h3>
+      <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2256449">9</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer (see <a href="#errors">Error Handling</a> for details).</p>
+      <p class="" style="">Each &lt;iq/&gt; stanza of type "set" MUST contain a SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://www.w3.org/2003/05/soap-envelope' namespace.</p>
+      <p class="caption">Example 3. Requesting entity sends IQ-set</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+   &lt;env:Header&gt;
+    &lt;m:reservation xmlns:m="http://travelcompany.example.org/reservation" 
+            env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+     &lt;m:dateAndTime&gt;2001-11-29T13:20:00.000-05:00&lt;/m:dateAndTime&gt;
+    &lt;/m:reservation&gt;
+    &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+            env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+    &lt;/n:passenger&gt;
+   &lt;/env:Header&gt;
+   &lt;env:Body&gt;
+    &lt;p:itinerary
+      xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+     &lt;p:departure&gt;
+       &lt;p:departing&gt;New York&lt;/p:departing&gt;
+       &lt;p:arriving&gt;Los Angeles&lt;/p:arriving&gt;
+       &lt;p:departureDate&gt;2001-12-14&lt;/p:departureDate&gt;
+       &lt;p:departureTime&gt;late afternoon&lt;/p:departureTime&gt;
+       &lt;p:seatPreference&gt;aisle&lt;/p:seatPreference&gt;
+     &lt;/p:departure&gt;
+     &lt;p:return&gt;
+       &lt;p:departing&gt;Los Angeles&lt;/p:departing&gt;
+       &lt;p:arriving&gt;New York&lt;/p:arriving&gt;
+       &lt;p:departureDate&gt;2001-12-20&lt;/p:departureDate&gt;
+       &lt;p:departureTime&gt;mid-morning&lt;/p:departureTime&gt;
+       &lt;p:seatPreference/&gt;
+     &lt;/p:return&gt;
+    &lt;/p:itinerary&gt;
+    &lt;q:lodging
+     xmlns:q="http://travelcompany.example.org/reservation/hotels"&gt;
+     &lt;q:preference&gt;none&lt;/q:preference&gt;
+    &lt;/q:lodging&gt;
+   &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;  
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the responding entity does not support the SOAP XMPP Binding, it SHOULD return a &lt;service-unavailable/&gt; error:</p>
+      <p class="caption">Example 4. Responding entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If a SOAP-related fault occurs, the mappings in <a href="#errors">Error Handling</a> SHOULD be used.</p>
+      <p class="caption">Example 5. Responding entity indicates SOAP fault</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the responding entity does not return an error, it MUST respond with an IQ of type "result":</p>
+      <p class="caption">Example 6. Responding entity returns IQ-result</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+   &lt;env:Header&gt;
+    &lt;m:reservation xmlns:m="http://travelcompany.example.org/reservation" 
+        env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+     &lt;m:dateAndTime&gt;2001-11-29T13:35:00.000-05:00&lt;/m:dateAndTime&gt;
+    &lt;/m:reservation&gt;
+    &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+        env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+    &lt;/n:passenger&gt;
+   &lt;/env:Header&gt;
+   &lt;env:Body&gt;
+    &lt;p:itineraryClarification 
+      xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+     &lt;p:departure&gt;
+       &lt;p:departing&gt;
+         &lt;p:airportChoices&gt;
+            JFK LGA EWR 
+         &lt;/p:airportChoices&gt;
+       &lt;/p:departing&gt;
+     &lt;/p:departure&gt;
+     &lt;p:return&gt;
+       &lt;p:arriving&gt;
+         &lt;p:airportChoices&gt;
+           JFK LGA EWR 
+         &lt;/p:airportChoices&gt;
+       &lt;/p:arriving&gt;
+     &lt;/p:return&gt;  
+    &lt;/p:itineraryClarification&gt;
+   &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">At this point the requesting entity could send another IQ-set:</p>
+      <p class="caption">Example 7. Requesting entity sends another IQ-set</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap2'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+   &lt;env:Header&gt;
+    &lt;m:reservation 
+       xmlns:m="http://travelcompany.example.org/reservation" 
+        env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+      &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+      &lt;m:dateAndTime&gt;2001-11-29T13:36:50.000-05:00&lt;/m:dateAndTime&gt;
+    &lt;/m:reservation&gt;
+    &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+        env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+    &lt;/n:passenger&gt;
+   &lt;/env:Header&gt;
+   &lt;env:Body&gt;
+    &lt;p:itinerary 
+     xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+     &lt;p:departure&gt;
+       &lt;p:departing&gt;LGA&lt;/p:departing&gt;
+     &lt;/p:departure&gt;
+     &lt;p:return&gt;
+       &lt;p:arriving&gt;EWR&lt;/p:arriving&gt;
+     &lt;/p:return&gt;
+    &lt;/p:itinerary&gt;
+   &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.2.2 <a name="exchange-message">Exchanging SOAP Messages Using XMPP Message Stanzas</a>
+</h3>
+      <p class="" style="">The process for exchanging SOAP messages using the XMPP &lt;message/&gt; stanza type is effectively no different from the use with &lt;iq/&gt; stanzas, except that message stanzas may be sent to bare JID (user@host) rather than full JIDs (user@host/resource), message stanzas may be stored for later delivery, etc. The following business rules apply:</p>
+      <ol start="" type="">
+        <li>The message stanza containing a request MUST carry one SOAP envelope as a first-level child element.</li>
+        <li>The 'id' attribute MUST be used to track the XMPP messages and eventually associate errors or answers with the related requests (this is for tracking at the XMPP level, not the SOAP level).</li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="attachments">Sending Attachments</a>
+</h3>
+    <p class="" style="">SOAP messages may contain binary data, and XMPP stanzas that encapsulate such SOAP messages could invoke bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components rather than XMPP nodes; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+    <p class="" style="">There are several potential methods for transporting binary data as attachments:</p>
+    <p class="" style="">First, inserting a link to the file directly either into the SOAP envelope (e.g., via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2256869">10</a>]) or into the XMPP message or IQ stanza (e.g, via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2256892">11</a>]). This is a general method that can be used by XMPP clients if they are able to retrieve the file via HTTP (see <span style="font-weight: bold">JEP-0066</span>).</p>
+    <p class="" style="">Second, encoding SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP 1.2 Attachment Feature</span>  [<a href="#nt-id2256928">12</a>] (or, more recently, <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2256951">13</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2256972">14</a>]). This can work well for the HTTP and email bindings of SOAP but cannot be used directly by native XMPP entities since XML streams transport pure XML only and not MIME messages; consider the following example:</p>
+    <p class="caption">Example 8. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start="&lt;claim061400a.xml@claiming-it.com&gt;"
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+    </pre></div>
+    <p class="" style="">Third, using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span>  [<a href="#nt-id2256984">15</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2257036">16</a>]. These methods are just other transport protocols and most likely would needlessly complicate implementations of SOAP over XMPP.</p>
+    <p class="" style="">Therefore, to transport binary data between native XMPP entities when a URL cannot be provided using <span style="font-weight: bold">JEP-0066</span> or some similar mechanism, the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2257072">17</a>] SHOULD be used.</p>
+    <ol start="" type="">
+      <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+      <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+      <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+    </ol>
+    <p class="caption">Example 9. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='offer1' to='receiver@example.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='2005-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If an XMPP entity also functions as a gateway to other SOAP bindings, it SHOULD use W3C-recommended protocols for transporting SOAP attachments over non-XMPP SOAP bindings (e.g., HTTP and SMTP) when communicating with non-XMPP entities (see the <a href="#impl">Implementation Notes</a> section of this document).</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="wsdl">Specifying a WSDL Definition</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2257169">18</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). WSDL definitions attempt to specify a loose coupling of SOAP envelopes and their transports in order to maintain their independence and flexibility.</p>
+    <p class="" style="">The definition of an XMPP SOAP transport in WSDL is straightforward. The following rules apply:</p>
+    <ol start="" type="">
+      <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+      <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to "document".</li>
+      <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+      <li>A valid <span class="ref" style="">XMPP IRI/URI</span>  [<a href="#nt-id2257238">19</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+    </ol>
+    <p class="" style="">The following is an example of a WSDL definition for an endpoint that supports the SOAP XMPP binding: a mythical service that translates Shakespearean English into selected modern languages and dialects.</p>
+    <p class="caption">Example 10. Example of WSDL definition for a translation service that supports SOAP over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='ShakespeareTranslation' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'
+    xmlns:tns='http://shakespeare.lit/translation.wsdl'&gt;
+  
+  &lt;binding name='ShakespeareTranslationSoap' type='tns:TranslationPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+
+  &lt;service name='ShakespeareTranslationService'&gt;
+    &lt;documentation&gt;Translates Shakespearean text.&lt;/documentation&gt;
+    &lt;port name='TranslationPort' binding='tns:ShakespeareTranslationSoap'&gt;
+      &lt;soap:address location='xmpp:translation@shakespeare.lit'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+
+&lt;/definitions&gt;
+    </pre></div>
+    <p class="" style="">Although there is no standard procedure for publishing WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257324">20</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257335">21</a>].</p>
+  </div>
+<h2>4.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2257368">22</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2257390">23</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2257412">24</a>]. (Additionaly, a binding to BEEP is described in <span style="font-weight: bold">RFC 3288</span>.) As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>4.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2257524">25</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2257550">26</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email (see the <a href="#impl">Implementation Notes</a> section of this document). Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>4.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>4.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 1: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encappsulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 2: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 3: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 4: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 5: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 6: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 7: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>4.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 8: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 9: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 10: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 11: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Becomes Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 12: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 13: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 14: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>5.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the <a href="#binding">SOAP XMPP Binding</a> section of this document. The current section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2259789">27</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>5.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2259836">28</a>], the SOAP XMPP Binding defined herein has been reviewed informally by one or more appropriate experts from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2259858">29</a>] advanced it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's <a href="http://www.w3.org/2000/xp/Group/">XML Protocol Working Group</a>. To that end, revised versions of this specification will be announced on the W3C's public xml-dist-app@w3.org mailing list.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1 or subsequent versions, this specification may be modified to address handling of SOAP messages that are encoded in versions other than XML 1.0.</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. These errors are mapped to corresponding HTTP status codes in the SOAP HTTP Binding and therefore are mapped in a similar way to XMPP error conditions in the SOAP XMPP Binding. Specifically, SOAP faults are mapped to &lt;iq/&gt; and &lt;message/&gt; stanzas of type "error" using standard XMPP error conditions (this approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and XMPP error conditions (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span> as well as <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2259977">30</a>]).</p>
+  <p class="caption">Table 15: Mapping of SOAP Faults to HTTP Status Codes and XMPP Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">SOAP Fault</th>
+      <th colspan="" rowspan="">HTTP Status Code</th>
+      <th colspan="" rowspan="">XMPP Error Condition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:Sender</td>
+      <td align="" colspan="" rowspan="">400</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:Receiver</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+    </tr>
+  </table>
+  <p class="" style="">Note: When errors are due to the XMPP transport protocol alone and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+<h2>7.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="bizrules-encoding">Encoding</a>
+</h3>
+    <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+    <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML as well as byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2260225">31</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded as UTF-8 in order to match the XML stream encoding.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2260248">32</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2260263">33</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2260300">34</a>].</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260345">35</a>] is required as a result of this JEP.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260394">36</a>] includes 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Identity</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a Service Discovery type of "soap" within the "automation" category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;automation&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;soap&lt;/name&gt;
+    &lt;desc&gt;A SOAP receiver (either intermediate or ultimate).&lt;/desc&gt;
+    &lt;doc&gt;JEP-0072&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>12.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p> 
+  <p class="" style="">An XMPP entity that supports the SOAP XMPP binding could function as a "SOAP intermediary" that hands a SOAP message off to some other deployment for subsequent processing (HTTP, email, a specialized enterprise messaging platform, etc.) rather than functioning as the "ultimate SOAP receiver" for the message (as these terms are defined in Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). If the intended recipient functions as a SOAP intermediary, implementations should be aware that subsequent processing may alter the representation of SOAP messages.</p>
+  <p class="" style="">As an example, consider a component that functions as a gateway between XMPP-based and HTTP-based web services. Its purpose might be to mix HTTP and XMPP for web services and to invoke any web services already accessible through HTTP from XMPP clients.</p>
+  <p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+  <p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+  <ol start="" type="">
+    <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+    <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+    <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+    <li>a blank return path</li>
+  </ol>
+  <p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+  <p class="caption">Example 11. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forward&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+  </pre></div>
+  <p class="" style="">Generic XMPP routers that conform to <span style="font-weight: bold">RFC 3920</span> may also "store and forward" Jabber messages. This feature is usually called "offline message handling": the router makes a decision as to whether to deliver the message to the local intended recipient based on the recipient's presence, and if the recipient is offline when the router processes the message then it may store the message for delivery when the recipient next comes online (rather than returning an error to the sender). Although it is possible to write an XMPP router that directly supports the SOAP XMPP binding and implements the SOAP processing model, generic XMPP routers do not contain such support. Accordingly, generic XMPP routers will not forward an XMPP message to an alternate SOAP transport such as HTTP or SMTP, or provide other functions of a SOAP intermediary or ultimate receiver. When a generic XMPP router delivers a message to the intended recipient (whether immediately or as delayed in "offline storage") and the intended recipient supports the SOAP XMPP binding, SOAP processing is performed; such an intended recipient MAY act either as a SOAP intermediary or as an ultimate SOAP receiver.</p>
+<h2>13.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Many thanks to Noah Mendelsohn for his assistance regarding SOAP binding definitions and conformance issues. Thanks also to Michael Mahan and Rich Salz for their comments.</p>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250615">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2250637">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250811">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2250657">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250750">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2256246">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256304">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256419">8</a>. SOAP Version 1.2 Part 0: Primer &lt;<a href="http://www.w3.org/TR/soap12-part0">http://www.w3.org/TR/soap12-part0</a>&gt;.</p>
+<p><a name="nt-id2256449">9</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2256869">10</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2256892">11</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2256928">12</a>. SOAP 1.2 Attachment Feature &lt;<a href="http://www.w3.org/TR/soap12-af/">http://www.w3.org/TR/soap12-af/</a>&gt;.</p>
+<p><a name="nt-id2256951">13</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2256972">14</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2256984">15</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2257036">16</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2257072">17</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2257169">18</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2257238">19</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2257324">20</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257335">21</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257368">22</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2257390">23</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2257412">24</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2257524">25</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2257550">26</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2259789">27</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2259836">28</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2259858">29</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2259977">30</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2260225">31</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2260248">32</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2260263">33</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2260300">34</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2260345">35</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260394">36</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.12 (2005-10-18)</h4>
+<div class="indent">Re-organized descriptive text around use cases in accordance with Council feedback. (psa)
+    </div>
+<h4>Version 0.11 (2005-09-07)</h4>
+<div class="indent">Modified service discovery category and type; made several other small text changes based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.10 (2005-09-01)</h4>
+<div class="indent">Added information about service discovery. (psa)
+    </div>
+<h4>Version 0.9 (2005-08-17)</h4>
+<div class="indent">Added implementation note about XMPP routers based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.8 (2005-07-21)</h4>
+<div class="indent">Cleaned up WSDL definition. (psa)
+    </div>
+<h4>Version 0.7 (2005-06-30)</h4>
+<div class="indent">Clarified implementation notes and text on attachments. (psa/ff)
+    </div>
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.13.html
+++ b/content/xep-0072-0.13.html
@@ -1,0 +1,1313 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.13<br>
+            Last Updated: 2005-11-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: soap<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/SOAP%20Over%20XMPP%20(JEP-0072)">http://wiki.jabber.org/index.php/SOAP Over XMPP (JEP-0072)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#uc">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>3.2.  <a href="#exchange">Exchanging SOAP Messages</a>
+</dt>
+<dl>
+<dt>3.2.1.  <a href="#exchange-iq">Exchanging SOAP Messages Using XMPP IQ Stanzas</a>
+</dt>
+<dt>3.2.2.  <a href="#exchange-message">Exchanging SOAP Messages Using XMPP Message Stanzas</a>
+</dt>
+</dl>
+<dt>3.3.  <a href="#data">Sending Associated Data</a>
+</dt>
+<dl>
+<dt>3.3.1.  <a href="#data-link">Links</a>
+</dt>
+<dt>3.3.2.  <a href="#data-mime">MIME</a>
+</dt>
+<dt>3.3.3.  <a href="#data-transport">Other Transports</a>
+</dt>
+<dt>3.3.4.  <a href="#data-ft">File Transfer</a>
+</dt>
+</dl>
+<dt>3.4.  <a href="#wsdl">Specifying a WSDL Definition</a>
+</dt>
+</dl>
+<dt>4.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>4.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>4.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>4.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>4.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>4.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>4.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>4.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>4.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>4.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>4.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>4.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>4.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>4.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>5.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>5.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>5.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl><dt>7.1.  <a href="#bizrules-encoding">Encoding</a>
+</dt></dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Identity</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-soap">SOAP Envelope</a>
+</dt>
+<dt>11.2.  <a href="#schema-error">Application-Specific XMPP Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>13.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2250646">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous request-response semantics. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250694">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2250674">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2250718">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250813">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP specification defines the concepts of "SOAP intermediary" and "ultimate SOAP receiver" (see Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). In general, this specification assumes that XMPP entities that support the SOAP XMPP Binding will be ultimate SOAP receivers, since SOAP intermediaries tend to be artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these issues are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2250305">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. One final justification for SOAP intermediaries is to act as gateways between different transport mechanisms (e.g., between HTTP and SMTP), and XMPP entities may well be SOAP intermediaries for that reason. For further details about gateways between XMPP and other SOAP bindings, refer to the <a href="#impl">Implementation Notes</a> section of this document.</p>
+<h2>3.
+       <a name="uc">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco">Discovering Support</a>
+</h3>
+    <p class="" style="">In order to determine whether a potential responding entity supports the SOAP XMPP Binding, a requesting entity SHOULD send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250402">7</a>] information request to the potential responding entity:</p>
+    <p class="caption">Example 1. Requester queries responder regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server' 
+    id='disco1'
+    type='get'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the responding entity supports the SOAP XMPP Binding and the requesting entity is not blocked from communicating with the responding entity, the responding entity MUST include a feature of "http://jabber.org/protocol/soap" in its reply and SHOULD specify a service discovery identity of "automation/soap".</p>
+    <p class="caption">Example 2. Responder replies regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    to='requester@example.com/soap-client'
+    id='disco1'
+    type='result'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='automation' type='soap'/&gt;
+    &lt;feature var='http://jabber.org/protocol/soap'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="exchange">Exchanging SOAP Messages</a>
+</h3>
+    <p class="" style="">When a requesting entity wants to interact with a responding entity via the SOAP XMPP Binding, it faces a fundamental choice: to use &lt;iq/&gt; stanzas or to use &lt;message/&gt; stanzas. The following guidelines may prove useful:</p>
+    <ol start="" type="">
+      <li>&lt;iq/&gt; stanzas SHOULD be used when more formal request-response semantics are needed or when an immediate answer is required.</li>
+      <li>&lt;message/&gt; stanzas SHOULD be used when less formal request-response semantics are acceptable or when store-and-forward ("offline message") delivery is needed (e.g., because the intended recipient may be temporarily unavailable).</li>
+    </ol>
+    <p class="" style="">Examples of both approaches are provided below, encapsulating the SOAP message examples (a travel reservation flow) to be found in <span class="ref" style="">SOAP Version 1.2 Part 0</span>  [<a href="#nt-id2256581">8</a>].</p>
+    <div class="indent">
+<h3>3.2.1 <a name="exchange-iq">Exchanging SOAP Messages Using XMPP IQ Stanzas</a>
+</h3>
+      <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2256624">9</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer (see <a href="#errors">Error Handling</a> for details).</p>
+      <p class="" style="">Each &lt;iq/&gt; stanza of type "set" MUST contain a SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://www.w3.org/2003/05/soap-envelope' namespace.</p>
+      <p class="caption">Example 3. Requesting entity sends IQ-set</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+   &lt;env:Header&gt;
+    &lt;m:reservation xmlns:m="http://travelcompany.example.org/reservation" 
+            env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+     &lt;m:dateAndTime&gt;2001-11-29T13:20:00.000-05:00&lt;/m:dateAndTime&gt;
+    &lt;/m:reservation&gt;
+    &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+            env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+    &lt;/n:passenger&gt;
+   &lt;/env:Header&gt;
+   &lt;env:Body&gt;
+    &lt;p:itinerary
+      xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+     &lt;p:departure&gt;
+       &lt;p:departing&gt;New York&lt;/p:departing&gt;
+       &lt;p:arriving&gt;Los Angeles&lt;/p:arriving&gt;
+       &lt;p:departureDate&gt;2001-12-14&lt;/p:departureDate&gt;
+       &lt;p:departureTime&gt;late afternoon&lt;/p:departureTime&gt;
+       &lt;p:seatPreference&gt;aisle&lt;/p:seatPreference&gt;
+     &lt;/p:departure&gt;
+     &lt;p:return&gt;
+       &lt;p:departing&gt;Los Angeles&lt;/p:departing&gt;
+       &lt;p:arriving&gt;New York&lt;/p:arriving&gt;
+       &lt;p:departureDate&gt;2001-12-20&lt;/p:departureDate&gt;
+       &lt;p:departureTime&gt;mid-morning&lt;/p:departureTime&gt;
+       &lt;p:seatPreference/&gt;
+     &lt;/p:return&gt;
+    &lt;/p:itinerary&gt;
+    &lt;q:lodging
+     xmlns:q="http://travelcompany.example.org/reservation/hotels"&gt;
+     &lt;q:preference&gt;none&lt;/q:preference&gt;
+    &lt;/q:lodging&gt;
+   &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;  
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the responding entity does not support the SOAP XMPP Binding, it SHOULD return a &lt;service-unavailable/&gt; error:</p>
+      <p class="caption">Example 4. Responding entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If a SOAP-related fault occurs, the mappings in <a href="#errors">Error Handling</a> SHOULD be used.</p>
+      <p class="caption">Example 5. Responding entity indicates SOAP fault</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='modify'&gt;
+    &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;Sender xmlns='http://jabber.org/protocol/soap#fault'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the responding entity does not return an error, it MUST respond with an IQ of type "result":</p>
+      <p class="caption">Example 6. Responding entity returns IQ-result</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+   &lt;env:Header&gt;
+    &lt;m:reservation xmlns:m="http://travelcompany.example.org/reservation" 
+        env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+     &lt;m:dateAndTime&gt;2001-11-29T13:35:00.000-05:00&lt;/m:dateAndTime&gt;
+    &lt;/m:reservation&gt;
+    &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+        env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+    &lt;/n:passenger&gt;
+   &lt;/env:Header&gt;
+   &lt;env:Body&gt;
+    &lt;p:itineraryClarification 
+      xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+     &lt;p:departure&gt;
+       &lt;p:departing&gt;
+         &lt;p:airportChoices&gt;
+            JFK LGA EWR 
+         &lt;/p:airportChoices&gt;
+       &lt;/p:departing&gt;
+     &lt;/p:departure&gt;
+     &lt;p:return&gt;
+       &lt;p:arriving&gt;
+         &lt;p:airportChoices&gt;
+           JFK LGA EWR 
+         &lt;/p:airportChoices&gt;
+       &lt;/p:arriving&gt;
+     &lt;/p:return&gt;  
+    &lt;/p:itineraryClarification&gt;
+   &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">At this point the requesting entity could send another IQ-set:</p>
+      <p class="caption">Example 7. Requesting entity sends another IQ-set</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap2'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+   &lt;env:Header&gt;
+    &lt;m:reservation 
+       xmlns:m="http://travelcompany.example.org/reservation" 
+        env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+      &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+      &lt;m:dateAndTime&gt;2001-11-29T13:36:50.000-05:00&lt;/m:dateAndTime&gt;
+    &lt;/m:reservation&gt;
+    &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+        env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+             env:mustUnderstand="true"&gt;
+     &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+    &lt;/n:passenger&gt;
+   &lt;/env:Header&gt;
+   &lt;env:Body&gt;
+    &lt;p:itinerary 
+     xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+     &lt;p:departure&gt;
+       &lt;p:departing&gt;LGA&lt;/p:departing&gt;
+     &lt;/p:departure&gt;
+     &lt;p:return&gt;
+       &lt;p:arriving&gt;EWR&lt;/p:arriving&gt;
+     &lt;/p:return&gt;
+    &lt;/p:itinerary&gt;
+   &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.2.2 <a name="exchange-message">Exchanging SOAP Messages Using XMPP Message Stanzas</a>
+</h3>
+      <p class="" style="">The process for exchanging SOAP messages using the XMPP &lt;message/&gt; stanza type is effectively no different from the use with &lt;iq/&gt; stanzas, except that message stanzas may be sent to bare JIDs (user@host) rather than full JIDs (user@host/resource), message stanzas may be stored for later delivery, etc. The following business rules apply:</p>
+      <ol start="" type="">
+        <li>The message stanza containing a request MUST carry one SOAP envelope as a first-level child element.</li>
+        <li>The 'id' attribute MUST be used to track the XMPP messages and eventually associate errors or answers with the related requests (this is for tracking at the XMPP level, not the SOAP level).</li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="data">Sending Associated Data</a>
+</h3>
+    <p class="" style="">SOAP messages may contain associated (usually binary) data, and XMPP stanzas that encapsulate such SOAP messages could invoke bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components rather than XMPP nodes; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent. Therefore, it is desirable to support the sending of attachments or files in order to exchange large amounts of binary data associated with SOAP requests and responses. The possible approaches are described below.</p>
+    <div class="indent">
+<h3>3.3.1 <a name="data-link">Links</a>
+</h3>
+      <p class="" style="">The first possible approach is to represent the binary data as a file, put it to an accessible location (e.g., HTTP or FTP URI), and insert a link to the file directly either into the SOAP envelope (e.g., via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2256387">10</a>]) or into the XMPP message or IQ stanza (e.g, via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2256414">11</a>]).</p>
+      <p class="caption">Example 8. SOAP representation header</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soaplink1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope' 
+                xmlns:rep='http://www.w3.org/2004/08/representation' 
+                xmlns:xmlmime='http://www.w3.org/2004/11/xmlmime'&gt;
+    &lt;env:Header&gt;
+      &lt;rep:Representation resource='http://example.org/me.png'&gt;
+        &lt;rep:Data xmlmime:contentType='image/png'&gt;/aWKKapGGyQ=&lt;/rep:Data&gt;
+      &lt;/rep:Representation&gt;
+    &lt;/env:Header&gt;
+    &lt;env:Body&gt;
+      &lt;x:MyData xmlns:x='http://example.org/mystuff'&gt;
+        &lt;x:name&gt;John Q. Public&lt;/x:name&gt;
+        &lt;x:img src='http://example.org/me.png'/&gt;
+      &lt;/x:MyData&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 9. XMPP IQ with out-of-band data</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soaplink2'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;query xmlns='jabber:iq:oob'&gt;
+    &lt;url&gt;http://example.org/me.png&lt;/url&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Although this is a general method that can be used by XMPP clients if they are able to put and retrieve files via HTTP or FTP, not all clients have access to HTTP/FTP servers. Therefore this approach SHOULD NOT be used except as a fallback.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.2 <a name="data-mime">MIME</a>
+</h3>
+      <p class="" style="">The second possible approach is to encode SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP 1.2 Attachment Feature</span>  [<a href="#nt-id2256524">12</a>] (or, more recently, <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2256492">13</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2257326">14</a>]).</p>
+      <p class="caption">Example 10. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start="&lt;claim061400a.xml@claiming-it.com&gt;"
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+      </pre></div>
+      <p class="" style="">Although this approach can work well for the HTTP and email bindings of SOAP, it cannot be used directly by native XMPP entities since XML streams transport pure XML only and not MIME messages. Therefore this approach MUST NOT be used within the XMPP binding.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.3 <a name="data-transport">Other Transports</a>
+</h3>
+      <p class="" style="">A third possible approach is to use other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span>  [<a href="#nt-id2257368">15</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2257399">16</a>].</p>
+      <p class="" style="">However, these methods are just other transport protocols and most likely would needlessly complicate implementations of SOAP over XMPP. Therefore, implementations SHOULD NOT use these approaches.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.4 <a name="data-ft">File Transfer</a>
+</h3>
+      <p class="" style="">A fourth possible approach is to use the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2257453">17</a>]. Because this is the common and standardized method for XMPP entities to transfer large or binary files outside the XMPP band, it SHOULD be used.</p>
+      <p class="" style="">In particular, the entity that has the file SHOULD advertise the availability of the associated stream using <span class="ref" style="">Publishing SI Requests</span>  [<a href="#nt-id2257486">18</a>], at which point the entity that is to receive the file SHOULD initiate the file transfer process.</p>
+      <p class="caption">Example 11. Requester advertises file</p>
+<div class="indent"><pre>
+&lt;message from='requester@example.com/soap-client'
+         id='soapft1'
+         to='responder@example.com/soap-server'&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+      id='publish-2345'
+      mime-type='image/png'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='me.png'
+          size='4238'
+          date='2005-11-01T23:11Z'/&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">A potential receiver starts the stream initiation session by sending an IQ-get to the sender, using the &lt;start xmlns='http://jabber.org/protocol/sipub'/&gt; element. This element contains the 'id' attribute to specify which published stream to retrieve:</p>
+      <p class="caption">Example 12. Receiver requests start of stream</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    id='sipub-request-0'
+    from='responder@example.com/soap-server'
+    to='requester@example.com/soap-client'&gt;
+  &lt;start xmlns='http://jabber.org/protocol/sipub'
+         id='publish-2345'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the sender accepts the request, it responds with an IQ-result containing a &lt;starting/&gt; element. This element indicates the stream initiation identifier to be used:</p>
+      <p class="caption">Example 13. Sender accepts request to start stream</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    id='sipub-request-0'
+    from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server'&gt;
+  &lt;starting xmlns='http://jabber.org/protocol/sipub'
+            sid='session-87651234'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Then the sender begins the stream initiation negotiation:</p>
+    <p class="caption">Example 14. Sender starts negotiation</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    id='sipub-set-1'
+    from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si'
+      id='session-87651234'
+        mime-type='image/png'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='me.png'
+          size='4238'
+          date='2005-11-01T23:11Z'/&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">For details regarding file transfer and advertising of file transfer stream initiation requests, refer to <span style="font-weight: bold">JEP-0096</span> and <span style="font-weight: bold">JEP-0137</span>.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="wsdl">Specifying a WSDL Definition</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2257624">19</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). WSDL definitions attempt to specify a loose coupling of SOAP envelopes and their transports in order to maintain their independence and flexibility.</p>
+    <p class="" style="">The definition of an XMPP SOAP transport in WSDL is straightforward. The following rules apply:</p>
+    <ol start="" type="">
+      <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+      <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to "document".</li>
+      <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+      <li>A valid <span class="ref" style="">XMPP IRI/URI</span>  [<a href="#nt-id2257696">20</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+    </ol>
+    <p class="" style="">The following is an example of a WSDL definition for an endpoint that supports the SOAP XMPP binding: a mythical service that translates Shakespearean English into selected modern languages and dialects.</p>
+    <p class="caption">Example 15. Example of WSDL definition for a translation service that supports SOAP over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='ShakespeareTranslation' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'
+    xmlns:tns='http://shakespeare.lit/translation.wsdl'&gt;
+  
+  &lt;binding name='ShakespeareTranslationSoap' type='tns:TranslationPortType'&gt;
+    &lt;soap:binding style='document' transport='http://jabber.org/protocol/soap'/&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+
+  &lt;service name='ShakespeareTranslationService'&gt;
+    &lt;documentation&gt;Translates Shakespearean text.&lt;/documentation&gt;
+    &lt;port name='TranslationPort' binding='tns:ShakespeareTranslationSoap'&gt;
+      &lt;soap:address location='xmpp:translation@shakespeare.lit'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+
+&lt;/definitions&gt;
+    </pre></div>
+    <p class="" style="">Although there is no standard procedure for publishing WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257780">21</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257793">22</a>].</p>
+  </div>
+<h2>4.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2257826">23</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2257849">24</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2257840">25</a>]. (Additionaly, a binding to BEEP is described in <span style="font-weight: bold">RFC 3288</span>.) As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>4.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2257982">26</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2258008">27</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email (see the <a href="#impl">Implementation Notes</a> section of this document). Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>4.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>4.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 1: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encappsulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 2: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 3: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 4: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 5: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 6: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 7: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>4.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 8: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 9: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 10: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 11: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Becomes Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 12: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 13: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 14: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>5.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the <a href="#binding">SOAP XMPP Binding</a> section of this document. The current section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2260246">28</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>5.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2260294">29</a>], the SOAP XMPP Binding defined herein has been reviewed informally by one or more appropriate experts from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2260316">30</a>] advanced it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's <a href="http://www.w3.org/2000/xp/Group/">XML Protocol Working Group</a>. To that end, revised versions of this specification will be announced on the W3C's public xml-dist-app@w3.org mailing list.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1 or subsequent versions, this specification may be modified to address handling of SOAP messages that are encoded in versions other than XML 1.0.</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. In the SOAP HTTP Binding, these errors are mapped to corresponding HTTP status codes. In the SOAP XMPP Binding, they are mapped to the catch-all XMPP error of &lt;undefined-condition/&gt; along with application-specific error condition elements qualified by the 'http://jabber.org/protocol/soap#fault' namespace (this is consistent with Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>, see also <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2260429">31</a>]). The element names of these application-specific error conditions map directly to the SOAP fault codes specified in Section 5.4.6 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>.</p>
+  <p class="" style="">The following table provides a mapping between SOAP, HTTP, and application-specific XMPP errors.</p>
+  <p class="caption">Table 15: Mapping of SOAP Faults to HTTP Status Codes and XMPP Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">SOAP Fault</th>
+      <th colspan="" rowspan="">HTTP Status Code</th>
+      <th colspan="" rowspan="">XMPP Application Error</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;DataEncodingUnknown/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;MustUnderstand/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:Receiver</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;Receiver/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:Sender</td>
+      <td align="" colspan="" rowspan="">400</td>
+      <td align="" colspan="" rowspan="">&lt;Sender/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;VersionMismatch/&gt;</td>
+      </tr>
+  </table>
+  <p class="" style="">Note: When errors are due to the XMPP transport protocol alone and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only instead of the XMPP &lt;undefined-condition/&gt; condition plus application-specific condition.</p> 
+<h2>7.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="bizrules-encoding">Encoding</a>
+</h3>
+    <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+    <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML as well as byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2260687">32</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded as UTF-8 in order to match the XML stream encoding.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2260712">33</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2260727">34</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2260765">35</a>].</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260809">36</a>] is required as a result of this JEP.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260860">37</a>] includes 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Identity</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a Service Discovery type of "soap" within the "automation" category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;automation&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;soap&lt;/name&gt;
+    &lt;desc&gt;A SOAP receiver (either intermediate or ultimate).&lt;/desc&gt;
+    &lt;doc&gt;JEP-0072&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-soap">SOAP Envelope</a>
+</h3>
+    <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided at &lt;<a href="http://www.w3.org/2003/05/soap-envelope/">http://www.w3.org/2003/05/soap-envelope/</a>&gt;.</p>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-error">Application-Specific XMPP Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/soap#fault'
+    xmlns='http://jabber.org/protocol/soap#fault'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='DataEncodingUnknown' type='empty'/&gt;
+  &lt;xs:element name='MustUnderstand' type='empty'/&gt;
+  &lt;xs:element name='Receiver' type='empty'/&gt;
+  &lt;xs:element name='Sender' type='empty'/&gt;
+  &lt;xs:element name='VersionMismatch' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p> 
+  <p class="" style="">An XMPP entity that supports the SOAP XMPP binding could function as a "SOAP intermediary" that hands a SOAP message off to some other deployment for subsequent processing (HTTP, email, a specialized enterprise messaging platform, etc.) rather than functioning as the "ultimate SOAP receiver" for the message (as these terms are defined in Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). If the intended recipient functions as a SOAP intermediary, implementations should be aware that subsequent processing may alter the representation of SOAP messages.</p>
+  <p class="" style="">As an example, consider a component that functions as a gateway between XMPP-based and HTTP-based web services. Its purpose might be to mix HTTP and XMPP for web services and to invoke any web services already accessible through HTTP from XMPP clients.</p>
+  <p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+  <p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+  <ol start="" type="">
+    <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+    <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+    <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+    <li>a blank return path</li>
+  </ol>
+  <p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+  <p class="caption">Example 16. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forward&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+  </pre></div>
+  <p class="" style="">Generic XMPP routers that conform to <span style="font-weight: bold">RFC 3920</span> may also "store and forward" Jabber messages. This feature is usually called "offline message handling": the router makes a decision as to whether to deliver the message to the local intended recipient based on the recipient's presence, and if the recipient is offline when the router processes the message then it may store the message for delivery when the recipient next comes online (rather than returning an error to the sender). Although it is possible to write an XMPP router that directly supports the SOAP XMPP binding and implements the SOAP processing model, generic XMPP routers do not contain such support. Accordingly, generic XMPP routers will not forward an XMPP message to an alternate SOAP transport such as HTTP or SMTP, or provide other functions of a SOAP intermediary or ultimate receiver. When a generic XMPP router delivers a message to the intended recipient (whether immediately or as delayed in "offline storage") and the intended recipient supports the SOAP XMPP binding, SOAP processing is performed; such an intended recipient MAY act either as a SOAP intermediary or as an ultimate SOAP receiver.</p>
+  <p class="" style="">With regarding to exchange of associated data, an XMPP entity that functions as a gateway to other SOAP bindings it SHOULD use W3C-recommended protocols for transporting SOAP attachments over non-XMPP SOAP bindings (e.g., HTTP and SMTP) when communicating with non-XMPP entities.</p>
+<h2>13.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Many thanks to Noah Mendelsohn for his assistance regarding SOAP binding definitions and conformance issues. Thanks also to Michael Mahan and Rich Salz for their comments.</p>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250646">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2250694">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250674">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2250718">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250813">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2250305">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2250402">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256581">8</a>. SOAP Version 1.2 Part 0: Primer &lt;<a href="http://www.w3.org/TR/soap12-part0">http://www.w3.org/TR/soap12-part0</a>&gt;.</p>
+<p><a name="nt-id2256624">9</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2256387">10</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2256414">11</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2256524">12</a>. SOAP 1.2 Attachment Feature &lt;<a href="http://www.w3.org/TR/soap12-af/">http://www.w3.org/TR/soap12-af/</a>&gt;.</p>
+<p><a name="nt-id2256492">13</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2257326">14</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2257368">15</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2257399">16</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2257453">17</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2257486">18</a>. JEP-0137: Publishing SI Requests &lt;<a href="http://www.jabber.org/jeps/jep-0137.html">http://www.jabber.org/jeps/jep-0137.html</a>&gt;.</p>
+<p><a name="nt-id2257624">19</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2257696">20</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2257780">21</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257793">22</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257826">23</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2257849">24</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2257840">25</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2257982">26</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2258008">27</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2260246">28</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2260294">29</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2260316">30</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2260429">31</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2260687">32</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2260712">33</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2260727">34</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2260765">35</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2260809">36</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260860">37</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.13 (2005-11-01)</h4>
+<div class="indent">In accordance with Council feedback: divided Sending Attachments text into multiple subsections and added XMPP examples to each subsection; specified use of JEP-0137 to publish SI requests related to file transfer; specified use of application-specific stanza errors; fixed typographical error in WSDL example. (psa)
+    </div>
+<h4>Version 0.12 (2005-10-18)</h4>
+<div class="indent">In accordance with Council feedback, re-organized descriptive text around use cases. (psa)
+    </div>
+<h4>Version 0.11 (2005-09-07)</h4>
+<div class="indent">Modified service discovery category and type; made several other small text changes based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.10 (2005-09-01)</h4>
+<div class="indent">Added information about service discovery. (psa)
+    </div>
+<h4>Version 0.9 (2005-08-17)</h4>
+<div class="indent">Added implementation note about XMPP routers based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.8 (2005-07-21)</h4>
+<div class="indent">Cleaned up WSDL definition. (psa)
+    </div>
+<h4>Version 0.7 (2005-06-30)</h4>
+<div class="indent">Clarified implementation notes and text on attachments. (psa/ff)
+    </div>
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.14.html
+++ b/content/xep-0072-0.14.html
@@ -1,0 +1,1429 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.14<br>
+            Last Updated: 2005-11-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: soap<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/SOAP%20Over%20XMPP%20(JEP-0072)">http://wiki.jabber.org/index.php/SOAP Over XMPP (JEP-0072)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#uc">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>3.2.  <a href="#exchange">Exchanging SOAP Messages</a>
+</dt>
+<dl>
+<dt>3.2.1.  <a href="#exchange-iq">Exchanging SOAP Messages Using XMPP IQ Stanzas</a>
+</dt>
+<dt>3.2.2.  <a href="#exchange-message">Exchanging SOAP Messages Using XMPP Message Stanzas</a>
+</dt>
+</dl>
+<dt>3.3.  <a href="#data">Sending Associated Data</a>
+</dt>
+<dl>
+<dt>3.3.1.  <a href="#data-ft">File Transfer</a>
+</dt>
+<dt>3.3.2.  <a href="#data-link">Including Links</a>
+</dt>
+</dl>
+<dt>3.4.  <a href="#wsdl">Specifying a WSDL Definition</a>
+</dt>
+</dl>
+<dt>4.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>4.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>4.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>4.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>4.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>4.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>4.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>4.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>4.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>4.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>4.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>4.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>4.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>4.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>5.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>5.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>5.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl><dt>7.1.  <a href="#bizrules-encoding">Encoding</a>
+</dt></dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Identity</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-soap">SOAP Envelope</a>
+</dt>
+<dt>11.2.  <a href="#schema-error">Application-Specific XMPP Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>13.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2250819">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous request-response semantics. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250868">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2250856">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2250890">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2256300">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP specification defines the concepts of "SOAP intermediary" and "ultimate SOAP receiver" (see Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). In general, this specification assumes that XMPP entities that support the SOAP XMPP Binding will be ultimate SOAP receivers, since SOAP intermediaries tend to be artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these issues are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256357">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. One final justification for SOAP intermediaries is to act as gateways between different transport mechanisms (e.g., between HTTP and SMTP), and XMPP entities may well be SOAP intermediaries for that reason. For further details about gateways between XMPP and other SOAP bindings, refer to the <a href="#impl">Implementation Notes</a> section of this document.</p>
+<h2>3.
+       <a name="uc">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco">Discovering Support</a>
+</h3>
+    <p class="" style="">In order to determine whether a potential responding entity supports the SOAP XMPP Binding, a requesting entity SHOULD send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256414">7</a>] information request to the potential responding entity:</p>
+    <p class="caption">Example 1. Requester queries responder regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server' 
+    id='disco1'
+    type='get'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the responding entity supports the SOAP XMPP Binding and the requesting entity is not blocked from communicating with the responding entity, the responding entity MUST include a feature of "http://jabber.org/protocol/soap" in its reply and SHOULD specify a service discovery identity of "automation/soap".</p>
+    <p class="caption">Example 2. Responder replies regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    to='requester@example.com/soap-client'
+    id='disco1'
+    type='result'&gt; 
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='automation' type='soap'/&gt;
+    &lt;feature var='http://jabber.org/protocol/soap'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="exchange">Exchanging SOAP Messages</a>
+</h3>
+    <p class="" style="">When a requesting entity wants to interact with a responding entity via the SOAP XMPP Binding, it faces a fundamental choice: to use &lt;iq/&gt; stanzas or to use &lt;message/&gt; stanzas. The following guidelines may prove useful:</p>
+    <ol start="" type="">
+      <li>&lt;iq/&gt; stanzas SHOULD be used when more formal request-response semantics are needed or when an immediate answer is required.</li>
+      <li>&lt;message/&gt; stanzas SHOULD be used when less formal request-response semantics are acceptable or when store-and-forward ("offline message") delivery is needed (e.g., because the intended recipient may be temporarily unavailable).</li>
+    </ol>
+    <p class="" style="">Examples of both approaches are provided below, encapsulating the SOAP message examples (a travel reservation flow) to be found in <span class="ref" style="">SOAP Version 1.2 Part 0</span>  [<a href="#nt-id2256525">8</a>].</p>
+    <div class="indent">
+<h3>3.2.1 <a name="exchange-iq">Exchanging SOAP Messages Using XMPP IQ Stanzas</a>
+</h3>
+      <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2256557">9</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer (see <a href="#errors">Error Handling</a> for details).</p>
+      <p class="" style="">Each &lt;iq/&gt; stanza of type "set" MUST contain a SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://www.w3.org/2003/05/soap-envelope' namespace.</p>
+      <p class="caption">Example 3. Requesting entity sends IQ-set</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+    &lt;env:Header&gt;
+      &lt;m:reservation 
+         xmlns:m="http://travelcompany.example.org/reservation" 
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+        &lt;m:dateAndTime&gt;2001-11-29T13:20:00.000-05:00&lt;/m:dateAndTime&gt;
+      &lt;/m:reservation&gt;
+      &lt;n:passenger 
+         xmlns:n="http://mycompany.example.com/employees"
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+      &lt;/n:passenger&gt;
+    &lt;/env:Header&gt;
+    &lt;env:Body&gt;
+      &lt;p:itinerary xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+        &lt;p:departure&gt;
+          &lt;p:departing&gt;New York&lt;/p:departing&gt;
+          &lt;p:arriving&gt;Los Angeles&lt;/p:arriving&gt;
+          &lt;p:departureDate&gt;2001-12-14&lt;/p:departureDate&gt;
+          &lt;p:departureTime&gt;late afternoon&lt;/p:departureTime&gt;
+          &lt;p:seatPreference&gt;aisle&lt;/p:seatPreference&gt;
+        &lt;/p:departure&gt;
+        &lt;p:return&gt;
+          &lt;p:departing&gt;Los Angeles&lt;/p:departing&gt;
+          &lt;p:arriving&gt;New York&lt;/p:arriving&gt;
+          &lt;p:departureDate&gt;2001-12-20&lt;/p:departureDate&gt;
+          &lt;p:departureTime&gt;mid-morning&lt;/p:departureTime&gt;
+          &lt;p:seatPreference/&gt;
+        &lt;/p:return&gt;
+      &lt;/p:itinerary&gt;
+      &lt;q:lodging xmlns:q="http://travelcompany.example.org/reservation/hotels"&gt;
+        &lt;q:preference&gt;none&lt;/q:preference&gt;
+      &lt;/q:lodging&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;  
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the responding entity does not support the SOAP XMPP Binding, it SHOULD return a &lt;service-unavailable/&gt; error:</p>
+      <p class="caption">Example 4. Responding entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If a SOAP-related fault occurs, the mappings in <a href="#errors">Error Handling</a> SHOULD be used.</p>
+      <p class="caption">Example 5. Responding entity indicates SOAP fault</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+       xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+       xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='modify'&gt;
+    &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;Sender xmlns='http://jabber.org/protocol/soap#fault'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the responding entity does not return an error, it MUST respond with an IQ of type "result":</p>
+      <p class="caption">Example 6. Responding entity returns IQ-result</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+    &lt;env:Header&gt;
+      &lt;m:reservation xmlns:m="http://travelcompany.example.org/reservation" 
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+        &lt;m:dateAndTime&gt;2001-11-29T13:35:00.000-05:00&lt;/m:dateAndTime&gt;
+      &lt;/m:reservation&gt;
+      &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+      &lt;/n:passenger&gt;
+    &lt;/env:Header&gt;
+    &lt;env:Body&gt;
+      &lt;p:itineraryClarification xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+        &lt;p:departure&gt;
+          &lt;p:departing&gt;
+            &lt;p:airportChoices&gt;JFK LGA EWR&lt;/p:airportChoices&gt;
+          &lt;/p:departing&gt;
+        &lt;/p:departure&gt;
+        &lt;p:return&gt;
+          &lt;p:arriving&gt;
+            &lt;p:airportChoices&gt;JFK LGA EWR&lt;/p:airportChoices&gt;
+          &lt;/p:arriving&gt;
+        &lt;/p:return&gt;  
+      &lt;/p:itineraryClarification&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">At this point the requesting entity could send another IQ-set:</p>
+      <p class="caption">Example 7. Requesting entity sends another IQ-set</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap2'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+    &lt;env:Header&gt;
+      &lt;m:reservation 
+         xmlns:m="http://travelcompany.example.org/reservation" 
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+        &lt;m:dateAndTime&gt;2001-11-29T13:36:50.000-05:00&lt;/m:dateAndTime&gt;
+      &lt;/m:reservation&gt;
+      &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+      &lt;/n:passenger&gt;
+    &lt;/env:Header&gt;
+    &lt;env:Body&gt;
+      &lt;p:itinerary xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+        &lt;p:departure&gt;
+           &lt;p:departing&gt;LGA&lt;/p:departing&gt;
+        &lt;/p:departure&gt;
+        &lt;p:return&gt;
+           &lt;p:arriving&gt;EWR&lt;/p:arriving&gt;
+        &lt;/p:return&gt;
+      &lt;/p:itinerary&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.2.2 <a name="exchange-message">Exchanging SOAP Messages Using XMPP Message Stanzas</a>
+</h3>
+      <p class="" style="">The process for exchanging SOAP messages using the XMPP &lt;message/&gt; stanza type is effectively no different from the use with &lt;iq/&gt; stanzas, except that message stanzas may be sent to bare JIDs (user@host) rather than full JIDs (user@host/resource), message stanzas may be stored for later delivery, etc. The following business rules apply:</p>
+      <ol start="" type="">
+        <li>The message stanza containing a request MUST carry one SOAP envelope as a first-level child element.</li>
+        <li>The 'id' attribute MUST be used to track the XMPP messages and eventually associate errors or answers with the related requests (this is for tracking at the XMPP level, not the SOAP level).</li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="data">Sending Associated Data</a>
+</h3>
+    <p class="" style="">SOAP messages may contain associated (usually binary) data, and XMPP stanzas that encapsulate such SOAP messages could invoke bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components rather than XMPP nodes; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent. Therefore, it is desirable to support the sending of attachments or files in order to exchange large amounts of binary data associated with SOAP requests and responses. As summarized in the following table, here are four possible methods:</p>
+    <p class="caption">Table 1: Possible Methods for Sending Associated Data</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Method</th>
+        <th colspan="" rowspan="">Description</th>
+        <th colspan="" rowspan="">Recommendation</th>
+        <th colspan="" rowspan="">Reasoning</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">File Transfer</td>
+        <td align="" colspan="" rowspan="">Negotiate file transfer using <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2250407">10</a>] and <span class="ref" style="">Publishing SI Requests</span>  [<a href="#nt-id2250362">11</a>].</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+        <td align="" colspan="" rowspan="">Recommended approach for file transfer over XMPP (e.g., see <span class="ref" style="">Intermediate IM Protocol Suite</span>  [<a href="#nt-id2257089">12</a>]).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Include Link</td>
+        <td align="" colspan="" rowspan="">Represent the binary data as a file, publish it to an accessible file server (e.g., HTTP or FTP URL), and insert a link to the file directly into the XMPP message stanza (via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2257127">13</a>]) or into the SOAP envelope (via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2257149">14</a>]).</td>
+        <td align="" colspan="" rowspan="">MAY</td>
+        <td align="" colspan="" rowspan="">Fallback if file transfer is not possible (not all clients can publish to file servers).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Alternate Transports</td>
+        <td align="" colspan="" rowspan="">Send SOAP XML plus binary data over alternate transports such as <span style="font-weight: bold">WS-Attachments</span>  [<a href="#nt-id2257186">15</a>] or SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2257219">16</a>].</td>
+        <td align="" colspan="" rowspan="">SHOULD NOT</td>
+        <td align="" colspan="" rowspan="">These methods are just other transport protocols and would needlessly complicate implementations of SOAP over XMPP.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">MIME</td>
+        <td align="" colspan="" rowspan="">Encode SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP 1.2 Attachment Feature</span>  [<a href="#nt-id2257278">17</a>] (or, more recently, <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2257301">18</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2257322">19</a>]).</td>
+        <td align="" colspan="" rowspan="">MUST NOT</td>
+        <td align="" colspan="" rowspan="">XML streams are pure XML and are not MIME-aware.</td>
+      </tr>
+    </table>
+    <p class="" style="">The recommended approaches (file transfer and including a link) are described more fully below.</p>
+    <div class="indent">
+<h3>3.3.1 <a name="data-ft">File Transfer</a>
+</h3>
+      <p class="" style="">The recommended method for sending associated data is to use the file transfer protocol described in <span style="font-weight: bold">JEP-0096</span>. Because this is the common and standardized method for XMPP entities to transfer large or binary files outside the XMPP band, it SHOULD be used.</p>
+      <p class="" style="">In particular, the entity that has the file SHOULD advertise the availability of the associated stream using <span style="font-weight: bold">JEP-0137</span> by including the SI-pub data extension along with the XMPP &lt;message/&gt; stanza with which the data is associated:  [<a href="#nt-id2256780">20</a>]</p>
+      <p class="caption">Example 8. Sender sends message with SI-pub</p>
+<div class="indent"><pre>
+&lt;message from='requester@example.com/soap-client'
+         id='soap2'
+         to='responder@example.com/soap-server'&gt;
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+    &lt;env:Header&gt;
+      &lt;m:reservation 
+         xmlns:m="http://travelcompany.example.org/reservation" 
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+        &lt;m:dateAndTime&gt;2001-11-29T13:36:50.000-05:00&lt;/m:dateAndTime&gt;
+      &lt;/m:reservation&gt;
+      &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+      &lt;/n:passenger&gt;
+    &lt;/env:Header&gt;
+    &lt;env:Body&gt;
+      &lt;p:itinerary xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+        &lt;p:departure&gt;
+         &lt;p:departing&gt;LGA&lt;/p:departing&gt;
+        &lt;/p:departure&gt;
+        &lt;p:return&gt;
+          &lt;p:arriving&gt;EWR&lt;/p:arriving&gt;
+        &lt;/p:return&gt;
+      &lt;/p:itinerary&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+         id='publish-2345'
+         mime-type='image/png'
+         profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='me.png'
+          size='4238'
+          date='2005-11-01T23:11Z'/&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The entity that is to receive the file SHOULD initiate the file transfer process sending an IQ-get to the sender, using the &lt;start xmlns='http://jabber.org/protocol/sipub'/&gt; element. This element contains the 'id' attribute to specify which published stream to retrieve:</p>
+      <p class="caption">Example 9. Receiver requests start of stream</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    id='sipub-request-0'
+    from='responder@example.com/soap-server'
+    to='requester@example.com/soap-client'&gt;
+  &lt;start xmlns='http://jabber.org/protocol/sipub'
+         id='publish-2345'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the sender accepts the request, it responds with an IQ-result containing a &lt;starting/&gt; element. This element indicates the stream initiation identifier to be used:</p>
+      <p class="caption">Example 10. Sender accepts request to start stream</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    id='sipub-request-0'
+    from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server'&gt;
+  &lt;starting xmlns='http://jabber.org/protocol/sipub'
+            sid='session-87651234'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Then the sender begins the stream initiation negotiation:</p>
+    <p class="caption">Example 11. Sender starts negotiation</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    id='sipub-set-1'
+    from='requester@example.com/soap-client'
+    to='responder@example.com/soap-server'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si'
+      id='session-87651234'
+        mime-type='image/png'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='me.png'
+          size='4238'
+          date='2005-11-01T23:11Z'/&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">For details regarding file transfer and advertising of file transfer stream initiation requests, refer to <span style="font-weight: bold">JEP-0096</span> and <span style="font-weight: bold">JEP-0137</span>.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.2 <a name="data-link">Including Links</a>
+</h3>
+      <p class="" style="">If the file transfer method is not possible (e.g., because file transfer is not implemented or transfer attempts fails), the entity that is sending the associated data MAY as a fallback publish the associated data as a file (e.g., at an HTTP or FTP URL) and include a link to the file as out-of-band content by including the out-of-band data extension along with the XMPP &lt;message/&gt; stanza with which the data is associated:  [<a href="#nt-id2256480">21</a>]</p>
+      <p class="caption">Example 12. Sender sends message with out-of-band data</p>
+<div class="indent"><pre>
+&lt;message from='requester@example.com/soap-client'
+         id='soap2'
+         to='responder@example.com/soap-server'&gt;
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+    &lt;env:Header&gt;
+      &lt;m:reservation 
+         xmlns:m="http://travelcompany.example.org/reservation" 
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+        &lt;m:dateAndTime&gt;2001-11-29T13:36:50.000-05:00&lt;/m:dateAndTime&gt;
+      &lt;/m:reservation&gt;
+      &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+      &lt;/n:passenger&gt;
+    &lt;/env:Header&gt;
+    &lt;env:Body&gt;
+      &lt;p:itinerary xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+        &lt;p:departure&gt;
+           &lt;p:departing&gt;LGA&lt;/p:departing&gt;
+        &lt;/p:departure&gt;
+        &lt;p:return&gt;
+           &lt;p:arriving&gt;EWR&lt;/p:arriving&gt;
+        &lt;/p:return&gt;
+      &lt;/p:itinerary&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;http://example.org/me.png&lt;/url&gt;
+    &lt;desc&gt;John Q. Public&lt;/desc&gt;
+  &lt;/x&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Alternatively, if all else fails, the file may be included as a SOAP representation header:</p>
+      <p class="caption">Example 13. IQ-set with SOAP representation header</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap2'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope' 
+                xmlns:rep='http://www.w3.org/2004/08/representation' 
+                xmlns:xmlmime='http://www.w3.org/2004/11/xmlmime'&gt;
+    &lt;env:Header&gt;
+      &lt;rep:Representation resource='http://example.org/me.png'&gt;
+        &lt;rep:Data xmlmime:contentType='image/png'&gt;/aWKKapGGyQ=&lt;/rep:Data&gt;
+      &lt;/rep:Representation&gt;
+      &lt;m:reservation 
+         xmlns:m="http://travelcompany.example.org/reservation" 
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+        &lt;m:dateAndTime&gt;2001-11-29T13:36:50.000-05:00&lt;/m:dateAndTime&gt;
+      &lt;/m:reservation&gt;
+      &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+      &lt;/n:passenger&gt;
+    &lt;/env:Header&gt;
+    &lt;env:Body&gt;
+      &lt;p:itinerary xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+        &lt;p:departure&gt;
+           &lt;p:departing&gt;LGA&lt;/p:departing&gt;
+        &lt;/p:departure&gt;
+        &lt;p:return&gt;
+           &lt;p:arriving&gt;EWR&lt;/p:arriving&gt;
+        &lt;/p:return&gt;
+      &lt;/p:itinerary&gt;
+      &lt;x:MyData xmlns:x='http://example.org/mystuff'&gt;
+        &lt;x:name&gt;John Q. Public&lt;/x:name&gt;
+        &lt;x:img src='http://example.org/me.png'/&gt;
+      &lt;/x:MyData&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Naturally, in order to maximize the likelihood that the receiver will be able to retrieve the file, the sender MAY include the SI-pub extension, out-of-band-data extension, and SOAP representation header in the message stanza:</p>
+      <p class="caption">Example 14. Sender sends message with SI-pub, OOB, and representation header</p>
+<div class="indent"><pre>
+&lt;message from='requester@example.com/soap-client'
+         id='soap2'
+         to='responder@example.com/soap-server'&gt;
+  &lt;env:Envelope xmlns:env="http://www.w3.org/2003/05/soap-envelope"&gt; 
+    &lt;env:Header&gt;
+      &lt;rep:Representation resource='http://example.org/me.png'&gt;
+        &lt;rep:Data xmlmime:contentType='image/png'&gt;/aWKKapGGyQ=&lt;/rep:Data&gt;
+      &lt;/rep:Representation&gt;
+      &lt;m:reservation 
+         xmlns:m="http://travelcompany.example.org/reservation" 
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;m:reference&gt;uuid:093a2da1-q345-739r-ba5d-pqff98fe8j7d&lt;/m:reference&gt;
+        &lt;m:dateAndTime&gt;2001-11-29T13:36:50.000-05:00&lt;/m:dateAndTime&gt;
+      &lt;/m:reservation&gt;
+      &lt;n:passenger xmlns:n="http://mycompany.example.com/employees"
+         env:role="http://www.w3.org/2003/05/soap-envelope/role/next"
+         env:mustUnderstand="true"&gt;
+        &lt;n:name&gt;Ake Jogvan Ovind&lt;/n:name&gt;
+      &lt;/n:passenger&gt;
+    &lt;/env:Header&gt;
+    &lt;env:Body&gt;
+      &lt;p:itinerary xmlns:p="http://travelcompany.example.org/reservation/travel"&gt;
+        &lt;p:departure&gt;
+         &lt;p:departing&gt;LGA&lt;/p:departing&gt;
+        &lt;/p:departure&gt;
+        &lt;p:return&gt;
+          &lt;p:arriving&gt;EWR&lt;/p:arriving&gt;
+        &lt;/p:return&gt;
+      &lt;/p:itinerary&gt;
+      &lt;x:MyData xmlns:x='http://example.org/mystuff'&gt;
+        &lt;x:name&gt;John Q. Public&lt;/x:name&gt;
+        &lt;x:img src='http://example.org/me.png'/&gt;
+      &lt;/x:MyData&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+         id='publish-2345'
+         mime-type='image/png'
+         profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='me.png'
+          size='4238'
+          date='2005-11-01T23:11Z'/&gt;
+  &lt;/sipub&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;http://example.org/me.png&lt;/url&gt;
+    &lt;desc&gt;John Q. Public&lt;/desc&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="wsdl">Specifying a WSDL Definition</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2257703">22</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). WSDL definitions attempt to specify a loose coupling of SOAP envelopes and their transports in order to maintain their independence and flexibility.</p>
+    <p class="" style="">The definition of an XMPP SOAP transport in WSDL is straightforward. The following rules apply:</p>
+    <ol start="" type="">
+      <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+      <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to "document".</li>
+      <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+      <li>A valid <span class="ref" style="">XMPP IRI/URI</span>  [<a href="#nt-id2257774">23</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+    </ol>
+    <p class="" style="">The following is an example of a WSDL definition for an endpoint that supports the SOAP XMPP binding: a mythical service that translates Shakespearean English into selected modern languages and dialects.</p>
+    <p class="caption">Example 15. Example of WSDL definition for a translation service that supports SOAP over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='ShakespeareTranslation' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'
+    xmlns:tns='http://shakespeare.lit/translation.wsdl'&gt;
+  
+  &lt;binding name='ShakespeareTranslationSoap' type='tns:TranslationPortType'&gt;
+    &lt;soap:binding style='document' transport='http://jabber.org/protocol/soap'/&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+
+  &lt;service name='ShakespeareTranslationService'&gt;
+    &lt;documentation&gt;Translates Shakespearean text.&lt;/documentation&gt;
+    &lt;port name='TranslationPort' binding='tns:ShakespeareTranslationSoap'&gt;
+      &lt;soap:address location='xmpp:translation@shakespeare.lit'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+
+&lt;/definitions&gt;
+    </pre></div>
+    <p class="" style="">Although there is no standard procedure for publishing WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257862">24</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257875">25</a>].</p>
+  </div>
+<h2>4.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2257908">26</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2257931">27</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2257922">28</a>]. (Additionaly, a binding to BEEP is described in <span style="font-weight: bold">RFC 3288</span>.) As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>4.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2258065">29</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2258088">30</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email (see the <a href="#impl">Implementation Notes</a> section of this document). Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>4.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>4.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encappsulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>4.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>4.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Becomes Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>4.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>5.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the <a href="#binding">SOAP XMPP Binding</a> section of this document. The current section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2260329">31</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>5.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2260376">32</a>], the SOAP XMPP Binding defined herein has been reviewed informally by one or more appropriate experts from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2260398">33</a>] advanced it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's <a href="http://www.w3.org/2000/xp/Group/">XML Protocol Working Group</a>. To that end, revised versions of this specification will be announced on the W3C's public xml-dist-app@w3.org mailing list.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1 or subsequent versions, this specification may be modified to address handling of SOAP messages that are encoded in versions other than XML 1.0.</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. In the SOAP HTTP Binding, these errors are mapped to corresponding HTTP status codes. In the SOAP XMPP Binding, they are mapped to the catch-all XMPP error of &lt;undefined-condition/&gt; along with application-specific error condition elements qualified by the 'http://jabber.org/protocol/soap#fault' namespace (this is consistent with Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>, see also <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2260512">34</a>]). The element names of these application-specific error conditions map directly to the SOAP fault codes specified in Section 5.4.6 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>.</p>
+  <p class="" style="">The following table provides a mapping between SOAP, HTTP, and application-specific XMPP errors.</p>
+  <p class="caption">Table 16: Mapping of SOAP Faults to HTTP Status Codes and XMPP Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">SOAP Fault</th>
+      <th colspan="" rowspan="">HTTP Status Code</th>
+      <th colspan="" rowspan="">XMPP Application Error</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;DataEncodingUnknown/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;MustUnderstand/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:Receiver</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;Receiver/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:Sender</td>
+      <td align="" colspan="" rowspan="">400</td>
+      <td align="" colspan="" rowspan="">&lt;Sender/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+      <td align="" colspan="" rowspan="">500</td>
+      <td align="" colspan="" rowspan="">&lt;VersionMismatch/&gt;</td>
+      </tr>
+  </table>
+  <p class="" style="">Note: When errors are due to the XMPP transport protocol alone and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only instead of the XMPP &lt;undefined-condition/&gt; condition plus application-specific condition.</p> 
+<h2>7.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="bizrules-encoding">Encoding</a>
+</h3>
+    <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+    <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML as well as byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2260770">35</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded as UTF-8 in order to match the XML stream encoding.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2260794">36</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2260810">37</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2260847">38</a>].</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260892">39</a>] is required as a result of this JEP.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260943">40</a>] includes 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Identity</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a Service Discovery type of "soap" within the "automation" category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;automation&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;soap&lt;/name&gt;
+    &lt;desc&gt;A SOAP receiver (either intermediate or ultimate).&lt;/desc&gt;
+    &lt;doc&gt;JEP-0072&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-soap">SOAP Envelope</a>
+</h3>
+    <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided at &lt;<a href="http://www.w3.org/2003/05/soap-envelope/">http://www.w3.org/2003/05/soap-envelope/</a>&gt;.</p>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-error">Application-Specific XMPP Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/soap#fault'
+    xmlns='http://jabber.org/protocol/soap#fault'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='DataEncodingUnknown' type='empty'/&gt;
+  &lt;xs:element name='MustUnderstand' type='empty'/&gt;
+  &lt;xs:element name='Receiver' type='empty'/&gt;
+  &lt;xs:element name='Sender' type='empty'/&gt;
+  &lt;xs:element name='VersionMismatch' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p> 
+  <p class="" style="">An XMPP entity that supports the SOAP XMPP binding could function as a "SOAP intermediary" that hands a SOAP message off to some other deployment for subsequent processing (HTTP, email, a specialized enterprise messaging platform, etc.) rather than functioning as the "ultimate SOAP receiver" for the message (as these terms are defined in Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). If the intended recipient functions as a SOAP intermediary, implementations should be aware that subsequent processing may alter the representation of SOAP messages.</p>
+  <p class="" style="">As an example, consider a component that functions as a gateway between XMPP-based and HTTP-based web services. Its purpose might be to mix HTTP and XMPP for web services and to invoke any web services already accessible through HTTP from XMPP clients.</p>
+  <p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+  <p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+  <ol start="" type="">
+    <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+    <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+    <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+    <li>a blank return path</li>
+  </ol>
+  <p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+  <p class="caption">Example 16. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forward&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+  </pre></div>
+  <p class="" style="">Generic XMPP routers that conform to <span style="font-weight: bold">RFC 3920</span> may also "store and forward" Jabber messages. This feature is usually called "offline message handling": the router makes a decision as to whether to deliver the message to the local intended recipient based on the recipient's presence, and if the recipient is offline when the router processes the message then it may store the message for delivery when the recipient next comes online (rather than returning an error to the sender). Although it is possible to write an XMPP router that directly supports the SOAP XMPP binding and implements the SOAP processing model, generic XMPP routers do not contain such support. Accordingly, generic XMPP routers will not forward an XMPP message to an alternate SOAP transport such as HTTP or SMTP, or provide other functions of a SOAP intermediary or ultimate receiver. When a generic XMPP router delivers a message to the intended recipient (whether immediately or as delayed in "offline storage") and the intended recipient supports the SOAP XMPP binding, SOAP processing is performed; such an intended recipient MAY act either as a SOAP intermediary or as an ultimate SOAP receiver.</p>
+  <p class="" style="">With regarding to exchange of associated data, an XMPP entity that functions as a gateway to other SOAP bindings it SHOULD use W3C-recommended protocols for transporting SOAP attachments over non-XMPP SOAP bindings (e.g., HTTP and SMTP) when communicating with non-XMPP entities.</p>
+<h2>13.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Many thanks to Noah Mendelsohn for his assistance regarding SOAP binding definitions and conformance issues. Thanks also to Michael Mahan and Rich Salz for their comments.</p>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250819">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2250868">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250856">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2250890">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2256300">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2256357">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256414">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256525">8</a>. SOAP Version 1.2 Part 0: Primer &lt;<a href="http://www.w3.org/TR/soap12-part0">http://www.w3.org/TR/soap12-part0</a>&gt;.</p>
+<p><a name="nt-id2256557">9</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2250407">10</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2250362">11</a>. JEP-0137: Publishing SI Requests &lt;<a href="http://www.jabber.org/jeps/jep-0137.html">http://www.jabber.org/jeps/jep-0137.html</a>&gt;.</p>
+<p><a name="nt-id2257089">12</a>. JEP-0117: Intermediate IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0117.html">http://www.jabber.org/jeps/jep-0117.html</a>&gt;.</p>
+<p><a name="nt-id2257127">13</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2257149">14</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2257186">15</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2257219">16</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2257278">17</a>. SOAP 1.2 Attachment Feature &lt;<a href="http://www.w3.org/TR/soap12-af/">http://www.w3.org/TR/soap12-af/</a>&gt;.</p>
+<p><a name="nt-id2257301">18</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2257322">19</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2256780">20</a>. In accordance with <span style="font-weight: bold">RFC 3920</span>, an &lt;iq/&gt; stanza MUST NOT include multiple payload child elements; therefore, a &lt;message/&gt; stanza must be used when sending associated data.</p>
+<p><a name="nt-id2256480">21</a>. As above, in accordance with <span style="font-weight: bold">RFC 3920</span>, an &lt;iq/&gt; stanza MUST NOT include multiple payload child elements; therefore, a &lt;message/&gt; stanza must be used when sending associated data.</p>
+<p><a name="nt-id2257703">22</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2257774">23</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2257862">24</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257875">25</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257908">26</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2257931">27</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2257922">28</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2258065">29</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2258088">30</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2260329">31</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2260376">32</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2260398">33</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2260512">34</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2260770">35</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2260794">36</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2260810">37</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2260847">38</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2260892">39</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260943">40</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.14 (2005-11-29)</h4>
+<div class="indent">In accordance with further Council feedback, cleaned up the section on file transfer by clarifying which methods are recommended, removing section on MIME, and correcting use of SI-Pub. (psa)
+    </div>
+<h4>Version 0.13 (2005-11-01)</h4>
+<div class="indent">In accordance with Council feedback: divided Sending Attachments text into multiple subsections and added XMPP examples to each subsection; specified use of JEP-0137 to publish SI requests related to file transfer; specified use of application-specific stanza errors; fixed typographical error in WSDL example. (psa)
+    </div>
+<h4>Version 0.12 (2005-10-18)</h4>
+<div class="indent">In accordance with Council feedback, re-organized descriptive text around use cases. (psa)
+    </div>
+<h4>Version 0.11 (2005-09-07)</h4>
+<div class="indent">Modified service discovery category and type; made several other small text changes based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.10 (2005-09-01)</h4>
+<div class="indent">Added information about service discovery. (psa)
+    </div>
+<h4>Version 0.9 (2005-08-17)</h4>
+<div class="indent">Added implementation note about XMPP routers based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.8 (2005-07-21)</h4>
+<div class="indent">Cleaned up WSDL definition. (psa)
+    </div>
+<h4>Version 0.7 (2005-06-30)</h4>
+<div class="indent">Clarified implementation notes and text on attachments. (psa/ff)
+    </div>
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.3.html
+++ b/content/xep-0072-0.3.html
@@ -1,0 +1,501 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-05-10">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.3<br>
+            Last Updated: 2004-05-10<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: None<br>
+</p>
+<h2>Author Information</h2>
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>2.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>2.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>3.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>4.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>5.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>6.  <a href="#gateways">HTTP &lt;-&gt; XMPP Gateways</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">SOAP</span>  [<a href="#nt-id2596170">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous RPC-like calls. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref">XMPP Core</span>  [<a href="#nt-id2596127">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2596140">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2596157">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses.</p>
+<h2>2.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both RPC-like calls and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with &lt;soap/&gt; child elements are used in order to assure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas MUST be used for RPC calls and when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas MUST be used for asynchronous one-way communications, and when store and forward may be necessary; examples of applications can be RSS feeds, news and headlines, and event notifications.</li>
+  </ol>
+  <p class="" style="">These approaches are defined in the following sections.</p>
+  <div class="indent">
+<h3>2.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref">Jabber-RPC</span>  [<a href="#nt-id2596301">5</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type &quot;set&quot;, and answer envelopes by &lt;iq/&gt; stanzas of type &quot;result&quot;. SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type &quot;error&quot; with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a unique SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://schemas.xmlsoap.org/soap/envelope' namespace.</p>
+    <p class="caption">Example 1. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@company-a.com/soap-client'
+    id='soap1'
+    to='responder@company-a.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. A SOAP response, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@company-a.com/soap-server' 
+    id='soap1'
+    to='requester@company-a.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>2.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track SOAP messages and eventually associate errors or answers to the relative requests.</p>
+    <p class="caption">Example 3. A SOAP envelope carrying an RDF descritpion of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@company-a.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>2.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP binding specifications  [<a href="#nt-id2596384">6</a>] map these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; stanzas of type &quot;error&quot;. This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and &lt;iq/&gt; error codes (for Jabber/XMPP error syntax, see <span style="font-weight: bold">XMPP Core</span> and <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602046">7</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">Short Description</th>
+        <th colspan="" rowspan="">IQ Error Description</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">Internal server error</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">Internal server error</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">Bad request</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">Internal server error</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">Internal server error</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 4. A SOAP response with error, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requesterr@company-a.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travelcompany.example.org/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type error to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 5. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@company-a.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents, and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 (&quot;XML Usage Within XMPP&quot;) of <span style="font-weight: bold">XMPP Core</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML, and also byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref">RFC 3548</span>  [<a href="#nt-id2602446">8</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>4.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with karma settings tuned for normal textual chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">However, SOAP provides several methods to transport binary data as attachments; the most common are:</p>
+  <ul>
+    <li>Inserting a link to the file directly into the SOAP envelope</li>
+    <li>Encoding SOAP envelopes and attachments as MIME multipart messages  [<a href="#nt-id2602399">9</a>]</li>
+    <li>Using other protocols designed to transport SOAP and binary data together, such such as <span style="font-weight: bold">WS-Attachments</span> 
+     [<a href="#nt-id2602422">10</a>] and SOAP-over-BEEP as defined in <span class="ref">RFC 3080</span>  [<a href="#nt-id2602559">11</a>]</li>
+  </ul>
+  <p class="" style="">The first method, using the file link in the envelope, is a general one, and can be used by XMPP clients if they are able to retrieve the file (e.g, using <span class="ref">Out-of-Band Data</span>  [<a href="#nt-id2602494">12</a>]). However, the other methods cannot be used directly with XMPP, since MIME messages do not fit in XML streams and WS-Attachments and BEEP are just other transport protocols.</p>
+  <p class="caption">Example 6. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start=&quot;&lt;claim061400a.xml@claiming-it.com&gt;&quot;
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+  </pre></div>
+  <p class="" style="">For the transport of binary data, the file transfer method described in <span class="ref">File Transfer</span>  [<a href="#nt-id2602540">13</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 7. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@jabber.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='1972-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style="">
+<span class="ref">WSDL</span>  [<a href="#nt-id2602640">14</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward. The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to &quot;http://jabber.org/protocol/soap&quot;.</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to 'rpc' for SOAP messages carried in &lt;iq/&gt; stanzas, and to 'document' for &lt;message/&gt; stanzas.</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref">XMPP URI</span>  [<a href="#nt-id2595889">15</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+ </ol>
+<p class="caption">Example 8. Example of WSDL definition for a SOAP-based translator over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='BabelFishService' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+  ...
+  &lt;binding name='BabelFishBinding' type='tns:BabelFishPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;soap:operation soapAction='urn:googleBabelFish#BabelFish'/&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+  &lt;service name='BabelFishService'&gt;
+    &lt;documentation&gt;
+      Translates text using Google's Babelfish.
+    &lt;/documentation&gt;
+    &lt;port name='BabelFishPort' binding='tns:BabelFishBinding'&gt;
+      &lt;soap:address location='xmpp:babel@jabber.example.org'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref">Service Discovery</span>  [<a href="#nt-id2595953">16</a>] or <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2603048">17</a>].</p>
+<h2>6.
+       <a name="gateways">HTTP &lt;-&gt; XMPP Gateways</a>
+</h2>
+<p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p>
+<p class="" style="">This section provides an example of a gateway between XMPP-based and HTTP-based web services and it is not meant to be part of the SOAP over XMPP specifications. Its purpose is only to demonstrate how HTTP and XMPP can be used together in web services, and how to invoke any web services already accessible through HTTP from XMPP clients.</p>
+<p class="" style="">
+<span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+
+<p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.com/soap'), and directed to an end point accessible through HTTP ('http://C.com/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+ <ol start="" type="">
+  <li>the &lt;to/&gt; element set to 'http://C.com/some/endpoint'</li>
+  <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.com/soap', in the forward path</li>
+  <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+  <li>a blank return path</li>
+ </ol>
+<p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type &quot;result&quot; or &quot;error&quot; and sends the result to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+
+<p class="caption">Example 9. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://www.im.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.com/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.com/soap&lt;/m:via&gt;
+         &lt;/m:forwawd&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+</pre></div>
+
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2603152">18</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2603172">19</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref">XMPP E2E</span>  [<a href="#nt-id2603291">20</a>].</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603234">21</a>] is required as a result of this JEP.</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603391">22</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596170">1</a>. SOAP 1.2 Specification &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p>
+<a name="nt-id2596127">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596140">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p>
+<a name="nt-id2596157">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p>
+<a name="nt-id2596301">5</a>. JEP-0009: Transporting XML-RPC over Jabber &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596384">6</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2/">http://www.w3.org/TR/soap12-part2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602046">7</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602446">8</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602399">9</a>. SOAP Messages with Attachments &lt;<a href="http://www.w3.org/TR/SOAP-attachments">http://www.w3.org/TR/SOAP-attachments</a>&gt;.</p>
+<p>
+<a name="nt-id2602422">10</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p>
+<a name="nt-id2602559">11</a>. RFC 3080: The Blocks Extensible Exchange Protocol Core (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3080.txt">http://www.ietf.org/rfc/rfc3080.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602494">12</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602540">13</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602640">14</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p>
+<a name="nt-id2595889">15</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-06.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-06.txt</a>&gt; (work in progress).</p>
+<p>
+<a name="nt-id2595953">16</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603048">17</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603152">18</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p>
+<a name="nt-id2603172">19</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p>
+<a name="nt-id2603291">20</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603234">21</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603391">22</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.4.html
+++ b/content/xep-0072-0.4.html
@@ -1,0 +1,1036 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-01-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.4<br>
+            Last Updated: 2005-01-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: None<br>
+</p>
+<h2>Author Information</h2>
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>2.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>2.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>3.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>4.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>5.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>6.  <a href="#gateways">HTTP &lt;-&gt; XMPP Gateways</a>
+</dt>
+<dt>7.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>7.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>7.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>7.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>7.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>7.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>7.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>7.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>7.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>7.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>7.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>7.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>8.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>8.2.  <a href="#w3c-versions">SOAP Versioning</a>
+</dt>
+</dl>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>13.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2596256">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous RPC-like calls. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref">XMPP Core</span>  [<a href="#nt-id2596203">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2596216">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2596233">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both RPC-like calls and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with &lt;soap/&gt; child elements are used in order to assure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas MUST be used for RPC calls and when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas MUST be used for asynchronous one-way communications, and when store and forward may be necessary.</li>
+  </ol>
+  <p class="" style="">These approaches are defined in the following sections.</p>
+  <div class="indent">
+<h3>2.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref">Jabber-RPC</span>  [<a href="#nt-id2596360">5</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type &quot;set&quot;, and answer envelopes by &lt;iq/&gt; stanzas of type &quot;result&quot;. SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type &quot;error&quot; with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a unique SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://schemas.xmlsoap.org/soap/envelope' namespace.</p>
+    <p class="caption">Example 1. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@company-a.com/soap-client'
+    id='soap1'
+    to='responder@company-a.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. A SOAP response, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@company-a.com/soap-server' 
+    id='soap1'
+    to='requester@company-a.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>2.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track SOAP messages and eventually associate errors or answers with the relative requests.</p>
+    <p class="caption">Example 3. A SOAP envelope carrying an RDF description of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@company-a.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>2.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP Binding maps these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; stanzas of type &quot;error&quot;. This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and &lt;iq/&gt; error codes (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">XMPP Core</span>, and also <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602177">6</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">IQ Error Description</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 4. A SOAP response with error, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requesterr@company-a.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travelcompany.example.org/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type &quot;error&quot; to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 5. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@company-a.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents, and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 (&quot;XML Usage Within XMPP&quot;) of <span style="font-weight: bold">XMPP Core</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML, and also byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref">RFC 3548</span>  [<a href="#nt-id2602519">7</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>4.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with &quot;karma&quot; (bandwidth restriction) settings tuned for normal textual chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">However, SOAP provides several methods to transport binary data as attachments; the most common are:</p>
+  <ul>
+    <li>Inserting a link to the file directly into the SOAP envelope</li>
+    <li>Encoding SOAP envelopes and attachments as MIME multipart messages  [<a href="#nt-id2602474">8</a>]</li>
+    <li>Using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span> 
+     [<a href="#nt-id2602496">9</a>] and SOAP-over-BEEP as defined in <span class="ref">RFC 3080</span>  [<a href="#nt-id2602633">10</a>]</li>
+  </ul>
+  <p class="" style="">The first method, using the file link in the envelope, is a general one, and can be used by XMPP clients if they are able to retrieve the file (e.g, using <span class="ref">Out-of-Band Data</span>  [<a href="#nt-id2602568">11</a>]). However, the other methods cannot be used directly with XMPP, since MIME messages do not fit in XML streams, and WS-Attachments and BEEP are just other transport protocols.</p>
+  <p class="caption">Example 6. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start=&quot;&lt;claim061400a.xml@claiming-it.com&gt;&quot;
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+  </pre></div>
+  <p class="" style="">For the transport of binary data where a URL cannot be provided, the file transfer method described in <span class="ref">File Transfer</span>  [<a href="#nt-id2602616">12</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 7. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@jabber.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='1972-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style="">
+<span class="ref">WSDL</span>  [<a href="#nt-id2602737">13</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward. The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to &quot;http://jabber.org/protocol/soap&quot;.</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to 'rpc' for SOAP messages carried in &lt;iq/&gt; stanzas, and to 'document' for &lt;message/&gt; stanzas.</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref">XMPP URI</span>  [<a href="#nt-id2595918">14</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+ </ol>
+<p class="caption">Example 8. Example of WSDL definition for a SOAP-based translator over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='BabelFishService' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+  ...
+  &lt;binding name='BabelFishBinding' type='tns:BabelFishPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;soap:operation soapAction='urn:googleBabelFish#BabelFish'/&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+  &lt;service name='BabelFishService'&gt;
+    &lt;documentation&gt;
+      Translates text using Google's Babelfish.
+    &lt;/documentation&gt;
+    &lt;port name='BabelFishPort' binding='tns:BabelFishBinding'&gt;
+      &lt;soap:address location='xmpp:babel@jabber.example.org'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref">Service Discovery</span>  [<a href="#nt-id2595978">15</a>] or <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2603123">16</a>].</p>
+<h2>6.
+       <a name="gateways">HTTP &lt;-&gt; XMPP Gateways</a>
+</h2>
+<p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p>
+<p class="" style="">This section provides an example of a gateway between XMPP-based and HTTP-based web services and it is not meant to be part of the SOAP over XMPP specifications. Its purpose is only to demonstrate how HTTP and XMPP can be used together in web services, and how to invoke any web services already accessible through HTTP from XMPP clients.</p>
+<p class="" style="">
+<span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+
+<p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.com/soap'), and directed to an end point accessible through HTTP ('http://C.com/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+ <ol start="" type="">
+  <li>the &lt;to/&gt; element set to 'http://C.com/some/endpoint'</li>
+  <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.com/soap', in the forward path</li>
+  <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+  <li>a blank return path</li>
+ </ol>
+<p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type &quot;result&quot; or &quot;error&quot; and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+
+<p class="caption">Example 9. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://www.im.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.com/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.com/soap&lt;/m:via&gt;
+         &lt;/m:forwawd&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+</pre></div>
+
+<h2>7.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2603322">17</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2603247">18</a>]) and the <span class="ref">SOAP Email Binding</span>  [<a href="#nt-id2603267">19</a>]. As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to &quot;conform to the SOAP 1.2 XMPP Binding&quot;.</p>
+  <div class="indent">
+<h3>7.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called &quot;XML stanzas&quot; (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the &quot;SOAP Web Method Feature&quot; described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref">RFC 2045</span>  [<a href="#nt-id2603489">20</a>]) or XML media types (<span class="ref">RFC 3023</span>  [<a href="#nt-id2603512">21</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the &quot;SOAP Action Feature&quot; described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email. Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of &quot;RequestingSOAPNode&quot;.</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of &quot;RespondingSOAPNode&quot;.</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string &quot;fail:&quot; is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string &quot;reqresp:&quot; is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>7.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where &quot;Requesting SOAP Node&quot; is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the &quot;Init&quot; state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table &quot;Init: XMPP Fields (Requesting)&quot;) encapsulating SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table &quot;Init: Transitions (Requesting)&quot;</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the &quot;Init&quot; state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be &quot;set&quot;; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the &quot;Init&quot; state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the &quot;Requesting&quot; state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table &quot;Requesting: Transitions&quot;</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the &quot;Requesting&quot; state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the &quot;Sending+Receiving&quot; state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table &quot;Sending+Receiving: Transitions&quot;</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the &quot;Sending+Receiving&quot; state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state &quot;Success&quot; or &quot;Fail&quot; is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>7.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where &quot;Responding SOAP Node&quot; is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the &quot;Init&quot; state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table &quot;Init: Transitions (Responding)&quot;</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the &quot;Init&quot; state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the &quot;Receiving&quot; state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table &quot;Receiving: Transitions&quot;</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the &quot;Receiving&quot; state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Becomes Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the &quot;Receiving+Sending&quot; state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table &quot;Receiving+Sending: XMPP Fields&quot;)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table &quot;Receiving+Sending: Transitions&quot;</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the &quot;Receiving+Sending&quot; state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be &quot;result&quot;; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the &quot;Receiving+Sending&quot; state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state &quot;Success&quot; or &quot;Fail&quot; is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>8.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the preceding section of this document (<a href="#binding">SOAP XMPP Binding</a>). This section addresses only the topic of organizational interaction between the W3C and the <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2606173">22</a>] regarding this JEP.</p>
+  <div class="indent">
+<h3>8.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref">XHTML-IM</span>  [<a href="#nt-id2606106">23</a>], the SOAP binding defined herein should be reviewed informally by an appropriate expert from the W3C before the <span class="ref">Jabber Council</span>  [<a href="#nt-id2606134">24</a>] advances it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's XML Protocol Working Group.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="w3c-versions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as defined by the W3C.</p>
+  </div>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2606223">25</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2606242">26</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref">XMPP E2E</span>  [<a href="#nt-id2606359">27</a>].</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2606303">28</a>] is required as a result of this JEP.</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2606460">29</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>13.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596256">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p>
+<a name="nt-id2596203">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596216">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p>
+<a name="nt-id2596233">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p>
+<a name="nt-id2596360">5</a>. JEP-0009: Transporting XML-RPC over Jabber &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602177">6</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602519">7</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602474">8</a>. SOAP Messages with Attachments &lt;<a href="http://www.w3.org/TR/SOAP-attachments">http://www.w3.org/TR/SOAP-attachments</a>&gt;.</p>
+<p>
+<a name="nt-id2602496">9</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p>
+<a name="nt-id2602633">10</a>. RFC 3080: The Blocks Extensible Exchange Protocol Core (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3080.txt">http://www.ietf.org/rfc/rfc3080.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602568">11</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602616">12</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602737">13</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p>
+<a name="nt-id2595918">14</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt</a>&gt; (work in progress).</p>
+<p>
+<a name="nt-id2595978">15</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603123">16</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603322">17</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p>
+<a name="nt-id2603247">18</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p>
+<a name="nt-id2603267">19</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p>
+<a name="nt-id2603489">20</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603512">21</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2606173">22</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2606106">23</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606134">24</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p>
+<a name="nt-id2606223">25</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p>
+<a name="nt-id2606242">26</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p>
+<a name="nt-id2606359">27</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2606303">28</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2606460">29</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.5.html
+++ b/content/xep-0072-0.5.html
@@ -1,0 +1,1009 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.5<br>
+            Last Updated: 2005-04-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: None<br></p>
+<h2>Author Information</h2>
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>2.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>2.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>3.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>4.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>5.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>6.  <a href="#gateways">HTTP &lt;-&gt; XMPP Gateways</a>
+</dt>
+<dt>7.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>7.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>7.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>7.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>7.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>7.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>7.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>7.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>7.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>7.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>7.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>7.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>8.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>8.2.  <a href="#w3c-versions">SOAP Versioning</a>
+</dt>
+</dl>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>13.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2251373">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous RPC-like calls. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251143">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2251133">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2251170">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both RPC-like calls and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with &lt;soap/&gt; child elements are used in order to assure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas MUST be used for RPC calls and when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas MUST be used for asynchronous one-way communications, and when store and forward may be necessary.</li>
+  </ol>
+  <p class="" style="">These approaches are defined in the following sections.</p>
+  <div class="indent">
+<h3>2.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2250417">5</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a unique SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://schemas.xmlsoap.org/soap/envelope' namespace.</p>
+    <p class="caption">Example 1. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. A SOAP response, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>2.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track SOAP messages and eventually associate errors or answers with the relative requests.</p>
+    <p class="caption">Example 3. A SOAP envelope carrying an RDF description of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@example.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>2.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP Binding maps these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; stanzas of type "error". This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and &lt;iq/&gt; error codes (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>, and also <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2250105">6</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">IQ Error Description</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 4. A SOAP response with error, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travel.example.com/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type "error" to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 5. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents, and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML, and also byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2255504">7</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>4.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with "karma" (bandwidth restriction) settings tuned for normal textual chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">However, SOAP provides several methods to transport binary data as attachments; the most common are:</p>
+  <ul>
+    <li>Inserting a link to the file directly into the SOAP envelope</li>
+    <li>Encoding SOAP envelopes and attachments as MIME multipart messages  [<a href="#nt-id2255547">8</a>]</li>
+    <li>Using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span> 
+     [<a href="#nt-id2255564">9</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2255597">10</a>]</li>
+  </ul>
+  <p class="" style="">The first method, using the file link in the envelope, is a general one, and can be used by XMPP clients if they are able to retrieve the file (e.g, using <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2255629">11</a>]). However, the other methods cannot be used directly with XMPP, since MIME messages do not fit in XML streams, and WS-Attachments and BEEP are just other transport protocols.</p>
+  <p class="caption">Example 6. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start="&lt;claim061400a.xml@claiming-it.com&gt;"
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+  </pre></div>
+  <p class="" style="">For the transport of binary data where a URL cannot be provided, the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2255677">12</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 7. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@example.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='1972-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2255765">13</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward. The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to 'rpc' for SOAP messages carried in &lt;iq/&gt; stanzas, and to 'document' for &lt;message/&gt; stanzas.</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref" style="">XMPP URI</span>  [<a href="#nt-id2255823">14</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+ </ol>
+<p class="caption">Example 8. Example of WSDL definition for a SOAP-based translator over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='BabelFishService' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'&gt;
+  ...
+  &lt;binding name='BabelFishBinding' type='tns:BabelFishPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;soap:operation soapAction='urn:googleBabelFish#BabelFish'/&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+  &lt;service name='BabelFishService'&gt;
+    &lt;documentation&gt;
+      Translates text using Google's Babelfish.
+    &lt;/documentation&gt;
+    &lt;port name='BabelFishPort' binding='tns:BabelFishBinding'&gt;
+      &lt;soap:address location='xmpp:babel@jabber.example.org'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255885">15</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2255908">16</a>].</p>
+<h2>6.
+       <a name="gateways">HTTP &lt;-&gt; XMPP Gateways</a>
+</h2>
+<p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p>
+<p class="" style="">This section provides an example of a gateway between XMPP-based and HTTP-based web services and it is not meant to be part of the SOAP over XMPP specifications. Its purpose is only to demonstrate how HTTP and XMPP can be used together in web services, and how to invoke any web services already accessible through HTTP from XMPP clients.</p>
+<p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+
+<p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+ <ol start="" type="">
+  <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+  <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+  <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+  <li>a blank return path</li>
+ </ol>
+<p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+
+<p class="caption">Example 9. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forwawd&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+</pre></div>
+
+<h2>7.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2256073">17</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2256095">18</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2256118">19</a>].  [<a href="#nt-id2256084">20</a>] As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>7.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2256233">21</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2256258">22</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email. Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>7.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encpasulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>7.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message B.example.orges Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>8.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the preceding section of this document (<a href="#binding">SOAP XMPP Binding</a>). This section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2258491">23</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>8.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2258538">24</a>], the SOAP XMPP Binding defined herein should be reviewed informally by an appropriate expert from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2258560">25</a>] advances it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's XML Protocol Working Group.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="w3c-versions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2258607">26</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2258622">27</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2258667">28</a>].</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258702">29</a>] is required as a result of this JEP.</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258748">30</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>13.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251373">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2251143">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251133">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2251170">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250417">5</a>. JEP-0009: Transporting XML-RPC over Jabber &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2250105">6</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2255504">7</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2255547">8</a>. SOAP Messages with Attachments &lt;<a href="http://www.w3.org/TR/SOAP-attachments">http://www.w3.org/TR/SOAP-attachments</a>&gt;.</p>
+<p><a name="nt-id2255564">9</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2255597">10</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2255629">11</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2255677">12</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2255765">13</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2255823">14</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2255885">15</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255908">16</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256073">17</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2256095">18</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2256118">19</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2256084">20</a>. Another binding is described in RFC 3288, but it does not formally conform to the SOAP Protocol Binding Framework.</p>
+<p><a name="nt-id2256233">21</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2256258">22</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2258491">23</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2258538">24</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2258560">25</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2258607">26</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2258622">27</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2258667">28</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2258702">29</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258748">30</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.6.html
+++ b/content/xep-0072-0.6.html
@@ -1,0 +1,1006 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.6<br>
+            Last Updated: 2005-06-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: None<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>3.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>3.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>4.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>5.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>6.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>7.  <a href="#gateways">HTTP &lt;-&gt; XMPP Gateways</a>
+</dt>
+<dt>8.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>8.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>8.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>8.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>8.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>8.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>8.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>8.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>8.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>8.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>8.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>8.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>8.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>8.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>9.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>9.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>9.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>10.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>11.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>12.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>12.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>13.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>14.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2251189">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous RPC-like calls. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251233">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2251445">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2251256">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250471">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP world has defined the concept of "intermediaries". In general, these intermediaries are artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these problems are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2250515">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. Therefore, SOAP intermediaries are not part of the architectural assumptions on which this specification is based.</p>
+<h2>3.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both RPC-like calls and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with &lt;soap/&gt; child elements are used in order to assure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas MUST be used for RPC calls and when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas MUST be used for asynchronous one-way communications and is useful when either store and forward or message tracing is desired.</li>
+  </ol>
+  <p class="" style="">These approaches are defined in the following sections.</p>
+  <div class="indent">
+<h3>3.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2255327">7</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a unique SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://schemas.xmlsoap.org/soap/envelope' namespace.</p>
+    <p class="caption">Example 1. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. A SOAP response, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>3.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track SOAP messages and eventually associate errors or answers with the relative requests.</p>
+    <p class="caption">Example 3. A SOAP envelope carrying an RDF description of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@example.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>3.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP Binding maps these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; stanzas of type "error". This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and &lt;iq/&gt; error codes (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>, and also <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2255458">8</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">IQ Error Description</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 4. A SOAP response with error, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travel.example.com/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type "error" to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 5. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents, and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML, and also byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2250179">9</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>5.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">SOAP provides several methods to transport binary data as attachments; the most common are:</p>
+  <ul>
+    <li><p class="" style="">Inserting a link to the file directly either into the XMPP message or IQ stanza (e.g, via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2250251">10</a>]) or into the SOAP envelope (e.g., via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2255983">11</a>]).</p></li>
+    <li><p class="" style="">Encoding SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2256010">12</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2256032">13</a>]; this can work well for the HTTP and email bindings of SOAP but cannot be used directly with XMPP since XML streams transport pure XML only and not MIME messages.</p></li>
+    <li><p class="" style="">Using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span> 
+     [<a href="#nt-id2256042">14</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2256074">15</a>]; these methods are just other transport protocols and most likely would needlessly complicate implementations of SOAP over XMPP.</p></li>
+  </ul>
+  <p class="" style="">Therefore, for the transport of binary data where a URL cannot be provided, the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256108">16</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 6. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@example.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='1972-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2256194">17</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward. The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to 'rpc' for SOAP messages carried in &lt;iq/&gt; stanzas, and to 'document' for &lt;message/&gt; stanzas.</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref" style="">XMPP URI</span>  [<a href="#nt-id2256255">18</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+ </ol>
+<p class="caption">Example 7. Example of WSDL definition for a SOAP-based translator over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='BabelFishService' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'&gt;
+  ...
+  &lt;binding name='BabelFishBinding' type='tns:BabelFishPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;soap:operation soapAction='urn:googleBabelFish#BabelFish'/&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+  &lt;service name='BabelFishService'&gt;
+    &lt;documentation&gt;
+      Translates text using Google's Babelfish.
+    &lt;/documentation&gt;
+    &lt;port name='BabelFishPort' binding='tns:BabelFishBinding'&gt;
+      &lt;soap:address location='xmpp:babel@jabber.example.org'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256315">19</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256336">20</a>].</p>
+<h2>7.
+       <a name="gateways">HTTP &lt;-&gt; XMPP Gateways</a>
+</h2>
+<p class="" style=""><span style="font-style: italic">This section is non-normative.</span></p>
+<p class="" style="">This section provides an example of a gateway between XMPP-based and HTTP-based web services and it is not meant to be part of the SOAP over XMPP specifications. Its purpose is only to demonstrate how HTTP and XMPP can be used together in web services, and how to invoke any web services already accessible through HTTP from XMPP clients.</p>
+<p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+
+<p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+ <ol start="" type="">
+  <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+  <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+  <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+  <li>a blank return path</li>
+ </ol>
+<p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+
+<p class="caption">Example 8. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forwawd&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+</pre></div>
+
+<h2>8.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2256503">21</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2256524">22</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2256548">23</a>].  [<a href="#nt-id2256513">24</a>] As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>8.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2256662">25</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2256687">26</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email. Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>8.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>8.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encpasulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>8.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>8.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>8.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message B.example.orges Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>8.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>9.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the preceding section of this document (<a href="#binding">SOAP XMPP Binding</a>). This section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2258920">27</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>9.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2258968">28</a>], the SOAP XMPP Binding defined herein should be reviewed informally by an appropriate expert from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2258989">29</a>] advances it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's XML Protocol Working Group.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1, this specification may be modified to address handling of SOAP messages that are encoded in XML 1.1.</p>
+  </div>
+<h2>10.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2259058">30</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2259074">31</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2259113">32</a>].</p>
+<h2>11.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259152">33</a>] is required as a result of this JEP.</p>
+<h2>12.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259200">34</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+<h2>13.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>14.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251189">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2251233">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251445">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2251256">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250471">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2250515">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255327">7</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2255458">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2250179">9</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2250251">10</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2255983">11</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2256010">12</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2256032">13</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2256042">14</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256074">15</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2256108">16</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256194">17</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2256255">18</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256315">19</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256336">20</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256503">21</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2256524">22</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2256548">23</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2256513">24</a>. Another binding is described in RFC 3288, but it does not formally conform to the SOAP Protocol Binding Framework.</p>
+<p><a name="nt-id2256662">25</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2256687">26</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2258920">27</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2258968">28</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2258989">29</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2259058">30</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2259074">31</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2259113">32</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2259152">33</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259200">34</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.7.html
+++ b/content/xep-0072-0.7.html
@@ -1,0 +1,1033 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.7<br>
+            Last Updated: 2005-06-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: soap<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>3.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>3.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>4.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>5.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>6.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>7.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>7.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>7.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>7.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>7.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>7.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>7.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>7.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>7.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>7.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>7.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>7.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>8.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>8.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>8.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>13.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>14.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2251200">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous RPC-like calls. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251250">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2251223">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2251274">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250486">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP world has defined the concept of "intermediaries". In general, these intermediaries are artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these problems are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2250566">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. Therefore, SOAP intermediaries are not directly part of the architectural assumptions on which this specification is based. However, see the discussion in the <a href="#impl">Implementation Notes</a> section of this document.</p>
+<h2>3.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both RPC-like calls and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with &lt;soap/&gt; child elements are used in order to assure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas MUST be used for RPC calls and when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas MUST be used for asynchronous one-way communications and is useful when either store and forward or message tracing is desired.</li>
+  </ol>
+  <p class="" style="">Examples of these approaches are provided below; for a formal definition, refer to the <a href="#binding">SOAP XMPP Binding</a> section of this document.</p>
+  <div class="indent">
+<h3>3.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2255364">7</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a unique SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://schemas.xmlsoap.org/soap/envelope' namespace.</p>
+    <p class="caption">Example 1. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. A SOAP response, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>3.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track SOAP messages and eventually associate errors or answers with the relative requests.</p>
+    <p class="caption">Example 3. A SOAP envelope carrying an RDF description of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@example.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>3.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP Binding maps these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; stanzas of type "error". This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and &lt;iq/&gt; error codes (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>, and also <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2255496">8</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">IQ Error Description</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 4. A SOAP response with error, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travel.example.com/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type "error" to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 5. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents, and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML, and also byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2255790">9</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>5.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">SOAP provides several methods to transport binary data as attachments; the most common are:</p>
+  <p class="" style="">First, inserting a link to the file directly either into the XMPP message or IQ stanza (e.g, via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2255855">10</a>]) or into the SOAP envelope (e.g., via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2255881">11</a>]). This is a general method that can be used by XMPP clients if they are able to retrieve the file via HTTP (see JEP-0066).</p>
+  <p class="" style="">Second, encoding SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP 1.2 Attachment Feature</span>  [<a href="#nt-id2255911">12</a>] (or, more recently, <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2255933">13</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2255953">14</a>]). This can work well for the HTTP and email bindings of SOAP but cannot be used directly with XMPP since XML streams transport pure XML only and not MIME messages; consider the following example:</p>
+  <p class="caption">Example 6. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start="&lt;claim061400a.xml@claiming-it.com&gt;"
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+  </pre></div>
+  <p class="" style="">Third, using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span>  [<a href="#nt-id2255969">15</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2256012">16</a>]. These methods are just other transport protocols and most likely would needlessly complicate implementations of SOAP over XMPP.</p>
+  <p class="" style="">Therefore, to transport binary data when a URL cannot be provided using JEP-0066 or some similar mechanism, the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256047">17</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 7. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@example.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='1972-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2256133">18</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward. The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to 'rpc' for SOAP messages carried in &lt;iq/&gt; stanzas, and to 'document' for &lt;message/&gt; stanzas.</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref" style="">XMPP URI</span>  [<a href="#nt-id2256194">19</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+ </ol>
+<p class="caption">Example 8. Example of WSDL definition for a SOAP-based translator over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='BabelFishService' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'&gt;
+  ...
+  &lt;binding name='BabelFishBinding' type='tns:BabelFishPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;soap:operation soapAction='urn:googleBabelFish#BabelFish'/&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+  &lt;service name='BabelFishService'&gt;
+    &lt;documentation&gt;
+      Translates text using Google's Babelfish.
+    &lt;/documentation&gt;
+    &lt;port name='BabelFishPort' binding='tns:BabelFishBinding'&gt;
+      &lt;soap:address location='xmpp:babel@jabber.example.org'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256255">20</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256276">21</a>].</p>
+<h2>7.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2256305">22</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2256327">23</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2256348">24</a>].  [<a href="#nt-id2256319">25</a>] As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>7.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2256461">26</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2256487">27</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email. Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>7.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encpasulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>7.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message B.example.orges Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>8.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the preceding section of this document (<a href="#binding">SOAP XMPP Binding</a>). This section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2258719">28</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>8.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2258767">29</a>], the SOAP XMPP Binding defined herein should be reviewed informally by an appropriate expert from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2258788">30</a>] advances it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's XML Protocol Working Group.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1, this specification may be modified to address handling of SOAP messages that are encoded in XML 1.1.</p>
+  </div>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2258858">31</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2258873">32</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2258912">33</a>].</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258951">34</a>] is required as a result of this JEP.</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258999">35</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>13.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative and is not part of the SOAP over XMPP specification itself.</span></p> 
+  <p class="" style="">Any XMPP entity that supports the SOAP XMPP binding could be a SOAP "intermediary" that hands a SOAP message off to some other deployment for subsequent processing (HTTP, email, a specialized enterprise messaging platform, etc.) rather than functioning as the final destination address for the message. Implementations should be aware that subsequent processing may alter the representation of SOAP messages.</p>
+  <p class="" style="">As an example, consider a component that functions as a gateway between XMPP-based and HTTP-based web services. Its purpose is only to demonstrate how HTTP and XMPP can be used together in web services, and how to invoke any web services already accessible through HTTP from XMPP clients.</p>
+  <p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+  <p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+  <ol start="" type="">
+    <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+    <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+    <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+    <li>a blank return path</li>
+  </ol>
+  <p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+  <p class="caption">Example 9. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forwawd&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+  </pre></div>
+<h2>14.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251200">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2251250">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251223">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2251274">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250486">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2250566">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255364">7</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2255496">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2255790">9</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2255855">10</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2255881">11</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2255911">12</a>. SOAP 1.2 Attachment Feature &lt;<a href="http://www.w3.org/TR/soap12-af/">http://www.w3.org/TR/soap12-af/</a>&gt;.</p>
+<p><a name="nt-id2255933">13</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2255953">14</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2255969">15</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256012">16</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2256047">17</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256133">18</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2256194">19</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256255">20</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256276">21</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256305">22</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2256327">23</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2256348">24</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2256319">25</a>. Another binding is described in RFC 3288, but it does not formally conform to the SOAP Protocol Binding Framework.</p>
+<p><a name="nt-id2256461">26</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2256487">27</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2258719">28</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2258767">29</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2258788">30</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2258858">31</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2258873">32</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2258912">33</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2258951">34</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258999">35</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2005-06-30)</h4>
+<div class="indent">Clarified implementation notes and text on attachments. (psa)
+    </div>
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.8.html
+++ b/content/xep-0072-0.8.html
@@ -1,0 +1,1038 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.8<br>
+            Last Updated: 2005-07-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: soap<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>3.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>3.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>4.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>5.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>6.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>7.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>7.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>7.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>7.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>7.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>7.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>7.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>7.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>7.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>7.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>7.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>7.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>8.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>8.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>8.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>13.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>14.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2251219">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous RPC-like calls. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251303">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2251294">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2251272">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250505">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP world has defined the concept of "intermediaries". In general, these intermediaries are artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these problems are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2250550">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. Therefore, SOAP intermediaries are not directly part of the architectural assumptions on which this specification is based. However, see the discussion in the <a href="#impl">Implementation Notes</a> section of this document.</p>
+<h2>3.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both RPC-like calls and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with SOAP child elements are used in order to ensure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas SHOULD be used for RPC calls and when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas SHOULD be used for asynchronous one-way communications and when either store and forward or message tracing is desired.</li>
+  </ol>
+  <p class="" style="">Examples of these approaches are provided below; for a formal definition, refer to the <a href="#binding">SOAP XMPP Binding</a> section of this document.</p>
+  <div class="indent">
+<h3>3.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2255419">7</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a unique SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://schemas.xmlsoap.org/soap/envelope' namespace.</p>
+    <p class="caption">Example 1. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. A SOAP response, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>3.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track SOAP messages and eventually associate errors or answers with the relative requests.</p>
+    <p class="caption">Example 3. A SOAP envelope carrying an RDF description of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@example.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>3.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP Binding maps these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; stanzas of type "error". This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and &lt;iq/&gt; error codes (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span> as well as <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2255550">8</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">IQ Error Description</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 4. A SOAP response with error, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travel.example.com/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type "error" to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 5. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents, and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML as well as byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2255841">9</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>5.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">SOAP provides several methods to transport binary data as attachments; the most common are:</p>
+  <p class="" style="">First, inserting a link to the file directly either into the XMPP message or IQ stanza (e.g, via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2255906">10</a>]) or into the SOAP envelope (e.g., via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2255932">11</a>]). This is a general method that can be used by XMPP clients if they are able to retrieve the file via HTTP (see JEP-0066).</p>
+  <p class="" style="">Second, encoding SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP 1.2 Attachment Feature</span>  [<a href="#nt-id2255962">12</a>] (or, more recently, <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2255985">13</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2256005">14</a>]). This can work well for the HTTP and email bindings of SOAP but cannot be used directly with XMPP since XML streams transport pure XML only and not MIME messages; consider the following example:</p>
+  <p class="caption">Example 6. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start="&lt;claim061400a.xml@claiming-it.com&gt;"
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+  </pre></div>
+  <p class="" style="">Third, using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span>  [<a href="#nt-id2256020">15</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2256064">16</a>]. These methods are just other transport protocols and most likely would needlessly complicate implementations of SOAP over XMPP.</p>
+  <p class="" style="">Therefore, to transport binary data when a URL cannot be provided using JEP-0066 or some similar mechanism, the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256098">17</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 7. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@example.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='1972-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2256186">18</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward.</p>
+<p class="" style="">The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to 'rpc' for SOAP messages carried in &lt;iq/&gt; stanzas, and to 'document' for &lt;message/&gt; stanzas.</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref" style="">XMPP IRI</span>  [<a href="#nt-id2256254">19</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+</ol>
+<p class="" style="">The following is an example of a WSDL definition for an endpoint that supports the SOAP XMPP binding: a mythical service that translates Shakespearean English into selected modern languages and dialects.</p>
+<p class="caption">Example 8. Example of WSDL definition for a translation service that supports SOAP over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='ShakespeareTranslation' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'
+    xmlns:tns='http://shakespeare.lit/translation.wsdl'&gt;
+  
+  &lt;binding name='ShakespeareTranslationSoap' type='tns:TranslationPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+
+  &lt;service name='ShakespeareTranslationService'&gt;
+    &lt;documentation&gt;Translates Shakespearean text.&lt;/documentation&gt;
+    &lt;port name='TranslationPort' binding='tns:ShakespeareTranslationSoap'&gt;
+      &lt;soap:address location='xmpp:translation@shakespeare.lit'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256328">20</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256349">21</a>].</p>
+<h2>7.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2256379">22</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2256401">23</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2256423">24</a>].  [<a href="#nt-id2256370">25</a>] As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>7.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2256533">26</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2256559">27</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email. Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>7.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encpasulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>7.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message B.example.orges Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>8.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the preceding section of this document (<a href="#binding">SOAP XMPP Binding</a>). This section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2258792">28</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>8.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2258839">29</a>], the SOAP XMPP Binding defined herein should be reviewed informally by an appropriate expert from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2258860">30</a>] advances it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's XML Protocol Working Group.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1, this specification may be modified to address handling of SOAP messages that are encoded in XML 1.1.</p>
+  </div>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2258930">31</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2258946">32</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2258985">33</a>].</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259023">34</a>] is required as a result of this JEP.</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259072">35</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>13.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative and is not part of the SOAP over XMPP specification itself.</span></p> 
+  <p class="" style="">Any XMPP entity that supports the SOAP XMPP binding could be a SOAP "intermediary" that hands a SOAP message off to some other deployment for subsequent processing (HTTP, email, a specialized enterprise messaging platform, etc.) rather than functioning as the final destination address for the message. Implementations should be aware that subsequent processing may alter the representation of SOAP messages.</p>
+  <p class="" style="">As an example, consider a component that functions as a gateway between XMPP-based and HTTP-based web services. Its purpose is only to demonstrate how HTTP and XMPP can be used together in web services, and how to invoke any web services already accessible through HTTP from XMPP clients.</p>
+  <p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+  <p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+  <ol start="" type="">
+    <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+    <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+    <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+    <li>a blank return path</li>
+  </ol>
+  <p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+  <p class="caption">Example 9. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forwawd&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+  </pre></div>
+<h2>14.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251219">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2251303">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251294">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2251272">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250505">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2250550">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255419">7</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2255550">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2255841">9</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2255906">10</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2255932">11</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2255962">12</a>. SOAP 1.2 Attachment Feature &lt;<a href="http://www.w3.org/TR/soap12-af/">http://www.w3.org/TR/soap12-af/</a>&gt;.</p>
+<p><a name="nt-id2255985">13</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2256005">14</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2256020">15</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256064">16</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2256098">17</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256186">18</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2256254">19</a>. An Internationalized Resource Identifier (IRI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-00.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-00.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256328">20</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256349">21</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256379">22</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2256401">23</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2256423">24</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2256370">25</a>. Another binding is described in RFC 3288, but it does not formally conform to the SOAP Protocol Binding Framework.</p>
+<p><a name="nt-id2256533">26</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2256559">27</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2258792">28</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2258839">29</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2258860">30</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2258930">31</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2258946">32</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2258985">33</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2259023">34</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259072">35</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2005-07-21)</h4>
+<div class="indent">Cleaned up WSDL definition. (psa)
+    </div>
+<h4>Version 0.7 (2005-06-30)</h4>
+<div class="indent">Clarified implementation notes and text on attachments. (psa)
+    </div>
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0072-0.9.html
+++ b/content/xep-0072-0.9.html
@@ -1,0 +1,1043 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0072: SOAP Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SOAP Over XMPP">
+<meta name="DC.Creator" content="Fabio Forno">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines methods for transporting SOAP messages over Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-08-17">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0072">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0072: SOAP Over XMPP</h1>
+<p>This JEP defines methods for transporting SOAP messages over Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0072<br>
+            Version: 0.9<br>
+            Last Updated: 2005-08-17<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, SOAP 1.2<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: soap<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Fabio Forno</h3>
+<p class="indent">
+        Email: fabio.forno@polito.it<br>
+        JID: sciasbat@jabber.linux.it</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>3.  <a href="#transport">Transport of SOAP Envelopes</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#transport-iq">Synchronous Transport within IQ Stanzas</a>
+</dt>
+<dt>3.2.  <a href="#transport-message">Asynchronous Transport within Message Stanzas</a>
+</dt>
+<dt>3.3.  <a href="#errors">Error Reporting</a>
+</dt>
+</dl>
+<dt>4.  <a href="#encoding">Encoding</a>
+</dt>
+<dt>5.  <a href="#attachments">Attachments</a>
+</dt>
+<dt>6.  <a href="#wsdl">WSDL Definition with XMPP Binding</a>
+</dt>
+<dt>7.  <a href="#binding">SOAP XMPP Binding</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#binding-name">Binding Name</a>
+</dt>
+<dt>7.2.  <a href="#binding-features">Supported Features</a>
+</dt>
+<dt>7.3.  <a href="#binding-patterns">Supported Message Exchange Patterns</a>
+</dt>
+<dt>7.4.  <a href="#binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</dt>
+<dl>
+<dt>7.4.1.  <a href="#binding-operation-request">Behavior of Requesting SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.1.1.  <a href="#binding-operation-request-init">Init</a>
+</dt>
+<dt>7.4.1.2.  <a href="#binding-operation-request-requesting">Requesting</a>
+</dt>
+<dt>7.4.1.3.  <a href="#binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</dt>
+<dt>7.4.1.4.  <a href="#binding-operation-request-successfail">Success and Fail</a>
+</dt>
+</dl>
+<dt>7.4.2.  <a href="#binding-operation-response">Behavior of Responding SOAP Node</a>
+</dt>
+<dl>
+<dt>7.4.2.1.  <a href="#binding-operation-response-init">Init</a>
+</dt>
+<dt>7.4.2.2.  <a href="#binding-operation-response-receiving">Receiving</a>
+</dt>
+<dt>7.4.2.3.  <a href="#binding-operation-response-receivingsending">Receiving+Sending</a>
+</dt>
+<dt>7.4.2.4.  <a href="#binding-operation-response-successfail">Success and Fail</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>8.  <a href="#w3c">W3C Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#w3c-review">W3C Review</a>
+</dt>
+<dt>8.2.  <a href="#w3c-soapversions">SOAP Versioning</a>
+</dt>
+<dt>8.3.  <a href="#w3c-xmlversions">XML Versioning</a>
+</dt>
+</dl>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>13.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>14.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Simple Object Access Protocol (SOAP)</span>  [<a href="#nt-id2251234">1</a>] is a lightweight protocol that defines a method for the exchange of messages independently from the programming language and platform. For interoperability, the SOAP specification is also agnostic about possible transport protocols, though almost all existing implementations use mainly HTTP.</p>
+  <p class="" style="">The primary limitation of HTTP consists in the fact that HTTP-based message exchanges allow only synchronous RPC-like calls. To overcome this limitation, SMTP is often used to carry asynchronous messages, but it is a complex protocol and inefficient for passing short and frequent messages that should be delivered in close to real time.</p>
+  <p class="" style="">Thus XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251280">2</a>]) can be the ideal transport protocol for many of the application fields of web services, since it can carry efficiently and reliably both types of messages, synchronous and asynchronous. Moreover, XMPP-based web services will not need complex support protocols, such as <span style="font-weight: bold">WS-Routing</span>  [<a href="#nt-id2251270">3</a>] and <span style="font-weight: bold">WS-Referral</span>  [<a href="#nt-id2250433">4</a>], in order to deliver messages to entities that cannot be identified by static public IP addresses. Therefore, this JEP defines a binding of SOAP to XMPP as an alternative to the existing HTTP and SMTP bindings.</p>
+  <p class="" style="">(Note: The main body of this JEP provides descriptive text suitable for use by XMPP developers. A formal description of the SOAP XMPP Binding itself is provided in the section of this document entitled <a href="#binding">SOAP XMPP Binding</a>.)</p>
+<h2>2.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+  <p class="" style="">The usual architecture of XMPP is described in Section 2 of <span style="font-weight: bold">RFC 3920</span>. In essence, XMPP is most commonly deployed using a client-server (or logical peer-to-peer) architecture quite similar to that of the email system, except that XMPP does not have multiple hops between servers, enforces domain names to prevent address spoofing, and enables channel encryption (via TLS) and authentication (via SASL) between client and server as well as among servers.</p>
+  <p class="" style="">The binding of SOAP to XMPP assumes that most SOAP-enabled XMPP entities will be implemented as XMPP clients that communicate with other entities as logical peers. However, in order to deploy more scalable services, such entities could also be implemented as server-side components (see <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250560">5</a>]) or even as special-purpose XMPP servers.</p>
+  <p class="" style="">The SOAP specification defines the concept of a "SOAP intermediary" (see Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). In general, SOAP intermediaries are artifacts of the existing SOAP bindings (HTTP and SMTP) rather than applicable to all possible bindings. SOAP intermediaries are usually deployed in order to (1) cross trust boundaries in protocols that do not enforce domain names or authenticate end-points, (2) ensure scalability, (3) secure messages sent over unencrypted channels, and (4) provide message tracing. However, these issues are addressed natively in XMPP (e.g., channel encryption is defined in <span style="font-weight: bold">RFC 3920</span>), in XMPP extensions (e.g., message tracing is defined in <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255636">6</a>]), or in deployment decisions such as business level agreements between XMPP domains. Therefore, SOAP intermediaries are not directly part of the architectural assumptions on which this specification is based. A final justification of SOAP intermediaries is to act as gateways between different transport mechanisms (e.g., between HTTP and SMTP); for further details about gateways between XMPP and other SOAP bindings, refer to the <a href="#impl">Implementation Notes</a> section of this document.</p>
+<h2>3.
+       <a name="transport">Transport of SOAP Envelopes</a>
+</h2>
+  <p class="" style="">Since SOAP envelopes can transport both RPC-like calls and asynchronous one-way messages, both &lt;iq/&gt; and &lt;message/&gt; with SOAP child elements are used in order to ensure maximum flexibility. It is up to implementors to choose the appropriate stanza type for their applications:</p>
+  <ol start="" type="">
+    <li>&lt;iq/&gt; stanzas SHOULD be used for RPC calls and when an immediate answer is required.</li>
+    <li>&lt;message/&gt; stanzas SHOULD be used for asynchronous one-way communications and when either store and forward or message tracing is desired.</li>
+  </ol>
+  <p class="" style="">Examples of these approaches are provided below; for a formal definition, refer to the <a href="#binding">SOAP XMPP Binding</a> section of this document.</p>
+  <div class="indent">
+<h3>3.1 <a name="transport-iq">Synchronous Transport within IQ Stanzas</a>
+</h3>
+    <p class="" style="">The transport with &lt;iq/&gt; stanzas is performed in a way similar to that described for XML-RPC in <span class="ref" style="">Jabber-RPC</span>  [<a href="#nt-id2255739">7</a>]. Request envelopes are carried by &lt;iq/&gt; stanzas of type "set", and answer envelopes by &lt;iq/&gt; stanzas of type "result". SOAP errors are encoded with standard SOAP envelopes, and returned in stanzas of type "error" with appropriate codes in order to distinguish them from errors specific to the XMPP transport layer. </p>
+    <p class="" style="">Each &lt;iq/&gt; stanza MUST contain a unique SOAP envelope as the first-level child element, since it already represents a properly namespaced XML subtree qualified by the 'http://schemas.xmlsoap.org/soap/envelope' namespace.</p>
+    <p class="caption">Example 1. A SOAP request inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='requester@example.com/soap-client'
+    id='soap1'
+    to='responder@example.com/soap-server' 
+    type='set'&gt; 
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePrice 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:symbol&gt;DIS&lt;/m:symbol&gt;
+      &lt;/m:GetLastTradePrice&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. A SOAP response, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq from='responder@example.com/soap-server' 
+    id='soap1'
+    to='requester@example.com/soap-client' 
+    type='result'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;m:GetLastTradePriceResponse 
+          xmlns:m='Some-URI'
+          env:encodingStyle='http://www.w3.org/2003/05/soap-encoding'&gt;
+        &lt;m:Price&gt;34.5&lt;/m:Price&gt;
+      &lt;/m:GetLastTradePriceResponse&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>3.2 <a name="transport-message">Asynchronous Transport within Message Stanzas</a>
+</h3>
+    <p class="" style="">Message stanzas MUST carry one SOAP envelope as a first-level child element, as is done with &lt;iq/&gt; stanzas; the only difference is given by the different semantics and benefits of &lt;message/&gt; stanzas, such as store and forward. The 'id' attribute MUST be used to track SOAP messages and eventually associate errors or answers with the relative requests.</p>
+    <p class="caption">Example 3. A SOAP envelope carrying an RDF description of a RSS feed inserted into a message stanza</p>
+<div class="indent"><pre>
+&lt;message to='endpoint@example.com/soap-client' id='soap2'&gt;
+  &lt;env:Envelope xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+    &lt;env:Body&gt;
+      &lt;rdf:RDF 
+          xmlns:rdf='http://www.w3.org/1999/02/22-rdf-syntax-ns#'
+          xmlns='http://my.netscape.com/rdf/simple/0.9/'&gt;
+        &lt;channel&gt;
+          &lt;title&gt;Slashdot&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/&lt;/link&gt;
+          &lt;description&gt;News for nerds, stuff that matters&lt;/description&gt;
+        &lt;/channel&gt;
+        &lt;item&gt;
+          &lt;title&gt;Jabber/XMPP now supports SOAP&lt;/title&gt;
+          &lt;link&gt;http://slashdot.org/somepath&lt;/link&gt;
+        &lt;/item&gt;
+      &lt;/rdf:RDF&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>3.3 <a name="errors">Error Reporting</a>
+</h3>
+    <p class="" style="">SOAP provides its own encoding scheme for errors due to message processing or application execution, and it uses SOAP envelopes for reporting. The SOAP HTTP Binding maps these errors to corresponding HTTP status codes. Since &lt;iq/&gt; stanzas have the same behavior as typical HTTP request/response interactions, SOAP faults are mapped in a similar way in &lt;iq/&gt; stanzas of type "error". This approach should facilitate the design of HTTP&lt;-&gt;XMPP gateways for web services. The following table provides a mapping between SOAP, HTTP, and &lt;iq/&gt; error codes (for Jabber/XMPP error syntax, see Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span> as well as <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2255876">8</a>]).</p>
+
+    <p class="caption">Table 1: Mapping of SOAP Error codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">SOAP Error</th>
+        <th colspan="" rowspan="">HTTP Code</th>
+        <th colspan="" rowspan="">IQ Error Description</th>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:VersionMismatch</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:MustUnderstand</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Sender</td>
+        <td align="" colspan="" rowspan="">400</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      </tr>
+      
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:Receiver</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+
+      <tr class="body">
+        <td align="" colspan="" rowspan="">env:DataEncodingUnknown</td>
+        <td align="" colspan="" rowspan="">500</td>
+        <td align="" colspan="" rowspan="">&lt;internal-server-error/&gt;</td>
+      </tr>
+    </table>
+    
+    <p class="caption">Example 4. A SOAP response with error, inserted into an IQ stanza</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;env:Envelope
+      xmlns:env='http://www.w3.org/2003/05/soap-envelope'
+      xmlns:rpc='http://www.w3.org/2003/05/soap-rpc'&gt;
+    &lt;env:Body&gt;
+      &lt;env:Fault&gt;
+        &lt;env:Code&gt;
+          &lt;env:Value&gt;env:Sender&lt;/env:Value&gt;
+          &lt;env:Subcode&gt;
+            &lt;env:Value&gt;rpc:BadArguments&lt;/env:Value&gt;
+          &lt;/env:Subcode&gt;
+        &lt;/env:Code&gt;
+        &lt;env:Reason&gt;
+          &lt;env:Text xml:lang='en-US'&gt;Processing error&lt;/env:Text&gt;
+        &lt;/env:Reason&gt;
+        &lt;env:Detail&gt;
+          &lt;e:myFaultDetails xmlns:e='http://travel.example.com/faults'&gt;
+            &lt;e:message&gt;Name does not match card number&lt;/e:message&gt;
+            &lt;e:errorcode&gt;999&lt;/e:errorcode&gt;
+          &lt;/e:myFaultDetails&gt;
+        &lt;/env:Detail&gt;
+      &lt;/env:Fault&gt;
+    &lt;/env:Body&gt;
+  &lt;/env:Envelope&gt;
+  &lt;error code='500' type='cancel'&gt;
+    &lt;internal-server-error xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Since errors could occur also for asynchronous interaction using &lt;message/&gt; stanzas, the same error mapping scheme of &lt;iq/&gt; stanzas SHOULD be used. A typical situation where this can happen is a service receiving regular messages reporting remote sensor readings with asynchronous messages. If the controlling device detects some malfunctions in the sensors, it can send a &lt;message/&gt; stanza of type "error" to the monitoring application.</p>
+    
+    <p class="" style="">When errors are due to the XMPP transport protocol, and not to the application layer defined by SOAP, errors MUST be reported with standard XMPP error codes only (i.e., not including the SOAP envelope).</p> 
+    <p class="caption">Example 5. An XMPP entity reports that it cannot handle SOAP messages</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='requester@example.com/soap-client' id='soap1'&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="encoding">Encoding</a>
+</h2>
+  <p class="" style="">Because XMPP does not require the parsing of arbitrary and complete XML documents, and does not require implementations to support the full XML specification, transported SOAP envelopes MUST comply with the XML restrictions specified in Section 11 ("XML Usage Within XMPP") of <span style="font-weight: bold">RFC 3920</span>. In particular, all envelope elements MUST be properly namespaced (SOAP allows elements within the default namespace, but they are deprecated since SOAP 1.2).</p>
+  <p class="" style="">SOAP envelopes may contain arbitrary data encoded in valid XML as well as byte arrays encoded with SOAP-specific elements. The SOAP specification recommends to encode byte arrays in Base 64 (see <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256164">9</a>]), with the result that envelopes with binary data can be transported within regular XMPP stanzas. All the remaining PCDATA MUST be encoded with UTF-8 in order to match the XML stream encoding.</p>
+<h2>5.
+       <a name="attachments">Attachments</a>
+</h2>
+  <p class="" style="">Binary data could grow significantly in size, and messages carrying it could be penalized by servers with bandwidth restriction settings (commonly called "karma" in XMPP) tuned for normal text chats. The problem could be bypassed by servers having special karma settings for larger messages, or by SOAP-enabled entities being implemented as components; however, server-to-server communications risk becoming a serious bottleneck, especially in terms of latency and responsiveness when too many large messages are sent.</p>
+  <p class="" style="">SOAP provides several methods to transport binary data as attachments; the most common are:</p>
+  <p class="" style="">First, inserting a link to the file directly either into the XMPP message or IQ stanza (e.g, via <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2256228">10</a>]) or into the SOAP envelope (e.g., via <span class="ref" style="">Resource Representation SOAP Header Block</span>  [<a href="#nt-id2256254">11</a>]). This is a general method that can be used by XMPP clients if they are able to retrieve the file via HTTP (see <span style="font-weight: bold">JEP-0066</span>).</p>
+  <p class="" style="">Second, encoding SOAP envelopes and attachments as MIME multipart messages using <span class="ref" style="">SOAP 1.2 Attachment Feature</span>  [<a href="#nt-id2256321">12</a>] (or, more recently, <span class="ref" style="">SOAP Message Transmission Optimization Mechanism</span>  [<a href="#nt-id2256295">13</a>] and <span class="ref" style="">XML-binary Optimized Packaging</span>  [<a href="#nt-id2250130">14</a>]). This can work well for the HTTP and email bindings of SOAP but cannot be used directly by native XMPP entities since XML streams transport pure XML only and not MIME messages; consider the following example:</p>
+  <p class="caption">Example 6. SOAP attachment using MIME</p>
+<div class="indent"><pre>
+MIME-Version: 1.0
+Content-Type: Multipart/Related; boundary=MIME_boundary; type=text/xml;
+        start="&lt;claim061400a.xml@claiming-it.com&gt;"
+Content-Description: This is the optional message description.
+
+--MIME_boundary
+Content-Type: text/xml; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+Content-ID: &lt;claim061400a.xml@claiming-it.com&gt;
+
+&lt;?xml version='1.0' ?&gt;
+&lt;env:Envelope
+xmlns:env='http://www.w3.org/2003/05/soap-envelope'&gt;
+&lt;env:Body&gt;
+..
+&lt;theSignedForm href='cid:claim061400a.tiff@claiming-it.com'/&gt;
+..
+&lt;/env:Body&gt;
+&lt;/env:Envelope&gt;
+
+--MIME_boundary
+Content-Type: image/tiff
+Content-Transfer-Encoding: binary
+Content-ID: &lt;claim061400a.tiff@claiming-it.com&gt;
+...
+  </pre></div>
+  <p class="" style="">Third, using other protocols designed to transport SOAP and binary data together, such as <span style="font-weight: bold">WS-Attachments</span>  [<a href="#nt-id2250147">15</a>] and SOAP-over-BEEP as defined in <span class="ref" style="">RFC 3288</span>  [<a href="#nt-id2250190">16</a>]. These methods are just other transport protocols and most likely would needlessly complicate implementations of SOAP over XMPP.</p>
+  <p class="" style="">Therefore, to transport binary data between native XMPP entities when a URL cannot be provided using <span style="font-weight: bold">JEP-0066</span> or some similar mechanism, the file transfer method described in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2250229">17</a>] SHOULD be used.</p>
+  <ol start="" type="">
+    <li>When some attachment must be sent, references are included in the relative SOAP envelope; fields using attachments for data have the 'href' attribute set to a unique ID designating the file, as shown above for multipart messages.</li>
+    <li>After having sent the envelope, the sender begins a file transfer negotiation as described in JEP-0096. The 'name' attribute of the &lt;file&gt; element MUST be set to the value of the previous 'href' attribute in order to match attachments with the associated envelopes.</li>
+    <li>The receiver picks a transfer mode, retrieves all the attachments, and then replies to the SOAP messages if required.</li>
+  </ol>
+  <p class="caption">Example 7. SOAP attachment using file transfer</p>
+<div class="indent"><pre>
+
+&lt;iq type='set' id='offer1' to='receiver@example.org/resource'&gt;
+  &lt;si xmlns='http://jabber.org/protocol/si' 
+      id='a0'
+      mime-type='img/tiff'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='claim061400a.tiff@claiming-it.com'
+          size='100228'
+          hash='552da749930852c69ae5d2141d3766b1'
+          date='1972-02-02T02:56:15Z'/&gt;
+    &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='stream-method' type='list-single'&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/bytestreams&lt;/value&gt;&lt;/option&gt;
+          &lt;option&gt;&lt;value&gt;http://jabber.org/protocol/ibb&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/feature&gt;
+  &lt;/si&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If an XMPP entity also functions as a SOAP intermediary, it SHOULD use W3C-recommended protocols for transporting SOAP attachments over non-XMPP SOAP bindings (e.g., HTTP and SMTP) when communicating with non-XMPP entities (see also the <a href="#impl">Implementation Notes</a> section of this document).</p>
+<h2>6.
+       <a name="wsdl">WSDL Definition with XMPP Binding</a>
+</h2>
+
+<p class="" style=""><span class="ref" style="">WSDL</span>  [<a href="#nt-id2256665">18</a>] provides a machine-readable, formal description of web services operations, protocol bindings, and end points (i.e., network addresses). This description is aimed at specifying a loose coupling of SOAP envelopes and their transports, in order to maintain their independence and flexibility. Thus the definition of an XMPP SOAP transport through WSDL is straightforward.</p>
+<p class="" style="">The following elements are relevant for the XMPP transport:</p>
+<ol start="" type="">
+  <li>The 'transport' attribute of the &lt;soap:binding&gt; element MUST be set to "http://jabber.org/protocol/soap".</li>
+  <li>The 'style' attribute of the &lt;soap:binding&gt; element SHOULD be set to 'rpc' for SOAP messages carried in &lt;iq/&gt; stanzas, and to 'document' for &lt;message/&gt; stanzas.</li>
+  <li>The 'soapAction' attribute of the &lt;soap:operation&gt; element MAY be used; if so, it SHOULD be transported in an appropriate env:Header element for compatibility with the HTTP transport.</li>
+  <li>A valid <span class="ref" style="">XMPP IRI</span>  [<a href="#nt-id2256732">19</a>] MUST be used for the 'location' attribute in the &lt;soap:address&gt; element.</li>
+</ol>
+<p class="" style="">The following is an example of a WSDL definition for an endpoint that supports the SOAP XMPP binding: a mythical service that translates Shakespearean English into selected modern languages and dialects.</p>
+<p class="caption">Example 8. Example of WSDL definition for a translation service that supports SOAP over XMPP</p>
+<div class="indent"><pre>
+&lt;definitions 
+    name='ShakespeareTranslation' 
+    targetNamespace='http://www.example.org/services/BabelFishService.wsdl'&gt;
+    xmlns='http://schemas.xmlsoap.org/wsdl/'
+    xmlns:soap='http://schemas.xmlsoap.org/wsdl/soap/'
+    xmlns:tns='http://shakespeare.lit/translation.wsdl'&gt;
+  
+  &lt;binding name='ShakespeareTranslationSoap' type='tns:TranslationPortType'&gt;
+    &lt;soap:binding style='rpc' transport='http://jabber.org/protocol/soap'&gt;
+    &lt;operation name='Translate'&gt;
+      &lt;input&gt;...&lt;/input&gt;
+      &lt;output&gt;...&lt;/output&gt;
+    &lt;/operation&gt;
+  &lt;/binding&gt;
+
+  &lt;service name='ShakespeareTranslationService'&gt;
+    &lt;documentation&gt;Translates Shakespearean text.&lt;/documentation&gt;
+    &lt;port name='TranslationPort' binding='tns:ShakespeareTranslationSoap'&gt;
+      &lt;soap:address location='xmpp:translation@shakespeare.lit'/&gt;
+    &lt;/port&gt;
+  &lt;/service&gt;
+
+&lt;/definitions&gt;
+</pre></div>
+<p class="" style="">Although there is no standard procedure to publish WSDL documents, usually they are made available through HTTP at some URL discoverable with public registries such as UDDI servers. WSDL descriptions for XMPP bindings MAY follow the same publishing process, or MAY be discoverable through Jabber/XMPP specific mechanisms such as <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256770">20</a>] or <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256830">21</a>].</p>
+<h2>7.
+       <a name="binding">SOAP XMPP Binding</a>
+</h2>
+  <p class="" style="">Section 4 of <span class="ref" style="">SOAP Version 1.2 Part 1</span>  [<a href="#nt-id2256862">22</a>] defines a SOAP Protocol Binding Framework; two instantiations of that framework are the SOAP HTTP Binding (specified in Section 7 of <span class="ref" style="">SOAP Version 1.2 Part 2</span>  [<a href="#nt-id2256882">23</a>]) and the <span class="ref" style="">SOAP Email Binding</span>  [<a href="#nt-id2256905">24</a>]. (Additionaly, a binding to BEEP is described in <span style="font-weight: bold">RFC 3288</span>.) As an alternative to the HTTP and Email bindings, this section formally defines the SOAP XMPP Binding in accordance with the SOAP Protocol Binding Framework.</p>
+  <p class="" style="">Note: The SOAP XMPP Binding is optional, and SOAP nodes are not required to implement it. A SOAP node that correctly and completely implements the SOAP XMPP Binding as described herein may be said to "conform to the SOAP 1.2 XMPP Binding".</p>
+  <div class="indent">
+<h3>7.1 <a name="binding-name">Binding Name</a>
+</h3>
+    <p class="" style="">The SOAP XMPP Binding is identified by the following URI:</p>
+    <ul>
+      <li>http://jabber.org/protocol/soap</li> 
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="binding-features">Supported Features</a>
+</h3>
+    <p class="" style="">XMPP is a pure XML streaming protocol used to exchange snippets of structured data called "XML stanzas" (see Section 4.1 of <span style="font-weight: bold">RFC 3920</span>) between any two network endpoints.</p>
+    <p class="" style="">Because XMPP is a direct messaging protocol, it does not possess the equivalent of web methods such as the HTTP GET, PUT, POST, and DELETE methods. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Web Method Feature" described in Section 6.4 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Web Method Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+    <p class="" style="">Because XMPP is a pure XML protocol, it does not use MIME types (<span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2257017">25</a>]) or XML media types (<span class="ref" style="">RFC 3023</span>  [<a href="#nt-id2257043">26</a>]), but rather sends XML directly over the wire. Therefore, it is NOT RECOMMENDED for a SOAP node that supports only the SOAP XMPP Binding to provide the "SOAP Action Feature" described in Section 6.5 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. (A SOAP gateway between XMPP and HTTP should support the SOAP Action Feature in order to ensure interoperability; however, description of such gateways is outside the scope of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="binding-patterns">Supported Message Exchange Patterns</a>
+</h3>
+    <p class="" style="">XMPP inherently provides request-response semantics via the &lt;iq/&gt; stanza type and &lt;message/&gt; stanza type, where the &lt;iq/&gt; stanza type requires more formality regarding preservation of request-response semantics in the context of synchronous communications, whereas the &lt;message/&gt; stanza provides a looser mapping to request-response semantics as well as the ability to ensure store-and-forward capabilities similar to those provided by email (see the <a href="#impl">Implementation Notes</a> section of this document). Because both stanza types support request-response semantics, an implementation of the SOAP XMPP Binding MUST support only the following message exchange pattern (MEP) defined in the core SOAP 1.2 specification:</p>
+    <ul>
+      <li>http://www.w3.org/2003/05/soap/mep/request-response/</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="binding-operation">Operation of Request-Response Message Exchange Pattern</a>
+</h3>
+    <p class="" style="">The request-response message exchange pattern is described in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.1 Part 2</span>. For binding instances conforming to the specification of the SOAP XMPP Binding:</p>
+    <ul>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RequestingSOAPNode".</li>
+      <li>A SOAP node instantiated at an XMPP entity may assume the role (i.e., the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt> property) of "RespondingSOAPNode".</li>
+    </ul>
+    <p class="" style="">The remainder of this section describes the message exchange pattern (MEP) state machine and its relation to XMPP as described in <span style="font-weight: bold">RFC 3920</span>. For the sake of brevity, relative URIs are used (the base URI being <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/Role</tt>), the string "fail:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/FailureReasons/</tt>, and the string "reqresp:" is used as a conventional prefix for the namespace <tt>http://www.example.org/2001/12/soap/mep/request-response/</tt>. In the state tables below, the states are defined as values of the <tt>http://www.w3.org/2003/05/soap/bindingFramework/ExchangeContext/State</tt> property (see Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>) and are of type xs:anyURI.</p>
+    <div class="indent">
+<h3>7.4.1 <a name="binding-operation-request">Behavior of Requesting SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Requesting SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Requesting SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that generates a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.1.1 <a name="binding-operation-request-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 2: Init: State Description (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Formulate and send request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza (see table "Init: XMPP Fields (Requesting)") that encpasulates SOAP envelope transferred from local SOAP node to binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Requesting)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Init" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Requesting SOAP Node according to the following table:</p>
+	<p class="caption">Table 3: Init: XMPP Fields (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "set"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally this is set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, a correlation request message ID is generated by the sender and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 4: Init: Transitions (Requesting)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Request Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Request</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.1.2 <a name="binding-operation-request-requesting">Requesting</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Requesting" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 5: Requesting: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Requesting</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for correlated XMPP response (Request Message completely sent on exit from Init state)</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Wait for a receive XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Requesting: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Requesting" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 6: Requesting: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Correlated XMPP Response</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.3 <a name="binding-operation-request-sendingreceiving">Sending+Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Sending+Receiving" state of the Requesting SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 7: Sending+Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Sending+Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive correlated XMPP response including SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Process XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza and included SOAP envelope, instantiating or replacing the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the SOAP envelope contained in the XMPP response stanza</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Sending+Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Sending+Receiving" state of the Requesting SOAP Node:</p>
+	<p class="caption">Table 8: Sending+Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Response Message</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Sections 9.3.3 and 4.7.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.1.4 <a name="binding-operation-request-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; control over the transport message exchange context returns to the Requesting SOAP Node.</p>
+      </div>
+    </div>
+    <div class="indent">
+<h3>7.4.2 <a name="binding-operation-response">Behavior of Responding SOAP Node</a>
+</h3>
+      <p class="" style="">The overall flow of the behavior of a Responding SOAP Node follows the outline state machine description contained in Section 6.2 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span>. The following subsections describe each state in more detail, where "Responding SOAP Node" is to be understood as a logical entity made up of the binding and the local SOAP node associated with the XMPP entity that responds to a SOAP request.</p>
+      <div class="indent">
+<h3>7.4.2.1 <a name="binding-operation-response-init">Init</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Init" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 9: Init: State Description (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Init</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Receive request message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Receive and validate inbound XMPP &lt;iq/&gt; or &lt;message/&gt; request stanza; instantiate or replace the <tt>reqresp:ImmediateSender</tt> property with an XMPP address (JID) that denotes the sender of the XMPP request; instantiate or replace the <tt>reqresp:InboundMessage</tt> property with an infoset representation of the included SOAP envelope</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the inbound transport message exchange context is transferred from the binding to the local SOAP node</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Init: Transitions (Responding)"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Init" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 10: Init: Transitions (Responding)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Received Well-Formed Request Message</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Reception Failure (various XMPP errors)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:ReceptionFailure</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Malformed Response Message (invalid SOAP envelope)</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:BadRequestMessage</td>
+	  </tr>
+	</table>
+	<p class="" style="">For a listing of relevant XMPP error conditions, refer to Section 9.3.3 of <span style="font-weight: bold">RFC 3920</span>.</p>
+      </div>
+      <div class="indent">
+<h3>7.4.2.2 <a name="binding-operation-response-receiving">Receiving</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 11: Receiving: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Init state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">Control of the outbound transport message exchange context is transferred from the local SOAP node to the binding</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 12: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message B.example.orges Available</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.3 <a name="binding-operation-response-receivingsending">Receiving+Sending</a>
+</h3>
+        <p class="" style="">The following table formally describes the "Receiving+Sending" state of the Responding SOAP Node in the SOAP XMPP Binding:</p>
+	<p class="caption">Table 13: Receiving+Sending: State Description</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Feature</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">State Name</td>
+	    <td align="" colspan="" rowspan="">Receiving+Sending</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Description</td>
+	    <td align="" colspan="" rowspan="">Waiting for local SOAP node to return response message</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Pre-Conditions</td>
+	    <td align="" colspan="" rowspan="">Completion of Receiving state</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Actions</td>
+	    <td align="" colspan="" rowspan="">Formulate and send XMPP &lt;iq/&gt; or &lt;message/&gt; response stanza (see table "Receiving+Sending: XMPP Fields")</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Post-Conditions</td>
+	    <td align="" colspan="" rowspan="">None</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Transitions</td>
+	    <td align="" colspan="" rowspan="">See table "Receiving+Sending: Transitions"</td>
+	  </tr>
+	</table>
+        <p class="" style="">In the "Receiving+Sending" state, an XMPP stanza (either &lt;iq/&gt; or &lt;message/&gt;) is formulated by the Responding SOAP Node according to the following table:</p>
+	<p class="caption">Table 14: Receiving+Sending: XMPP Fields</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Field</th>
+	    <th colspan="" rowspan="">Value / Description</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Method</td>
+	    <td align="" colspan="" rowspan="">For XMPP &lt;iq/&gt; stanzas, the value of the XMPP 'type' attribute MUST be "result"; does not apply to XMPP &lt;message/&gt; stanzas</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Originator</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateSender</tt> property of the message exchange context is encapsulated as the value of the XMPP 'from' attribute; normally set by the XMPP server to which the originator connects</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Destination</td>
+	    <td align="" colspan="" rowspan="">The XMPP address (JID) carried in the <tt>reqresp:ImmediateDestination</tt> property of the message exchange context is encapsulated as the value of the XMPP 'to' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Correlation Request Message ID</td>
+	    <td align="" colspan="" rowspan="">As required for XMPP &lt;iq/&gt; stanzas in general and required for XMPP &lt;message/&gt; stanzas sent in the context of the SOAP XMPP Binding, the correlation request message ID is copied from the ID of the request and encapsulated as the value of the XMPP 'id' attribute</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">XMPP Stanza Contents</td>
+	    <td align="" colspan="" rowspan="">The XML of the SOAP envelope carried in the <tt>reqresp:OutboundMessage</tt> property of the transport message exchange context is encapsulated as a direct child element of the XMPP &lt;iq/&gt; or &lt;message/&gt; stanza</td>
+	  </tr>
+	</table>
+        <p class="" style="">The following table summarizes the transitions from the "Receiving+Sending" state of the Responding SOAP Node:</p>
+	<p class="caption">Table 15: Receiving: Transitions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+	  <tr class="body">
+	    <th colspan="" rowspan="">Event / Condition</th>
+	    <th colspan="" rowspan="">Next State</th>
+	    <th colspan="" rowspan="">Failure Reason</th>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Response Message Successfully Sent</td>
+	    <td align="" colspan="" rowspan="">Success</td>
+	    <td align="" colspan="" rowspan="">N/A</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Failure to Send Response Message</td>
+	    <td align="" colspan="" rowspan="">Fail</td>
+	    <td align="" colspan="" rowspan="">fail:TransmissionFailure</td>
+	  </tr>
+	</table>
+      </div>
+      <div class="indent">
+<h3>7.4.2.4 <a name="binding-operation-response-successfail">Success and Fail</a>
+</h3>
+        <p class="" style="">A given instance of a request-response transport message exchange terminates when the state "Success" or "Fail" is reached; from the perspective of the Responding SOAP Node, the transport message exchange has completed.</p>
+      </div>
+    </div>
+  </div>
+<h2>8.
+       <a name="w3c">W3C Considerations</a>
+</h2>
+  <p class="" style="">The main body of text that addresses the requirements of the W3C with regard to SOAP bindings is provided in the <a href="#binding">SOAP XMPP Binding</a> section of this document. The current section addresses only the topic of organizational interaction between the W3C and the <span class="ref" style="">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2259281">27</a>] regarding the SOAP XMPP Binding.</p>
+  <div class="indent">
+<h3>8.1 <a name="w3c-review">W3C Review</a>
+</h3>
+    <p class="" style="">As was done with <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2259328">28</a>], the SOAP XMPP Binding defined herein should be reviewed informally by one or more appropriate experts from the W3C before the <span class="ref" style="">Jabber Council</span>  [<a href="#nt-id2259350">29</a>] advances it to a status of Draft within the JSF's standards process. Before this specification proceeds to a status of Final within the JSF's standards process, it should undergo a formal review through communication with the W3C's XML Protocol Working Group.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="w3c-soapversions">SOAP Versioning</a>
+</h3>
+    <p class="" style="">This specification addresses SOAP 1.2 only. This specification may be superseded or supplemented in the future by a Jabber Enhancement Proposal that defines methods for encapsulating content defined by future versions of SOAP as published by the W3C.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="w3c-xmlversions">XML Versioning</a>
+</h3>
+    <p class="" style="">Per <span style="font-weight: bold">RFC 3920</span>, XMPP supports XML 1.0 only. If future versions of XMPP support XML 1.1, this specification may be modified to address handling of SOAP messages that are encoded in XML 1.1.</p>
+  </div>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">SOAP has been supplemented by several support protocols that help ensure message integrity and confidentiality (<span style="font-weight: bold">WS-Security</span>  [<a href="#nt-id2259421">30</a>]) as well as transaction management for failing message exchanges (<span style="font-weight: bold">WS-Transaction</span>
+     [<a href="#nt-id2259437">31</a>]). These protocols are all based on SOAP messages and take into account that the underlying protocols can be unreliable and not trusted, thus there are no arguments against their application with XMPP. Alternatively, implementations MAY use native XMPP security such as <span class="ref" style="">XMPP E2E</span>  [<a href="#nt-id2259475">32</a>].</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259514">33</a>] is required as a result of this JEP.</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259562">34</a>] shall include 'http://jabber.org/protocol/soap' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the SOAP envelope is included as a first-level child element of an &lt;iq/&gt; or &lt;message/&gt; stanza via standard XMPP extension mechanisms, an XML schema is not required for this JEP. An XML schema for the SOAP envelope element is provided in the SOAP 1.2 Specification.</p>
+<h2>13.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is non-normative and is not part of the SOAP over XMPP specification itself.</span></p> 
+  <p class="" style="">An XMPP entity that supports the SOAP XMPP binding could function as a "SOAP intermediary" that hands a SOAP message off to some other deployment for subsequent processing (HTTP, email, a specialized enterprise messaging platform, etc.) rather than functioning as the "ultimate SOAP receiver" for the message (as these terms are defined in Section 1.5.3 of <span style="font-weight: bold">SOAP Version 1.2 Part 1</span>). If the intended recipient functions as a SOAP intermediary, implementations should be aware that subsequent processing may alter the representation of SOAP messages.</p>
+  <p class="" style="">As an example, consider a component that functions as a gateway between XMPP-based and HTTP-based web services. Its purpose might be to mix HTTP and XMPP for web services and to invoke any web services already accessible through HTTP from XMPP clients.</p>
+  <p class="" style=""><span style="font-weight: bold">WS-Routing</span>, whose aim is to dynamically compose SOAP message paths and processing sequences, can be used in order to reference web services outside of an XMPP network from within it. WS-Routing extends SOAP Envelope Headers with the &lt;path/&gt; element, which specifies the following for the message: the sender's URL (&lt;from/&gt;), the final destination's URL (&lt;to/&gt;), a forward (&lt;forward/&gt;) path with an arbitrary number of intermediaries (&lt;via/&gt;), and an optional return path (&lt;reverse/&gt;). Each intermediary MUST process the &lt;path/&gt; header and update it accordingly to the already performed path; moreover it MAY process the Body of the message.</p>
+  <p class="" style="">A SOAP message originated by an XMPP entity ('xmpp:orig@A.example.com/soap'), and directed to an end point accessible through HTTP ('http://C.example.net/some/endpoint'), could be built using a &lt;path/&gt; header having:</p>
+  <ol start="" type="">
+    <li>the &lt;to/&gt; element set to 'http://C.example.net/some/endpoint'</li>
+    <li>one &lt;via/&gt; element set to an HTTP&lt;-&gt;XMPP gateway, such as 'xmpp:soapgw@B.example.org/soap', in the forward path</li>
+    <li>an appropriate SOAP action in the  &lt;action&gt; element of the &lt;path/&gt; header (this may be required by the HTTP end point)</li>
+    <li>a blank return path</li>
+  </ol>
+  <p class="" style="">Then the SOAP message can be sent within an &lt;iq/&gt; stanza to the gateway's JID. The gateway processes the SOAP headers, and looking through the headers it discovers that it must act only as intermediary. From the &lt;to/&gt; element it reads the URL of the final end point, extracts the SOAP action, changes the path removing the step already performed, and issues an HTTP request with the modified envelope and appropriate HTTP headers. Once it has received a response, it prepares a new &lt;iq/&gt; stanza of type "result" or "error" and sends its reply to the original requester. The following example shows the possible SOAP headers of the described process.</p>
+  <p class="caption">Example 9. Gateway-generated SOAP headers</p>
+<div class="indent"><pre>
+&lt;S:Envelope xmlns:S='http://www.w3.org/2003/05/soap-envelope'&gt;
+   &lt;S:Header&gt;
+      &lt;m:path xmlns:m='http://www.soap.org/path'&gt;
+         &lt;m:action&gt;http://im.example.org/chat&lt;/m:action&gt;
+         &lt;m:to&gt;http://C.example.net/some/endpoint&lt;/m:to&gt;
+         &lt;m:forward&gt;
+            &lt;m:via&gt;xmpp:soapgw@B.example.org/soap&lt;/m:via&gt;
+         &lt;/m:forwawd&gt;
+         &lt;m:reverse&gt;
+            &lt;m:via/&gt;
+         &lt;/m:reverse&gt;
+         &lt;m:from&gt;xmpp:orig@A.example.com/soap&lt;/m:from&gt;
+         &lt;m:id&gt;uuid:84b9f5d0-33fb-4a81-b02b-5b760641c1d6&lt;/m:id&gt;
+      &lt;/m:path&gt;
+   &lt;/S:Header&gt;
+   &lt;S:Body&gt;
+      ...
+   &lt;/S:Body&gt;
+&lt;/S:Envelope&gt;
+  </pre></div>
+  <p class="" style="">Generic XMPP routers that conform to <span style="font-weight: bold">RFC 3920</span> may also "store and forward" Jabber messages. This feature is usually called "offline message handling": the router makes a decision as to whether to deliver the message to the local intended recipient based on the recipient's presence, and if the recipient is offline when the router processes the message then it may store the message for delivery when the recipient next comes online (rather than returning an error to the sender). Although it is possible to write an XMPP router that directly supports the SOAP XMPP binding and implements the SOAP processing model, generic XMPP routers do not contain such support. Accordingly, generic XMPP routers will not forward an XMPP message to an alternate SOAP transport such as HTTP or SMTP, or provide other functions of a SOAP intermediary or ultimate receiver. When a generic XMPP router delivers a message to the intended recipient (whether immediately or as delayed in "offline storage") and the intended recipient supports the SOAP XMPP binding, SOAP processing is performed; such an intended recipient MAY act either as a SOAP intermediary or as an ultimate SOAP receiver.</p>
+<h2>14.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Many thanks to Noah Mendelsohn and Michael Mahan for their assistance regarding SOAP binding definitions and conformance issues.</p>
+  <p class="" style="">Some text in the <a href="#binding">SOAP XMPP Binding</a> section of this document is closely modelled on Section 7 of <span style="font-weight: bold">SOAP Version 1.2 Part 2</span> and on <span style="font-weight: bold">SOAP Version 1.2 Email Binding</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251234">1</a>. Simple Object Access Protocol (SOAP) &lt;<a href="http://www.w3.org/TR/SOAP/">http://www.w3.org/TR/SOAP/</a>&gt;.</p>
+<p><a name="nt-id2251280">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251270">3</a>. WS-Routing Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-routing.asp</a>&gt;.</p>
+<p><a name="nt-id2250433">4</a>. WS-Referral Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-referral.asp</a>&gt;.</p>
+<p><a name="nt-id2250560">5</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2255636">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255739">7</a>. JEP-0009: Jabber-RPC &lt;<a href="http://www.jabber.org/jeps/jep-0009.html">http://www.jabber.org/jeps/jep-0009.html</a>&gt;.</p>
+<p><a name="nt-id2255876">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2256164">9</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256228">10</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2256254">11</a>. Resource Representation SOAP Header Block &lt;<a href="http://www.w3.org/TR/soap12-rep">http://www.w3.org/TR/soap12-rep</a>&gt;.</p>
+<p><a name="nt-id2256321">12</a>. SOAP 1.2 Attachment Feature &lt;<a href="http://www.w3.org/TR/soap12-af/">http://www.w3.org/TR/soap12-af/</a>&gt;.</p>
+<p><a name="nt-id2256295">13</a>. SOAP Message Transmission Optimization Mechanism &lt;<a href="http://www.w3.org/TR/soap12-mtom">http://www.w3.org/TR/soap12-mtom</a>&gt;.</p>
+<p><a name="nt-id2250130">14</a>. XML-binary Optimized Packaging &lt;<a href="http://www.w3.org/TR/xop10/">http://www.w3.org/TR/xop10/</a>&gt;.</p>
+<p><a name="nt-id2250147">15</a>. WS-Attachments &lt;<a href="http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt">http://www.watersprings.org/pub/id/draft-nielsen-dime-soap-01.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2250190">16</a>. RFC 3288: Using the Simple Object Access Protocol (SOAP) in Blocks Extensible Exchange Protocol (BEEP) &lt;<a href="http://www.ietf.org/rfc/rfc3288.txt">http://www.ietf.org/rfc/rfc3288.txt</a>&gt;.</p>
+<p><a name="nt-id2250229">17</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256665">18</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2256732">19</a>. An Internationalized Resource Identifier (IRI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-00.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-00.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256770">20</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256830">21</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256862">22</a>. SOAP Version 1.2 Part 1: Messaging &lt;<a href="http://www.w3.org/TR/soap12-part1">http://www.w3.org/TR/soap12-part1</a>&gt;.</p>
+<p><a name="nt-id2256882">23</a>. SOAP Version 1.2 Part 2: Adjuncts &lt;<a href="http://www.w3.org/TR/soap12-part2">http://www.w3.org/TR/soap12-part2</a>&gt;.</p>
+<p><a name="nt-id2256905">24</a>. SOAP Version 1.2 Email Binding &lt;<a href="http://www.w3.org/TR/soap12-email">http://www.w3.org/TR/soap12-email</a>&gt;.</p>
+<p><a name="nt-id2257017">25</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2257043">26</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p><a name="nt-id2259281">27</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p><a name="nt-id2259328">28</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2259350">29</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p><a name="nt-id2259421">30</a>. WS-Security &lt;<a href="http://msdn.microsoft.com/ws/2002/04/Security/">http://msdn.microsoft.com/ws/2002/04/Security/</a>&gt;.</p>
+<p><a name="nt-id2259437">31</a>. WS-Transaction &lt;<a href="http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp">http://msdn.microsoft.com/library/en-us/dnglobspec/html/ws-transaction.asp</a>&gt;.</p>
+<p><a name="nt-id2259475">32</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2259514">33</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259562">34</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2005-08-17)</h4>
+<div class="indent">Added implementation note about XMPP routers based on W3C feedback. (psa)
+    </div>
+<h4>Version 0.8 (2005-07-21)</h4>
+<div class="indent">Cleaned up WSDL definition. (psa)
+    </div>
+<h4>Version 0.7 (2005-06-30)</h4>
+<div class="indent">Clarified implementation notes and text on attachments. (psa/ff)
+    </div>
+<h4>Version 0.6 (2005-06-29)</h4>
+<div class="indent">Addressed W3C feedback by (1) adding section on architectural assumptions, (2) adding references to recent W3C attachments work, and (3) discussing XML 1.1 support. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-01)</h4>
+<div class="indent">Corrected several small errors throughout. (psa)
+    </div>
+<h4>Version 0.4 (2005-01-06)</h4>
+<div class="indent">Added W3C Considerations and formal description of SOAP XMPP Binding. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Changed namespaces to keep in sync with latest SOAP specs. Removed the encodingStyle attribute, since in SOAP 1.2 it is allowed only in child elements of the Body. Removed the &lt;soap&gt; element from the error message example. Fixed the Fault encoding. Explicitly prohibited SOAP elements within the default namespace. (ff)
+    </div>
+<h4>Version 0.2 (2003-11-11)</h4>
+<div class="indent">Deleted the superfluous &lt;soap&gt; element for envelope encapsulation; Changed error reporting semantics; Added a WSDL Binding example; Added a routing example for HTTP&lt;-&gt;XMPP gateways; Added XML Schema; References to Jabber changed in references to XMPP; Other minor changes. (ff)
+    </div>
+<h4>Version 0.1 (2003-02-17)</h4>
+<div class="indent">Initial version. (ff)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0073-0.10.html
+++ b/content/xep-0073-0.10.html
@@ -1,0 +1,219 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0073: Basic IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Basic IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-12-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0073">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0073: Basic IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0073<br>
+            Version: 0.10<br>
+            Last Updated: 2004-12-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0077, JEP-0078, JEP-0086<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Given the large number of Jabber/XMPP protocols, 
+     [<a href="#nt-id2596242">1</a>]
+  it is not always clear to developers exactly which protocols they need to implement in order to interoperate over Jabber/XMPP networks. This JEP attempts to assist developers by defining a protocol suite for basic instant messaging and presence.</p>
+<h2>2.
+       <a name="reqs">Requirements and Approach</a>
+</h2>
+  <p class="" style="">Defining a protocol suite provides a high-level &quot;bucket&quot; into which we can place specific functionality areas for development and compliance testing. A baseline is provided by RFCs 3920 and 3921, which define XML streams, JID processing, channel encryption, authentication, the three primary XML stanza types (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), namespace handling, presence subscriptions, roster management, and privacy lists (whitelisting/blacklisting). However, basic Jabber instant messaging and presence applications should support several additional protocols that were not included in the XMPP specifications for either of the following reasons:</p>
+  <ul>
+    <li>They were not required to meet the requirements of <span class="ref">RFC 2779</span>  [<a href="#nt-id2602054">10</a>] (e.g, service discovery)</li>
+    <li>They were and remain in common use within the Jabber community but did not meet the more stringent requirements of the IETF (e.g., old-style, non-SASL authentication)</li>
+  </ul>
+  <p class="" style="">The Basic IM Protocol Suite does not include more advanced IM functionality, such as groupchat or HTML message formatting; see <span class="ref">Intermediate IM Protocol Suite</span>  [<a href="#nt-id2602173">11</a>] for such features.</p>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">The software developed in the Jabber community is built on the foundation of XML streams, a consistent addressing scheme (JIDs), channel encryption, authentication of an entity (client or server) with a server, three core data elements (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), and proper handling of XML namespaces. These foundational building blocks have been formalized within RFC 3920, support for which is REQUIRED by this protocol suite. However, XMPP Core is not fully congruent with the core of what has traditionally been known as &quot;Jabber&quot;, and this divergence needs to be captured in the Basic IM Protocol Suite. In particular, the following are REQUIRED herein in order to ensure compatibility with the large deployed base of older Jabber software: 
+     [<a href="#nt-id2602097">12</a>]
+  </p>
+  <ul>
+    <li>Support for <span class="ref">Non-SASL Authentication</span>  [<a href="#nt-id2602147">13</a>] as a fallback method for authentication.</li>
+    <li>Support for the error 'code' attribute specified in <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602272">14</a>].</li>
+  </ul>
+  <p class="" style="">RFC 3920 does not define everything that is normally expected of even a minimal instant messaging and presence application (in effect, it defines the transport layer rather than the IM and presence application layer). Much of this IM and presence functionality is defined in RFC 3921 in order to meet the requirements of RFC 2779. In particular, RFC 3921 defines roster management, presence subscriptions, privacy lists (whitelisting/blacklisting), and routing and delivery guidelines for clients and servers.</p>
+  <p class="" style="">However, Jabber instant messaging and presence applications have traditionally also included the ability to discover information about other entities on the network, and to reply to queries for information. This behavior is extremely helpful because it ensures that entities on the network can determine each other's capabilities and thus understand how to communicate together. (The original such protocol was <span class="ref">Agent Information</span>  [<a href="#nt-id2602234">15</a>], but that protocol has been superseded by <span class="ref">Service Discovery</span>  [<a href="#nt-id2602249">16</a>].) Support for Service Discovery is therefore REQUIRED by this protocol suite, as well.</p>
+  <p class="" style="">Traditionally, Jabber servers (and some services) have also offered the ability for clients to register accounts &quot;in-band&quot; (i.e., over Jabber/XMPP) in order to bootstrap participation on the network; this protocol is defined in <span class="ref">In-Band Registration</span>  [<a href="#nt-id2602308">17</a>] and support for it is REQUIRED for servers but RECOMMENDED for clients (however, any given server deployment MAY disable in-band registration as a matter of service provisioning).</p>
+  <p class="" style="">Thus we define the Basic IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">RFC 3920: XMPP Core</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">RFC 3921: XMPP IM</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0078: Non-SASL Authentication</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0086: Error Condition Mappings</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0030: Service Discovery</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0077: In-Band Registration</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">RFC 3920 requires support for SASL and TLS as must-implement protocols, and that support is not modified herein. Refer to <span style="font-weight: bold">JEP-0078: Non-SASL Authentication</span> for an explanation of the older authentication method still in use by various existing client and server implementations and deployments, as well as the proper order of precedence between SASL authentication (RFC 3920) and non-SASL authentication (JEP-0078).</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602654">18</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602596">19</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596242">1</a>. The protocols developed by the Jabber community have matured considerably since 1999. The core protocols were originally created by a small group of developers who worked on early Jabber-related open-source software projects such as the <span class="ref">jabberd</span>  [<a href="#nt-id2596351">2</a>] server, the Winjab, Gabber, and Jarl clients, the Net::Jabber and Jabberbeans libraries, and gateways to consumer IM services. In the summer of 2001, the <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596380">3</a>] was founded to institute a formal standards process within the growing Jabber community (codified in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596408">4</a>]). In late 2002, the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2601946">5</a>] formed the <span class="ref">XMPP Working Group</span>  [<a href="#nt-id2601973">6</a>], which formalized the core Jabber protocols under the name Extensible Messaging and Presence Protocol (XMPP). In early 2004, the IETF approved the main XMPP specifications as Proposed Standards within the Internet Standards Process defined by <span class="ref">RFC 2026</span>  [<a href="#nt-id2596277">7</a>], resulting in publication of <span style="font-weight: bold">RFC 3920</span> (<span class="ref">XMPP Core</span>  [<a href="#nt-id2596301">8</a>]) and <span style="font-weight: bold">RFC 3921</span> (<span class="ref">XMPP IM</span>  [<a href="#nt-id2596327">9</a>]). In the meantime, the JSF has continued to develop additional protocols on top of XMPP in order to address functionality areas (such as file transfer) that were too application-specific for consideration within the IETF.</p>
+<p>
+<a name="nt-id2596351">2</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596380">3</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596408">4</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601946">5</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601973">6</a>. The XMPP Working Group was created by the Internet Engineering Task Force to define an adaptation of the base Jabber protocols that could be considered an IETF-approved instant messaging and presence technology. For further information, see &lt;<a href="http://www.ietf.org/html.charters/xmpp-charter.html">http://www.ietf.org/html.charters/xmpp-charter.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596277">7</a>. RFC 2026: The Internet Standards Process &lt;<a href="http://www.ietf.org/rfc/rfc2026.txt">http://www.ietf.org/rfc/rfc2026.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596301">8</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596327">9</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602054">10</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602173">11</a>. JEP-0117: Intermediate IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0117.html">http://www.jabber.org/jeps/jep-0117.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602097">12</a>. Older software also used port 5223 for SSL-enabled communications between a client and a server, rather than upgrading port 5222 as is done during TLS negotiation (the equivalent for server-to-server communications was never implemented); while support for this behavior is OPTIONAL, it may be quite desirable in order to interoperate with older software and deployments.</p>
+<p>
+<a name="nt-id2602147">13</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602272">14</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602234">15</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602249">16</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602308">17</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602654">18</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602596">19</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2004-12-06)</h4>
+<div class="indent">Per feedback from the Jabber Council, made all of RFC 3920 mandatory (no loophole allowing certain client platforms to not support TLS and SASL). (psa)
+    </div>
+<h4>Version 0.9 (2004-12-01)</h4>
+<div class="indent">Removed reference to deployments and moved historical paragraph to a footnote. (psa)
+    </div>
+<h4>Version 0.8 (2004-11-18)</h4>
+<div class="indent">Updated references to reflect publication of RFCs 3920 and 3921. (psa)
+    </div>
+<h4>Version 0.7 (2004-08-18)</h4>
+<div class="indent">Changed In-Band Registration to recommended for clients; added note about SSL communications over port 5223; clarified wording throughout. (psa)
+    </div>
+<h4>Version 0.6 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.5 (2003-11-24)</h4>
+<div class="indent">Updated to reflect work by the XMPP WG; changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.4 (2003-08-13)</h4>
+<div class="indent">Renamed. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.2 (2003-04-06)</h4>
+<div class="indent">Limited scope to definition of &quot;Jabber IM Basic&quot;. (psa)
+    </div>
+<h4>Version 0.1 (2003-03-04)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0073-0.6.html
+++ b/content/xep-0073-0.6.html
@@ -1,0 +1,207 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0073: Basic IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Basic IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0073">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0073: Basic IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0073<br>
+            Version: 0.7<br>
+            Last Updated: 2004-08-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0077, JEP-0078, JEP-0086<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The protocols developed by the Jabber community have matured considerably since 1999. The core protocols were originally created by a small group of developers who worked on early Jabber-related open-source software projects such as the <span class="ref">jabberd</span>  [<a href="#nt-id2596280">1</a>] server, the Winjab, Gabber, and Jarl clients, the Net::Jabber and Jabberbeans libraries, and gateways to consumer IM services. In the summer of 2001, the <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596308">2</a>] was founded to institute a formal standards process within the growing Jabber community (codified in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596325">3</a>]). In late 2002, the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2596358">4</a>] formed the <span class="ref">XMPP Working Group</span>  [<a href="#nt-id2596386">5</a>], which formalized the core Jabber protocols under the name Extensible Messaging and Presence Protocol (XMPP). In early 2004, the IETF approved the main XMPP specifications as Proposed Standards within the Internet Standards Process defined by <span class="ref">RFC 2026</span>  [<a href="#nt-id2596200">6</a>]. In the meantime, the JSF has continued to develop additional protocols on top of XMPP in order to address functionality areas (such as file transfer) that were too application-specific for consideration within the IETF.</p>
+  <p class="" style="">Given the large number of Jabber/XMPP protocols, it is not always clear to developers exactly which protocols they need to implement in order to interoperate over Jabber/XMPP networks. This JEP attempts to assist developers by defining a protocol suite for basic instant messaging and presence.</p>
+<h2>2.
+       <a name="reqs">Requirements and Approach</a>
+</h2>
+  <p class="" style="">Defining a protocol suite provides a high-level &quot;bucket&quot; into which we can place specific functionality areas for development and compliance testing (note that this entire JEP applies to software implementations, not necessarily to particular deployments thereof). A baseline is provided by the XMPP specifications produced by the IETF's XMPP WG, which define XML streams, JID processing, channel encryption, authentication, the three primary XML stanza types (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), namespace handling, presence subscriptions, roster management, and privacy lists (whitelisting/blacklisting). However, basic Jabber instant messaging and presence applications should support several additional protocols that were not included in the XMPP specifications for either of the following reasons:</p>
+  <ul>
+    <li>They were not required to meet the requirements of <span class="ref">RFC 2779</span>  [<a href="#nt-id2601904">7</a>] (e.g, service discovery)</li>
+    <li>They were and remain in common use within the Jabber community but did not meet the more stringent requirements of the IETF (e.g., old-style, non-SASL authentication)</li>
+  </ul>
+  <p class="" style="">The Basic IM Protocol Suite does not include more advanced IM functionality, such as groupchat or HTML message formatting; see <span class="ref">Intermediate IM Protocol Suite</span>  [<a href="#nt-id2601946">8</a>] for such features.</p>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">The software developed in the Jabber community is built on the foundation of XML streams, a consistent addressing scheme (JIDs), channel encryption, authentication of an entity (client or server) with a server, three core data elements (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), and proper handling of XML namespaces. These foundational building blocks have been formalized within the <span class="ref">XMPP Core</span>  [<a href="#nt-id2602071">9</a>] specification produced by the XMPP WG, support for which is REQUIRED by this protocol suite (except as qualified for certain computing platforms in the <a href="#security">Security Considerations</a> section of this document). However, XMPP Core is not fully congruent with the core of what has traditionally been known as &quot;Jabber&quot;, and this divergence needs to be captured in the Basic IM Protocol Suite. In particular, the following are REQUIRED herein in order to ensure compatibility with the large deployed base of older Jabber software: 
+     [<a href="#nt-id2601994">10</a>]
+  </p>
+  <ul>
+    <li>Support for <span class="ref">Non-SASL Authentication</span>  [<a href="#nt-id2602038">11</a>] as a fallback method for authentication.</li>
+    <li>Support for the error 'code' attribute specified in <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602023">12</a>].</li>
+  </ul>
+  <p class="" style="">The core specifications do not define everything that is normally expected of even a minimal instant messaging and presence application (in effect, they define the transport layer rather than the IM and presence application layer). Much of this IM and presence functionality is defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2602110">13</a>] in order to meet the requirements of RFC 2779. In particular, XMPP IM defines roster management, presence subscriptions, privacy lists (whitelisting/blacklisting), and routing and delivery guidelines for clients and servers.</p>
+  <p class="" style="">However, Jabber instant messaging and presence applications have traditionally also included the ability to discover information about other entities on the network, and to reply to queries for information. This behavior is extremely helpful because it ensures that entities on the network can determine each other's capabilities and thus understand how to communicate together. (The original such protocol was <span class="ref">Agent Information</span>  [<a href="#nt-id2602153">14</a>], but that protocol has been superseded by <span class="ref">Service Discovery</span>  [<a href="#nt-id2602263">15</a>].) Support for Service Discovery is therefore REQUIRED by this protocol suite, as well.</p>
+  <p class="" style="">Traditionally, Jabber servers (and some services) have also offered the ability for clients to register accounts &quot;in-band&quot; (i.e., over Jabber/XMPP) in order to bootstrap participation on the network; this protocol is defined in <span class="ref">In-Band Registration</span>  [<a href="#nt-id2602194">16</a>] and support for it is REQUIRED for servers but RECOMMENDED for clients (however, any given server deployment MAY disable in-band registration as a matter of service provisioning).</p>
+  <p class="" style="">Thus we define the Basic IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP Core</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED (except as qualified under <a href="#security">Security Considerations</a>)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP IM</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0078: Non-SASL Authentication</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0086: Error Condition Mappings</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0030: Service Discovery</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0077: In-Band Registration</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP Core requires support for SASL and TLS as must-implement protocols. Unfortunately, support for these advanced security protocols is non-existent or unreliable at the time of writing on computing platforms for some common devices, most notably J2ME, Java, .NET, and Symbian. A client implementation of the Basic IM Protocol Suite is STRONGLY RECOMMENDED to support SASL and TLS; however, a client implementation MAY lack support for SASL and TLS if those protocols are difficult or impossible to implement on a particular computing platform given the existing state of technology. This proviso does not apply to server implementations, which MUST support SASL and TLS.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602574">17</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602516">18</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596280">1</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596308">2</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596325">3</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596358">4</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596386">5</a>. The XMPP Working Group was created by the Internet Engineering Task Force to define an adaptation of the base Jabber protocols that could be considered an IETF-approved instant messaging and presence technology. For further information, see &lt;<a href="http://www.ietf.org/html.charters/xmpp-charter.html">http://www.ietf.org/html.charters/xmpp-charter.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596200">6</a>. RFC 2026: The Internet Standards Process &lt;<a href="http://www.ietf.org/rfc/rfc2026.txt">http://www.ietf.org/rfc/rfc2026.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601904">7</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601946">8</a>. JEP-0117: Intermediate IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0117.html">http://www.jabber.org/jeps/jep-0117.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602071">9</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601994">10</a>. Older software also used port 5223 for SSL-enabled communications between a client and a server, rather than upgrading port 5222 as is done during TLS negotiation (the equivalent for server-to-server communications was never implemented); while support for this behavior is OPTIONAL, it may be quite desirable in order to support older software as well as newer software that is unable to implement TLS as explained in the <a href="#security">Security Considerations</a> section of this document.</p>
+<p>
+<a name="nt-id2602038">11</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602023">12</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602110">13</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602153">14</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602263">15</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602194">16</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602574">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602516">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2004-08-18)</h4>
+<div class="indent">Changed In-Band Registration to recommended for clients; added note about SSL communications over port 5223; clarified wording throughout. (psa)
+    </div>
+<h4>Version 0.6 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.5 (2003-11-24)</h4>
+<div class="indent">Updated to reflect work by the XMPP WG; changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.4 (2003-08-13)</h4>
+<div class="indent">Renamed. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.2 (2003-04-06)</h4>
+<div class="indent">Limited scope to definition of &quot;Jabber IM Basic&quot;. (psa)
+    </div>
+<h4>Version 0.1 (2003-03-04)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0073-0.7.html
+++ b/content/xep-0073-0.7.html
@@ -1,0 +1,207 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0073: Basic IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Basic IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0073">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0073: Basic IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0073<br>
+            Version: 0.7<br>
+            Last Updated: 2004-08-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0077, JEP-0078, JEP-0086<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The protocols developed by the Jabber community have matured considerably since 1999. The core protocols were originally created by a small group of developers who worked on early Jabber-related open-source software projects such as the <span class="ref">jabberd</span>  [<a href="#nt-id2596280">1</a>] server, the Winjab, Gabber, and Jarl clients, the Net::Jabber and Jabberbeans libraries, and gateways to consumer IM services. In the summer of 2001, the <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596308">2</a>] was founded to institute a formal standards process within the growing Jabber community (codified in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596325">3</a>]). In late 2002, the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2596358">4</a>] formed the <span class="ref">XMPP Working Group</span>  [<a href="#nt-id2596386">5</a>], which formalized the core Jabber protocols under the name Extensible Messaging and Presence Protocol (XMPP). In early 2004, the IETF approved the main XMPP specifications as Proposed Standards within the Internet Standards Process defined by <span class="ref">RFC 2026</span>  [<a href="#nt-id2596200">6</a>]. In the meantime, the JSF has continued to develop additional protocols on top of XMPP in order to address functionality areas (such as file transfer) that were too application-specific for consideration within the IETF.</p>
+  <p class="" style="">Given the large number of Jabber/XMPP protocols, it is not always clear to developers exactly which protocols they need to implement in order to interoperate over Jabber/XMPP networks. This JEP attempts to assist developers by defining a protocol suite for basic instant messaging and presence.</p>
+<h2>2.
+       <a name="reqs">Requirements and Approach</a>
+</h2>
+  <p class="" style="">Defining a protocol suite provides a high-level &quot;bucket&quot; into which we can place specific functionality areas for development and compliance testing (note that this entire JEP applies to software implementations, not necessarily to particular deployments thereof). A baseline is provided by the XMPP specifications produced by the IETF's XMPP WG, which define XML streams, JID processing, channel encryption, authentication, the three primary XML stanza types (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), namespace handling, presence subscriptions, roster management, and privacy lists (whitelisting/blacklisting). However, basic Jabber instant messaging and presence applications should support several additional protocols that were not included in the XMPP specifications for either of the following reasons:</p>
+  <ul>
+    <li>They were not required to meet the requirements of <span class="ref">RFC 2779</span>  [<a href="#nt-id2601904">7</a>] (e.g, service discovery)</li>
+    <li>They were and remain in common use within the Jabber community but did not meet the more stringent requirements of the IETF (e.g., old-style, non-SASL authentication)</li>
+  </ul>
+  <p class="" style="">The Basic IM Protocol Suite does not include more advanced IM functionality, such as groupchat or HTML message formatting; see <span class="ref">Intermediate IM Protocol Suite</span>  [<a href="#nt-id2601946">8</a>] for such features.</p>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">The software developed in the Jabber community is built on the foundation of XML streams, a consistent addressing scheme (JIDs), channel encryption, authentication of an entity (client or server) with a server, three core data elements (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), and proper handling of XML namespaces. These foundational building blocks have been formalized within the <span class="ref">XMPP Core</span>  [<a href="#nt-id2602071">9</a>] specification produced by the XMPP WG, support for which is REQUIRED by this protocol suite (except as qualified for certain computing platforms in the <a href="#security">Security Considerations</a> section of this document). However, XMPP Core is not fully congruent with the core of what has traditionally been known as &quot;Jabber&quot;, and this divergence needs to be captured in the Basic IM Protocol Suite. In particular, the following are REQUIRED herein in order to ensure compatibility with the large deployed base of older Jabber software: 
+     [<a href="#nt-id2601994">10</a>]
+  </p>
+  <ul>
+    <li>Support for <span class="ref">Non-SASL Authentication</span>  [<a href="#nt-id2602038">11</a>] as a fallback method for authentication.</li>
+    <li>Support for the error 'code' attribute specified in <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602023">12</a>].</li>
+  </ul>
+  <p class="" style="">The core specifications do not define everything that is normally expected of even a minimal instant messaging and presence application (in effect, they define the transport layer rather than the IM and presence application layer). Much of this IM and presence functionality is defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2602110">13</a>] in order to meet the requirements of RFC 2779. In particular, XMPP IM defines roster management, presence subscriptions, privacy lists (whitelisting/blacklisting), and routing and delivery guidelines for clients and servers.</p>
+  <p class="" style="">However, Jabber instant messaging and presence applications have traditionally also included the ability to discover information about other entities on the network, and to reply to queries for information. This behavior is extremely helpful because it ensures that entities on the network can determine each other's capabilities and thus understand how to communicate together. (The original such protocol was <span class="ref">Agent Information</span>  [<a href="#nt-id2602153">14</a>], but that protocol has been superseded by <span class="ref">Service Discovery</span>  [<a href="#nt-id2602263">15</a>].) Support for Service Discovery is therefore REQUIRED by this protocol suite, as well.</p>
+  <p class="" style="">Traditionally, Jabber servers (and some services) have also offered the ability for clients to register accounts &quot;in-band&quot; (i.e., over Jabber/XMPP) in order to bootstrap participation on the network; this protocol is defined in <span class="ref">In-Band Registration</span>  [<a href="#nt-id2602194">16</a>] and support for it is REQUIRED for servers but RECOMMENDED for clients (however, any given server deployment MAY disable in-band registration as a matter of service provisioning).</p>
+  <p class="" style="">Thus we define the Basic IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP Core</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED (except as qualified under <a href="#security">Security Considerations</a>)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP IM</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0078: Non-SASL Authentication</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0086: Error Condition Mappings</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0030: Service Discovery</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0077: In-Band Registration</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP Core requires support for SASL and TLS as must-implement protocols. Unfortunately, support for these advanced security protocols is non-existent or unreliable at the time of writing on computing platforms for some common devices, most notably J2ME, Java, .NET, and Symbian. A client implementation of the Basic IM Protocol Suite is STRONGLY RECOMMENDED to support SASL and TLS; however, a client implementation MAY lack support for SASL and TLS if those protocols are difficult or impossible to implement on a particular computing platform given the existing state of technology. This proviso does not apply to server implementations, which MUST support SASL and TLS.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602574">17</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602516">18</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596280">1</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596308">2</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596325">3</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596358">4</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596386">5</a>. The XMPP Working Group was created by the Internet Engineering Task Force to define an adaptation of the base Jabber protocols that could be considered an IETF-approved instant messaging and presence technology. For further information, see &lt;<a href="http://www.ietf.org/html.charters/xmpp-charter.html">http://www.ietf.org/html.charters/xmpp-charter.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596200">6</a>. RFC 2026: The Internet Standards Process &lt;<a href="http://www.ietf.org/rfc/rfc2026.txt">http://www.ietf.org/rfc/rfc2026.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601904">7</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601946">8</a>. JEP-0117: Intermediate IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0117.html">http://www.jabber.org/jeps/jep-0117.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602071">9</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601994">10</a>. Older software also used port 5223 for SSL-enabled communications between a client and a server, rather than upgrading port 5222 as is done during TLS negotiation (the equivalent for server-to-server communications was never implemented); while support for this behavior is OPTIONAL, it may be quite desirable in order to support older software as well as newer software that is unable to implement TLS as explained in the <a href="#security">Security Considerations</a> section of this document.</p>
+<p>
+<a name="nt-id2602038">11</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602023">12</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602110">13</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602153">14</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602263">15</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602194">16</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602574">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602516">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2004-08-18)</h4>
+<div class="indent">Changed In-Band Registration to recommended for clients; added note about SSL communications over port 5223; clarified wording throughout. (psa)
+    </div>
+<h4>Version 0.6 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.5 (2003-11-24)</h4>
+<div class="indent">Updated to reflect work by the XMPP WG; changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.4 (2003-08-13)</h4>
+<div class="indent">Renamed. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.2 (2003-04-06)</h4>
+<div class="indent">Limited scope to definition of &quot;Jabber IM Basic&quot;. (psa)
+    </div>
+<h4>Version 0.1 (2003-03-04)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0073-0.8.html
+++ b/content/xep-0073-0.8.html
@@ -1,0 +1,210 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0073: Basic IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Basic IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0073">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0073: Basic IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0073<br>
+            Version: 0.8<br>
+            Last Updated: 2004-11-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0077, JEP-0078, JEP-0086<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The protocols developed by the Jabber community have matured considerably since 1999. The core protocols were originally created by a small group of developers who worked on early Jabber-related open-source software projects such as the <span class="ref">jabberd</span>  [<a href="#nt-id2596302">1</a>] server, the Winjab, Gabber, and Jarl clients, the Net::Jabber and Jabberbeans libraries, and gateways to consumer IM services. In the summer of 2001, the <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596330">2</a>] was founded to institute a formal standards process within the growing Jabber community (codified in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596358">3</a>]). In late 2002, the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2596381">4</a>] formed the <span class="ref">XMPP Working Group</span>  [<a href="#nt-id2596408">5</a>], which formalized the core Jabber protocols under the name Extensible Messaging and Presence Protocol (XMPP). In early 2004, the IETF approved the main XMPP specifications as Proposed Standards within the Internet Standards Process defined by <span class="ref">RFC 2026</span>  [<a href="#nt-id2596226">6</a>], resulting in publication of <span style="font-weight: bold">RFC 3920</span> (<span class="ref">XMPP Core</span>  [<a href="#nt-id2596245">7</a>]) and <span style="font-weight: bold">RFC 3921</span> (<span class="ref">XMPP IM</span>  [<a href="#nt-id2596275">8</a>]). In the meantime, the JSF has continued to develop additional protocols on top of XMPP in order to address functionality areas (such as file transfer) that were too application-specific for consideration within the IETF.</p>
+  <p class="" style="">Given the large number of Jabber/XMPP protocols, it is not always clear to developers exactly which protocols they need to implement in order to interoperate over Jabber/XMPP networks. This JEP attempts to assist developers by defining a protocol suite for basic instant messaging and presence.</p>
+<h2>2.
+       <a name="reqs">Requirements and Approach</a>
+</h2>
+  <p class="" style="">Defining a protocol suite provides a high-level &quot;bucket&quot; into which we can place specific functionality areas for development and compliance testing (note that this entire JEP applies to software implementations, not necessarily to particular deployments thereof). A baseline is provided by RFCs 3920 and 3921, which define XML streams, JID processing, channel encryption, authentication, the three primary XML stanza types (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), namespace handling, presence subscriptions, roster management, and privacy lists (whitelisting/blacklisting). However, basic Jabber instant messaging and presence applications should support several additional protocols that were not included in the XMPP specifications for either of the following reasons:</p>
+  <ul>
+    <li>They were not required to meet the requirements of <span class="ref">RFC 2779</span>  [<a href="#nt-id2602008">9</a>] (e.g, service discovery)</li>
+    <li>They were and remain in common use within the Jabber community but did not meet the more stringent requirements of the IETF (e.g., old-style, non-SASL authentication)</li>
+  </ul>
+  <p class="" style="">The Basic IM Protocol Suite does not include more advanced IM functionality, such as groupchat or HTML message formatting; see <span class="ref">Intermediate IM Protocol Suite</span>  [<a href="#nt-id2595911">10</a>] for such features.</p>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">The software developed in the Jabber community is built on the foundation of XML streams, a consistent addressing scheme (JIDs), channel encryption, authentication of an entity (client or server) with a server, three core data elements (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), and proper handling of XML namespaces. These foundational building blocks have been formalized within RFC 3920, support for which is REQUIRED by this protocol suite (except as qualified for certain computing platforms in the <a href="#security">Security Considerations</a> section of this document). However, XMPP Core is not fully congruent with the core of what has traditionally been known as &quot;Jabber&quot;, and this divergence needs to be captured in the Basic IM Protocol Suite. In particular, the following are REQUIRED herein in order to ensure compatibility with the large deployed base of older Jabber software: 
+     [<a href="#nt-id2595956">11</a>]
+  </p>
+  <ul>
+    <li>Support for <span class="ref">Non-SASL Authentication</span>  [<a href="#nt-id2595847">12</a>] as a fallback method for authentication.</li>
+    <li>Support for the error 'code' attribute specified in <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2595875">13</a>].</li>
+  </ul>
+  <p class="" style="">RFC 3920 does not define everything that is normally expected of even a minimal instant messaging and presence application (in effect, it defines the transport layer rather than the IM and presence application layer). Much of this IM and presence functionality is defined in RFC 3921 in order to meet the requirements of RFC 2779. In particular, RFC 3921 defines roster management, presence subscriptions, privacy lists (whitelisting/blacklisting), and routing and delivery guidelines for clients and servers.</p>
+  <p class="" style="">However, Jabber instant messaging and presence applications have traditionally also included the ability to discover information about other entities on the network, and to reply to queries for information. This behavior is extremely helpful because it ensures that entities on the network can determine each other's capabilities and thus understand how to communicate together. (The original such protocol was <span class="ref">Agent Information</span>  [<a href="#nt-id2602373">14</a>], but that protocol has been superseded by <span class="ref">Service Discovery</span>  [<a href="#nt-id2602395">15</a>].) Support for Service Discovery is therefore REQUIRED by this protocol suite, as well.</p>
+  <p class="" style="">Traditionally, Jabber servers (and some services) have also offered the ability for clients to register accounts &quot;in-band&quot; (i.e., over Jabber/XMPP) in order to bootstrap participation on the network; this protocol is defined in <span class="ref">In-Band Registration</span>  [<a href="#nt-id2602427">16</a>] and support for it is REQUIRED for servers but RECOMMENDED for clients (however, any given server deployment MAY disable in-band registration as a matter of service provisioning).</p>
+  <p class="" style="">Thus we define the Basic IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">RFC 3920: XMPP Core</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED (except as qualified under <a href="#security">Security Considerations</a>)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">RFC 3921: XMPP IM</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0078: Non-SASL Authentication</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0086: Error Condition Mappings</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0030: Service Discovery</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0077: In-Band Registration</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">RFC 3920 requires support for SASL and TLS as must-implement protocols. Unfortunately, support for these advanced security protocols is non-existent or unreliable at the time of writing on computing platforms for some common devices, such as J2ME and Symbian. A client implementation of the Basic IM Protocol Suite is STRONGLY RECOMMENDED to support SASL and TLS; however, a client implementation MAY lack support for SASL and TLS if and only if those protocols are difficult or impossible to implement on a particular computing platform given the existing state of technology. This proviso does not apply to server implementations, which MUST support SASL and TLS.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602786">17</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602727">18</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596302">1</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596330">2</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596358">3</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596381">4</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596408">5</a>. The XMPP Working Group was created by the Internet Engineering Task Force to define an adaptation of the base Jabber protocols that could be considered an IETF-approved instant messaging and presence technology. For further information, see &lt;<a href="http://www.ietf.org/html.charters/xmpp-charter.html">http://www.ietf.org/html.charters/xmpp-charter.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596226">6</a>. RFC 2026: The Internet Standards Process &lt;<a href="http://www.ietf.org/rfc/rfc2026.txt">http://www.ietf.org/rfc/rfc2026.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596245">7</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596275">8</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602008">9</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595911">10</a>. JEP-0117: Intermediate IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0117.html">http://www.jabber.org/jeps/jep-0117.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595956">11</a>. Older software also used port 5223 for SSL-enabled communications between a client and a server, rather than upgrading port 5222 as is done during TLS negotiation (the equivalent for server-to-server communications was never implemented); while support for this behavior is OPTIONAL, it may be quite desirable in order to support older software as well as newer software that is unable to implement TLS as explained in the <a href="#security">Security Considerations</a> section of this document.</p>
+<p>
+<a name="nt-id2595847">12</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595875">13</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602373">14</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602395">15</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602427">16</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602786">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602727">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-11-18)</h4>
+<div class="indent">Updated references to reflect publication of RFCs 3920 and 3921. (psa)
+    </div>
+<h4>Version 0.7 (2004-08-18)</h4>
+<div class="indent">Changed In-Band Registration to recommended for clients; added note about SSL communications over port 5223; clarified wording throughout. (psa)
+    </div>
+<h4>Version 0.6 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.5 (2003-11-24)</h4>
+<div class="indent">Updated to reflect work by the XMPP WG; changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.4 (2003-08-13)</h4>
+<div class="indent">Renamed. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.2 (2003-04-06)</h4>
+<div class="indent">Limited scope to definition of &quot;Jabber IM Basic&quot;. (psa)
+    </div>
+<h4>Version 0.1 (2003-03-04)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0073-0.9.html
+++ b/content/xep-0073-0.9.html
@@ -1,0 +1,216 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0073: Basic IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Basic IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-12-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0073">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0073: Basic IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by basic instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0073<br>
+            Version: 0.9<br>
+            Last Updated: 2004-12-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0077, JEP-0078, JEP-0086<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Given the large number of Jabber/XMPP protocols, 
+     [<a href="#nt-id2596220">1</a>]
+  it is not always clear to developers exactly which protocols they need to implement in order to interoperate over Jabber/XMPP networks. This JEP attempts to assist developers by defining a protocol suite for basic instant messaging and presence.</p>
+<h2>2.
+       <a name="reqs">Requirements and Approach</a>
+</h2>
+  <p class="" style="">Defining a protocol suite provides a high-level &quot;bucket&quot; into which we can place specific functionality areas for development and compliance testing. A baseline is provided by RFCs 3920 and 3921, which define XML streams, JID processing, channel encryption, authentication, the three primary XML stanza types (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), namespace handling, presence subscriptions, roster management, and privacy lists (whitelisting/blacklisting). However, basic Jabber instant messaging and presence applications should support several additional protocols that were not included in the XMPP specifications for either of the following reasons:</p>
+  <ul>
+    <li>They were not required to meet the requirements of <span class="ref">RFC 2779</span>  [<a href="#nt-id2602015">10</a>] (e.g, service discovery)</li>
+    <li>They were and remain in common use within the Jabber community but did not meet the more stringent requirements of the IETF (e.g., old-style, non-SASL authentication)</li>
+  </ul>
+  <p class="" style="">The Basic IM Protocol Suite does not include more advanced IM functionality, such as groupchat or HTML message formatting; see <span class="ref">Intermediate IM Protocol Suite</span>  [<a href="#nt-id2602052">11</a>] for such features.</p>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">The software developed in the Jabber community is built on the foundation of XML streams, a consistent addressing scheme (JIDs), channel encryption, authentication of an entity (client or server) with a server, three core data elements (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;), and proper handling of XML namespaces. These foundational building blocks have been formalized within RFC 3920, support for which is REQUIRED by this protocol suite (except as qualified for certain computing platforms in the <a href="#security">Security Considerations</a> section of this document). However, XMPP Core is not fully congruent with the core of what has traditionally been known as &quot;Jabber&quot;, and this divergence needs to be captured in the Basic IM Protocol Suite. In particular, the following are REQUIRED herein in order to ensure compatibility with the large deployed base of older Jabber software: 
+     [<a href="#nt-id2602105">12</a>]
+  </p>
+  <ul>
+    <li>Support for <span class="ref">Non-SASL Authentication</span>  [<a href="#nt-id2602229">13</a>] as a fallback method for authentication.</li>
+    <li>Support for the error 'code' attribute specified in <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602157">14</a>].</li>
+  </ul>
+  <p class="" style="">RFC 3920 does not define everything that is normally expected of even a minimal instant messaging and presence application (in effect, it defines the transport layer rather than the IM and presence application layer). Much of this IM and presence functionality is defined in RFC 3921 in order to meet the requirements of RFC 2779. In particular, RFC 3921 defines roster management, presence subscriptions, privacy lists (whitelisting/blacklisting), and routing and delivery guidelines for clients and servers.</p>
+  <p class="" style="">However, Jabber instant messaging and presence applications have traditionally also included the ability to discover information about other entities on the network, and to reply to queries for information. This behavior is extremely helpful because it ensures that entities on the network can determine each other's capabilities and thus understand how to communicate together. (The original such protocol was <span class="ref">Agent Information</span>  [<a href="#nt-id2602216">15</a>], but that protocol has been superseded by <span class="ref">Service Discovery</span>  [<a href="#nt-id2602335">16</a>].) Support for Service Discovery is therefore REQUIRED by this protocol suite, as well.</p>
+  <p class="" style="">Traditionally, Jabber servers (and some services) have also offered the ability for clients to register accounts &quot;in-band&quot; (i.e., over Jabber/XMPP) in order to bootstrap participation on the network; this protocol is defined in <span class="ref">In-Band Registration</span>  [<a href="#nt-id2602261">17</a>] and support for it is REQUIRED for servers but RECOMMENDED for clients (however, any given server deployment MAY disable in-band registration as a matter of service provisioning).</p>
+  <p class="" style="">Thus we define the Basic IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">RFC 3920: XMPP Core</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED (except as qualified under <a href="#security">Security Considerations</a>)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">RFC 3921: XMPP IM</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0078: Non-SASL Authentication</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0086: Error Condition Mappings</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0030: Service Discovery</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0077: In-Band Registration</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED for servers; RECOMMENDED for clients</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">RFC 3920 requires support for SASL and TLS as must-implement protocols. Unfortunately, support for these advanced security protocols is non-existent or unreliable at the time of writing on computing platforms for some common devices, such as J2ME and Symbian. A client implementation of the Basic IM Protocol Suite is STRONGLY RECOMMENDED to support SASL and TLS; however, a client implementation MAY lack support for SASL and TLS if and only if those protocols are difficult or impossible to implement on a particular computing platform given the existing state of technology. This proviso does not apply to server implementations, which MUST support SASL and TLS.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602646">18</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602588">19</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596220">1</a>. The protocols developed by the Jabber community have matured considerably since 1999. The core protocols were originally created by a small group of developers who worked on early Jabber-related open-source software projects such as the <span class="ref">jabberd</span>  [<a href="#nt-id2596328">2</a>] server, the Winjab, Gabber, and Jarl clients, the Net::Jabber and Jabberbeans libraries, and gateways to consumer IM services. In the summer of 2001, the <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596357">3</a>] was founded to institute a formal standards process within the growing Jabber community (codified in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596386">4</a>]). In late 2002, the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2596407">5</a>] formed the <span class="ref">XMPP Working Group</span>  [<a href="#nt-id2601939">6</a>], which formalized the core Jabber protocols under the name Extensible Messaging and Presence Protocol (XMPP). In early 2004, the IETF approved the main XMPP specifications as Proposed Standards within the Internet Standards Process defined by <span class="ref">RFC 2026</span>  [<a href="#nt-id2596252">7</a>], resulting in publication of <span style="font-weight: bold">RFC 3920</span> (<span class="ref">XMPP Core</span>  [<a href="#nt-id2596275">8</a>]) and <span style="font-weight: bold">RFC 3921</span> (<span class="ref">XMPP IM</span>  [<a href="#nt-id2596301">9</a>]). In the meantime, the JSF has continued to develop additional protocols on top of XMPP in order to address functionality areas (such as file transfer) that were too application-specific for consideration within the IETF.</p>
+<p>
+<a name="nt-id2596328">2</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596357">3</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596386">4</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596407">5</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601939">6</a>. The XMPP Working Group was created by the Internet Engineering Task Force to define an adaptation of the base Jabber protocols that could be considered an IETF-approved instant messaging and presence technology. For further information, see &lt;<a href="http://www.ietf.org/html.charters/xmpp-charter.html">http://www.ietf.org/html.charters/xmpp-charter.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596252">7</a>. RFC 2026: The Internet Standards Process &lt;<a href="http://www.ietf.org/rfc/rfc2026.txt">http://www.ietf.org/rfc/rfc2026.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596275">8</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596301">9</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602015">10</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602052">11</a>. JEP-0117: Intermediate IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0117.html">http://www.jabber.org/jeps/jep-0117.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602105">12</a>. Older software also used port 5223 for SSL-enabled communications between a client and a server, rather than upgrading port 5222 as is done during TLS negotiation (the equivalent for server-to-server communications was never implemented); while support for this behavior is OPTIONAL, it may be quite desirable in order to support older software as well as newer software that is unable to implement TLS as explained in the <a href="#security">Security Considerations</a> section of this document.</p>
+<p>
+<a name="nt-id2602229">13</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602157">14</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602216">15</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602335">16</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602261">17</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602646">18</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602588">19</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2004-12-01)</h4>
+<div class="indent">Removed reference to deployments and moved historical paragraph to a footnote. (psa)
+    </div>
+<h4>Version 0.8 (2004-11-18)</h4>
+<div class="indent">Updated references to reflect publication of RFCs 3920 and 3921. (psa)
+    </div>
+<h4>Version 0.7 (2004-08-18)</h4>
+<div class="indent">Changed In-Band Registration to recommended for clients; added note about SSL communications over port 5223; clarified wording throughout. (psa)
+    </div>
+<h4>Version 0.6 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.5 (2003-11-24)</h4>
+<div class="indent">Updated to reflect work by the XMPP WG; changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.4 (2003-08-13)</h4>
+<div class="indent">Renamed. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.2 (2003-04-06)</h4>
+<div class="indent">Limited scope to definition of &quot;Jabber IM Basic&quot;. (psa)
+    </div>
+<h4>Version 0.1 (2003-03-04)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0077-2.0.html
+++ b/content/xep-0077-2.0.html
@@ -1,0 +1,775 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0077: In-Band Registration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="In-Band Registration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP documents a protocol for in-band registration with instant messaging servers and associated services using the jabber:iq:register namespace.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0077">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0077: In-Band Registration</h1>
+<p>This JEP documents a protocol for in-band registration with instant messaging servers and associated services using the jabber:iq:register namespace.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Final Standard of the Jabber Software Foundation and may be considered a stable technology for implementation and deployment.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Final<br>
+            Type: Standards Track<br>
+            Number: 0077<br>
+            Version: 2.0<br>
+            Last Updated: 2004-08-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: iq-register<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/iq-register/iq-register.xsd">http://jabber.org/protocol/iq-register/iq-register.xsd</a>&gt;<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#usecases-register">Entity Registers with a Host</a>
+</dt>
+<dl><dt>3.1.1.  <a href="#usecases-register-server">Registration with a Server</a>
+</dt></dl>
+<dt>3.2.  <a href="#usecases-cancel">Entity Cancels an Existing Registration</a>
+</dt>
+<dt>3.3.  <a href="#usecases-changepw">User Changes Password</a>
+</dt>
+</dl>
+<dt>4.  <a href="#extensibility">Extensibility</a>
+</dt>
+<dt>5.  <a href="#redirect">Redirection</a>
+</dt>
+<dt>6.  <a href="#precedence">Precedence Order</a>
+</dt>
+<dt>7.  <a href="#key">Key Element</a>
+</dt>
+<dt>8.  <a href="#streamfeature">Stream Feature</a>
+</dt>
+<dt>9.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>10.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>11.  <a href="#expiration">Expiration Date</a>
+</dt>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>13.2.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+<dt>13.3.  <a href="#registrar-formtypes">Field Standardization</a>
+</dt>
+</dl>
+<dt>14.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#schemas-register">jabber:iq:register</a>
+</dt>
+<dt>14.2.  <a href="#schemas-streams">Stream Feature</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for in-band registration with instant messaging servers and associated services. This method makes use of the 'jabber:iq:register' namespace and has been documented variously in Internet-Drafts and elsewhere. Because in-band registration is not required by <span class="ref" style="">RFC 2779</span>  [<a href="#nt-id2251371">1</a>], documentation of the 'jabber:iq:register' namespace was removed from <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2251398">2</a>]. This JEP fills the void for canonical documentation.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">In-band registration must make it possible for an entity to register with a host, or cancel an existing registration with a host. By "host" is meant either of the following:</p>
+  <ol start="1" type="1">
+    <li>an instant messaging server, such as described in <span style="font-weight: bold">XMPP IM</span> and identified by the "server/im" <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255217">3</a>] category+type</li>
+    <li>an add-on service, such as a gateway (see <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2255241">4</a>]) or a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255259">5</a>] service</li>
+  </ol>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="usecases-register">Entity Registers with a Host</a>
+</h3>
+    <p class="" style="">In order to determine which fields are required for registration with a host, an entity SHOULD first send an IQ get to the host. The entity SHOULD NOT attempt to guess at the required fields by first sending an IQ set, since the nature of the required data is subject to service provisioning.</p>
+    <p class="caption">Example 1. Entity Requests Registration Fields from Host</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the entity is not already registered and the host supports In-Band Registration, the host MUST inform the entity of the required registration fields. If the host does not support In-Band Registration, it MUST return a &lt;service-unavailable/&gt; error. If the host is redirecting registration requests to some other medium (e.g., a website), it MAY return an &lt;instructions/&gt; element only, as shown in the <a href="#redirect">Redirection</a> section of this document.</p>
+    <p class="caption">Example 2. Host Returns Registration Fields to Entity</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      Choose a username and password for use with this service.
+      Please also provide your email address.
+    &lt;/instructions&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+    &lt;email/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the host determines (based on the 'from' address) that the entity is already registered, the IQ result that it sends in response to the IQ get MUST contain an empty &lt;registered/&gt; element (indicating that the entity is already registered), SHOULD contain the registration information currently on file for the entity (although the &lt;password/&gt; element MAY be empty), and SHOULD contain an &lt;instructions/&gt; element (whose XML character data MAY be modified to reflect the fact that the entity is currently registered).</p>
+    <p class="" style="">If the host is an instant messaging server, it SHOULD assume that the requesting entity is unregistered at this stage unless the entity has already authenticated (for details, see the <a href="#usecases-register-server">Registration with a Server</a> section below).</p>
+    <p class="caption">Example 3. Host Informs Entity of Current Registration</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;registered/&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+    &lt;email&gt;juliet@capulet.com&lt;/email&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the entity is not already registered, the entity SHOULD provide the required information.</p>
+    <p class="caption">Example 4. Entity Provides Required Information</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;Calliope&lt;/password&gt;
+    &lt;email&gt;bill@shakespeare.lit&lt;/email&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The requesting entity MUST provide information for all of the elements (other than &lt;instructions/&gt;) contained in the IQ result.</p>
+    <p class="" style="">If the requesting entity provides an empty password element or a password element that contains no XML character data (i.e., either &lt;password/&gt; or &lt;password&gt;&lt;/password&gt;) during initial registration, the server or service MUST return a "Not Acceptable" error to the requesting entity.</p>
+    <p class="caption">Example 5. Host Informs Entity of Successful Registration</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='reg2'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, registration may fail. Possible causes of failure include a username conflict (the desired username is already in use by another entity) and the fact that the requesting entity neglected to provide all of the required information.</p>
+    <p class="caption">Example 6. Host Informs Entity of Failed Registration (Username Conflict)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;m1cro$oft&lt;/password&gt;
+    &lt;email&gt;billg@bigcompany.com&lt;/email&gt;
+  &lt;/query&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 7. Host Informs Entity of Failed Registration (Some Required Information Not Provided)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;Calliope&lt;/password&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <div class="indent">
+<h3>3.1.1 <a name="usecases-register-server">Registration with a Server</a>
+</h3>
+      <p class="" style="">Special care must be taken when an unregistered entity interacts with a server rather than a service. Normally, a server enables in-band registration so that entities can "bootstrap" their participation in the Jabber network; this bootstrapping happens when an unregistered and unauthenticated entity opens a TCP connection to a server and immediately completes the registration use case with the server, then authenticates using the newly-registered identity. As noted, when a server receives an IQ-get for registration information, it SHOULD assume that the requesting entity is unregistered unless the entity has already authenticated.</p>
+      <p class="" style="">Depending on local service provisioning, a server MAY return a &lt;not-acceptable/&gt; stanza error if an unregistered entity attempts to register too many times before authenticating or if an entity attempts to register a second identity after successfully completing the registration use case; a server MAY also return a &lt;not-authorized/&gt; stream error if the unregistered entity waits too long before authenticating or attempts to complete a task other than authentication after successfully completing the registration use case.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="usecases-cancel">Entity Cancels an Existing Registration</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:register' namespace also makes it possible for an entity to cancel a registration with a host by sending a &lt;remove/&gt; element in an IQ set. The host MUST determine the identity of the requesting entity based on the 'from' address of the IQ get.</p>
+    <p class="caption">Example 8. Entity Requests Cancellation of Existing Registration</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bill@shakespeare.lit/globe' id='unreg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;remove/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="caption">Example 9. Host Informs Entity of Successful Cancellation</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='bill@shakespeare.lit/globe' id='unreg_1'/&gt;
+    </pre></div>
+    <p class="" style="">The host MUST perform the remove based on the 'from' address of the IQ set, usually matching based on bare JID (user@domain).</p>
+    <p class="" style="">Several error cases are possible:</p>
+    <p class="caption">Table 1: Unregister Error Cases</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+<td align="" colspan="" rowspan="">The &lt;remove/&gt; element was not the only child element of the &lt;query/&gt; element.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+<td align="" colspan="" rowspan="">The sender does not have sufficient permissions to cancel the registration.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;registration-required/&gt;</td>
+<td align="" colspan="" rowspan="">The entity sending the remove request was not previously registered.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+<td align="" colspan="" rowspan="">The host is an instant messaging server and the IQ get does not contain a 'from' address because the entity is not registered with the server.</td>
+</tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="usecases-changepw">User Changes Password</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:register' namespace enables a user to change his or her password with a server or service. Once registered, the user can change passwords by sending an XML stanza of the following form (where 'somehost' is the domain identifier of the server or service):</p>
+    <p class="caption">Example 10. Password Change</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='somehost' id='change1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;newpass&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Because the password change request contains the password in plain text, a client SHOULD NOT send such a request unless the underlying stream is encrypted (using SSL or TLS) and the client has verified that the server certificate is signed by a trusted certificate authority. A given domain MAY choose to disable password changes if the stream is not properly encrypted, or to disable in-band password changes entirely.</p>
+    <p class="" style="">If the user provides an empty password element or a password element that contains no XML character data (i.e., either &lt;password/&gt; or &lt;password&gt;&lt;/password&gt;), the server or service MUST NOT change the password to a null value, but instead MUST maintain the existing password.</p>
+    <p class="caption">Example 11. Host Informs Client of Successful Password Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='change1'/&gt;
+    </pre></div>
+    <p class="" style="">Several error conditions are possible:</p>
+    <p class="caption">Table 2: Password Change Error Cases</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+<td align="" colspan="" rowspan="">The password change request does not contain complete information (both &lt;username/&gt; and &lt;password/&gt; are required).</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+<td align="" colspan="" rowspan="">The server or service does not consider the channel safe enough to enable a password change.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+<td align="" colspan="" rowspan="">The server or service does not allow password changes.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+<td align="" colspan="" rowspan="">The host is an instant messaging server and the IQ set does not contain a 'from' address because the entity is not registered with the server.</td>
+</tr>
+    </table>
+    <p class="" style="">The server or service SHOULD NOT return the original XML sent in IQ error stanzas related to password changes.</p>
+    <p class="caption">Example 12. Host Informs Client of Failed Password Change (Bad Request)</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='somehost' to='user@host/resource' id='change1'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 13. Host Informs Client of Failed Password Change (Not Authorized)</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='somehost' to='user@host/resource' id='change1'&gt;
+  &lt;error code='401' type='cancel'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Server Informs Client of Failed Password Change (Not Allowed)</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='somehost' to='user@host/resource' id='change1'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="extensibility">Extensibility</a>
+</h2>
+  <p class="" style="">The fields defined in the 'jabber:iq:register' namespace are strictly limited to those specified in the schema. If a host needs to gather additional information, <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2255971">6</a>] SHOULD be used, with the x:data form taking precedence over the iq:register fields (see the <a href="#precedence">Precedence Order</a> section below for further details); a host MUST NOT add new fields to the 'jabber:iq:register' namespace. Support for extensibility via jabber:x:data is RECOMMENDED but is not required for compliance with this JEP.</p>
+  <p class="" style="">If the entity supports the <span style="font-weight: bold">Data Forms</span> protocol, it SHOULD submit the data form rather than the predefined 'jabber:iq:register' fields, and MUST NOT submit both the data form and the predefined fields.</p>
+  <p class="" style="">The extensibility mechanism for registration makes use of a hidden FORM_TYPE field for the purpose of standardizing field names within the form, as defined in <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2255993">7</a>]. Implementations supporting this extensibility mechanism SHOULD support the standardized fields as well.</p>
+  <p class="caption">Example 15. Entity Requests Registration Fields from Host</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='juliet@capulet.com/balcony'
+    to='contests.shakespeare.lit'
+    id='reg3'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 16. Host Returns Registration Form to Entity</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='contests.shakespeare.lit'
+    to='juliet@capulet.com/balcony'
+    id='reg3'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      Use the enclosed form to register. If your Jabber client does not
+      support Data Forms, visit http://www.shakespeare.lit/contests.php
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Contest Registration&lt;/title&gt;
+      &lt;instructions&gt;
+        Please provide the following information
+        to sign up for our special contests!
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;jabber:iq:register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          type='text-single'
+          label='Given Name'
+          var='first'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          type='text-single'
+          label='Family Name'
+          var='last'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          type='text-single'
+          label='Email Address'
+          var='email'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          type='list-single'
+          label='Gender'
+          var='x-gender'&gt;
+        &lt;option label='Male'&gt;&lt;value&gt;M&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Female'&gt;&lt;value&gt;F&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="redirect">Redirection</a>
+</h2>
+  <p class="" style="">A given deployment MAY wish to redirect users to another medium (e.g., a website) for registration, rather than allowing in-band registration. The recommended approach is to include only the &lt;instructions/&gt; element rather than the required fields or a data form in the IQ result, as well as a URL encoded using <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2256070">8</a>] (see the <a href="#precedence">Precedence Order</a> section below for further details).</p>
+  <p class="caption">Example 17. Host Redirects Entity to Web Registration</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='contests.shakespeare.lit'
+    to='juliet@capulet.com/balcony'
+    id='reg3'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      To register, visit http://www.shakespeare.lit/contests.php
+    &lt;/instructions&gt;
+  &lt;/query&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;http://www.shakespeare.lit/contests.php&lt;/url&gt;
+  &lt;/x&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="precedence">Precedence Order</a>
+</h2>
+  <p class="" style="">Given the foregoing discussion, it is evident that an entity could receive any combination of iq:register, x:data, and x:oob namespaces from a service in response to a request for information. The precedence order is as follows:</p>
+  <ol start="1" type="">
+    <li>x:data</li>
+    <li>iq:register</li>
+    <li>x:oob</li>
+  </ol>
+  <p class="" style="">(Naturally, if the receiving application does not understand any of the foregoing namespaces, it MUST ignore the data qualified by that namespace.)</p>
+  <p class="" style="">Thus it is possible that the host may return any of the following combinations, in which case the submitting application MUST proceed as defined in the table below (it is assumed that "iq:register fields" means instructions plus fields, whereas "iq:register instructions" means the &lt;instructions/&gt; element only):</p>
+  <p class="caption">Table 3: Recommended Processing of Namespace Combinations</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Included Data</th>
+      <th colspan="" rowspan="">Recommended Processing</th>
+      <th colspan="" rowspan="">Notes</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">iq:register fields</td>
+      <td align="" colspan="" rowspan="">Submit the completed iq:register fields.</td>
+      <td align="" colspan="" rowspan="">This is the normal processing model for "legacy" services and clients.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x:data form + iq:register fields</td>
+      <td align="" colspan="" rowspan="">Submit the completed x:data form if understood, otherwise submit the completed iq:register fields; however, an application MUST NOT submit both.</td>
+      <td align="" colspan="" rowspan="">The iq:register fields would be included for "legacy" clients; this combination SHOULD NOT be used if the x:data form includes required fields (e.g., a public key) that are not equivalent to defined iq:register fields (the next combination SHOULD be used instead).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x:data form + iq:register instructions</td>
+      <td align="" colspan="" rowspan="">Submit the completed x:data form if understood, otherwise present the iq:register instructions to the user.</td>
+      <td align="" colspan="" rowspan="">This combination SHOULD be used if the x:data form includes required fields (e.g., a public key) that are not equivalent to defined iq:register fields and an alternate URL is not available.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x:data form + x:oob URL</td>
+      <td align="" colspan="" rowspan="">Submit the completed x:data form if understood, otherwise present the provided URL as an alternative.</td>
+      <td align="" colspan="" rowspan="">This combination MAY be returned by a host, but a host SHOULD return the next combination instead in order to support the full range of legacy clients.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x:data form + iq:register instructions + x:oob URL</td>
+      <td align="" colspan="" rowspan="">Submit the completed x:data form if understood, otherwise present the iq:register instructions and provided URL as an alternative.</td>
+      <td align="" colspan="" rowspan="">This combination SHOULD be used if the x:data form includes required fields (e.g., a public key) that are not equivalent to defined iq:register fields and an alternate URL is available.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">iq:register instructions + x:oob URL</td>
+      <td align="" colspan="" rowspan="">Present the iq:register instructions and provided URL as a redirect.</td>
+      <td align="" colspan="" rowspan="">This combination MAY be returned by a host that wishes to redirect registration to a URL.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">iq:register fields + x:oob URL</td>
+      <td align="" colspan="" rowspan="">Submit the completed iq:register fields but optionally present the provided URL as an alternative.</td>
+      <td align="" colspan="" rowspan="">This combination is NOT RECOMMENDED.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="key">Key Element</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This element is obsolete, but is documented here for historical completeness.</span></p>
+  <p class="" style="">The &lt;key/&gt; element was used as a "transaction key" in certain IQ interactions in order to verify the identity of the sender. In particular, it was used by servers (but generally not services) during in-band registration, since normally a user does not yet have a 'from' address before registering. The flow is as follows:</p>
+  <ol start="" type="">
+    <li>Client sends IQ-get request to server.</li>
+    <li>Server returns required elements to client, including &lt;key/&gt; element containing a random string (often a SHA-1 hash).</li>
+    <li>Client sends registration information to server, including &lt;key/&gt; element with the same value provided by the server.</li>
+    <li>Server checks key information and processes registration request; if key is missing or the key value does not match the transaction key provided, the server returns an error.</li>
+  </ol>
+  <p class="" style="">The &lt;key/&gt; element was also used during registration removal.</p>
+<h2>8.
+       <a name="streamfeature">Stream Feature</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2256516">9</a>] defines methods for advertising feature support during stream negotiation. For the sake of efficiency, it may be desirable for a server to advertise support for in-band registration as a stream feature. The namespace for reporting support within &lt;stream:features/&gt; is "http://jabber.org/features/iq-register". Upon receiving a stream header qualified by the 'jabber:client' namespace, a server returns a stream header to the client and MAY announce support for in-band registration by including the relevant stream feature:</p>
+  <p class="caption">Example 18. Advertising registration as a stream feature</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='utf-8'?&gt;
+&lt;stream:stream xmlns:stream='http://etherx.jabber.org/streams/'
+    xmlns='jabber:client'
+    from='somedomain'
+    version='1.0'&gt;
+  &lt;stream:features&gt;
+    ...
+    &lt;register xmlns='http://jabber.org/features/iq-register'/&gt;
+    ...
+  &lt;/stream:features&gt;
+  </pre></div>
+  <p class="" style="">A server SHOULD NOT advertise in-band registration to another server (i.e., if the initial stream header was qualified by the 'jabber:server' namespace).</p>
+<h2>9.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">As defined herein, the 'jabber:iq:register' namespace supports both the old (HTTP-style) error codes and the extensible error classes and conditions specified in XMPP Core. A compliant server or service implementation MUST support both old-style and new-style error handling. A compliant client implementation SHOULD support both. For mappings of HTTP-style errors to XMPP-style conditions, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256605">10</a>].</p>
+<h2>10.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">In-band registration is usually not included in other messaging protocols (for example, SMTP does not include a method for registering with an email server), often for reasons of security. The registration methods defined herein are known to be insecure and SHOULD NOT be used unless the channel between the registrant and the entity that accepts registration has been secured. For these reasons, the deployment of in-band registration is a policy matter and a given domain MAY choose to disable in-band registration and password changes. Furthermore, this JEP should be deprecated as soon as a successor protocol is defined and implemented.</p>
+<h2>11.
+       <a name="expiration">Expiration Date</a>
+</h2>
+  <p class="" style="">In accordance with Section 8 of <span class="ref" style="">Jabber Enhancement Proposals</span>  [<a href="#nt-id2256675">11</a>], this JEP shall expire 6 months from the date of its advancement to a status of Final. The Jabber Council shall review this JEP before its expiration date, and at that time shall determine whether to change its status to Deprecated or to extend the expiration date for an additional six months. That process will continue until the JEP is deprecated or made a permanent standard.</p>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256717">12</a>].</p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256765">13</a>] includes the 'jabber:iq:register' namespace in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="registrar-stream">Stream Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the 'http://jabber.org/features/iq-register' namespace in its registry of stream feature namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>13.3 <a name="registrar-formtypes">Field Standardization</a>
+</h3>
+    <p class="" style="">As described in the <a href="#extensibility">Extensibility</a> section above, this proposal includes registration of a FORM_TYPE and associated field types and names for field standardization as defined in JEP-0068. The initial submission is as follows (additional fields may be provided in future submissions):</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;jabber:iq:register&lt;/name&gt;
+  &lt;doc&gt;JEP-0077&lt;/doc&gt;
+  &lt;desc&gt;
+    Standardization of fields related to in-band registration.
+  &lt;/desc&gt;
+  &lt;field
+      var='username'
+      type='text-single'
+      label='Account name associated with the user'/&gt;
+  &lt;field
+      var='nick'
+      type='text-single'
+      label='Familiar name of the user'/&gt;
+  &lt;field
+      var='password'
+      type='text-private'
+      label='Password or secret for the user'/&gt;
+  &lt;field
+      var='name'
+      type='text-single'
+      label='Full name of the user'/&gt;
+  &lt;field
+      var='first'
+      type='text-single'
+      label='First name or given name of the user'/&gt;
+  &lt;field
+      var='last'
+      type='text-single'
+      label='Last name, surname, or family name of the user'/&gt;
+  &lt;field
+      var='email'
+      type='text-single'
+      label='Email address of the user'/&gt;
+  &lt;field
+      var='address'
+      type='text-single'
+      label='Street portion of a physical or mailing address'/&gt;
+  &lt;field
+      var='city'
+      type='text-single'
+      label='Locality portion of a physical or mailing address'/&gt;
+  &lt;field
+      var='state'
+      type='text-single'
+      label='Region portion of a physical or mailing address'/&gt;
+  &lt;field
+      var='zip'
+      type='text-single'
+      label='Postal code portion of a physical or mailing address'/&gt;
+  &lt;field
+      var='phone'
+      type='text-single'
+      label='Telephone number of the user'/&gt;
+  &lt;field
+      var='url'
+      type='text-single'
+      label='URL to web page describing the user'/&gt;
+  &lt;field
+      var='date'
+      type='text-single'
+      label='Some date (e.g., birth date, hire date, sign-up date)'/&gt;
+  &lt;field
+      var='misc'
+      type='text-single'
+      label='Free-form text field (obsolete)'/&gt;
+  &lt;field
+      var='text'
+      type='text-single'
+      label='Free-form text field (obsolete)'/&gt;
+  &lt;field
+      var='key'
+      type='text-single'
+      label='Session key for transaction (obsolete)'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>14.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="schemas-register">jabber:iq:register</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:register'
+    xmlns='jabber:iq:register'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0077: http://www.jabber.org/jeps/jep-0077.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence minOccurs='0'&gt;
+          &lt;xs:element name='registered' type='empty' minOccurs='0'/&gt;
+          &lt;xs:element name='instructions' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='username' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='nick' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='name' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='first' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='last' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='email' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='address' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='city' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='state' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='zip' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='phone' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='url' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='date' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='misc' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='text' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='key' type='xs:string' minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element name='remove' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>14.2 <a name="schemas-streams">Stream Feature</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/iq-register'
+    xmlns='http://jabber.org/features/iq-register'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0077: http://www.jabber.org/jeps/jep-0077.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='register' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251371">1</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p><a name="nt-id2251398">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255217">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255241">4</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2255259">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255971">6</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2255993">7</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2256070">8</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2256516">9</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256605">10</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2256675">11</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p><a name="nt-id2256717">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256765">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 2.0 (2004-08-30)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Final; also specified that by server is meant an instant messaging server. (psa)
+    </div>
+<h4>Version 1.6 (2004-08-23)</h4>
+<div class="indent">In order to address Council concerns, clarified precedence order of x:data, iq:register, and x:oob; further specified server handling of initial registration requests from unregistered entities. (psa)
+    </div>
+<h4>Version 1.5 (2004-07-21)</h4>
+<div class="indent">Specified server handling of requests from unregistered entities. (psa)
+    </div>
+<h4>Version 1.4 (2004-05-10)</h4>
+<div class="indent">Removed conformance language regarding servers and services (belongs in a protocol suite specification). (psa)
+    </div>
+<h4>Version 1.3 (2004-02-24)</h4>
+<div class="indent">Added text about redirection to web registration. (psa)
+    </div>
+<h4>Version 1.2 (2003-11-26)</h4>
+<div class="indent">Documented use of &lt;key/&gt; element; added optional stream feature; added XMPP error handling; specified handling of empty passwords. (psa)
+    </div>
+<h4>Version 1.1 (2003-10-02)</h4>
+<div class="indent">Moved change password use case from JEP-0078. (psa)
+    </div>
+<h4>Version 1.0 (2003-06-18)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.9 (2003-06-18)</h4>
+<div class="indent">Changes to address Council concerns. (psa)
+    </div>
+<h4>Version 0.8 (2003-06-13)</h4>
+<div class="indent">Restored the &lt;misc/&gt; and &lt;text/&gt; elements; added the old &lt;key/&gt; element; specified these three elements as obsolete. (psa)
+    </div>
+<h4>Version 0.7 (2003-06-12)</h4>
+<div class="indent">Added &lt;registered/&gt; element; specified FORM_TYPE for x:data form; clarified that support for the extensibility mechanism is optional; removed the &lt;misc/&gt; and &lt;text/&gt; elements (not necessary given extensibility option); added &lt;nick/&gt;, &lt;first/&gt;, and &lt;last/&gt; elements that were traditionally documented as part of jabber:iq:register. (psa)
+    </div>
+<h4>Version 0.6 (2003-06-06)</h4>
+<div class="indent">Removed XMPP-style error conditions until formats are stable. (psa)
+    </div>
+<h4>Version 0.5 (2003-05-30)</h4>
+<div class="indent">Removed "encrypted secret" content, added information about expiration date. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-28)</h4>
+<div class="indent">Added "encrypted secret" content. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.2 (2003-04-29)</h4>
+<div class="indent">Fixed schema, made minor editorial changes. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-06)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0077-2.1.html
+++ b/content/xep-0077-2.1.html
@@ -1,0 +1,791 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0077: In-Band Registration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="In-Band Registration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP documents a protocol for in-band registration with instant messaging servers and associated services using the jabber:iq:register namespace.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-14">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0077">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0077: In-Band Registration</h1>
+<p>This JEP documents a protocol for in-band registration with instant messaging servers and associated services using the jabber:iq:register namespace.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Final Standard of the Jabber Software Foundation and may be considered a stable technology for implementation and deployment.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Final<br>
+            Type: Standards Track<br>
+            Number: 0077<br>
+            Version: 2.1<br>
+            Last Updated: 2005-07-14<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: iq-register<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/iq-register/iq-register.xsd">http://jabber.org/protocol/iq-register/iq-register.xsd</a>&gt;<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/In-Band%20Registration%20(JEP-0077)">http://wiki.jabber.org/index.php/In-Band Registration (JEP-0077)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#usecases-register">Entity Registers with a Host</a>
+</dt>
+<dl><dt>3.1.1.  <a href="#usecases-register-server">Registration with a Server</a>
+</dt></dl>
+<dt>3.2.  <a href="#usecases-cancel">Entity Cancels an Existing Registration</a>
+</dt>
+<dt>3.3.  <a href="#usecases-changepw">User Changes Password</a>
+</dt>
+</dl>
+<dt>4.  <a href="#extensibility">Extensibility</a>
+</dt>
+<dt>5.  <a href="#redirect">Redirection</a>
+</dt>
+<dt>6.  <a href="#precedence">Precedence Order</a>
+</dt>
+<dt>7.  <a href="#key">Key Element</a>
+</dt>
+<dt>8.  <a href="#streamfeature">Stream Feature</a>
+</dt>
+<dt>9.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>10.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>11.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>12.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>12.2.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+<dt>12.3.  <a href="#registrar-formtypes">Field Standardization</a>
+</dt>
+</dl>
+<dt>13.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#schemas-register">jabber:iq:register</a>
+</dt>
+<dt>13.2.  <a href="#schemas-streams">Stream Feature</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for in-band registration with instant messaging servers and associated services. This method makes use of the 'jabber:iq:register' namespace and has been documented variously in Internet-Drafts and elsewhere. Because in-band registration is not required by <span class="ref" style="">RFC 2779</span>  [<a href="#nt-id2250714">1</a>], documentation of the 'jabber:iq:register' namespace was removed from <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250740">2</a>]. This JEP fills the void for canonical documentation.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">In-band registration must make it possible for an entity to register with a host, or cancel an existing registration with a host. By "host" is meant either of the following:</p>
+  <ol start="1" type="1">
+    <li>an instant messaging server, such as described in <span style="font-weight: bold">XMPP IM</span> and identified by the "server/im" <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250791">3</a>] category+type</li>
+    <li>an add-on service, such as a gateway (see <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2256230">4</a>]) or a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256249">5</a>] service</li>
+  </ol>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="usecases-register">Entity Registers with a Host</a>
+</h3>
+    <p class="" style="">In order to determine which fields are required for registration with a host, an entity SHOULD first send an IQ get to the host. The entity SHOULD NOT attempt to guess at the required fields by first sending an IQ set, since the nature of the required data is subject to service provisioning.</p>
+    <p class="caption">Example 1. Entity Requests Registration Fields from Host</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the entity is not already registered and the host supports In-Band Registration, the host MUST inform the entity of the required registration fields. If the host does not support In-Band Registration, it MUST return a &lt;service-unavailable/&gt; error. If the host is redirecting registration requests to some other medium (e.g., a website), it MAY return an &lt;instructions/&gt; element only, as shown in the <a href="#redirect">Redirection</a> section of this document.</p>
+    <p class="caption">Example 2. Host Returns Registration Fields to Entity</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      Choose a username and password for use with this service.
+      Please also provide your email address.
+    &lt;/instructions&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+    &lt;email/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the host determines (based on the 'from' address) that the entity is already registered, the IQ result that it sends in response to the IQ get MUST contain an empty &lt;registered/&gt; element (indicating that the entity is already registered), SHOULD contain the registration information currently on file for the entity (although the &lt;password/&gt; element MAY be empty), and SHOULD contain an &lt;instructions/&gt; element (whose XML character data MAY be modified to reflect the fact that the entity is currently registered).</p>
+    <p class="" style="">If the host is an instant messaging server, it SHOULD assume that the requesting entity is unregistered at this stage unless the entity has already authenticated (for details, see the <a href="#usecases-register-server">Registration with a Server</a> section below).</p>
+    <p class="caption">Example 3. Host Informs Entity of Current Registration</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;registered/&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+    &lt;email&gt;juliet@capulet.com&lt;/email&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the entity is not already registered, the entity SHOULD provide the required information.</p>
+    <p class="caption">Example 4. Entity Provides Required Information</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;Calliope&lt;/password&gt;
+    &lt;email&gt;bill@shakespeare.lit&lt;/email&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The requesting entity MUST provide information for all of the elements (other than &lt;instructions/&gt;) contained in the IQ result.</p>
+    <p class="" style="">If the requesting entity provides an empty password element or a password element that contains no XML character data (i.e., either &lt;password/&gt; or &lt;password&gt;&lt;/password&gt;) during initial registration, the server or service MUST return a "Not Acceptable" error to the requesting entity.</p>
+    <p class="caption">Example 5. Host Informs Entity of Successful Registration</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='reg2'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, registration may fail. Possible causes of failure include a username conflict (the desired username is already in use by another entity) and the fact that the requesting entity neglected to provide all of the required information.</p>
+    <p class="caption">Example 6. Host Informs Entity of Failed Registration (Username Conflict)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;m1cro$oft&lt;/password&gt;
+    &lt;email&gt;billg@bigcompany.com&lt;/email&gt;
+  &lt;/query&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 7. Host Informs Entity of Failed Registration (Some Required Information Not Provided)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;Calliope&lt;/password&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <div class="indent">
+<h3>3.1.1 <a name="usecases-register-server">Registration with a Server</a>
+</h3>
+      <p class="" style="">Special care must be taken when an unregistered entity interacts with a server rather than a service. Normally, a server enables in-band registration so that entities can "bootstrap" their participation in the Jabber network; this bootstrapping happens when an unregistered and unauthenticated entity opens a TCP connection to a server and immediately completes the registration use case with the server, then authenticates using the newly-registered identity. As noted, when a server receives an IQ-get for registration information, it SHOULD assume that the requesting entity is unregistered unless the entity has already authenticated.</p>
+      <p class="" style="">Depending on local service provisioning, a server MAY return a &lt;not-acceptable/&gt; stanza error if an unregistered entity attempts to register too many times before authenticating or if an entity attempts to register a second identity after successfully completing the registration use case; a server MAY also return a &lt;not-authorized/&gt; stream error if the unregistered entity waits too long before authenticating or attempts to complete a task other than authentication after successfully completing the registration use case.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="usecases-cancel">Entity Cancels an Existing Registration</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:register' namespace also makes it possible for an entity to cancel a registration with a host by sending a &lt;remove/&gt; element in an IQ set. The host MUST determine the identity of the requesting entity based on the 'from' address of the IQ get.</p>
+    <p class="caption">Example 8. Entity Requests Cancellation of Existing Registration</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bill@shakespeare.lit/globe' id='unreg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;remove/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="caption">Example 9. Host Informs Entity of Successful Cancellation</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='bill@shakespeare.lit/globe' id='unreg_1'/&gt;
+    </pre></div>
+    <p class="" style="">The host MUST perform the remove based on the 'from' address of the IQ set, usually matching based on bare JID (user@domain).</p>
+    <p class="" style="">Several error cases are possible:</p>
+    <p class="caption">Table 1: Unregister Error Cases</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+<td align="" colspan="" rowspan="">The &lt;remove/&gt; element was not the only child element of the &lt;query/&gt; element.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+<td align="" colspan="" rowspan="">The sender does not have sufficient permissions to cancel the registration.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;registration-required/&gt;</td>
+<td align="" colspan="" rowspan="">The entity sending the remove request was not previously registered.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+<td align="" colspan="" rowspan="">The host is an instant messaging server and the IQ get does not contain a 'from' address because the entity is not registered with the server.</td>
+</tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="usecases-changepw">User Changes Password</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:register' namespace enables a user to change his or her password with a server or service. Once registered, the user can change passwords by sending an XML stanza of the following form (where 'somehost' is the domain identifier of the server or service):</p>
+    <p class="caption">Example 10. Password Change</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='somehost' id='change1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;newpass&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Because the password change request contains the password in plain text, a client SHOULD NOT send such a request unless the underlying stream is encrypted (using SSL or TLS) and the client has verified that the server certificate is signed by a trusted certificate authority. A given domain MAY choose to disable password changes if the stream is not properly encrypted, or to disable in-band password changes entirely.</p>
+    <p class="" style="">If the user provides an empty password element or a password element that contains no XML character data (i.e., either &lt;password/&gt; or &lt;password&gt;&lt;/password&gt;), the server or service MUST NOT change the password to a null value, but instead MUST maintain the existing password.</p>
+    <p class="caption">Example 11. Host Informs Client of Successful Password Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='change1'/&gt;
+    </pre></div>
+    <p class="" style="">Several error conditions are possible:</p>
+    <p class="caption">Table 2: Password Change Error Cases</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+<td align="" colspan="" rowspan="">The password change request does not contain complete information (both &lt;username/&gt; and &lt;password/&gt; are required).</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+<td align="" colspan="" rowspan="">The server or service does not consider the channel safe enough to enable a password change.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+<td align="" colspan="" rowspan="">The server or service does not allow password changes.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+<td align="" colspan="" rowspan="">The host is an instant messaging server and the IQ set does not contain a 'from' address because the entity is not registered with the server.</td>
+</tr>
+    </table>
+    <p class="" style="">The server or service SHOULD NOT return the original XML sent in IQ error stanzas related to password changes.</p>
+    <p class="caption">Example 12. Host Informs Client of Failed Password Change (Bad Request)</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='somehost' to='user@host/resource' id='change1'&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 13. Host Informs Client of Failed Password Change (Not Authorized)</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='somehost' to='user@host/resource' id='change1'&gt;
+  &lt;error code='401' type='cancel'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 14. Server Informs Client of Failed Password Change (Not Allowed)</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='somehost' to='user@host/resource' id='change1'&gt;
+  &lt;error code='405' type='cancel'&gt;
+    &lt;not-allowed xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="extensibility">Extensibility</a>
+</h2>
+  <p class="" style="">The fields defined for the 'jabber:iq:register' namespace are strictly limited to those specified in the schema. If a host needs to gather additional information, <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2256963">6</a>] ("x:data") SHOULD be used according to the following rules:</p>
+  <ol start="" type="">
+    <li>A host MUST NOT add new fields to the 'jabber:iq:register' namespace; instead, extensibility SHOULD be pursued via the <span style="font-weight: bold">Data Forms</span> protocol as specified herein.</li>
+    <li>The x:data form shall be contained as a child element of the &lt;query xmlns='jabber:iq:register'/&gt; element (it cannot be a child of the &lt;iq/&gt; stanza and comply with Section 9.2.3 of <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2256942">7</a>]).</li>
+    <li>The x:data form SHOULD contain x:data fields that correspond to all of the iq:register fields (e.g., username and password).</li>
+    <li>The x:data form SHOULD use a hidden FORM_TYPE field for the purpose of standardizing field names within the form, as defined in <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2257005">8</a>].</li>
+    <li>The x:data form shall take precedence over the iq:register fields; if the submitting entity supports the <span style="font-weight: bold">Data Forms</span> protocol, it SHOULD submit the data form rather than the predefined 'jabber:iq:register' fields, and MUST NOT submit both the data form and the predefined fields (see the <a href="#precedence">Precedence Order</a> section of this document).</li>
+  </ol>
+  <p class="" style="">Support for extensibility via <span style="font-weight: bold">Data Forms</span> is RECOMMENDED but is not required for compliance with this JEP.</p>
+  <p class="caption">Example 15. Entity Requests Registration Fields from Host</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='juliet@capulet.com/balcony'
+    to='contests.shakespeare.lit'
+    id='reg3'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 16. Host Returns Registration Form to Entity</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='contests.shakespeare.lit'
+    to='juliet@capulet.com/balcony'
+    id='reg3'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      Use the enclosed form to register. If your Jabber client does not
+      support Data Forms, visit http://www.shakespeare.lit/contests.php
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Contest Registration&lt;/title&gt;
+      &lt;instructions&gt;
+        Please provide the following information
+        to sign up for our special contests!
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;jabber:iq:register&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field
+          type='text-single'
+          label='Given Name'
+          var='first'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          type='text-single'
+          label='Family Name'
+          var='last'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          type='text-single'
+          label='Email Address'
+          var='email'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field
+          type='list-single'
+          label='Gender'
+          var='x-gender'&gt;
+        &lt;option label='Male'&gt;&lt;value&gt;M&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='Female'&gt;&lt;value&gt;F&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="redirect">Redirection</a>
+</h2>
+  <p class="" style="">A given deployment MAY wish to redirect users to another medium (e.g., a website) for registration, rather than allowing in-band registration. The recommended approach is to include only the &lt;instructions/&gt; element rather than the required fields or a data form in the IQ result, as well as a URL encoded using <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2250304">9</a>] (see the <a href="#precedence">Precedence Order</a> section below for further details).</p>
+  <p class="caption">Example 17. Host Redirects Entity to Web Registration</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='contests.shakespeare.lit'
+    to='juliet@capulet.com/balcony'
+    id='reg3'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      To register, visit http://www.shakespeare.lit/contests.php
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:oob'&gt;
+      &lt;url&gt;http://www.shakespeare.lit/contests.php&lt;/url&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="precedence">Precedence Order</a>
+</h2>
+  <p class="" style="">Given the foregoing discussion, it is evident that an entity could receive any combination of iq:register, x:data, and x:oob namespaces from a service in response to a request for information. The precedence order is as follows:</p>
+  <ol start="1" type="">
+    <li>x:data</li>
+    <li>iq:register</li>
+    <li>x:oob</li>
+  </ol>
+  <p class="" style="">(Naturally, if the receiving application does not understand any of the foregoing namespaces, it MUST ignore the data qualified by that namespace.)</p>
+  <p class="" style="">Thus it is possible that the host may return any of the following combinations, in which case the submitting application MUST proceed as defined in the table below (it is assumed that "iq:register fields" means instructions plus fields, whereas "iq:register instructions" means the &lt;instructions/&gt; element only):</p>
+  <p class="caption">Table 3: Recommended Processing of Namespace Combinations</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Included Data</th>
+      <th colspan="" rowspan="">Recommended Processing</th>
+      <th colspan="" rowspan="">Notes</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">iq:register fields</td>
+      <td align="" colspan="" rowspan="">Submit the completed iq:register fields.</td>
+      <td align="" colspan="" rowspan="">This is the normal processing model for "legacy" services and clients.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x:data form + iq:register fields</td>
+      <td align="" colspan="" rowspan="">Submit the completed x:data form if understood, otherwise submit the completed iq:register fields; however, an application MUST NOT submit both.</td>
+      <td align="" colspan="" rowspan="">The iq:register fields would be included for "legacy" clients; this combination SHOULD NOT be used if the x:data form includes required fields (e.g., a public key) that are not equivalent to defined iq:register fields (the next combination SHOULD be used instead).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x:data form + iq:register instructions</td>
+      <td align="" colspan="" rowspan="">Submit the completed x:data form if understood, otherwise present the iq:register instructions to the user.</td>
+      <td align="" colspan="" rowspan="">This combination SHOULD be used if the x:data form includes required fields (e.g., a public key) that are not equivalent to defined iq:register fields and an alternate URL is not available.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x:data form + x:oob URL</td>
+      <td align="" colspan="" rowspan="">Submit the completed x:data form if understood, otherwise present the provided URL as an alternative.</td>
+      <td align="" colspan="" rowspan="">This combination MAY be returned by a host, but a host SHOULD return the next combination instead in order to support the full range of legacy clients.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x:data form + iq:register instructions + x:oob URL</td>
+      <td align="" colspan="" rowspan="">Submit the completed x:data form if understood, otherwise present the iq:register instructions and provided URL as an alternative.</td>
+      <td align="" colspan="" rowspan="">This combination SHOULD be used if the x:data form includes required fields (e.g., a public key) that are not equivalent to defined iq:register fields and an alternate URL is available.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">iq:register instructions + x:oob URL</td>
+      <td align="" colspan="" rowspan="">Present the iq:register instructions and provided URL as a redirect.</td>
+      <td align="" colspan="" rowspan="">This combination MAY be returned by a host that wishes to redirect registration to a URL.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">iq:register fields + x:oob URL</td>
+      <td align="" colspan="" rowspan="">Submit the completed iq:register fields but optionally present the provided URL as an alternative.</td>
+      <td align="" colspan="" rowspan="">This combination is NOT RECOMMENDED.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="key">Key Element</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This element is obsolete, but is documented here for historical completeness.</span></p>
+  <p class="" style="">The &lt;key/&gt; element was used as a "transaction key" in certain IQ interactions in order to verify the identity of the sender. In particular, it was used by servers (but generally not services) during in-band registration, since normally a user does not yet have a 'from' address before registering. The flow is as follows:</p>
+  <ol start="" type="">
+    <li>Client sends IQ-get request to server.</li>
+    <li>Server returns required elements to client, including &lt;key/&gt; element containing a random string (often a SHA-1 hash).</li>
+    <li>Client sends registration information to server, including &lt;key/&gt; element with the same value provided by the server.</li>
+    <li>Server checks key information and processes registration request; if key is missing or the key value does not match the transaction key provided, the server returns an error.</li>
+  </ol>
+  <p class="" style="">The &lt;key/&gt; element was also used during registration removal.</p>
+<h2>8.
+       <a name="streamfeature">Stream Feature</a>
+</h2>
+  <p class="" style=""><span style="font-weight: bold">RFC 3920</span> defines methods for advertising feature support during stream negotiation. For the sake of efficiency, it may be desirable for a server to advertise support for in-band registration as a stream feature. The namespace for reporting support within &lt;stream:features/&gt; is "http://jabber.org/features/iq-register". Upon receiving a stream header qualified by the 'jabber:client' namespace, a server returns a stream header to the client and MAY announce support for in-band registration by including the relevant stream feature:</p>
+  <p class="caption">Example 18. Advertising registration as a stream feature</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='utf-8'?&gt;
+&lt;stream:stream xmlns:stream='http://etherx.jabber.org/streams/'
+    xmlns='jabber:client'
+    from='somedomain'
+    version='1.0'&gt;
+  &lt;stream:features&gt;
+    ...
+    &lt;register xmlns='http://jabber.org/features/iq-register'/&gt;
+    ...
+  &lt;/stream:features&gt;
+  </pre></div>
+  <p class="" style="">A server SHOULD NOT advertise in-band registration to another server (i.e., if the initial stream header was qualified by the 'jabber:server' namespace).</p>
+<h2>9.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">As defined herein, the 'jabber:iq:register' namespace supports both the old (HTTP-style) error codes and the extensible error classes and conditions specified in XMPP Core. A compliant server or service implementation MUST support both old-style and new-style error handling. A compliant client implementation SHOULD support both. For mappings of HTTP-style errors to XMPP-style conditions, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257768">10</a>].</p>
+<h2>10.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">In-band registration is usually not included in other messaging protocols (for example, SMTP does not include a method for registering with an email server), often for reasons of security. The registration methods defined herein are known to be insecure and SHOULD NOT be used unless the channel between the registrant and the entity that accepts registration has been secured. For these reasons, the deployment of in-band registration is a policy matter and a given domain MAY choose to disable in-band registration and password changes. Furthermore, this JEP should be deprecated as soon as a successor protocol is defined and implemented.</p>
+<h2>11.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257831">11</a>].</p>
+<h2>12.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257921">12</a>] includes the 'jabber:iq:register' namespace in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="registrar-stream">Stream Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the 'http://jabber.org/features/iq-register' namespace in its registry of stream feature namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>12.3 <a name="registrar-formtypes">Field Standardization</a>
+</h3>
+    <p class="" style="">As described in the <a href="#extensibility">Extensibility</a> section above, this proposal includes registration of a FORM_TYPE and associated field types and names for field standardization as defined in JEP-0068. The initial submission is as follows (additional fields may be provided in future submissions):</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;jabber:iq:register&lt;/name&gt;
+  &lt;doc&gt;JEP-0077&lt;/doc&gt;
+  &lt;desc&gt;
+    Standardization of fields related to in-band registration.
+  &lt;/desc&gt;
+  &lt;field
+      var='username'
+      type='text-single'
+      label='Account name associated with the user'/&gt;
+  &lt;field
+      var='nick'
+      type='text-single'
+      label='Familiar name of the user'/&gt;
+  &lt;field
+      var='password'
+      type='text-private'
+      label='Password or secret for the user'/&gt;
+  &lt;field
+      var='name'
+      type='text-single'
+      label='Full name of the user'/&gt;
+  &lt;field
+      var='first'
+      type='text-single'
+      label='First name or given name of the user'/&gt;
+  &lt;field
+      var='last'
+      type='text-single'
+      label='Last name, surname, or family name of the user'/&gt;
+  &lt;field
+      var='email'
+      type='text-single'
+      label='Email address of the user'/&gt;
+  &lt;field
+      var='address'
+      type='text-single'
+      label='Street portion of a physical or mailing address'/&gt;
+  &lt;field
+      var='city'
+      type='text-single'
+      label='Locality portion of a physical or mailing address'/&gt;
+  &lt;field
+      var='state'
+      type='text-single'
+      label='Region portion of a physical or mailing address'/&gt;
+  &lt;field
+      var='zip'
+      type='text-single'
+      label='Postal code portion of a physical or mailing address'/&gt;
+  &lt;field
+      var='phone'
+      type='text-single'
+      label='Telephone number of the user'/&gt;
+  &lt;field
+      var='url'
+      type='text-single'
+      label='URL to web page describing the user'/&gt;
+  &lt;field
+      var='date'
+      type='text-single'
+      label='Some date (e.g., birth date, hire date, sign-up date)'/&gt;
+  &lt;field
+      var='misc'
+      type='text-single'
+      label='Free-form text field (obsolete)'/&gt;
+  &lt;field
+      var='text'
+      type='text-single'
+      label='Free-form text field (obsolete)'/&gt;
+  &lt;field
+      var='key'
+      type='text-single'
+      label='Session key for transaction (obsolete)'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>13.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="schemas-register">jabber:iq:register</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:register'
+    xmlns='jabber:iq:register'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import 
+      namespace='jabber:x:data'
+      schemaLocation='http://jabber.org/protocol/x-data/x-data.xsd'/&gt;
+  &lt;xs:import 
+      namespace='jabber:x:oob'
+      schemaLocation='http://jabber.org/protocol/oob/x-oob.xsd'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0077: http://www.jabber.org/jeps/jep-0077.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence xmlns:xdata='jabber:x:data'
+                   xmlns:xoob='jabber:x:oob'&gt;
+        &lt;xs:choice minOccurs='0'&gt;
+          &lt;xs:sequence minOccurs='0'&gt;
+            &lt;xs:element name='registered' type='empty' minOccurs='0'/&gt;
+            &lt;xs:element name='instructions' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='username' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='nick' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='name' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='first' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='last' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='email' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='address' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='city' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='state' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='zip' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='phone' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='url' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='date' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='misc' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='text' type='xs:string' minOccurs='0'/&gt;
+            &lt;xs:element name='key' type='xs:string' minOccurs='0'/&gt;
+          &lt;/xs:sequence&gt;
+          &lt;xs:element name='remove' type='empty' minOccurs='0'/&gt;
+        &lt;/xs:choice&gt;
+        &lt;xs:element ref='xdata:x' minOccurs='0'/&gt;
+        &lt;xs:element ref='xoob:x' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="schemas-streams">Stream Feature</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/iq-register'
+    xmlns='http://jabber.org/features/iq-register'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0077: http://www.jabber.org/jeps/jep-0077.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='register' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250714">1</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p><a name="nt-id2250740">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250791">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256230">4</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2256249">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256963">6</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2256942">7</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2257005">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2250304">9</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2257768">10</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257831">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257921">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 2.1 (2005-07-14)</h4>
+<div class="indent">Clarified the extensibility rules; removed expiration date; modified schema to document optional inclusion of jabber:x:data and jabber:x:oob information. (psa)
+    </div>
+<h4>Version 2.0 (2004-08-30)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Final; also specified that by server is meant an instant messaging server. (psa)
+    </div>
+<h4>Version 1.6 (2004-08-23)</h4>
+<div class="indent">In order to address Council concerns, clarified precedence order of x:data, iq:register, and x:oob; further specified server handling of initial registration requests from unregistered entities. (psa)
+    </div>
+<h4>Version 1.5 (2004-07-21)</h4>
+<div class="indent">Specified server handling of requests from unregistered entities. (psa)
+    </div>
+<h4>Version 1.4 (2004-05-10)</h4>
+<div class="indent">Removed conformance language regarding servers and services (belongs in a protocol suite specification). (psa)
+    </div>
+<h4>Version 1.3 (2004-02-24)</h4>
+<div class="indent">Added text about redirection to web registration. (psa)
+    </div>
+<h4>Version 1.2 (2003-11-26)</h4>
+<div class="indent">Documented use of &lt;key/&gt; element; added optional stream feature; added XMPP error handling; specified handling of empty passwords. (psa)
+    </div>
+<h4>Version 1.1 (2003-10-02)</h4>
+<div class="indent">Moved change password use case from JEP-0078. (psa)
+    </div>
+<h4>Version 1.0 (2003-06-18)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.9 (2003-06-18)</h4>
+<div class="indent">Changes to address Council concerns. (psa)
+    </div>
+<h4>Version 0.8 (2003-06-13)</h4>
+<div class="indent">Restored the &lt;misc/&gt; and &lt;text/&gt; elements; added the old &lt;key/&gt; element; specified these three elements as obsolete. (psa)
+    </div>
+<h4>Version 0.7 (2003-06-12)</h4>
+<div class="indent">Added &lt;registered/&gt; element; specified FORM_TYPE for x:data form; clarified that support for the extensibility mechanism is optional; removed the &lt;misc/&gt; and &lt;text/&gt; elements (not necessary given extensibility option); added &lt;nick/&gt;, &lt;first/&gt;, and &lt;last/&gt; elements that were traditionally documented as part of jabber:iq:register. (psa)
+    </div>
+<h4>Version 0.6 (2003-06-06)</h4>
+<div class="indent">Removed XMPP-style error conditions until formats are stable. (psa)
+    </div>
+<h4>Version 0.5 (2003-05-30)</h4>
+<div class="indent">Removed "encrypted secret" content, added information about expiration date. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-28)</h4>
+<div class="indent">Added "encrypted secret" content. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.2 (2003-04-29)</h4>
+<div class="indent">Fixed schema, made minor editorial changes. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-06)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0078-1.7.html
+++ b/content/xep-0078-1.7.html
@@ -1,0 +1,418 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0078: Non-SASL Authentication</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Non-SASL Authentication">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP documents a protocol for authentication with Jabber servers and services using the 'jabber:iq:auth' namespace.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-07-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0078">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0078: Non-SASL Authentication</h1>
+<p>This JEP documents a protocol for authentication with Jabber servers and services using the 'jabber:iq:auth' namespace.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0078<br>
+            Version: 1.7<br>
+            Last Updated: 2004-07-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: iq-auth<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/iq-auth/iq-auth.xsd">http://jabber.org/protocol/iq-auth/iq-auth.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl><dt>3.1.  <a href="#usecases-auth">User Authenticates with Server</a>
+</dt></dl>
+<dt>4.  <a href="#streamfeature">Stream Feature</a>
+</dt>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#expiration">Expiration Date</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#schemas-auth">jabber:iq:auth</a>
+</dt>
+<dt>10.2.  <a href="#schemas-stream">Stream Feature</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method that enables a client to authenticate with a server (component authentication is specified in <span class="ref">Jabber Component Protocol</span>  [<a href="#nt-id2596294">1</a>]). This method makes use of the 'jabber:iq:auth' namespace and has been documented variously in Internet-Drafts and elsewhere. Because the XMPP Internet-Drafts required upgraded authentication methods using SASL, documentation of the 'jabber:iq:auth' namespace for authentication was removed from the XMPP specifications (<span class="ref">XMPP Core</span>  [<a href="#nt-id2596316">2</a>] and <span class="ref">XMPP IM</span>  [<a href="#nt-id2601872">3</a>]). Unfortunately, SASL libraries are not available (and are unlikely to be available soon if ever) for all platforms on which Jabber clients may be written (this is especially true of platforms with small footprints, such as J2ME). While use of old-style authentication is unacceptable for the IETF's XMPP WG, there is value in allowing its use on the Jabber network as a fallback method for authentication between client and server if SASL is not supported by one party.</p>
+  <p class="" style="">Note well that this JEP defines a standard component of the <span class="ref">Basic IM Protocol Suite</span>  [<a href="#nt-id2596309">4</a>]. Thus, despite its perceived limitations, the 'jabber:iq:auth' namespace is not informational. If more secure authentication is required or desired, implementations SHOULD use the SASL authentication protocol defined in <span style="font-weight: bold">XMPP Core</span>.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The 'jabber:iq:auth' namespace must make it possible for a Jabber client to authenticate with a server. In particular, the client must provide a username and appropriate credentials for the specific authentication method used. The methods defined herein are:</p>
+  <ol start="" type="">
+    <li>plaintext</li>
+    <li>digest</li>
+  </ol>
+  <p class="" style="">Note that this JEP does not include the so-called &quot;zero-knowledge&quot; method; this method did not provide stronger security than digest authentication and thus is unnecessary. As noted, those desiring stronger security SHOULD use SASL authentication as defined in XMPP Core.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="usecases-auth">User Authenticates with Server</a>
+</h3>
+    <p class="" style="">In order to determine which fields are required for authentication with a server, a client SHOULD first send an IQ get to the server. A client SHOULD NOT attempt to guess at the required fields, since the nature of the required data is subject to service provisioning.</p>
+    <p class="caption">Example 1. Client Opens Stream to Server</p>
+<div class="indent"><pre>
+&lt;stream:stream to='shakespeare.lit'
+               xmlns='jabber:client'
+               xmlns:stream='http://etherx.jabber.org/streams'&gt;
+    </pre></div>
+    <p class="caption">Example 2. Server Opens Streams to Client</p>
+<div class="indent"><pre>
+&lt;stream:stream from='shakespeare.lit'
+               xmlns='jabber:client'
+               xmlns:stream='http://etherx.jabber.org/streams'
+               id='3EE948B0'&gt;
+    </pre></div>
+    <p class="caption">Example 3. Client Requests Authentication Fields from Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='shakespeare.lit' id='auth1'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Server Returns Authentication Fields to Client</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='auth1'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+    &lt;digest/&gt;
+    &lt;resource/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there is no such username, the server SHOULD NOT return an error, but instead SHOULD return the normal authentication fields (this helps to prevent unknown users from discovering which usernames are in use). If the server does not support non-SASL authentication (e.g., because it supports only SASL authentication as defined in <span style="font-weight: bold">XMPP Core</span>, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="" style="">Both the username and the resource are REQUIRED for client authentication using the 'jabber:iq:auth' namespace; if more flexible authentication and resource provisioning are desired, a server SHOULD implement SASL authentication and resource binding as defined in <span style="font-weight: bold">XMPP Core</span> (e.g., to enable the server to provide the resource). The &lt;username/&gt; and &lt;resource/&gt; elements MUST be included in the IQ result returned by the server in response to the initial IQ get, and also MUST be included in the IQ set sent by the client when providing authentication credentials.</p>
+    <p class="" style="">The foregoing stanza shows that the server supports both plaintext authentication (via the &lt;password/&gt; element) and digest authentication with SHA1-encrypted passwords (via the &lt;digest/&gt; element).</p>
+    <p class="" style="">Therefore, in order to successfully authenticate with the server in this example, a client MUST provide a username, a resource, and one of password or digest.</p>
+    <p class="caption">Example 5. Client Provides Required Information (Plaintext)</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auth2'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;Calli0pe&lt;/password&gt;
+    &lt;resource&gt;globe&lt;/resource&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Plaintext passwords are straightforward (obviously, characters that map to predefined XML entities MUST be escaped according to the rules defined in section 4.6 of the XML specification, and any non-US-ASCII characters MUST be encoded according to the encoding of XML streams as specified in <span style="font-weight: bold">XMPP Core</span>, i.e., UTF-8 as defined in <span class="ref">RFC 3269</span>  [<a href="#nt-id2602189">5</a>]).</p>
+    <p class="" style="">The value of the &lt;digest/&gt; element MUST be computed according to the following algorithm:</p>
+    <ol start="" type="">
+      <li>Concatenate the Stream ID received from the server with the password.  [<a href="#nt-id2602114">6</a>]</li>
+      <li>Hash the concatenated string according to the SHA1 algorithm, i.e., SHA1( concat (sid, password)).</li>
+      <li>Ensure that the hash output is in hexidecimal format, not binary or base64.</li>
+      <li>Convert the hash output to all lowercase characters.</li>
+    </ol>
+    <p class="caption">Example 6. Client Provides Required Information (Digest)</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auth2'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;digest&gt;48fc78be9ec8f86d8ce1c39c320c97c21d62334d&lt;/digest&gt;
+    &lt;resource&gt;globe&lt;/resource&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The CDATA shown in the &lt;digest/&gt; element is the output produced as a result of following the algorithm defined above when the stream ID is '3EE948B0' and the password is 'Calli0pe'.</p>
+    <p class="" style="">If the credentials provided match those known by the server, the client will be successfully authenticated.</p>
+    <p class="caption">Example 7. Server Informs Client of Successful Authentication</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='auth2'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, authentication may fail. Possible causes of failure include:</p>
+    <ol start="" type="">
+      <li>the user provided incorrect credentials</li>
+      <li>there is a resource conflict (there is already an active session with that resource identifier associated with the same username); note that the RECOMMENDED behavior is for the server to terminate the existing session and create the new one, but that the server MAY provide the opposite behavior if desired, leading to a conflict error for the newly requested login</li>
+      <li>the user did not provide all of the required information (e.g., did not provide a username or resource)</li>
+    </ol>
+    <p class="" style="">Although XMPP Core specifies that error stanzas SHOULD include the original XML sent, error stanzas qualified by the 'jabber:iq:auth' namespace SHOULD NOT do so given the sensitive nature of the information being exchanged.</p>
+    <p class="caption">Example 8. Server Informs Client of Failed Authentication (Incorrect Credentials)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 9. Server Informs Client of Failed Authentication (Resource Conflict)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 10. Server Informs Client of Failed Authentication (Required Information Not Provided)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="streamfeature">Stream Feature</a>
+</h2>
+  <p class="" style="">
+<span class="ref">XMPP Core</span>  [<a href="#nt-id2602320">7</a>] defines methods for advertising feature support during stream negotiation. It may be desirable for a server to advertise support for non-SASL authentication as a stream feature. The namespace for reporting support within &lt;stream:features/&gt; is &quot;http://jabber.org/features/iq-auth&quot;. Upon receiving a stream header qualified by the 'jabber:client' namespace, a server that returns stream features MUST also announce support for non-SASL authentication by including the relevant stream feature whenever it also sends SASL authentication features that are safe over TLS or SSL (e.g., SASL PLAIN). Obviously, this does not apply to servers that do not support stream features (e.g., older, non-XMPP servers).</p>
+  <p class="caption">Example 11. Advertising non-SASL authentication as a stream feature</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='utf-8'?&gt;
+&lt;stream:stream xmlns:stream='http://etherx.jabber.org/streams/'
+    xmlns='jabber:client'
+    from='somedomain'
+    version='1.0'&gt;
+  &lt;stream:features&gt;
+    ...
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;auth xmlns='http://jabber.org/features/iq-auth'/&gt;
+    ...
+  &lt;/stream:features&gt;
+  </pre></div>
+  <p class="" style="">A server SHOULD NOT advertise non-SASL authentication to another server (i.e., if the initial stream header was qualified by the 'jabber:server' namespace).</p>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">As defined herein, the 'jabber:iq:auth' namespace supports both the old (HTTP-style) error codes and the extensible error classes and conditions specified in XMPP Core. A compliant server or service implementation MUST support both old-style and new-style error handling. A compliant client implementation SHOULD support both.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Use of the 'jabber:iq:auth' namespace for client-server authentication is not as secure as SASL authentication (defined in XMPP Core). If both client and server implement SASL, they SHOULD use SASL. If a client attempts to authenticate using the 'jabber:iq:auth' namespace after an attempt at SASL authentication fails, the server MUST refuse the 'jabber:iq:auth' attempt by returning a &lt;policy-violation/&gt; stream error to the client.</p>
+  <p class="" style="">Client implementations MUST NOT make plaintext the default mechanism, and SHOULD warn the user that the plaintext mechanism is insecure. The plaintext mechanism SHOULD NOT be used unless the underlying stream is encrypted (using SSL or TLS) and the client has verified that the server certificate is signed by a trusted certificate authority. A given domain MAY choose to disable plaintext logins if the stream is not properly encrypted, or disable them entirely. If a client implements the plaintext mechanism and a server allows both the digest mechanism and the plaintext mechanism, an upgrade attack is possible, in which a man-in-the-middle tricks the client into revealing the user's plaintext password.</p>
+  <p class="" style="">Authentication using the 'jabber:iq:auth' namespace is known to be less secure than SASL authentication, and this JEP should be fully deprecated as soon as SASL authentication is implemented widely enough.</p>
+  <p class="" style="">A server MUST NOT advertise the 'jabber:iq:auth' stream feature unless the server deems it safe to also advertise SASL mechanisms that are safe to use over TLS or SSL (e.g., SASL PLAIN); this helps to prevent a downgrade attack against non-SASL authentication by a man in the middle.</p>
+<h2>7.
+       <a name="expiration">Expiration Date</a>
+</h2>
+  <p class="" style="">In accordance with Section 8 of <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2602627">8</a>], this JEP shall expire six months from the date of its advancement to a status of Final. The Jabber Council shall review this JEP before its expiration date, and at that time shall determine whether to change its status to Deprecated or to extend the expiration date for an additional six months. This process will continue until the JEP is deprecated.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602578">9</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602732">10</a>] includes the 'jabber:iq:auth' namespace in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="registrar-stream">Stream Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the 'http://jabber.org/features/iq-auth' namespace in its registry of stream feature namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="schemas-auth">jabber:iq:auth</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:auth'
+    xmlns='jabber:iq:auth'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0078: http://www.jabber.org/jeps/jep-0078.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:element name='username' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:choice&gt;
+          &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='digest' type='xs:string' minOccurs='0'/&gt;
+        &lt;/xs:choice&gt;
+        &lt;xs:element name='resource' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="schemas-stream">Stream Feature</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/iq-auth'
+    xmlns='http://jabber.org/features/iq-auth'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0078: http://www.jabber.org/jeps/jep-0078.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='auth' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596294">1</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596316">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601872">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596309">4</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602189">5</a>. RFC 3269: UTF-8, a transformation format of ISO 10646 &lt;<a href="http://www.ietf.org/rfc/rfc3269.txt">http://www.ietf.org/rfc/rfc3269.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602114">6</a>. In Digest authentication, password characters that map to predefined XML entities SHOULD NOT be escaped as they are for plaintext passwords, but non-US-ASCII characters MUST be encoded as UTF-8 since the SHA-1 hashing algorithm operates on byte arrays.</p>
+<p>
+<a name="nt-id2602320">7</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602627">8</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602578">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602732">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.7 (2004-07-27)</h4>
+<div class="indent">Added reference to character escaping in digest authentication; required inclusion of stream feature when server supports stream features and it is safe to advertise non-SASL authentication. (psa)
+    </div>
+<h4>Version 1.6 (2004-07-21)</h4>
+<div class="indent">Removed reference to UTF-16, which is disallowed by XMPP Core; removed reference to character escaping in digest authentication pending list discussion. (psa)
+    </div>
+<h4>Version 1.5 (2004-02-18)</h4>
+<div class="indent">Added optional stream feature. (psa)
+    </div>
+<h4>Version 1.4 (2004-02-03)</h4>
+<div class="indent">Clarified that username and resource are required for authentication. (psa)
+    </div>
+<h4>Version 1.3 (2003-11-26)</h4>
+<div class="indent">Added XMPP error handling. (psa)
+    </div>
+<h4>Version 1.2 (2003-11-06)</h4>
+<div class="indent">Addressed case of attempting jabber:iq:auth after SASL failure. (psa)
+    </div>
+<h4>Version 1.1 (2003-10-02)</h4>
+<div class="indent">Moved change password use case to JEP-0077. (psa)
+    </div>
+<h4>Version 1.0 (2003-06-18)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.8 (2003-06-18)</h4>
+<div class="indent">Changes to address Council concerns. (psa)
+    </div>
+<h4>Version 0.7 (2003-06-13)</h4>
+<div class="indent">Added change password use case; added more details to security considerations. (psa)
+    </div>
+<h4>Version 0.6 (2003-06-12)</h4>
+<div class="indent">Added digest example; clarified escaping requirements; further specified error conditions; added more details to security considerations. (psa)
+    </div>
+<h4>Version 0.5 (2003-06-06)</h4>
+<div class="indent">Removed XMPP-style error conditions until formats are stable. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-30)</h4>
+<div class="indent">Removed &quot;enhanced digest&quot; content, added information about expiration date. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-28)</h4>
+<div class="indent">Added &quot;enhanced digest&quot; method. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-10)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0078-1.8.html
+++ b/content/xep-0078-1.8.html
@@ -1,0 +1,424 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0078: Non-SASL Authentication</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Non-SASL Authentication">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP documents a protocol for authentication with Jabber servers and services using the jabber:iq:auth namespace.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0078">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0078: Non-SASL Authentication</h1>
+<p>This JEP documents a protocol for authentication with Jabber servers and services using the jabber:iq:auth namespace.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0078<br>
+            Version: 1.8<br>
+            Last Updated: 2004-10-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 3174<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: iq-auth<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/iq-auth/iq-auth.xsd">http://jabber.org/protocol/iq-auth/iq-auth.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl><dt>3.1.  <a href="#usecases-auth">User Authenticates with Server</a>
+</dt></dl>
+<dt>4.  <a href="#streamfeature">Stream Feature</a>
+</dt>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#expiration">Expiration Date</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#schemas-auth">jabber:iq:auth</a>
+</dt>
+<dt>10.2.  <a href="#schemas-stream">Stream Feature</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Jabber technologies have long included a wire protocol that enables a client to authenticate with a server.  [<a href="#nt-id2596384">1</a>] This method makes use of the 'jabber:iq:auth' namespace and has been documented variously in Internet-Drafts and elsewhere. Because the XMPP specifications required upgraded authentication methods using SASL in order to progress through the Internet Standards Process, documentation of the 'jabber:iq:auth' namespace was removed from the XMPP specifications (<span class="ref">XMPP Core</span>  [<a href="#nt-id2601885">3</a>] and <span class="ref">XMPP IM</span>  [<a href="#nt-id2601906">4</a>]).</p>
+  <p class="" style="">Unfortunately, SASL libraries are not available (and are unlikely to be available soon, if ever) for all platforms on which Jabber clients may be written (this is especially true of platforms with small footprints, such as J2ME, Symbian, and the like). Furthermore, it will take some time for existing server implementations and deployments to be upgraded to use of SASL as specified in <span style="font-weight: bold">XMPP Core</span>. Therefore, while use of old-style authentication is discouraged and will eventually be deprecated, there is value in allowing its use on the Jabber network as a fallback method for authentication between client and server if SASL is not supported by one party.</p>
+  <p class="" style="">Note well that this JEP defines a standard component of the <span class="ref">Basic IM Protocol Suite</span>  [<a href="#nt-id2602059">5</a>]. Thus, despite its perceived limitations, the 'jabber:iq:auth' namespace is not informational. If more secure authentication is required or desired, implementations SHOULD use the SASL authentication protocol defined in <span style="font-weight: bold">XMPP Core</span>.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The 'jabber:iq:auth' namespace must make it possible for a Jabber client to authenticate with a server. In particular, the client must provide a username and appropriate credentials for the specific authentication method used. The methods defined herein are:</p>
+  <ol start="" type="">
+    <li>plaintext</li>
+    <li>digest (using the SHA1 algorithm specified in <span class="ref">RFC 3174</span>  [<a href="#nt-id2602031">6</a>])</li>
+  </ol>
+  <p class="" style="">Note: This JEP does not include the so-called &quot;zero-knowledge&quot; method; that method did not provide stronger security than digest authentication and thus is unnecessary. As noted, those desiring stronger security SHOULD use SASL authentication as defined in <span style="font-weight: bold">XMPP Core</span>.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="usecases-auth">User Authenticates with Server</a>
+</h3>
+    <p class="" style="">In order to determine which fields are required for authentication with a server, a client SHOULD first send an IQ get to the server. A client SHOULD NOT attempt to guess at the required fields, since the nature of the required data is subject to service provisioning.</p>
+    <p class="caption">Example 1. Client Opens Stream to Server</p>
+<div class="indent"><pre>
+&lt;stream:stream to='shakespeare.lit'
+               xmlns='jabber:client'
+               xmlns:stream='http://etherx.jabber.org/streams'&gt;
+    </pre></div>
+    <p class="caption">Example 2. Server Opens Streams to Client</p>
+<div class="indent"><pre>
+&lt;stream:stream from='shakespeare.lit'
+               xmlns='jabber:client'
+               xmlns:stream='http://etherx.jabber.org/streams'
+               id='3EE948B0'&gt;
+    </pre></div>
+    <p class="caption">Example 3. Client Requests Authentication Fields from Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='shakespeare.lit' id='auth1'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Server Returns Authentication Fields to Client</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='auth1'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+    &lt;digest/&gt;
+    &lt;resource/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If there is no such username, the server SHOULD NOT return an error, but instead SHOULD return the normal authentication fields (this helps to prevent unknown users from discovering which usernames are in use). If the server does not support non-SASL authentication (e.g., because it supports only SASL authentication as defined in <span style="font-weight: bold">XMPP Core</span>), it MUST return a &lt;service-unavailable/&gt; error. If the client previously attempted SASL authentication but that attempt failed, the server MUST return a &lt;policy-violation/&gt; stream error (see <span style="font-weight: bold">XMPP Core</span> regarding stream error syntax).</p>
+    <p class="" style="">Both the username and the resource are REQUIRED for client authentication using the 'jabber:iq:auth' namespace; if more flexible authentication and resource provisioning are desired, a server SHOULD implement SASL authentication and resource binding as defined in <span style="font-weight: bold">XMPP Core</span> (e.g., to enable the server to provide the resource). The &lt;username/&gt; and &lt;resource/&gt; elements MUST be included in the IQ result returned by the server in response to the initial IQ get, and also MUST be included in the IQ set sent by the client when providing authentication credentials.</p>
+    <p class="" style="">The foregoing stanza shows that the server supports both plaintext authentication (via the &lt;password/&gt; element) and digest authentication with SHA1-encrypted passwords (via the &lt;digest/&gt; element).</p>
+    <p class="" style="">Therefore, in order to successfully authenticate with the server in this example, a client MUST provide a username, a resource, and one of password or digest.</p>
+    <p class="caption">Example 5. Client Provides Required Information (Plaintext)</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auth2'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;Calli0pe&lt;/password&gt;
+    &lt;resource&gt;globe&lt;/resource&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Plaintext passwords are straightforward (obviously, characters that map to predefined XML entities MUST be escaped according to the rules defined in section 4.6 of the XML specification, and any non-US-ASCII characters MUST be encoded according to the encoding of XML streams as specified in <span style="font-weight: bold">XMPP Core</span>, i.e., UTF-8 as defined in <span class="ref">RFC 3269</span>  [<a href="#nt-id2602364">7</a>]).</p>
+    <p class="" style="">The value of the &lt;digest/&gt; element MUST be computed according to the following algorithm:</p>
+    <ol start="" type="">
+      <li>Concatenate the Stream ID received from the server with the password.  [<a href="#nt-id2602293">8</a>]</li>
+      <li>Hash the concatenated string according to the SHA1 algorithm, i.e., SHA1(concat(sid, password)).</li>
+      <li>Ensure that the hash output is in hexidecimal format, not binary or base64.</li>
+      <li>Convert the hash output to all lowercase characters.</li>
+    </ol>
+    <p class="caption">Example 6. Client Provides Required Information (Digest)</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auth2'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;digest&gt;48fc78be9ec8f86d8ce1c39c320c97c21d62334d&lt;/digest&gt;
+    &lt;resource&gt;globe&lt;/resource&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The character data shown in the &lt;digest/&gt; element is the output produced as a result of following the algorithm defined above when the stream ID is '3EE948B0' and the password is 'Calli0pe'.</p>
+    <p class="" style="">If the credentials provided match those known by the server, the client will be successfully authenticated.</p>
+    <p class="caption">Example 7. Server Informs Client of Successful Authentication</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='auth2'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, authentication may fail. Possible causes of failure include:</p>
+    <ol start="" type="">
+      <li>The user provided incorrect credentials.</li>
+      <li>There is a resource conflict (i.e., there is already an active session with that resource identifier associated with the same username). The RECOMMENDED behavior is for the server to terminate the existing session and create the new one; however, the server MAY provide the opposite behavior if desired, leading to a conflict error for the newly requested login.</li>
+      <li>The user did not provide all of the required information (e.g., did not provide a username or resource).</li>
+    </ol>
+    <p class="" style="">Although <span style="font-weight: bold">XMPP Core</span> specifies that error stanzas SHOULD include the original XML sent, error stanzas qualified by the 'jabber:iq:auth' namespace SHOULD NOT do so given the sensitive nature of the information being exchanged.</p>
+    <p class="caption">Example 8. Server Informs Client of Failed Authentication (Incorrect Credentials)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 9. Server Informs Client of Failed Authentication (Resource Conflict)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 10. Server Informs Client of Failed Authentication (Required Information Not Provided)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="streamfeature">Stream Feature</a>
+</h2>
+  <p class="" style="">
+<span style="font-weight: bold">XMPP Core</span> defines methods for advertising feature support during stream negotiation. It may be desirable for a server to advertise support for non-SASL authentication as a stream feature. The namespace for reporting support within &lt;stream:features/&gt; is &quot;http://jabber.org/features/iq-auth&quot;. Upon receiving a stream header qualified by the 'jabber:client' namespace, a server that returns stream features SHOULD also announce support for non-SASL authentication by including the relevant stream feature. Exactly when a server advertises the iq-auth stream feature is up to the implementation or deployment (e.g., a server MAY advertise this feature only after successful TLS negotiation or if the channel is encrypted via the older SSL method). Obviously, this does not apply to servers that do not support stream features (e.g., older servers that do not comply with XMPP 1.0).</p>
+  <p class="caption">Example 11. Advertising non-SASL authentication as a stream feature</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='utf-8'?&gt;
+&lt;stream:stream xmlns:stream='http://etherx.jabber.org/streams/'
+    xmlns='jabber:client'
+    from='somedomain'
+    version='1.0'&gt;
+  &lt;stream:features&gt;
+    ...
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;auth xmlns='http://jabber.org/features/iq-auth'/&gt;
+    ...
+  &lt;/stream:features&gt;
+  </pre></div>
+  <p class="" style="">A server SHOULD NOT advertise non-SASL authentication to another server (i.e., if the initial stream header was qualified by the 'jabber:server' namespace).</p>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">As defined herein, the 'jabber:iq:auth' namespace supports both the old (HTTP-style) error codes and the extensible error classes and conditions specified in <span style="font-weight: bold">XMPP Core</span>. A compliant server or service implementation MUST support both old-style and new-style error handling. A compliant client implementation SHOULD support both.</p>
+<h2>6.
+       <a name="expiration">Expiration Date</a>
+</h2>
+  <p class="" style="">In accordance with Section 8 of <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2602717">9</a>], this JEP shall expire six months from the date of its advancement to a status of Final. The Jabber Council shall review this JEP before its expiration date, and at that time shall determine whether to change its status to Deprecated or to extend the expiration date for an additional six months. This process will continue until the JEP is deprecated.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Use of the 'jabber:iq:auth' namespace for client-server authentication is not as secure as SASL authentication (defined in <span style="font-weight: bold">XMPP Core</span>). If both client and server implement SASL, they SHOULD use SASL. If a client attempts to authenticate using the 'jabber:iq:auth' namespace after an attempt at SASL authentication fails, the server MUST refuse the 'jabber:iq:auth' attempt by returning a &lt;policy-violation/&gt; stream error to the client.</p>
+  <p class="" style="">Client implementations MUST NOT make plaintext the default mechanism, and SHOULD warn the user that the plaintext mechanism is insecure. The plaintext mechanism SHOULD NOT be used unless the underlying stream is encrypted (using SSL or TLS) and the client has verified that the server certificate is signed by a trusted certificate authority. A given domain MAY choose to disable plaintext logins if the stream is not properly encrypted, or disable them entirely. If a client implements the plaintext mechanism and a server allows both the digest mechanism and the plaintext mechanism, an upgrade attack is possible, in which a man-in-the-middle tricks the client into revealing the user's plaintext password.</p>
+  <p class="" style="">Authentication using the 'jabber:iq:auth' namespace is known to be less secure than SASL authentication, and this JEP shall be fully deprecated as soon as SASL authentication is implemented widely enough.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602844">10</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602792">11</a>] includes the 'jabber:iq:auth' namespace in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="registrar-stream">Stream Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the 'http://jabber.org/features/iq-auth' namespace in its registry of stream feature namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="schemas-auth">jabber:iq:auth</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:auth'
+    xmlns='jabber:iq:auth'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0078: http://www.jabber.org/jeps/jep-0078.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:element name='username' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:choice&gt;
+          &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='digest' type='xs:string' minOccurs='0'/&gt;
+        &lt;/xs:choice&gt;
+        &lt;xs:element name='resource' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="schemas-stream">Stream Feature</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/iq-auth'
+    xmlns='http://jabber.org/features/iq-auth'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0078: http://www.jabber.org/jeps/jep-0078.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='auth' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596384">1</a>. Component authentication is out of scope for this JEP, and is specified separately in <span class="ref">Jabber Component Protocol</span>  [<a href="#nt-id2601952">2</a>].</p>
+<p>
+<a name="nt-id2601952">2</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601885">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601906">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602059">5</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602031">6</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602364">7</a>. RFC 3269: UTF-8, a transformation format of ISO 10646 &lt;<a href="http://www.ietf.org/rfc/rfc3269.txt">http://www.ietf.org/rfc/rfc3269.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602293">8</a>. In Digest authentication, password characters that map to predefined XML entities SHOULD NOT be escaped as they are for plaintext passwords, but non-US-ASCII characters MUST be encoded as UTF-8 since the SHA-1 hashing algorithm operates on byte arrays.</p>
+<p>
+<a name="nt-id2602717">9</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602844">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602792">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.8 (2004-10-18)</h4>
+<div class="indent">Specified advertising iq-auth stream feature is implementation-specific; clarified several small matters in the text. (psa)
+    </div>
+<h4>Version 1.7 (2004-07-27)</h4>
+<div class="indent">Added reference to character escaping in digest authentication; required inclusion of stream feature when server supports stream features and it is safe to advertise non-SASL authentication. (psa)
+    </div>
+<h4>Version 1.6 (2004-07-21)</h4>
+<div class="indent">Removed reference to UTF-16, which is disallowed by XMPP Core; removed reference to character escaping in digest authentication pending list discussion. (psa)
+    </div>
+<h4>Version 1.5 (2004-02-18)</h4>
+<div class="indent">Added optional stream feature. (psa)
+    </div>
+<h4>Version 1.4 (2004-02-03)</h4>
+<div class="indent">Clarified that username and resource are required for authentication. (psa)
+    </div>
+<h4>Version 1.3 (2003-11-26)</h4>
+<div class="indent">Added XMPP error handling. (psa)
+    </div>
+<h4>Version 1.2 (2003-11-06)</h4>
+<div class="indent">Addressed case of attempting jabber:iq:auth after SASL failure. (psa)
+    </div>
+<h4>Version 1.1 (2003-10-02)</h4>
+<div class="indent">Moved change password use case to JEP-0077. (psa)
+    </div>
+<h4>Version 1.0 (2003-06-18)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.8 (2003-06-18)</h4>
+<div class="indent">Changes to address Council concerns. (psa)
+    </div>
+<h4>Version 0.7 (2003-06-13)</h4>
+<div class="indent">Added change password use case; added more details to security considerations. (psa)
+    </div>
+<h4>Version 0.6 (2003-06-12)</h4>
+<div class="indent">Added digest example; clarified escaping requirements; further specified error conditions; added more details to security considerations. (psa)
+    </div>
+<h4>Version 0.5 (2003-06-06)</h4>
+<div class="indent">Removed XMPP-style error conditions until formats are stable. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-30)</h4>
+<div class="indent">Removed &quot;enhanced digest&quot; content, added information about expiration date. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-28)</h4>
+<div class="indent">Added &quot;enhanced digest&quot; method. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-10)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0078-2.2.html
+++ b/content/xep-0078-2.2.html
@@ -1,0 +1,430 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0078: Non-SASL Authentication</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Non-SASL Authentication">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP documents a protocol for authentication with Jabber servers and services using the jabber:iq:auth namespace.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0078">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0078: Non-SASL Authentication</h1>
+<p>This JEP documents a protocol for authentication with Jabber servers and services using the jabber:iq:auth namespace.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Final Standard of the Jabber Software Foundation and may be considered a stable technology for implementation and deployment.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Final">Final</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0078<br>
+            Version: 2.2<br>
+            Last Updated: 2005-06-28<br>
+              Expires: 2006-09-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, RFC 3174<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: iq-auth<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/iq-auth/iq-auth.xsd">http://jabber.org/protocol/iq-auth/iq-auth.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Non-SASL%20Authentication%20(JEP-0078)">http://wiki.jabber.org/index.php/Non-SASL Authentication (JEP-0078)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl><dt>3.1.  <a href="#usecases-auth">User Authenticates with Server</a>
+</dt></dl>
+<dt>4.  <a href="#streamfeature">Stream Feature</a>
+</dt>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#expiration">Expiration Date</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#schemas-auth">jabber:iq:auth</a>
+</dt>
+<dt>10.2.  <a href="#schemas-stream">Stream Feature</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Jabber technologies have long included a wire protocol that enables a client to authenticate with a server.  [<a href="#nt-id2250949">1</a>] This method makes use of the 'jabber:iq:auth' namespace and has been documented variously in Internet-Drafts and elsewhere. Because the XMPP specifications required upgraded authentication methods using SASL (see <span class="ref" style="">RFC 4422</span>  [<a href="#nt-id2250996">3</a>]) in order to progress through the Internet Standards Process, documentation of the 'jabber:iq:auth' namespace was removed from the XMPP specifications (<span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251022">4</a>] and <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2259604">5</a>]).</p>
+  <p class="" style="">Unfortunately, SASL libraries are not available (and are unlikely to be available soon, if ever) for all platforms on which Jabber clients may be written (this is especially true of platforms with small footprints, such as J2ME, Symbian, and the like). Furthermore, it will take some time for existing server implementations and deployments to be upgraded to use of SASL as specified in <span style="font-weight: bold">RFC 3920</span>. Therefore, while use of old-style authentication is discouraged and will eventually be deprecated, there is value in allowing its use on the Jabber network as a fallback method for authentication between client and server if SASL is not supported by one party.</p>
+  <p class="" style="">Note well that this JEP defines a standard component of the <span class="ref" style="">Basic IM Protocol Suite</span>  [<a href="#nt-id2259654">6</a>]. Thus, despite its perceived limitations, the 'jabber:iq:auth' namespace is not informational.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The 'jabber:iq:auth' namespace must make it possible for a Jabber client to authenticate with a server. In particular, the client must provide a username and appropriate credentials for the specific authentication method used. The methods defined herein are:</p>
+  <ol start="" type="">
+    <li>plaintext</li>
+    <li>digest (using the SHA1 algorithm specified in <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2259709">7</a>])</li>
+  </ol>
+  <p class="" style="">Note: This JEP does not include the so-called "zero-knowledge" method; that method did not provide stronger security than digest authentication and thus is unnecessary.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="usecases-auth">User Authenticates with Server</a>
+</h3>
+    <p class="" style="">In order to determine which fields are required for authentication with a server, a client SHOULD first send an IQ get to the server. A client SHOULD NOT attempt to guess at the required fields, since the nature of the required data is subject to service provisioning.</p>
+    <p class="caption">Example 1. Client Opens Stream to Server</p>
+<div class="indent"><pre>
+&lt;stream:stream to='shakespeare.lit'
+               xmlns='jabber:client'
+               xmlns:stream='http://etherx.jabber.org/streams'&gt;
+    </pre></div>
+    <p class="caption">Example 2. Server Opens Streams to Client</p>
+<div class="indent"><pre>
+&lt;stream:stream from='shakespeare.lit'
+               xmlns='jabber:client'
+               xmlns:stream='http://etherx.jabber.org/streams'
+               id='3EE948B0'&gt;
+    </pre></div>
+    <p class="caption">Example 3. Client Requests Authentication Fields from Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='shakespeare.lit' id='auth1'&gt;
+  &lt;query xmlns='jabber:iq:auth'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Server Returns Authentication Fields to Client</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='auth1'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+    &lt;digest/&gt;
+    &lt;resource/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the client included a username with the IQ-get but there is no such username, the server SHOULD NOT return an error, but instead SHOULD return the normal authentication fields (this helps to prevent unknown users from discovering which usernames are in use). If the server does not support non-SASL authentication (e.g., because it supports only SASL authentication as defined in <span style="font-weight: bold">RFC 3920</span>), it MUST return a &lt;service-unavailable/&gt; error. If the client previously attempted SASL authentication but that attempt failed, the server MUST return a &lt;policy-violation/&gt; stream error (see <span style="font-weight: bold">RFC 3920</span> regarding stream error syntax).</p>
+    <p class="" style="">Both the username and the resource are REQUIRED for client authentication using the 'jabber:iq:auth' namespace; if more flexible authentication and resource provisioning are desired, a server SHOULD implement SASL authentication and resource binding as defined in <span style="font-weight: bold">RFC 3920</span> (e.g., to enable the server to provide the resource). The &lt;username/&gt; and &lt;resource/&gt; elements MUST be included in the IQ result returned by the server in response to the initial IQ get, and also MUST be included in the IQ set sent by the client when providing authentication credentials.</p>
+    <p class="" style="">The foregoing stanza shows that the server supports both plaintext authentication (via the &lt;password/&gt; element) and digest authentication with SHA1-encrypted passwords (via the &lt;digest/&gt; element).</p>
+    <p class="" style="">Therefore, in order to successfully authenticate with the server in this example, a client MUST provide a username, a resource, and one of password or digest.</p>
+    <p class="caption">Example 5. Client Provides Required Information (Plaintext)</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auth2'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;password&gt;Calli0pe&lt;/password&gt;
+    &lt;resource&gt;globe&lt;/resource&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Plaintext passwords are straightforward (obviously, characters that map to predefined XML entities MUST be escaped according to the rules defined in section 4.6 of the XML specification, and any non-US-ASCII characters MUST be encoded according to the encoding of XML streams as specified in <span style="font-weight: bold">RFC 3920</span>, i.e., UTF-8 as defined in <span class="ref" style="">RFC 3269</span>  [<a href="#nt-id2259909">8</a>]).</p>
+    <p class="" style="">The value of the &lt;digest/&gt; element MUST be computed according to the following algorithm:</p>
+    <ol start="" type="">
+      <li>Concatenate the Stream ID received from the server with the password.  [<a href="#nt-id2259932">9</a>]</li>
+      <li>Hash the concatenated string according to the SHA1 algorithm, i.e., SHA1(concat(sid, password)).</li>
+      <li>Ensure that the hash output is in hexidecimal format, not binary or base64.</li>
+      <li>Convert the hash output to all lowercase characters.</li>
+    </ol>
+    <p class="caption">Example 6. Client Provides Required Information (Digest)</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auth2'&gt;
+  &lt;query xmlns='jabber:iq:auth'&gt;
+    &lt;username&gt;bill&lt;/username&gt;
+    &lt;digest&gt;48fc78be9ec8f86d8ce1c39c320c97c21d62334d&lt;/digest&gt;
+    &lt;resource&gt;globe&lt;/resource&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The character data shown in the &lt;digest/&gt; element is the output produced as a result of following the algorithm defined above when the stream ID is '3EE948B0' and the password is 'Calli0pe'.</p>
+    <p class="" style="">If the credentials provided match those known by the server, the client will be successfully authenticated.</p>
+    <p class="caption">Example 7. Server Informs Client of Successful Authentication</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='auth2'/&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, authentication may fail. Possible causes of failure include:</p>
+    <ol start="" type="">
+      <li>The user provided incorrect credentials.</li>
+      <li>There is a resource conflict (i.e., there is already an active session with that resource identifier associated with the same username). The RECOMMENDED behavior is for the server to terminate the existing session and create the new one; however, the server MAY provide the opposite behavior if desired, leading to a conflict error for the newly requested login.</li>
+      <li>The user did not provide all of the required information (e.g., did not provide a username or resource).</li>
+    </ol>
+    <p class="" style="">Although <span style="font-weight: bold">RFC 3920</span> specifies that error stanzas SHOULD include the original XML sent, error stanzas qualified by the 'jabber:iq:auth' namespace SHOULD NOT do so given the sensitive nature of the information being exchanged.</p>
+    <p class="caption">Example 8. Server Informs Client of Failed Authentication (Incorrect Credentials)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 9. Server Informs Client of Failed Authentication (Resource Conflict)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='409' type='cancel'&gt;
+    &lt;conflict xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 10. Server Informs Client of Failed Authentication (Required Information Not Provided)</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='auth2'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="streamfeature">Stream Feature</a>
+</h2>
+  <p class="" style=""><span style="font-weight: bold">RFC 3920</span> defines methods for advertising feature support during stream negotiation. It may be desirable for a server to advertise support for non-SASL authentication as a stream feature. The namespace for reporting support within &lt;stream:features/&gt; is "http://jabber.org/features/iq-auth". Upon receiving a stream header qualified by the 'jabber:client' namespace, a server that returns stream features SHOULD also announce support for non-SASL authentication by including the relevant stream feature. Exactly when a server advertises the iq-auth stream feature is up to the implementation or deployment (e.g., a server MAY advertise this feature only after successful TLS negotiation or if the channel is encrypted via the older SSL method). Obviously, this does not apply to servers that do not support stream features (e.g., older servers that do not comply with XMPP 1.0).</p>
+  <p class="caption">Example 11. Advertising non-SASL authentication as a stream feature</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='utf-8'?&gt;
+&lt;stream:stream xmlns:stream='http://etherx.jabber.org/streams/'
+    xmlns='jabber:client'
+    from='somedomain'
+    version='1.0'&gt;
+  &lt;stream:features&gt;
+    ...
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;auth xmlns='http://jabber.org/features/iq-auth'/&gt;
+    ...
+  &lt;/stream:features&gt;
+  </pre></div>
+  <p class="" style="">A server SHOULD NOT advertise non-SASL authentication to another server (i.e., if the initial stream header was qualified by the 'jabber:server' namespace).</p>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">As defined herein, the 'jabber:iq:auth' namespace supports both the old (HTTP-style) error codes and the extensible error classes and conditions specified in <span style="font-weight: bold">RFC 3920</span>. A compliant server or service implementation MUST support both old-style and new-style error handling. A compliant client implementation SHOULD support both.</p>
+<h2>6.
+       <a name="expiration">Expiration Date</a>
+</h2>
+  <p class="" style="">In accordance with Section 8 of <span class="ref" style="">Jabber Enhancement Proposals</span>  [<a href="#nt-id2260209">10</a>], this JEP was advanced to a status of Final with the understanding that it would expire in six months. Since that time, the Jabber Council has reviewed this JEP every six months to determine whether to change its status to Deprecated or to extend the expiration date for an additional six months. This process will continue until the JEP is deprecated. For the latest expiration date, refer to the JEP Information block at the beginning of this document.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Use of the 'jabber:iq:auth' namespace for client-server authentication is not as secure as SASL authentication (defined in <span style="font-weight: bold">RFC 3920</span>). If both client and server implement SASL, they MUST use SASL. If a client attempts to authenticate using the 'jabber:iq:auth' namespace after an attempt at SASL authentication fails, the server MUST refuse the 'jabber:iq:auth' attempt by returning a &lt;policy-violation/&gt; stream error to the client.</p>
+  <p class="" style="">Client implementations MUST NOT make plaintext the default mechanism, and SHOULD warn the user that the plaintext mechanism is insecure. The plaintext mechanism SHOULD NOT be used unless the underlying stream is encrypted (using SSL or TLS) and the client has verified that the server certificate is signed by a trusted certificate authority. A given domain MAY choose to disable plaintext logins if the stream is not properly encrypted, or disable them entirely. If a client implements the plaintext mechanism and a server allows both the digest mechanism and the plaintext mechanism, an upgrade attack is possible, in which a man-in-the-middle tricks the client into revealing the user's plaintext password.</p>
+  <p class="" style="">Authentication using the 'jabber:iq:auth' namespace is known to be less secure than SASL authentication, and this JEP shall be fully deprecated as soon as SASL authentication is implemented widely enough.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260355">11</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260334">12</a>] includes the 'jabber:iq:auth' namespace in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="registrar-stream">Stream Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes the 'http://jabber.org/features/iq-auth' namespace in its registry of stream feature namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="schemas-auth">jabber:iq:auth</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:auth'
+    xmlns='jabber:iq:auth'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0078: http://www.jabber.org/jeps/jep-0078.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='username' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:choice&gt;
+          &lt;xs:element name='password' type='xs:string' minOccurs='0'/&gt;
+          &lt;xs:element name='digest' type='xs:string' minOccurs='0'/&gt;
+        &lt;/xs:choice&gt;
+        &lt;xs:element name='resource' type='xs:string' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="schemas-stream">Stream Feature</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/iq-auth'
+    xmlns='http://jabber.org/features/iq-auth'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0078: http://www.jabber.org/jeps/jep-0078.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='auth' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250949">1</a>. Component authentication is out of scope for this JEP, and is specified separately in <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2250973">2</a>].</p>
+<p><a name="nt-id2250973">2</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2250996">3</a>. RFC 4422: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc4422.txt">http://www.ietf.org/rfc/rfc4422.txt</a>&gt;.</p>
+<p><a name="nt-id2251022">4</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2259604">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2259654">6</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p><a name="nt-id2259709">7</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2259909">8</a>. RFC 3269: UTF-8, a transformation format of ISO 10646 &lt;<a href="http://www.ietf.org/rfc/rfc3269.txt">http://www.ietf.org/rfc/rfc3269.txt</a>&gt;.</p>
+<p><a name="nt-id2259932">9</a>. In Digest authentication, password characters that map to predefined XML entities SHOULD NOT be escaped as they are for plaintext passwords, but non-US-ASCII characters MUST be encoded as UTF-8 since the SHA-1 hashing algorithm operates on byte arrays.</p>
+<p><a name="nt-id2260209">10</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p><a name="nt-id2260355">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260334">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 2.2 (2005-06-28)</h4>
+<div class="indent">Corrected error in schema and example (username is not required in IQ-get). (psa)
+    </div>
+<h4>Version 2.1 (2004-12-09)</h4>
+<div class="indent">Changed SHOULD to MUST regarding priority of SASL (RFC 3920) over jabber:iq:auth (JEP-0078). (psa)
+    </div>
+<h4>Version 2.0 (2004-10-20)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Final. (psa)
+    </div>
+<h4>Version 1.8 (2004-10-18)</h4>
+<div class="indent">Specified advertising iq-auth stream feature is implementation-specific; clarified several small matters in the text. (psa)
+    </div>
+<h4>Version 1.7 (2004-07-27)</h4>
+<div class="indent">Added reference to character escaping in digest authentication; required inclusion of stream feature when server supports stream features and it is safe to advertise non-SASL authentication. (psa)
+    </div>
+<h4>Version 1.6 (2004-07-21)</h4>
+<div class="indent">Removed reference to UTF-16, which is disallowed by XMPP Core; removed reference to character escaping in digest authentication pending list discussion. (psa)
+    </div>
+<h4>Version 1.5 (2004-02-18)</h4>
+<div class="indent">Added optional stream feature. (psa)
+    </div>
+<h4>Version 1.4 (2004-02-03)</h4>
+<div class="indent">Clarified that username and resource are required for authentication. (psa)
+    </div>
+<h4>Version 1.3 (2003-11-26)</h4>
+<div class="indent">Added XMPP error handling. (psa)
+    </div>
+<h4>Version 1.2 (2003-11-06)</h4>
+<div class="indent">Addressed case of attempting jabber:iq:auth after SASL failure. (psa)
+    </div>
+<h4>Version 1.1 (2003-10-02)</h4>
+<div class="indent">Moved change password use case to JEP-0077. (psa)
+    </div>
+<h4>Version 1.0 (2003-06-18)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.8 (2003-06-18)</h4>
+<div class="indent">Changes to address Council concerns. (psa)
+    </div>
+<h4>Version 0.7 (2003-06-13)</h4>
+<div class="indent">Added change password use case; added more details to security considerations. (psa)
+    </div>
+<h4>Version 0.6 (2003-06-12)</h4>
+<div class="indent">Added digest example; clarified escaping requirements; further specified error conditions; added more details to security considerations. (psa)
+    </div>
+<h4>Version 0.5 (2003-06-06)</h4>
+<div class="indent">Removed XMPP-style error conditions until formats are stable. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-30)</h4>
+<div class="indent">Removed "enhanced digest" content, added information about expiration date. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-28)</h4>
+<div class="indent">Added "enhanced digest" method. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-20)</h4>
+<div class="indent">Slight editorial revisions. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-10)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0079-0.12.html
+++ b/content/xep-0079-0.12.html
@@ -1,0 +1,1387 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0079: Advanced Message Processing</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Advanced Message Processing">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol that enables entities to request, and servers to perform, advanced processing of XMPP &lt;message/&gt; stanzas, including reliable data transport, time-sensitive delivery, and transient messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0079">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0079: Advanced Message Processing</h1>
+<p>This JEP defines a protocol that enables entities to request, and servers to perform, advanced processing of XMPP &lt;message/&gt; stanzas, including reliable data transport, time-sensitive delivery, and transient messages.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0079<br>
+            Version: 0.12<br>
+            Last Updated: 2004-09-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: amp<br>
+</p>
+<h2>Author Information</h2>
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dl>
+<dt>1.1.  <a href="#intro-motivation">Motivation</a>
+</dt>
+<dt>1.2.  <a href="#intro-concepts">Concepts</a>
+</dt>
+<dt>1.3.  <a href="#intro-prereq">Prerequisites</a>
+</dt>
+</dl>
+<dt>2.  <a href="#process">Process Flows</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#process-s2s">Sender-to-Server</a>
+</dt>
+<dl>
+<dt>2.1.1.  <a href="#process-s2s-disco">Discovery</a>
+</dt>
+<dt>2.1.2.  <a href="#process-s2s-semantics">Specifying Semantics</a>
+</dt>
+</dl>
+<dt>2.2.  <a href="#process-server">Server Processing</a>
+</dt>
+<dl>
+<dt>2.2.1.  <a href="#process-server-semantics">Validating Semantics</a>
+</dt>
+<dt>2.2.2.  <a href="#process-server-default">Determine Default Action</a>
+</dt>
+<dt>2.2.3.  <a href="#process-server-rules">Process Rules</a>
+</dt>
+<dt>2.2.4.  <a href="#process-server-execute">Execute Determined Action</a>
+</dt>
+</dl>
+</dl>
+<dt>3.  <a href="#conditionsactions">Conditions and Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#conditions-guide">Rule Condition Guidelines</a>
+</dt>
+<dt>3.2.  <a href="#actions-guide">Rule Action Guidelines</a>
+</dt>
+<dt>3.3.  <a href="#conditions-def">Defined Conditions</a>
+</dt>
+<dl>
+<dt>3.3.1.  <a href="#conditions-def-deliver">deliver</a>
+</dt>
+<dt>3.3.2.  <a href="#conditions-def-expireat">expire-at</a>
+</dt>
+<dt>3.3.3.  <a href="#conditions-def-match">match-resource</a>
+</dt>
+</dl>
+<dt>3.4.  <a href="#actions-def">Defined Actions</a>
+</dt>
+<dl>
+<dt>3.4.1.  <a href="#actions-def-drop">drop</a>
+</dt>
+<dt>3.4.2.  <a href="#actions-def-error">error</a>
+</dt>
+<dt>3.4.3.  <a href="#actions-def-notify">notify</a>
+</dt>
+<dt>3.4.4.  <a href="#actions-def-alert">alert</a>
+</dt>
+</dl>
+<dt>3.5.  <a href="#security-conditions">Security Considerations for the Defined Conditions/Actions</a>
+</dt>
+<dl><dt>3.5.1.  <a href="#security-deliver">&quot;deliver&quot; Condition</a>
+</dt></dl>
+</dl>
+<dt>4.  <a href="#formal">Formal Description</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#formal-root">&lt;amp/&gt; Root Element</a>
+</dt>
+<dt>4.2.  <a href="#formal-rule">&lt;rule/&gt; Element</a>
+</dt>
+</dl>
+<dt>5.  <a href="#examples">Example Scenarios</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#examples-reliabledata">Reliable Data Transport</a>
+</dt>
+<dt>5.2.  <a href="#examples-time">Time-Sensitive Messages</a>
+</dt>
+<dt>5.3.  <a href="#examples-transient">Transient Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#errors-conditions">Conditions</a>
+</dt>
+<dt>6.2.  <a href="#errors-examples">Examples</a>
+</dt>
+<dl>
+<dt>6.2.1.  <a href="#errors-action">Unsupported Action</a>
+</dt>
+<dt>6.2.2.  <a href="#errors-condition">Unsupported Condition</a>
+</dt>
+<dt>6.2.3.  <a href="#errors-notacceptable">Not Acceptable</a>
+</dt>
+<dt>6.2.4.  <a href="#errors-unavail">Service Unavailable</a>
+</dt>
+<dt>6.2.5.  <a href="#errors-undefined">Undefined Condition</a>
+</dt>
+</dl>
+</dl>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>10.3.  <a href="#registrar-reg">Registries</a>
+</dt>
+<dl>
+<dt>10.3.1.  <a href="#registrar-reg-conditions">Rule Conditions Registry</a>
+</dt>
+<dl>
+<dt>10.3.1.1.  <a href="#registrar-reg-conditions-process">Process</a>
+</dt>
+<dt>10.3.1.2.  <a href="#registrar-reg-conditions-initial">Initial Submission</a>
+</dt>
+</dl>
+<dt>10.3.2.  <a href="#registrar-reg-actions">Rule Actions Registry</a>
+</dt>
+<dl>
+<dt>10.3.2.1.  <a href="#registrar-reg-actions-process">Process</a>
+</dt>
+<dt>10.3.2.2.  <a href="#registrar-reg-actions-initial">Initial Submission</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>11.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schemas-amp">AMP</a>
+</dt>
+<dt>11.2.  <a href="#schemas-err">Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#acks">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a protocol that enables an end-point entity to specify additional delivery semantics for an XMPP &lt;message/&gt; stanza. This protocol is typically used by clients to inform the receiving server how to deliver a particular stanza, such as providing an expiration time or a resource-matching strategy.</p>
+  <div class="indent">
+<h3>1.1 <a name="intro-motivation">Motivation</a>
+</h3>
+    <p class="" style="">The built-in delivery semantics for &lt;message/&gt; stanzas (defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2596322">1</a>] and, for instant messaging applications, also in <span class="ref">XMPP IM</span>  [<a href="#nt-id2601891">2</a>]) are adequate for most current applications. However, there are various cases where more stringent delivery semantics are necessary. The most common cases discussed in this JEP are:</p>
+    <ul>
+      <li>Reliable data transport -- the sender requires notification (positive and/or negative) of message delivery.</li>
+      <li>Time-sensitive messages -- the message is valid only until a certain date and time.</li>
+      <li>Transient messages -- the message should not be stored offline for later delivery.</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>1.2 <a name="intro-concepts">Concepts</a>
+</h3>
+    <p class="" style="">This protocol is mostly handled by the server or servers processing the &lt;message/&gt;. The protocol consists of a list of rules, with conditions and actions for each rule. Upon receipt of an appropriately marked message, the server interprets the rules in the order they are received, looking for met conditions. When a condition is met, the action for that rule is executed, and message processing stops.</p>
+    <p class="" style="">Each rule is flagged for the scope it applies to, whether it be the overall route, or for each hop in the route.  Additionally, while this JEP defines a default set of conditions and actions, the protocol is extensible enough to allow for more to be defined in the future.</p>
+    <p class="" style="">The namespace for the protocol is &quot;http://jabber.org/protocol/amp&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>1.3 <a name="intro-prereq">Prerequisites</a>
+</h3>
+    <p class="" style="">In order for this protocol to function properly, the containing &lt;message/&gt; stanza MUST possess an 'id' attribute, and the value of the 'id' attribute MUST NOT be an empty string. The server MUST specify this 'id' attribute value with any response back to the sender. This is necessary so that servers and clients can properly relate the initial request with any subsequent error or notification.</p>
+  </div>
+<h2>2.
+       <a name="process">Process Flows</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="process-s2s">Sender-to-Server</a>
+</h3>
+    <p class="" style="">This flow describes the interaction between the sender and a server. As illustrated below, this interaction is actually rather simple:</p>
+    <ol start="1" type="1">
+      <li>Sender determines support (E1)</li>
+      <li>Sender specifies appropriate rules and sends message to server (E1,E2)</li>
+      <li>Sender awaits any protocol-specific responses (UCE)</li>
+    </ol>
+    <ul>
+      <li>
+<span style="font-weight: bold">E1:</span> The server does not support this protocol (UCE)</li>
+      <li>
+<span style="font-weight: bold">E2:</span> The server does not support one or more specified rule conditions/actions (UCE)</li>
+    </ul>
+    <div class="indent">
+<h3>2.1.1 <a name="process-s2s-disco">Discovery</a>
+</h3>
+      <p class="" style="">Sending entities that wish to use AMP SHOULD discover support for this protocol (using <span class="ref">Service Discovery</span>  [<a href="#nt-id2602121">3</a>]) along the intended path. Typically, this would involve sending disco#info queries to the sending entity's own server and the server of the intended recipient. The results of these queries MAY be cached for up to 24 hours, unless otherwise expired.</p>
+      <p class="" style="">If a server supports Advanced Message Processing, it MUST report that by including a service discovery feature of &quot;http://jabber.org/protocol/amp&quot; in the service discovery information result that it returns to the requesting entity.</p>
+      <p class="caption">Example 1. Initial Service Discovery information request</p>
+<div class="indent"><pre>
+&lt;iq from='northumberland@shakespeare.lit/westminster'
+    to='shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 2. Service Discovery information response</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    to='northumberland@shakespeare.lit/westminster'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity name='Shakespeare IM' category='im' type='server'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">A server SHOULD also maintain a service discovery node named &quot;http://jabber.org/protocol/amp&quot;, at which it advertises the individual actions and conditions it supports. If an entity needs to determine whether the server supports individual actions and conditions, it SHOULD send a service discovery information request to that node; the server then MUST either return the list of supported actions and conditions or return an error such as &lt;feature-not-implemented/&gt;. (Note: If the server does not provide information for this disco node, the requesting entity MUST assume that all actions and conditons are supported for each reported action set or condition set.)</p>
+      <p class="" style="">Each supported action shall be reported as a feature using the following format:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>http://jabber.org/protocol/amp?action={action}</pre></div>
+      <p class="" style="">Each supported condition shall be reported as a feature using the following format:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>http://jabber.org/protocol/amp?condition={condition}</pre></div>
+      <p class="" style="">The following examples show the request-response flow for information about individual actions and conditions (note the inclusion of the 'node' attribute).</p>
+      <p class="caption">Example 3. Request for information about individual actions and conditions</p>
+<div class="indent"><pre>
+&lt;iq from='northumberland@shakespeare.lit/westminster'
+    to='shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/amp'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 4. Response for individual actions and conditions</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    to='northumberland@shakespeare.lit/westminster'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/amp'&gt;
+    &lt;identity name='Shakespeare IM AMP Support' category='im' type='server'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=drop'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=error'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=deliver'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=expire-at'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=match-resource'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>2.1.2 <a name="process-s2s-semantics">Specifying Semantics</a>
+</h3>
+      <p class="" style="">Once support is determined, the sender can attach the desired delivery semantics to the message:</p>
+      <p class="caption">Example 5. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The semantics are defined as a set of &lt;rule/&gt; elements within the &lt;amp/&gt; root element. Each &lt;rule/&gt; declares the condition to trigger on and the action to execute if triggered.</p>
+      <p class="" style="">By default, the ruleset applies only to the &quot;edge servers&quot;: those servers to which the sending and receiving entities are connected. (Note: For the purposes of Advanced Message Processing, &quot;server&quot; is defined as in <span style="font-weight: bold">XMPP Core</span> and does not include any internal components, such as connection managers, that may provide functionality within a server implementation or installation.)</p>
+      <p class="" style="">The ruleset MAY be applied to all server-to-server &quot;hops&quot; along the route from the sending and receiving entities by adding the &quot;per-hop' attribute to the &lt;amp/&gt; element. The value of this attribute is either &quot;true&quot; (apply rules to all hops) or &quot;false&quot; (follow default behavior, i.e., apply rules at the edge servers only).</p>
+      <p class="caption">Example 6. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+       per-hop='true'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">For examples of validation failure, refer to the <a href="#errors">Error Handling</a> section of this document.</p>
+      <p class="" style="">Note: Even if &quot;per-hop&quot; processing is requested, each server in the route MUST ignore rules that cannot apply to it; the <a href="#conditions-def">Defined Conditions</a> outline if they can be applied per-hop.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="process-server">Server Processing</a>
+</h3>
+    <p class="" style="">Server operation is where the bulk of the work is performed. Upon receiving a message with an AMP extension, the server performs the following flow:</p>
+    <ol start="1" type="1">
+      <li>Validate the semantics (E1, E2).</li>
+      <li>Determine the default behavior.</li>
+      <li>Process rules until condition is met.
+        <ul>
+          <li>If a condition is met, execute that rule's action</li>
+          <li>If no conditions are met, perform &quot;default&quot; behavior for message</li>
+        </ul>
+      </li>
+      <li>Execute determined action (UCE) (E3).</li>
+    </ol>
+    <ul>
+      <li>
+<span style="font-weight: bold">E1:</span> The provided semantics (rule's condition/action) are not supported or valid (UCE)</li>
+      <li>
+<span style="font-weight: bold">E2:</span> The requested semantics are not acceptable (UCE)</li>
+      <li>
+<span style="font-weight: bold">E3:</span> The next server does not support this protocol (UCE)</li>
+    </ul>
+    <div class="indent">
+<h3>2.2.1 <a name="process-server-semantics">Validating Semantics</a>
+</h3>
+      <p class="" style="">Validation can take many forms, but at the very least the server MUST verify that it understands each of the rule conditions and actions, and that the condition contents are appropriate. The server MAY also refused to accept certain combinations of conditions and actions, for example if they present a risk of overriding security. If the semantics are not valid, supported, or acceptable, the server MUST reply with an error specifying the rule(s) that are at issue. The server SHOULD validate all the semantics before returning an error. For syntax and examples of error handling related to validation failure, refer to the <a href="#errors">Error Handling</a> section of this document.</p>
+    </div>
+    <div class="indent">
+<h3>2.2.2 <a name="process-server-default">Determine Default Action</a>
+</h3>
+      <p class="" style="">This step is essentially what a server normally does, except that it does not actually perform the action. This determines what would happen to the message if there were no semantics attached (such as dispatch to another server or store offline). At this point, the server SHOULD also calculate any timing or calendar requirements (if applicable).</p>
+    </div>
+    <div class="indent">
+<h3>2.2.3 <a name="process-server-rules">Process Rules</a>
+</h3>
+      <p class="" style="">At this step, the server processes the attached semantics. The server MUST process the rules serially, and in the order they are presented within the &lt;amp/&gt; element. As soon as a rule's condition is met, processing ends with that action overriding the default action determined earlier (unless the action permits continued processing).</p>
+    </div>
+    <div class="indent">
+<h3>2.2.4 <a name="process-server-execute">Execute Determined Action</a>
+</h3>
+      <p class="" style="">Once all rules have been processed or otherwise accounted for, the server executes the action determined at this point.</p>
+      <p class="" style="">A server SHOULD NOT dispatch a &lt;message/&gt; stanza with AMP semantics to another server unless it knows that the next server supports AMP (this SHOULD be discovered via <span style="font-weight: bold">Service Discovery</span> and MAY be cached to avoid delivery delays). If the next server does not support AMP, the current server replies to the original sender with a &lt;service-unavailable/&gt; error condition. Otherwise this flow starts again for the server to which the message has been dispatched.</p>
+    </div>
+  </div>
+<h2>3.
+       <a name="conditionsactions">Conditions and Actions</a>
+</h2>
+  <p class="" style="">The preceding sections of this JEP define the general behavior regarding AMP. This section outlines how &lt;rule/&gt; action and condition sets are defined. It also provides defined action and condition sets; these action and condition sets SHOULD be supported by any implementation of Advanced Message Processing, but support for any given action or condition set it not required. (Note: The action and condition sets defined herein may be supplemented in the future via registration of additional action and condition sets with the Jabber Registrar.)</p>
+  <div class="indent">
+<h3>3.1 <a name="conditions-guide">Rule Condition Guidelines</a>
+</h3>
+    <p class="" style="">The definition of a &lt;rule/&gt; condition MUST provide the following information:</p>
+    <ul>
+      <li>Define a namespace governing the condition set</li>
+      <li>Define the condition:
+        <ul>
+          <li>Define the 'condition' attribute value</li>
+          <li>Specify if the &quot;per-hop&quot; flag applies</li>
+          <li>Define the syntax/format of the 'value' attribute value</li>
+          <li>Define how the &quot;value&quot; is interpreted to meet a condition</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-guide">Rule Action Guidelines</a>
+</h3>
+    <p class="" style="">The definition of a &lt;rule/&gt; action MUST provide the following information:</p>
+    <ul>
+      <li>Define a namespace governing the action set</li>
+      <li>Define the action:
+        <ul>
+          <li>Define each 'action' attribute value</li>
+          <li>Define the expected behavior if the &lt;rule/&gt; is triggered</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="conditions-def">Defined Conditions</a>
+</h3>
+    <p class="" style="">The condition defines how or when a particular rule is triggered. The value of the condition attribute determines what the contents of the &lt;rule/&gt; mean.</p>
+    <p class="" style="">The following conditions are defined by this JEP and SHOULD be supported by any implementation.</p>
+    <p class="" style="">In the following sections, the terms &quot;content&quot; and &quot;contents&quot; refers to the XML character data contained by the &lt;rule/&gt; element.</p>
+    <div class="indent">
+<h3>3.3.1 <a name="conditions-def-deliver">deliver</a>
+</h3>
+      <p class="" style="">The &quot;deliver&quot; condition is used to ensure delivery (or non-delivery) in one of five ways:</p>
+      <ol start="1" type="1">
+        <li>Directly to an appropriate resource over XMPP</li>
+        <li>Delayed to offline storage (for later delivery via XMPP)</li>
+        <li>Forwarded to an alternate address over XMPP</li>
+        <li>Indirectly to an alternate address through a gateway to a non-XMPP system</li>
+      </ol>
+      <p class="" style="">The possible contents for this condition are defined in the following table:</p>
+      <p class="caption">Table 1: &quot;deliver&quot; values</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Value</th>
+          <th colspan="" rowspan="">Description</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&quot;direct&quot;</td>
+          <td align="" colspan="" rowspan="">The message can be delivered immediately to the intended resource.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&quot;forward&quot;</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be forwarded to another XMPP address.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&quot;gateway&quot;</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be sent through a gateway to an address on a non-XMPP system.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&quot;none&quot;</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and is to be dropped (e.g., because offline storage is not enabled).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&quot;stored&quot;</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be stored offline for later delivery via XMPP.</td>
+        </tr>
+      </table>
+      <p class="" style="">This condition is met based on what the processor is able to do with the message at the moment of receipt. To correctly process this condition, a processor first determines if the message can be delivered immediately to the intended resource or further dispatched to another hop. If so and the contents are &quot;direct&quot;, the condition is met. If not and the contents are &quot;stored&quot;, the condition is also met if offline storage is enabled. In all other cases the condition is not met.</p>
+      <p class="" style="">This condition MAY be applied to each &quot;hop&quot; in the server route.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.2 <a name="conditions-def-expireat">expire-at</a>
+</h3>
+      <p class="" style="">The &quot;expire-at&quot; condition is used to ensure delivery before an absolute point in time. Naturally, this does not <span style="font-style: italic">guarantee</span>  [<a href="#nt-id2603199">4</a>] that the message will not be delivered after that time from the sender's perspective, since this JEP does not assume that all machine clocks (e.g., for all servers along the delivery route) are synchronized. However, in order to help ensure that this condition is met correctly, servers that implement this JEP (or the machines that host such servers) SHOULD use the Network Time Protocol (<span class="ref">RFC 1305</span>  [<a href="#nt-id2603316">5</a>]) to keep in sync with established time authorities. Note also that expire-at functionality becomes less reliable the closer the expire-at time is to the present (e.g., the sender will receive less reliable delivery of a message speciifying an expire-at time two seconds in the future than of a message specifying an expire-at time two hours or two days in the future).</p>
+      <p class="" style="">The content of the 'value' attribute specifies some point after the exact moment the message is sent; the content MUST be a DateTime as specified in <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2603256">6</a>], and the timezone MUST be UTC.</p>
+      <p class="" style="">The condition is met if the message cannot be delivered to the recipient before the specified datetime. To determine the datetime to compare to, the processor first determines if and when a message can be dispatched (e.g. not stored offline). The processor then records this datetime, and compares it with the specified datetime. If the current datetime is on or after that specified, the condition is met.</p>
+      <p class="" style="">This condition MAY be applied to each &quot;hop&quot; in the server route.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.3 <a name="conditions-def-match">match-resource</a>
+</h3>
+      <p class="" style="">The &quot;match-resource&quot; condition is used to restrict delivery based on the resource identifier of the recipient JID.</p>
+      <p class="" style="">The possible contents for this condition are:</p>
+      <p class="caption">Table 2: &quot;match-resource&quot; values</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Value</th>
+          <th colspan="" rowspan="">Description</th>
+          <th colspan="" rowspan="">Example</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&quot;exact&quot;</td>
+          <td align="" colspan="" rowspan="">Destination resource exactly matches the specified resource.</td>
+          <td align="" colspan="" rowspan="">&quot;home/laptop&quot; only matches &quot;home/laptop&quot; and not &quot;home/desktop&quot; or &quot;work/desktop&quot;</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&quot;any&quot;</td>
+          <td align="" colspan="" rowspan="">Destination resource matches any value, effectively ignoring the specified resource.</td>
+          <td align="" colspan="" rowspan="">&quot;home/laptop&quot; matches &quot;home&quot;, &quot;home/desktop&quot; or &quot;work/desktop&quot;</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">&quot;other&quot;</td>
+          <td align="" colspan="" rowspan="">Destination resource matches any value except for the specified resource.</td>
+          <td align="" colspan="" rowspan="">&quot;home/laptop&quot; matches &quot;work/desktop&quot;, &quot;home&quot; or &quot;home/desktop&quot;, but not &quot;home/laptop&quot;</td>
+        </tr>
+      </table>
+      <p class="" style="">The condition is met if the resource for the actual destination JID matches the specified destination JID using the above rules. For instance, if a message is intended for &quot;romeo@montague.net/work&quot; with the &quot;match-resource&quot; condition of &quot;other&quot;, the condition is met if the message can be immediately delivered only to &quot;romeo@montague.net/home&quot;.</p>
+      <p class="" style="">For purposes of this condition, a JID with no resource has the following behavior:</p>
+      <ul>
+        <li>If the value is &quot;exact&quot;, the condition is met only if the server would deliver to a non-resource JID (e.g., a <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2603615">7</a>] room or offline storage).</li>
+        <li>If the value is &quot;other&quot;, the condition is met only if the server would not deliver to a non-resource JID.</li>
+      </ul>
+      <p class="" style="">This condition MUST NOT be applied to each &quot;hop&quot; in the server route, only at the edge servers. If an &lt;amp/&gt; element includes this condition and also indicates that it should be processed per hop, this &lt;rule/&gt; shall be ignored.</p>
+      <p class="" style="">Note: By design, this protocol does not include support for partial JID matching (which would stipulate, for example, that the resource identifiers &quot;home/laptop&quot; and &quot;homeboy&quot; both match &quot;home&quot;).</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-def">Defined Actions</a>
+</h3>
+    <p class="" style="">The action defines what occurs when a particular rule is triggered. The value of the action attribute determines the behavior if the rule's condition is met.</p>
+    <p class="" style="">The following actions are defined by this JEP.</p>
+    <div class="indent">
+<h3>3.4.1 <a name="actions-def-drop">drop</a>
+</h3>
+      <p class="" style="">The &quot;drop&quot; action silently discards the message from any further delivery attempts and ensures that it is not placed into offline storage. The drop MUST NOT result in other responses.</p>
+    </div>
+    <div class="indent">
+<h3>3.4.2 <a name="actions-def-error">error</a>
+</h3>
+      <p class="" style="">The &quot;error&quot; action triggers a reply &lt;message/&gt; stanza of type &quot;error&quot; to the sending entity. The &lt;message/&gt; stanza's &lt;error/&gt; child MUST contain a &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'/&gt; error condition, which itself contains the rules that triggered this action.</p>
+      <p class="caption">Example 7. &quot;error&quot; response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           type='error'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+    &lt;error type='modify' code='500'&gt;
+      &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+        &lt;rule condition='deliver' value='stored' action='error'/&gt;
+      &lt;/failed-rules&gt;
+    &lt;/error&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+      <p class="" style="">Note that the error SHOULD be of type &quot;modify&quot;, and the general error condition SHOULD be &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;.</p>
+    </div>
+    <div class="indent">
+<h3>3.4.3 <a name="actions-def-notify">notify</a>
+</h3>
+      <p class="" style="">The &quot;notify&quot; action triggers a reply &lt;message/&gt; stanza to the sending entity. This &lt;message/&gt; stanza MUST contain the element &lt;amp status='notify'/&gt;, which itself contains the &lt;rule/&gt; that triggered this action. Unlike the other actions, this action does not override the default behavior for a server. Instead, the server then executes its default behavior after sending the notify.</p>
+      <p class="caption">Example 8. &quot;error&quot; response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='notify'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='notify'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+    </div>
+    <div class="indent">
+<h3>3.4.4 <a name="actions-def-alert">alert</a>
+</h3>
+      <p class="" style="">The &quot;alert&quot; action triggers a reply &lt;message/&gt; stanza to the sending entity. This &lt;message/&gt; stanza MUST contain the element &lt;amp type='alert'/&gt;, which itself contains the &lt;rule/&gt; that triggered this action. In all other respects, this action behaves as &quot;drop&quot;.</p>
+      <p class="caption">Example 9. &quot;error&quot; response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='alert'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="security-conditions">Security Considerations for the Defined Conditions/Actions</a>
+</h3>
+    <div class="indent">
+<h3>3.5.1 <a name="security-deliver">&quot;deliver&quot; Condition</a>
+</h3>
+      <p class="" style="">This condition has the largest potential for abuse, as it can appear to bypass presence. [<a href="#nt-id2603822">8</a>] A naive server could simply check to see the outcome for a particular message, regardless of whether the sender and receiver are subscribed to each other. This behavior SHOULD NOT be implemented, although it may be desirable in some environments (such as fully-trusted networks).</p>
+      <p class="" style="">There are several directions server implementors can follow in this regard:</p>
+      <ul>
+        <li>This condition is not implemented. The result MUST be to reply to the sender with a &lt;feature-not-implemented/&gt; error condition.</li>
+        <li>This condition is accepted only if the action is &quot;drop&quot;. The result otherwise MUST be to reply to the sender with a &lt;not-acceptable/&gt; error condition.</li>
+        <li>This condition is accepted only if the sender is subscribed to the receiver's presence. The result otherwise MUST be to reply to the sender with a &lt;not-acceptable/&gt; error condition.</li>
+      </ul>
+    </div>
+  </div>
+<h2>4.
+       <a name="formal">Formal Description</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="formal-root">&lt;amp/&gt; Root Element</a>
+</h3>
+    <p class="" style="">All delivery semantics are encapsulated in the &lt;amp/&gt; element. This element contains one or more &lt;rule/&gt; elements specifying the specific rules to process. It can optionally possess attributes about the current status, the original sender and recipient, and route applicability.</p>
+    <p class="" style="">The 'status' attribute specifies the reason for this &lt;amp/&gt; element. When specifying semantics to be applied (client to server), this attribute MUST NOT be present. When replying to a sending entity regarding a met condition, this attribute MUST be present and SHOULD be the value of the 'action' attribute for the triggered rule. (Note: Individual action definitions MAY provide their own requirements.)</p>
+    <p class="" style="">The 'from' attribute specifies the original sender of the containing &lt;message/&gt; stanza. This attribute MUST be specified for any &lt;message/&gt; stanza sent from a supporting server, regardless of the recipient. It SHOULD NOT be specified otherwise. The value of the 'from' attribute MUST be the full JID (node@domain/resource) of the sender for the original &lt;message/&gt; stanza.</p>
+    <p class="" style="">The 'to' attribute specifies the original (intended) recipient of the containing &lt;message/&gt; stanza. This attribute MUST be specified for any &lt;message/&gt; stanza sent from a supporting server, regardless of the recipient. It SHOULD NOT be specified otherwise. The value of the 'to' attribute MUST be the full JID (node@domain/resource) of the intended recipient for the original &lt;message/&gt; stanza.</p>
+    <p class="" style="">The 'per-hop' attribute flags the contained ruleset for processing at each server in the route between the original sender and original intended recipient. This attribute MAY be present, and MUST be either &quot;true&quot; or &quot;false&quot;. If not present, the default is &quot;false&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="formal-rule">&lt;rule/&gt; Element</a>
+</h3>
+    <p class="" style="">Each semantic rule is specified with a &lt;rule/&gt; element. This element possesses attributes for the condition, value, and action.</p>
+    <p class="" style="">The 'action' attribute defines the result for this rule. This attribute MUST be present, and MUST be either a value defined in the <a href="#actions-def">Defined Actions</a> section, or one registered with the Jabber Registrar.</p>
+    <p class="" style="">The 'condition' attribute defines the overall condition this rule applies to. This attribute MUST be present, and MUST be either a value defined in the <a href="#conditions-def">Defined Conditions</a> section, or one registered with the Jabber Registrar.</p>
+    <p class="" style="">The 'value' attribute defines how the condition is matched. This attribute MUST be present, and MUST NOT be an empty string (&quot;&quot;). The interpretation of this attribute's value is determined by the 'condition' attribute.</p>
+  </div>
+<h2>5.
+       <a name="examples">Example Scenarios</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="examples-reliabledata">Reliable Data Transport</a>
+</h3>
+    <p class="" style="">The &lt;message/&gt; stanza is nearly ideal for data transport, but to ensure reliability it is often desirable that such messages not be delivered to any resource but that specified. To facilitate this, the sending entity includes a &lt;rule action='drop' condition='match-resource' value='exact'/&gt; (if failure notification is unnecessary) or &lt;rule action='error' condition='match-resource' value='exact'/&gt; (if failure notification is required). The following example illustrates this using <span class="ref">In-Band Bytestreams</span>  [<a href="#nt-id2604223">9</a>]:</p>
+    <p class="caption">Example 10. Sending a message for reliable data transport</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit/pda'
+         from='bernardo@hamlet.lit/elsinore'
+         id='ibb1'&gt;
+  &lt;data xmlns='http://jabber.org/protocol/ibb' sid='mySID' seq='0'&gt;
+    qANQR1DBwU4DX7jmYZnncmUQB/9KuKBddzQH+tZ1ZywKK0yHKnq57kWq+RFtQdCJ
+    WpdWpR0uQsuJe7+vh3NWn59/gTc5MDlX8dS9p0ovStmNcyLhxVgmqS8ZKhsblVeu
+    IpQ0JgavABqibJolc3BKrVtVV1igKiX/N7Pi8RtY1K18toaMDhdEfhBRzO/XB0+P
+    AQhYlRjNacGcslkhXqNjK5Va4tuOAPy2n1Q8UUrHbUd0g+xJ9Bm0G0LZXyvCWyKH
+    kuNEHFQiLuCY6Iv0myq6iX6tjuHehZlFSh80b5BVV9tNLwNR5Eqz1klxMhoghJOA
+  &lt;/data&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule condition='expire-at' value='2004-09-10T08:33:14Z' action='error'/&gt;
+    &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the above case, the sender would receive an error reply if the message could not be delivered specifically to &quot;francisco@hamlet.lit/pda&quot; within 500 seconds.</p>
+    <p class="caption">Example 11. Failed reliable data transport message</p>
+<div class="indent"><pre>
+&lt;message from='hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'
+         id='ibb1'&gt;
+  &lt;data xmlns='http://jabber.org/protocol/ibb' sid='mySID' seq='0'&gt;
+    qANQR1DBwU4DX7jmYZnncmUQB/9KuKBddzQH+tZ1ZywKK0yHKnq57kWq+RFtQdCJ
+    WpdWpR0uQsuJe7+vh3NWn59/gTc5MDlX8dS9p0ovStmNcyLhxVgmqS8ZKhsblVeu
+    IpQ0JgavABqibJolc3BKrVtVV1igKiX/N7Pi8RtY1K18toaMDhdEfhBRzO/XB0+P
+    AQhYlRjNacGcslkhXqNjK5Va4tuOAPy2n1Q8UUrHbUd0g+xJ9Bm0G0LZXyvCWyKH
+    kuNEHFQiLuCY6Iv0myq6iX6tjuHehZlFSh80b5BVV9tNLwNR5Eqz1klxMhoghJOA
+  &lt;/data&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+      from='bernardo@hamlet.lit/elsinore'
+      to='francisco@hamlet.lit/pda'&gt;
+    &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='500'&gt;
+    &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+      &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+    &lt;/failed-rules&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="examples-time">Time-Sensitive Messages</a>
+</h3>
+    <p class="" style="">Time-sensitive messages are a frequent occurrence in some environments (e.g., front-office personnel routinely notify others of &quot;events&quot; such as guests, unexpected refreshments, and ad-hoc gatherings). To send a time-sensitive message, the sending entity includes a &lt;rule condition='expire-at' action='drop'/&gt; with the time when the event is to occur:</p>
+    <p class="caption">Example 12. Sending a time-sensitive message</p>
+<div class="indent"><pre>
+&lt;message to='linuxwolf@outer-planes.net'
+         from='receptionist@outer-planes.net'
+         id='alert849'&gt;
+  &lt;subject&gt;Guest Alert!&lt;/subject&gt;
+  &lt;body&gt;
+    There will be clients in the conference room today around 1 PM!
+    As always, be courteous and quiet nearby...
+  &lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2003-06-23T23:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the above case, the server for &quot;linuxwolf@outer-planes.net&quot; would not deliver the message once 23:00 UTC (3:00 PM Pacific Daylight Time) has passed.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="examples-transient">Transient Messages</a>
+</h3>
+    <p class="" style="">Transient messages are messages that should never be stored offline. To send a transient message, the sending entity includes a &lt;rule condition='deliver' action='drop' value='stored'/&gt;:</p>
+    <p class="caption">Example 13. Sending a transient message</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit'
+         from='bernardo@hamlet.lit/elsinore'
+         type='chat'
+         id='chatty1'&gt;
+  &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='deliver' value='stored' action='drop'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the sending entity includes a &lt;rule condition='deliver' action='alert' value='stored'/&gt; to be alerted instead of having the message silently dropped:</p>
+    <p class="caption">Example 14. Sending a transient message (requesting alert)</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit'
+         from='bernardo@hamlet.lit/elsinore'
+         type='chat'
+         id='chatty2'&gt;
+  &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 15. Sender alerted regarding transient message</p>
+<div class="indent"><pre>
+&lt;message from='hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'
+         id='chatty2'&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+       action='alert'
+       from='bernardo@hamlet.lit/elsinore'
+       to='francisco@hamlet.lit'&gt;
+    &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="errors-conditions">Conditions</a>
+</h3>
+    <p class="" style="">To simplify the discussion of error conditions, this document uses the following mappings between namespace URIs and namespace prefixes (note: this mapping is provided only for the purpose of simplifying the discussion and is not intended for use within the protocol itself).</p>
+    <p class="caption">Table 3: Namespace Mappings</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Prefix</th>
+        <th colspan="" rowspan="">URI</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">xmpp</td>
+        <td align="" colspan="" rowspan="">urn:ietf:params:xml:ns:xmpp-stanzas</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">msg</td>
+        <td align="" colspan="" rowspan="">http://jabber.org/protocol/amp</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">err</td>
+        <td align="" colspan="" rowspan="">http://jabber.org/protocol/amp#errors</td>
+      </tr>
+    </table>
+    <p class="" style="">The following table shows the possible error conditions in relation to general AMP rules and conditions as well as the <a href="#actions-def">Defined Actions</a>.</p>
+    <p class="caption">Table 4: Error conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">General Condition</th>
+        <th colspan="" rowspan="">Error Type</th>
+        <th colspan="" rowspan="">Specific Condition</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:bad-request/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:unsupported-actions/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rule's specified actions are not supported. The element &lt;msg:unsupported-actions/&gt; contains the &lt;rule/&gt; elements that specify the unsupported actions.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:bad-request/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:unsupported-conditions/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rule's specified conditions are not supported. The element &lt;msg:unsupported-conditions/&gt; contains the &lt;rule/&gt; elements that specify the unsupported conditions.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:not-acceptable/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:invalid-rules/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rules are not acceptable by this server, usually because the condition/action combination is restricted. The element &lt;msg:invalid-rules/&gt; contains the &lt;rule/&gt; elements that are not acceptable.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:service-unavailable/&gt;</td>
+        <td align="" colspan="" rowspan="">cancel</td>
+        <td align="" colspan="" rowspan="">NONE</td>
+        <td align="" colspan="" rowspan="">This protocol is not supported. This error is returned to the sending entity if a server along the route to the recipient does not implement this protocol.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:undefined-condition/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;err:failed-rules/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more &lt;rule/&gt; elements triggered the &quot;error&quot; action. This condition contains the triggered &lt;rule/&gt; elements.</td>
+      </tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="errors-examples">Examples</a>
+</h3>
+    <p class="" style="">This section shows examples of the error conditions described in the previous section (for information regarding mapping of XMPP error conditions to Jabber error codes, refer to <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2604904">10</a>]).</p>
+    <div class="indent">
+<h3>6.2.1 <a name="errors-action">Unsupported Action</a>
+</h3>
+      <p class="caption">Example 16. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 17. Server does not support action</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='400'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-actions xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/unsupported-actions&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.2 <a name="errors-condition">Unsupported Condition</a>
+</h3>
+      <p class="caption">Example 18. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 19. Server does not support condition</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='400'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-conditions xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/unsupported-conditions&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.3 <a name="errors-notacceptable">Not Acceptable</a>
+</h3>
+      <p class="caption">Example 20. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 21. The rule is not acceptable to the server</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='405'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-rules xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/invalid-rules&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.4 <a name="errors-unavail">Service Unavailable</a>
+</h3>
+      <p class="caption">Example 22. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 23. AMP service is unavailable</p>
+<div class="indent"><pre>
+&lt;message
+    from='royalty.england.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='cancel' code='503'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.5 <a name="errors-undefined">Undefined Condition</a>
+</h3>
+      <p class="caption">Example 24. A message with semantics</p>
+<div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 25. Failed rules</p>
+<div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           type='error'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+    &lt;error type='modify' code='500'&gt;
+      &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+        &lt;rule condition='deliver' value='stored' action='error'/&gt;
+      &lt;/failed-rules&gt;
+    &lt;/error&gt;
+  &lt;/message&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">If the recipient's server implements &quot;offline storage&quot;, it will need to keep track of which offline messages are subject to expiration and not deliver those which have expired. Exactly how to do so is a matter of implementation. One possible implementation is for the server to maintain a separate database of expirable messages and periodically scan it; upon discovering an expired message, it could flag the messages as eligible for discarding and inform the sender, but not discard the message until the intended recipient next becomes available.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The security considerations are dependent upon the specific conditions and actions in use. The considerations for the defined conditions and actions are outlined with their definitions in the <a href="#conditionsactions">Conditions and Actions</a> section of this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2605220">11</a>] is necessary as a result of this JEP.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605168">12</a>] shall include 'http://jabber.org/protocol/amp' and 'http://jabber.org/protocol/amp#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/amp' in its registry of well-known Service Discovery nodes.</p>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="registrar-reg">Registries</a>
+</h3>
+    <div class="indent">
+<h3>10.3.1 <a name="registrar-reg-conditions">Rule Conditions Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall maintain a registry of AMP &lt;rule/&gt; conditions.</p>
+      <div class="indent">
+<h3>10.3.1.1 <a name="registrar-reg-conditions-process">Process</a>
+</h3>
+        <p>In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;name&gt;the value of the 'condition' attribute&lt;/name&gt;
+  &lt;ns&gt;the namespace to be used as a service discovery feature&lt;/ns&gt;
+  &lt;per-hop&gt;does the &quot;per-hop&quot; flag apply? [true|false]&lt;/per-hop&gt;
+  &lt;value&gt;
+     The syntax (e.g., datatype or allowable values) of the
+     'value' attribute.
+  &lt;/value&gt;
+  &lt;processing&gt;values that result in message processing&lt;/processing&gt;
+  &lt;doc&gt;the document (e.g., JEP) in which this condition is specified&lt;/doc&gt;
+&lt;/condition&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one condition at a time, each contained in a separate &lt;condition/&gt; element.</p>
+        <p class="" style="">Note: The namespace for the condition set shall be included in the Service Discovery features registry.</p>
+      </div>
+      <div class="indent">
+<h3>10.3.1.2 <a name="registrar-reg-conditions-initial">Initial Submission</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;name&gt;deliver&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=deliver&lt;/ns&gt;
+  &lt;per-hop&gt;true&lt;/per-hop&gt;
+  &lt;value&gt;[direct|forward|gateway|none|stored]&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if (1) the value is &quot;direct&quot; and the message
+    can be immediately delivered or further dispatched, or (2) the 
+    value is &quot;stored&quot; and offline storage is enabled.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+
+&lt;condition&gt;
+  &lt;name&gt;expire-at&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=expire-at&lt;/ns&gt;
+  &lt;per-hop&gt;true&lt;/per-hop&gt;
+  &lt;value&gt;DateTime per JEP-0082&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if the message cannot be delivered before
+    the specified DateTime.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+
+&lt;condition&gt;
+  &lt;name&gt;match-resource&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=match-resource&lt;/ns&gt;
+  &lt;per-hop&gt;false&lt;/per-hop&gt;
+  &lt;value&gt;[any|exact|other]&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if (1) the value is &quot;any&quot; and the intended
+    recipient has at least one available resource (as defined in the
+    XMPP IM specification); (2) the value &quot;exact&quot; and the intended
+    recipient has an available resource that exactly matches the JID
+    specified in the 'to' address; (3) the value is &quot;other&quot; and the
+    intended recipient has an available resource whose full JID is
+    other than that specified in the 'to' address.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>10.3.2 <a name="registrar-reg-actions">Rule Actions Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall maintain a registry of AMP &lt;rule/&gt; actions.</p>
+      <div class="indent">
+<h3>10.3.2.1 <a name="registrar-reg-actions-process">Process</a>
+</h3>
+        <p>In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;action&gt;
+  &lt;name&gt;the value of the 'action' attribute&lt;/name&gt;
+  &lt;ns&gt;the namespace to be used as a service discovery feature&lt;/ns&gt;
+  &lt;behavior&gt;the expected behavior if the rule is triggered&lt;/behavior&gt;
+  &lt;doc&gt;the document (e.g., JEP) in which this action is specified&lt;/doc&gt;
+&lt;/action&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one action at a time, each contained in a separate &lt;action/&gt; element.</p>
+        <p class="" style="">Note: The namespace for the action set shall be included in the Service Discovery features registry.</p>
+      </div>
+      <div class="indent">
+<h3>10.3.2.2 <a name="registrar-reg-actions-initial">Initial Submission</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;action&gt;
+  &lt;name&gt;alert&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=drop&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is silently discarded but an alert is returned to the
+    sender.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;drop&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=drop&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is silently discarded.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;error&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=error&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is not processed and an error is returned to the sender,
+    specifying which rule resulted in failed processing.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;notify&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=notify&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is processed and a notification message is returned to
+    the sender, specifying which rule was processed.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+        </pre></div>
+      </div>
+    </div>
+  </div>
+<h2>11.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schemas-amp">AMP</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/amp'
+    xmlns='http://jabber.org/protocol/amp'
+    elementFormDefault='qualified'&gt;
+ 
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0079: http://www.jabber.org/jeps/jep-0079.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='amp'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' usage='optional' type='xs:string'/&gt;
+      &lt;xs:attribute name='per-hop' use='optional' type='xs:bool' default='false'/&gt;
+      &lt;xs:attribute name='status' usage='optional' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='to' usage='optional' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+ 
+  &lt;xs:element name='invalid-rules'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsupported-actions'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsupported-conditions'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='rule'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='action' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='condition' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='value' use='required' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schemas-err">Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/amp#errors'
+    xmlns='http://jabber.org/protocol/amp#errors'
+    elementFormDefault='qualified'&gt;
+ 
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0079: http://www.jabber.org/jeps/jep-0079.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='failed-rules'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='rule'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='action' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='condition' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='value' use='required' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="acks">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Marshall Rose and Craig Kaes for their comments.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596322">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601891">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602121">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603199">4</a>. Guarantee is a strong word. This JEP defines methods for making message delivery more reliable within certain bounds, but does not pretend that such methods provide any form of guaranteed delivery.</p>
+<p>
+<a name="nt-id2603316">5</a>. RFC 1305: Network Time Protocol (Version 3) &lt;<a href="http://www.ietf.org/rfc/rfc1305.txt">http://www.ietf.org/rfc/rfc1305.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603256">6</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603615">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603822">8</a>. Consider the following scenario: the user &lt;romeo@montague.net&gt; is not an authorized subscriber to the presence of the user &lt;nurse@capulet.com&gt;, but sends a &lt;message/&gt; stanza with a &quot;deliver&quot; rule of &quot;direct&quot; to that address; if the Nurse is not online, Romeo could discover that fact if the capulet.com server informs him that the message could not be delivered immediately.</p>
+<p>
+<a name="nt-id2604223">9</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604904">10</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605220">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605168">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.12 (2004-09-09)</h4>
+<div class="indent">Relaxed server-to-server requirements; clarified discovery rules; removed expire-in condition. (lw)
+    </div>
+<h4>Version 0.11 (2004-08-25)</h4>
+<div class="indent">Specified that the timestamp for an expire-at condition must be a UTC DateTime per JEP-0082; provided further explanation regarding expire-at and expire-in conditions. (lw/psa)
+    </div>
+<h4>Version 0.10 (2004-07-14)</h4>
+<div class="indent">Changes to address Council feedback: clarified error handling and provided error examples; specified that server should validate all rule semantics before returning an error; specified that service discovery information can be cached (not necessary to send disco query before dispatching each message); added &quot;forward&quot; and &quot;gateway&quot; to values of &quot;deliver&quot; condition to handle redirection of messages to alternate XMPP addresses and non-XMPP systems respectively; more clearly specified processing rules for &quot;expire-in&quot; condition; changed milliseconds to seconds for &quot;expire-in&quot;; made explicit that partial JID-matching is not included for &quot;match-resource&quot; condition; added clarifying note to security consideration regarding &quot;deliver&quot; condition; corrected values of per-hop from [yes|no] to [true|false]; changed &quot;standard&quot; conditions to &quot;defined&quot; conditions and mandated that they should be supported; changed &quot;http://jabber.org/protocol/amp#std-actions&quot; namespace to &quot;http://jabber.org/protocol/amp#errors&quot;. (lw/psa)
+    </div>
+<h4>Version 0.9 (2004-04-25)</h4>
+<div class="indent">JEP Editor's review: clarified some matters in the text; fully defined the Jabber Registrar Considerations. (psa)
+    </div>
+<h4>Version 0.8 (2004-01-20)</h4>
+<div class="indent">Reorganized for JEP editor's preferences; revised error conditions to properly align with XMPP-Core (lw)
+    </div>
+<h4>Version 0.7 (2003-12-10)</h4>
+<div class="indent">Incorported changes requested from Standards-JIG discussions: Changed entity-to-server discovery behavior; s2s discovery behavior; Expanded application-specific error conditions; Reorganized for better presentation; Changed &quot;per-hop&quot; to apply to the entire ruleset; Fixed minor typos and missteps (lw)
+    </div>
+<h4>Version 0.6 (2003-10-15)</h4>
+<div class="indent">Changed disco behavior; Changed schema to reflect customizations (lw)
+    </div>
+<h4>Version 0.5.1 (2003-09-20)</h4>
+<div class="indent">Fixed many typos (lw)
+    </div>
+<h4>Version 0.5 (2003-08-28)</h4>
+<div class="indent">Renamed to &quot;amp&quot; (thanks stpeter!); Added information about the original addressing; Added requirement for id attribute in &lt;message/&gt;; Restricted behavior within the &quot;Security Considerations&quot;; (lw)
+    </div>
+<h4>Version 0.4 (2003-06-23)</h4>
+<div class="indent">Completely rewritten to better account for various suggested usage details and requirements; Completely reorganized to better codify the protocol(s) and their possible uses; Added more conditions; Added more actions; Added common usage scenarios (lw)
+    </div>
+<h4>Version 0.3 (2003-04-21)</h4>
+<div class="indent">Clarified client-side processing; Removed semantics scope; Clarified &quot;fail&quot; action; Moved existing &quot;use-cases&quot; into &quot;Usage&quot; section in &quot;Overview&quot;; Added more relevant use cases; Added XMPP-style error conditions (lw)
+    </div>
+<h4>Version 0.2 (2003-04-15)</h4>
+<div class="indent">Added XML Schema (with author's assistance). (psa)
+    </div>
+<h4>Version 0.1 (2003-04-15)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0079-1.0.html
+++ b/content/xep-0079-1.0.html
@@ -1,0 +1,1385 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0079: Advanced Message Processing</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Advanced Message Processing">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol that enables entities to request, and servers to perform, advanced processing of XMPP &lt;message/&gt; stanzas, including reliable data transport, time-sensitive delivery, and transient messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0079">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0079: Advanced Message Processing</h1>
+<p>This JEP defines a protocol that enables entities to request, and servers to perform, advanced processing of XMPP &lt;message/&gt; stanzas, including reliable data transport, time-sensitive delivery, and transient messages.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0079<br>
+            Version: 1.0<br>
+            Last Updated: 2004-10-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0082<br>Supersedes: JEP-0023<br>
+                Superseded By: None<br>
+            Short Name: amp<br>
+        Schema for amp: &lt;<a href="http://jabber.org/protocol/amp/amp.xsd">http://jabber.org/protocol/amp/amp.xsd</a>&gt;<br>
+        Schema for amp#errors: &lt;<a href="http://jabber.org/protocol/amp/errors.xsd">http://jabber.org/protocol/amp/errors.xsd</a>&gt;<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/amp.html">http://www.jabber.org/registrar/amp.html</a>&gt;
+              <br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dl>
+<dt>1.1.  <a href="#intro-motivation">Motivation</a>
+</dt>
+<dt>1.2.  <a href="#intro-concepts">Concepts</a>
+</dt>
+<dt>1.3.  <a href="#intro-prereq">Prerequisites</a>
+</dt>
+</dl>
+<dt>2.  <a href="#process">Process Flows</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#process-s2s">Sender-to-Server</a>
+</dt>
+<dl>
+<dt>2.1.1.  <a href="#process-s2s-disco">Discovery</a>
+</dt>
+<dt>2.1.2.  <a href="#process-s2s-semantics">Specifying Semantics</a>
+</dt>
+</dl>
+<dt>2.2.  <a href="#process-server">Server Processing</a>
+</dt>
+<dl>
+<dt>2.2.1.  <a href="#process-server-semantics">Validating Semantics</a>
+</dt>
+<dt>2.2.2.  <a href="#process-server-default">Determine Default Action</a>
+</dt>
+<dt>2.2.3.  <a href="#process-server-rules">Process Rules</a>
+</dt>
+<dt>2.2.4.  <a href="#process-server-execute">Execute Determined Action</a>
+</dt>
+</dl>
+</dl>
+<dt>3.  <a href="#conditionsactions">Conditions and Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#conditions-guide">Rule Condition Guidelines</a>
+</dt>
+<dt>3.2.  <a href="#actions-guide">Rule Action Guidelines</a>
+</dt>
+<dt>3.3.  <a href="#conditions-def">Defined Conditions</a>
+</dt>
+<dl>
+<dt>3.3.1.  <a href="#conditions-def-deliver">deliver</a>
+</dt>
+<dt>3.3.2.  <a href="#conditions-def-expireat">expire-at</a>
+</dt>
+<dt>3.3.3.  <a href="#conditions-def-match">match-resource</a>
+</dt>
+</dl>
+<dt>3.4.  <a href="#actions-def">Defined Actions</a>
+</dt>
+<dl>
+<dt>3.4.1.  <a href="#actions-def-drop">drop</a>
+</dt>
+<dt>3.4.2.  <a href="#actions-def-error">error</a>
+</dt>
+<dt>3.4.3.  <a href="#actions-def-notify">notify</a>
+</dt>
+<dt>3.4.4.  <a href="#actions-def-alert">alert</a>
+</dt>
+</dl>
+<dt>3.5.  <a href="#security-conditions">Security Considerations for the Defined Conditions/Actions</a>
+</dt>
+<dl><dt>3.5.1.  <a href="#security-deliver">"deliver" Condition</a>
+</dt></dl>
+</dl>
+<dt>4.  <a href="#formal">Formal Description</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#formal-root">&lt;amp/&gt; Root Element</a>
+</dt>
+<dt>4.2.  <a href="#formal-rule">&lt;rule/&gt; Element</a>
+</dt>
+</dl>
+<dt>5.  <a href="#examples">Example Scenarios</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#examples-reliabledata">Reliable Data Transport</a>
+</dt>
+<dt>5.2.  <a href="#examples-time">Time-Sensitive Messages</a>
+</dt>
+<dt>5.3.  <a href="#examples-transient">Transient Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#errors-conditions">Conditions</a>
+</dt>
+<dt>6.2.  <a href="#errors-examples">Examples</a>
+</dt>
+<dl>
+<dt>6.2.1.  <a href="#errors-action">Unsupported Action</a>
+</dt>
+<dt>6.2.2.  <a href="#errors-condition">Unsupported Condition</a>
+</dt>
+<dt>6.2.3.  <a href="#errors-notacceptable">Not Acceptable</a>
+</dt>
+<dt>6.2.4.  <a href="#errors-unavail">Service Unavailable</a>
+</dt>
+<dt>6.2.5.  <a href="#errors-undefined">Undefined Condition</a>
+</dt>
+</dl>
+</dl>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>10.3.  <a href="#registrar-reg">Registries</a>
+</dt>
+<dl>
+<dt>10.3.1.  <a href="#registrar-reg-conditions">Rule Conditions Registry</a>
+</dt>
+<dl>
+<dt>10.3.1.1.  <a href="#registrar-reg-conditions-process">Process</a>
+</dt>
+<dt>10.3.1.2.  <a href="#registrar-reg-conditions-initial">Initial Submission</a>
+</dt>
+</dl>
+<dt>10.3.2.  <a href="#registrar-reg-actions">Rule Actions Registry</a>
+</dt>
+<dl>
+<dt>10.3.2.1.  <a href="#registrar-reg-actions-process">Process</a>
+</dt>
+<dt>10.3.2.2.  <a href="#registrar-reg-actions-initial">Initial Submission</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>11.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schemas-amp">AMP</a>
+</dt>
+<dt>11.2.  <a href="#schemas-err">Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#acks">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a protocol that enables an end-point entity to specify additional delivery semantics for an XMPP &lt;message/&gt; stanza. This protocol is typically used by clients to inform the receiving server how to deliver a particular stanza, such as providing an expiration time or a resource-matching strategy.</p>
+  <div class="indent">
+<h3>1.1 <a name="intro-motivation">Motivation</a>
+</h3>
+    <p class="" style="">The built-in delivery semantics for &lt;message/&gt; stanzas (defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250600">1</a>] and, for instant messaging applications, also in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250660">2</a>]) are adequate for most current applications. However, there are various cases where more stringent delivery semantics are necessary. The most common cases discussed in this JEP are:</p>
+    <ul>
+      <li>Reliable data transport -- the sender requires notification (positive and/or negative) of message delivery.</li>
+      <li>Time-sensitive messages -- the message is valid only until a certain date and time.</li>
+      <li>Transient messages -- the message should not be stored offline for later delivery.</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>1.2 <a name="intro-concepts">Concepts</a>
+</h3>
+    <p class="" style="">This protocol is mostly handled by the server or servers processing the &lt;message/&gt;. The protocol consists of a list of rules, with conditions and actions for each rule. Upon receipt of an appropriately marked message, the server interprets the rules in the order they are received, looking for met conditions. When a condition is met, the action for that rule is executed, and message processing stops.</p>
+    <p class="" style="">Each rule is flagged for the scope it applies to, whether it be the overall route, or for each hop in the route.  Additionally, while this JEP defines a default set of conditions and actions, the protocol is extensible enough to allow for more to be defined in the future.</p>
+    <p class="" style="">The namespace for the protocol is "http://jabber.org/protocol/amp".</p>
+  </div>
+  <div class="indent">
+<h3>1.3 <a name="intro-prereq">Prerequisites</a>
+</h3>
+    <p class="" style="">In order for this protocol to function properly, the containing &lt;message/&gt; stanza MUST possess an 'id' attribute, and the value of the 'id' attribute MUST NOT be an empty string. The server MUST specify this 'id' attribute value with any response back to the sender. This is necessary so that servers and clients can properly relate the initial request with any subsequent error or notification.</p>
+  </div>
+<h2>2.
+       <a name="process">Process Flows</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="process-s2s">Sender-to-Server</a>
+</h3>
+    <p class="" style="">This flow describes the interaction between the sender and a server. As illustrated below, this interaction is actually rather simple:</p>
+    <ol start="1" type="1">
+      <li>Sender determines support (E1)</li>
+      <li>Sender specifies appropriate rules and sends message to server (E1,E2)</li>
+      <li>Sender awaits any protocol-specific responses (UCE)</li>
+    </ol>
+    <ul>
+      <li>
+<span style="font-weight: bold">E1:</span> The server does not support this protocol (UCE)</li>
+      <li>
+<span style="font-weight: bold">E2:</span> The server does not support one or more specified rule conditions/actions (UCE)</li>
+    </ul>
+    <div class="indent">
+<h3>2.1.1 <a name="process-s2s-disco">Discovery</a>
+</h3>
+      <p class="" style="">Sending entities that wish to use AMP SHOULD discover support for this protocol (using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256185">3</a>]) along the intended path. Typically, this would involve sending disco#info queries to the sending entity's own server and the server of the intended recipient. The results of these queries MAY be cached for up to 24 hours, unless otherwise expired.</p>
+      <p class="" style="">If a server supports Advanced Message Processing, it MUST report that by including a service discovery feature of "http://jabber.org/protocol/amp" in the service discovery information result that it returns to the requesting entity.</p>
+      <p class="caption">Example 1. Initial Service Discovery information request</p>
+<div class="indent"><pre>
+&lt;iq from='northumberland@shakespeare.lit/westminster'
+    to='shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 2. Service Discovery information response</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    to='northumberland@shakespeare.lit/westminster'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity name='Shakespeare IM' category='im' type='server'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">A server SHOULD also maintain a service discovery node named "http://jabber.org/protocol/amp", at which it advertises the individual actions and conditions it supports. If an entity needs to determine whether the server supports individual actions and conditions, it SHOULD send a service discovery information request to that node; the server then MUST either return the list of supported actions and conditions or return an error such as &lt;feature-not-implemented/&gt;. (Note: If the server does not provide information for this disco node, the requesting entity MUST assume that all actions and conditons are supported for each reported action set or condition set.)</p>
+      <p class="" style="">Each supported action shall be reported as a feature using the following format:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>http://jabber.org/protocol/amp?action={action}</pre></div>
+      <p class="" style="">Each supported condition shall be reported as a feature using the following format:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>http://jabber.org/protocol/amp?condition={condition}</pre></div>
+      <p class="" style="">The following examples show the request-response flow for information about individual actions and conditions (note the inclusion of the 'node' attribute).</p>
+      <p class="caption">Example 3. Request for information about individual actions and conditions</p>
+<div class="indent"><pre>
+&lt;iq from='northumberland@shakespeare.lit/westminster'
+    to='shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/amp'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 4. Response for individual actions and conditions</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    to='northumberland@shakespeare.lit/westminster'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/amp'&gt;
+    &lt;identity name='Shakespeare IM AMP Support' category='im' type='server'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=drop'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=error'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=deliver'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=expire-at'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=match-resource'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>2.1.2 <a name="process-s2s-semantics">Specifying Semantics</a>
+</h3>
+      <p class="" style="">Once support is determined, the sender can attach the desired delivery semantics to the message:</p>
+      <p class="caption">Example 5. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The semantics are defined as a set of &lt;rule/&gt; elements within the &lt;amp/&gt; root element. Each &lt;rule/&gt; declares the condition to trigger on and the action to execute if triggered.</p>
+      <p class="" style="">By default, the ruleset applies only to the "edge servers": those servers to which the sending and receiving entities are connected. (Note: For the purposes of Advanced Message Processing, "server" is defined as in <span style="font-weight: bold">XMPP Core</span> and does not include any internal components, such as connection managers, that may provide functionality within a server implementation or installation.)</p>
+      <p class="" style="">The ruleset MAY be applied to all server-to-server "hops" along the route from the sending and receiving entities by adding the "per-hop' attribute to the &lt;amp/&gt; element. The value of this attribute is either "true" (apply rules to all hops) or "false" (follow default behavior, i.e., apply rules at the edge servers only).</p>
+      <p class="caption">Example 6. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+       per-hop='true'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">For examples of validation failure, refer to the <a href="#errors">Error Handling</a> section of this document.</p>
+      <p class="" style="">Note: Even if "per-hop" processing is requested, each server in the route MUST ignore rules that cannot apply to it; the <a href="#conditions-def">Defined Conditions</a> outline if they can be applied per-hop.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="process-server">Server Processing</a>
+</h3>
+    <p class="" style="">Server operation is where the bulk of the work is performed. Upon receiving a message with an AMP extension, the server performs the following flow:</p>
+    <ol start="1" type="1">
+      <li>Validate the semantics (E1, E2).</li>
+      <li>Determine the default behavior.</li>
+      <li>Process rules until condition is met.
+        <ul>
+          <li>If a condition is met, execute that rule's action</li>
+          <li>If no conditions are met, perform "default" behavior for message</li>
+        </ul>
+      </li>
+      <li>Execute determined action (UCE) (E3).</li>
+    </ol>
+    <ul>
+      <li>
+<span style="font-weight: bold">E1:</span> The provided semantics (rule's condition/action) are not supported or valid (UCE)</li>
+      <li>
+<span style="font-weight: bold">E2:</span> The requested semantics are not acceptable (UCE)</li>
+      <li>
+<span style="font-weight: bold">E3:</span> The next server does not support this protocol (UCE)</li>
+    </ul>
+    <div class="indent">
+<h3>2.2.1 <a name="process-server-semantics">Validating Semantics</a>
+</h3>
+      <p class="" style="">Validation can take many forms, but at the very least the server MUST verify that it understands each of the rule conditions and actions, and that the condition contents are appropriate. The server MAY also refused to accept certain combinations of conditions and actions, for example if they present a risk of overriding security. If the semantics are not valid, supported, or acceptable, the server MUST reply with an error specifying the rule(s) that are at issue. The server SHOULD validate all the semantics before returning an error. For syntax and examples of error handling related to validation failure, refer to the <a href="#errors">Error Handling</a> section of this document.</p>
+    </div>
+    <div class="indent">
+<h3>2.2.2 <a name="process-server-default">Determine Default Action</a>
+</h3>
+      <p class="" style="">This step is essentially what a server normally does, except that it does not actually perform the action. This determines what would happen to the message if there were no semantics attached (such as dispatch to another server or store offline). At this point, the server SHOULD also calculate any timing or calendar requirements (if applicable).</p>
+    </div>
+    <div class="indent">
+<h3>2.2.3 <a name="process-server-rules">Process Rules</a>
+</h3>
+      <p class="" style="">At this step, the server processes the attached semantics. The server MUST process the rules serially, and in the order they are presented within the &lt;amp/&gt; element. As soon as a rule's condition is met, processing ends with that action overriding the default action determined earlier (unless the action permits continued processing).</p>
+    </div>
+    <div class="indent">
+<h3>2.2.4 <a name="process-server-execute">Execute Determined Action</a>
+</h3>
+      <p class="" style="">Once all rules have been processed or otherwise accounted for, the server executes the action determined at this point.</p>
+      <p class="" style="">A server SHOULD NOT dispatch a &lt;message/&gt; stanza with AMP semantics to another server unless it knows that the next server supports AMP (this SHOULD be discovered via <span style="font-weight: bold">Service Discovery</span> and MAY be cached to avoid delivery delays). If the next server does not support AMP, the current server replies to the original sender with a &lt;service-unavailable/&gt; error condition. Otherwise this flow starts again for the server to which the message has been dispatched.</p>
+    </div>
+  </div>
+<h2>3.
+       <a name="conditionsactions">Conditions and Actions</a>
+</h2>
+  <p class="" style="">The preceding sections of this JEP define the general behavior regarding AMP. This section outlines how &lt;rule/&gt; action and condition sets are defined. It also provides defined action and condition sets; these action and condition sets SHOULD be supported by any implementation of Advanced Message Processing, but support for any given action or condition set it not required. (Note: The action and condition sets defined herein may be supplemented in the future via registration of additional action and condition sets with the Jabber Registrar.)</p>
+  <div class="indent">
+<h3>3.1 <a name="conditions-guide">Rule Condition Guidelines</a>
+</h3>
+    <p class="" style="">The definition of a &lt;rule/&gt; condition MUST provide the following information:</p>
+    <ul>
+      <li>Define a namespace governing the condition set</li>
+      <li>Define the condition:
+        <ul>
+          <li>Define the 'condition' attribute value</li>
+          <li>Specify if the "per-hop" flag applies</li>
+          <li>Define the syntax/format of the 'value' attribute value</li>
+          <li>Define how the "value" is interpreted to meet a condition</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-guide">Rule Action Guidelines</a>
+</h3>
+    <p class="" style="">The definition of a &lt;rule/&gt; action MUST provide the following information:</p>
+    <ul>
+      <li>Define a namespace governing the action set</li>
+      <li>Define the action:
+        <ul>
+          <li>Define each 'action' attribute value</li>
+          <li>Define the expected behavior if the &lt;rule/&gt; is triggered</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="conditions-def">Defined Conditions</a>
+</h3>
+    <p class="" style="">The condition defines how or when a particular rule is triggered. The value of the condition attribute determines what the contents of the &lt;rule/&gt; mean.</p>
+    <p class="" style="">The following conditions are defined by this JEP and SHOULD be supported by any implementation.</p>
+    <p class="" style="">In the following sections, the terms "content" and "contents" refers to the XML character data contained by the &lt;rule/&gt; element.</p>
+    <div class="indent">
+<h3>3.3.1 <a name="conditions-def-deliver">deliver</a>
+</h3>
+      <p class="" style="">The "deliver" condition is used to ensure delivery (or non-delivery) in one of five ways:</p>
+      <ol start="1" type="1">
+        <li>Directly to an appropriate resource over XMPP</li>
+        <li>Delayed to offline storage (for later delivery via XMPP)</li>
+        <li>Forwarded to an alternate address over XMPP</li>
+        <li>Indirectly to an alternate address through a gateway to a non-XMPP system</li>
+      </ol>
+      <p class="" style="">The possible contents for this condition are defined in the following table:</p>
+      <p class="caption">Table 1: "deliver" values</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Value</th>
+          <th colspan="" rowspan="">Description</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"direct"</td>
+          <td align="" colspan="" rowspan="">The message can be delivered immediately to the intended resource.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"forward"</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be forwarded to another XMPP address.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"gateway"</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be sent through a gateway to an address on a non-XMPP system.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"none"</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and is to be dropped (e.g., because offline storage is not enabled).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"stored"</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be stored offline for later delivery via XMPP.</td>
+        </tr>
+      </table>
+      <p class="" style="">This condition is met based on what the processor is able to do with the message at the moment of receipt. To correctly process this condition, a processor first determines if the message can be delivered immediately to the intended resource or further dispatched to another hop. If so and the contents are "direct", the condition is met. If not and the contents are "stored", the condition is also met if offline storage is enabled. In all other cases the condition is not met.</p>
+      <p class="" style="">This condition MAY be applied to each "hop" in the server route.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.2 <a name="conditions-def-expireat">expire-at</a>
+</h3>
+      <p class="" style="">The "expire-at" condition is used to ensure delivery before an absolute point in time. Naturally, this does not <span style="font-style: italic">guarantee</span>  [<a href="#nt-id2257029">4</a>] that the message will not be delivered after that time from the sender's perspective, since this JEP does not assume that all machine clocks (e.g., for all servers along the delivery route) are synchronized. However, in order to help ensure that this condition is met correctly, servers that implement this JEP (or the machines that host such servers) SHOULD use the Network Time Protocol (<span class="ref" style="">RFC 1305</span>  [<a href="#nt-id2257064">5</a>]) to keep in sync with established time authorities. Note also that expire-at functionality becomes less reliable the closer the expire-at time is to the present (e.g., the sender will receive less reliable delivery of a message speciifying an expire-at time two seconds in the future than of a message specifying an expire-at time two hours or two days in the future).</p>
+      <p class="" style="">The content of the 'value' attribute specifies some point after the exact moment the message is sent; the content MUST be a DateTime as specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2257226">6</a>], and the timezone MUST be UTC.</p>
+      <p class="" style="">The condition is met if the message cannot be delivered to the recipient before the specified datetime. To determine the datetime to compare to, the processor first determines if and when a message can be dispatched (e.g. not stored offline). The processor then records this datetime, and compares it with the specified datetime. If the current datetime is on or after that specified, the condition is met.</p>
+      <p class="" style="">This condition MAY be applied to each "hop" in the server route.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.3 <a name="conditions-def-match">match-resource</a>
+</h3>
+      <p class="" style="">The "match-resource" condition is used to restrict delivery based on the resource identifier of the recipient JID.</p>
+      <p class="" style="">The possible contents for this condition are:</p>
+      <p class="caption">Table 2: "match-resource" values</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Value</th>
+          <th colspan="" rowspan="">Description</th>
+          <th colspan="" rowspan="">Example</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"exact"</td>
+          <td align="" colspan="" rowspan="">Destination resource exactly matches the specified resource.</td>
+          <td align="" colspan="" rowspan="">"home/laptop" only matches "home/laptop" and not "home/desktop" or "work/desktop"</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"any"</td>
+          <td align="" colspan="" rowspan="">Destination resource matches any value, effectively ignoring the specified resource.</td>
+          <td align="" colspan="" rowspan="">"home/laptop" matches "home", "home/desktop" or "work/desktop"</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"other"</td>
+          <td align="" colspan="" rowspan="">Destination resource matches any value except for the specified resource.</td>
+          <td align="" colspan="" rowspan="">"home/laptop" matches "work/desktop", "home" or "home/desktop", but not "home/laptop"</td>
+        </tr>
+      </table>
+      <p class="" style="">The condition is met if the resource for the actual destination JID matches the specified destination JID using the above rules. For instance, if a message is intended for "romeo@montague.net/work" with the "match-resource" condition of "other", the condition is met if the message can be immediately delivered only to "romeo@montague.net/home".</p>
+      <p class="" style="">For purposes of this condition, a JID with no resource has the following behavior:</p>
+      <ul>
+        <li>If the value is "exact", the condition is met only if the server would deliver to a non-resource JID (e.g., a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257210">7</a>] room or offline storage).</li>
+        <li>If the value is "other", the condition is met only if the server would not deliver to a non-resource JID.</li>
+      </ul>
+      <p class="" style="">This condition MUST NOT be applied to each "hop" in the server route, only at the edge servers. If an &lt;amp/&gt; element includes this condition and also indicates that it should be processed per hop, this &lt;rule/&gt; shall be ignored.</p>
+      <p class="" style="">Note: By design, this protocol does not include support for partial JID matching (which would stipulate, for example, that the resource identifiers "home/laptop" and "homeboy" both match "home").</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-def">Defined Actions</a>
+</h3>
+    <p class="" style="">The action defines what occurs when a particular rule is triggered. The value of the action attribute determines the behavior if the rule's condition is met.</p>
+    <p class="" style="">The following actions are defined by this JEP.</p>
+    <div class="indent">
+<h3>3.4.1 <a name="actions-def-drop">drop</a>
+</h3>
+      <p class="" style="">The "drop" action silently discards the message from any further delivery attempts and ensures that it is not placed into offline storage. The drop MUST NOT result in other responses.</p>
+    </div>
+    <div class="indent">
+<h3>3.4.2 <a name="actions-def-error">error</a>
+</h3>
+      <p class="" style="">The "error" action triggers a reply &lt;message/&gt; stanza of type "error" to the sending entity. The &lt;message/&gt; stanza's &lt;error/&gt; child MUST contain a &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'/&gt; error condition, which itself contains the rules that triggered this action.</p>
+      <p class="caption">Example 7. "error" response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           type='error'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+    &lt;error type='modify' code='500'&gt;
+      &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+        &lt;rule condition='deliver' value='stored' action='error'/&gt;
+      &lt;/failed-rules&gt;
+    &lt;/error&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+      <p class="" style="">Note that the error SHOULD be of type "modify", and the general error condition SHOULD be &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;.</p>
+    </div>
+    <div class="indent">
+<h3>3.4.3 <a name="actions-def-notify">notify</a>
+</h3>
+      <p class="" style="">The "notify" action triggers a reply &lt;message/&gt; stanza to the sending entity. This &lt;message/&gt; stanza MUST contain the element &lt;amp status='notify'/&gt;, which itself contains the &lt;rule/&gt; that triggered this action. Unlike the other actions, this action does not override the default behavior for a server. Instead, the server then executes its default behavior after sending the notify.</p>
+      <p class="caption">Example 8. "error" response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='notify'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='notify'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+    </div>
+    <div class="indent">
+<h3>3.4.4 <a name="actions-def-alert">alert</a>
+</h3>
+      <p class="" style="">The "alert" action triggers a reply &lt;message/&gt; stanza to the sending entity. This &lt;message/&gt; stanza MUST contain the element &lt;amp type='alert'/&gt;, which itself contains the &lt;rule/&gt; that triggered this action. In all other respects, this action behaves as "drop".</p>
+      <p class="caption">Example 9. "error" response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='alert'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="security-conditions">Security Considerations for the Defined Conditions/Actions</a>
+</h3>
+    <div class="indent">
+<h3>3.5.1 <a name="security-deliver">"deliver" Condition</a>
+</h3>
+      <p class="" style="">This condition has the largest potential for abuse, as it can appear to bypass presence. [<a href="#nt-id2257702">8</a>] A naive server could simply check to see the outcome for a particular message, regardless of whether the sender and receiver are subscribed to each other. This behavior SHOULD NOT be implemented, although it may be desirable in some environments (such as fully-trusted networks).</p>
+      <p class="" style="">There are several directions server implementors can follow in this regard:</p>
+      <ul>
+        <li>This condition is not implemented. The result MUST be to reply to the sender with a &lt;feature-not-implemented/&gt; error condition.</li>
+        <li>This condition is accepted only if the action is "drop". The result otherwise MUST be to reply to the sender with a &lt;not-acceptable/&gt; error condition.</li>
+        <li>This condition is accepted only if the sender is subscribed to the receiver's presence. The result otherwise MUST be to reply to the sender with a &lt;not-acceptable/&gt; error condition.</li>
+      </ul>
+    </div>
+  </div>
+<h2>4.
+       <a name="formal">Formal Description</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="formal-root">&lt;amp/&gt; Root Element</a>
+</h3>
+    <p class="" style="">All delivery semantics are encapsulated in the &lt;amp/&gt; element. This element contains one or more &lt;rule/&gt; elements specifying the specific rules to process. It can optionally possess attributes about the current status, the original sender and recipient, and route applicability.</p>
+    <p class="" style="">The 'status' attribute specifies the reason for this &lt;amp/&gt; element. When specifying semantics to be applied (client to server), this attribute MUST NOT be present. When replying to a sending entity regarding a met condition, this attribute MUST be present and SHOULD be the value of the 'action' attribute for the triggered rule. (Note: Individual action definitions MAY provide their own requirements.)</p>
+    <p class="" style="">The 'from' attribute specifies the original sender of the containing &lt;message/&gt; stanza. This attribute MUST be specified for any &lt;message/&gt; stanza sent from a supporting server, regardless of the recipient. It SHOULD NOT be specified otherwise. The value of the 'from' attribute MUST be the full JID (node@domain/resource) of the sender for the original &lt;message/&gt; stanza.</p>
+    <p class="" style="">The 'to' attribute specifies the original (intended) recipient of the containing &lt;message/&gt; stanza. This attribute MUST be specified for any &lt;message/&gt; stanza sent from a supporting server, regardless of the recipient. It SHOULD NOT be specified otherwise. The value of the 'to' attribute MUST be the full JID (node@domain/resource) of the intended recipient for the original &lt;message/&gt; stanza.</p>
+    <p class="" style="">The 'per-hop' attribute flags the contained ruleset for processing at each server in the route between the original sender and original intended recipient. This attribute MAY be present, and MUST be either "true" or "false". If not present, the default is "false".</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="formal-rule">&lt;rule/&gt; Element</a>
+</h3>
+    <p class="" style="">Each semantic rule is specified with a &lt;rule/&gt; element. This element possesses attributes for the condition, value, and action.</p>
+    <p class="" style="">The 'action' attribute defines the result for this rule. This attribute MUST be present, and MUST be either a value defined in the <a href="#actions-def">Defined Actions</a> section, or one registered with the Jabber Registrar.</p>
+    <p class="" style="">The 'condition' attribute defines the overall condition this rule applies to. This attribute MUST be present, and MUST be either a value defined in the <a href="#conditions-def">Defined Conditions</a> section, or one registered with the Jabber Registrar.</p>
+    <p class="" style="">The 'value' attribute defines how the condition is matched. This attribute MUST be present, and MUST NOT be an empty string (""). The interpretation of this attribute's value is determined by the 'condition' attribute.</p>
+  </div>
+<h2>5.
+       <a name="examples">Example Scenarios</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="examples-reliabledata">Reliable Data Transport</a>
+</h3>
+    <p class="" style="">The &lt;message/&gt; stanza is nearly ideal for data transport, but to ensure reliability it is often desirable that such messages not be delivered to any resource but that specified. To facilitate this, the sending entity includes a &lt;rule action='drop' condition='match-resource' value='exact'/&gt; (if failure notification is unnecessary) or &lt;rule action='error' condition='match-resource' value='exact'/&gt; (if failure notification is required). The following example illustrates this using <span class="ref" style="">In-Band Bytestreams</span>  [<a href="#nt-id2257982">9</a>]:</p>
+    <p class="caption">Example 10. Sending a message for reliable data transport</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit/pda'
+         from='bernardo@hamlet.lit/elsinore'
+         id='ibb1'&gt;
+  &lt;data xmlns='http://jabber.org/protocol/ibb' sid='mySID' seq='0'&gt;
+    qANQR1DBwU4DX7jmYZnncmUQB/9KuKBddzQH+tZ1ZywKK0yHKnq57kWq+RFtQdCJ
+    WpdWpR0uQsuJe7+vh3NWn59/gTc5MDlX8dS9p0ovStmNcyLhxVgmqS8ZKhsblVeu
+    IpQ0JgavABqibJolc3BKrVtVV1igKiX/N7Pi8RtY1K18toaMDhdEfhBRzO/XB0+P
+    AQhYlRjNacGcslkhXqNjK5Va4tuOAPy2n1Q8UUrHbUd0g+xJ9Bm0G0LZXyvCWyKH
+    kuNEHFQiLuCY6Iv0myq6iX6tjuHehZlFSh80b5BVV9tNLwNR5Eqz1klxMhoghJOA
+  &lt;/data&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule condition='expire-at' value='2004-09-10T08:33:14Z' action='error'/&gt;
+    &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the above case, the sender would receive an error reply if the message could not be delivered specifically to "francisco@hamlet.lit/pda" within 500 seconds.</p>
+    <p class="caption">Example 11. Failed reliable data transport message</p>
+<div class="indent"><pre>
+&lt;message from='hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'
+         id='ibb1'&gt;
+  &lt;data xmlns='http://jabber.org/protocol/ibb' sid='mySID' seq='0'&gt;
+    qANQR1DBwU4DX7jmYZnncmUQB/9KuKBddzQH+tZ1ZywKK0yHKnq57kWq+RFtQdCJ
+    WpdWpR0uQsuJe7+vh3NWn59/gTc5MDlX8dS9p0ovStmNcyLhxVgmqS8ZKhsblVeu
+    IpQ0JgavABqibJolc3BKrVtVV1igKiX/N7Pi8RtY1K18toaMDhdEfhBRzO/XB0+P
+    AQhYlRjNacGcslkhXqNjK5Va4tuOAPy2n1Q8UUrHbUd0g+xJ9Bm0G0LZXyvCWyKH
+    kuNEHFQiLuCY6Iv0myq6iX6tjuHehZlFSh80b5BVV9tNLwNR5Eqz1klxMhoghJOA
+  &lt;/data&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+      from='bernardo@hamlet.lit/elsinore'
+      to='francisco@hamlet.lit/pda'&gt;
+    &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='500'&gt;
+    &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+      &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+    &lt;/failed-rules&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="examples-time">Time-Sensitive Messages</a>
+</h3>
+    <p class="" style="">Time-sensitive messages are a frequent occurrence in some environments (e.g., front-office personnel routinely notify others of "events" such as guests, unexpected refreshments, and ad-hoc gatherings). To send a time-sensitive message, the sending entity includes a &lt;rule condition='expire-at' action='drop'/&gt; with the time when the event is to occur:</p>
+    <p class="caption">Example 12. Sending a time-sensitive message</p>
+<div class="indent"><pre>
+&lt;message to='linuxwolf@outer-planes.net'
+         from='receptionist@outer-planes.net'
+         id='alert849'&gt;
+  &lt;subject&gt;Guest Alert!&lt;/subject&gt;
+  &lt;body&gt;
+    There will be clients in the conference room today around 1 PM!
+    As always, be courteous and quiet nearby...
+  &lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2003-06-23T23:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the above case, the server for "linuxwolf@outer-planes.net" would not deliver the message once 23:00 UTC (3:00 PM Pacific Daylight Time) has passed.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="examples-transient">Transient Messages</a>
+</h3>
+    <p class="" style="">Transient messages are messages that should never be stored offline. To send a transient message, the sending entity includes a &lt;rule condition='deliver' action='drop' value='stored'/&gt;:</p>
+    <p class="caption">Example 13. Sending a transient message</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit'
+         from='bernardo@hamlet.lit/elsinore'
+         type='chat'
+         id='chatty1'&gt;
+  &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='deliver' value='stored' action='drop'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the sending entity includes a &lt;rule condition='deliver' action='alert' value='stored'/&gt; to be alerted instead of having the message silently dropped:</p>
+    <p class="caption">Example 14. Sending a transient message (requesting alert)</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit'
+         from='bernardo@hamlet.lit/elsinore'
+         type='chat'
+         id='chatty2'&gt;
+  &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 15. Sender alerted regarding transient message</p>
+<div class="indent"><pre>
+&lt;message from='hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'
+         id='chatty2'&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+       action='alert'
+       from='bernardo@hamlet.lit/elsinore'
+       to='francisco@hamlet.lit'&gt;
+    &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="errors-conditions">Conditions</a>
+</h3>
+    <p class="" style="">To simplify the discussion of error conditions, this document uses the following mappings between namespace URIs and namespace prefixes (note: this mapping is provided only for the purpose of simplifying the discussion and is not intended for use within the protocol itself).</p>
+    <p class="caption">Table 3: Namespace Mappings</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Prefix</th>
+        <th colspan="" rowspan="">URI</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">xmpp</td>
+        <td align="" colspan="" rowspan="">urn:ietf:params:xml:ns:xmpp-stanzas</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">msg</td>
+        <td align="" colspan="" rowspan="">http://jabber.org/protocol/amp</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">err</td>
+        <td align="" colspan="" rowspan="">http://jabber.org/protocol/amp#errors</td>
+      </tr>
+    </table>
+    <p class="" style="">The following table shows the possible error conditions in relation to general AMP rules and conditions as well as the <a href="#actions-def">Defined Actions</a>.</p>
+    <p class="caption">Table 4: Error conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">General Condition</th>
+        <th colspan="" rowspan="">Error Type</th>
+        <th colspan="" rowspan="">Specific Condition</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:bad-request/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:unsupported-actions/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rule's specified actions are not supported. The element &lt;msg:unsupported-actions/&gt; contains the &lt;rule/&gt; elements that specify the unsupported actions.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:bad-request/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:unsupported-conditions/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rule's specified conditions are not supported. The element &lt;msg:unsupported-conditions/&gt; contains the &lt;rule/&gt; elements that specify the unsupported conditions.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:not-acceptable/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:invalid-rules/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rules are not acceptable by this server, usually because the condition/action combination is restricted. The element &lt;msg:invalid-rules/&gt; contains the &lt;rule/&gt; elements that are not acceptable.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:service-unavailable/&gt;</td>
+        <td align="" colspan="" rowspan="">cancel</td>
+        <td align="" colspan="" rowspan="">NONE</td>
+        <td align="" colspan="" rowspan="">This protocol is not supported. This error is returned to the sending entity if a server along the route to the recipient does not implement this protocol.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:undefined-condition/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;err:failed-rules/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more &lt;rule/&gt; elements triggered the "error" action. This condition contains the triggered &lt;rule/&gt; elements.</td>
+      </tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="errors-examples">Examples</a>
+</h3>
+    <p class="" style="">This section shows examples of the error conditions described in the previous section (for information regarding mapping of XMPP error conditions to Jabber error codes, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2258557">10</a>]).</p>
+    <div class="indent">
+<h3>6.2.1 <a name="errors-action">Unsupported Action</a>
+</h3>
+      <p class="caption">Example 16. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 17. Server does not support action</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='400'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-actions xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/unsupported-actions&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.2 <a name="errors-condition">Unsupported Condition</a>
+</h3>
+      <p class="caption">Example 18. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 19. Server does not support condition</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='400'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-conditions xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/unsupported-conditions&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.3 <a name="errors-notacceptable">Not Acceptable</a>
+</h3>
+      <p class="caption">Example 20. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 21. The rule is not acceptable to the server</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='405'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-rules xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/invalid-rules&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.4 <a name="errors-unavail">Service Unavailable</a>
+</h3>
+      <p class="caption">Example 22. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 23. AMP service is unavailable</p>
+<div class="indent"><pre>
+&lt;message
+    from='royalty.england.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='cancel' code='503'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.5 <a name="errors-undefined">Undefined Condition</a>
+</h3>
+      <p class="caption">Example 24. A message with semantics</p>
+<div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 25. Failed rules</p>
+<div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           type='error'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+    &lt;error type='modify' code='500'&gt;
+      &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+        &lt;rule condition='deliver' value='stored' action='error'/&gt;
+      &lt;/failed-rules&gt;
+    &lt;/error&gt;
+  &lt;/message&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">If the recipient's server implements "offline storage", it will need to keep track of which offline messages are subject to expiration and not deliver those which have expired. Exactly how to do so is a matter of implementation. One possible implementation is for the server to maintain a separate database of expirable messages and periodically scan it; upon discovering an expired message, it could flag the messages as eligible for discarding and inform the sender, but not discard the message until the intended recipient next becomes available.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The security considerations are dependent upon the specific conditions and actions in use. The considerations for the defined conditions and actions are outlined with their definitions in the <a href="#conditionsactions">Conditions and Actions</a> section of this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258828">11</a>] is necessary as a result of this JEP.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258880">12</a>] includes 'http://jabber.org/protocol/amp' and 'http://jabber.org/protocol/amp#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes 'http://jabber.org/protocol/amp' in its registry of well-known Service Discovery nodes.</p>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="registrar-reg">Registries</a>
+</h3>
+    <div class="indent">
+<h3>10.3.1 <a name="registrar-reg-conditions">Rule Conditions Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar maintains a registry of AMP &lt;rule/&gt; conditions (see &lt;<a href="http://www.jabber.org/registrar/amp-conditions.html">http://www.jabber.org/registrar/amp-conditions.html</a>&gt;).</p>
+      <div class="indent">
+<h3>10.3.1.1 <a name="registrar-reg-conditions-process">Process</a>
+</h3>
+        <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;name&gt;the value of the 'condition' attribute&lt;/name&gt;
+  &lt;ns&gt;the namespace to be used as a service discovery feature&lt;/ns&gt;
+  &lt;per-hop&gt;does the "per-hop" flag apply? [true|false]&lt;/per-hop&gt;
+  &lt;value&gt;
+     The syntax (e.g., datatype or allowable values) of the
+     'value' attribute.
+  &lt;/value&gt;
+  &lt;processing&gt;values that result in message processing&lt;/processing&gt;
+  &lt;doc&gt;the document (e.g., JEP) in which this condition is specified&lt;/doc&gt;
+&lt;/condition&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one condition at a time, each contained in a separate &lt;condition/&gt; element.</p>
+        <p class="" style="">Note: The namespace for the condition set shall be included in the Service Discovery features registry.</p>
+      </div>
+      <div class="indent">
+<h3>10.3.1.2 <a name="registrar-reg-conditions-initial">Initial Submission</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;name&gt;deliver&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=deliver&lt;/ns&gt;
+  &lt;per-hop&gt;true&lt;/per-hop&gt;
+  &lt;value&gt;[direct|forward|gateway|none|stored]&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if (1) the value is "direct" and the message
+    can be immediately delivered or further dispatched, or (2) the 
+    value is "stored" and offline storage is enabled.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+
+&lt;condition&gt;
+  &lt;name&gt;expire-at&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=expire-at&lt;/ns&gt;
+  &lt;per-hop&gt;true&lt;/per-hop&gt;
+  &lt;value&gt;DateTime per JEP-0082&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if the message cannot be delivered before
+    the specified DateTime.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+
+&lt;condition&gt;
+  &lt;name&gt;match-resource&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=match-resource&lt;/ns&gt;
+  &lt;per-hop&gt;false&lt;/per-hop&gt;
+  &lt;value&gt;[any|exact|other]&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if (1) the value is "any" and the intended
+    recipient has at least one available resource (as defined in the
+    XMPP IM specification); (2) the value "exact" and the intended
+    recipient has an available resource that exactly matches the JID
+    specified in the 'to' address; (3) the value is "other" and the
+    intended recipient has an available resource whose full JID is
+    other than that specified in the 'to' address.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>10.3.2 <a name="registrar-reg-actions">Rule Actions Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar maintains a registry of AMP &lt;rule/&gt; actions (see &lt;<a href="http://www.jabber.org/registrar/amp-actions.html">http://www.jabber.org/registrar/amp-actions.html</a>&gt;).</p>
+      <div class="indent">
+<h3>10.3.2.1 <a name="registrar-reg-actions-process">Process</a>
+</h3>
+        <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;action&gt;
+  &lt;name&gt;the value of the 'action' attribute&lt;/name&gt;
+  &lt;ns&gt;the namespace to be used as a service discovery feature&lt;/ns&gt;
+  &lt;behavior&gt;the expected behavior if the rule is triggered&lt;/behavior&gt;
+  &lt;doc&gt;the document (e.g., JEP) in which this action is specified&lt;/doc&gt;
+&lt;/action&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one action at a time, each contained in a separate &lt;action/&gt; element.</p>
+        <p class="" style="">Note: The namespace for the action set shall be included in the Service Discovery features registry.</p>
+      </div>
+      <div class="indent">
+<h3>10.3.2.2 <a name="registrar-reg-actions-initial">Initial Submission</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;action&gt;
+  &lt;name&gt;alert&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=drop&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is silently discarded but an alert is returned to the
+    sender.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;drop&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=drop&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is silently discarded.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;error&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=error&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is not processed and an error is returned to the sender,
+    specifying which rule resulted in failed processing.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;notify&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=notify&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is processed and a notification message is returned to
+    the sender, specifying which rule was processed.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+        </pre></div>
+      </div>
+    </div>
+  </div>
+<h2>11.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schemas-amp">AMP</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/amp'
+    xmlns='http://jabber.org/protocol/amp'
+    elementFormDefault='qualified'&gt;
+ 
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0079: http://www.jabber.org/jeps/jep-0079.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='amp'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' usage='optional' type='xs:string'/&gt;
+      &lt;xs:attribute name='per-hop' use='optional' type='xs:bool' default='false'/&gt;
+      &lt;xs:attribute name='status' usage='optional' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='to' usage='optional' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+ 
+  &lt;xs:element name='invalid-rules'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsupported-actions'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsupported-conditions'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='rule'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='action' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='condition' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='value' use='required' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schemas-err">Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/amp#errors'
+    xmlns='http://jabber.org/protocol/amp#errors'
+    elementFormDefault='qualified'&gt;
+ 
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0079: http://www.jabber.org/jeps/jep-0079.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='failed-rules'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='rule'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='action' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='condition' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='value' use='required' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="acks">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Marshall Rose and Craig Kaes for their comments.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250600">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250660">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256185">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257029">4</a>. Guarantee is a strong word. This JEP defines methods for making message delivery more reliable within certain bounds, but does not pretend that such methods provide any form of guaranteed delivery.</p>
+<p><a name="nt-id2257064">5</a>. RFC 1305: Network Time Protocol (Version 3) &lt;<a href="http://www.ietf.org/rfc/rfc1305.txt">http://www.ietf.org/rfc/rfc1305.txt</a>&gt;.</p>
+<p><a name="nt-id2257226">6</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2257210">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257702">8</a>. Consider the following scenario: the user &lt;romeo@montague.net&gt; is not an authorized subscriber to the presence of the user &lt;nurse@capulet.com&gt;, but sends a &lt;message/&gt; stanza with a "deliver" rule of "direct" to that address; if the Nurse is not online, Romeo could discover that fact if the capulet.com server informs him that the message could not be delivered immediately.</p>
+<p><a name="nt-id2257982">9</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p><a name="nt-id2258557">10</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2258828">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258880">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2004-10-11)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced to a status of Draft. (psa)
+    </div>
+<h4>Version 0.12 (2004-09-09)</h4>
+<div class="indent">Relaxed server-to-server requirements; clarified discovery rules; removed expire-in condition. (lw)
+    </div>
+<h4>Version 0.11 (2004-08-25)</h4>
+<div class="indent">Specified that the timestamp for an expire-at condition must be a UTC DateTime per JEP-0082; provided further explanation regarding expire-at and expire-in conditions. (lw/psa)
+    </div>
+<h4>Version 0.10 (2004-07-14)</h4>
+<div class="indent">Changes to address Council feedback: clarified error handling and provided error examples; specified that server should validate all rule semantics before returning an error; specified that service discovery information can be cached (not necessary to send disco query before dispatching each message); added "forward" and "gateway" to values of "deliver" condition to handle redirection of messages to alternate XMPP addresses and non-XMPP systems respectively; more clearly specified processing rules for "expire-in" condition; changed milliseconds to seconds for "expire-in"; made explicit that partial JID-matching is not included for "match-resource" condition; added clarifying note to security consideration regarding "deliver" condition; corrected values of per-hop from [yes|no] to [true|false]; changed "standard" conditions to "defined" conditions and mandated that they should be supported; changed "http://jabber.org/protocol/amp#std-actions" namespace to "http://jabber.org/protocol/amp#errors". (lw/psa)
+    </div>
+<h4>Version 0.9 (2004-04-25)</h4>
+<div class="indent">JEP Editor's review: clarified some matters in the text; fully defined the Jabber Registrar Considerations. (psa)
+    </div>
+<h4>Version 0.8 (2004-01-20)</h4>
+<div class="indent">Reorganized for JEP editor's preferences; revised error conditions to properly align with XMPP-Core (lw)
+    </div>
+<h4>Version 0.7 (2003-12-10)</h4>
+<div class="indent">Incorported changes requested from Standards-JIG discussions: Changed entity-to-server discovery behavior; s2s discovery behavior; Expanded application-specific error conditions; Reorganized for better presentation; Changed "per-hop" to apply to the entire ruleset; Fixed minor typos and missteps (lw)
+    </div>
+<h4>Version 0.6 (2003-10-15)</h4>
+<div class="indent">Changed disco behavior; Changed schema to reflect customizations (lw)
+    </div>
+<h4>Version 0.5.1 (2003-09-20)</h4>
+<div class="indent">Fixed many typos (lw)
+    </div>
+<h4>Version 0.5 (2003-08-28)</h4>
+<div class="indent">Renamed to "amp" (thanks stpeter!); Added information about the original addressing; Added requirement for id attribute in &lt;message/&gt;; Restricted behavior within the "Security Considerations"; (lw)
+    </div>
+<h4>Version 0.4 (2003-06-23)</h4>
+<div class="indent">Completely rewritten to better account for various suggested usage details and requirements; Completely reorganized to better codify the protocol(s) and their possible uses; Added more conditions; Added more actions; Added common usage scenarios (lw)
+    </div>
+<h4>Version 0.3 (2003-04-21)</h4>
+<div class="indent">Clarified client-side processing; Removed semantics scope; Clarified "fail" action; Moved existing "use-cases" into "Usage" section in "Overview"; Added more relevant use cases; Added XMPP-style error conditions (lw)
+    </div>
+<h4>Version 0.2 (2003-04-15)</h4>
+<div class="indent">Added XML Schema (with author's assistance). (psa)
+    </div>
+<h4>Version 0.1 (2003-04-15)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0079-1.1.html
+++ b/content/xep-0079-1.1.html
@@ -1,0 +1,1390 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0079: Advanced Message Processing</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Advanced Message Processing">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol that enables entities to request, and servers to perform, advanced processing of XMPP &lt;message/&gt; stanzas, including reliable data transport, time-sensitive delivery, and transient messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0079">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0079: Advanced Message Processing</h1>
+<p>This JEP defines a protocol that enables entities to request, and servers to perform, advanced processing of XMPP &lt;message/&gt; stanzas, including reliable data transport, time-sensitive delivery, and transient messages.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0079<br>
+            Version: 1.1<br>
+            Last Updated: 2005-10-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0082<br>Supersedes: JEP-0023<br>
+                Superseded By: None<br>
+            Short Name: amp<br>
+        Schema for amp: &lt;<a href="http://jabber.org/protocol/amp/amp.xsd">http://jabber.org/protocol/amp/amp.xsd</a>&gt;<br>
+        Schema for amp#errors: &lt;<a href="http://jabber.org/protocol/amp/errors.xsd">http://jabber.org/protocol/amp/errors.xsd</a>&gt;<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/amp.html">http://www.jabber.org/registrar/amp.html</a>&gt;
+              <br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Advanced%20Message%20Processing%20(JEP-0079)">http://wiki.jabber.org/index.php/Advanced Message Processing (JEP-0079)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dl>
+<dt>1.1.  <a href="#intro-motivation">Motivation</a>
+</dt>
+<dt>1.2.  <a href="#intro-concepts">Concepts</a>
+</dt>
+<dt>1.3.  <a href="#intro-prereq">Prerequisites</a>
+</dt>
+</dl>
+<dt>2.  <a href="#process">Process Flows</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#process-s2s">Sender-to-Server</a>
+</dt>
+<dl>
+<dt>2.1.1.  <a href="#process-s2s-disco">Discovery</a>
+</dt>
+<dt>2.1.2.  <a href="#process-s2s-semantics">Specifying Semantics</a>
+</dt>
+</dl>
+<dt>2.2.  <a href="#process-server">Server Processing</a>
+</dt>
+<dl>
+<dt>2.2.1.  <a href="#process-server-semantics">Validating Semantics</a>
+</dt>
+<dt>2.2.2.  <a href="#process-server-default">Determine Default Action</a>
+</dt>
+<dt>2.2.3.  <a href="#process-server-rules">Process Rules</a>
+</dt>
+<dt>2.2.4.  <a href="#process-server-execute">Execute Determined Action</a>
+</dt>
+</dl>
+</dl>
+<dt>3.  <a href="#conditionsactions">Conditions and Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#conditions-guide">Rule Condition Guidelines</a>
+</dt>
+<dt>3.2.  <a href="#actions-guide">Rule Action Guidelines</a>
+</dt>
+<dt>3.3.  <a href="#conditions-def">Defined Conditions</a>
+</dt>
+<dl>
+<dt>3.3.1.  <a href="#conditions-def-deliver">deliver</a>
+</dt>
+<dt>3.3.2.  <a href="#conditions-def-expireat">expire-at</a>
+</dt>
+<dt>3.3.3.  <a href="#conditions-def-match">match-resource</a>
+</dt>
+</dl>
+<dt>3.4.  <a href="#actions-def">Defined Actions</a>
+</dt>
+<dl>
+<dt>3.4.1.  <a href="#actions-def-drop">drop</a>
+</dt>
+<dt>3.4.2.  <a href="#actions-def-error">error</a>
+</dt>
+<dt>3.4.3.  <a href="#actions-def-notify">notify</a>
+</dt>
+<dt>3.4.4.  <a href="#actions-def-alert">alert</a>
+</dt>
+</dl>
+<dt>3.5.  <a href="#security-conditions">Security Considerations for the Defined Conditions/Actions</a>
+</dt>
+<dl><dt>3.5.1.  <a href="#security-deliver">"deliver" Condition</a>
+</dt></dl>
+</dl>
+<dt>4.  <a href="#formal">Formal Description</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#formal-root">&lt;amp/&gt; Root Element</a>
+</dt>
+<dt>4.2.  <a href="#formal-rule">&lt;rule/&gt; Element</a>
+</dt>
+</dl>
+<dt>5.  <a href="#examples">Example Scenarios</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#examples-reliabledata">Reliable Data Transport</a>
+</dt>
+<dt>5.2.  <a href="#examples-time">Time-Sensitive Messages</a>
+</dt>
+<dt>5.3.  <a href="#examples-transient">Transient Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#errors-conditions">Conditions</a>
+</dt>
+<dt>6.2.  <a href="#errors-examples">Examples</a>
+</dt>
+<dl>
+<dt>6.2.1.  <a href="#errors-action">Unsupported Action</a>
+</dt>
+<dt>6.2.2.  <a href="#errors-condition">Unsupported Condition</a>
+</dt>
+<dt>6.2.3.  <a href="#errors-notacceptable">Not Acceptable</a>
+</dt>
+<dt>6.2.4.  <a href="#errors-unavail">Service Unavailable</a>
+</dt>
+<dt>6.2.5.  <a href="#errors-undefined">Undefined Condition</a>
+</dt>
+</dl>
+</dl>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>10.3.  <a href="#registrar-reg">Registries</a>
+</dt>
+<dl>
+<dt>10.3.1.  <a href="#registrar-reg-conditions">Rule Conditions Registry</a>
+</dt>
+<dl>
+<dt>10.3.1.1.  <a href="#registrar-reg-conditions-process">Process</a>
+</dt>
+<dt>10.3.1.2.  <a href="#registrar-reg-conditions-initial">Initial Submission</a>
+</dt>
+</dl>
+<dt>10.3.2.  <a href="#registrar-reg-actions">Rule Actions Registry</a>
+</dt>
+<dl>
+<dt>10.3.2.1.  <a href="#registrar-reg-actions-process">Process</a>
+</dt>
+<dt>10.3.2.2.  <a href="#registrar-reg-actions-initial">Initial Submission</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>11.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schemas-amp">AMP</a>
+</dt>
+<dt>11.2.  <a href="#schemas-err">Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#acks">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a protocol that enables an end-point entity to specify additional delivery semantics for an XMPP &lt;message/&gt; stanza. This protocol is typically used by clients to inform the receiving server how to deliver a particular stanza, such as providing an expiration time or a resource-matching strategy.</p>
+  <div class="indent">
+<h3>1.1 <a name="intro-motivation">Motivation</a>
+</h3>
+    <p class="" style="">The built-in delivery semantics for &lt;message/&gt; stanzas (defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250770">1</a>] and, for instant messaging applications, also in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250713">2</a>]) are adequate for most current applications. However, there are various cases where more stringent delivery semantics are necessary. The most common cases discussed in this JEP are:</p>
+    <ul>
+      <li>Reliable data transport -- the sender requires notification (positive and/or negative) of message delivery.</li>
+      <li>Time-sensitive messages -- the message is valid only until a certain date and time.</li>
+      <li>Transient messages -- the message should not be stored offline for later delivery.</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>1.2 <a name="intro-concepts">Concepts</a>
+</h3>
+    <p class="" style="">This protocol is mostly handled by the server or servers processing the &lt;message/&gt;. The protocol consists of a list of rules, with conditions and actions for each rule. Upon receipt of an appropriately marked message, the server interprets the rules in the order they are received, looking for met conditions. When a condition is met, the action for that rule is executed, and message processing stops.</p>
+    <p class="" style="">Each rule is flagged for the scope it applies to, whether it be the overall route, or for each hop in the route.  Additionally, while this JEP defines a default set of conditions and actions, the protocol is extensible enough to allow for more to be defined in the future.</p>
+    <p class="" style="">The namespace for the protocol is "http://jabber.org/protocol/amp".</p>
+  </div>
+  <div class="indent">
+<h3>1.3 <a name="intro-prereq">Prerequisites</a>
+</h3>
+    <p class="" style="">In order for this protocol to function properly, the containing &lt;message/&gt; stanza MUST possess an 'id' attribute, and the value of the 'id' attribute MUST NOT be an empty string. The server MUST specify this 'id' attribute value with any response back to the sender. This is necessary so that servers and clients can properly relate the initial request with any subsequent error or notification.</p>
+  </div>
+<h2>2.
+       <a name="process">Process Flows</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="process-s2s">Sender-to-Server</a>
+</h3>
+    <p class="" style="">This flow describes the interaction between the sender and a server. As illustrated below, this interaction is actually rather simple:</p>
+    <ol start="1" type="1">
+      <li>Sender determines support (E1)</li>
+      <li>Sender specifies appropriate rules and sends message to server (E1,E2)</li>
+      <li>Sender awaits any protocol-specific responses (UCE)</li>
+    </ol>
+    <ul>
+      <li>
+<span style="font-weight: bold">E1:</span> The server does not support this protocol (UCE)</li>
+      <li>
+<span style="font-weight: bold">E2:</span> The server does not support one or more specified rule conditions/actions (UCE)</li>
+    </ul>
+    <div class="indent">
+<h3>2.1.1 <a name="process-s2s-disco">Discovery</a>
+</h3>
+      <p class="" style="">Sending entities that wish to use AMP SHOULD discover support for this protocol (using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256385">3</a>]) along the intended path. Typically, this would involve sending disco#info queries to the sending entity's own server and the server of the intended recipient. The results of these queries MAY be cached for up to 24 hours, unless otherwise expired.</p>
+      <p class="" style="">If a server supports Advanced Message Processing, it MUST report that by including a service discovery feature of "http://jabber.org/protocol/amp" in the service discovery information result that it returns to the requesting entity.</p>
+      <p class="caption">Example 1. Initial Service Discovery information request</p>
+<div class="indent"><pre>
+&lt;iq from='northumberland@shakespeare.lit/westminster'
+    to='shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 2. Service Discovery information response</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    to='northumberland@shakespeare.lit/westminster'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity name='Shakespeare IM' category='im' type='server'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">A server SHOULD also maintain a service discovery node named "http://jabber.org/protocol/amp", at which it advertises the individual actions and conditions it supports. If an entity needs to determine whether the server supports individual actions and conditions, it SHOULD send a service discovery information request to that node; the server then MUST either return the list of supported actions and conditions or return an error such as &lt;feature-not-implemented/&gt;. (Note: If the server does not provide information for this disco node, the requesting entity MUST assume that all actions and conditons are supported for each reported action set or condition set.)</p>
+      <p class="" style="">Each supported action shall be reported as a feature using the following format:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>http://jabber.org/protocol/amp?action={action}</pre></div>
+      <p class="" style="">Each supported condition shall be reported as a feature using the following format:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>http://jabber.org/protocol/amp?condition={condition}</pre></div>
+      <p class="" style="">The following examples show the request-response flow for information about individual actions and conditions (note the inclusion of the 'node' attribute).</p>
+      <p class="caption">Example 3. Request for information about individual actions and conditions</p>
+<div class="indent"><pre>
+&lt;iq from='northumberland@shakespeare.lit/westminster'
+    to='shakespeare.lit'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/amp'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 4. Response for individual actions and conditions</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    to='northumberland@shakespeare.lit/westminster'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/amp'&gt;
+    &lt;identity name='Shakespeare IM AMP Support' category='im' type='server'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=drop'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=error'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?action=notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=deliver'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=expire-at'/&gt;
+    &lt;feature var='http://jabber.org/protocol/amp?condition=match-resource'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>2.1.2 <a name="process-s2s-semantics">Specifying Semantics</a>
+</h3>
+      <p class="" style="">Once support is determined, the sender can attach the desired delivery semantics to the message:</p>
+      <p class="caption">Example 5. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The semantics are defined as a set of &lt;rule/&gt; elements within the &lt;amp/&gt; root element. Each &lt;rule/&gt; declares the condition to trigger on and the action to execute if triggered.</p>
+      <p class="" style="">By default, the ruleset applies only to the "edge servers": those servers to which the sending and receiving entities are connected. (Note: For the purposes of Advanced Message Processing, "server" is defined as in <span style="font-weight: bold">XMPP Core</span> and does not include any internal components, such as connection managers, that may provide functionality within a server implementation or installation.)</p>
+      <p class="" style="">The ruleset MAY be applied to all server-to-server "hops" along the route from the sending and receiving entities by adding the "per-hop' attribute to the &lt;amp/&gt; element. The value of this attribute is either "true" (apply rules to all hops) or "false" (follow default behavior, i.e., apply rules at the edge servers only).</p>
+      <p class="caption">Example 6. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+       per-hop='true'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">For examples of validation failure, refer to the <a href="#errors">Error Handling</a> section of this document.</p>
+      <p class="" style="">Note: Even if "per-hop" processing is requested, each server in the route MUST ignore rules that cannot apply to it; the <a href="#conditions-def">Defined Conditions</a> outline if they can be applied per-hop.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="process-server">Server Processing</a>
+</h3>
+    <p class="" style="">Server operation is where the bulk of the work is performed. Upon receiving a message with an AMP extension, the server performs the following flow:</p>
+    <ol start="1" type="1">
+      <li>Validate the semantics (E1, E2).</li>
+      <li>Determine the default behavior.</li>
+      <li>Process rules until condition is met.
+        <ul>
+          <li>If a condition is met, execute that rule's action</li>
+          <li>If no conditions are met, perform "default" behavior for message</li>
+        </ul>
+      </li>
+      <li>Execute determined action (UCE) (E3).</li>
+    </ol>
+    <ul>
+      <li>
+<span style="font-weight: bold">E1:</span> The provided semantics (rule's condition/action) are not supported or valid (UCE)</li>
+      <li>
+<span style="font-weight: bold">E2:</span> The requested semantics are not acceptable (UCE)</li>
+      <li>
+<span style="font-weight: bold">E3:</span> The next server does not support this protocol (UCE)</li>
+    </ul>
+    <div class="indent">
+<h3>2.2.1 <a name="process-server-semantics">Validating Semantics</a>
+</h3>
+      <p class="" style="">Validation can take many forms, but at the very least the server MUST verify that it understands each of the rule conditions and actions, and that the condition contents are appropriate. The server MAY also refused to accept certain combinations of conditions and actions, for example if they present a risk of overriding security. If the semantics are not valid, supported, or acceptable, the server MUST reply with an error specifying the rule(s) that are at issue. The server SHOULD validate all the semantics before returning an error. For syntax and examples of error handling related to validation failure, refer to the <a href="#errors">Error Handling</a> section of this document.</p>
+    </div>
+    <div class="indent">
+<h3>2.2.2 <a name="process-server-default">Determine Default Action</a>
+</h3>
+      <p class="" style="">This step is essentially what a server normally does, except that it does not actually perform the action. This determines what would happen to the message if there were no semantics attached (such as dispatch to another server or store offline). At this point, the server SHOULD also calculate any timing or calendar requirements (if applicable).</p>
+    </div>
+    <div class="indent">
+<h3>2.2.3 <a name="process-server-rules">Process Rules</a>
+</h3>
+      <p class="" style="">At this step, the server processes the attached semantics. The server MUST process the rules serially, and in the order they are presented within the &lt;amp/&gt; element. As soon as a rule's condition is met, processing ends with that action overriding the default action determined earlier (unless the action permits continued processing).</p>
+    </div>
+    <div class="indent">
+<h3>2.2.4 <a name="process-server-execute">Execute Determined Action</a>
+</h3>
+      <p class="" style="">Once all rules have been processed or otherwise accounted for, the server executes the action determined at this point.</p>
+      <p class="" style="">A server SHOULD NOT dispatch a &lt;message/&gt; stanza with AMP semantics to another server unless it knows that the next server supports AMP (this SHOULD be discovered via <span style="font-weight: bold">Service Discovery</span> and MAY be cached to avoid delivery delays). If the next server does not support AMP, the current server replies to the original sender with a &lt;service-unavailable/&gt; error condition. Otherwise this flow starts again for the server to which the message has been dispatched.</p>
+    </div>
+  </div>
+<h2>3.
+       <a name="conditionsactions">Conditions and Actions</a>
+</h2>
+  <p class="" style="">The preceding sections of this JEP define the general behavior regarding AMP. This section outlines how &lt;rule/&gt; action and condition sets are defined. It also provides defined action and condition sets; these action and condition sets SHOULD be supported by any implementation of Advanced Message Processing, but support for any given action or condition set it not required. (Note: The action and condition sets defined herein may be supplemented in the future via registration of additional action and condition sets with the Jabber Registrar.)</p>
+  <div class="indent">
+<h3>3.1 <a name="conditions-guide">Rule Condition Guidelines</a>
+</h3>
+    <p class="" style="">The definition of a &lt;rule/&gt; condition MUST provide the following information:</p>
+    <ul>
+      <li>Define a namespace governing the condition set</li>
+      <li>Define the condition:
+        <ul>
+          <li>Define the 'condition' attribute value</li>
+          <li>Specify if the "per-hop" flag applies</li>
+          <li>Define the syntax/format of the 'value' attribute value</li>
+          <li>Define how the "value" is interpreted to meet a condition</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-guide">Rule Action Guidelines</a>
+</h3>
+    <p class="" style="">The definition of a &lt;rule/&gt; action MUST provide the following information:</p>
+    <ul>
+      <li>Define a namespace governing the action set</li>
+      <li>Define the action:
+        <ul>
+          <li>Define each 'action' attribute value</li>
+          <li>Define the expected behavior if the &lt;rule/&gt; is triggered</li>
+        </ul>
+      </li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="conditions-def">Defined Conditions</a>
+</h3>
+    <p class="" style="">The condition defines how or when a particular rule is triggered. The value of the condition attribute determines what the contents of the &lt;rule/&gt; mean.</p>
+    <p class="" style="">The following conditions are defined by this JEP and SHOULD be supported by any implementation.</p>
+    <p class="" style="">In the following sections, the terms "content" and "contents" refers to the XML character data contained by the &lt;rule/&gt; element.</p>
+    <div class="indent">
+<h3>3.3.1 <a name="conditions-def-deliver">deliver</a>
+</h3>
+      <p class="" style="">The "deliver" condition is used to ensure delivery (or non-delivery) in one of five ways:</p>
+      <ol start="1" type="1">
+        <li>Directly to an appropriate resource over XMPP</li>
+        <li>Delayed to offline storage (for later delivery via XMPP)</li>
+        <li>Forwarded to an alternate address over XMPP</li>
+        <li>Indirectly to an alternate address through a gateway to a non-XMPP system</li>
+      </ol>
+      <p class="" style="">The possible contents for this condition are defined in the following table:</p>
+      <p class="caption">Table 1: "deliver" values</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Value</th>
+          <th colspan="" rowspan="">Description</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"direct"</td>
+          <td align="" colspan="" rowspan="">The message can be delivered immediately to the intended resource.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"forward"</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be forwarded to another XMPP address.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"gateway"</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be sent through a gateway to an address on a non-XMPP system.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"none"</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and is to be dropped (e.g., because offline storage is not enabled).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"stored"</td>
+          <td align="" colspan="" rowspan="">The message cannot be delivered immediately to the intended resource and shall be stored offline for later delivery via XMPP.</td>
+        </tr>
+      </table>
+      <p class="" style="">This condition is met based on what the processor is able to do with the message at the moment of receipt. To correctly process this condition, a processor first determines if the message can be delivered immediately to the intended resource or further dispatched to another hop. If so and the contents are "direct", the condition is met. If not and the contents are "stored", the condition is also met if offline storage is enabled. In all other cases the condition is not met.</p>
+      <p class="" style="">This condition MAY be applied to each "hop" in the server route.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.2 <a name="conditions-def-expireat">expire-at</a>
+</h3>
+      <p class="" style="">The "expire-at" condition is used to ensure delivery before an absolute point in time. Naturally, this does not <span style="font-style: italic">guarantee</span>  [<a href="#nt-id2257365">4</a>] that the message will not be delivered after that time from the sender's perspective, since this JEP does not assume that all machine clocks (e.g., for all servers along the delivery route) are synchronized. However, in order to help ensure that this condition is met correctly, servers that implement this JEP (or the machines that host such servers) SHOULD use the Network Time Protocol (<span class="ref" style="">RFC 1305</span>  [<a href="#nt-id2257399">5</a>]) to keep in sync with established time authorities. Note also that expire-at functionality becomes less reliable the closer the expire-at time is to the present (e.g., the sender will receive less reliable delivery of a message speciifying an expire-at time two seconds in the future than of a message specifying an expire-at time two hours or two days in the future).</p>
+      <p class="" style="">The content of the 'value' attribute specifies some point after the exact moment the message is sent; the content MUST be a DateTime as specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2257444">6</a>], and the timezone MUST be UTC.</p>
+      <p class="" style="">The condition is met if the message cannot be delivered to the recipient before the specified datetime. To determine the datetime to compare to, the processor first determines if and when a message can be dispatched (e.g. not stored offline). The processor then records this datetime, and compares it with the specified datetime. If the current datetime is on or after that specified, the condition is met.</p>
+      <p class="" style="">This condition MAY be applied to each "hop" in the server route.</p>
+    </div>
+    <div class="indent">
+<h3>3.3.3 <a name="conditions-def-match">match-resource</a>
+</h3>
+      <p class="" style="">The "match-resource" condition is used to restrict delivery based on the resource identifier of the recipient JID.</p>
+      <p class="" style="">The possible contents for this condition are:</p>
+      <p class="caption">Table 2: "match-resource" values</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Value</th>
+          <th colspan="" rowspan="">Description</th>
+          <th colspan="" rowspan="">Example</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"exact"</td>
+          <td align="" colspan="" rowspan="">Destination resource exactly matches the specified resource.</td>
+          <td align="" colspan="" rowspan="">"home/laptop" only matches "home/laptop" and not "home/desktop" or "work/desktop"</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"any"</td>
+          <td align="" colspan="" rowspan="">Destination resource matches any value, effectively ignoring the specified resource.</td>
+          <td align="" colspan="" rowspan="">"home/laptop" matches "home", "home/desktop" or "work/desktop"</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">"other"</td>
+          <td align="" colspan="" rowspan="">Destination resource matches any value except for the specified resource.</td>
+          <td align="" colspan="" rowspan="">"home/laptop" matches "work/desktop", "home" or "home/desktop", but not "home/laptop"</td>
+        </tr>
+      </table>
+      <p class="" style="">The condition is met if the resource for the actual destination JID matches the specified destination JID using the above rules. For instance, if a message is intended for "romeo@montague.net/work" with the "match-resource" condition of "other", the condition is met if the message can be immediately delivered only to "romeo@montague.net/home".</p>
+      <p class="" style="">For purposes of this condition, a JID with no resource has the following behavior:</p>
+      <ul>
+        <li>If the value is "exact", the condition is met only if the server would deliver to a non-resource JID (e.g., a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257668">7</a>] room or offline storage).</li>
+        <li>If the value is "other", the condition is met only if the server would not deliver to a non-resource JID.</li>
+      </ul>
+      <p class="" style="">This condition MUST NOT be applied to each "hop" in the server route, only at the edge servers. If an &lt;amp/&gt; element includes this condition and also indicates that it should be processed per hop, this &lt;rule/&gt; shall be ignored.</p>
+      <p class="" style="">Note: By design, this protocol does not include support for partial JID matching (which would stipulate, for example, that the resource identifiers "home/laptop" and "homeboy" both match "home").</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-def">Defined Actions</a>
+</h3>
+    <p class="" style="">The action defines what occurs when a particular rule is triggered. The value of the action attribute determines the behavior if the rule's condition is met.</p>
+    <p class="" style="">The following actions are defined by this JEP.</p>
+    <div class="indent">
+<h3>3.4.1 <a name="actions-def-drop">drop</a>
+</h3>
+      <p class="" style="">The "drop" action silently discards the message from any further delivery attempts and ensures that it is not placed into offline storage. The drop MUST NOT result in other responses.</p>
+    </div>
+    <div class="indent">
+<h3>3.4.2 <a name="actions-def-error">error</a>
+</h3>
+      <p class="" style="">The "error" action triggers a reply &lt;message/&gt; stanza of type "error" to the sending entity. The &lt;message/&gt; stanza's &lt;error/&gt; child MUST contain a &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'/&gt; error condition, which itself contains the rules that triggered this action.</p>
+      <p class="caption">Example 7. "error" response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           type='error'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+    &lt;error type='modify' code='500'&gt;
+      &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+        &lt;rule condition='deliver' value='stored' action='error'/&gt;
+      &lt;/failed-rules&gt;
+    &lt;/error&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+      <p class="" style="">Note that the error SHOULD be of type "modify", and the general error condition SHOULD be &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;.</p>
+    </div>
+    <div class="indent">
+<h3>3.4.3 <a name="actions-def-notify">notify</a>
+</h3>
+      <p class="" style="">The "notify" action triggers a reply &lt;message/&gt; stanza to the sending entity. This &lt;message/&gt; stanza MUST contain the element &lt;amp status='notify'/&gt;, which itself contains the &lt;rule/&gt; that triggered this action. Unlike the other actions, this action does not override the default behavior for a server. Instead, the server then executes its default behavior after sending the notify.</p>
+      <p class="caption">Example 8. "error" response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='notify'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='notify'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+    </div>
+    <div class="indent">
+<h3>3.4.4 <a name="actions-def-alert">alert</a>
+</h3>
+      <p class="" style="">The "alert" action triggers a reply &lt;message/&gt; stanza to the sending entity. This &lt;message/&gt; stanza MUST contain the element &lt;amp type='alert'/&gt;, which itself contains the &lt;rule/&gt; that triggered this action. In all other respects, this action behaves as "drop".</p>
+      <p class="caption">Example 9. "error" response</p>
+<div class="indent"><pre><p class="caption"></p><div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='alert'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div></pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="security-conditions">Security Considerations for the Defined Conditions/Actions</a>
+</h3>
+    <div class="indent">
+<h3>3.5.1 <a name="security-deliver">"deliver" Condition</a>
+</h3>
+      <p class="" style="">This condition has the largest potential for abuse, as it can appear to bypass presence. [<a href="#nt-id2257907">8</a>] A naive server could simply check to see the outcome for a particular message, regardless of whether the sender and receiver are subscribed to each other. This behavior SHOULD NOT be implemented, although it may be desirable in some environments (such as fully-trusted networks).</p>
+      <p class="" style="">There are several directions server implementors can follow in this regard:</p>
+      <ul>
+        <li>This condition is not implemented. The result MUST be to reply to the sender with a &lt;feature-not-implemented/&gt; error condition.</li>
+        <li>This condition is accepted only if the action is "drop". The result otherwise MUST be to reply to the sender with a &lt;not-acceptable/&gt; error condition.</li>
+        <li>This condition is accepted only if the sender is subscribed to the receiver's presence. The result otherwise MUST be to reply to the sender with a &lt;not-acceptable/&gt; error condition.</li>
+      </ul>
+    </div>
+  </div>
+<h2>4.
+       <a name="formal">Formal Description</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="formal-root">&lt;amp/&gt; Root Element</a>
+</h3>
+    <p class="" style="">All delivery semantics are encapsulated in the &lt;amp/&gt; element. This element contains one or more &lt;rule/&gt; elements specifying the specific rules to process. It can optionally possess attributes about the current status, the original sender and recipient, and route applicability.</p>
+    <p class="" style="">The 'status' attribute specifies the reason for this &lt;amp/&gt; element. When specifying semantics to be applied (client to server), this attribute MUST NOT be present. When replying to a sending entity regarding a met condition, this attribute MUST be present and SHOULD be the value of the 'action' attribute for the triggered rule. (Note: Individual action definitions MAY provide their own requirements.)</p>
+    <p class="" style="">The 'from' attribute specifies the original sender of the containing &lt;message/&gt; stanza. This attribute MUST be specified for any &lt;message/&gt; stanza sent from a supporting server, regardless of the recipient. It SHOULD NOT be specified otherwise. The value of the 'from' attribute MUST be the full JID (node@domain/resource) of the sender for the original &lt;message/&gt; stanza.</p>
+    <p class="" style="">The 'to' attribute specifies the original (intended) recipient of the containing &lt;message/&gt; stanza. This attribute MUST be specified for any &lt;message/&gt; stanza sent from a supporting server, regardless of the recipient. It SHOULD NOT be specified otherwise. The value of the 'to' attribute MUST be the full JID (node@domain/resource) of the intended recipient for the original &lt;message/&gt; stanza.</p>
+    <p class="" style="">The 'per-hop' attribute flags the contained ruleset for processing at each server in the route between the original sender and original intended recipient. This attribute MAY be present, and MUST be either "true" or "false". If not present, the default is "false".</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="formal-rule">&lt;rule/&gt; Element</a>
+</h3>
+    <p class="" style="">Each semantic rule is specified with a &lt;rule/&gt; element. This element possesses attributes for the condition, value, and action.</p>
+    <p class="" style="">The 'action' attribute defines the result for this rule. This attribute MUST be present, and MUST be either a value defined in the <a href="#actions-def">Defined Actions</a> section, or one registered with the Jabber Registrar.</p>
+    <p class="" style="">The 'condition' attribute defines the overall condition this rule applies to. This attribute MUST be present, and MUST be either a value defined in the <a href="#conditions-def">Defined Conditions</a> section, or one registered with the Jabber Registrar.</p>
+    <p class="" style="">The 'value' attribute defines how the condition is matched. This attribute MUST be present, and MUST NOT be an empty string (""). The interpretation of this attribute's value is determined by the 'condition' attribute.</p>
+  </div>
+<h2>5.
+       <a name="examples">Example Scenarios</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="examples-reliabledata">Reliable Data Transport</a>
+</h3>
+    <p class="" style="">The &lt;message/&gt; stanza is nearly ideal for data transport, but to ensure reliability it is often desirable that such messages not be delivered to any resource but that specified. To facilitate this, the sending entity includes a &lt;rule action='drop' condition='match-resource' value='exact'/&gt; (if failure notification is unnecessary) or &lt;rule action='error' condition='match-resource' value='exact'/&gt; (if failure notification is required). The following example illustrates this using <span class="ref" style="">In-Band Bytestreams</span>  [<a href="#nt-id2258187">9</a>]:</p>
+    <p class="caption">Example 10. Sending a message for reliable data transport</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit/pda'
+         from='bernardo@hamlet.lit/elsinore'
+         id='ibb1'&gt;
+  &lt;data xmlns='http://jabber.org/protocol/ibb' sid='mySID' seq='0'&gt;
+    qANQR1DBwU4DX7jmYZnncmUQB/9KuKBddzQH+tZ1ZywKK0yHKnq57kWq+RFtQdCJ
+    WpdWpR0uQsuJe7+vh3NWn59/gTc5MDlX8dS9p0ovStmNcyLhxVgmqS8ZKhsblVeu
+    IpQ0JgavABqibJolc3BKrVtVV1igKiX/N7Pi8RtY1K18toaMDhdEfhBRzO/XB0+P
+    AQhYlRjNacGcslkhXqNjK5Va4tuOAPy2n1Q8UUrHbUd0g+xJ9Bm0G0LZXyvCWyKH
+    kuNEHFQiLuCY6Iv0myq6iX6tjuHehZlFSh80b5BVV9tNLwNR5Eqz1klxMhoghJOA
+  &lt;/data&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule condition='expire-at' value='2004-09-10T08:33:14Z' action='error'/&gt;
+    &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the above case, the sender would receive an error reply if the message could not be delivered specifically to "francisco@hamlet.lit/pda" within 500 seconds.</p>
+    <p class="caption">Example 11. Failed reliable data transport message</p>
+<div class="indent"><pre>
+&lt;message from='hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'
+         id='ibb1'&gt;
+  &lt;data xmlns='http://jabber.org/protocol/ibb' sid='mySID' seq='0'&gt;
+    qANQR1DBwU4DX7jmYZnncmUQB/9KuKBddzQH+tZ1ZywKK0yHKnq57kWq+RFtQdCJ
+    WpdWpR0uQsuJe7+vh3NWn59/gTc5MDlX8dS9p0ovStmNcyLhxVgmqS8ZKhsblVeu
+    IpQ0JgavABqibJolc3BKrVtVV1igKiX/N7Pi8RtY1K18toaMDhdEfhBRzO/XB0+P
+    AQhYlRjNacGcslkhXqNjK5Va4tuOAPy2n1Q8UUrHbUd0g+xJ9Bm0G0LZXyvCWyKH
+    kuNEHFQiLuCY6Iv0myq6iX6tjuHehZlFSh80b5BVV9tNLwNR5Eqz1klxMhoghJOA
+  &lt;/data&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+      from='bernardo@hamlet.lit/elsinore'
+      to='francisco@hamlet.lit/pda'&gt;
+    &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='500'&gt;
+    &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+      &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+    &lt;/failed-rules&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="examples-time">Time-Sensitive Messages</a>
+</h3>
+    <p class="" style="">Time-sensitive messages are a frequent occurrence in some environments (e.g., front-office personnel routinely notify others of "events" such as guests, unexpected refreshments, and ad-hoc gatherings). To send a time-sensitive message, the sending entity includes a &lt;rule condition='expire-at' action='drop'/&gt; with the time when the event is to occur:</p>
+    <p class="caption">Example 12. Sending a time-sensitive message</p>
+<div class="indent"><pre>
+&lt;message to='linuxwolf@outer-planes.net'
+         from='receptionist@outer-planes.net'
+         id='alert849'&gt;
+  &lt;subject&gt;Guest Alert!&lt;/subject&gt;
+  &lt;body&gt;
+    There will be clients in the conference room today around 1 PM!
+    As always, be courteous and quiet nearby...
+  &lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2003-06-23T23:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the above case, the server for "linuxwolf@outer-planes.net" would not deliver the message once 23:00 UTC (3:00 PM Pacific Daylight Time) has passed.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="examples-transient">Transient Messages</a>
+</h3>
+    <p class="" style="">Transient messages are messages that should never be stored offline. To send a transient message, the sending entity includes a &lt;rule condition='deliver' action='drop' value='stored'/&gt;:</p>
+    <p class="caption">Example 13. Sending a transient message</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit'
+         from='bernardo@hamlet.lit/elsinore'
+         type='chat'
+         id='chatty1'&gt;
+  &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='deliver' value='stored' action='drop'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the sending entity includes a &lt;rule condition='deliver' action='alert' value='stored'/&gt; to be alerted instead of having the message silently dropped:</p>
+    <p class="caption">Example 14. Sending a transient message (requesting alert)</p>
+<div class="indent"><pre>
+&lt;message to='francisco@hamlet.lit'
+         from='bernardo@hamlet.lit/elsinore'
+         type='chat'
+         id='chatty2'&gt;
+  &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 15. Sender alerted regarding transient message</p>
+<div class="indent"><pre>
+&lt;message from='hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'
+         id='chatty2'&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'
+       action='alert'
+       from='bernardo@hamlet.lit/elsinore'
+       to='francisco@hamlet.lit'&gt;
+    &lt;rule condition='deliver' value='stored' action='alert'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="errors-conditions">Conditions</a>
+</h3>
+    <p class="" style="">To simplify the discussion of error conditions, this document uses the following mappings between namespace URIs and namespace prefixes (note: this mapping is provided only for the purpose of simplifying the discussion and is not intended for use within the protocol itself).</p>
+    <p class="caption">Table 3: Namespace Mappings</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Prefix</th>
+        <th colspan="" rowspan="">URI</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">xmpp</td>
+        <td align="" colspan="" rowspan="">urn:ietf:params:xml:ns:xmpp-stanzas</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">msg</td>
+        <td align="" colspan="" rowspan="">http://jabber.org/protocol/amp</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">err</td>
+        <td align="" colspan="" rowspan="">http://jabber.org/protocol/amp#errors</td>
+      </tr>
+    </table>
+    <p class="" style="">The following table shows the possible error conditions in relation to general AMP rules and conditions as well as the <a href="#actions-def">Defined Actions</a>.</p>
+    <p class="caption">Table 4: Error conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">General Condition</th>
+        <th colspan="" rowspan="">Error Type</th>
+        <th colspan="" rowspan="">Specific Condition</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:bad-request/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:unsupported-actions/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rule's specified actions are not supported. The element &lt;msg:unsupported-actions/&gt; contains the &lt;rule/&gt; elements that specify the unsupported actions.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:bad-request/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:unsupported-conditions/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rule's specified conditions are not supported. The element &lt;msg:unsupported-conditions/&gt; contains the &lt;rule/&gt; elements that specify the unsupported conditions.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:not-acceptable/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;msg:invalid-rules/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more rules are not acceptable by this server, usually because the condition/action combination is restricted. The element &lt;msg:invalid-rules/&gt; contains the &lt;rule/&gt; elements that are not acceptable.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:service-unavailable/&gt;</td>
+        <td align="" colspan="" rowspan="">cancel</td>
+        <td align="" colspan="" rowspan="">NONE</td>
+        <td align="" colspan="" rowspan="">This protocol is not supported. This error is returned to the sending entity if a server along the route to the recipient does not implement this protocol.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;xmpp:undefined-condition/&gt;</td>
+        <td align="" colspan="" rowspan="">modify</td>
+        <td align="" colspan="" rowspan="">&lt;err:failed-rules/&gt;</td>
+        <td align="" colspan="" rowspan="">One or more &lt;rule/&gt; elements triggered the "error" action. This condition contains the triggered &lt;rule/&gt; elements.</td>
+      </tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="errors-examples">Examples</a>
+</h3>
+    <p class="" style="">This section shows examples of the error conditions described in the previous section (for information regarding mapping of XMPP error conditions to Jabber error codes, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2258762">10</a>]).</p>
+    <div class="indent">
+<h3>6.2.1 <a name="errors-action">Unsupported Action</a>
+</h3>
+      <p class="caption">Example 16. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 17. Server does not support action</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='400'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-actions xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/unsupported-actions&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.2 <a name="errors-condition">Unsupported Condition</a>
+</h3>
+      <p class="caption">Example 18. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 19. Server does not support condition</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='400'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-conditions xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/unsupported-conditions&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.3 <a name="errors-notacceptable">Not Acceptable</a>
+</h3>
+      <p class="caption">Example 20. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 21. The rule is not acceptable to the server</p>
+<div class="indent"><pre>
+&lt;message
+    from='shakespeare.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='modify' code='405'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-rules xmlns='http://jabber.org/protocol/amp'&gt;
+      &lt;rule condition='expire-at'
+            action='drop'
+            value='2004-01-01T00:00:00Z'/&gt;
+    &lt;/invalid-rules&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.4 <a name="errors-unavail">Service Unavailable</a>
+</h3>
+      <p class="caption">Example 22. A message with semantics</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 23. AMP service is unavailable</p>
+<div class="indent"><pre>
+&lt;message
+    from='royalty.england.lit'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'
+    type='error'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='expire-at'
+          action='drop'
+          value='2004-01-01T00:00:00Z'/&gt;
+  &lt;/amp&gt;
+  &lt;error type='cancel' code='503'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.5 <a name="errors-undefined">Undefined Condition</a>
+</h3>
+      <p class="caption">Example 24. A message with semantics</p>
+<div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+  &lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 25. Failed rules</p>
+<div class="indent"><pre>
+  &lt;message from='hamlet.lit'
+           to='bernardo@hamlet.lit/elsinore'
+           type='error'
+           id='chatty2'&gt;
+    &lt;body&gt;Who&amp;apos;s there?&lt;/body&gt;
+    &lt;amp xmlns='http://jabber.org/protocol/amp'
+         status='error'
+         from='francisco@hamlet.lit'
+         to='bernardo@hamlet.lit/elsinore'&gt;
+      &lt;rule condition='deliver' value='stored' action='error'/&gt;
+    &lt;/amp&gt;
+    &lt;error type='modify' code='500'&gt;
+      &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;failed-rules xmlns='http://jabber.org/protocol/amp#errors'&gt;
+        &lt;rule condition='deliver' value='stored' action='error'/&gt;
+      &lt;/failed-rules&gt;
+    &lt;/error&gt;
+  &lt;/message&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">If the recipient's server implements "offline storage", it will need to keep track of which offline messages are subject to expiration and not deliver those which have expired. Exactly how to do so is a matter of implementation. One possible implementation is for the server to maintain a separate database of expirable messages and periodically scan it; upon discovering an expired message, it could flag the messages as eligible for discarding and inform the sender, but not discard the message until the intended recipient next becomes available.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The security considerations are dependent upon the specific conditions and actions in use. The considerations for the defined conditions and actions are outlined with their definitions in the <a href="#conditionsactions">Conditions and Actions</a> section of this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259033">11</a>] is necessary as a result of this JEP.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259084">12</a>] includes 'http://jabber.org/protocol/amp' and 'http://jabber.org/protocol/amp#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes 'http://jabber.org/protocol/amp' in its registry of well-known Service Discovery nodes.</p>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="registrar-reg">Registries</a>
+</h3>
+    <div class="indent">
+<h3>10.3.1 <a name="registrar-reg-conditions">Rule Conditions Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar maintains a registry of AMP &lt;rule/&gt; conditions (see &lt;<a href="http://www.jabber.org/registrar/amp-conditions.html">http://www.jabber.org/registrar/amp-conditions.html</a>&gt;).</p>
+      <div class="indent">
+<h3>10.3.1.1 <a name="registrar-reg-conditions-process">Process</a>
+</h3>
+        <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;name&gt;the value of the 'condition' attribute&lt;/name&gt;
+  &lt;ns&gt;the namespace to be used as a service discovery feature&lt;/ns&gt;
+  &lt;per-hop&gt;does the "per-hop" flag apply? [true|false]&lt;/per-hop&gt;
+  &lt;value&gt;
+     The syntax (e.g., datatype or allowable values) of the
+     'value' attribute.
+  &lt;/value&gt;
+  &lt;processing&gt;values that result in message processing&lt;/processing&gt;
+  &lt;doc&gt;the document (e.g., JEP) in which this condition is specified&lt;/doc&gt;
+&lt;/condition&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one condition at a time, each contained in a separate &lt;condition/&gt; element.</p>
+        <p class="" style="">Note: The namespace for the condition set shall be included in the Service Discovery features registry.</p>
+      </div>
+      <div class="indent">
+<h3>10.3.1.2 <a name="registrar-reg-conditions-initial">Initial Submission</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;name&gt;deliver&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=deliver&lt;/ns&gt;
+  &lt;per-hop&gt;true&lt;/per-hop&gt;
+  &lt;value&gt;[direct|forward|gateway|none|stored]&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if (1) the value is "direct" and the message
+    can be immediately delivered or further dispatched, or (2) the 
+    value is "stored" and offline storage is enabled.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+
+&lt;condition&gt;
+  &lt;name&gt;expire-at&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=expire-at&lt;/ns&gt;
+  &lt;per-hop&gt;true&lt;/per-hop&gt;
+  &lt;value&gt;DateTime per JEP-0082&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if the message cannot be delivered before
+    the specified DateTime.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+
+&lt;condition&gt;
+  &lt;name&gt;match-resource&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=match-resource&lt;/ns&gt;
+  &lt;per-hop&gt;false&lt;/per-hop&gt;
+  &lt;value&gt;[any|exact|other]&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if (1) the value is "any" and the intended
+    recipient has at least one available resource (as defined in the
+    XMPP IM specification); (2) the value "exact" and the intended
+    recipient has an available resource that exactly matches the JID
+    specified in the 'to' address; (3) the value is "other" and the
+    intended recipient has an available resource whose full JID is
+    other than that specified in the 'to' address.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/condition&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>10.3.2 <a name="registrar-reg-actions">Rule Actions Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar maintains a registry of AMP &lt;rule/&gt; actions (see &lt;<a href="http://www.jabber.org/registrar/amp-actions.html">http://www.jabber.org/registrar/amp-actions.html</a>&gt;).</p>
+      <div class="indent">
+<h3>10.3.2.1 <a name="registrar-reg-actions-process">Process</a>
+</h3>
+        <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;action&gt;
+  &lt;name&gt;the value of the 'action' attribute&lt;/name&gt;
+  &lt;ns&gt;the namespace to be used as a service discovery feature&lt;/ns&gt;
+  &lt;behavior&gt;the expected behavior if the rule is triggered&lt;/behavior&gt;
+  &lt;doc&gt;the document (e.g., JEP) in which this action is specified&lt;/doc&gt;
+&lt;/action&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one action at a time, each contained in a separate &lt;action/&gt; element.</p>
+        <p class="" style="">Note: The namespace for the action set shall be included in the Service Discovery features registry.</p>
+      </div>
+      <div class="indent">
+<h3>10.3.2.2 <a name="registrar-reg-actions-initial">Initial Submission</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;action&gt;
+  &lt;name&gt;alert&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=drop&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is silently discarded but an alert is returned to the
+    sender.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;drop&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=drop&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is silently discarded.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;error&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=error&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is not processed and an error is returned to the sender,
+    specifying which rule resulted in failed processing.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+
+&lt;action&gt;
+  &lt;name&gt;notify&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?action=notify&lt;/ns&gt;
+  &lt;behavior&gt;
+    The message is processed and a notification message is returned to
+    the sender, specifying which rule was processed.
+  &lt;/behavior&gt;
+  &lt;doc&gt;JEP-0079&lt;/doc&gt;
+&lt;/action&gt;
+        </pre></div>
+      </div>
+    </div>
+  </div>
+<h2>11.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schemas-amp">AMP</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/amp'
+    xmlns='http://jabber.org/protocol/amp'
+    elementFormDefault='qualified'&gt;
+ 
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0079: http://www.jabber.org/jeps/jep-0079.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='amp'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from' usage='optional' type='xs:string'/&gt;
+      &lt;xs:attribute name='per-hop' use='optional' type='xs:bool' default='false'/&gt;
+      &lt;xs:attribute name='status' usage='optional' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='to' usage='optional' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+ 
+  &lt;xs:element name='invalid-rules'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsupported-actions'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='unsupported-conditions'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='rule'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='action' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='condition' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='value' use='required' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schemas-err">Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/amp#errors'
+    xmlns='http://jabber.org/protocol/amp#errors'
+    elementFormDefault='qualified'&gt;
+ 
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0079: http://www.jabber.org/jeps/jep-0079.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='failed-rules'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='rule' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='rule'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='action' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='condition' use='required' type='xs:NCName'/&gt;
+      &lt;xs:attribute name='value' use='required' type='xs:string'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="acks">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Marshall Rose and Craig Kaes for their comments.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250770">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250713">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256385">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257365">4</a>. Guarantee is a strong word. This JEP defines methods for making message delivery more reliable within certain bounds, but does not pretend that such methods provide any form of guaranteed delivery.</p>
+<p><a name="nt-id2257399">5</a>. RFC 1305: Network Time Protocol (Version 3) &lt;<a href="http://www.ietf.org/rfc/rfc1305.txt">http://www.ietf.org/rfc/rfc1305.txt</a>&gt;.</p>
+<p><a name="nt-id2257444">6</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2257668">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257907">8</a>. Consider the following scenario: the user &lt;romeo@montague.net&gt; is not an authorized subscriber to the presence of the user &lt;nurse@capulet.com&gt;, but sends a &lt;message/&gt; stanza with a "deliver" rule of "direct" to that address; if the Nurse is not online, Romeo could discover that fact if the capulet.com server informs him that the message could not be delivered immediately.</p>
+<p><a name="nt-id2258187">9</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p><a name="nt-id2258762">10</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2259033">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259084">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2005-10-19)</h4>
+<div class="indent">Reversed the meaning of conditions other than expire-at (per list discussion); correctly specified stream feature. (psa)
+    </div>
+<h4>Version 1.0 (2004-10-11)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced to a status of Draft. (psa)
+    </div>
+<h4>Version 0.12 (2004-09-09)</h4>
+<div class="indent">Relaxed server-to-server requirements; clarified discovery rules; removed expire-in condition. (lw)
+    </div>
+<h4>Version 0.11 (2004-08-25)</h4>
+<div class="indent">Specified that the timestamp for an expire-at condition must be a UTC DateTime per JEP-0082; provided further explanation regarding expire-at and expire-in conditions. (lw/psa)
+    </div>
+<h4>Version 0.10 (2004-07-14)</h4>
+<div class="indent">Changes to address Council feedback: clarified error handling and provided error examples; specified that server should validate all rule semantics before returning an error; specified that service discovery information can be cached (not necessary to send disco query before dispatching each message); added "forward" and "gateway" to values of "deliver" condition to handle redirection of messages to alternate XMPP addresses and non-XMPP systems respectively; more clearly specified processing rules for "expire-in" condition; changed milliseconds to seconds for "expire-in"; made explicit that partial JID-matching is not included for "match-resource" condition; added clarifying note to security consideration regarding "deliver" condition; corrected values of per-hop from [yes|no] to [true|false]; changed "standard" conditions to "defined" conditions and mandated that they should be supported; changed "http://jabber.org/protocol/amp#std-actions" namespace to "http://jabber.org/protocol/amp#errors". (lw/psa)
+    </div>
+<h4>Version 0.9 (2004-04-25)</h4>
+<div class="indent">JEP Editor's review: clarified some matters in the text; fully defined the Jabber Registrar Considerations. (psa)
+    </div>
+<h4>Version 0.8 (2004-01-20)</h4>
+<div class="indent">Reorganized for JEP editor's preferences; revised error conditions to properly align with XMPP-Core (lw)
+    </div>
+<h4>Version 0.7 (2003-12-10)</h4>
+<div class="indent">Incorported changes requested from Standards-JIG discussions: Changed entity-to-server discovery behavior; s2s discovery behavior; Expanded application-specific error conditions; Reorganized for better presentation; Changed "per-hop" to apply to the entire ruleset; Fixed minor typos and missteps (lw)
+    </div>
+<h4>Version 0.6 (2003-10-15)</h4>
+<div class="indent">Changed disco behavior; Changed schema to reflect customizations (lw)
+    </div>
+<h4>Version 0.5.1 (2003-09-20)</h4>
+<div class="indent">Fixed many typos (lw)
+    </div>
+<h4>Version 0.5 (2003-08-28)</h4>
+<div class="indent">Renamed to "amp" (thanks stpeter!); Added information about the original addressing; Added requirement for id attribute in &lt;message/&gt;; Restricted behavior within the "Security Considerations"; (lw)
+    </div>
+<h4>Version 0.4 (2003-06-23)</h4>
+<div class="indent">Completely rewritten to better account for various suggested usage details and requirements; Completely reorganized to better codify the protocol(s) and their possible uses; Added more conditions; Added more actions; Added common usage scenarios (lw)
+    </div>
+<h4>Version 0.3 (2003-04-21)</h4>
+<div class="indent">Clarified client-side processing; Removed semantics scope; Clarified "fail" action; Moved existing "use-cases" into "Usage" section in "Overview"; Added more relevant use cases; Added XMPP-style error conditions (lw)
+    </div>
+<h4>Version 0.2 (2003-04-15)</h4>
+<div class="indent">Added XML Schema (with author's assistance). (psa)
+    </div>
+<h4>Version 0.1 (2003-04-15)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0080-0.8.html
+++ b/content/xep-0080-0.8.html
@@ -1,0 +1,424 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0080: User Geolocation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Geolocation">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0080">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0080: User Geolocation</h1>
+<p>This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0080<br>
+            Version: 0.8<br>
+            Last Updated: 2004-09-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: geoloc<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecases-pubsub">Entity publishes location via pubsub</a>
+</dt>
+<dt>4.2.  <a href="#usecases-request">Entity requests the location of another entity</a>
+</dt>
+<dt>4.3.  <a href="#usecases-send">Sending location</a>
+</dt>
+<dt>4.4.  <a href="#usecases-presence">Entity publishes location in presence</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a format for capturing data about an entity's geographical location (geoloc). The namespace defined herein is intended to provide a semi-structured format for describing a geographical location that may change fairly frequently, where the geoloc information is provided as Global Positioning System (GPS) coordinates. Potential uses for this approach include:</p>
+  <ul>
+    <li>Publishing geoloc information to a set of subscribers.</li>
+    <li>Querying another entity for its geoloc.</li>
+    <li>Sending geoloc information to another entity.</li>
+    <li>Attaching geoloc information to presence.</li>
+  </ul>
+  <p class="" style="">As specified herein, geographical location is captured in terms of GPS coordinates (and associated data) only; a format for communicating temporary changes in physical location (i.e., address) is defined in <span class="ref">User Physical Location</span>  [<a href="#nt-id2596264">1</a>].</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol was designed to address the following requirements:</p>
+  <ul>
+    <li>The GPS encoding mechanism shall have a single set of units, so that receivers do not need to use heuristics to determine actual position.</li>
+    <li>It shall be possible to specify the known amount of error in the GPS coordinates.</li>
+    <li>Since this protocol will often be used from mobile devices, size of XML is a factor.</li>
+  </ul>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the entity's geoloc is provided by the entity and propagated on the network by the entity's associated application (usually a client). The information is structured by means of a &lt;geoloc/&gt; element that is qualified by the 'http://jabber.org/protocol/geoloc' namespace; the geolocation information itself is provided as the XML character data of the following child elements:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Element Name</th>
+      <th colspan="" rowspan="">Inclusion</th>
+      <th colspan="" rowspan="">Datatype</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">alt</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:int</td>
+      <td align="" colspan="" rowspan="">Altitude in meters above or below sea level</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">bearing</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS bearing (direction in which the entity is heading to reach its next waypoint)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">datum</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS datum  [<a href="#nt-id2601896">2</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">description</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">A natural-language description of the location</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">error</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Horizontal GPS error in minutes</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lat</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Latitude in decimal degrees North</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lon</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Longitude in decimal degrees East</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">timestamp</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:datetime</td>
+      <td align="" colspan="" rowspan="">UTC timestamp specifying the moment when the reading was taken (MUST conform to the DateTime profile of <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2602215">3</a>])</td>
+    </tr>
+  </table>
+  <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602150">4</a>].</p>
+  <p class="" style="">The location information SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602181">5</a>]. Because location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;, although an application MAY do so if necessary.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecases-pubsub">Entity publishes location via pubsub</a>
+</h3>
+    <p class="" style="">In order to provide information about one's location, Publish-Subscribe SHOULD be used.</p>
+    <p class="caption">Example 1. Entity publishes location</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='portia@merchantofvenice.lit' 
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Subscriber receives event with payload</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602379">6</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='i1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='portia@merchantofvenice.lit'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecases-request">Entity requests the location of another entity</a>
+</h3>
+    <p class="" style="">If an entity wishes to request the location of another entity but the requestee does not publish that information via pubsub, the requestor MAY send an IQ to the requestee:</p>
+    <p class="caption">Example 4. Location request</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    id='loc_1'
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+&lt;/iq&gt;</pre></div>
+  <p class="" style="">The receiving entity SHOULD make a careful access control decision before returning the actual location.</p>
+    <p class="caption">Example 5. Successful location response</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Verona&lt;/description&gt;
+    &lt;lat&gt;45.45&lt;/lat&gt;
+    &lt;lon&gt;11.00&lt;/lon&gt;
+  &lt;/geoloc&gt;
+&lt;/iq&gt;</pre></div>
+    <p class="" style="">If the receiving entity decides not to return the actual location, it MUST return an IQ error, which SHOULD be &lt;forbidden/&gt; but MAY be some other appropriate error, such as &lt;not-allowed/&gt;:</p>
+    <p class="caption">Example 6. Access to location information denied</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecases-send">Sending location</a>
+</h3>
+  <p class="" style="">If an entity wants to send another entity its postition but it does not publish that information via pubsub, it MAY do so in a message. There SHOULD be a body element so that receiving entities that do not support this JEP can present a message to the recipient.</p>
+    <p class="caption">Example 7. Message containing location</p>
+<div class="indent"><pre>
+&lt;message 
+    to='polonius@hamlet.lit'
+    from='horatio@hamlet.lit/castle'&gt;
+  &lt;body&gt;This message contains a location.&lt;/body&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Elsinore&lt;/description&gt;
+    &lt;lat&gt;56.033&lt;/lat&gt;
+    &lt;lon&gt;12.618&lt;/lon&gt;
+  &lt;/geoloc&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;
+      http://www.mapquest.com/maps/map.adp?latlongtype=\
+      decimal&amp;latitude=56.033&amp;longitude=12.618
+    &lt;/url&gt;
+    &lt;desc&gt;Where would the castle have been?&lt;/desc&gt;
+  &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="usecases-presence">Entity publishes location in presence</a>
+</h3>
+    <p class="" style="">If an entity wishes all of the entities on its roster to be informed of a new location, the entity MAY publish a presence stanza that includes a location, although this is NOT RECOMMENDED (since location SHOULD be published using pubsub instead in order to ensure appropriate access control):</p>
+    <p class="caption">Example 8. Location in presence</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;alt&gt;1609&lt;/alt&gt;
+    &lt;description&gt;Jabber, Inc.&lt;/description&gt;
+    &lt;error&gt;10&lt;/error&gt;
+    &lt;lat&gt;39.75477&lt;/lat&gt;
+    &lt;lon&gt;-104.99768&lt;/lon&gt;
+    &lt;timestamp&gt;2004-02-19T21:12Z&lt;/timestamp&gt;
+  &lt;/geoloc&gt;
+&lt;/presence&gt;</pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">Avoid Mars probe issues. All units are in decimal degrees or meters. South and West are negative.</p>
+  <p class="" style="">In applications where updates are sent whenever there is a certain distance change in location, those applications SHOULD account for time as well, to avoid rate-limiting when the user is on a jet plane. One possible way to do this would be to send updates at most once per minute.</p>
+  <p class="" style="">Inferences MUST NOT be made about accuracy from the number of digits specified in the location or altitude.</p>
+  <p class="" style="">Why the datum madness? An <a href="http://www.nb.net/~resteele/newsites/gpsdatum.htm">example</a>.</p>
+  <p class="" style="">A GPS path can be provided by publishing a group of items with appropriate timestamps.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. If an error is deliberately added to a location, the error SHOULD be the same for all receivers, to minimize the likelihood of triangulation. In the case of deliberate error, the &lt;error/&gt; element SHOULD NOT be included.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602872">7</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602820">8</a>] shall add the 'http://jabber.org/protocol/geoloc' namespace to its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema 
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/geoloc' 
+    xmlns='http://jabber.org/protocol/geoloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='geoloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccur='0'&gt;
+        &lt;xs:element name='alt' minOccurs='0' type='xs:int'/&gt;
+        &lt;xs:element name='bearing' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='datum' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='description' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='error' minOccurs='0' type='xs:decimal'/&gt;
+        &lt;xs:element name='lat' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='lon' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='timestamp' minOccurs='0' type='xs:datetime'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596264">1</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601896">2</a>. If datum is not included, receiver MUST assume WGS84; receivers MUST implement WGS84; senders MAY use another datum, but it is not recommended.</p>
+<p>
+<a name="nt-id2602215">3</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602150">4</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602181">5</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602379">6</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602872">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602820">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-09-15)</h4>
+<div class="indent">Specified error flow for IQ example. (psa)
+    </div>
+<h4>Version 0.7 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to geoloc elements; moved physical address protocol back to JEP-0112. (psa)
+    </div>
+<h4>Version 0.5 (2003-12-16)</h4>
+<div class="indent">Converted to use of infobits. (psa)
+    </div>
+<h4>Version 0.4 (2003-09-08)</h4>
+<div class="indent">Merged in contents of JEP-0112. (psa)
+    </div>
+<h4>Version 0.3 (2003-08-21)</h4>
+<div class="indent">Changed protocol name from 'location' to 'geoloc'. (psa)
+    </div>
+<h4>Version 0.2 (2003-07-29)</h4>
+<div class="indent">Incorporated Standards JIG feedback; changed JEP type to Informational. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-15)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0080-0.9.html
+++ b/content/xep-0080-0.9.html
@@ -1,0 +1,427 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0080: User Geolocation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Geolocation">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0080">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0080: User Geolocation</h1>
+<p>This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0080<br>
+            Version: 0.9<br>
+            Last Updated: 2004-10-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: geoloc<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecases-pubsub">Entity publishes location via pubsub</a>
+</dt>
+<dt>4.2.  <a href="#usecases-request">Entity requests the location of another entity</a>
+</dt>
+<dt>4.3.  <a href="#usecases-send">Sending location</a>
+</dt>
+<dt>4.4.  <a href="#usecases-presence">Entity publishes location in presence</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a format for capturing data about an entity's geographical location (geoloc). The namespace defined herein is intended to provide a semi-structured format for describing a geographical location that may change fairly frequently, where the geoloc information is provided as Global Positioning System (GPS) coordinates. Potential uses for this approach include:</p>
+  <ul>
+    <li>Publishing geoloc information to a set of subscribers.</li>
+    <li>Querying another entity for its geoloc.</li>
+    <li>Sending geoloc information to another entity.</li>
+    <li>Attaching geoloc information to presence.</li>
+  </ul>
+  <p class="" style="">As specified herein, geographical location is captured in terms of GPS coordinates (and associated data) only; a format for communicating temporary changes in physical location (i.e., address) is defined in <span class="ref">User Physical Location</span>  [<a href="#nt-id2596285">1</a>].</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol was designed to address the following requirements:</p>
+  <ul>
+    <li>The GPS encoding mechanism shall have a single set of units, so that receivers do not need to use heuristics to determine actual position.</li>
+    <li>It shall be possible to specify the known amount of error in the GPS coordinates.</li>
+    <li>Since this protocol will often be used from mobile devices, size of XML is a factor.</li>
+  </ul>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the entity's geoloc is provided by the entity and propagated on the network by the entity's associated application (usually a client). The information is structured by means of a &lt;geoloc/&gt; element that is qualified by the 'http://jabber.org/protocol/geoloc' namespace; the geolocation information itself is provided as the XML character data of the following child elements:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Element Name</th>
+      <th colspan="" rowspan="">Inclusion</th>
+      <th colspan="" rowspan="">Datatype</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">alt</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:int</td>
+      <td align="" colspan="" rowspan="">Altitude in meters above or below sea level</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">bearing</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS bearing (direction in which the entity is heading to reach its next waypoint)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">datum</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS datum  [<a href="#nt-id2601918">2</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">description</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">A natural-language description of the location</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">error</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Horizontal GPS error in arc minutes</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lat</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Latitude in decimal degrees North</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lon</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Longitude in decimal degrees East</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">timestamp</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:datetime</td>
+      <td align="" colspan="" rowspan="">UTC timestamp specifying the moment when the reading was taken (MUST conform to the DateTime profile of <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2602237">3</a>])</td>
+    </tr>
+  </table>
+  <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602172">4</a>].</p>
+  <p class="" style="">The location information SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602203">5</a>]. Because location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;, although an application MAY do so if necessary.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecases-pubsub">Entity publishes location via pubsub</a>
+</h3>
+    <p class="" style="">In order to provide information about one's location, Publish-Subscribe SHOULD be used.</p>
+    <p class="caption">Example 1. Entity publishes location</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='portia@merchantofvenice.lit' 
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Subscriber receives event with payload</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602401">6</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='i1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='portia@merchantofvenice.lit'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecases-request">Entity requests the location of another entity</a>
+</h3>
+    <p class="" style="">If an entity wishes to request the location of another entity but the requestee does not publish that information via pubsub, the requestor MAY send an IQ to the requestee:</p>
+    <p class="caption">Example 4. Location request</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    id='loc_1'
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+&lt;/iq&gt;</pre></div>
+  <p class="" style="">The receiving entity SHOULD make a careful access control decision before returning the actual location.</p>
+    <p class="caption">Example 5. Successful location response</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Verona&lt;/description&gt;
+    &lt;lat&gt;45.45&lt;/lat&gt;
+    &lt;lon&gt;11.00&lt;/lon&gt;
+  &lt;/geoloc&gt;
+&lt;/iq&gt;</pre></div>
+    <p class="" style="">If the receiving entity decides not to return the actual location, it MUST return an IQ error, which SHOULD be &lt;forbidden/&gt; but MAY be some other appropriate error, such as &lt;not-allowed/&gt;:</p>
+    <p class="caption">Example 6. Access to location information denied</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecases-send">Sending location</a>
+</h3>
+  <p class="" style="">If an entity wants to send another entity its postition but it does not publish that information via pubsub, it MAY do so in a message. There SHOULD be a body element so that receiving entities that do not support this JEP can present a message to the recipient.</p>
+    <p class="caption">Example 7. Message containing location</p>
+<div class="indent"><pre>
+&lt;message 
+    to='polonius@hamlet.lit'
+    from='horatio@hamlet.lit/castle'&gt;
+  &lt;body&gt;This message contains a location.&lt;/body&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Elsinore&lt;/description&gt;
+    &lt;lat&gt;56.033&lt;/lat&gt;
+    &lt;lon&gt;12.618&lt;/lon&gt;
+  &lt;/geoloc&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;
+      http://www.mapquest.com/maps/map.adp?latlongtype=\
+      decimal&amp;latitude=56.033&amp;longitude=12.618
+    &lt;/url&gt;
+    &lt;desc&gt;Where would the castle have been?&lt;/desc&gt;
+  &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="usecases-presence">Entity publishes location in presence</a>
+</h3>
+    <p class="" style="">If an entity wishes all of the entities on its roster to be informed of a new location, the entity MAY publish a presence stanza that includes a location, although this is NOT RECOMMENDED (since location SHOULD be published using pubsub instead in order to ensure appropriate access control):</p>
+    <p class="caption">Example 8. Location in presence</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;alt&gt;1609&lt;/alt&gt;
+    &lt;description&gt;Jabber, Inc.&lt;/description&gt;
+    &lt;error&gt;10&lt;/error&gt;
+    &lt;lat&gt;39.75477&lt;/lat&gt;
+    &lt;lon&gt;-104.99768&lt;/lon&gt;
+    &lt;timestamp&gt;2004-02-19T21:12Z&lt;/timestamp&gt;
+  &lt;/geoloc&gt;
+&lt;/presence&gt;</pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">Avoid Mars probe issues. As specified in Table 1, the units for &lt;lat/&gt; and &lt;lon/&gt; MUST be decimal degrees (where South and West are negative, North and East are positive), the units for &lt;alt/&gt; MUST be meters above or below sea level, and the units for &lt;error/&gt; MUST be arc minutes.</p>
+  <p class="" style="">In applications where updates are sent whenever there is a certain distance change in location, those applications SHOULD account for time as well, to avoid rate-limiting when the user is (for example) on a jet plane. One possible way to do this would be to send updates at most once per minute of time (every 60 seconds).</p>
+  <p class="" style="">Inferences MUST NOT be made about accuracy from the number of digits specified in the location or altitude.</p>
+  <p class="" style="">Why the datum madness? An <a href="http://www.nb.net/~resteele/newsites/gpsdatum.htm">example</a>.</p>
+  <p class="" style="">An entity can provide a GPS path by publishing a series of items (i.e., multiple pubsub events) with appropriate values of the &lt;timestamp/&gt; element.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. If an error is deliberately added to a location, the error SHOULD be the same for all receivers, to minimize the likelihood of triangulation. In the case of deliberate error, the &lt;error/&gt; element SHOULD NOT be included.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602751">7</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602698">8</a>] shall include 'http://jabber.org/protocol/geoloc' to its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema 
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/geoloc' 
+    xmlns='http://jabber.org/protocol/geoloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='geoloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccur='0'&gt;
+        &lt;xs:element name='alt' minOccurs='0' type='xs:int'/&gt;
+        &lt;xs:element name='bearing' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='datum' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='description' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='error' minOccurs='0' type='xs:decimal'/&gt;
+        &lt;xs:element name='lat' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='lon' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='timestamp' minOccurs='0' type='xs:datetime'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596285">1</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601918">2</a>. If datum is not included, receiver MUST assume WGS84; receivers MUST implement WGS84; senders MAY use another datum, but it is not recommended.</p>
+<p>
+<a name="nt-id2602237">3</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602172">4</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602203">5</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602401">6</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602751">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602698">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2004-10-12)</h4>
+<div class="indent">Clarified several points in the implementation notes. (psa)
+    </div>
+<h4>Version 0.8 (2004-09-15)</h4>
+<div class="indent">Specified error flow for IQ example. (psa)
+    </div>
+<h4>Version 0.7 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to geoloc elements; moved physical address protocol back to JEP-0112. (psa)
+    </div>
+<h4>Version 0.5 (2003-12-16)</h4>
+<div class="indent">Converted to use of infobits. (psa)
+    </div>
+<h4>Version 0.4 (2003-09-08)</h4>
+<div class="indent">Merged in contents of JEP-0112. (psa)
+    </div>
+<h4>Version 0.3 (2003-08-21)</h4>
+<div class="indent">Changed protocol name from 'location' to 'geoloc'. (psa)
+    </div>
+<h4>Version 0.2 (2003-07-29)</h4>
+<div class="indent">Incorporated Standards JIG feedback; changed JEP type to Informational. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-15)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0080-1.0.html
+++ b/content/xep-0080-1.0.html
@@ -1,0 +1,444 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0080: User Geolocation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Geolocation">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0080">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0080: User Geolocation</h1>
+<p>This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0080<br>
+            Version: 1.0<br>
+            Last Updated: 2004-10-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: geoloc<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/geoloc/geoloc.xsd">http://jabber.org/protocol/geoloc/geoloc.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecases-pubsub">Entity publishes location via pubsub</a>
+</dt>
+<dt>4.2.  <a href="#usecases-request">Entity requests the location of another entity</a>
+</dt>
+<dt>4.3.  <a href="#usecases-send">Sending location</a>
+</dt>
+<dt>4.4.  <a href="#usecases-presence">Entity publishes location in presence</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a format for capturing data about an entity's geographical location (geoloc). The namespace defined herein is intended to provide a semi-structured format for describing a geographical location that may change fairly frequently, where the geoloc information is provided as Global Positioning System (GPS) coordinates. Potential uses for this approach include:</p>
+  <ul>
+    <li>Publishing geoloc information to a set of subscribers.</li>
+    <li>Querying another entity for its geoloc.</li>
+    <li>Sending geoloc information to another entity.</li>
+    <li>Attaching geoloc information to presence.</li>
+  </ul>
+  <p class="" style="">As specified herein, geographical location is captured in terms of GPS coordinates (and associated data) only; a format for communicating temporary changes in physical location (i.e., address) is defined in <span class="ref">User Physical Location</span>  [<a href="#nt-id2596318">1</a>].</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol was designed to address the following requirements:</p>
+  <ul>
+    <li>The GPS encoding mechanism shall have a single set of units, so that receivers do not need to use heuristics to determine actual position.</li>
+    <li>It shall be possible to specify the known amount of error in the GPS coordinates.</li>
+    <li>Since this protocol will often be used from mobile devices, size of XML is a factor.</li>
+  </ul>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the entity's geoloc is provided by the entity and propagated on the network by the entity's associated application (usually a client). The information is structured by means of a &lt;geoloc/&gt; element that is qualified by the 'http://jabber.org/protocol/geoloc' namespace; the geolocation information itself is provided as the XML character data of the following child elements:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Element Name</th>
+      <th colspan="" rowspan="">Inclusion</th>
+      <th colspan="" rowspan="">Datatype</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">alt</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:int</td>
+      <td align="" colspan="" rowspan="">Altitude in meters above or below sea level</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">bearing</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS bearing (direction in which the entity is heading to reach its next waypoint)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">datum</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS datum  [<a href="#nt-id2601950">2</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">description</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">A natural-language description of the location</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">error</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Horizontal GPS error in arc minutes</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lat</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Latitude in decimal degrees North</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lon</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Longitude in decimal degrees East</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">timestamp</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:datetime</td>
+      <td align="" colspan="" rowspan="">UTC timestamp specifying the moment when the reading was taken (MUST conform to the DateTime profile of <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2602270">3</a>])</td>
+    </tr>
+  </table>
+  <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602204">4</a>].</p>
+  <p class="" style="">The location information SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602236">5</a>]. Because location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;, although an application MAY do so if necessary.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecases-pubsub">Entity publishes location via pubsub</a>
+</h3>
+    <p class="" style="">In order to provide information about one's location, Publish-Subscribe SHOULD be used.</p>
+    <p class="caption">Example 1. Entity publishes location</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='portia@merchantofvenice.lit' 
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Subscriber receives event with payload</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602357">6</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='i1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='portia@merchantofvenice.lit'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecases-request">Entity requests the location of another entity</a>
+</h3>
+    <p class="" style="">If an entity wishes to request the location of another entity but the requestee does not publish that information via pubsub, the requestor MAY send an IQ to the requestee:</p>
+    <p class="caption">Example 4. Location request</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    id='loc_1'
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+&lt;/iq&gt;</pre></div>
+  <p class="" style="">The receiving entity SHOULD make a careful access control decision before returning the actual location.</p>
+    <p class="caption">Example 5. Successful location response</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Verona&lt;/description&gt;
+    &lt;lat&gt;45.45&lt;/lat&gt;
+    &lt;lon&gt;11.00&lt;/lon&gt;
+  &lt;/geoloc&gt;
+&lt;/iq&gt;</pre></div>
+    <p class="" style="">If the receiving entity decides not to return the actual location, it MUST return an IQ error, which SHOULD be &lt;forbidden/&gt; but MAY be some other appropriate error, such as &lt;not-allowed/&gt;:</p>
+    <p class="caption">Example 6. Access to location information denied</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecases-send">Sending location</a>
+</h3>
+  <p class="" style="">If an entity wants to send another entity its postition but it does not publish that information via pubsub, it MAY do so in a message. There SHOULD be a body element so that receiving entities that do not support this JEP can present a message to the recipient.</p>
+    <p class="caption">Example 7. Message containing location</p>
+<div class="indent"><pre>
+&lt;message 
+    to='polonius@hamlet.lit'
+    from='horatio@hamlet.lit/castle'&gt;
+  &lt;body&gt;This message contains a location.&lt;/body&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Elsinore&lt;/description&gt;
+    &lt;lat&gt;56.033&lt;/lat&gt;
+    &lt;lon&gt;12.618&lt;/lon&gt;
+  &lt;/geoloc&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;
+      http://www.mapquest.com/maps/map.adp?latlongtype=\
+      decimal&amp;latitude=56.033&amp;longitude=12.618
+    &lt;/url&gt;
+    &lt;desc&gt;Where would the castle have been?&lt;/desc&gt;
+  &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="usecases-presence">Entity publishes location in presence</a>
+</h3>
+    <p class="" style="">If an entity wishes all of the entities on its roster to be informed of a new location, the entity MAY publish a presence stanza that includes a location, although this is NOT RECOMMENDED (since location SHOULD be published using pubsub instead in order to ensure appropriate access control):</p>
+    <p class="caption">Example 8. Location in presence</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;alt&gt;1609&lt;/alt&gt;
+    &lt;description&gt;Jabber, Inc.&lt;/description&gt;
+    &lt;error&gt;10&lt;/error&gt;
+    &lt;lat&gt;39.75477&lt;/lat&gt;
+    &lt;lon&gt;-104.99768&lt;/lon&gt;
+    &lt;timestamp&gt;2004-02-19T21:12Z&lt;/timestamp&gt;
+  &lt;/geoloc&gt;
+&lt;/presence&gt;</pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">Avoid &quot;Mars probe&quot; issues: as specified in Table 1, the units for &lt;lat/&gt; and &lt;lon/&gt; MUST be decimal degrees (where South and West are negative, North and East are positive), the units for &lt;alt/&gt; MUST be meters above or below sea level, and the units for &lt;error/&gt; MUST be arc minutes.</p>
+  <p class="" style="">In applications where updates are sent whenever there is a certain distance change in location, those applications SHOULD account for time as well, to avoid rate-limiting when the user is (for example) on a jet plane. One possible way to do this would be to send updates at most once per minute of time (every time 60 seconds have elapsed).</p>
+  <p class="" style="">Inferences MUST NOT be made about accuracy from the number of digits specified in the location or altitude.</p>
+  <p class="" style="">Why the datum madness? See &lt;<a href="http://www.jabber.org/protocol/geoloc/gps_datum.html">http://www.jabber.org/protocol/geoloc/gps_datum.html</a>&gt; for an example.</p>
+  <p class="" style="">An entity can provide a GPS path by publishing a series of items (i.e., multiple pubsub events) with appropriate values of the &lt;timestamp/&gt; element.</p>
+<h2>6.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Because the character data contained in the &lt;description/&gt; element is intended to be readable by humans, if that element is included then either the &lt;geoloc/&gt; element or the &lt;description/&gt; element SHOULD possess an 'xml:lang' attribute specifying the natural language of such character data.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. If an error is deliberately added to a location, the error SHOULD be the same for all receivers, to minimize the likelihood of triangulation. In the case of deliberate error, the &lt;error/&gt; element SHOULD NOT be included.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602972">7</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602919">8</a>] includes 'http://jabber.org/protocol/geoloc' to its registry of protocol namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema 
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/geoloc' 
+    xmlns='http://jabber.org/protocol/geoloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0080: http://www.jabber.org/jeps/jep-0080.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='geoloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccur='0'&gt;
+        &lt;xs:element name='alt' minOccurs='0' type='xs:int'/&gt;
+        &lt;xs:element name='bearing' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='datum' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='description' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='error' minOccurs='0' type='xs:decimal'/&gt;
+        &lt;xs:element name='lat' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='lon' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='timestamp' minOccurs='0' type='xs:datetime'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596318">1</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601950">2</a>. If datum is not included, receiver MUST assume WGS84; receivers MUST implement WGS84; senders MAY use another datum, but it is not recommended.</p>
+<p>
+<a name="nt-id2602270">3</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602204">4</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602236">5</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602357">6</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602972">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602919">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2004-10-12)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft; also added internationalization considerations and linked to an archived version of the GPS datum example. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-12)</h4>
+<div class="indent">Clarified several points in the implementation notes. (psa)
+    </div>
+<h4>Version 0.8 (2004-09-15)</h4>
+<div class="indent">Specified error flow for IQ example. (psa)
+    </div>
+<h4>Version 0.7 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to geoloc elements; moved physical address protocol back to JEP-0112. (psa)
+    </div>
+<h4>Version 0.5 (2003-12-16)</h4>
+<div class="indent">Converted to use of infobits. (psa)
+    </div>
+<h4>Version 0.4 (2003-09-08)</h4>
+<div class="indent">Merged in contents of JEP-0112. (psa)
+    </div>
+<h4>Version 0.3 (2003-08-21)</h4>
+<div class="indent">Changed protocol name from 'location' to 'geoloc'. (psa)
+    </div>
+<h4>Version 0.2 (2003-07-29)</h4>
+<div class="indent">Incorporated Standards JIG feedback; changed JEP type to Informational. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-15)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0080-1.1.html
+++ b/content/xep-0080-1.1.html
@@ -1,0 +1,447 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0080: User Geolocation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Geolocation">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0080">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0080: User Geolocation</h1>
+<p>This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0080<br>
+            Version: 1.1<br>
+            Last Updated: 2004-10-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: geoloc<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/geoloc/geoloc.xsd">http://jabber.org/protocol/geoloc/geoloc.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecases-pubsub">Entity publishes location via pubsub</a>
+</dt>
+<dt>4.2.  <a href="#usecases-request">Entity requests the location of another entity</a>
+</dt>
+<dt>4.3.  <a href="#usecases-send">Sending location</a>
+</dt>
+<dt>4.4.  <a href="#usecases-presence">Entity publishes location in presence</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a format for capturing data about an entity's geographical location (geoloc). The namespace defined herein is intended to provide a semi-structured format for describing a geographical location that may change fairly frequently, where the geoloc information is provided as Global Positioning System (GPS) coordinates. Potential uses for this approach include:</p>
+  <ul>
+    <li>Publishing geoloc information to a set of subscribers.</li>
+    <li>Querying another entity for its geoloc.</li>
+    <li>Sending geoloc information to another entity.</li>
+    <li>Attaching geoloc information to presence.</li>
+  </ul>
+  <p class="" style="">As specified herein, geographical location is captured in terms of GPS coordinates (and associated data) only; a format for communicating temporary changes in physical location (i.e., address) is defined in <span class="ref">User Physical Location</span>  [<a href="#nt-id2596336">1</a>].</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol was designed to address the following requirements:</p>
+  <ul>
+    <li>The GPS encoding mechanism shall have a single set of units, so that receivers do not need to use heuristics to determine actual position.</li>
+    <li>It shall be possible to specify the known amount of error in the GPS coordinates.</li>
+    <li>Since this protocol will often be used from mobile devices, size of XML is a factor.</li>
+  </ul>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the entity's geoloc is provided by the entity and propagated on the network by the entity's associated application (usually a client). The information is structured by means of a &lt;geoloc/&gt; element that is qualified by the 'http://jabber.org/protocol/geoloc' namespace; the geolocation information itself is provided as the XML character data of the following child elements:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Element Name</th>
+      <th colspan="" rowspan="">Inclusion</th>
+      <th colspan="" rowspan="">Datatype</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">alt</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Altitude in meters above or below sea level</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">bearing</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS bearing (direction in which the entity is heading to reach its next waypoint)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">datum</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS datum  [<a href="#nt-id2602056">2</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">description</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">A natural-language description of the location</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">error</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Horizontal GPS error in arc minutes</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lat</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Latitude in decimal degrees North</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lon</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Longitude in decimal degrees East</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">timestamp</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:datetime</td>
+      <td align="" colspan="" rowspan="">UTC timestamp specifying the moment when the reading was taken (MUST conform to the DateTime profile of <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2602373">3</a>])</td>
+    </tr>
+  </table>
+  <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602308">4</a>].</p>
+  <p class="" style="">The location information SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602340">5</a>]. Because location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;, although an application MAY do so if necessary.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecases-pubsub">Entity publishes location via pubsub</a>
+</h3>
+    <p class="" style="">In order to provide information about one's location, Publish-Subscribe SHOULD be used.</p>
+    <p class="caption">Example 1. Entity publishes location</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='portia@merchantofvenice.lit' 
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Subscriber receives event with payload</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602536">6</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='i1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='portia@merchantofvenice.lit'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecases-request">Entity requests the location of another entity</a>
+</h3>
+    <p class="" style="">If an entity wishes to request the location of another entity but the requestee does not publish that information via pubsub, the requestor MAY send an IQ to the requestee:</p>
+    <p class="caption">Example 4. Location request</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    id='loc_1'
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+&lt;/iq&gt;</pre></div>
+  <p class="" style="">The receiving entity SHOULD make a careful access control decision before returning the actual location.</p>
+    <p class="caption">Example 5. Successful location response</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Verona&lt;/description&gt;
+    &lt;lat&gt;45.45&lt;/lat&gt;
+    &lt;lon&gt;11.00&lt;/lon&gt;
+  &lt;/geoloc&gt;
+&lt;/iq&gt;</pre></div>
+    <p class="" style="">If the receiving entity decides not to return the actual location, it MUST return an IQ error, which SHOULD be &lt;forbidden/&gt; but MAY be some other appropriate error, such as &lt;not-allowed/&gt;:</p>
+    <p class="caption">Example 6. Access to location information denied</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecases-send">Sending location</a>
+</h3>
+  <p class="" style="">If an entity wants to send another entity its postition but it does not publish that information via pubsub, it MAY do so in a message. There SHOULD be a body element so that receiving entities that do not support this JEP can present a message to the recipient.</p>
+    <p class="caption">Example 7. Message containing location</p>
+<div class="indent"><pre>
+&lt;message 
+    to='polonius@hamlet.lit'
+    from='horatio@hamlet.lit/castle'&gt;
+  &lt;body&gt;This message contains a location.&lt;/body&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Elsinore&lt;/description&gt;
+    &lt;lat&gt;56.033&lt;/lat&gt;
+    &lt;lon&gt;12.618&lt;/lon&gt;
+  &lt;/geoloc&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;
+      http://www.mapquest.com/maps/map.adp?latlongtype=\
+      decimal&amp;latitude=56.033&amp;longitude=12.618
+    &lt;/url&gt;
+    &lt;desc&gt;Where would the castle have been?&lt;/desc&gt;
+  &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="usecases-presence">Entity publishes location in presence</a>
+</h3>
+    <p class="" style="">If an entity wishes all of the entities on its roster to be informed of a new location, the entity MAY publish a presence stanza that includes a location, although this is NOT RECOMMENDED (since location SHOULD be published using pubsub instead in order to ensure appropriate access control):</p>
+    <p class="caption">Example 8. Location in presence</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;alt&gt;1609&lt;/alt&gt;
+    &lt;description&gt;Jabber, Inc.&lt;/description&gt;
+    &lt;error&gt;10&lt;/error&gt;
+    &lt;lat&gt;39.75477&lt;/lat&gt;
+    &lt;lon&gt;-104.99768&lt;/lon&gt;
+    &lt;timestamp&gt;2004-02-19T21:12Z&lt;/timestamp&gt;
+  &lt;/geoloc&gt;
+&lt;/presence&gt;</pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">Avoid &quot;Mars probe&quot; issues: as specified in Table 1, the units for &lt;lat/&gt; and &lt;lon/&gt; MUST be decimal degrees (where South and West are negative, North and East are positive), the units for &lt;alt/&gt; MUST be meters above or below sea level, and the units for &lt;error/&gt; MUST be arc minutes.</p>
+  <p class="" style="">In applications where updates are sent whenever there is a certain distance change in location, those applications SHOULD account for time as well, to avoid rate-limiting when the user is (for example) on a jet plane. One possible way to do this would be to send updates at most once per minute of time (every time 60 seconds have elapsed).</p>
+  <p class="" style="">Inferences SHOULD NOT be made about accuracy from the number of digits specified in the location or altitude.</p>
+  <p class="" style="">Why the datum madness? See &lt;<a href="http://www.jabber.org/protocol/geoloc/gps_datum.html">http://www.jabber.org/protocol/geoloc/gps_datum.html</a>&gt; for an example.</p>
+  <p class="" style="">An entity can provide a GPS path by publishing a series of items (i.e., multiple pubsub events) with appropriate values of the &lt;timestamp/&gt; element.</p>
+<h2>6.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Because the character data contained in the &lt;description/&gt; element is intended to be readable by humans, if that element is included then either the &lt;geoloc/&gt; element or the &lt;description/&gt; element SHOULD possess an 'xml:lang' attribute specifying the natural language of such character data.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. If an error is deliberately added to a location, the error SHOULD be the same for all receivers, to minimize the likelihood of triangulation. In the case of deliberate error, the &lt;error/&gt; element SHOULD NOT be included.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602916">7</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602864">8</a>] includes 'http://jabber.org/protocol/geoloc' to its registry of protocol namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema 
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/geoloc' 
+    xmlns='http://jabber.org/protocol/geoloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0080: http://www.jabber.org/jeps/jep-0080.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='geoloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccur='0'&gt;
+        &lt;xs:element name='alt' minOccurs='0' type='xs:decimal'/&gt;
+        &lt;xs:element name='bearing' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='datum' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='description' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='error' minOccurs='0' type='xs:decimal'/&gt;
+        &lt;xs:element name='lat' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='lon' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='timestamp' minOccurs='0' type='xs:datetime'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596336">1</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602056">2</a>. If datum is not included, receiver MUST assume WGS84; receivers MUST implement WGS84; senders MAY use another datum, but it is not recommended.</p>
+<p>
+<a name="nt-id2602373">3</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602308">4</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602340">5</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602536">6</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602916">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602864">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2004-10-29)</h4>
+<div class="indent">Changed xs:int to xs:decimal for altitude; changed MUST NOT to SHOULD NOT regarding inferences about accuracy. (psa)
+    </div>
+<h4>Version 1.0 (2004-10-12)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft; also added internationalization considerations and linked to an archived version of the GPS datum example. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-12)</h4>
+<div class="indent">Clarified several points in the implementation notes. (psa)
+    </div>
+<h4>Version 0.8 (2004-09-15)</h4>
+<div class="indent">Specified error flow for IQ example. (psa)
+    </div>
+<h4>Version 0.7 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to geoloc elements; moved physical address protocol back to JEP-0112. (psa)
+    </div>
+<h4>Version 0.5 (2003-12-16)</h4>
+<div class="indent">Converted to use of infobits. (psa)
+    </div>
+<h4>Version 0.4 (2003-09-08)</h4>
+<div class="indent">Merged in contents of JEP-0112. (psa)
+    </div>
+<h4>Version 0.3 (2003-08-21)</h4>
+<div class="indent">Changed protocol name from 'location' to 'geoloc'. (psa)
+    </div>
+<h4>Version 0.2 (2003-07-29)</h4>
+<div class="indent">Incorporated Standards JIG feedback; changed JEP type to Informational. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-15)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0080-1.2.html
+++ b/content/xep-0080-1.2.html
@@ -1,0 +1,448 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0080: User Geolocation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Geolocation">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0080">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0080: User Geolocation</h1>
+<p>This JEP defines a protocol for communicating information about the current geographical location of a Jabber entity.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0080<br>
+            Version: 1.2<br>
+            Last Updated: 2005-05-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: geoloc<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/geoloc/geoloc.xsd">http://jabber.org/protocol/geoloc/geoloc.xsd</a>&gt;<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Geolocation%20(JEP-0080)">http://wiki.jabber.org/index.php/User Geolocation (JEP-0080)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecases-pubsub">Entity publishes location via pubsub</a>
+</dt>
+<dt>4.2.  <a href="#usecases-request">Entity requests the location of another entity</a>
+</dt>
+<dt>4.3.  <a href="#usecases-send">Sending location</a>
+</dt>
+<dt>4.4.  <a href="#usecases-presence">Entity publishes location in presence</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a format for capturing data about an entity's geographical location (geoloc). The namespace defined herein is intended to provide a semi-structured format for describing a geographical location that may change fairly frequently, where the geoloc information is provided as Global Positioning System (GPS) coordinates. Potential uses for this approach include:</p>
+  <ul>
+    <li>Publishing geoloc information to a set of subscribers.</li>
+    <li>Querying another entity for its geoloc.</li>
+    <li>Sending geoloc information to another entity.</li>
+    <li>Attaching geoloc information to presence.</li>
+  </ul>
+  <p class="" style="">As specified herein, geographical location is captured in terms of GPS coordinates (and associated data) only; a format for communicating temporary changes in physical location (i.e., address) is defined in <span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2250648">1</a>].</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol was designed to address the following requirements:</p>
+  <ul>
+    <li>The GPS encoding mechanism shall have a single set of units, so that receivers do not need to use heuristics to determine actual position.</li>
+    <li>It shall be possible to specify the known amount of error in the GPS coordinates.</li>
+    <li>Since this protocol will often be used from mobile devices, size of XML is a factor.</li>
+  </ul>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the entity's geoloc is provided by the entity and propagated on the network by the entity's associated application (usually a client). The information is structured by means of a &lt;geoloc/&gt; element that is qualified by the 'http://jabber.org/protocol/geoloc' namespace; the geolocation information itself is provided as the XML character data of the following child elements:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Element Name</th>
+      <th colspan="" rowspan="">Inclusion</th>
+      <th colspan="" rowspan="">Datatype</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">alt</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Altitude in meters above or below sea level</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">bearing</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">GPS bearing (direction in which the entity is heading to reach its next waypoint), measured in decimal degrees relative to true north  [<a href="#nt-id2256231">2</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">datum</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">GPS datum  [<a href="#nt-id2256270">3</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">description</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:string</td>
+      <td align="" colspan="" rowspan="">A natural-language description of the location</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">error</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Horizontal GPS error in arc minutes</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lat</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Latitude in decimal degrees North</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">lon</td>
+      <td align="" colspan="" rowspan="">MUST</td>
+      <td align="" colspan="" rowspan="">xs:decimal</td>
+      <td align="" colspan="" rowspan="">Longitude in decimal degrees East</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">timestamp</td>
+      <td align="" colspan="" rowspan="">MAY</td>
+      <td align="" colspan="" rowspan="">xs:datetime</td>
+      <td align="" colspan="" rowspan="">UTC timestamp specifying the moment when the reading was taken (MUST conform to the DateTime profile of <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2256474">4</a>])</td>
+    </tr>
+  </table>
+  <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref" style="">XML Schema Part 2</span>  [<a href="#nt-id2256506">5</a>].</p>
+  <p class="" style="">The location information SHOULD be communicated by means of <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256536">6</a>]. Because location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;, although an application MAY do so if necessary.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecases-pubsub">Entity publishes location via pubsub</a>
+</h3>
+    <p class="" style="">In order to provide information about one's location, Publish-Subscribe SHOULD be used.</p>
+    <p class="caption">Example 1. Entity publishes location</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='portia@merchantofvenice.lit' 
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Subscriber receives event with payload</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2256623">7</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='bassanio@merchantofvenice.lit'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='i1s2d3f4g5h6bjeh936'&gt;
+        &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+          &lt;description&gt;Venice&lt;/description&gt;
+          &lt;lat&gt;45.44&lt;/lat&gt;
+          &lt;lon&gt;12.33&lt;/lon&gt;
+        &lt;/geoloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='portia@merchantofvenice.lit'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecases-request">Entity requests the location of another entity</a>
+</h3>
+    <p class="" style="">If an entity wishes to request the location of another entity but the requestee does not publish that information via pubsub, the requestor MAY send an IQ to the requestee:</p>
+    <p class="caption">Example 4. Location request</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    id='loc_1'
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+&lt;/iq&gt;</pre></div>
+  <p class="" style="">The receiving entity SHOULD make a careful access control decision before returning the actual location.</p>
+    <p class="caption">Example 5. Successful location response</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Verona&lt;/description&gt;
+    &lt;lat&gt;45.45&lt;/lat&gt;
+    &lt;lon&gt;11.00&lt;/lon&gt;
+  &lt;/geoloc&gt;
+&lt;/iq&gt;</pre></div>
+    <p class="" style="">If the receiving entity decides not to return the actual location, it MUST return an IQ error, which SHOULD be &lt;forbidden/&gt; but MAY be some other appropriate error, such as &lt;not-allowed/&gt;:</p>
+    <p class="caption">Example 6. Access to location information denied</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    id='loc_1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;error code='403' type='auth'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecases-send">Sending location</a>
+</h3>
+  <p class="" style="">If an entity wants to send another entity its postition but it does not publish that information via pubsub, it MAY do so in a message. There SHOULD be a body element so that receiving entities that do not support this JEP can present a message to the recipient.</p>
+    <p class="caption">Example 7. Message containing location</p>
+<div class="indent"><pre>
+&lt;message 
+    to='polonius@hamlet.lit'
+    from='horatio@hamlet.lit/castle'&gt;
+  &lt;body&gt;This message contains a location.&lt;/body&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;description&gt;Elsinore&lt;/description&gt;
+    &lt;lat&gt;56.033&lt;/lat&gt;
+    &lt;lon&gt;12.618&lt;/lon&gt;
+  &lt;/geoloc&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;
+      http://www.mapquest.com/maps/map.adp?latlongtype=\
+      decimal&amp;latitude=56.033&amp;longitude=12.618
+    &lt;/url&gt;
+    &lt;desc&gt;Where would the castle have been?&lt;/desc&gt;
+  &lt;/x&gt;
+&lt;/message&gt;</pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="usecases-presence">Entity publishes location in presence</a>
+</h3>
+    <p class="" style="">If an entity wishes all of the entities on its roster to be informed of a new location, the entity MAY publish a presence stanza that includes a location, although this is NOT RECOMMENDED (since location SHOULD be published using pubsub instead in order to ensure appropriate access control):</p>
+    <p class="caption">Example 8. Location in presence</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;geoloc xmlns='http://jabber.org/protocol/geoloc'&gt;
+    &lt;alt&gt;1609&lt;/alt&gt;
+    &lt;description&gt;Jabber, Inc.&lt;/description&gt;
+    &lt;error&gt;10&lt;/error&gt;
+    &lt;lat&gt;39.75477&lt;/lat&gt;
+    &lt;lon&gt;-104.99768&lt;/lon&gt;
+    &lt;timestamp&gt;2004-02-19T21:12Z&lt;/timestamp&gt;
+  &lt;/geoloc&gt;
+&lt;/presence&gt;</pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">Avoid "Mars probe" issues: as specified in Table 1, the units for &lt;lat/&gt; and &lt;lon/&gt; MUST be decimal degrees (where South and West are negative, North and East are positive), the units for &lt;alt/&gt; MUST be meters above or below sea level, and the units for &lt;error/&gt; MUST be arc minutes.</p>
+  <p class="" style="">In applications where updates are sent whenever there is a certain distance change in location, those applications SHOULD account for time as well, to avoid rate-limiting when the user is (for example) on a jet plane. One possible way to do this would be to send updates at most once per minute of time (every time 60 seconds have elapsed).</p>
+  <p class="" style="">Inferences SHOULD NOT be made about accuracy from the number of digits specified in the location or altitude.</p>
+  <p class="" style="">Why the datum madness? See &lt;<a href="http://www.jabber.org/protocol/geoloc/gps_datum.html">http://www.jabber.org/protocol/geoloc/gps_datum.html</a>&gt; for an example.</p>
+  <p class="" style="">An entity can provide a GPS path by publishing a series of items (i.e., multiple pubsub events) with appropriate values of the &lt;timestamp/&gt; element.</p>
+<h2>6.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Because the character data contained in the &lt;description/&gt; element is intended to be readable by humans, if that element is included then either the &lt;geoloc/&gt; element or the &lt;description/&gt; element SHOULD possess an 'xml:lang' attribute specifying the natural language of such character data.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. If an error is deliberately added to a location, the error SHOULD be the same for all receivers, to minimize the likelihood of triangulation. In the case of deliberate error, the &lt;error/&gt; element SHOULD NOT be included.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257080">8</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257131">9</a>] includes 'http://jabber.org/protocol/geoloc' to its registry of protocol namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema 
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/geoloc' 
+    xmlns='http://jabber.org/protocol/geoloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0080: http://www.jabber.org/jeps/jep-0080.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='geoloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccur='0'&gt;
+        &lt;xs:element name='alt' minOccurs='0' type='xs:decimal'/&gt;
+        &lt;xs:element name='bearing' minOccurs='0' type='xs:decimal'/&gt;
+        &lt;xs:element name='datum' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='description' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='error' minOccurs='0' type='xs:decimal'/&gt;
+        &lt;xs:element name='lat' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='lon' minOccurs='1' type='xs:decimal'/&gt;
+        &lt;xs:element name='timestamp' minOccurs='0' type='xs:datetime'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250648">1</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2256231">2</a>. It is the responsibility of the receiver to translate bearing into decimal degrees relative to magnetic north, if desired.</p>
+<p><a name="nt-id2256270">3</a>. If datum is not included, receiver MUST assume WGS84; receivers MUST implement WGS84; senders MAY use another datum, but it is not recommended.</p>
+<p><a name="nt-id2256474">4</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2256506">5</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p><a name="nt-id2256536">6</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256623">7</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2257080">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257131">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.2 (2005-05-12)</h4>
+<div class="indent">Changed xs:string to xs:decimal for bearing and specified that bearing is to be interpreted as decimal degrees relative to true north. (psa)
+    </div>
+<h4>Version 1.1 (2004-10-29)</h4>
+<div class="indent">Changed xs:int to xs:decimal for altitude; changed MUST NOT to SHOULD NOT regarding inferences about accuracy. (psa)
+    </div>
+<h4>Version 1.0 (2004-10-12)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft; also added internationalization considerations and linked to an archived version of the GPS datum example. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-12)</h4>
+<div class="indent">Clarified several points in the implementation notes. (psa)
+    </div>
+<h4>Version 0.8 (2004-09-15)</h4>
+<div class="indent">Specified error flow for IQ example. (psa)
+    </div>
+<h4>Version 0.7 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to geoloc elements; moved physical address protocol back to JEP-0112. (psa)
+    </div>
+<h4>Version 0.5 (2003-12-16)</h4>
+<div class="indent">Converted to use of infobits. (psa)
+    </div>
+<h4>Version 0.4 (2003-09-08)</h4>
+<div class="indent">Merged in contents of JEP-0112. (psa)
+    </div>
+<h4>Version 0.3 (2003-08-21)</h4>
+<div class="indent">Changed protocol name from 'location' to 'geoloc'. (psa)
+    </div>
+<h4>Version 0.2 (2003-07-29)</h4>
+<div class="indent">Incorporated Standards JIG feedback; changed JEP type to Informational. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-15)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0081-0.3.html
+++ b/content/xep-0081-0.3.html
@@ -1,0 +1,309 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0081: XMPP/Jabber MIME Type</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP/Jabber MIME Type">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="Note: This proposal has been superseded by the MIME type defined in draft-ietf-xmpp-e2e and the URI scheme defined in draft-saintandre-ietf-xmpp-uri; please refer to those documents for the successor protocols.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-07-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0081">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0081: XMPP/Jabber MIME Type</h1>
+<p>Note: This proposal has been superseded by the MIME type defined in draft-ietf-xmpp-e2e and the URI scheme defined in draft-saintandre-ietf-xmpp-uri; please refer to those documents for the successor protocols.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This JEP has been retracted by the author(s). Implementation of the protocol described herein is not recommended. Developers desiring similar functionality should implement the protocol that supersedes this one (if any).</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Retracted<br>
+            Type: Standards Track<br>
+            Number: 0081<br>
+            Version: 0.3<br>
+            Last Updated: 2004-07-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2595939">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596084">Overview</a>
+</dt>
+<dt>3.  <a href="#sect-id2596154">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2596296">Sending a Message</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2601789">Starting a Chat</a>
+</dt>
+<dt>3.3.  <a href="#sect-id2601813">Joining a Groupchat Room</a>
+</dt>
+<dt>3.4.  <a href="#sect-id2601841">Subscribing to Presence</a>
+</dt>
+<dt>3.5.  <a href="#sect-id2601869">Requesting a vCard</a>
+</dt>
+<dt>3.6.  <a href="#sect-id2601896">Registering with a Service</a>
+</dt>
+<dt>3.7.  <a href="#sect-id2601925">Searching a Directory</a>
+</dt>
+<dt>3.8.  <a href="#sect-id2601955">Making a Service Discovery Request</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2601985">Authentication</a>
+</dt>
+<dt>5.  <a href="#sect-id2602035">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2602056">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2602074">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2602093">XML Schema</a>
+</dt>
+<dt>9.  <a href="#sect-id2602143">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2595939">Introduction</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This JEP has been superseded by the MIME type defined in <span class="ref">XMPP E2E</span>  [<a href="#nt-id2596096">1</a>] and the URI scheme defined in <span class="ref">XMPP URI</span>  [<a href="#nt-id2596129">2</a>]; please refer to those documents for the successor protocols.</span></p>
+  <p class="" style="">The potential value of a URI scheme (see <span class="ref">RFC 2396</span>  [<a href="#nt-id2596023">3</a>]) for XMPP/Jabber has long been recognized within the Jabber community. The traditional consensus was captured in <span class="ref">Jabber URI Scheme</span>  [<a href="#nt-id2596045">4</a>]. Unfortunately, URI schemes are slow to be accepted on the Internet, such that it might be years (if ever) before widely deployed software such as web browsers would support addresses of the form &lt;xmpp:user@domain&gt;.</p>
+  <p class="" style="">Thankfully, it is not necessary to define a URI scheme in order to integrate XMPP/Jabber support into the large existing base of deployed software. A well-accepted alternative approach is to define a MIME type (in accordance with <span class="ref">RFC 2045</span>  [<a href="#nt-id2596223">5</a>]) and then reconfigure the relevant server and client software to correctly handle the new MIME type. The latter approach is the one taken in the current proposal.</p>
+<h2>2.
+       <a name="sect-id2596084">Overview</a>
+</h2>
+  <p class="" style="">A MIME type of &quot;application/xmpp+xml&quot; is defined (in accordance with <span class="ref">RFC 3023</span>  [<a href="#nt-id2596170">6</a>]). Files of this MIME type would commonly be accessed with a web browser via HTTP, although other access methods are possible. On opening a file of this type, a browser would (by configuration) invoke an appropriate external software program (i.e., a Jabber client, or potentially an internal module) that would enable the user's interaction with an XMPP/Jabber server. If the user is not currently connected to a server, the invoked program would be responsible for connecting the user with appropriate prompting for authentication credentials. The file passed to the Jabber client would define parameters needed to complete a certain use case, such as starting a chat session with another user.</p>
+<h2>3.
+       <a name="sect-id2596154">Use Cases</a>
+</h2>
+  <p class="" style="">The solution must enable a user to complete the following use cases:</p>
+  <ul>
+    <li>Send a single message to another user.</li>
+    <li>Initiate a chat session with another user.</li>
+    <li>Join a groupchat room.</li>
+    <li>Subscribe to another user's presence.</li>
+    <li>Request another user's vCard.</li>
+    <li>Send a <span class="ref">Service Discovery</span>  [<a href="#nt-id2596274">7</a>] request.</li>
+    <li>Register with a service.</li>
+    <li>Search a user directory.</li>
+  </ul>
+  <p class="" style="">These use cases are defined below.</p>
+  <div class="indent">
+<h3>3.1 <a name="sect-id2596296">Sending a Message</a>
+</h3>
+    <p class="" style="">In order to send a message to a contact, the user opens an XMPP file of the following form:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;message jid='stpeter@jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which instantiates an appropriate interface for sending a message to the JID defined in the file.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sect-id2601789">Starting a Chat</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;chat jid='stpeter@jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which instantiates an appropriate interface for chatting with the JID defined in the file.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="sect-id2601813">Joining a Groupchat Room</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;groupchat jid='jdev@conference.jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which instantiates an appropriate interface for joining the conference room associated with the JID defined in the file.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="sect-id2601841">Subscribing to Presence</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;subscribe jid='stpeter@jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which instantiates an appropriate interface for subscribing to the presence of the JID defined in the file.</p>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="sect-id2601869">Requesting a vCard</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;vcard jid='stpeter@jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which instantiates an appropriate interface for requesting the vCard of the JID defined in the file.</p>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="sect-id2601896">Registering with a Service</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;register jid='headlines.shakespeare.lit'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which instantiates an appropriate interface for registering with the service associated with the JID defined in the file.</p>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="sect-id2601925">Searching a Directory</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;search jid='users.jabber.org'&gt;
+    &lt;nick&gt;stpeter&lt;/nick&gt;
+  &lt;/search&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which instantiates an appropriate interface for searching the directory associated with the JID defined in the file, including pre-populated information as specified (e.g., nick, first name, last name).</p>
+  </div>
+  <div class="indent">
+<h3>3.8 <a name="sect-id2601955">Making a Service Discovery Request</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;disco jid='shakespeare.lit'&gt;
+    &lt;items/&gt;
+    &lt;info/&gt;
+  &lt;/disco&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which instantiates an appropriate interface for sending a service discovery request to the JID defined in the file.</p>
+  </div>
+<h2>4.
+       <a name="sect-id2601985">Authentication</a>
+</h2>
+  <p class="" style="">The solution should also enable a user to authenticate with a server using parameters defined in the file, e.g., for the purpose of single-sign-on (SSO).</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+  &lt;connect&gt;
+	&lt;host&gt;somehost&lt;/host&gt;
+        &lt;ip&gt;10.1.1.1&lt;/ip&gt;
+	&lt;port&gt;5222&lt;/port&gt;
+	&lt;ssl/&gt;
+	&lt;authenticate&gt;
+	  &lt;username&gt;foo&lt;/username&gt;
+	  &lt;password&gt;test&lt;/password&gt;
+	  &lt;resource&gt;Work&lt;/resource&gt;
+	&lt;/authenticate&gt;
+  &lt;/connect&gt;
+  </pre></div>
+  <p class="" style="">The username, password, and resource are not required if there is some other extension inside authenticate, that, e.g. does SSO. Authenticate is mostly useful only for these SSO situations, anyway. If the user is already connected, the application SHOULD ignore the &lt;connect/&gt; block.</p>
+<h2>5.
+       <a name="sect-id2602035">Security Considerations</a>
+</h2>
+  <p class="" style="">The receiver SHOULD delete the XMPP file when done with it. This will help prevent certain HTTP caching problems.</p>
+<h2>6.
+       <a name="sect-id2602056">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires registration of the &quot;application/xmpp+xml&quot; MIME type with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602175">8</a>]. Details to follow.</p>
+<h2>7.
+       <a name="sect-id2602074">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602114">9</a>] as a result of this JEP.</p>
+<h2>8.
+       <a name="sect-id2602093">XML Schema</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>9.
+       <a name="sect-id2602143">Open Issues</a>
+</h2>
+  <ol start="" type="">
+    <li>Fully specify invocation process flow.</li>
+    <li>Define IANA registration.</li>
+    <li>Add implementation notes for server MIME type registration and HTTP Content-Type output.</li>
+    <li>Add implementation notes for client handling on various platforms (e.g., DDE messages in Windows).</li>
+    <li>Add optional support for authentication (e.g., for Single Sign On).</li>
+  </ol>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596096">1</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596129">2</a>. XMPP URI Format &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-05.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-05.txt</a>&gt; (work in progress).</p>
+<p>
+<a name="nt-id2596023">3</a>. RFC 2396: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc2396.txt">http://www.ietf.org/rfc/rfc2396.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596045">4</a>. JEP-0032: Jabber URI Scheme &lt;<a href="http://www.jabber.org/jeps/jep-0032.html">http://www.jabber.org/jeps/jep-0032.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596223">5</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596170">6</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596274">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602175">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602114">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2004-07-26)</h4>
+<div class="indent">Formally retracted this proposal in favor of the relevant Internet-Drafts. (psa)
+    </div>
+<h4>Version 0.2 (2003-08-18)</h4>
+<div class="indent">Added authentication example. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-21)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0081-0.4.html
+++ b/content/xep-0081-0.4.html
@@ -1,0 +1,325 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0081: Jabber MIME Type</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jabber MIME Type">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a MIME type for launching a Jabber client as a helper application from most modern web browsers, and for completing basic use cases once the client is launched.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-01-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0081">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0081: Jabber MIME Type</h1>
+<p>This JEP specifies a MIME type for launching a Jabber client as a helper application from most modern web browsers, and for completing basic use cases once the client is launched.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0081<br>
+            Version: 0.4<br>
+            Last Updated: 2005-01-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, RFC 2045, RFC 3023, JEP-0045, JEP-0077<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: mimetype<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#message">Sending a Message</a>
+</dt>
+<dt>2.2.  <a href="#chat">Starting a Chat</a>
+</dt>
+<dt>2.3.  <a href="#subscribe">Subscribing to Presence</a>
+</dt>
+<dt>2.4.  <a href="#groupchat">Joining a Groupchat Room</a>
+</dt>
+<dt>2.5.  <a href="#register">Registering with a Service</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>5.2.  <a href="#registrar-iana">IANA Interaction</a>
+</dt>
+</dl>
+<dt>6.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>7.  <a href="#sect-id2602680">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The value of a URI scheme (see <span class="ref">RFC 3986</span>  [<a href="#nt-id2596267">1</a>]) for Jabber/XMPP communications has long been recognized within the Jabber community, and such a scheme has been formally defined in <span class="ref">XMPP URI</span>  [<a href="#nt-id2596298">2</a>] as a way of identifying entities that adhere to <span class="ref">XMPP Core</span>  [<a href="#nt-id2596325">3</a>] or its antecedents. Unfortunately, URI schemes are slow to be accepted on the Internet, such that it might be years (if ever) before widely deployed software such as web browsers will support addresses of the form &lt;xmpp:user@domain&gt;.</p>
+  <p class="" style="">Thankfully, it is not necessary for the large existing base of deployed software to support the xmpp: URI scheme in order to integrate Jabber/XMPP support. A well-accepted alternative approach 
+     [<a href="#nt-id2596198">4</a>]
+  is to define a MIME type (in accordance with <span class="ref">RFC 2045</span>  [<a href="#nt-id2596425">5</a>]) and then reconfigure the relevant server and client software to correctly handle the new MIME type.</p>
+  <p class="" style="">Therefore, this JEP defines a MIME type of &quot;application/jabber+xml&quot; (in particular, an XML media type in accordance with <span class="ref">RFC 3023</span>  [<a href="#nt-id2596238">6</a>]). Files of this MIME type would commonly be accessed with a web browser via HTTP, although other access methods are possible (e.g., attachment of the MIME type to an email message). On opening a file of this type, a browser would (by configuration) invoke an appropriate &quot;helper&quot; application (i.e., an external Jabber client, plugin, or internal module) that would enable the user to interact with a Jabber/XMPP server. If the user is not currently connected to a server, the invoked program would be responsible for connecting the user with appropriate prompting for authentication credentials. The file passed to the helper application would define parameters needed to complete a certain use case, such as sending a message to another user.</p>
+  <p class="" style="">Note: The &quot;application/jabber+xml&quot; MIME type defined herein is not to be confused with the &quot;application/xmpp+xml&quot; MIME type defined in <span class="ref">RFC 3923</span>  [<a href="#nt-id2596358">7</a>]; the two MIME types address different requirements and do not overlap or conflict.</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">The solution MUST enable a user to complete the following use cases, support for which is REQUIRED:</p>
+  <ul>
+    <li>Send a single message to another user.</li>
+    <li>Initiate a one-to-one chat session with another user.</li>
+    <li>Subscribe to another user's presence.</li>
+  </ul>
+  <p class="" style="">In addition, the solution SHOULD enable a user to complete the following use cases, support for which is RECOMMENDED:</p>
+  <ul>
+    <li>Join a groupchat room.</li>
+    <li>Register with a service.</li>
+    
+  </ul>
+  <p class="" style="">These use cases are defined below.</p>
+  <div class="indent">
+<h3>2.1 <a name="message">Sending a Message</a>
+</h3>
+    <p class="" style="">In order to send a message to a contact, the user opens an XMPP file of the following form:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;message jid='stpeter@jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which shall instantiate an appropriate interface for sending a single message to the JID defined in the file. If the user completes the interface, the helper application shall then send a message stanza of type='normal' as specified in <span class="ref">XMPP IM</span>  [<a href="#nt-id2595919">8</a>], first authenticating with the user's Jabber/XMPP server if necessary.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="chat">Starting a Chat</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;chat jid='stpeter@jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which shall instantiate an appropriate interface for chatting with the JID defined in the file. If the user completes the interface, the helper application shall then send a message stanza of type='chat' as specified in <span style="font-weight: bold">XMPP IM</span>, first authenticating with the user's Jabber/XMPP server if necessary.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="subscribe">Subscribing to Presence</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;subscribe jid='stpeter@jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which shall instantiate an appropriate interface for sending a presence subscription request to the JID defined in the file (e.g., specifying a name and/or group for the contact).  If the user completes the interface, the helper application shall then send a presence stanza of type='subscribe' as specified in <span style="font-weight: bold">XMPP IM</span>, first authenticating with the user's Jabber/XMPP server if necessary. The helper application SHOULD perform a &quot;roster set&quot; before sending the presence subscription request, as described in <span style="font-weight: bold">XMPP IM</span>.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="groupchat">Joining a Groupchat Room</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;groupchat jid='jdev@conference.jabber.org'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which shall instantiate an appropriate interface for joining the conference room associated with the JID defined in the file. If the user completes the interface, the helper application shall then send a directed presence stanza to the JID (appending a room nickname to the JID as the resource identifier) as described in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2595908">9</a>], first authenticating with the user's Jabber/XMPP server if necessary.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="register">Registering with a Service</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;jabber&gt;
+  &lt;register jid='headlines.shakespeare.lit'/&gt;
+&lt;/jabber&gt;
+    </pre></div>
+    <p class="" style="">The browser passes this file to the helper application, which shall send an IQ stanza of type='get' to the service associated with the JID defined in the file in order to determine the registration requirements (first authenticating with the user's Jabber/XMPP server if necessary), as described in <span class="ref">In-Band Registration</span>  [<a href="#nt-id2602406">10</a>]. The helper application shall then instantiate an appropriate interface for registering with the service. If the user completes the interface, the helper application shall then send an IQ stanza of type='set' to the JID as described in <span style="font-weight: bold">JEP-0077</span>.</p>
+  </div>
+  
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Detailed security considerations for instant messaging and presence protocols are given in <span class="ref">RFC 2779</span>  [<a href="#nt-id2602587">11</a>] (Sections 5.1 through 5.4), and for XMPP in particular are given in <span style="font-weight: bold">RFC 3920</span> (Sections 12.1 through 12.6).  In addition, all of the security considerations specified in <span style="font-weight: bold">RFC 3023</span> apply to the &quot;application/jabber+xml&quot; media type.</p>
+  <p class="" style="">When a helper application has finished processing a file of type &quot;application/jabber+xml&quot;, it SHOULD discard the file; this helps to prevent security-related problems that may result from HTTP caching.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires registration of the &quot;application/jabber+xml&quot; content type with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602564">12</a>]. The registration is as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+To: ietf-types@iana.org
+
+Subject: Registration of MIME media type application/jabber+xml
+
+MIME media type name: application
+MIME subtype name: jabber+xml
+Required parameters: (none)
+Optional parameters: (charset) Same as charset parameter of
+   application/xml as specified in RFC 3023; per Section 11.5
+   of RFC 3920, the charset must be UTF-8.
+Encoding considerations: Same as encoding considerations of
+   application/xml as specified in RFC 3023; per Section 11.5
+   of RFC 3920, the encoding must be UTF-8.
+Security considerations: All of the security considerations 
+   specified in RFC 3023 and RFC 3920 apply to this XML media 
+   type.  Refer to Section 11 of JSF JEP-0081.
+Interoperability considerations: (none)
+Specification: JSF JEP-0081
+Applications which use this media type: non-XMPP applications
+   (e.g., web browsers or email clients) that wish to invoke
+   XMPP-compliant applications for instant messaging and 
+   presence functionality.
+Additional information: This media type is not to be confused 
+   with the &quot;application/xmpp+xml&quot; media type, which is for 
+   use by native XMPP applications.
+Person and email address to contact for further information: 
+   Jabber Registrar, &lt;registrar@jabber.org&gt;
+Intended usage: COMMON
+Author/Change controller: JSF, Jabber Registrar
+  </pre></div>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602740">13</a>] shall include 'http://jabber.org/protocol/mimetype' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="registrar-iana">IANA Interaction</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall interact with the IANA in order to register the media type defined herein.</p>
+  </div>
+<h2>6.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/mimetype'
+    xmlns='http://jabber.org/protocol/mimetype'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jabber'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element name='chat' type='JabberAction'/&gt;
+        &lt;xs:element name='groupchat' type='JabberAction'/&gt;
+        &lt;xs:element name='message' type='JabberAction'/&gt;
+        &lt;xs:element name='register' type='JabberAction'/&gt;
+        &lt;xs:element name='subscribe' type='JabberAction'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:complexType name='JabberAction'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+    &lt;xs:attribute name='jid' use='required'&gt;
+  &lt;/xs:complexType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>7.
+       <a name="sect-id2602680">Open Issues</a>
+</h2>
+  <ol start="" type="">
+    <li>Add implementation notes for server MIME type registration and HTTP Content-Type output.</li>
+    <li>Add implementation notes for client handling on various platforms (e.g., DDE messages in Windows).</li>
+  </ol>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596267">1</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596298">2</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt</a>&gt; (work in progress).</p>
+<p>
+<a name="nt-id2596325">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596198">4</a>. See, for instance, &lt;<a href="http://www.mozilla.org/docs/web-developer/mimetypes.html">http://www.mozilla.org/docs/web-developer/mimetypes.html</a>&gt; for information about MIME support in the Mozilla family of web browsers.</p>
+<p>
+<a name="nt-id2596425">5</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596238">6</a>. RFC 3023: XML Media Types &lt;<a href="http://www.ietf.org/rfc/rfc3023.txt">http://www.ietf.org/rfc/rfc3023.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596358">7</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595919">8</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595908">9</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602406">10</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602587">11</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602564">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602740">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2005-01-05)</h4>
+<div class="indent">Reinstated the proposal since it fills a need not met by RFC 3923 and draft-saintandre-xmpp-uri; specified XML schema; specified IANA considerations, including content-type registration; further specified security considerations; removed use cases for service discovery, directory search, vCard lookup, and authentication; added more detailed descriptive text to remaining use cases. (psa)
+    </div>
+<h4>Version 0.3 (2004-07-26)</h4>
+<div class="indent">Formally retracted this proposal in favor of the relevant Internet-Drafts. (psa)
+    </div>
+<h4>Version 0.2 (2003-08-18)</h4>
+<div class="indent">Added authentication example. (psa)
+    </div>
+<h4>Version 0.1 (2003-04-21)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0083-0.1.html
+++ b/content/xep-0083-0.1.html
@@ -1,0 +1,220 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0083: Nested Roster Groups</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Nested Roster Groups">
+<meta name="DC.Creator" content="Rachel Blackman">
+<meta name="DC.Description" content="This JEP defines a protocol extension that enables nested sub-groups to exist within the Jabber roster, while retaining backwards compatibility and ensuring that the roster remains usable by all clients.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2003-05-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0083">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0083: Nested Roster Groups</h1>
+<p>This JEP defines a protocol extension that enables nested sub-groups to exist within the Jabber roster, while retaining backwards compatibility and ensuring that the roster remains usable by all clients.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0083<br>
+            Version: 0.1<br>
+            Last Updated: 2003-05-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0049<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Rachel Blackman</h3>
+<p class="indent">
+        Email: rcb@ceruleanstudios.com<br>
+        JID: sparks@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2595940">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2595967">roster:delimiter Namespace</a>
+</dt>
+<dt>3.  <a href="#sect-id2596030">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2596049">Querying for the delimiter</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2596102">Retrieving the Roster</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2596190">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2596208">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2596329">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2596260">Formal Definition</a>
+</dt>
+<dl><dt>7.1.  <a href="#sect-id2601805">Schema</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2595940">Introduction</a>
+</h2>
+  <p class="" style="">In many modern instant messaging clients, client authors implement a way to nest contact groups within other contact groups.  Usually this is implemented on the client side, since many instant messaging networks do not support nesting contact groups in this manner.  The limitation of this system is that if the user changes from one client to another, or even a second installation of the same client, the user loses all of his or her sub-group information.  This JEP aims to solve that problem within Jabber, by providing for a way to store sub-groups on the Jabber roster without breaking existing clients.</p>
+<h2>2.
+       <a name="sect-id2595967">roster:delimiter Namespace</a>
+</h2>
+  <p class="" style="">Jabber already provides a useful method for storing client data on the server using <span class="ref">Private XML Storage</span>  [<a href="#nt-id2596087">1</a>].  All we need to do is create a new roster element and a namespace to store the delimiter for nested groups, roster:delimiter.  This element MUST contain XML character data that defines a string to be used as a delimiter in the roster groups.  [<a href="#nt-id2595987">2</a>]</p>
+  <p class="" style="">A single-character roster delimiter (e.g., &quot;/&quot;) would make client implementation easier, but be more limiting to the end-user in terms of choices for naming roster groups, so a string is ideal.  Therefore, the delimiter SHOULD contain multiple characters in order to avoid inconveniencing the user, but single-character delimiters MUST be honored by the client.  The exception is if the delimiter is a single alphanumeric character (a-z, A-Z, 0-9); in this case compliant clients MUST treat the situation as if nesting were disabled, to avoid malicious use of this element by setting 'e' or 'm' or some other common single character as a delimiter.</p>
+  <p class="" style="">A compliant client SHOULD ask for the nested delimiter before requesting the user's roster, in order to know whether or not to parse the roster 'group' fields accordingly.  If there is no delimiter stored, a client MAY set a delimiter but MUST either prompt the user for a delimiter, or use a user-configurable default.</p>
+<h2>3.
+       <a name="sect-id2596030">Use Cases</a>
+</h2>
+  <p class="" style="">Use cases for this extension are straightforward, and are shown below as examples.</p>
+  <div class="indent">
+<h3>3.1 <a name="sect-id2596049">Querying for the delimiter</a>
+</h3>
+    <p class="" style="">All compliant clients SHOULD query for an existing delimiter at login.</p>
+    <p class="caption">Example 1. Querying for the Delimiter</p>
+<div class="indent"><pre>
+CLIENT:
+&lt;iq type='get'
+    id='1'&gt;
+  &lt;query xmlns='jabber:iq:private'&gt;
+    &lt;roster xmlns='roster:delimiter'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+SERVER:
+&lt;iq type='result'
+    id='1'
+    from='bill@shakespeare.lit/Globe'
+    to='bill@shakespeare.lit/Globe'&gt;
+  &lt;query xmlns='jabber:iq:private'&gt;
+    &lt;roster xmlns='roster:delimiter'&gt;::&lt;/roster&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sect-id2596102">Retrieving the Roster</a>
+</h3>
+    <p class="" style="">Now that the client has a delimiter, we can retrieve and parse the roster properly.</p>
+    <p class="caption">Example 2. Retrieving a Roster with Nested Groups</p>
+<div class="indent"><pre>
+
+CLIENT:
+&lt;iq type='get'
+    id='2'&gt;
+  &lt;query xmlns='jabber:iq:roster'/&gt;
+&lt;/iq&gt;
+
+SERVER:
+&lt;iq type='result'
+    to='bill@shakespeare.lit/Globe'
+    id='2'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='bottom@athens.gr' subscription='both'&gt;
+      &lt;group&gt;Midsummer::Actors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='quince@athens.gr' subscription='both'&gt;
+      &lt;group&gt;Midsummer::Actors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='snug@athens.gr' subscription='both'&gt;
+      &lt;group&gt;Midsummer::Actors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='theseus@athens.gr' subscription='both'&gt;
+      &lt;group&gt;Midsummer::Royalty&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='hippolyta@athens.gr' subscription='both'&gt;
+      &lt;group&gt;Midsummer::Royalty&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='robin@faeries.underhill.org' subscription='both'&gt;
+      &lt;group&gt;Midsummer&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='hamlet@denmark.net' subscription='both'&gt;
+      &lt;group&gt;Hamlet&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='gertrude@denmark.net' subscription='both'&gt;
+      &lt;group&gt;Hamlet&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Bottom, Quince and Snug should be grouped together in a group 'Actors' underneath the group 'Midsummer'.  Theseus and Hippolyta should be grouped together in a group 'Royalty' under 'Midsummer'.  Robin Goodfellow, meanwhile, being in a class unto himself, is a plain contact under the 'Midsummer' group rather than in an actual sub-group.  The group Hamlet, containing only one melancholy prince and his mother, contains no sub-groups at all.</p>
+  <p class="" style="">As should be apparent, a client which does not support the delimiter will instead create a separate group -- such as 'Midsummer::Actors' -- and thus will still have each set of contacts grouped with the other appropriate contacts.</p>
+  </div>
+<h2>4.
+       <a name="sect-id2596190">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal above and beyond those specified for roster management in <span class="ref">XMPP IM</span>  [<a href="#nt-id2596299">3</a>].</p>
+<h2>5.
+       <a name="sect-id2596208">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2596232">4</a>].</p>
+<h2>6.
+       <a name="sect-id2596329">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2596280">5</a>] as a result of this JEP.</p>
+<h2>7.
+       <a name="sect-id2596260">Formal Definition</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="sect-id2601805">Schema</a>
+</h3>
+    <p class="" style="">As the private storage element is simple, the schema is similarly simple.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='roster:delimiter'
+    xmlns='roster:delimiter'&gt;
+
+&lt;xs:element name='roster' type='xs:string'/&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596087">1</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595987">2</a>. If the element does not contain XML character data, a compliant client SHOULD assume that nested groups are disabled for the user's account.</p>
+<p>
+<a name="nt-id2596299">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596232">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596280">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2003-05-05)</h4>
+<div class="indent">Initial version. (rcb)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0084-0.4.html
+++ b/content/xep-0084-0.4.html
@@ -1,0 +1,614 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0084: User Avatars in Jabber</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Avatars in Jabber">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Creator" content="Julian Missig">
+<meta name="DC.Description" content="This JEP defines a protocol for exchanging user avatars in Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2003-05-20">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0084">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0084: User Avatars in Jabber</h1>
+<p>This JEP defines a protocol for exchanging user avatars in Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0084<br>
+            Version: 0.4<br>
+            Last Updated: 2003-05-20<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0060<br>Supersedes: JEP-0008<br>
+                Superseded By: None<br>
+            Short Name: avatar<br>
+</p>
+<h2>Author Information</h2>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h3>Peter Millard</h3>
+<p class="indent">
+        Email: me@pgmillard.com<br>
+        JID: pgmillard@jabber.org</p>
+<h3>Julian Missig</h3>
+<p class="indent">
+        Email: julian@jabber.org<br>
+        JID: julian@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2596042">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596101">Basic Usage</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#sect-id2596069">Avatar Availability</a>
+</dt>
+<dt>2.2.  <a href="#sect-id2596181">Avatar Retrieval</a>
+</dt>
+<dt>2.3.  <a href="#sect-id2601836">Publishing an Avatar</a>
+</dt>
+</dl>
+<dt>3.  <a href="#sect-id2602007">Detailed Usage</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2602025">PubSub and Disco Interaction</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2602062">&lt;avatar&gt; Element Description</a>
+</dt>
+<dt>3.3.  <a href="#sect-id2602273">Image Requirements</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2602341">Implementation Notes</a>
+</dt>
+<dt>5.  <a href="#sect-id2602367">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2602388">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2602408">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2602429">Formal Definition</a>
+</dt>
+<dl><dt>8.1.  <a href="#sect-id2602438">Schema</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2596042">Introduction</a>
+</h2>
+  <p class="" style="">
+    Many communication applications now allow for the association of a small
+    image or buddy icon (avatar) with a user of that application. The avatar is
+    not intended to be a defining portrait of the user, but rather a simple
+    expression of the user's appearance, mood, status, and the like. This
+    proposal outlines a way to incorporate avatars into the current Jabber
+    platform by layering this functionality on top of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596164">1</a>].
+  </p>
+  <p class="" style="">
+    Publish-Subscribe was chosen as the base layer for avatars because of the 
+    need to publish a large amount of data to any number of users.  PubSub 
+    provides an easy mechanism for any user to subscribe to the avatar source 
+    and receive notifications from the publisher.  Furthermore, the publiser 
+    only has to send the data once to the pubsub component, and it relays it 
+    to all the subscribers.
+  </p>
+  <p class="" style="">The protocol defined herein uses two pubsub nodes: one node for &quot;meta-information&quot; about the avatar state (called the &quot;info-node&quot;) and one for the avatar data itself (called the &quot;data-node&quot;). This separation of meta-information from data conserves bandwidth and enables both the publisher and the subscriber to cache the avatar data.</p>
+<h2>2.
+       <a name="sect-id2596101">Basic Usage</a>
+</h2>
+    <div class="indent">
+<h3>2.1 <a name="sect-id2596069">Avatar Availability</a>
+</h3>
+    <p class="" style="">Other clients can see if avatar support is available by sending a <span class="ref">Service Discovery</span>  [<a href="#nt-id2596141">2</a>] items request to the other client and looking for the avatar item.  The request MUST be sent to the bare JID (&lt;user@host&gt;) of the other user, further specified by a disco node of &quot;http://jabber.org/protocol/avatar&quot;.  (Sending the request to the bare JID enables one to discover whether an offline user has published disco information regarding avatars).</p>
+    <p class="caption">Example 1. Disco Items Request</p>
+<div class="indent"><pre>
+      
+      &lt;iq
+        type='get'
+        from='romeo@montague.net/orchard'
+        to='juliet@capulet.com'
+        id='items1'&gt;
+        &lt;query 
+          xmlns='http://jabber.org/protocol/disco#items'
+          node='http://jabber.org/protocol/avatar'/&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+    <p class="" style="">
+      The result contains an item with the JID of the pubsub component where
+      the owner's avatar information is published and the specific node for
+      that information:
+    </p>
+    <p class="caption">Example 2. Disco Items Result</p>
+<div class="indent"><pre>
+      
+      &lt;iq
+        type='result'
+        from='juliet@capulet.com'
+        to='romeo@montague.net/orchard'
+        id='items1'&gt;
+        &lt;query 
+          xmlns='http://jabber.org/protocol/disco#items'
+          node='http://jabber.org/protocol/avatar'&gt;
+          &lt;item
+            jid='pubsub.shakespeare.lit'
+            node='avatar/info/juliet@capulet.com'/&gt;
+        &lt;/query&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+    <p class="" style="">
+      The owner of an avatar SHOULD publish their information to the server,
+      so that when the owner is offline the avatar can still be retrieved:
+    </p>
+    <p class="caption">Example 3. Publishing Disco Items</p>
+<div class="indent"><pre>
+      
+      &lt;iq
+        type='set'
+        from='juliet@capulet.com/chamber'
+        id='dset1'&gt;
+        &lt;query 
+          xmlns=&quot;http://jabber.org/protocol/disco#items&quot;
+          node='http://jabber.org/protocol/avatar'&gt;
+          &lt;item
+            jid='pubsub.shakespeare.lit'
+            node='avatar/info/juliet@capulet.com'
+            action='update' /&gt;
+        &lt;/query&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="sect-id2596181">Avatar Retrieval</a>
+</h3>
+    <p class="" style="">
+      The avatar information is retrieved from the pubsub component.  There MUST
+      only be one item in the information node, so we limit the request with
+      max_items:
+    </p>
+    <p class="caption">Example 4. Retrieving the Avatar Information</p>
+<div class="indent"><pre>
+      
+      &lt;iq
+        type='get'
+        from='romeo@montague.net/orchard'
+        to='pubsub.shakespeare.lit'
+        id='ps-items1'&gt;
+        &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+          &lt;items node='avatar/info/juliet@capulet.com' max_items='1'/&gt;
+        &lt;/pubsub&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+    <p class="" style="">
+      The item returned contains information about the currently active avatar.
+      Most important is the id attribute, which is also the SHA1 sum of the 
+      current avatar image data.  This can be used to see if a cached copy is 
+      still valid:
+    </p>
+    <p class="caption">Example 5. Result from Avatar Information Request</p>
+<div class="indent"><pre>
+      
+      &lt;iq
+        type='result'
+        from='pubsub.shakespeare.lit'
+        to='romeo@montague.net/orchard''
+        id='ps-items1'&gt;
+        &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+          &lt;items node='avatar/info/juliet@capulet.com'&gt;
+            &lt;item&gt;
+              &lt;avatar
+                xmlns='http://jabber.org/protocol/avatar'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                mime-type='image/png'
+                id='a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'/&gt;
+            &lt;/item&gt;
+          &lt;/items&gt;
+        &lt;/pubsub&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+    <p class="" style="">
+      In order to retrieve the actual avatar image data the JID and node from
+      the avatar information describe the pubsub node to interact with.  The
+      retrieval is done for the item id as specified in the avatar information:
+    </p>
+    <p class="caption">Example 6. Retrieving the Current Avatar</p>
+<div class="indent"><pre>
+      
+      &lt;iq 
+        type=&quot;get&quot;
+        from=&quot;romeo@montague.net/orchard&quot;
+        to=&quot;pubsub.shakespeare.lit&quot; 
+        id=&quot;ps-items2&quot;&gt;
+        &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+          &lt;items node=&quot;avatar/data/juliet@capulet.com&quot;&gt;
+            &lt;item id='a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'/&gt;
+          &lt;/items&gt;
+        &lt;/pubsub&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+    <p class="" style="">
+      The result contains the avatar image data.  The format of the
+      element is described in detail below:
+    </p>
+    <p class="caption">Example 7. Retrieval Result</p>
+<div class="indent"><pre>
+      
+      &lt;iq type=&quot;result&quot; from=&quot;pubsub.shakespeare.lit&quot; id=&quot;ps-items2&quot;&gt;
+        &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+          &lt;items node=&quot;avatar/data/juliet@capulet.com&quot;&gt;
+            &lt;item id=&quot;a94a8fe5ccb19ba61c4c0873d391e987982fbbd3&quot;&gt;
+              &lt;avatar 
+                xmlns=&quot;http://jabber.org/protocol/avatar&quot;
+                mime-type='image/png'&gt;
+                qANQR1DBwU4DX7jmYZnncm...
+              &lt;/avatar&gt;
+            &lt;/item&gt;
+          &lt;/items&gt;
+        &lt;/pubsub&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="sect-id2601836">Publishing an Avatar</a>
+</h3>
+    <p class="" style="">
+      Whenever the owner wishes to change the current avatar, the info-node MUST
+      be updated. If the actual image has not been previously published, it also
+      MUST be published to the data-node before the info-node is changed.
+    </p>
+    <p class="caption">Example 8. Publishing Avatar Data</p>
+<div class="indent"><pre>
+      
+      &lt;iq 
+        type=&quot;set&quot;
+        from=&quot;juliet@capulet.com/orchard&quot;
+        to=&quot;pubsub.shakespeare.lit&quot; 
+        id=&quot;publish1&quot;&gt;
+        &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+          &lt;publish node=&quot;avatar/data/juliet@capulet.com&quot;&gt;
+            &lt;item id=&quot;109f4b3c50d7b0df729d299bc6f8e9ef9066971f&quot;&gt;
+              &lt;avatar 
+                xmlns=&quot;http://jabber.org/protocol/avatar&quot;
+                mime-type=&quot;image/png&quot;&gt;
+                qANQR1DBwU4DX7jmYZnncm...
+              &lt;/avatar&gt;
+            &lt;/item&gt;
+          &lt;/publish&gt;
+        &lt;/pubsub&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+    <p class="" style="">
+      The result from the pubsub component:
+    </p>
+    <p class="caption">Example 9. Data Publish Result</p>
+<div class="indent"><pre>
+      
+      &lt;iq 
+        type=&quot;result&quot; 
+        from=&quot;pubsub.shakespeare.lit&quot; 
+        to=&quot;juliet@capulet.com/chamber&quot; 
+        id=&quot;publish1&quot;/&gt;
+      
+    </pre></div>
+    <p class="" style="">
+      Finally the avatar info-node must be updated.  The &lt;avatar&gt;
+      id attribute MUST be the same as the item id stored previously:
+    </p>
+    <p class="caption">Example 10. Publishing Avatar Information</p>
+<div class="indent"><pre>
+      
+      &lt;iq
+        type='set'
+        from='juliet@capulet.com/orchard'
+        to='pubsub.shakespeare.lit'
+        id='publish2'&gt;
+        &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+          &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+            &lt;item id='current'&gt;
+              &lt;avatar
+                xmlns='http://jabber.org/protocol/avatar'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                mime-type='image/png'
+                id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f' /&gt;
+            &lt;/item&gt;
+          &lt;/publish&gt;
+        &lt;/pubsub&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+    <p class="" style="">Subscribers to the avatar would then receive an update from the info-node:</p>
+    <p class="caption">Example 11. Receiving a Published Avatar</p>
+<div class="indent"><pre>
+      
+      &lt;message to=&quot;romeo@montague.net&quot; from=&quot;pubsub.shakespeare.lit&quot;&gt;
+        &lt;x xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+          &lt;items node=&quot;avatar/info/juliet@capulet.com&quot;&gt;
+            &lt;item id=&quot;current&quot;&gt;
+              &lt;avatar 
+                xmlns=&quot;http://jabber.org/protocol/avatar&quot;
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                mime-type='image/png'
+                id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f' /&gt;
+            &lt;/item&gt;
+          &lt;/items&gt;
+        &lt;/x&gt;
+      &lt;/message&gt;
+      
+    </pre></div>
+    <p class="" style="">In order to temporarily disable the avatar an empty &lt;avatar/&gt; node is published to the info-node:
+    </p>
+    <p class="caption">Example 12. Temporarily Disabling an Avatar</p>
+<div class="indent"><pre>
+      
+      &lt;iq 
+        type=&quot;set&quot;
+        from=&quot;juliet@capulet.com/orchard&quot;
+        to=&quot;pubsub.shakespeare.lit&quot; 
+        id=&quot;publish3&quot;&gt;
+        &lt;pubsub xmlns=&quot;http://jabber.org/protocol/pubsub&quot;&gt;
+          &lt;publish node=&quot;avatar/info/juliet@capulet.com&quot;&gt;
+            &lt;item id=&quot;current&quot;&gt;
+              &lt;avatar xmlns=&quot;http://jabber.org/protocol/avatar&quot;/&gt;
+            &lt;/item&gt;
+          &lt;/publish&gt;
+        &lt;/pubsub&gt;
+      &lt;/iq&gt;
+      
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="sect-id2602007">Detailed Usage</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="sect-id2602025">PubSub and Disco Interaction</a>
+</h3>
+    <p class="" style="">
+      The avatar info-node that is used on the pubsub component for 
+      all interaction MUST be created by the avatar owner as described in 
+      JEP-0060. The node identifier is then used for all updates and in 
+      the disco items retrieval.
+    </p>
+    <p class="" style="">
+      Once the pubsub node is created with the component, it MUST be listed
+      in disco item results for the node &quot;http://jabber.org/protocol/avatar&quot;.
+      The node SHOULD also be published via disco to the avatar owner's server
+      so that it is available even when the owner is offline.
+    </p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sect-id2602062">&lt;avatar&gt; Element Description</a>
+</h3>
+    <p class="" style="">
+      The &lt;avatar&gt; element is the root and only element in the
+      http://jabber.org/protocol/avatar namespace.  It has three forms,
+      first is:
+    </p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+      &lt;avatar xmlns='http://jabber.org/protocol/avatar'/&gt;
+    </pre></div>
+    <p class="" style="">
+      This is only used when disabling an avatar.  The second format is more
+      common:
+    </p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+      &lt;avatar
+        xmlns='http://jabber.org/protocol/avatar'
+        jid='pubsub.shakespeare.lit'
+        node='avatar/data/juliet@capulet.com'
+        id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f' /&gt;
+    </pre></div>
+    <p class="" style="">
+      This is the format used to publish an information update.  The attributes
+      of the node are:
+      <ul>
+        <li>
+          <span style="font-style: italic">jid</span> - jid of the pubsub component that the data node is 
+          present on.
+        </li>
+        <li>
+          <span style="font-style: italic">node</span> - the pubsub node that image data may be retrieved 
+          from.
+        </li>
+        <li>
+          <span style="font-style: italic">id</span> - a SHA1 sum of the image data.  It is also the value 
+          that should be used as the id of the pubsub item retrieved from the 
+          data node.
+        </li>
+        <li>
+          <span style="font-style: italic">mime-type</span> - the IANA registered MIME type of the image data.
+        </li>
+      </ul>
+      All four of these attributes MUST be present when publising an information
+      update, and there MUST NOT be CDATA.
+    </p>
+    <p class="" style="">
+      The final format of the avatar data-node is the carrier of the data:
+    </p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+      &lt;avatar 
+        xmlns='http://jabber.org/protocol/avatar'
+        mime-type='image/png'&gt;
+        BASE 64 DATA
+      &lt;/avatar&gt;
+    </pre></div>
+    <p class="" style="">
+      This is the main carrier of the image data.  The mime-type MUST be one of
+      the following MIME types as registered with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602305">3</a>]:
+      <ul>
+        <li>
+<span style="font-style: italic">image/png</span> - for the PNG image format  [<a href="#nt-id2602213">4</a>].</li>
+        <li>
+<span style="font-style: italic">video/x-mng</span> - for the MNG image format  [<a href="#nt-id2602229">5</a>].</li>
+      </ul>
+      image/png support is REQUIRED, image/jpeg and image/gif SHOULD be 
+      implemented, all other formats are OPTIONAL.
+    </p>
+    <p class="" style="">
+      Other formats MAY be used, but interoperability is unsure at that point.
+    </p>
+    <p class="" style="">
+      The CDATA of the &lt;avatar&gt; MUST be the Base64 encoded image
+      data.  If the CDATA for the image data is present, the 'mime-type'
+      attribute MUST be included.
+    </p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="sect-id2602273">Image Requirements</a>
+</h3>
+    <p class="" style="">
+      Certain restrictions are placed upon the image. First, the image height
+      and width MUST be between thirty-two (32) and sixty-four (64) pixels. The
+      suggested size is sixty-four (64) pixels high and sixty-four (64) pixels
+      wide. Images SHOULD be square, but this is not
+      required. Images SHOULD be in PNG or MNG format, although it is
+      more formats will be allowed in the future.  Finally, images MUST use less than eight (8) kilobytes of data.
+    </p>
+  </div>
+<h2>4.
+       <a name="sect-id2602341">Implementation Notes</a>
+</h2>
+  <ul>
+    <li>
+      Implementations that use formats other than image/png SHOULD warn users
+      before publishing that not everyone may be able to view their selected
+      image.
+    </li>
+    <li>
+      Image displays SHOULD NOT scale up an image when displaying it.
+    </li>
+  </ul>
+<h2>5.
+       <a name="sect-id2602367">Security Considerations</a>
+</h2>
+  <p class="" style="">
+    There are no security features or concerns related to this proposal.
+  </p>
+<h2>6.
+       <a name="sect-id2602388">IANA Considerations</a>
+</h2>
+  <p class="" style="">
+    This JEP makes use of IANA-registered MIME types.  No further interaction is
+    required with the IANA.
+  </p>
+<h2>7.
+       <a name="sect-id2602408">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The Jabber Registrar shall register the 'http://jabber.org/protocol/avatar' namespace.</p>
+<h2>8.
+       <a name="sect-id2602429">Formal Definition</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="sect-id2602438">Schema</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+      
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/avatar'
+    xmlns='http://jabber.org/protocol/avatar'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='avatar'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base=&quot;xs:string&quot;&gt;
+        &lt;xs:attribute name='mime-type' type='xs:string' use='optional'/&gt;
+        &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+        &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+        &lt;xs:attribute name='id' type='xs:string' use='optional'/&gt;
+      &lt;/xs:extension&gt;
+     &lt;/xsd:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+      
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596164">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596141">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602305">3</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602213">4</a>. <a href="http://www.libpng.org/pub/png/spec/">PNG
+                  Specification</a>
+</p>
+<p>
+<a name="nt-id2602229">5</a>. <a href="http://www.libmng.com/pub/mng/spec/">MNG
+              Specification</a>
+</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2003-05-20)</h4>
+<div class="indent">
+      Lessen the image requirements.  Include the mime-type in info.
+     (tjm)
+    </div>
+<h4>Version 0.3 (2003-05-08)</h4>
+<div class="indent">
+      Drastic change to use two nodes on pubsub, allowing for hash updates
+      independently of the data.  This makes client caching much easier.  Allow
+      only PNG and MNG currently.
+     (tjm)
+    </div>
+<h4>Version 0.2 (2003-05-07)</h4>
+<div class="indent">
+      Clarified the use of &quot;current&quot; as the item id.  Fixed some example errors.
+      Made the interaction with disco more clear.  The reason to use pubsub is
+      made more clear as well.
+     (tjm)
+    </div>
+<h4>Version 0.1 (2003-05-07)</h4>
+<div class="indent">Initial release (tjm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0084-0.5.html
+++ b/content/xep-0084-0.5.html
@@ -1,0 +1,663 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0084: User Avatar</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Avatar">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Creator" content="Julian Missig">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for exchanging user avatars in Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0084">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0084: User Avatar</h1>
+<p>This JEP defines a protocol for exchanging user avatars in Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0084<br>
+            Version: 0.5<br>
+            Last Updated: 2005-03-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0060<br>Supersedes: JEP-0008<br>
+                Superseded By: None<br>
+            Short Name: avatar<br></p>
+<h2>Author Information</h2>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h3>Peter Millard</h3>
+<p class="indent">
+        Email: pgmillard@jabber.org<br>
+        JID: pgmillard@jabber.org</p>
+<h3>Julian Missig</h3>
+<p class="indent">
+        Email: julian@jabber.org<br>
+        JID: julian@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#publisher">Publisher User Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#metadatanode-create">Creating a Metadata Node</a>
+</dt>
+<dt>3.2.  <a href="#datanode-create">Creating a Data Node</a>
+</dt>
+<dt>3.3.  <a href="#datanode-publish">Publishing Data to the Data Node</a>
+</dt>
+<dt>3.4.  <a href="#update">Updating Avatar Metadata</a>
+</dt>
+<dt>3.5.  <a href="#disable">Disabling Avatars</a>
+</dt>
+</dl>
+<dt>4.  <a href="#consumer">Consumer User Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#consumer-discover">Discovering Avatar Availability</a>
+</dt>
+<dt>4.2.  <a href="#subscribe">Subscribing to Avatar Metadata Node</a>
+</dt>
+<dt>4.3.  <a href="#consumer-pubsub">Retrieving Avatar Data via Pubsub</a>
+</dt>
+<dt>4.4.  <a href="#consumer-http">Retrieving Avatar Data via HTTP</a>
+</dt>
+</dl>
+<dt>5.  <a href="#desc">Formal Description of &lt;avatar/&gt; Element</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#desc-disabley">Empty Element Possessing No Attributes</a>
+</dt>
+<dt>5.2.  <a href="#desc-metadata">Empty Element Possessing Attributes</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#desc-metadata-pubsub">Metadata About a Pubsub Data Node</a>
+</dt>
+<dt>5.2.2.  <a href="#desc-metadata-http">Metadata About an HTTP URL</a>
+</dt>
+</dl>
+<dt>5.3.  <a href="#desc-data">Element Containing Character Data</a>
+</dt>
+</dl>
+<dt>6.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl><dt>6.1.  <a href="#bizrules-images">Image Requirements</a>
+</dt></dl>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many communication applications now allow for the association of a small image or buddy icon (avatar) with a user of that application. The avatar is not intended to be a defining portrait of the user, but rather a simple expression of the user's appearance, mood, status, and the like. This proposal outlines a way to incorporate avatars into the current Jabber platform by layering this functionality on top of <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2251151">1</a>] (pubsub).</p>
+  <p class="" style="">Pubsub was chosen as the base layer for avatars because of the need to publish a large amount of data to any number of users. Pubsub provides a straightforward mechanism for any user to subscribe to the avatar source and receive notifications from the publisher. The protocol defined herein uses two pubsub nodes: one node for "metadata" about the avatar state (called the "metadata node") and one for the avatar data itself (called the "data node"). This separation of metadata from data conserves bandwidth and enables both the publisher and the subscriber to cache the avatar data. (For example, a user might toggle between two or three avatars, in which case the user's contacts can display a locally cached version of the images without having to retrieve the full image each time.)</p>
+  <p class="" style="">Finally, this JEP also allows storage of avatar data at an HTTP URL (see <span class="ref" style="">RFC 2068</span>  [<a href="#nt-id2251239">2</a>]). This can be helpful as a fallback mechanism if a pubsub-aware data repository is not available. It also makes it possible for avatar images to be hosted on public websites (e.g., an end-user-oriented community site) and retrieved from that site rather than handled directly by the publishing client in any fashion.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following use cases for avatar publishers:</p>
+  <ol start="" type="">
+    <li>Publishing avatar data</li>
+    <li>Updating metadata about the current avatar</li>
+    <li>Disabling avatars</li>
+  </ol>
+  <p class="" style="">This JEP addresses the following use cases for avatar consumers:</p>
+  <ol start="" type="">
+    <li>Discovering avatar availability</li>
+    <li>Receiving notification of avatar metadata updates</li>
+    <li>Retrieving avatar data via pubsub</li>
+    <li>Retrieving avatar data via HTTP</li>
+  </ol>
+<h2>3.
+       <a name="publisher">Publisher User Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="metadatanode-create">Creating a Metadata Node</a>
+</h3>
+    <p class="" style="">In order to publish notifications related to its avatar, the avatar publisher MUST first create a node for its avatar metadata:</p>
+    <p class="caption">Example 1. Pubsub metadata node creation request</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='avatar/info/juliet@capulet.com'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">The avatar publisher SHOULD also publish information about its metadata node to its XMPP server via the "disco publish" protocol specified in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250466">3</a>], so that consumers of its avatar data can discover the metadata node even when the publisher is offline.</p>
+    <p class="caption">Example 3. Publishing disco items</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    id='dset1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/avatar'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='avatar/info/juliet@capulet.com'
+          action='update'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="datanode-create">Creating a Data Node</a>
+</h3>
+    <p class="" style="">There are two allowable sources from which consumers retrieve avatar data:</p>
+    <ol start="" type="">
+      <li>A data node on a pubsub service (which need not be the same service used for the metadata node)</li>
+      <li>An HTTP URL</li>
+    </ol>
+    <p class="" style="">If a data node is used, obviously the publisher MUST create a data node in addition to the already-created metadata node:</p>
+    <p class="caption">Example 4. Pubsub data node creation request</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='create2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='avatar/data/juliet@capulet.com'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    id='create2'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="datanode-publish">Publishing Data to the Data Node</a>
+</h3>
+    <p class="" style="">Before updating the avatar metadata node, the publisher MUST make sure that the avatar data is available at the data node or at an HTTP URL. When publishing the avatar data to the data node, the publisher MUST ensure that the value of the item 'id' attribute is the SHA1 (<span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2255051">4</a>]) hash of the image data (this can be used by the consumer to determine if a cached copy is still valid).</p>
+    <p class="caption">Example 6. Publishing avatar data to data node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/data/juliet@capulet.com'&gt;
+      &lt;item id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'
+                type='image/png'&gt;
+          qANQR1DBwU4DX7jmYZnncm...
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 7. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='pubsub.shakespeare.lit' 
+    to='juliet@capulet.com/chamber' 
+    id='publish1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="update">Updating Avatar Metadata</a>
+</h3>
+    <p class="" style="">Whenever the publisher wishes to change its current avatar, it MUST update the metadata node, ensuring that the value of the avatar 'id' attribute is the SHA1 hash of the image data.</p>
+    <p class="" style="">The following example shows metadata that specifies a pubsub data node:</p>
+    <p class="caption">Example 8. Publishing avatar metadata (pubsub data node)</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='publish2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                type='image/png'
+                id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f'/&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subscribers to the avatar would then receive an update from the metadata node:</p>
+    <p class="caption">Example 9. Subscribers receive avatar metadata</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='pubsub.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                type='image/png'
+                id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f'/&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the metadata can specify an HTTP URL:</p>
+    <p class="caption">Example 10. Publishing avatar metadata (pubsub data node)</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='publish2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'
+                url='http://www.jabbercentral.org/avatars/happy.png'
+                id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f'/&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subscribers to the avatar would then receive an update from the metadata node:</p>
+    <p class="caption">Example 11. Subscribers receive avatar metadata</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='pubsub.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'
+                url='http://www.jabbercentral.org/avatars/happy.png'
+                id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f'/&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="disable">Disabling Avatars</a>
+</h3>
+    <p class="" style="">In order to temporarily disable any avatar images, the publishing entity MUST send an empty &lt;avatar/&gt; element to the metadata node:</p>
+    <p class="caption">Example 12. Temporarily disabling an avatar</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit' 
+    id='publish3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'/&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="consumer">Consumer User Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="consumer-discover">Discovering Avatar Availability</a>
+</h3>
+    <p class="" style="">Other clients can see if avatar support is available by sending a <span style="font-weight: bold">Service Discovery</span> items request to the other client and looking for the avatar item. The request MUST be sent to the bare JID (&lt;user@host&gt;) of the other user, further specified by a disco node of "http://jabber.org/protocol/avatar". (Sending the request to the bare JID enables one to discover whether an offline user has published disco information regarding avatars.)</p>
+    <p class="caption">Example 13. Disco items request</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/avatar'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The result contains an item with the JID of the pubsub service where the publisher's avatar metadata (but not the avatar data itself) is published, along with the specific node for that metadata:</p>
+    <p class="caption">Example 14. Disco items result</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/avatar'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='avatar/info/juliet@capulet.com'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The consumer application SHOULD then send a disco#info request to the node in order to determine its identity.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="subscribe">Subscribing to Avatar Metadata Node</a>
+</h3>
+    <p class="" style="">In order to receive notifications of changes to the publisher's avatar, a consumer MUST subscribe to the metadata node maintained by the publisher.</p>
+    <p class="caption">Example 15. Consumer subscribes to metadata node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='pubsub.shakespeare.lit'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe 
+        node='avatar/info/juliet@capulet.com'
+        jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;entity node='avatar/info/juliet@capulet.com'
+            jid='romeo@montague.net'
+            affiliation='none'
+            subscription='subscribed'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The consumer will now receive notifications published to the metadata node by the avatar publisher.</p>
+    <p class="" style="">Alternatively, the consumer MAY retrieve the current avatar metadata from the pubsub service:</p>
+    <p class="caption">Example 17. Retrieving the avatar metadata</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='pubsub.shakespeare.lit'
+    id='ps-items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com' 
+           max_items='1'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 18. Avatar metadata result</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='romeo@montague.net/orchard''
+    id='ps-items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                type='image/png'
+                id='a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'/&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="consumer-pubsub">Retrieving Avatar Data via Pubsub</a>
+</h3>
+    <p class="" style="">If the &lt;avatar/&gt; element sent to the metadata node possesses a 'jid' attribute (optionally supplemented by a 'node' attribute), the avatar data is hosted at a pubsub service. Therefore, in order to retrieve the avatar image data, the requesting entity MUST send a request to the specified JID or JID+node, including an 'id' attribute that matches the value provided in the metadata result.</p>
+    <p class="caption">Example 19. Data retrieval request</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='pubsub.shakespeare.lit' 
+    id='ps-items2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='avatar/data/juliet@capulet.com'&gt;
+      &lt;item id='a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'/&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The result contains the avatar image data:</p>
+    <p class="caption">Example 20. Data retrieval result</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='pubsub.shakespeare.lit' id='ps-items2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='avatar/data/juliet@capulet.com'&gt;
+      &lt;item id='a94a8fe5ccb19ba61c4c0873d391e987982fbbd3'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'
+                type='image/png'&gt;
+          qANQR1DBwU4DX7jmYZnncm...
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="consumer-http">Retrieving Avatar Data via HTTP</a>
+</h3>
+    <p class="" style="">If the &lt;avatar/&gt; element sent to the metadata node possesses a 'url' attribute, the avatar data is hosted at an HTTP URL. Therefore, in order to retrieve the avatar image data, the requesting entity MUST send an HTTP request to the specified URL.</p>
+  </div>
+<h2>5.
+       <a name="desc">Formal Description of &lt;avatar/&gt; Element</a>
+</h2>
+  <p class="" style="">The &lt;avatar&gt; element is the root and only element qualified by the 'http://jabber.org/protocol/avatar' namespace. It has three forms, as described below.</p>
+  <div class="indent">
+<h3>5.1 <a name="desc-disabley">Empty Element Possessing No Attributes</a>
+</h3>
+    <p class="" style="">When the &lt;avatar/&gt; element is empty but possesses no attributes, avatar publishing has been disabled:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;avatar xmlns='http://jabber.org/protocol/avatar'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="desc-metadata">Empty Element Possessing Attributes</a>
+</h3>
+    <p class="" style="">When the &lt;avatar/&gt; element is empty and possesses attributes, the element specifies metadata about an avatar image. There are two cases:</p>
+    <ol start="" type="">
+      <li>The metadata specifies information about a pubsub data node at which the avatar data can be retrieved.</li>
+      <li>The metadata specifies information about an HTTP URL at which the avatar data can be retrieved.</li>
+    </ol>
+    <p class="" style="">In both cases, the element MUST possess an 'id' attribute whose value is the SHA1 sum of the image data (note: this is also the value that MUST be used as the ItemID of the pubsub item). In addition, the element MUST NOT contain character data.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="desc-metadata-pubsub">Metadata About a Pubsub Data Node</a>
+</h3>
+      <p class="" style="">When the metadata specifies a pubsub data node, the element MUST possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-style: italic">id</span> -- The SHA1 sum of the image data.</li>
+        <li>
+<span style="font-style: italic">jid</span> -- The JID of the pubsub data node or of the pubsub service hosting the data node.</li>
+        <li>
+<span style="font-style: italic">type</span> -- The IANA-registered MIME type of the image data.</li>
+      </ul>
+      <p class="" style="">In addition, the element MAY possess the following attribute:</p>
+      <ul>
+        <li>
+<span style="font-style: italic">node</span> -- The NodeID of the pubsub data node (MUST be included if the 'jid' attribute specified a pubsub service rather than a pubsub node).</li>
+      </ul>
+      <p class="" style="">Here is an example:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;avatar xmlns='http://jabber.org/protocol/avatar'
+        jid='pubsub.shakespeare.lit'
+        node='avatar/data/juliet@capulet.com'
+	type='image/png'
+        id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f'/&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="desc-metadata-http">Metadata About an HTTP URL</a>
+</h3>
+      <p class="" style="">When the metadata specifies an HTTP URL, the element MUST possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-style: italic">id</span> -- The SHA1 sum of the image data.</li>
+        <li>
+<span style="font-style: italic">url</span> -- An HTTP URL at which the image may be found.</li>
+      </ul>
+      <p class="" style="">Here is an example:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;avatar xmlns='http://jabber.org/protocol/avatar'
+        url='http://www.jabbercentral.org/avatars/happy.png'
+        id='109f4b3c50d7b0df729d299bc6f8e9ef9066971f'/&gt;
+      </pre></div>
+      <p class="" style="">Note: Naturally, the 'type' attribute is unnecessary in metadata about HTTP URLs, since it can be determined via HTTP.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="desc-data">Element Containing Character Data</a>
+</h3>
+    <p class="" style="">The final format of the avatar data node is the carrier of the data:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;avatar xmlns='http://jabber.org/protocol/avatar'
+        type='image/png'&gt;
+    BASE 64 DATA
+&lt;/avatar&gt;
+    </pre></div>
+    <p class="" style="">This is the main carrier of the image data. The type SHOULD be one of the following MIME types registered with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255891">5</a>]:</p>
+    <ul>
+      <li><span style="font-style: italic">image/png</span></li>
+      <li><span style="font-style: italic">image/jpeg</span></li> 
+      <li><span style="font-style: italic">image/gif</span></li>
+    </ul>
+    <p class="" style="">Support for image/png is REQUIRED, support for image/jpeg and image/gif are RECOMMENDED, and all other formats are OPTIONAL.</p>
+    <p class="" style="">Other formats MAY be used, but interoperability may be compromised at that point.</p>
+    <p class="" style="">The character data of the &lt;avatar/&gt; MUST be image data encoded as Base64 as specified in Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2255968">6</a>]. If the character data for the image data is present, the 'type' attribute MUST be included.</p>
+  </div>
+<h2>6.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="bizrules-images">Image Requirements</a>
+</h3>
+    <p class="" style="">Certain restrictions are placed upon the image. First, the image height and width MUST be between thirty-two (32) and sixty-four (64) pixels. The suggested size is sixty-four (64) pixels high and sixty-four (64) pixels wide. Images SHOULD be square, but this is not required. Finally, images MUST use less than eight (8) kilobytes of data.</p>
+  </div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <ul>
+    <li>Implementations that use formats other than image/png SHOULD warn users before publishing that not all recipients may be able to view their selected image.</li>
+    <li>Image displays SHOULD NOT scale up an image when displaying it.</li>
+  </ul>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP makes use of IANA-registered MIME types, but requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256064">7</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256113">8</a>] shall include 'http://jabber.org/protocol/avatar' in its registry of protocol namespaces.</p>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/avatar'
+    xmlns='http://jabber.org/protocol/avatar'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='avatar'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='id' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='type' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='url' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251151">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251239">2</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+<p><a name="nt-id2250466">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255051">4</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2255891">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255968">6</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256064">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256113">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2005-03-28)</h4>
+<div class="indent">Friendly fork per Council discussion: allowed data to be stored in a pubsub data repository or at an HTTP URL; also split text into publisher and consumer use cases, specified requirements, added more examples, etc. (psa/pgm)
+    </div>
+<h4>Version 0.4 (2003-05-20)</h4>
+<div class="indent">Lessen the image requirements. Include the MIME type in info. (tjm)
+    </div>
+<h4>Version 0.3 (2003-05-08)</h4>
+<div class="indent">Drastic change to use two nodes on pubsub, allowing for hash updates independently of the data. This makes client caching much easier. Allow only PNG and MNG currently. (tjm)
+    </div>
+<h4>Version 0.2 (2003-05-07)</h4>
+<div class="indent">Clarified the use of "current" as the item id. Fixed some example errors. Made the interaction with disco more clear. The reason to use pubsub is made more clear as well. (tjm)
+    </div>
+<h4>Version 0.1 (2003-05-07)</h4>
+<div class="indent">Initial version. (tjm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0084-0.6.html
+++ b/content/xep-0084-0.6.html
@@ -1,0 +1,880 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0084: User Avatar</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Avatar">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Creator" content="Julian Missig">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension for exchanging user avatars.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-13">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0084">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0084: User Avatar</h1>
+<p>This JEP defines an XMPP protocol extension for exchanging user avatars.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0084<br>
+            Version: 0.6<br>
+            Last Updated: 2005-04-13<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0060<br>Supersedes: JEP-0008<br>
+                Superseded By: None<br>
+            Short Name: avatar<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Avatar%20(JEP-0084)">http://wiki.jabber.org/index.php/User Avatar (JEP-0084)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Peter Millard</h3>
+<p class="indent">
+        Email: pgmillard@jabber.org<br>
+        JID: pgmillard@jabber.org</p>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h3>Julian Missig</h3>
+<p class="indent">
+        Email: julian@jabber.org<br>
+        JID: julian@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#proto">Protocol</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#proto-data">Data Element</a>
+</dt>
+<dt>3.2.  <a href="#proto-info">Info Element</a>
+</dt>
+<dt>3.3.  <a href="#proto-pointer">Pointer Element</a>
+</dt>
+<dt>3.4.  <a href="#proto-stop">Stop Element</a>
+</dt>
+</dl>
+<dt>4.  <a href="#publisher">Publisher User Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#metadatanode-create">Creating a Metadata Node</a>
+</dt>
+<dt>4.2.  <a href="#datanode-create">Creating a Data Node</a>
+</dt>
+<dt>4.3.  <a href="#datanode-publish">Publishing Data to the Data Node</a>
+</dt>
+<dt>4.4.  <a href="#update">Updating Avatar Metadata</a>
+</dt>
+<dt>4.5.  <a href="#disable">Disabling Avatars</a>
+</dt>
+</dl>
+<dt>5.  <a href="#subscriber">Subscriber User Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#subscriber-discover">Discovering Avatar Availability</a>
+</dt>
+<dt>5.2.  <a href="#subscribe">Subscribing to Avatar Metadata Node</a>
+</dt>
+<dt>5.3.  <a href="#subscriber-pubsub">Retrieving Avatar Data via Pubsub</a>
+</dt>
+<dt>5.4.  <a href="#subscriber-http">Retrieving Avatar Data via HTTP</a>
+</dt>
+</dl>
+<dt>6.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl><dt>6.1.  <a href="#bizrules-images">Image Requirements</a>
+</dt></dl>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many communication applications allow for the association of a small image or icon with a user of that application. Usually, such an "avatar" is not intended to be an accurate picture of the user's actual physical appearance, but rather a representation (often fanciful) of the user's desired self-image or a transient state of the user (such as a mood or activity). This proposal outlines a way to incorporate avatars into current Jabber/XMPP systems by layering this functionality on top of <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250570">1</a>] (pubsub).</p>
+  <p class="" style="">Pubsub was chosen as the base layer for avatars because of the need to publish a large amount of data to any number of users. Pubsub provides a straightforward mechanism for any user to subscribe to the avatar source and receive notifications from the publisher. The protocol defined herein uses two pubsub nodes: one node for "metadata" about the avatar state (called the "metadata node") and one for the avatar data itself (called the "data node"). This separation of metadata from data conserves bandwidth and enables both the publisher and the subscriber to cache the avatar data. (For example, a user might toggle between two or three avatars, in which case the user's contacts can display a locally cached version of the images without having to retrieve the full image each time.)</p>
+  <p class="" style="">This JEP also allows storage of avatar data at a URL accessible via HTTP (see <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250729">2</a>]). This can be helpful as a fallback mechanism if a pubsub-aware data repository is not available. It also makes it possible for avatar images to be hosted on public websites (e.g., an end-user-oriented community site) and retrieved from that site rather than handled directly by the publishing client in any fashion.</p>
+  <p class="" style="">This JEP also enables XMPP applications to optionally integrate with third-party services that host user avatars (e.g., online gaming systems and virtual worlds).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following use cases for avatar publishers:</p>
+  <ol start="" type="">
+    <li>Publishing avatar data</li>
+    <li>Updating metadata about the current avatar</li>
+    <li>Disabling avatars</li>
+  </ol>
+  <p class="" style="">This JEP addresses the following use cases for avatar subscribers:</p>
+  <ol start="" type="">
+    <li>Discovering avatar availability</li>
+    <li>Receiving notification of avatar changes</li>
+    <li>Retrieving avatar data via pubsub</li>
+    <li>Retrieving avatar data via HTTP  [<a href="#nt-id2250621">3</a>]</li>
+  </ol>
+<h2>3.
+       <a name="proto">Protocol</a>
+</h2>
+  <p class="" style="">The root or "wrapper" element for all avatar-related communications is the &lt;avatar/&gt; element qualified by the 'http://jabber.org/protocol/avatar' namespace. There are four allowable child elements of the &lt;avatar/&gt; root element, as described below.</p>
+  <div class="indent">
+<h3>3.1 <a name="proto-data">Data Element</a>
+</h3>
+    <p class="" style="">The &lt;data/&gt; child element is used to communicate avatar data:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;data id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+      type='image/png'
+      bytes='12345'
+      height='64'
+      width='64'&gt;
+  IMAGE DATA
+&lt;/data&gt;
+    </pre></div>
+    <p class="" style="">The &lt;data/&gt; element MUST possess the following attributes:</p>
+    <ul>
+      <li>
+<span style="font-style: italic">bytes</span> -- The size of the image data in bytes.</li>
+      <li>
+<span style="font-style: italic">height</span> -- The height of the image in pixels.</li>
+      <li>
+<span style="font-style: italic">id</span> -- The SHA1 hash of the image data.</li>
+      <li>
+<span style="font-style: italic">type</span> -- The IANA-registered content type of the image data.</li>
+      <li>
+<span style="font-style: italic">width</span> -- The width of the image in pixels.</li>
+    </ul>
+    <p class="" style="">The value of the 'type' attribute MAY be any IANA-registered content type of type "image" or "video".  [<a href="#nt-id2256231">4</a>] Support for the "image/png" content type is REQUIRED. Support for the "image/gif" and "image/jpeg" content types is RECOMMENDED. Support for any other content type is OPTIONAL.</p>
+    <p class="" style="">The value of the 'id' attribute MUST be the SHA1 (<span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2256276">5</a>]) hash of the image data, and the same value MUST be used as the ItemID of the pubsub item for the avatar data (see below).</p>
+    <p class="" style="">The &lt;data/&gt; element MUST contain content that is appropriate for the specified content type:</p>
+    <ul>
+      <li>If the content type specifies a binary image format, the content MUST be XML character data that represents the avatar data, Base64-encoded in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256323">6</a>].</li>
+      <li>If the content type specifies a structured data format (e.g., "image/svg+xml"), the content MUST be a properly-namespaced child element of the &lt;data/&gt; element.</li>
+    </ul>
+    <p class="" style="">Support for the &lt;data/&gt; element is REQUIRED.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="proto-info">Info Element</a>
+</h3>
+    <p class="" style="">The &lt;info/&gt; child element is used to communicate avatar metadata:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+      jid='pubsub.shakespeare.lit'
+      node='avatar/data/juliet@capulet.com'
+      url='http://www.jabbercentral.org/avatars/happy.png'
+      type='image/png'
+      bytes='12345'
+      height='64'
+      width='64'/&gt;
+    </pre></div>
+    <p class="" style="">The &lt;info/&gt; child element MUST be empty.</p>
+    <p class="" style="">The &lt;info/&gt; child element MUST possess the following attributes:</p>
+    <ul>
+      <li>
+<span style="font-style: italic">bytes</span> -- The size of the image data in bytes.</li>
+      <li>
+<span style="font-style: italic">type</span> -- The IANA-registered content type of the image data.</li>
+      <li>
+<span style="font-style: italic">height</span> -- The height of the image in pixels.</li>
+      <li>
+<span style="font-style: italic">id</span> -- The SHA1 hash of the image data.</li>
+      <li>
+<span style="font-style: italic">width</span> -- The width of the image in pixels.</li>
+    </ul>
+    <p class="" style="">The &lt;info/&gt; element MUST possess at least one of the following attributes, and MAY possess both:</p>
+    <ul>
+      <li>
+<span style="font-style: italic">jid</span> -- The JID of the pubsub data node or of the pubsub service hosting the data node.</li>
+      <li>
+<span style="font-style: italic">url</span> -- An http: or https: URI at which the image data file may be found.</li>
+    </ul>
+    <p class="" style="">In addition, the &lt;info/&gt; element MAY possess the following attribute:</p>
+    <ul>
+      <li>
+<span style="font-style: italic">node</span> -- The NodeID of the pubsub data node at the avatar data is to be retrieved (this supplements the 'jid' attribute and MUST be included if the 'jid' attribute specifies a pubsub service rather than a pubsub node).</li>
+    </ul>
+    <p class="" style="">The &lt;avatar/&gt; root element MAY contain more than one &lt;info/&gt; element. Each element MUST specify metadata for the same avatar but in alternate formats (e.g., "image/png", "image/gif", and "image/jpeg"), and one of the formats MUST be "image/png" in order to help ensure interoperability.</p>
+    <p class="" style="">Support for the &lt;info/&gt; element is REQUIRED.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="proto-pointer">Pointer Element</a>
+</h3>
+    <p class="" style="">The &lt;pointer/&gt; child element is used to point to an avatar that is not published via pubsub or HTTP, but rather is provided by a third-party service such as an online gaming system or virtual world:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+  &lt;pointer&gt;
+    &lt;x xmlns='http://example.com/virtualworlds'&gt;
+      &lt;game&gt;Ancapistan&lt;/game&gt;
+      &lt;character&gt;Kropotkin&lt;/character&gt;
+    &lt;/x&gt;
+  &lt;/pointer&gt;
+&lt;/avatar&gt;
+    </pre></div>
+    <p class="" style="">The &lt;pointer/&gt; element MAY possess the following attributes if the publishing application has the relevant information:</p>
+    <ul>
+      <li>
+<span style="font-style: italic">bytes</span> -- The size of the image data in bytes.</li>
+      <li>
+<span style="font-style: italic">type</span> -- The IANA-registered content type of the image data.</li>
+      <li>
+<span style="font-style: italic">height</span> -- The height of the image in pixels.</li>
+      <li>
+<span style="font-style: italic">id</span> -- The SHA1 hash of the image data.</li>
+      <li>
+<span style="font-style: italic">width</span> -- The width of the image in pixels.</li>
+    </ul>
+    <p class="" style="">The content of the &lt;pointer/&gt; element MUST be a properly-namespaced child element that specifies information about how to retrieve the avatar from the third-party service. The structure for any such child element is out of scope for this JEP.</p>
+    <p class="" style="">Even if the &lt;pointer&gt; element is included, it MUST be preceded by at least one instance of the &lt;info/&gt; element so that implementations that do not support the &lt;pointer/&gt; element can display a "fallback" format of the avatar (at a minimum, "image/png").</p>
+    <p class="" style="">Support for the &lt;pointer/&gt; element is OPTIONAL.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="proto-stop">Stop Element</a>
+</h3>
+    <p class="" style="">The &lt;stop/&gt; child element is used to signal that avatar publishing has been disabled:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+  &lt;stop/&gt;
+&lt;/avatar&gt;
+    </pre></div>
+    <p class="" style="">The &lt;stop/&gt; element MUST be empty and MUST NOT possess any attributes.</p>
+    <p class="" style="">Support for the &lt;stop/&gt; element is REQUIRED.</p>
+  </div>
+<h2>4.
+       <a name="publisher">Publisher User Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="metadatanode-create">Creating a Metadata Node</a>
+</h3>
+    <p class="" style="">In order to publish notifications related to its avatar, the avatar publisher MUST first create a node for its avatar metadata:</p>
+    <p class="caption">Example 1. Pubsub metadata node creation request</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='avatar/info/juliet@capulet.com'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">The avatar publisher SHOULD also publish information about its metadata node to its XMPP server via the "disco publish" protocol specified in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256737">7</a>], so that subscribers to its avatar data can discover the metadata node even when the publisher is offline.</p>
+    <p class="caption">Example 3. Publishing disco items</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    id='dset1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/avatar'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='avatar/info/juliet@capulet.com'
+          action='update'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="datanode-create">Creating a Data Node</a>
+</h3>
+    <p class="" style="">There are two allowable sources from which subscribers retrieve avatar data:</p>
+    <ol start="" type="">
+      <li>A data node on a pubsub service (which need not be the same service used for the metadata node)</li>
+      <li>A data file accessible via HTTP</li>
+    </ol>
+    <p class="" style="">If a data node is used, obviously the publisher needs to create a data node in addition to the already-created metadata node:</p>
+    <p class="caption">Example 4. Pubsub data node creation request</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='create2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='avatar/data/juliet@capulet.com'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    id='create2'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="datanode-publish">Publishing Data to the Data Node</a>
+</h3>
+    <p class="" style="">Before updating the avatar metadata node, the publisher MUST make sure that the avatar data is available at the data node or URL. When publishing the avatar data to the data node, the publisher MUST ensure that the value of the item 'id' attribute is the SHA1 hash of the image data (this can be used by the subscriber to determine if a cached copy is still valid).</p>
+    <p class="" style="">The following example illustrates the XML structure to be sent when publishing avatar data to the data node.</p>
+    <p class="caption">Example 6. Publishing avatar data to data node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/data/juliet@capulet.com'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;data id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'&gt;
+            qANQR1DBwU4DX7jmYZnncm...
+          &lt;/data&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 7. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    from='pubsub.shakespeare.lit' 
+    to='juliet@capulet.com/chamber' 
+    id='publish1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="update">Updating Avatar Metadata</a>
+</h3>
+    <p class="" style="">Whenever the publisher wishes to change its current avatar, it MUST update the metadata node.</p>
+    <p class="" style="">The following example shows metadata specifying avatar data that is available in only one format ("image/png") and accessible only at a pubsub data node:</p>
+    <p class="caption">Example 8. Publishing avatar metadata (pubsub data node)</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='publish2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subscribers to the avatar would then receive an update from the metadata node:</p>
+    <p class="caption">Example 9. Subscribers receive avatar metadata</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='pubsub.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The following example shows metadata specifying avatar data that is available in only one format ("image/gif") and accessible only at an HTTP URL:</p>
+    <p class="caption">Example 10. Publishing avatar metadata (HTTP URL)</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='publish2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;info id='222f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                url='http://www.jabbercentral.org/avatars/happy.gif'
+                type='image/gif'
+                bytes='23456'
+                height='64'
+                width='64'/&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subscribers to the avatar would then receive an update from the metadata node:</p>
+    <p class="caption">Example 11. Subscribers receive avatar metadata</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='pubsub.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;info id='222f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                url='http://www.jabbercentral.org/avatars/happy.gif'
+                type='image/gif'
+                bytes='23456'
+                height='64'
+                width='64'/&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The following example shows metadata specifying avatar data that is available in multiple formats, each of which is accessible at both an HTTP URL and a pubsub data node:</p>
+    <p class="caption">Example 12. Publishing avatar metadata (multiple formats)</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit'
+    id='publish3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                url='http://www.jabbercentral.org/avatars/happy.png'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+          &lt;info id='222f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                url='http://www.jabbercentral.org/avatars/happy.gif'
+                type='image/gif'
+                bytes='23456'
+                height='64'
+                width='64'/&gt;
+          &lt;info id='333f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                url='http://www.jabbercentral.org/avatars/happy.mng'
+                type='image/mng'
+                bytes='78912'
+                height='64'
+                width='64'/&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subscribers to the avatar would then receive an update from the metadata node:</p>
+    <p class="caption">Example 13. Subscribers receive avatar metadata</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='pubsub.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                url='http://www.jabbercentral.org/avatars/happy.png'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+          &lt;info id='222f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                url='http://www.jabbercentral.org/avatars/happy.gif'
+                type='image/gif'
+                bytes='23456'
+                height='64'
+                width='64'/&gt;
+          &lt;info id='333f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                url='http://www.jabbercentral.org/avatars/happy.mng'
+                type='image/mng'
+                bytes='78912'
+                height='64'
+                width='64'/&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="disable">Disabling Avatars</a>
+</h3>
+    <p class="" style="">In order to temporarily disable any avatar images, the publishing entity publishes an empty &lt;stop/&gt; element to the metadata node:</p>
+    <p class="caption">Example 14. Temporarily disabling an avatar</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='juliet@capulet.com/chamber'
+    to='pubsub.shakespeare.lit' 
+    id='publish3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item id='current'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;stop/&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="subscriber">Subscriber User Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="subscriber-discover">Discovering Avatar Availability</a>
+</h3>
+    <p class="" style="">Other clients can see if avatar support is available by sending a <span style="font-weight: bold">Service Discovery</span> items request to the other client and looking for the avatar item. The request SHOULD be sent to the bare JID (&lt;user@host&gt;) of the other user (but may be sent to a full JID), further specified by a disco node of "http://jabber.org/protocol/avatar". (Sending the request to the bare JID enables one to discover whether an offline user has published disco information regarding avatars.)</p>
+    <p class="caption">Example 15. Disco items request</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/avatar'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The result contains an item with the JID of the pubsub service where the publisher's avatar metadata (but not the avatar data itself) is published, along with the specific node for that metadata:</p>
+    <p class="caption">Example 16. Disco items result</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/avatar'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          node='avatar/info/juliet@capulet.com'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The subscriber application SHOULD then send a disco#info request to the node in order to determine its identity.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="subscribe">Subscribing to Avatar Metadata Node</a>
+</h3>
+    <p class="" style="">In order to receive notifications of changes to the publisher's avatar, a subscriber MUST subscribe to the metadata node maintained by the publisher.</p>
+    <p class="caption">Example 17. Consumer subscribes to metadata node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='pubsub.shakespeare.lit'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe 
+        node='avatar/info/juliet@capulet.com'
+        jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 18. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;entity node='avatar/info/juliet@capulet.com'
+            jid='romeo@montague.net'
+            affiliation='none'
+            subscription='subscribed'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The subscriber will now receive notifications published to the metadata node by the avatar publisher.</p>
+    <p class="" style="">Alternatively, the subscriber MAY retrieve the current avatar metadata from the pubsub service:</p>
+    <p class="caption">Example 19. Retrieving the avatar metadata</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='pubsub.shakespeare.lit'
+    id='ps-items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com' 
+           max_items='1'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Avatar metadata result</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.shakespeare.lit'
+    to='romeo@montague.net/orchard''
+    id='ps-items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                jid='pubsub.shakespeare.lit'
+                node='avatar/data/juliet@capulet.com'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="subscriber-pubsub">Retrieving Avatar Data via Pubsub</a>
+</h3>
+    <p class="" style="">If the &lt;avatar/&gt; element sent to the metadata node possesses a 'jid' attribute (optionally supplemented by a 'node' attribute), the avatar data is hosted at a pubsub service. Therefore, in order to retrieve the avatar image data, the requesting entity can send a request to the specified JID or JID+node, including an 'id' attribute that matches the value provided in the metadata result.</p>
+    <p class="caption">Example 21. Data retrieval request</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='pubsub.shakespeare.lit' 
+    id='ps-items2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='avatar/data/juliet@capulet.com'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'/&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The result contains the avatar image data:</p>
+    <p class="caption">Example 22. Data retrieval result</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='pubsub.shakespeare.lit' id='ps-items2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='avatar/data/juliet@capulet.com'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+          &lt;data id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'&gt;
+            qANQR1DBwU4DX7jmYZnncm...
+          &lt;/data&gt;
+        &lt;/avatar&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="subscriber-http">Retrieving Avatar Data via HTTP</a>
+</h3>
+    <p class="" style="">If the &lt;avatar/&gt; element sent to the metadata node possesses a 'url' attribute, the avatar data is hosted at a URL. Therefore, in order to retrieve the avatar image data, the requesting entity can send an HTTP request to the specified URL.</p>
+  </div>
+<h2>6.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="bizrules-images">Image Requirements</a>
+</h3>
+    <p class="" style="">Certain restrictions are placed upon the image. First, the image height and width SHOULD be between thirty-two (32) and ninety-six (96) pixels. The suggested size is sixty-four (64) pixels high and sixty-four (64) pixels wide. Images SHOULD be square, but this is not required. Finally, images SHOULD use less than eight (8) kilobytes of data.</p>
+  </div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <ul>
+    <li>It is the responsibility of the receiving application to determine which avatar format to retrieve (e.g., "image/gif" rather than "image/png") and to determine the appropriate method for retrieval (e.g., HTTP rather than pubsub).</li>
+    <li>The receiving application SHOULD NOT scale up an image when displaying it.</li>
+    <li>If an avatar is not available for a contact, the receiving MAY display the contact's photo, e.g., as provided in the contact's vCard (see <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257576">8</a>]) or other profile information.</li>
+  </ul>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP makes use of IANA-registered content types, but requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257635">9</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257721">10</a>] shall include 'http://jabber.org/protocol/avatar' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/avatar'
+    xmlns='http://jabber.org/protocol/avatar'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='avatar'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element ref='data'/&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='info' maxOccurs='unbounded'/&gt;
+          &lt;xs:element ref='pointer' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element name='stop' type='empty'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='data'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='bytes' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='type' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='height' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='width' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='info'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='bytes' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='type' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='height' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='url' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='width' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='pointer'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='bytes' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='height' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='width' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250570">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250729">2</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2250621">3</a>. By "accessible via HTTP" is meant that the data is available at an http: or https: URI.</p>
+<p><a name="nt-id2256231">4</a>. The IANA registry of content types is located at &lt;<a href="http://www.iana.org/assignments/media-types/">http://www.iana.org/assignments/media-types/</a>&gt;.</p>
+<p><a name="nt-id2256276">5</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2256323">6</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256737">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257576">8</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257635">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257721">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-04-13)</h4>
+<div class="indent">Major modification per list discussion: specified that metadata may include the same avatar in multiple alternate formats; allowed pointers to third-party avatars not available via pubsub or HTTP; changed pixel size restrictions; specified that bytes, content-type, height, id, and width are required metadata; changed type attribute to content-type; made explicit that URLs can be http: or https: URIs; more fully specified protocol, updated the examples, updated the schemas. (psa)
+    </div>
+<h4>Version 0.5 (2005-03-28)</h4>
+<div class="indent">Friendly fork per Council discussion: allowed data to be stored in a pubsub data repository or at a URL accessible via HTTP; also split text into publisher and subscriber use cases, specified requirements, added more examples, etc. (psa/pgm)
+    </div>
+<h4>Version 0.4 (2003-05-20)</h4>
+<div class="indent">Lessen the image requirements. Include the content type in info. (tjm)
+    </div>
+<h4>Version 0.3 (2003-05-08)</h4>
+<div class="indent">Drastic change to use two nodes on pubsub, allowing for hash updates independently of the data. This makes client caching much easier. Allow only PNG and MNG currently. (tjm)
+    </div>
+<h4>Version 0.2 (2003-05-07)</h4>
+<div class="indent">Clarified the use of "current" as the item id. Fixed some example errors. Made the interaction with disco more clear. The reason to use pubsub is made more clear as well. (tjm)
+    </div>
+<h4>Version 0.1 (2003-05-07)</h4>
+<div class="indent">Initial version. (tjm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0084-0.7.html
+++ b/content/xep-0084-0.7.html
@@ -1,0 +1,740 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0084: User Avatar</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Avatar">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Creator" content="Julian Missig">
+<meta name="DC.Description" content="This document defines an XMPP protocol extension for exchanging user avatars.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-17">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0084">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0084: User Avatar</h1>
+<p>This document defines an XMPP protocol extension for exchanging user avatars.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0084<br>
+            Version: 0.7<br>
+            Last Updated: 2006-01-17<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0060, JEP-0163<br>Supersedes: JEP-0008<br>
+                Superseded By: None<br>
+            Short Name: avatar<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Avatar%20(JEP-0084)">http://wiki.jabber.org/index.php/User Avatar (JEP-0084)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Peter Millard</h3>
+<p class="indent">
+        See <a href="#authornote">Author Note</a><br></p>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:temas@jabber.org">temas@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:temas@jabber.org">temas@jabber.org</a></p>
+<h3>Julian Missig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:julian@jabber.org">julian@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:julian@jabber.org">julian@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#process">Basic Process Flow</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#process-createmeta">User Creates Metadata Node</a>
+</dt>
+<dt>3.2.  <a href="#process-createdata">User Creates Data Node</a>
+</dt>
+<dt>3.3.  <a href="#process-pubdata">User Publishes Data</a>
+</dt>
+<dt>3.4.  <a href="#process-pubmeta">User Publishes Metadata Notification</a>
+</dt>
+<dt>3.5.  <a href="#process-subnotify">Subscribers Receive Metadata Notification</a>
+</dt>
+<dt>3.6.  <a href="#process-subretrieve">Subscribers Retrieve Data</a>
+</dt>
+<dt>3.7.  <a href="#pub-stop">Publisher Disables Avatars</a>
+</dt>
+</dl>
+<dt>4.  <a href="#proto">Protocol Syntax</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#proto-data">Data Element</a>
+</dt>
+<dt>4.2.  <a href="#proto-meta">Metadata Element</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#proto-info">Info Element</a>
+</dt>
+<dt>4.2.2.  <a href="#proto-pointer">Pointer Element</a>
+</dt>
+<dt>4.2.3.  <a href="#proto-stop">Stop Element</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#examples">Additional Examples</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#examples-multiple">Metadata With Multiple Content-Types</a>
+</dt>
+<dt>5.2.  <a href="#examples-pointer">Metadata With Pointer</a>
+</dt>
+</dl>
+<dt>6.  <a href="#disco">Service Discovery</a>
+</dt>
+<dl><dt>6.1.  <a href="#disco-sub">Discovering Avatar Availability</a>
+</dt></dl>
+<dt>7.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl><dt>7.1.  <a href="#bizrules-images">Image Requirements</a>
+</dt></dl>
+<dt>8.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#schema-data">Data Namespace</a>
+</dt>
+<dt>12.2.  <a href="#schema-metadata">Metadata Namespace</a>
+</dt>
+</dl>
+<dt>13.  <a href="#authornote">Author Note</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many communication applications allow for the association of a small image or icon with a user of that application. Usually, such an "avatar" is not intended to be an accurate picture of the user's actual physical appearance, but rather a representation (often fanciful) of the user's desired self-image or a transient state of the user (such as a mood or activity). This document outlines a way to incorporate avatars into current Jabber/XMPP systems by layering this functionality on top of the XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250741">1</a>] extension ("pubsub"), specifically the <span class="ref" style="">Personal Eventing via Pubsub</span>  [<a href="#nt-id2250902">2</a>] subset ("SPPS"), which is designed for use in the context of XMPP instant messaging and presence systems that conform to <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250925">3</a>].</p>
+  <p class="" style="">The protocol defined herein uses two pubsub nodes: one node for "metadata" about the avatar state (called the "metadata node") and one for the avatar data itself (called the "data node"). This separation of metadata from data conserves bandwidth and enables both the publisher and the subscriber to cache the avatar data. (For example, a user might toggle between two or three avatars, in which case the user's contacts can display a locally cached version of the images without having to retrieve the full image each time.)</p>
+  <p class="" style="">This protocol also allows storage of avatar data at a URL accessible via HTTP (see <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250763">4</a>]).  [<a href="#nt-id2250966">5</a>] This can be helpful as a fallback mechanism if a pubsub-aware data repository is not available. It also makes it possible for avatar images to be hosted on public websites (e.g., an end-user-oriented community site) and retrieved from that site rather than handled directly by the publishing client in any fashion.</p>
+  <p class="" style="">Finally, this protocol also enables XMPP applications to optionally integrate with third-party services that host user avatars (e.g., online gaming systems and virtual worlds).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This document addresses the following use cases for avatar publishers:</p>
+  <ol start="" type="">
+    <li>Publishing avatar data</li>
+    <li>Updating metadata about the current avatar</li>
+    <li>Disabling avatars</li>
+  </ol>
+  <p class="" style="">This document addresses the following use cases for avatar subscribers:</p>
+  <ol start="" type="">
+    <li>Discovering avatar availability</li>
+    <li>Receiving notification of avatar changes</li>
+    <li>Retrieving avatar data via pubsub</li>
+    <li>Retrieving avatar data via HTTP</li>
+  </ol>
+<h2>3.
+       <a name="process">Basic Process Flow</a>
+</h2>
+  <p class="" style="">The process for publishing and updating user avatars is as follows:</p>
+  <ol start="" type="">
+    <li>User creates metadata node</li>
+    <li>User creates data node for "image/png" content-type</li>
+    <li>User publishes avatar data for "image/png" content-type to data node and optionally publishes other content-types to HTTP URLs</li>
+    <li>User publishes notification of updated avatar to metadata node, with ItemID that matches SHA1 hash of image data for "image/png" content-type (note: this is a hash of the image data itself, not the base64-encoded version)</li>
+    <li>Subscribers receive notification</li>
+    <li>Optionally (and if necessary), subscribers retrieve avatar data identified by ItemID from data node using pubsub get-items feature (or via HTTP)</li>
+    <li>Optionally, user disables avatar display.</li>
+  </ol>
+  <p class="" style="">This process flow is described more fully in the following sections.</p>
+  <p class="" style="">Note: Before publishing avatar data and metadata, the user MUST determine if his or her server supports the SPPS subset of pubsub by following the procedures specified in <span style="font-weight: bold">JEP-0163</span>.</p>
+  <div class="indent">
+<h3>3.1 <a name="process-createmeta">User Creates Metadata Node</a>
+</h3>
+    <p class="" style="">In order to publish notifications related to its avatar, the user MUST first create a node for his or her avatar metadata:</p>
+    <p class="caption">Example 1. Pubsub metadata node creation request</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/chamber' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/avatar#metadata' access='presence'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The NodeID MUST be "http://jabber.org/protocol/avatar#metadata" and the access model SHOULD be "presence".</p>
+    <p class="caption">Example 2. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/chamber' id='create1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="process-createdata">User Creates Data Node</a>
+</h3>
+    <p class="" style="">Next, the user MUST create a node for his or her avatar data:</p>
+    <p class="caption">Example 3. Pubsub data node creation request</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/chamber' id='create2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/avatar#data' access='presence'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The NodeID MUST be "http://jabber.org/protocol/avatar#data" and the access model SHOULD be "presence".</p>
+    <p class="caption">Example 4. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/chamber' id='create2'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="process-pubdata">User Publishes Data</a>
+</h3>
+    <p class="" style="">Before updating the avatar metadata node, the publisher MUST make sure that the avatar data is available at the data node or URL. When publishing the avatar data to the data node, the publisher MUST ensure that the value of the pubsub ItemID is the SHA1 hash of the data for the "image/png" content-type (this is used by the subscriber to determine if a locally cached copy can be displayed).</p>
+    <p class="" style="">The following example illustrates the XML structure to be sent when publishing avatar data to the data node.</p>
+    <p class="caption">Example 5. Publishing avatar data to data node</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/chamber' id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/avatar#data'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;data xmlns='http://jabber.org/protocol/avatar#data'&gt;
+          qANQR1DBwU4DX7jmYZnncm...
+        &lt;/data&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Pubsub service replies with success</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/chamber' id='publish1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="process-pubmeta">User Publishes Metadata Notification</a>
+</h3>
+    <p class="" style="">Whenever the publisher wishes to change its current avatar, it MUST update the metadata node.</p>
+    <p class="" style="">The following example shows metadata specifying avatar data that is available in only one format ("image/png") and accessible only at the data node:</p>
+    <p class="caption">Example 7. Publishing avatar metadata</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/chamber' id='publish2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/avatar#metadata'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+        &lt;/metadata&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="process-subnotify">Subscribers Receive Metadata Notification</a>
+</h3>
+    <p class="" style="">Subscribers to the metadata node would then receive the notification:</p>
+    <p class="caption">Example 8. Subscribers receive avatar metadata notification</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='juliet@capulet.com/chamber'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/avatar#metadata'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+        &lt;/metadata&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="process-subretrieve">Subscribers Retrieve Data</a>
+</h3>
+    <p class="" style="">Upon receiving the notification, each subscriber SHOULD determine if it has a locally cached copy of that avatar (which it can determine by searching for an image identified by the ItemID). If the subscriber already has a locally cached copy of the avatar image, it MUST NOT retrieve the image data.</p>
+    <p class="" style="">If the subscriber does not have a locally cached copy of the avatar image, it SHOULD retrieve the data. It can do this by sending a pubsub get-items request to the data node, specifying the appropriate ItemID:</p>
+    <p class="caption">Example 9. Subscriber requests last item by ItemID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/home'
+    to='juliet@capulet.com'
+    id='retrieve1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='http://jabber.org/protocol/avatar#metadata'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The SPPS service running at the user's server then SHOULD return the avatar data:</p>
+    <p class="caption">Example 10. Publishing avatar data to data node</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com' to='romeo@montague.net/home' id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/avatar#data'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;data xmlns='http://jabber.org/protocol/avatar#data'&gt;
+          qANQR1DBwU4DX7jmYZnncm...
+        &lt;/data&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the &lt;info/&gt; element sent to the metadata node possesses a 'url' attribute, the avatar data is hosted at a URL. Therefore, in order to retrieve the avatar image data for that content-type, the requesting entity MUST send an HTTP request to the specified URL. Methods for doing so are out of scope for this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="pub-stop">Publisher Disables Avatars</a>
+</h3>
+    <p class="" style="">In order to temporarily disable any avatar, the user publishes an empty &lt;stop/&gt; element to the metadata node (this item SHOULD NOT possess an ItemID):</p>
+    <p class="caption">Example 11. Temporarily disabling an avatar</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/chamber' id='publish3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='avatar/info/juliet@capulet.com'&gt;
+      &lt;item&gt;
+        &lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'&gt;
+          &lt;stop/&gt;
+        &lt;/metadata&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As before, subscribers to the metadata node would then receive the notification:</p>
+    <p class="caption">Example 12. Subscribers receive avatar metadata notification</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net' from='juliet@capulet.com/chamber'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/avatar#metadata'&gt;
+      &lt;item&gt;
+        &lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'&gt;
+          &lt;stop/&gt;
+        &lt;/metadata&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="proto">Protocol Syntax</a>
+</h2>
+  <p class="" style="">The SPPS subset of pubsub requires that there shall exist a one-to-one relationship between namespaces and nodes. Because the protocol defined herein stipulates the use of two nodes (one for avatar data and one for avatar metadata), we define two namespaces, each with a corresponding root element:</p>
+  <ul>
+    <li>&lt;data xmlns='http://jabber.org/protocol/avatar#data'/&gt;</li>
+    <li>&lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'/&gt;</li>
+  </ul>
+  <p class="" style="">These are further specified below.</p>
+  <div class="indent">
+<h3>4.1 <a name="proto-data">Data Element</a>
+</h3>
+    <p class="" style="">The &lt;data/&gt; element is used to communicate the avatar data itself, and only for the "image/png" content-type (support for which is REQUIRED):</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;data xmlns='http://jabber.org/protocol/avatar#data'&gt;
+  IMAGE DATA
+&lt;/data&gt;
+    </pre></div>
+    <p class="" style="">The XML character data MUST represent the image data for the avatar with a content-type of "image/png", Base64-encoded in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2257623">6</a>]. (Note: Line feeds SHOULD NOT be added but MUST be accepted.)</p>
+    <p class="" style="">Support for the &lt;data/&gt; element is REQUIRED.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="proto-meta">Metadata Element</a>
+</h3>
+    <p class="" style="">The &lt;metadata/&gt; element is used to communicate information about the avatar. There are three allowable children of the &lt;metadata/&gt; element:</p>
+    <ul>
+      <li>&lt;info/&gt;</li>
+      <li>&lt;pointer/&gt;</li>
+      <li>&lt;stop/&gt;</li>
+    </ul>
+    <p class="" style="">These are further specified below.</p>
+    <div class="indent">
+<h3>4.2.1 <a name="proto-info">Info Element</a>
+</h3>
+      <p class="" style="">The &lt;info/&gt; child element is used to communicate avatar metadata:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'
+  &lt;info id='SHA1-hash-of-image-data'
+        url='HTTP-URL-for-image-data'
+        id='SHA1-hash-of-image-data'
+        type='content-type-of-image-data'
+        bytes='size-of-image-data-in-bytes'
+        height='image-height-in-pixels'
+        width='image-width-in-pixels'/&gt;
+&lt;/metadata&gt;
+      </pre></div>
+      <p class="" style="">The &lt;info/&gt; child element MUST be empty.</p>
+      <p class="" style="">The &lt;info/&gt; child element MUST possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-style: italic">bytes</span> -- The size of the image data in bytes.</li>
+        <li>
+<span style="font-style: italic">height</span> -- The height of the image in pixels.</li>
+        <li>
+<span style="font-style: italic">id</span> -- The SHA1 hash of the image data for the specified content-type.</li>
+        <li>
+<span style="font-style: italic">type</span> -- The IANA-registered content type of the image data.</li>
+        <li>
+<span style="font-style: italic">width</span> -- The width of the image in pixels.</li>
+      </ul>
+      <p class="" style="">The &lt;info/&gt; element MAY possess the following attribute:</p>
+      <ul>
+        <li>
+<span style="font-style: italic">url</span> -- An http: or https: URI at which the image data file may be found.</li>
+      </ul>
+      <p class="" style="">The &lt;metadata/&gt; root element MAY contain more than one &lt;info/&gt; element. Each &lt;info/&gt; element MUST specify metadata for the same avatar image but in alternate content-types (e.g., "image/png", "image/gif", and "image/jpeg"), and one of the formats MUST be "image/png" to ensure interoperability. The value of the 'type' attribute MUST be an IANA-registered content type of type "image" or "video".  [<a href="#nt-id2257804">7</a>] Support for the "image/png" content type is REQUIRED. Support for the "image/gif" and "image/jpeg" content types is RECOMMENDED. Support for any other content type is OPTIONAL.</p>
+      <p class="" style="">The value of the 'id' attribute MUST be the SHA1 (<span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2257848">8</a>]) hash of the image data for the specified content-type.</p>
+      <p class="" style="">Support for the &lt;info/&gt; element is REQUIRED.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="proto-pointer">Pointer Element</a>
+</h3>
+      <p class="" style="">The &lt;pointer/&gt; child element is used to point to an avatar that is not published via pubsub or HTTP, but rather is provided by a third-party service such as an online gaming system or virtual world:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;avatar xmlns='http://jabber.org/protocol/avatar'&gt;
+  &lt;pointer&gt;
+    ... APPLICATION-SPECIFIC DATA ...
+  &lt;/pointer&gt;
+&lt;/avatar&gt;
+      </pre></div>
+      <p class="" style="">The &lt;pointer/&gt; element MAY possess the following attributes if the publishing application has the relevant information:</p>
+      <ul>
+        <li>
+<span style="font-style: italic">bytes</span> -- The size of the image data in bytes.</li>
+        <li>
+<span style="font-style: italic">height</span> -- The height of the image in pixels.</li>
+        <li>
+<span style="font-style: italic">id</span> -- The SHA1 hash of the image data for the specified content-type.</li>
+        <li>
+<span style="font-style: italic">type</span> -- The IANA-registered content type of the image data.</li>
+        <li>
+<span style="font-style: italic">width</span> -- The width of the image in pixels.</li>
+      </ul>
+      <p class="" style="">The content of the &lt;pointer/&gt; element MUST be a properly-namespaced child element that specifies information about how to retrieve the avatar from the third-party service. The structure for any such child element is out of scope for this document.</p>
+      <p class="" style="">Even if the &lt;pointer&gt; element is included, it MUST be preceded by at least one instance of the &lt;info/&gt; element so that implementations that do not support the &lt;pointer/&gt; element can display a "fallback" format of the avatar (at a minimum, "image/png").</p>
+      <p class="" style="">Support for the &lt;pointer/&gt; element is OPTIONAL.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="proto-stop">Stop Element</a>
+</h3>
+      <p class="" style="">The &lt;stop/&gt; child element is used to signal that avatar publishing has been disabled:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'&gt;
+  &lt;stop/&gt;
+&lt;/metadata&gt;
+      </pre></div>
+      <p class="" style="">The &lt;stop/&gt; element MUST be empty and MUST NOT possess any attributes.</p>
+      <p class="" style="">Support for the &lt;stop/&gt; element is REQUIRED.</p>
+    </div>
+  </div>
+<h2>5.
+       <a name="examples">Additional Examples</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="examples-multiple">Metadata With Multiple Content-Types</a>
+</h3>
+    <p class="" style="">The following example shows metadata specifying avatar data that is available in multiple formats ("image/png", "image/gif", and "image/mng"), where the "image/png" content-type is available only at the data node and the other content-types are available HTTP URLs:</p>
+    <p class="caption">Example 13. Publishing avatar metadata (multiple formats)</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/chamber' id='publish3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/avatar#metadata'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+          &lt;info id='222f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                url='http://avatars.jabberstudio.org/happy.gif'
+                type='image/gif'
+                bytes='23456'
+                height='64'
+                width='64'/&gt;
+          &lt;info id='333f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                url='http://avatars.jabberstudio.org/happy.mng'
+                type='image/mng'
+                bytes='78912'
+                height='64'
+                width='64'/&gt;
+        &lt;/metadata&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="examples-pointer">Metadata With Pointer</a>
+</h3>
+    <p class="" style="">The following example shows metadata specifying avatar data that is available in "image/png" and also with a pointer to an external service.</p>
+    <p class="caption">Example 14. Publishing avatar metadata (with pointer)</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/chamber' id='publish4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/avatar#metadata'&gt;
+      &lt;item id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'&gt;
+        &lt;metadata xmlns='http://jabber.org/protocol/avatar#metadata'&gt;
+          &lt;info id='111f4b3c50d7b0df729d299bc6f8e9ef9066971f'
+                type='image/png'
+                bytes='12345'
+                height='64'
+                width='64'/&gt;
+          &lt;pointer&gt;
+            &lt;x xmlns='http://example.com/virtualworlds'&gt;
+              &lt;game&gt;Ancapistan&lt;/game&gt;
+              &lt;character&gt;Kropotkin&lt;/character&gt;
+            &lt;/x&gt;
+          &lt;/pointer&gt;
+        &lt;/metadata&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="disco-sub">Discovering Avatar Availability</a>
+</h3>
+    <p class="" style="">A contact can determine if another user publishes avatars using this protocol by sending a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2258157">9</a>] items ("disco#items") request to the user's bare JID (&lt;node@domain.tld&gt;):</p>
+    <p class="caption">Example 15. Disco items request</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user publishes avatar data to an SPPS node, the result MUST contain the appropriate items:</p>
+    <p class="caption">Example 16. Disco items result</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    id='items1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/avatar#data'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/avatar#metadata'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The contact then may subscribe to the metadata node following the protocol specified in <span style="font-weight: bold">JEP-0060</span>. However, the contact SHOULD NOT subscribe to the data node (instead, it SHOULD simply retrieve items from that node when needed, as described above).</p>
+  </div>
+<h2>7.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="bizrules-images">Image Requirements</a>
+</h3>
+    <p class="" style="">Certain restrictions are placed upon the image. First, the image height and width SHOULD be between thirty-two (32) and ninety-six (96) pixels. The suggested size is sixty-four (64) pixels high and sixty-four (64) pixels wide. Images SHOULD be square, but this is not required. Finally, images SHOULD use less than eight (8) kilobytes of data.</p>
+  </div>
+<h2>8.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <ul>
+    <li>It is the responsibility of the receiving application to determine which avatar format to retrieve (e.g., "image/gif" rather than "image/png") and to determine the appropriate method for retrieval (e.g., HTTP rather than pubsub).</li>
+    <li>The receiving application SHOULD NOT scale up an image when displaying it.</li>
+    <li>If an avatar is not available for a contact, the receiving MAY display the contact's photo, e.g., as provided in the contact's vCard (see <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2258273">10</a>]) or other profile information.</li>
+  </ul>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document makes use of IANA-registered content types, but requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258344">11</a>].</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258389">12</a>] shall include 'http://jabber.org/protocol/avatar#data' and 'http://jabber.org/protocol/avatar#metadata' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="schema-data">Data Namespace</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/avatar#metadata'
+    xmlns='http://jabber.org/protocol/avatar#metadata'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='data' type='xs:base64Binary'&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="schema-metadata">Metadata Namespace</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/avatar#metadata'
+    xmlns='http://jabber.org/protocol/avatar#metadata'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='metadata'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='info' maxOccurs='unbounded'/&gt;
+          &lt;xs:element ref='pointer' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element name='stop' type='empty'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='info'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='bytes' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='type' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='height' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='url' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='width' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='pointer'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>13.
+       <a name="authornote">Author Note</a>
+</h2>
+  <p class="" style="">Peter Millard, a co-author of this specification from version 0.1 through version 0.7, died on April 26, 2006.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250741">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250902">2</a>. JEP-0163: Personal Eventing via Pubsub &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2250925">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250763">4</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2250966">5</a>. By "accessible via HTTP" is meant that the data is available at an http: or https: URI.</p>
+<p><a name="nt-id2257623">6</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2257804">7</a>. The IANA registry of content types is located at &lt;<a href="http://www.iana.org/assignments/media-types/">http://www.iana.org/assignments/media-types/</a>&gt;.</p>
+<p><a name="nt-id2257848">8</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2258157">9</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2258273">10</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2258344">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258389">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2006-01-17)</h4>
+<div class="indent">Updated to use Simplified Personal Publish-Subscribe. (psa)
+    </div>
+<h4>Version 0.6 (2005-04-13)</h4>
+<div class="indent">Major modification per list discussion: specified that metadata may include the same avatar in multiple alternate formats; allowed pointers to third-party avatars not available via pubsub or HTTP; changed pixel size restrictions; specified that bytes, content-type, height, id, and width are required metadata; changed type attribute to content-type; made explicit that URLs can be http: or https: URIs; more fully specified protocol, updated the examples, updated the schemas. (psa)
+    </div>
+<h4>Version 0.5 (2005-03-28)</h4>
+<div class="indent">Friendly fork per Council discussion: allowed data to be stored in a pubsub data repository or at a URL accessible via HTTP; also split text into publisher and subscriber use cases, specified requirements, added more examples, etc. (psa/pgm)
+    </div>
+<h4>Version 0.4 (2003-05-20)</h4>
+<div class="indent">Lessen the image requirements. Include the content type in info. (tjm)
+    </div>
+<h4>Version 0.3 (2003-05-08)</h4>
+<div class="indent">Drastic change to use two nodes on pubsub, allowing for hash updates independently of the data. This makes client caching much easier. Allow only PNG and MNG currently. (tjm)
+    </div>
+<h4>Version 0.2 (2003-05-07)</h4>
+<div class="indent">Clarified the use of "current" as the item id. Fixed some example errors. Made the interaction with disco more clear. The reason to use pubsub is made more clear as well. (tjm)
+    </div>
+<h4>Version 0.1 (2003-05-07)</h4>
+<div class="indent">Initial version. (tjm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.10.html
+++ b/content/xep-0085-0.10.html
@@ -1,0 +1,613 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.10<br>
+            Last Updated: 2005-06-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0022<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-rep">Repetition</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.8.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Message Events</span>  [<a href="#nt-id2251272">1</a>] protocol was an early attempt to define notifications related to message processing and composing events. However, it is informational only and has the following drawbacks:</p>
+  <ol start="" type="">
+    <li>Message events are used both to communicate the state of one's conversation partner (the composing event) and to track message delivery states (the offline storage, delivery, and display events); this is confusing, especially since message delivery states are now more fully defined by <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2251308">2</a>], which in part supersedes JEP-0022.</li>
+    <li>Message events can be generated either by a client or by a server, and the sender must depend on the recipient's server in order to receive notification of certain events; this introduces an unnecessary dependency.</li>
+    <li>Message events must be requested on a per-message basis; this is not only verbose but unnecessary in the context of most chat conversations, and requires implementations to maintain a more complex state machine than is desirable.</li>
+    <li>The connection between the 'id' attribute and the &lt;id/&gt; element has traditionally been difficult for developers to understand; this has led to a large number of non-compliant implementations.</li>
+    <li>The necessity for cancelling previously-generated composing events is introduced because the protocol does not define a complete state chart for chat conversations; this is not only incomplete but confusing.</li>
+    <li>There is no message event indicating that the chat session should be considered inactive or finished.</li>
+  </ol>
+  <p class="" style="">This proposal attempts to address those issues and to provide a protocol that can be accepted as a standard by the Jabber Software Foundation.</p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">This proposal supplements the traditional "is-composing" state by defining five additional chat states, for a total of six states that together fully describe the possible states for a chat conversation. These states refer to a user's participation in the chat session, not necessarily to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user "loses" a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to "away"), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">The six chat states addressed in this document are described below. The suggested triggers are simply that: suggestions. It is up to the implementation to determine its own rules for generation of chat state notifications.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;initial/&gt;</td>
+      <td align="" colspan="" rowspan="">User has joined the chat session but has not yet sent a message.</td>
+      <td align="" colspan="" rowspan="">User opens a chat window in preparation for sending a message to a contact.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+      <td align="" colspan="" rowspan="">User is actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User accepts initial chat message, sends a message, gives focus to the chat interface, or is otherwise paying attention to the conversation.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+      <td align="" colspan="" rowspan="">User is composing a message.</td>
+      <td align="" colspan="" rowspan="">User interacts with an input interface specific to this chat session (e.g., types in the input area of a chat window).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped.</td>
+      <td align="" colspan="" rowspan="">User was composing but stops interacting with the input interface for a short period of time (e.g., 5 seconds) or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User does not interact with the chat interface for an intermediate period of time (e.g., 30 seconds), minimizes the chat interface, or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session.</td>
+      <td align="" colspan="" rowspan="">User terminates the chat interface (e.g., closes a chat window) or does not interact with the chat interface, system, or device for a long period of time (e.g., 2 minutes).</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+             INITIAL
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+  </pre></div>
+  <p class="" style="">Note: All five of the states shown may transition to the GONE state.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A User MUST NOT notify a Contact of any chat state other than &lt;initial/&gt; or &lt;active/&gt; until the User has discovered that the Contact supports this protocol (the same is true of the Contact).</li>
+      <li>If the User desires chat state notifications, the user's client MUST either send an &lt;initial/&gt; state notification or include an &lt;active/&gt; notification in its first message.</li>
+      <li>If the user's client sent an &lt;initial&gt; state notification, the contact's client SHOULD send an &lt;initial/&gt; state notification to the user's full JID if it supports the &lt;initial/&gt; state.</li>
+      <li>If the user's client did not send an &lt;initial/&gt; state notification, the Contact MUST NOT send any chat state notifications to the User (e.g., a composing event) before sending a reply to the User's first message in the conversation; the only allowable chat state notification in the Contact's first reply is the &lt;active/&gt; notification.</li>
+      <li>If the Contact replies to the first message but does not include an &lt;active/&gt; notification, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the first message and includes an &lt;active/&gt; notification, the Contact SHOULD send subsequent notifications for supported chat states as specified in the next subsection.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;initial/&gt;</td>
+        <td align="" colspan="" rowspan="">MAY</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications. (Note: Support for only &lt;active/&gt; and &lt;composing/&gt; is functionally equivalent to supporting JEP-0022.)</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-rep">Repetition</a>
+</h3>
+    <p class="" style="">Even if the user types continuously for a long time (e.g., while composing a lengthy reply), the client MUST NOT send more than one &lt;composing/&gt; notification in a row. More generally, a client MUST NOT send a second instance of any given chat state notification (i.e., any given notification MUST be followed by a different state, not repetition of the same state).</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than "chat" or "groupchat".</li>
+      <li>The 'type' attribute for chat state notification messages SHOULD be set to a value of "chat" or "groupchat" (as appropriate for the context).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <ol start="" type="">
+      <li>In the context of groupchat (e.g., as defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255825">3</a>]), a client SHOULD NOT generate &lt;gone/&gt; notifications, and SHOULD ignore &lt;gone/&gt; notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>Chat state notification messages MUST contain one and only one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace, unless threads are used (in which case the chat state notification message MUST contain the &lt;thread/&gt; element and the appropriate state element); this is true of all states except &lt;active/&gt;.</li>
+      <li>A &lt;composing/&gt; notification message MUST NOT contain a &lt;subject/&gt; element or a &lt;body/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if all of the clients participating in a chat both support and use threads, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a &lt;gone/&gt; event.</li>
+      <li>Upon receiving a &lt;gone/&gt; event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers in constrained network environments (e.g., serving small-footprint clients via <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2255963">4</a>] or <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2255985">5</a>]) and services that rebroadcast message stanzas (e.g., Multi-User Chat services) MAY process chat state notification messages differently from other messages. In particular, a server or service MAY refuse to deliver standalone chat state notifications to its users, and SHOULD NOT store them offline. In contrast to the Message Events protocol, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Message With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="" style="">First, the user Romeo opens a chat window in preparation for starting to talk with a contact named Juliet. His client supports the optional &lt;initial/&gt; state and sends that to Juliet.</p>
+  <p class="caption">Example 5. User Sends Initial State (OPTIONAL)</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;initial xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point Juliet's client knows that Romeo's client supports chat state notifications. If desired, her client MAY also send an initial state notification to Romeo's full JID.</p>
+  <p class="caption">Example 6. Contact Sends Initial State (OPTIONAL)</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    from='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;initial xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Now Romeo types a message to Juliet.</p>
+  <p class="caption">Example 7. User Sends First Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Juliet replies to the first message and her client includes a notification that her state is &lt;active/&gt;:</p>
+  <p class="caption">Example 8. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so the conversation continues. After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 9. User's Client Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of &lt;paused/&gt;.</p>
+  <p class="caption">Example 10. User's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a &lt;composing/&gt; notification to Juliet's client.</p>
+  <p class="caption">Example 11. User's Clients Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 12. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 13. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet minimizes the chat window, so her client generates an &lt;inactive/&gt; notification:</p>
+  <p class="caption">Example 14. Contact's Client Sends &lt;inactive/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an &lt;active/&gt; notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 16. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet closes the chat window, so her client generates a &lt;gone/&gt; notification:</p>
+  <p class="caption">Example 17. Contact's Client Sends &lt;gone/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo's client now considers the chat thread to be over and generates a new Thread ID when he sends a new message:</p>
+  <p class="caption">Example 18. User's Client Sends Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an &lt;active/&gt; notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 19. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client that receives a chat state notification should expect that it may never receive another message or chat state notification from the other entity (e.g., because the other entity crashes or goes offline) and should plan accordingly.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256496">6</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256547">7</a>] shall include 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='initial' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251272">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2251308">2</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255825">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255963">4</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2255985">5</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2256496">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256547">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2005-06-28)</h4>
+<div class="indent">Added optional &lt;initial/&gt; state; added business rule on repetition of notifications added implementation note. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-28)</h4>
+<div class="indent">Made &lt;inactive/&gt; state definition consistent with &lt;paused/&gt; per list discussion; made slight adjustments to wording throughout. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the &lt;gone/&gt; state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added &lt;paused/&gt; state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be "chat" or "groupchat" for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made &lt;inactive/&gt; and &lt;gone/&gt; states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.11.html
+++ b/content/xep-0085-0.11.html
@@ -1,0 +1,582 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.11<br>
+            Last Updated: 2005-07-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0022<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-rep">Repetition</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.8.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Message Events</span>  [<a href="#nt-id2251285">1</a>] protocol was an early attempt to define notifications related to message processing and composing events. However, it is informational only and has the following drawbacks:</p>
+  <ol start="" type="">
+    <li>Message events are used both to communicate the state of one's conversation partner (the composing event) and to track message delivery states (the offline storage, delivery, and display events); this is confusing, especially since message delivery states are now more fully defined by <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2250444">2</a>], which in part supersedes JEP-0022.</li>
+    <li>Message events can be generated either by a client or by a server, and the sender must depend on the recipient's server in order to receive notification of certain events; this introduces an unnecessary dependency.</li>
+    <li>Message events must be requested on a per-message basis; this is not only verbose but unnecessary in the context of most chat conversations, and requires implementations to maintain a more complex state machine than is desirable.</li>
+    <li>The connection between the 'id' attribute and the &lt;id/&gt; element has traditionally been difficult for developers to understand; this has led to a large number of non-compliant implementations.</li>
+    <li>The necessity for cancelling previously-generated composing events is introduced because the protocol does not define a complete state chart for chat conversations; this is not only incomplete but confusing.</li>
+    <li>There is no message event indicating that the chat session should be considered inactive or finished.</li>
+  </ol>
+  <p class="" style="">This proposal attempts to address those issues and to provide a protocol that can be accepted as a standard by the Jabber Software Foundation.</p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">This proposal supplements the traditional "is-composing" state by defining four additional chat states, for a total of five states that together fully describe the possible states for a chat conversation. These states refer to a user's participation in the chat session, not necessarily to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user "loses" a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to "away"), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">The five chat states addressed in this document are described below. The suggested triggers are simply that: suggestions. It is up to the implementation to determine its own rules for generation of chat state notifications.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+      <td align="" colspan="" rowspan="">User is actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User accepts initial chat message, sends a message, gives focus to the chat interface, or is otherwise paying attention to the conversation.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+      <td align="" colspan="" rowspan="">User is composing a message.</td>
+      <td align="" colspan="" rowspan="">User interacts with an input interface specific to this chat session (e.g., types in the input area of a chat window).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped.</td>
+      <td align="" colspan="" rowspan="">User was composing but stops interacting with the input interface for a short period of time (e.g., 5 seconds) or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User does not interact with the chat interface for an intermediate period of time (e.g., 30 seconds), minimizes the chat interface, or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session.</td>
+      <td align="" colspan="" rowspan="">User terminates the chat interface (e.g., closes a chat window) or does not interact with the chat interface, system, or device for a long period of time (e.g., 2 minutes).</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to the GONE state.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A User MUST NOT notify a Contact of any chat state other than &lt;active/&gt; until the User has discovered that the Contact supports this protocol (the same is true of the Contact).</li>
+      <li>If the User desires chat state notifications, the initial message MUST contain an &lt;active/&gt; notification.</li>
+      <li>The Contact MUST NOT send any chat state notifications to the User (e.g., a composing event) before sending a reply to the User's initial message in the conversation; the only allowable chat state notification in the initial reply is the &lt;active/&gt; notification.</li>
+      <li>If the Contact replies to the initial message but does not include an &lt;active/&gt; notification, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message and includes an &lt;active/&gt; notification, the Contact SHOULD send subsequent notifications for supported chat states as specified in the next subsection.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications. (Note: Support for only &lt;active/&gt; and &lt;composing/&gt; is functionally equivalent to supporting JEP-0022.)</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-rep">Repetition</a>
+</h3>
+    <p class="" style="">Even if the user types continuously for a long time (e.g., while composing a lengthy reply), the client MUST NOT send more than one &lt;composing/&gt; notification in a row. More generally, a client MUST NOT send a second instance of any given chat state notification (i.e., any given notification MUST be followed by a different state, not repetition of the same state).</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than "chat" or "groupchat".</li>
+      <li>The 'type' attribute for chat state notification messages SHOULD be set to a value of "chat" or "groupchat" (as appropriate for the context).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <ol start="" type="">
+      <li>In the context of groupchat (e.g., as defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255823">3</a>]), a client SHOULD NOT generate &lt;gone/&gt; notifications, and SHOULD ignore &lt;gone/&gt; notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>Chat state notification messages MUST contain one and only one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace, unless threads are used (in which case the chat state notification message MUST contain the &lt;thread/&gt; element and the appropriate state element); this is true of all states except &lt;active/&gt;.</li>
+      <li>A &lt;composing/&gt; notification message MUST NOT contain a &lt;subject/&gt; element or a &lt;body/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if all of the clients participating in a chat both support and use threads, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a &lt;gone/&gt; event.</li>
+      <li>Upon receiving a &lt;gone/&gt; event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers in constrained network environments (e.g., serving small-footprint clients via <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2255961">4</a>] or <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2255983">5</a>]) and services that rebroadcast message stanzas (e.g., Multi-User Chat services) MAY process chat state notification messages differently from other messages. In particular, a server or service MAY refuse to deliver standalone chat state notifications to its users, and SHOULD NOT store them offline. In contrast to the Message Events protocol, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Message With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point Juliet's client knows that Romeo's client supports chat state notifications. Thus she replies to the initial message and her client includes a notification that her state is &lt;active/&gt;:</p>
+  <p class="caption">Example 6. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so the conversation continues. After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of &lt;paused/&gt;.</p>
+  <p class="caption">Example 8. User's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a &lt;composing/&gt; notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet minimizes the chat window, so her client generates an &lt;inactive/&gt; notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends &lt;inactive/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an &lt;active/&gt; notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet closes the chat window, so her client generates a &lt;gone/&gt; notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends &lt;gone/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo's client now considers the chat thread to be over and generates a new Thread ID when he sends a new message:</p>
+  <p class="caption">Example 16. User's Client Sends Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an &lt;active/&gt; notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client that receives a chat state notification should expect that it may never receive another message or chat state notification from the other entity (e.g., because the other entity crashes or goes offline) and should plan accordingly.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256446">6</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256497">7</a>] shall include 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251285">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2250444">2</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255823">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255961">4</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2255983">5</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2256446">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256497">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.11 (2005-07-05)</h4>
+<div class="indent">Removed &lt;initial/&gt; state. (psa)
+    </div>
+<h4>Version 0.10 (2005-06-28)</h4>
+<div class="indent">Added optional &lt;initial/&gt; state; added business rule on repetition of notifications; added implementation note. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-28)</h4>
+<div class="indent">Made &lt;inactive/&gt; state definition consistent with &lt;paused/&gt; per list discussion; made slight adjustments to wording throughout. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the &lt;gone/&gt; state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added &lt;paused/&gt; state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be "chat" or "groupchat" for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made &lt;inactive/&gt; and &lt;gone/&gt; states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.12.html
+++ b/content/xep-0085-0.12.html
@@ -1,0 +1,608 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.12<br>
+            Last Updated: 2005-07-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0022<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-rep">Repetition</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.8.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#supersede">Superseding JEP-0022</a>
+</dt>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many instant messaging systems include notifications about the state of one's conversation partner in a one-to-one chat (or, sometimes, in a many-to-many chat). Usually these are limited to notification that one's partner is currently typing -- e.g., the Composing event in <span style="font-weight: bold">JEP-0022</span> (see <span class="ref" style="">Message Events</span>  [<a href="#nt-id2250443">1</a>]). However, a composing event is essentially information about a person's participation in or involvement with the chat "session" and therefore is really a session-level state rather than a per-message event -- e.g., the Delivered and Displayed events in <span style="font-weight: bold">JEP-0022</span>. While the composing event is interesting, the concept of a session-level state can be extended to answer a variety of questions about the participation of a person in a real-time chat conversation, such as:</p>
+  <ul>
+    <li>Has this person paused the composition?</li>
+    <li>Is this person actively paying attention to the chat?</li>
+    <li>Is this person temporarily inactive (i.e., not paying attention right now)?</li>
+    <li>Is this person simply gone (i.e., no longer participating in the chat)?</li>
+  </ul>
+  <p class="" style="">To answer such questions, this JEP supplements the traditional composing state by defining four additional chat states (paused, active, inactive, gone), for a total of five states that (it is hoped) together fully describe the possible states of a person's participation in or involvement with a chat conversation.  [<a href="#nt-id2250482">2</a>]</p>
+  <p class="" style=""><span style="font-style: italic">Note: This JEP is intended to supersede much of the Historical message events protocol documented in <span style="font-weight: bold">JEP-0022</span>; for details, refer to the <a href="#supersede">Superseding JEP-0022</a> section of this JEP.</span></p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user "loses" a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to "away"), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">The five chat states addressed in this document are described below. The suggested triggers are simply that: suggestions. It is up to the implementation to determine its own rules for generation of chat state notifications.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+      <td align="" colspan="" rowspan="">User is actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User accepts initial chat message, sends a message, gives focus to the chat interface, or is otherwise paying attention to the conversation.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+      <td align="" colspan="" rowspan="">User is composing a message.</td>
+      <td align="" colspan="" rowspan="">User interacts with an input interface specific to this chat session (e.g., types in the input area of a chat window).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped.</td>
+      <td align="" colspan="" rowspan="">User was composing but stops interacting with the input interface for a short period of time (e.g., 5 seconds) or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User does not interact with the chat interface for an intermediate period of time (e.g., 30 seconds), minimizes the chat interface, or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session.</td>
+      <td align="" colspan="" rowspan="">User terminates the chat interface (e.g., closes a chat window) or does not interact with the chat interface, system, or device for a long period of time (e.g., 2 minutes).</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to the GONE state.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <p class="" style="">In the absence of explicit negotiation of a chat session (e.g., as specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2255575">3</a>]), the following business rules apply:</p>
+    <ol start="1" type="">
+      <li>If the User desires chat state notifications, the initial message sent to the Contact MUST contain an &lt;active/&gt; notification.</li>
+      <li>Until receiving a reply to the initial message (or a standalone chat state notification message) from the Contact, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message but does not include an &lt;active/&gt; notification, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message and includes an &lt;active/&gt; notification (or sends a standalone chat state notification message to the User), the User and Contact SHOULD send subsequent notifications for supported chat states as specified in the next subsection.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications. (Note: Support for only &lt;active/&gt; and &lt;composing/&gt; is functionally equivalent to supporting the Composing event from <span style="font-weight: bold">JEP-0022</span>.)</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-rep">Repetition</a>
+</h3>
+    <p class="" style="">Even if the user types continuously for a long time (e.g., while composing a lengthy reply), the client MUST NOT send more than one &lt;composing/&gt; notification in a row. More generally, a client MUST NOT send a second instance of any given chat state notification (i.e., any given notification MUST be followed by a different state, not repetition of the same state).</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than "chat" or "groupchat".</li>
+      <li>The 'type' attribute for chat state notification messages SHOULD be set to a value of "chat" or "groupchat" (as appropriate for the context).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <ol start="" type="">
+      <li>In the context of groupchat (e.g., as defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255886">4</a>]), a client SHOULD NOT generate &lt;gone/&gt; notifications, and SHOULD ignore &lt;gone/&gt; notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>Standalone chat state notification messages MUST contain one and only one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace, unless threads are used (in which case the standalone chat state notification message MUST contain the &lt;thread/&gt; element and the appropriate state element); this is true of all states except &lt;active/&gt;.</li>
+      <li>A standalone message containing a &lt;composing/&gt; notification MUST NOT contain a &lt;subject/&gt; element or a &lt;body/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if all of the clients participating in a chat both support and use threads, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a &lt;gone/&gt; event.</li>
+      <li>Upon receiving a &lt;gone/&gt; event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers in constrained network environments (e.g., serving small-footprint clients via <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2256026">5</a>] or <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2256048">6</a>]) and services that rebroadcast message stanzas (e.g., Multi-User Chat services) MAY process standalone chat state notification messages differently from other messages. In particular, a server or service MAY refuse to deliver standalone chat state notifications to its users, and SHOULD NOT store them offline. In contrast to <span style="font-weight: bold">JEP-0022</span>, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Message With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point Juliet's client knows that Romeo's client supports chat state notifications. Thus she replies to the initial message and her client includes a notification that her state is &lt;active/&gt;:</p>
+  <p class="caption">Example 6. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so the conversation continues. After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of &lt;paused/&gt;.</p>
+  <p class="caption">Example 8. User's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a &lt;composing/&gt; notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet minimizes the chat window, so her client generates an &lt;inactive/&gt; notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends &lt;inactive/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an &lt;active/&gt; notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet closes the chat window, so her client generates a &lt;gone/&gt; notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends &lt;gone/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo's client now considers the chat thread to be over and generates a new Thread ID when he sends a new message:</p>
+  <p class="caption">Example 16. User's Client Sends Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an &lt;active/&gt; notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client that receives a chat state notification should expect that it may never receive another message or chat state notification from the other entity (e.g., because the other entity crashes or goes offline) and should plan accordingly.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256513">7</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256564">8</a>] shall include 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="supersede">Superseding JEP-0022</a>
+</h2>
+  <p class="" style="">This JEP proposes to supersede (parts of) <span style="font-weight: bold">JEP-0022</span>, an Historical JEP that documents a protocol that has been in use within the Jabber community since the year 2000. Some justification is in order.</p>
+  <p class="" style="">The message events protocol was an early attempt to define notifications related to (1) processing of messages by clients (the Delivered and Displayed events) and servers (the Offline event) as well as (2) a person's involvement in the conversation (the Composing event). We argue that the message events protocol has the following drawbacks:</p>
+  <ol start="" type="">
+    <li><p class="" style="">Message events are used both to communicate the state of one's conversation partner (the Composing event) and to track message delivery states (the Offline, Delivered, and Displayed events); this is confusing, especially since the Offline and Delivered states are now more fully defined by <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256647">9</a>], which in part supersedes <span style="font-weight: bold">JEP-0022</span>.  [<a href="#nt-id2256628">10</a>]</p></li>
+    <li><p class="" style="">Message events can be generated either by a client or by a server, and the sender must depend on the recipient's server in order to receive notification of the Offline event; this introduces an unnecessary dependency (although it must be noted that no servers ever implemented the Offline event as far as we know).</p></li>
+    <li><p class="" style="">Message events must be requested on a per-message basis; this is not only verbose but unnecessary in the context of most chat conversations, and requires implementations to maintain a more complex state machine than is desirable.</p></li>
+    <li><p class="" style="">The connection between the &lt;message/&gt; stanza's 'id' attribute and the <span style="font-weight: bold">JEP-0022</span> &lt;id/&gt; element has traditionally been quite difficult for implementors to keep straight (especially in the context of the typical, rapid-fire IM discussion); this has led to a large number of non-compliant implementations.</p></li>
+    <li><p class="" style="">The protocol does not define a complete state chart for message events; among other things this introduces the necessity for cancelling previously-generated composing events, which again has confused implementors.</p></li>
+    <li><p class="" style="">The composing event is useful but limited; for example, there is no message event indicating that one's conversation party is no longer actively involved in the chat or is gone.</p></li>
+    <li><p class="" style="">Many implementors have used only the Composing event (ignoring the Delivered and Displayed events); yet the Composing event is better seen as a session-level state (as in JEP-0085) rather than a per-message event (as in <span style="font-weight: bold">JEP-0022</span>), which led the authors of this JEP to generalize the concept of session-level states as defined herein.</p></li>
+  </ol>
+  <p class="" style="">In general, the message events protocol enabled the Jabber community to experiment with the concept of per-message and session-level events. The results of that experiment are two-fold:</p>
+  <ol start="" type="">
+    <li>Per-message events need to be more robust than what is defined in <span style="font-weight: bold">JEP-0022</span> in order to meet needs for more reliable delivery of &lt;message/&gt; stanzas; this led directly to the development of JEP-0079.</li>
+    <li>Session-level events can provide more helpful information than simply the composing state; this led directly to the development of JEP-0085.</li>
+  </ol>
+  <p class="" style=""><span style="font-weight: bold">JEP-0022</span> is not bad or evil, but it has outlived its usefulness. We have done better for message events (JEP-0079) and it is time to do better for session events (JEP-0085).</p>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250443">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2250482">2</a>. These states do no necessarily refer to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+<p><a name="nt-id2255575">3</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2255886">4</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256026">5</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2256048">6</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2256513">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256564">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256647">9</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256628">10</a>. The JEP-0022 Delivered state was to be raised by the client rather than the server; however, it is effectively superseded by the JEP-0079 deliver condition.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.12 (2005-07-15)</h4>
+<div class="indent">Clarified business rules regarding generation of notifications; added reference to JEP-0155; rewrote introduction; moved previous introductory text to section on superseding JEP-0022. (psa)
+    </div>
+<h4>Version 0.11 (2005-07-05)</h4>
+<div class="indent">Removed &lt;initial/&gt; state. (psa)
+    </div>
+<h4>Version 0.10 (2005-06-28)</h4>
+<div class="indent">Added optional &lt;initial/&gt; state; added business rule on repetition of notifications; added implementation note. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-28)</h4>
+<div class="indent">Made &lt;inactive/&gt; state definition consistent with &lt;paused/&gt; per list discussion; made slight adjustments to wording throughout. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the &lt;gone/&gt; state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added &lt;paused/&gt; state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be "chat" or "groupchat" for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made &lt;inactive/&gt; and &lt;gone/&gt; states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.13.html
+++ b/content/xep-0085-0.13.html
@@ -1,0 +1,616 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.13<br>
+            Last Updated: 2005-07-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0022<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-rep">Repetition</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.8.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#supersede">Superseding JEP-0022</a>
+</dt>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many instant messaging systems include notifications about the state of one's conversation partner in a one-to-one chat (or, sometimes, in a many-to-many chat). Usually these are limited to notification that one's partner is currently typing -- e.g., the Composing event in <span style="font-weight: bold">JEP-0022</span> (see <span class="ref" style="">Message Events</span>  [<a href="#nt-id2250454">1</a>]). However, a composing event is essentially information about a person's participation in or involvement with the chat "session" and therefore is really a session-level state rather than a per-message event -- e.g., the Delivered and Displayed events in <span style="font-weight: bold">JEP-0022</span>. While the composing event is interesting, the concept of a session-level state can be extended to answer a variety of questions about the participation of a person in a real-time chat conversation, such as:</p>
+  <ul>
+    <li>Has this person paused the composition?</li>
+    <li>Is this person actively paying attention to the chat?</li>
+    <li>Is this person temporarily inactive (i.e., not paying attention right now)?</li>
+    <li>Is this person simply gone (i.e., no longer participating in the chat)?</li>
+  </ul>
+  <p class="" style="">To answer such questions, this JEP supplements the traditional composing state by defining four additional chat states (paused, active, inactive, gone), for a total of five states that (it is hoped) together fully describe the possible states of a person's participation in or involvement with a chat conversation.  [<a href="#nt-id2250500">2</a>]</p>
+  <p class="" style=""><span style="font-style: italic">Note: This JEP is intended to supersede much of the Historical message events protocol documented in <span style="font-weight: bold">JEP-0022</span>; for details, refer to the <a href="#supersede">Superseding JEP-0022</a> section of this JEP.</span></p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user "loses" a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to "away"), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">The five chat states addressed in this document are described below. The suggested triggers are simply that: suggestions. It is up to the implementation to determine its own rules for generation of chat state notifications.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+      <td align="" colspan="" rowspan="">User is actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User accepts initial chat message, sends a message, gives focus to the chat interface, or is otherwise paying attention to the conversation.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+      <td align="" colspan="" rowspan="">User is composing a message.</td>
+      <td align="" colspan="" rowspan="">User interacts with an input interface specific to this chat session (e.g., types in the input area of a chat window).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped.</td>
+      <td align="" colspan="" rowspan="">User was composing but stops interacting with the input interface for a short period of time (e.g., 5 seconds) or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User does not interact with the chat interface for an intermediate period of time (e.g., 30 seconds), minimizes the chat interface, or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session.</td>
+      <td align="" colspan="" rowspan="">User terminates the chat interface (e.g., closes a chat window) or does not interact with the chat interface, system, or device for a long period of time (e.g., 2 minutes).</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to the GONE state.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <p class="" style="">In the absence of explicit negotiation of a chat session between the User and the Contact (e.g., as specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2255593">3</a>]) or explicit discovery by the User of the Contact's capabilities (e.g., as gained through <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255617">4</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2255642">5</a>]), the following business rules apply to the use of chat state notifications in the context of one-to-one chat sessions:</p>
+    <ol start="1" type="">
+      <li>If the User desires chat state notifications, the initial message sent to the Contact MUST contain a chat state notification extension, which SHOULD be &lt;active/&gt;.</li>
+      <li>Until receiving a reply to the initial message (or a standalone chat state notification message) from the Contact, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message but does not include a chat state notification extension, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message and includes an &lt;active/&gt; notification (or sends a standalone chat state notification message to the User), the User and Contact SHOULD send subsequent notifications for supported chat states as specified in the next subsection.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications.</p>
+    <p class="" style="">Note: Support for only &lt;active/&gt; and &lt;composing/&gt; is functionally equivalent to supporting the Composing event from <span style="font-weight: bold">JEP-0022</span>.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-rep">Repetition</a>
+</h3>
+    <p class="" style="">Even if the user types continuously for a long time (e.g., while composing a lengthy reply), the client MUST NOT send more than one &lt;composing/&gt; notification in a row. More generally, a client MUST NOT send a second instance of any given chat state notification (i.e., any given notification MUST be followed by a different state, not repetition of the same state).</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than "chat" or "groupchat".</li>
+      <li>The 'type' attribute for chat state notification messages SHOULD be set to a value of "chat" or "groupchat" (as appropriate for the context).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <ol start="" type="">
+      <li>In the context of groupchat (e.g., as defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255952">6</a>]), a client SHOULD NOT generate &lt;gone/&gt; notifications, and SHOULD ignore &lt;gone/&gt; notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A message stanza MUST NOT contain more than one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace.</li>
+      <li>A message stanza that contains standard messaging content -- i.e., the &lt;body/&gt;, &lt;subject/&gt;, and &lt;thread/&gt; child elements defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256008">7</a>] and/or any other properly-namespaced child element(s) -- SHOULD NOT contain a chat state notification extension other than &lt;active/&gt;.</li>
+      <li>A message stanza that does not contain standard messaging content and is intended to specify only the chat state MUST NOT contain any child elements other than the chat state notification extension, which SHOULD be a state other than &lt;active/&gt;; however, if threads are used (see below) then the standalone chat state notification message MUST also contain the &lt;thread/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if all of the clients participating in a chat both support and use threads, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a &lt;gone/&gt; event.</li>
+      <li>Upon receiving a &lt;gone/&gt; event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers in constrained network environments (e.g., serving small-footprint clients via <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2256121">8</a>] or <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2256143">9</a>]) and services that rebroadcast message stanzas (e.g., Multi-User Chat services) MAY process standalone chat state notification messages differently from other messages. In particular, a server or service MAY refuse to deliver standalone chat state notifications to its users, and SHOULD NOT store them offline. In contrast to <span style="font-weight: bold">JEP-0022</span>, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Message With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point Juliet's client knows that Romeo's client supports chat state notifications. Thus she replies to the initial message and her client includes a notification that her state is &lt;active/&gt;:</p>
+  <p class="caption">Example 6. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so the conversation continues. After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of &lt;paused/&gt;.</p>
+  <p class="caption">Example 8. User's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a &lt;composing/&gt; notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet minimizes the chat window, so her client generates an &lt;inactive/&gt; notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends &lt;inactive/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an &lt;active/&gt; notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet closes the chat window, so her client generates a &lt;gone/&gt; notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends &lt;gone/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo's client now considers the chat thread to be over and generates a new Thread ID when he sends a new message:</p>
+  <p class="caption">Example 16. User's Client Sends Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an &lt;active/&gt; notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client that receives a chat state notification should expect that it may never receive another message or chat state notification from the other entity (e.g., because the other entity crashes or goes offline) and should plan accordingly.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256608">10</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256659">11</a>] shall include 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="supersede">Superseding JEP-0022</a>
+</h2>
+  <p class="" style="">This JEP proposes to supersede (parts of) <span style="font-weight: bold">JEP-0022</span>, an Historical JEP that documents a protocol that has been in use within the Jabber community since the year 2000. Some justification is in order.</p>
+  <p class="" style="">The message events protocol was an early attempt to define notifications related to (1) processing of messages by clients (the Delivered and Displayed events) and servers (the Offline event) as well as (2) a person's involvement in the conversation (the Composing event). We argue that the message events protocol has the following drawbacks:</p>
+  <ol start="" type="">
+    <li><p class="" style="">Message events are used both to communicate the state of one's conversation partner (the Composing event) and to track message delivery states (the Offline, Delivered, and Displayed events); this is confusing, especially since the Offline and Delivered states are now more fully defined by <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256741">12</a>], which in part supersedes <span style="font-weight: bold">JEP-0022</span>.  [<a href="#nt-id2256723">13</a>]</p></li>
+    <li><p class="" style="">Message events can be generated either by a client or by a server, and the sender must depend on the recipient's server in order to receive notification of the Offline event; this introduces an unnecessary dependency (although it must be noted that no servers ever implemented the Offline event as far as we know).</p></li>
+    <li><p class="" style="">Message events must be requested on a per-message basis; this is not only verbose but unnecessary in the context of most chat conversations, and requires implementations to maintain a more complex state machine than is desirable.</p></li>
+    <li><p class="" style="">The connection between the &lt;message/&gt; stanza's 'id' attribute and the <span style="font-weight: bold">JEP-0022</span> &lt;id/&gt; element has traditionally been quite difficult for implementors to keep straight (especially in the context of the typical, rapid-fire IM discussion); this has led to a large number of non-compliant implementations.</p></li>
+    <li><p class="" style="">The protocol does not define a complete state chart for message events; among other things this introduces the necessity for cancelling previously-generated composing events, which again has confused implementors.</p></li>
+    <li><p class="" style="">The composing event is useful but limited; for example, there is no message event indicating that one's conversation party is no longer actively involved in the chat or is gone.</p></li>
+    <li><p class="" style="">Many implementors have used only the Composing event (ignoring the Delivered and Displayed events); yet the Composing event is better seen as a session-level state (as in JEP-0085) rather than a per-message event (as in <span style="font-weight: bold">JEP-0022</span>), which led the authors of this JEP to generalize the concept of session-level states as defined herein.</p></li>
+  </ol>
+  <p class="" style="">In general, the message events protocol enabled the Jabber community to experiment with the concept of per-message and session-level events. The results of that experiment are two-fold:</p>
+  <ol start="" type="">
+    <li>Per-message events need to be more robust than what is defined in <span style="font-weight: bold">JEP-0022</span> in order to meet the need for more reliable delivery of &lt;message/&gt; stanzas; this led directly to the development of JEP-0079.</li>
+    <li>Session-level events can provide more complete and helpful information than simply the composing state; this led directly to the development of JEP-0085.</li>
+  </ol>
+  <p class="" style=""><span style="font-weight: bold">JEP-0022</span> is not bad or evil, but it has outlived its usefulness. We have done better for message events (JEP-0079) and it is time to do better for session events (JEP-0085).</p>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250454">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2250500">2</a>. These states do not necessarily refer to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+<p><a name="nt-id2255593">3</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2255617">4</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255642">5</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2255952">6</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256008">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256121">8</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2256143">9</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2256608">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256659">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256741">12</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256723">13</a>. The JEP-0022 Delivered state was to be raised by the client rather than the server; however, it is effectively superseded by the JEP-0079 deliver condition.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.13 (2005-07-19)</h4>
+<div class="indent">Further clarified business rules regarding generation of notifications. (psa)
+    </div>
+<h4>Version 0.12 (2005-07-15)</h4>
+<div class="indent">Clarified business rules regarding generation of notifications; added reference to JEP-0155; rewrote introduction; moved previous introductory text to section on superseding JEP-0022. (psa)
+    </div>
+<h4>Version 0.11 (2005-07-05)</h4>
+<div class="indent">Removed &lt;initial/&gt; state. (psa)
+    </div>
+<h4>Version 0.10 (2005-06-28)</h4>
+<div class="indent">Added optional &lt;initial/&gt; state; added business rule on repetition of notifications; added implementation note. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-28)</h4>
+<div class="indent">Made &lt;inactive/&gt; state definition consistent with &lt;paused/&gt; per list discussion; made slight adjustments to wording throughout. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the &lt;gone/&gt; state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added &lt;paused/&gt; state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be "chat" or "groupchat" for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made &lt;inactive/&gt; and &lt;gone/&gt; states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.14.html
+++ b/content/xep-0085-0.14.html
@@ -1,0 +1,611 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-20">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.14<br>
+            Last Updated: 2005-07-20<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-rep">Repetition</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.8.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many instant messaging systems include notifications about the state of one's conversation partner in a one-to-one chat (or, sometimes, in a many-to-many chat). Usually these are limited to notification that one's partner is currently typing -- e.g., the Composing event in <span style="font-weight: bold">JEP-0022</span> (see <span class="ref" style="">Message Events</span>  [<a href="#nt-id2250467">1</a>]). However, a composing event is essentially information about a person's participation in or involvement with the chat "session" and therefore is really a session-level state rather than a per-message event -- e.g., the Delivered and Displayed events in <span style="font-weight: bold">JEP-0022</span>. While the composing event is interesting, the concept of a session-level state can be extended to answer a variety of questions about the participation of a person in a real-time chat conversation, such as:</p>
+  <ul>
+    <li>Has this person paused the composition?</li>
+    <li>Is this person actively paying attention to the chat?</li>
+    <li>Is this person temporarily inactive (i.e., not paying attention right now)?</li>
+    <li>Is this person simply gone (i.e., no longer participating in the chat)?</li>
+  </ul>
+  <p class="" style="">To answer such questions, this JEP supplements the traditional composing state by defining four additional chat states (paused, active, inactive, gone), for a total of five states that (it is hoped) together fully describe the possible states of a person's participation in or involvement with a chat conversation.  [<a href="#nt-id2250514">2</a>]</p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user "loses" a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to "away"), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">Chat state notifications can appear in two kinds of &lt;message/&gt; stanzas:</p>
+  <ul>
+    <li>A "content message" -- that is, a message stanza that contains standard messaging content such as the &lt;body/&gt;, &lt;subject/&gt;, and &lt;thread/&gt; child elements defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2255540">3</a>] and/or any other properly-namespaced child element(s).</li>
+    <li>A "standalone notification" -- that is, a message stanza that does not contain standard messaging content but instead is intended to specify only the chat state since it contains only a child element qualified by the "http://jabber.org/protocol/chatstates" namespace (or possibly also the XMPP &lt;thread/&gt; element; see the <a href="#bizrules-threads">Threads</a> section below).</li>
+  </ul>
+  <p class="" style="">The five chat states specified in this document are described below. The suggested triggers and state changes are simply that: suggestions. It is up to the implementation to determine when to generate chat state notifications and which notifications to generate.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+      <th colspan="" rowspan="">Suggested State Changes</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+      <td align="" colspan="" rowspan="">User is actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User accepts an initial content message, sends a content message, gives focus to the chat interface, or is otherwise paying attention to the conversation.</td>
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;, &lt;composing/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+      <td align="" colspan="" rowspan="">User is composing a message.</td>
+      <td align="" colspan="" rowspan="">User interacts with a message input interface specific to this chat session (e.g., types in the input area of a chat window).</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;paused/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped.</td>
+      <td align="" colspan="" rowspan="">User was composing but stops interacting with the input interface for a short period of time (e.g., 5 seconds) or starts interacting with another chat interface or application.</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;composing/&gt;, &lt;inactive/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User does not interact with the chat interface for an intermediate period of time (e.g., 30 seconds), minimizes the chat interface, or starts interacting with another chat interface or application.</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;gone/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session.</td>
+      <td align="" colspan="" rowspan="">User terminates the chat interface (e.g., closes a chat window) or does not interact with the chat interface, system, or device for a long period of time (e.g., 2 minutes).</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to the GONE state.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <p class="" style="">In the absence of explicit negotiation of a one-to-one chat session between a User and Contact (e.g., as specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2255882">4</a>]) or explicit discovery by the User of the Contact's capabilities (e.g., as gained through <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255906">5</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2255931">6</a>]), the following business rules apply to the use of chat state notifications in the context of one-to-one chat sessions:</p>
+    <ol start="1" type="">
+      <li>If the User desires chat state notifications, the initial content message sent to the Contact MUST contain a chat state notification extension, which SHOULD be &lt;active/&gt;.</li>
+      <li>Until receiving a reply to the initial content message (or a standalone notification) from the Contact, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial content message but does not include a chat state notification extension, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial content message and includes an &lt;active/&gt; notification (or sends a standalone notification to the User), the User and Contact SHOULD send subsequent notifications for supported chat states (as specified in the next subsection) by including an &lt;active/&gt; notification in each content message and sending standalone notifications for the chat states they support (at a minimum, the &lt;composing/&gt; state).</li>
+    </ol>
+    <p class="" style="">The foregoing rules imply that the sending of chat state notifications is bidirectional (i.e., both User and Contact will either send or not send chat state notifications) rather than unidirectional (i.e., one of the conversation partners will send chat state notifications but the other will not); this is intentional.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications.</p>
+    <p class="" style="">Note: Support for only &lt;active/&gt; and &lt;composing/&gt; is functionally equivalent to supporting the Composing event from <span style="font-weight: bold">JEP-0022</span>.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-rep">Repetition</a>
+</h3>
+    <p class="" style="">Even if the user types continuously for a long time (e.g., while composing a lengthy reply), the client MUST NOT send more than one standalone &lt;composing/&gt; notification in a row. More generally, a client MUST NOT send a second instance of any given standalone notification (i.e., a standalone notification MUST be followed by a different state, not repetition of the same state). However, every content message SHOULD contain an &lt;active/&gt; notification.</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than "chat" or "groupchat".</li>
+      <li>The 'type' attribute for content messages and standalone notifications SHOULD be set to a value of "chat" (for one-to-one sessions) or "groupchat" (for many-to-many sessions).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <p class="" style="">Chat state notifications MAY be sent in the context of groupchat rooms (e.g., as defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256383">7</a>]). The following business rules apply:</p>
+    <ol start="" type="">
+      <li>A client MAY send chat state notifications even if not all room occupants do so.</li>
+      <li>A client SHOULD NOT generate &lt;gone/&gt; notifications.</li>
+      <li>A client SHOULD ignore &lt;gone/&gt; notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A message stanza MUST NOT contain more than one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace.</li>
+      <li>A message stanza that contains standard messaging content -- i.e., the &lt;body/&gt;, &lt;subject/&gt;, and &lt;thread/&gt; child elements defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256454">8</a>] and/or any other properly-namespaced child element(s) -- SHOULD NOT contain a chat state notification extension other than &lt;active/&gt;.</li>
+      <li>A message stanza that does not contain standard messaging content and is intended to specify only the chat state MUST NOT contain any child elements other than the chat state notification extension, which SHOULD be a state other than &lt;active/&gt;; however, if threads are used (see below) then the standalone notification MUST also contain the &lt;thread/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if all of the clients participating in a chat both support and use threads, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a &lt;gone/&gt; event.</li>
+      <li>Upon receiving a &lt;gone/&gt; event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers in constrained network environments (e.g., serving small-footprint clients via <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2256578">9</a>] or <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2256601">10</a>]) and services that rebroadcast message stanzas (e.g., Multi-User Chat services) MAY process standalone notifications differently from other messages. In particular, a server or service MAY refuse to deliver standalone notifications to its users, and SHOULD NOT store them offline. In contrast to <span style="font-weight: bold">JEP-0022</span>, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Content Message With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point Juliet's client knows that Romeo's client supports chat state notifications. Thus she replies to the initial content message and her client includes a notification that her state is &lt;active/&gt;:</p>
+  <p class="caption">Example 6. Contact's Client Sends Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so the conversation continues. After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of &lt;paused/&gt;.</p>
+  <p class="caption">Example 8. User's Client Sends Standalone &lt;paused/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a &lt;composing/&gt; notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet minimizes the chat window, so her client generates an &lt;inactive/&gt; notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends Standalone &lt;inactive/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an &lt;active/&gt; notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends Standalone &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet closes the chat window, so her client generates a &lt;gone/&gt; notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends Standalone &lt;gone/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo's client now considers the chat thread to be over and generates a new Thread ID when he sends a new message:</p>
+  <p class="caption">Example 16. User's Client Sends Content Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an &lt;active/&gt; notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client that receives a chat state notification should expect that it may never receive another message or chat state notification from the other entity (e.g., because the other entity crashes or goes offline) and should plan accordingly.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257071">11</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257121">12</a>] shall include 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250467">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2250514">2</a>. These states do not necessarily refer to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+<p><a name="nt-id2255540">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255882">4</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2255906">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255931">6</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256383">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256454">8</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256578">9</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2256601">10</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2257071">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257121">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.14 (2005-07-20)</h4>
+<div class="indent">Clarified terminology; specified suggested state changes; removed section on superseding JEP-0022. (psa)
+    </div>
+<h4>Version 0.13 (2005-07-19)</h4>
+<div class="indent">Further clarified business rules regarding generation of notifications. (psa)
+    </div>
+<h4>Version 0.12 (2005-07-15)</h4>
+<div class="indent">Clarified business rules regarding generation of notifications; added reference to JEP-0155; rewrote introduction; moved previous introductory text to section on superseding JEP-0022. (psa)
+    </div>
+<h4>Version 0.11 (2005-07-05)</h4>
+<div class="indent">Removed &lt;initial/&gt; state. (psa)
+    </div>
+<h4>Version 0.10 (2005-06-28)</h4>
+<div class="indent">Added optional &lt;initial/&gt; state; added business rule on repetition of notifications; added implementation note. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-28)</h4>
+<div class="indent">Made &lt;inactive/&gt; state definition consistent with &lt;paused/&gt; per list discussion; made slight adjustments to wording throughout. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the &lt;gone/&gt; state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added &lt;paused/&gt; state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be "chat" or "groupchat" for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made &lt;inactive/&gt; and &lt;gone/&gt; states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.6.html
+++ b/content/xep-0085-0.6.html
@@ -1,0 +1,548 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="A standards-track proposal for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-02-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>A standards-track proposal for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.6<br>
+            Last Updated: 2004-02-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br>
+</p>
+<h2>Author Information</h2>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2596063">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596111">Definitions</a>
+</dt>
+<dt>3.  <a href="#sect-id2601932">State Chart</a>
+</dt>
+<dt>4.  <a href="#sect-id2601956">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#sect-id2601970">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#sect-id2602026">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#sect-id2602192">Context of Usage</a>
+</dt>
+<dt>4.4.  <a href="#sect-id2602236">Use in Groupchat</a>
+</dt>
+<dt>4.5.  <a href="#sect-id2602294">Syntax of Notifications</a>
+</dt>
+<dt>4.6.  <a href="#sect-id2602332">Threads</a>
+</dt>
+<dt>4.7.  <a href="#sect-id2602392">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sect-id2602420">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#sect-id2602506">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#sect-id2602848">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2602874">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#sect-id2602892">Jabber Registrar Considerations</a>
+</dt>
+<dt>10.  <a href="#sect-id2602912">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2596063">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Message Events</span>  [<a href="#nt-id2596176">1</a>] protocol was an early attempt to define notifications related to message processing and composing events. However, it is informational only and has the following drawbacks:</p>
+  <ol start="" type="">
+    <li>Message events are used both to communicate the state of one's conversation partner (the composing event) and to track message delivery states (the offline storage, delivery, and display events); this is confusing, especially since message delivery states are now more fully defined by <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2596275">2</a>], which in part supersedes message events.</li>
+    <li>Message events can be generated either by a client or by a server, and the sender must depend on the recipient's server in order to receive notification of certain events; this introduces an unnecessary dependency.</li>
+    <li>Message events must be requested on a per-message basis; this is not only verbose but unnecessary in the context of most chat conversations, and requires implementations to maintain a more complex state machine than is desirable.</li>
+    <li>The connection between the 'id' attribute and the &lt;id/&gt; element has traditionally been difficult for developers to understand; this has led to a large number of non-compliant implementations.</li>
+    <li>The necessity for cancelling previously-generated composing events is introduced because the protocol does not define a complete state chart for chat conversations; this is not only incomplete but confusing.</li>
+  </ol>
+  <p class="" style="">This proposal attempts to address those concerns and to provide a protocol that can be accepted as a standard by the Jabber Software Foundation.</p>
+<h2>2.
+       <a name="sect-id2596111">Definitions</a>
+</h2>
+  <p class="" style="">This proposal supplements the traditional &quot;is-composing&quot; state by defining four additional chat states, for a total of five states that together fully describe the possible states for a chat conversation. These states refer to a user's participation in the chat session, not necessarily to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user &quot;loses&quot; a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing to &quot;away&quot;), but the user's state with regard to the chat might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">The five chat states addressed in this document are described below. The suggested triggers are simply that: suggestions. It is up to the implementation to determine its own rules for generation of chat state notifications.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">ACTIVE</td>
+      <td align="" colspan="" rowspan="">User is participating in the chat session</td>
+      <td align="" colspan="" rowspan="">User accepts initial chat message, sends a message, or is otherwise paying attention to the chat interface</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">COMPOSING</td>
+      <td align="" colspan="" rowspan="">User is currently composing a message</td>
+      <td align="" colspan="" rowspan="">User interaction with the input interface specific to this chat session (e.g., typing in an input area)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">PAUSED</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped</td>
+      <td align="" colspan="" rowspan="">Lack of user interaction with the input interface for a short period (e.g., 15 seconds)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">INACTIVE</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session</td>
+      <td align="" colspan="" rowspan="">Lack of user interaction with the chat interface for a longer period (e.g., 2 minutes)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">GONE</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session</td>
+      <td align="" colspan="" rowspan="">Lack of user interaction with the chat interface, system, or device for a long period (e.g., 10 minutes)</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="sect-id2601932">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form (all four of the states shown may transition to GONE).</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+
+  </pre></div>
+<h2>4.
+       <a name="sect-id2601956">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="sect-id2601970">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A User MUST NOT notify a Contact of any chat state other than Active until the User has discovered that the Contact supports this protocol (the same is true of the Contact).</li>
+      <li>If the User desires chat state notifications, the initial message MUST contain an Active notification.</li>
+      <li>The Contact MUST NOT send any chat state notifications to the User (e.g., a composing event) before sending a reply to the User's initial message in the conversation; the only allowable chat state notification in the initial reply is the Active notification.</li>
+      <li>If the Contact replies to the initial message but does not include an Active notification, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message and includes an Active notification, the Contact SHOULD send subsequent notifications for supported chat states as specified in the next subsection.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="sect-id2602026">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Active</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Composing</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Paused</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Inactive</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Gone</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="sect-id2602192">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than &quot;chat&quot; or &quot;groupchat&quot;.</li>
+      <li>The 'type' attribute for chat state notification messages SHOULD be set to a value of &quot;chat&quot; or &quot;groupchat&quot; (as appropriate for the context).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner).</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="sect-id2602236">Use in Groupchat</a>
+</h3>
+    <ol start="" type="">
+      <li>In the context of groupchat (e.g., as defined in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602273">3</a>]), a client SHOULD NOT generate Gone notifications, and SHOULD ignore Gone notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">NOTE: use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="sect-id2602294">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>Chat state notification messages MUST contain one and only one element qualified by the 'http://jabber.org/protocol/chatstates' namespace.</li>
+      <li>A Composing notification message MUST NOT contain a &lt;subject/&gt; element or a &lt;body/&gt; element (i.e., it MUST be &quot;standalone&quot;).</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="sect-id2602332">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if threads are used, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a Gone event.</li>
+      <li>Upon receiving a Gone event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="sect-id2602392">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers and services that handle or rebroadcast message stanzas may want to process chat state notification messages differently from other messages. In particular, a server or service MAY refuse to deliver standalone chat state notifications to its users, and SHOULD NOT store them offline. In contrast to the Message Events protocol, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="sect-id2602420">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Message With Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Reply Plus Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Reply With Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="sect-id2602506">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point the Contact's client knows that the User's client supports chat state notifications. Thus the Contact replies to the initial message, including a notification that the Contact's state is Active:</p>
+  <p class="caption">Example 6. Contact's Client Sends Reply Plus Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of Paused.</p>
+  <p class="caption">Example 8. User's Client Sends Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a Composing notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because Juliet is away from the chat interface for a while, her client (optionally) generates an Inactive notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends Inactive Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an Active notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Now Juliet is away from the chat window for a longer time, and her client generates a Gone notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends Gone Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The User's client now considers the chat thread to be over and generates a new thread:</p>
+  <p class="caption">Example 16. User's Client Sends Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an Active notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="sect-id2602848">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>8.
+       <a name="sect-id2602874">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602992">4</a>].</p>
+<h2>9.
+       <a name="sect-id2602892">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'http://jabber.org/protocol/chatstates' namespace shall be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602934">5</a>] as a result of this JEP.</p>
+<h2>10.
+       <a name="sect-id2602912">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596176">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596275">2</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602273">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602992">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602934">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added Paused state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be &quot;chat&quot; or &quot;groupchat&quot; for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made Inactive and Gone states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.7.html
+++ b/content/xep-0085-0.7.html
@@ -1,0 +1,558 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="A standards-track proposal for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>A standards-track proposal for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.7<br>
+            Last Updated: 2004-10-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0022<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br>
+</p>
+<h2>Author Information</h2>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Message Events</span>  [<a href="#nt-id2596290">1</a>] protocol was an early attempt to define notifications related to message processing and composing events. However, it is informational only and has the following drawbacks:</p>
+  <ol start="" type="">
+    <li>Message events are used both to communicate the state of one's conversation partner (the composing event) and to track message delivery states (the offline storage, delivery, and display events); this is confusing, especially since message delivery states are now more fully defined by <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2596385">2</a>], which in part supersedes message events.</li>
+    <li>Message events can be generated either by a client or by a server, and the sender must depend on the recipient's server in order to receive notification of certain events; this introduces an unnecessary dependency.</li>
+    <li>Message events must be requested on a per-message basis; this is not only verbose but unnecessary in the context of most chat conversations, and requires implementations to maintain a more complex state machine than is desirable.</li>
+    <li>The connection between the 'id' attribute and the &lt;id/&gt; element has traditionally been difficult for developers to understand; this has led to a large number of non-compliant implementations.</li>
+    <li>The necessity for cancelling previously-generated composing events is introduced because the protocol does not define a complete state chart for chat conversations; this is not only incomplete but confusing.</li>
+    <li>There is no message event indicating that the chat session should be considered finished.</li>
+  </ol>
+  <p class="" style="">This proposal attempts to address those issues and to provide a protocol that can be accepted as a standard by the Jabber Software Foundation.</p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">This proposal supplements the traditional &quot;is-composing&quot; state by defining four additional chat states, for a total of five states that together fully describe the possible states for a chat conversation. These states refer to a user's participation in the chat session, not necessarily to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user &quot;loses&quot; a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to &quot;away&quot;), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">The five chat states addressed in this document are described below. The suggested triggers are simply that: suggestions. It is up to the implementation to determine its own rules for generation of chat state notifications.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">ACTIVE</td>
+      <td align="" colspan="" rowspan="">User is participating in the chat session</td>
+      <td align="" colspan="" rowspan="">User accepts initial chat message, sends a message, or is otherwise paying attention to the chat interface</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">COMPOSING</td>
+      <td align="" colspan="" rowspan="">User is currently composing a message</td>
+      <td align="" colspan="" rowspan="">User interacts with an input interface specific to this chat session (e.g., types in the input area of a chat window)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">PAUSED</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped</td>
+      <td align="" colspan="" rowspan="">User does not interact with the input interface for a short period (e.g., 10 seconds)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">INACTIVE</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session</td>
+      <td align="" colspan="" rowspan="">User does not interact with the chat interface for a longer period (e.g., 30 seconds)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">GONE</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session</td>
+      <td align="" colspan="" rowspan="">User terminates the chat interface (e.g., closes a chat window) or does not interact with the chat interface, system, or device for a long period (e.g., 2 minutes)</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to GONE.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A User MUST NOT notify a Contact of any chat state other than Active until the User has discovered that the Contact supports this protocol (the same is true of the Contact).</li>
+      <li>If the User desires chat state notifications, the initial message MUST contain an Active notification.</li>
+      <li>The Contact MUST NOT send any chat state notifications to the User (e.g., a composing event) before sending a reply to the User's initial message in the conversation; the only allowable chat state notification in the initial reply is the Active notification.</li>
+      <li>If the Contact replies to the initial message but does not include an Active notification, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message and includes an Active notification, the Contact SHOULD send subsequent notifications for supported chat states as specified in the next subsection.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Active</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Composing</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Paused</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Inactive</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Gone</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than &quot;chat&quot; or &quot;groupchat&quot;.</li>
+      <li>The 'type' attribute for chat state notification messages SHOULD be set to a value of &quot;chat&quot; or &quot;groupchat&quot; (as appropriate for the context).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <ol start="" type="">
+      <li>In the context of groupchat (e.g., as defined in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602417">3</a>]), a client SHOULD NOT generate Gone notifications, and SHOULD ignore Gone notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>Chat state notification messages MUST contain one and only one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace.</li>
+      <li>A Composing notification message MUST NOT contain a &lt;subject/&gt; element or a &lt;body/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if threads are used, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a Gone event.</li>
+      <li>Upon receiving a Gone event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Services that rebroadcast message stanzas (e.g., Multi-User Chat services) may want to process chat state notification messages differently from other messages. In particular, a service MAY refuse to deliver standalone chat state notifications to its users, and SHOULD NOT store them offline. In contrast to the Message Events protocol, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Message With Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Reply Plus Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Reply With Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point the Contact's client knows that the User's client supports chat state notifications. Thus the Contact replies to the initial message, including a notification that the Contact's state is Active:</p>
+  <p class="caption">Example 6. Contact's Client Sends Reply Plus Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of Paused.</p>
+  <p class="caption">Example 8. User's Client Sends Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a Composing notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because Juliet is away from the chat interface for a while, her client (optionally) generates an Inactive notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends Inactive Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an Active notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Now Juliet is away from the chat window for a longer time, and her client generates a Gone notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends Gone Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The User's client now considers the chat thread to be over and generates a new thread:</p>
+  <p class="caption">Example 16. User's Client Sends Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an Active notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603134">4</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603081">5</a>] shall include 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596290">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596385">2</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602417">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603134">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603081">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the Gone state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added Paused state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be &quot;chat&quot; or &quot;groupchat&quot; for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made Inactive and Gone states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.8.html
+++ b/content/xep-0085-0.8.html
@@ -1,0 +1,561 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="A standards-track proposal for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>A standards-track proposal for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.8<br>
+            Last Updated: 2004-10-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0022<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br>
+</p>
+<h2>Author Information</h2>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Message Events</span>  [<a href="#nt-id2596312">1</a>] protocol was an early attempt to define notifications related to message processing and composing events. However, it is informational only and has the following drawbacks:</p>
+  <ol start="" type="">
+    <li>Message events are used both to communicate the state of one's conversation partner (the composing event) and to track message delivery states (the offline storage, delivery, and display events); this is confusing, especially since message delivery states are now more fully defined by <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2596344">2</a>], which in part supersedes message events.</li>
+    <li>Message events can be generated either by a client or by a server, and the sender must depend on the recipient's server in order to receive notification of certain events; this introduces an unnecessary dependency.</li>
+    <li>Message events must be requested on a per-message basis; this is not only verbose but unnecessary in the context of most chat conversations, and requires implementations to maintain a more complex state machine than is desirable.</li>
+    <li>The connection between the 'id' attribute and the &lt;id/&gt; element has traditionally been difficult for developers to understand; this has led to a large number of non-compliant implementations.</li>
+    <li>The necessity for cancelling previously-generated composing events is introduced because the protocol does not define a complete state chart for chat conversations; this is not only incomplete but confusing.</li>
+    <li>There is no message event indicating that the chat session should be considered finished.</li>
+  </ol>
+  <p class="" style="">This proposal attempts to address those issues and to provide a protocol that can be accepted as a standard by the Jabber Software Foundation.</p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">This proposal supplements the traditional &quot;is-composing&quot; state by defining four additional chat states, for a total of five states that together fully describe the possible states for a chat conversation. These states refer to a user's participation in the chat session, not necessarily to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user &quot;loses&quot; a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to &quot;away&quot;), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">The five chat states addressed in this document are described below. The suggested triggers are simply that: suggestions. It is up to the implementation to determine its own rules for generation of chat state notifications.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">ACTIVE</td>
+      <td align="" colspan="" rowspan="">User is participating in the chat session</td>
+      <td align="" colspan="" rowspan="">User accepts initial chat message, sends a message, or is otherwise paying attention to the chat interface</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">COMPOSING</td>
+      <td align="" colspan="" rowspan="">User is currently composing a message</td>
+      <td align="" colspan="" rowspan="">User interacts with an input interface specific to this chat session (e.g., types in the input area of a chat window)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">PAUSED</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped</td>
+      <td align="" colspan="" rowspan="">User was composing but stops interacting with the input interface for a short period of time (e.g., 5 seconds) or starts interacting with another chat interface or application</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">INACTIVE</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session</td>
+      <td align="" colspan="" rowspan="">User does not interact with the chat interface for an intermediate period of time (e.g., 30 seconds)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">GONE</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session</td>
+      <td align="" colspan="" rowspan="">User terminates the chat interface (e.g., closes a chat window) or does not interact with the chat interface, system, or device for a long period of time (e.g., 2 minutes)</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to GONE.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A User MUST NOT notify a Contact of any chat state other than Active until the User has discovered that the Contact supports this protocol (the same is true of the Contact).</li>
+      <li>If the User desires chat state notifications, the initial message MUST contain an Active notification.</li>
+      <li>The Contact MUST NOT send any chat state notifications to the User (e.g., a composing event) before sending a reply to the User's initial message in the conversation; the only allowable chat state notification in the initial reply is the Active notification.</li>
+      <li>If the Contact replies to the initial message but does not include an Active notification, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message and includes an Active notification, the Contact SHOULD send subsequent notifications for supported chat states as specified in the next subsection.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Active</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Composing</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Paused</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Inactive</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Gone</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than &quot;chat&quot; or &quot;groupchat&quot;.</li>
+      <li>The 'type' attribute for chat state notification messages SHOULD be set to a value of &quot;chat&quot; or &quot;groupchat&quot; (as appropriate for the context).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <ol start="" type="">
+      <li>In the context of groupchat (e.g., as defined in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602441">3</a>]), a client SHOULD NOT generate Gone notifications, and SHOULD ignore Gone notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>Chat state notification messages MUST contain one and only one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace.</li>
+      <li>A Composing notification message MUST NOT contain a &lt;subject/&gt; element or a &lt;body/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if threads are used, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a Gone event.</li>
+      <li>Upon receiving a Gone event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Services that rebroadcast message stanzas (e.g., Multi-User Chat services) may want to process chat state notification messages differently from other messages. In particular, a service MAY refuse to deliver standalone chat state notifications to its users, and SHOULD NOT store them offline. In contrast to the Message Events protocol, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Message With Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Reply Plus Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Reply With Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point the Contact's client knows that the User's client supports chat state notifications. Thus the Contact replies to the initial message, including a notification that the Contact's state is Active:</p>
+  <p class="caption">Example 6. Contact's Client Sends Reply Plus Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of Paused.</p>
+  <p class="caption">Example 8. User's Client Sends Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a Composing notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends Composing Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because Juliet is away from the chat interface for a while, her client (optionally) generates an Inactive notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends Inactive Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an Active notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends Active Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Now Juliet is away from the chat window for a longer time, and her client generates a Gone notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends Gone Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The User's client now considers the chat thread to be over and generates a new thread:</p>
+  <p class="caption">Example 16. User's Client Sends Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an Active notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603157">4</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603105">5</a>] shall include 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596312">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596344">2</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602441">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603157">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603105">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the Gone state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added Paused state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be &quot;chat&quot; or &quot;groupchat&quot; for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made Inactive and Gone states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-0.9.html
+++ b/content/xep-0085-0.9.html
@@ -1,0 +1,567 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>This JEP defines a standards-track protocol for communicating notifications related to chat states, including message composing events.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 0.9<br>
+            Last Updated: 2004-10-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0022<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Message Events</span>  [<a href="#nt-id2596341">1</a>] protocol was an early attempt to define notifications related to message processing and composing events. However, it is informational only and has the following drawbacks:</p>
+  <ol start="" type="">
+    <li>Message events are used both to communicate the state of one's conversation partner (the composing event) and to track message delivery states (the offline storage, delivery, and display events); this is confusing, especially since message delivery states are now more fully defined by <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2596381">2</a>], which in part supersedes JEP-0022.</li>
+    <li>Message events can be generated either by a client or by a server, and the sender must depend on the recipient's server in order to receive notification of certain events; this introduces an unnecessary dependency.</li>
+    <li>Message events must be requested on a per-message basis; this is not only verbose but unnecessary in the context of most chat conversations, and requires implementations to maintain a more complex state machine than is desirable.</li>
+    <li>The connection between the 'id' attribute and the &lt;id/&gt; element has traditionally been difficult for developers to understand; this has led to a large number of non-compliant implementations.</li>
+    <li>The necessity for cancelling previously-generated composing events is introduced because the protocol does not define a complete state chart for chat conversations; this is not only incomplete but confusing.</li>
+    <li>There is no message event indicating that the chat session should be considered inactive or finished.</li>
+  </ol>
+  <p class="" style="">This proposal attempts to address those issues and to provide a protocol that can be accepted as a standard by the Jabber Software Foundation.</p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">This proposal supplements the traditional &quot;is-composing&quot; state by defining four additional chat states, for a total of five states that together fully describe the possible states for a chat conversation. These states refer to a user's participation in the chat session, not necessarily to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user &quot;loses&quot; a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to &quot;away&quot;), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">The five chat states addressed in this document are described below. The suggested triggers are simply that: suggestions. It is up to the implementation to determine its own rules for generation of chat state notifications.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+      <td align="" colspan="" rowspan="">User is actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User accepts initial chat message, sends a message, gives focus to the chat interface, or is otherwise paying attention to the conversation.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+      <td align="" colspan="" rowspan="">User is composing a message.</td>
+      <td align="" colspan="" rowspan="">User interacts with an input interface specific to this chat session (e.g., types in the input area of a chat window).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped.</td>
+      <td align="" colspan="" rowspan="">User was composing but stops interacting with the input interface for a short period of time (e.g., 5 seconds) or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+      <td align="" colspan="" rowspan="">User is not actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User does not interact with the chat interface for an intermediate period of time (e.g., 30 seconds), minimizes the chat interface, or starts interacting with another chat interface or application.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+      <td align="" colspan="" rowspan="">User has ended their participation in the chat session.</td>
+      <td align="" colspan="" rowspan="">User terminates the chat interface (e.g., closes a chat window) or does not interact with the chat interface, system, or device for a long period of time (e.g., 2 minutes).</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to the GONE state.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A User MUST NOT notify a Contact of any chat state other than &lt;active/&gt; until the User has discovered that the Contact supports this protocol (the same is true of the Contact).</li>
+      <li>If the User desires chat state notifications, the initial message MUST contain an &lt;active/&gt; notification.</li>
+      <li>The Contact MUST NOT send any chat state notifications to the User (e.g., a composing event) before sending a reply to the User's initial message in the conversation; the only allowable chat state notification in the initial reply is the &lt;active/&gt; notification.</li>
+      <li>If the Contact replies to the initial message but does not include an &lt;active/&gt; notification, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial message and includes an &lt;active/&gt; notification, the Contact SHOULD send subsequent notifications for supported chat states as specified in the next subsection.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications. (Note: Support for only &lt;active/&gt; and &lt;composing/&gt; is functionally equivalent to supporting JEP-0022.)</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than &quot;chat&quot; or &quot;groupchat&quot;.</li>
+      <li>The 'type' attribute for chat state notification messages SHOULD be set to a value of &quot;chat&quot; or &quot;groupchat&quot; (as appropriate for the context).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <ol start="" type="">
+      <li>In the context of groupchat (e.g., as defined in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602504">3</a>]), a client SHOULD NOT generate &lt;gone/&gt; notifications, and SHOULD ignore &lt;gone/&gt; notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>Chat state notification messages MUST contain one and only one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace.</li>
+      <li>A &lt;composing/&gt; notification message MUST NOT contain a &lt;subject/&gt; element or a &lt;body/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if threads are used, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a &lt;gone/&gt; event.</li>
+      <li>Upon receiving a &lt;gone/&gt; event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers in constrained network environments (e.g., serving small-footprint clients via <span class="ref">Jabber HTTP Polling</span>  [<a href="#nt-id2602743">4</a>] or <span class="ref">HTTP Binding</span>  [<a href="#nt-id2602764">5</a>]) and services that rebroadcast message stanzas (e.g., Multi-User Chat services) MAY process chat state notification messages differently from other messages. In particular, a server or service MAY refuse to deliver standalone chat state notifications to its users, and SHOULD NOT store them offline. In contrast to the Message Events protocol, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Message With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point Juliet's client knows that Romeo's client supports chat state notifications. Thus she replies to the initial message and her client includes a notification that her state is &lt;active/&gt;:</p>
+  <p class="caption">Example 6. Contact's Client Sends Reply Plus &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so the conversation continues. After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of &lt;paused/&gt;.</p>
+  <p class="caption">Example 8. User's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a &lt;composing/&gt; notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet minimizes the chat window, so her client generates an &lt;inactive/&gt; notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends &lt;inactive/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an &lt;active/&gt; notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet closes the chat window, so her client generates a &lt;gone/&gt; notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends &lt;gone/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo's client now considers the chat thread to be over and generates a new Thread ID when he sends a new message:</p>
+  <p class="caption">Example 16. User's Client Sends Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an &lt;active/&gt; notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603285">6</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603233">7</a>] shall include 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596341">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596381">2</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602504">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602743">4</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602764">5</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603285">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603233">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2004-10-28)</h4>
+<div class="indent">Made &lt;inactive/&gt; state definition consistent with &lt;paused/&gt; per list discussion; made slight adjustments to wording throughout. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the &lt;gone/&gt; state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added &lt;paused/&gt; state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be &quot;chat&quot; or &quot;groupchat&quot; for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made &lt;inactive/&gt; and &lt;gone/&gt; states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-1.0.html
+++ b/content/xep-0085-1.0.html
@@ -1,0 +1,626 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating the status of a person in a chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-09-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>This JEP defines a protocol for communicating the status of a person in a chat session.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 1.1<br>
+            Last Updated: 2005-09-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/chatstates/chatstates.xsd">http://jabber.org/protocol/chatstates/chatstates.xsd</a>&gt;<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-rep">Repetition</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.8.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many instant messaging systems include notifications about the state of one's conversation partner in a one-to-one chat (or, sometimes, in a many-to-many chat). Usually these are limited to notification that one's partner is currently typing -- e.g., the Composing event in <span style="font-weight: bold">JEP-0022</span> (see <span class="ref" style="">Message Events</span>  [<a href="#nt-id2250513">1</a>]). However, a composing event is essentially information about a person's participation in or involvement with the chat "session" and therefore is really a session-level state rather than a per-message event -- e.g., the Delivered and Displayed events in <span style="font-weight: bold">JEP-0022</span>. While the composing event is interesting, the concept of a session-level state can be extended to answer a variety of questions about the participation of a person in a real-time chat conversation, such as:</p>
+  <ul>
+    <li>Has this person paused the composition?</li>
+    <li>Is this person actively paying attention to the chat?</li>
+    <li>Is this person temporarily inactive (i.e., not paying attention right now)?</li>
+    <li>Is this person simply gone (i.e., no longer participating in the chat)?</li>
+  </ul>
+  <p class="" style="">To answer such questions, this JEP supplements the traditional composing state by defining four additional chat states (paused, active, inactive, gone), for a total of five states that (it is hoped) together fully describe the possible states of a person's participation in or involvement with a chat conversation.  [<a href="#nt-id2250559">2</a>]</p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user "loses" a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to "away"), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">Chat state notifications can appear in two kinds of &lt;message/&gt; stanzas:</p>
+  <ul>
+    <li>A "content message" -- that is, a message stanza that contains standard messaging content such as the &lt;body/&gt;, &lt;subject/&gt;, and &lt;thread/&gt; child elements defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2255887">3</a>] and/or any other properly-namespaced child element(s).</li>
+    <li>A "standalone notification" -- that is, a message stanza that does not contain standard messaging content but instead is intended to specify only the chat state since it contains only a child element qualified by the "http://jabber.org/protocol/chatstates" namespace (or possibly also the XMPP &lt;thread/&gt; element; see the <a href="#bizrules-threads">Threads</a> section below).</li>
+  </ul>
+  <p class="" style="">The five chat states specified in this document are described below. The suggested triggers and state changes are simply that: suggestions. It is up to the implementation to determine when to generate chat state notifications and which notifications to generate.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+      <th colspan="" rowspan="">Suggested State Changes</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+      <td align="" colspan="" rowspan="">User is actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User accepts an initial content message, sends a content message, gives focus to the chat interface, or is otherwise paying attention to the conversation.</td>
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;, &lt;composing/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+      <td align="" colspan="" rowspan="">User is composing a message.</td>
+      <td align="" colspan="" rowspan="">User is interacting with a message input interface specific to this chat session (e.g., by typing in the input area of a chat window).</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;paused/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped.</td>
+      <td align="" colspan="" rowspan="">User was composing but has not interacted with the message input interface for a short period of time (e.g., 5 seconds).  [<a href="#nt-id2256066">4</a>]</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;composing/&gt;, &lt;inactive/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+      <td align="" colspan="" rowspan="">User has not been actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User has not interacted with the chat interface for an intermediate period of time (e.g., 30 seconds).</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;gone/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+      <td align="" colspan="" rowspan="">User has effectively ended their participation in the chat session.</td>
+      <td align="" colspan="" rowspan="">User has not interacted with the chat interface, system, or device for a relatively long period of time (e.g., 2 minutes), or has terminated the chat interface (e.g., by closing the chat window).</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to the GONE state.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <p class="" style="">In the absence of explicit negotiation of a one-to-one chat session between a User and Contact (e.g., as specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2256239">5</a>]) or explicit discovery by the User of the Contact's capabilities (e.g., as gained through <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256263">6</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256288">7</a>]), the following business rules apply to the use of chat state notifications in the context of one-to-one chat sessions:</p>
+    <ol start="1" type="">
+      <li>If the User desires chat state notifications, the initial content message sent to the Contact MUST contain a chat state notification extension, which SHOULD be &lt;active/&gt;.</li>
+      <li>Until receiving a reply to the initial content message (or a standalone notification) from the Contact, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial content message but does not include a chat state notification extension, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial content message and includes an &lt;active/&gt; notification (or sends a standalone notification to the User), the User and Contact SHOULD send subsequent notifications for supported chat states (as specified in the next subsection) by including an &lt;active/&gt; notification in each content message and sending standalone notifications for the chat states they support (at a minimum, the &lt;composing/&gt; state).</li>
+    </ol>
+    <p class="" style="">The foregoing rules imply that the sending of chat state notifications is bidirectional (i.e., both User and Contact will either send or not send chat state notifications) rather than unidirectional (i.e., one of the conversation partners will send chat state notifications but the other will not); this is intentional.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications.</p>
+    <p class="" style="">Note: Support for only &lt;active/&gt; and &lt;composing/&gt; is functionally equivalent to supporting the Composing event from <span style="font-weight: bold">JEP-0022</span>.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-rep">Repetition</a>
+</h3>
+    <p class="" style="">Even if the user types continuously for a long time (e.g., while composing a lengthy reply), the client MUST NOT send more than one standalone &lt;composing/&gt; notification in a row. More generally, a client MUST NOT send a second instance of any given standalone notification (i.e., a standalone notification MUST be followed by a different state, not repetition of the same state). However, every content message SHOULD contain an &lt;active/&gt; notification.</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than "chat" or "groupchat".</li>
+      <li>The 'type' attribute for content messages and standalone notifications SHOULD be set to a value of "chat" (for one-to-one sessions) or "groupchat" (for many-to-many sessions).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <p class="" style="">Chat state notifications MAY be sent in the context of groupchat rooms (e.g., as defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256606">8</a>]). The following business rules apply:</p>
+    <ol start="" type="">
+      <li>A client MAY send chat state notifications even if not all room occupants do so.</li>
+      <li>A client SHOULD NOT generate &lt;gone/&gt; notifications.</li>
+      <li>A client SHOULD ignore &lt;gone/&gt; notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A message stanza MUST NOT contain more than one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace.</li>
+      <li>A message stanza that contains standard messaging content -- i.e., the &lt;body/&gt;, &lt;subject/&gt;, and &lt;thread/&gt; child elements defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256674">9</a>] and/or any other properly-namespaced child element(s) -- SHOULD NOT contain a chat state notification extension other than &lt;active/&gt;.</li>
+      <li>A message stanza that does not contain standard messaging content and is intended to specify only the chat state MUST NOT contain any child elements other than the chat state notification extension, which SHOULD be a state other than &lt;active/&gt;; however, if threads are used (see below) then the standalone notification MUST also contain the &lt;thread/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if all of the clients participating in a chat both support and use threads, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a &lt;gone/&gt; event.</li>
+      <li>Upon receiving a &lt;gone/&gt; event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers in constrained network environments (e.g., serving small-footprint clients via <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2256798">10</a>] or <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2256822">11</a>]) and services that rebroadcast message stanzas (e.g., Multi-User Chat services) MAY process standalone notifications differently from other messages. In particular, a server or service MAY refuse to deliver standalone notifications to its users, and SHOULD NOT store them offline. In contrast to <span style="font-weight: bold">JEP-0022</span>, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Content Message With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point Juliet's client knows that Romeo's client supports chat state notifications. Thus she replies to the initial content message and her client includes a notification that her state is &lt;active/&gt;:</p>
+  <p class="caption">Example 6. Contact's Client Sends Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so the conversation continues. After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of &lt;paused/&gt;.</p>
+  <p class="caption">Example 8. User's Client Sends Standalone &lt;paused/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a &lt;composing/&gt; notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet minimizes the chat window, so her client generates an &lt;inactive/&gt; notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends Standalone &lt;inactive/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an &lt;active/&gt; notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends Standalone &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet closes the chat window, so her client generates a &lt;gone/&gt; notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends Standalone &lt;gone/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo's client now considers the chat thread to be over and generates a new Thread ID when he sends a new message:</p>
+  <p class="caption">Example 16. User's Client Sends Content Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an &lt;active/&gt; notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client that receives a chat state notification should expect that it may never receive another message or chat state notification from the other entity (e.g., because the other entity crashes or goes offline) and should plan accordingly.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257428">12</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257478">13</a>] includes 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0085: http://www.jabber.org/jeps/jep-0085.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250513">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2250559">2</a>. These states do not necessarily refer to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+<p><a name="nt-id2255887">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256066">4</a>. An implementation may also "guess" that composing has been paused based on a change in the user's interaction with the message input interface, e.g. if the user switches window or application focus.</p>
+<p><a name="nt-id2256239">5</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2256263">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256288">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256606">8</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256674">9</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256798">10</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2256822">11</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2257428">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257478">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2005-09-29)</h4>
+<div class="indent">Clarified suggested triggers to discourage prospective notifications. (psa)
+    </div>
+<h4>Version 1.0 (2005-08-26)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.14 (2005-07-20)</h4>
+<div class="indent">Clarified terminology; specified suggested state changes; removed section on superseding JEP-0022. (psa)
+    </div>
+<h4>Version 0.13 (2005-07-19)</h4>
+<div class="indent">Further clarified business rules regarding generation of notifications. (psa)
+    </div>
+<h4>Version 0.12 (2005-07-15)</h4>
+<div class="indent">Clarified business rules regarding generation of notifications; added reference to JEP-0155; rewrote introduction; moved previous introductory text to section on superseding JEP-0022. (psa)
+    </div>
+<h4>Version 0.11 (2005-07-05)</h4>
+<div class="indent">Removed &lt;initial/&gt; state. (psa)
+    </div>
+<h4>Version 0.10 (2005-06-28)</h4>
+<div class="indent">Added optional &lt;initial/&gt; state; added business rule on repetition of notifications; added implementation note. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-28)</h4>
+<div class="indent">Made &lt;inactive/&gt; state definition consistent with &lt;paused/&gt; per list discussion; made slight adjustments to wording throughout. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the &lt;gone/&gt; state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added &lt;paused/&gt; state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be "chat" or "groupchat" for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made &lt;inactive/&gt; and &lt;gone/&gt; states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0085-1.1.html
+++ b/content/xep-0085-1.1.html
@@ -1,0 +1,628 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0085: Chat State Notifications</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat State Notifications">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating the status of a person in a chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0085">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0085: Chat State Notifications</h1>
+<p>This JEP defines a protocol for communicating the status of a person in a chat session.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0085<br>
+            Version: 1.1<br>
+            Last Updated: 2005-10-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatstates<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/chatstates/chatstates.xsd">http://jabber.org/protocol/chatstates/chatstates.xsd</a>&gt;<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Chat%20State%20Notifications%20(JEP-0085)">http://wiki.jabber.org/index.php/Chat State Notifications (JEP-0085)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#definitions">Definitions</a>
+</dt>
+<dt>3.  <a href="#statechart">State Chart</a>
+</dt>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-support">Support Requirements</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-rep">Repetition</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-context">Context of Usage</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-groupchat">Use in Groupchat</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-syntax">Syntax of Notifications</a>
+</dt>
+<dt>4.7.  <a href="#bizrules-threads">Threads</a>
+</dt>
+<dt>4.8.  <a href="#bizrules-notify">Server Handling of Notifications</a>
+</dt>
+</dl>
+<dt>5.  <a href="#example-basic">A Simple Example</a>
+</dt>
+<dt>6.  <a href="#example-detail">A Detailed Conversation</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many instant messaging systems include notifications about the state of one's conversation partner in a one-to-one chat (or, sometimes, in a many-to-many chat). Usually these are limited to notification that one's partner is currently typing -- e.g., the Composing event in <span style="font-weight: bold">JEP-0022</span> (see <span class="ref" style="">Message Events</span>  [<a href="#nt-id2250710">1</a>]). However, a composing event is essentially information about a person's participation in or involvement with the chat "session" and therefore is really a session-level state rather than a per-message event -- e.g., the Delivered and Displayed events in <span style="font-weight: bold">JEP-0022</span>. While the composing event is interesting, the concept of a session-level state can be extended to answer a variety of questions about the participation of a person in a real-time chat conversation, such as:</p>
+  <ul>
+    <li>Has this person paused the composition?</li>
+    <li>Is this person actively paying attention to the chat?</li>
+    <li>Is this person temporarily inactive (i.e., not paying attention right now)?</li>
+    <li>Is this person simply gone (i.e., no longer participating in the chat)?</li>
+  </ul>
+  <p class="" style="">To answer such questions, this JEP supplements the traditional composing state by defining four additional chat states (paused, active, inactive, gone), for a total of five states that (it is hoped) together fully describe the possible states of a person's participation in or involvement with a chat conversation.  [<a href="#nt-id2250755">2</a>]</p>
+<h2>2.
+       <a name="definitions">Definitions</a>
+</h2>
+  <p class="" style="">In essence, chat state notifications can be thought of as a form of chat-specific presence. For example, consider what might happen if a user "loses" a chat window on his desktop; the user might still be interacting with his messaging client (thus never automatically changing his basic presence to "away"), but the user's state with regard to the chat session might change progressively from active to inactive to gone. This information would help the user's conversation partner understand why she has not received a response to her messages in the chat session.</p>
+  <p class="" style="">Chat state notifications can appear in two kinds of &lt;message/&gt; stanzas:</p>
+  <ul>
+    <li>A "content message" -- that is, a message stanza that contains standard messaging content such as the &lt;body/&gt;, &lt;subject/&gt;, and &lt;thread/&gt; child elements defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256244">3</a>] and/or any other properly-namespaced child element(s).</li>
+    <li>A "standalone notification" -- that is, a message stanza that does not contain standard messaging content but instead is intended to specify only the chat state since it contains only a child element qualified by the "http://jabber.org/protocol/chatstates" namespace (or possibly also the XMPP &lt;thread/&gt; element; see the <a href="#bizrules-threads">Threads</a> section below).</li>
+  </ul>
+  <p class="" style="">The five chat states specified in this document are described below. The suggested triggers and state changes are simply that: suggestions. It is up to the implementation to determine when to generate chat state notifications and which notifications to generate.</p>
+  <p class="caption">Table 1: Chat States</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">State</th>
+      <th colspan="" rowspan="">Definition</th>
+      <th colspan="" rowspan="">Suggested Triggers</th>
+      <th colspan="" rowspan="">Suggested State Changes</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+      <td align="" colspan="" rowspan="">User is actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User accepts an initial content message, sends a content message, gives focus to the chat interface, or is otherwise paying attention to the conversation.</td>
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;, &lt;composing/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+      <td align="" colspan="" rowspan="">User is composing a message.</td>
+      <td align="" colspan="" rowspan="">User is interacting with a message input interface specific to this chat session (e.g., by typing in the input area of a chat window).</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;paused/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+      <td align="" colspan="" rowspan="">User had been composing but now has stopped.</td>
+      <td align="" colspan="" rowspan="">User was composing but has not interacted with the message input interface for a short period of time (e.g., 5 seconds).  [<a href="#nt-id2256420">4</a>]</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;composing/&gt;, &lt;inactive/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+      <td align="" colspan="" rowspan="">User has not been actively participating in the chat session.</td>
+      <td align="" colspan="" rowspan="">User has not interacted with the chat interface for an intermediate period of time (e.g., 30 seconds).</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;, &lt;gone/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+      <td align="" colspan="" rowspan="">User has effectively ended their participation in the chat session.</td>
+      <td align="" colspan="" rowspan="">User has not interacted with the chat interface, system, or device for a relatively long period of time (e.g., 2 minutes), or has terminated the chat interface (e.g., by closing the chat window).</td>
+      <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="statechart">State Chart</a>
+</h2>
+  <p class="" style="">The following figure attempts to capture the possible state transitions in visual form.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+
+                o (start)
+                |
+                |
+INACTIVE &lt;--&gt; ACTIVE &lt;--&gt; COMPOSING 
+    |           ^            |
+    |           |            |
+    + &lt;------ PAUSED &lt;-----&gt; +
+  </pre></div>
+  <p class="" style="">Note: All four of the states shown may transition to the GONE state.</p>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery of Support and Generation of Notifications</a>
+</h3>
+    <p class="" style="">In the absence of explicit negotiation of a one-to-one chat session between a User and Contact (e.g., as specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2256594">5</a>]) or explicit discovery by the User of the Contact's capabilities (e.g., as gained through <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256618">6</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256609">7</a>]), the following business rules apply to the use of chat state notifications in the context of one-to-one chat sessions:</p>
+    <ol start="1" type="">
+      <li>If the User desires chat state notifications, the initial content message sent to the Contact MUST contain a chat state notification extension, which SHOULD be &lt;active/&gt;.</li>
+      <li>Until receiving a reply to the initial content message (or a standalone notification) from the Contact, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial content message but does not include a chat state notification extension, the User MUST NOT send subsequent chat state notifications to the Contact.</li>
+      <li>If the Contact replies to the initial content message and includes an &lt;active/&gt; notification (or sends a standalone notification to the User), the User and Contact SHOULD send subsequent notifications for supported chat states (as specified in the next subsection) by including an &lt;active/&gt; notification in each content message and sending standalone notifications for the chat states they support (at a minimum, the &lt;composing/&gt; state).</li>
+    </ol>
+    <p class="" style="">The foregoing rules imply that the sending of chat state notifications is bidirectional (i.e., both User and Contact will either send or not send chat state notifications) rather than unidirectional (i.e., one of the conversation partners will send chat state notifications but the other will not); this is intentional.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-support">Support Requirements</a>
+</h3>
+    <p class="caption">Table 2: Requirements for Supporting Each Chat State</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Chat State</th>
+        <th colspan="" rowspan="">Requirement</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;active/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;composing/&gt;</td>
+        <td align="" colspan="" rowspan="">MUST</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;paused/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;inactive/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;gone/&gt;</td>
+        <td align="" colspan="" rowspan="">SHOULD</td>
+      </tr>
+    </table>
+    <p class="" style="">A client MUST allow the user to configure whether he or she wants to send chat state notifications.</p>
+    <p class="" style="">Note: Support for only &lt;active/&gt; and &lt;composing/&gt; is functionally equivalent to supporting the Composing event from <span style="font-weight: bold">JEP-0022</span>.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-rep">Repetition</a>
+</h3>
+    <p class="" style="">Even if the user types continuously for a long time (e.g., while composing a lengthy reply), the client MUST NOT send more than one standalone &lt;composing/&gt; notification in a row. More generally, a client MUST NOT send a second instance of any given standalone notification (i.e., a standalone notification MUST be followed by a different state, not repetition of the same state). However, every content message SHOULD contain an &lt;active/&gt; notification.</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-context">Context of Usage</a>
+</h3>
+    <ol start="" type="">
+      <li>This protocol MUST NOT be used with stanzas other than &lt;message/&gt;.</li>
+      <li>This protocol SHOULD NOT be used with message types other than "chat" or "groupchat".</li>
+      <li>The 'type' attribute for content messages and standalone notifications SHOULD be set to a value of "chat" (for one-to-one sessions) or "groupchat" (for many-to-many sessions).</li>
+      <li>A chat session MAY span multiple user sessions (i.e., chat state is orthogonal to the availability and presence of one's conversation partner), although this is unlikely given the suggested timing of event triggers.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-groupchat">Use in Groupchat</a>
+</h3>
+    <p class="" style="">Chat state notifications MAY be sent in the context of groupchat rooms (e.g., as defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256959">8</a>]). The following business rules apply:</p>
+    <ol start="" type="">
+      <li>A client MAY send chat state notifications even if not all room occupants do so.</li>
+      <li>A client SHOULD NOT generate &lt;gone/&gt; notifications.</li>
+      <li>A client SHOULD ignore &lt;gone/&gt; notifications received from other room occupants.</li>
+    </ol>
+    <p class="" style="">Note: Use of chat state notifications in the context of groupchat may result in multicasting of such notifications. Forewarned is forearmed.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-syntax">Syntax of Notifications</a>
+</h3>
+    <ol start="" type="">
+      <li>A message stanza MUST NOT contain more than one child element qualified by the 'http://jabber.org/protocol/chatstates' namespace.</li>
+      <li>A message stanza that contains standard messaging content -- i.e., the &lt;body/&gt;, &lt;subject/&gt;, and &lt;thread/&gt; child elements defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2257026">9</a>] and/or any other properly-namespaced child element(s) -- SHOULD NOT contain a chat state notification extension other than &lt;active/&gt;.</li>
+      <li>A message stanza that does not contain standard messaging content and is intended to specify only the chat state MUST NOT contain any child elements other than the chat state notification extension, which SHOULD be a state other than &lt;active/&gt;; however, if threads are used (see below) then the standalone notification MUST also contain the &lt;thread/&gt; element.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="bizrules-threads">Threads</a>
+</h3>
+    <p class="" style="">While chat state notifications provide a mechanism for managing chat threads (i.e., the &lt;thread/&gt; element), support for threads is OPTIONAL. However, if all of the clients participating in a chat both support and use threads, the following additional business rules apply:</p>
+    <ol start="" type="">
+      <li>Clients MUST copy back Thread IDs (i.e., the value of the &lt;thread/&gt; element) in any replies.</li>
+      <li>When a client terminates a one-to-one chat session (e.g., when a user closes the chat session interface), it MUST generate a &lt;gone/&gt; event.</li>
+      <li>Upon receiving a &lt;gone/&gt; event, a client MUST NOT re-use the same Thread ID and MUST generate a new Thread ID for any subsequent chat messages sent to the conversation partner.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="bizrules-notify">Server Handling of Notifications</a>
+</h3>
+    <p class="" style="">Servers in constrained network environments (e.g., serving small-footprint clients via <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2257150">10</a>] or <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2257174">11</a>]) and services that rebroadcast message stanzas (e.g., Multi-User Chat services) MAY process standalone notifications differently from other messages. In particular, a server or service MAY refuse to deliver standalone notifications to its users, and SHOULD NOT store them offline. In contrast to <span style="font-weight: bold">JEP-0022</span>, chat state notifications are completely the responsibility of the client, and MUST NOT be generated by a server or service.</p>
+  </div>
+<h2>5.
+       <a name="example-basic">A Simple Example</a>
+</h2>
+  <p class="" style="">In the following conversation, both User and Contact support chat state notifications.</p>
+  <p class="caption">Example 1. User Sends Initial Content Message With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit'
+    type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 2. Contact's Client Sends Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='francisco@shakespeare.lit/elsinore'
+    to='bernardo@shakespeare.lit/pda'
+    type='chat'&gt;
+  &lt;body&gt;Nay, answer me: stand, and unfold yourself.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Because the User now knows that the Contact supports chat state notifications, the User can send other notification types.</p>
+  <p class="caption">Example 3. User Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="caption">Example 4. User Sends a Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='bernardo@shakespeare.lit/pda'
+    to='francisco@shakespeare.lit/elsinore'
+    type='chat'&gt;
+  &lt;body&gt;Long live the king!&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+<h2>6.
+       <a name="example-detail">A Detailed Conversation</a>
+</h2>
+  <p class="" style="">The following conversation flow illustrates in more detail the workings of chat state notifications (in this case also using threads).</p> 
+  <p class="caption">Example 5. User Sends Initial Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I take thee at thy word:
+    Call me but love, and I'll be new baptized;
+    Henceforth I never will be Romeo.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">At this point Juliet's client knows that Romeo's client supports chat state notifications. Thus she replies to the initial content message and her client includes a notification that her state is &lt;active/&gt;:</p>
+  <p class="caption">Example 6. Contact's Client Sends Content Message Reply With &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    What man art thou that thus bescreen'd in night
+    So stumblest on my counsel?
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so the conversation continues. After a while, Juliet asks a question that brings Romeo up short. Romeo begins composing a reply to Juliet's heartfelt question, and his Jabber client notifies Juliet that he is composing a reply.</p>
+  <p class="caption">Example 7. User's Client Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo realizes his reply is too rash and pauses to choose the right words; after some (configurable) time period, his Jabber client senses the delay and sends a state of &lt;paused/&gt;.</p>
+  <p class="caption">Example 8. User's Client Sends Standalone &lt;paused/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;paused xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo starts composing again, and his Jabber client sends a &lt;composing/&gt; notification to Juliet's client.</p>
+  <p class="caption">Example 9. User's Clients Sends Standalone &lt;composing/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;composing xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo finally sends his reply.</p>
+  <p class="caption">Example 10. User Replies</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation ebbs and flows, waxes and wanes, until Juliet is called away by her Nurse...</p>
+  <p class="caption">Example 11. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    I hear some noise within; dear love, adieu!
+    Anon, good nurse! Sweet Montague, be true.
+    Stay but a little, I will come again.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet minimizes the chat window, so her client generates an &lt;inactive/&gt; notification:</p>
+  <p class="caption">Example 12. Contact's Client Sends Standalone &lt;inactive/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;inactive xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When she returns and brings the window up again, her client generates an &lt;active/&gt; notification:</p>
+  <p class="caption">Example 13. Contact's Client Sends Standalone &lt;active/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The conversation continues, but Juliet is called away again by that nagging Nurse:</p>
+  <p class="caption">Example 14. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times good night!
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">We suppose that Juliet closes the chat window, so her client generates a &lt;gone/&gt; notification:</p>
+  <p class="caption">Example 15. Contact's Client Sends Standalone &lt;gone/&gt; Notification</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat1&lt;/thread&gt;
+  &lt;gone xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Romeo's client now considers the chat thread to be over and generates a new Thread ID when he sends a new message:</p>
+  <p class="caption">Example 16. User's Client Sends Content Message with New Thread ID</p>
+<div class="indent"><pre>
+&lt;message 
+    from='romeo@shakespeare.lit/orchard'
+    to='juliet@capulet.com/balcony'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    A thousand times the worse, to want thy light.
+    Love goes toward love, as schoolboys from their books,
+    But love from love, toward school with heavy looks.
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">When Juliet returns to her computer on the balcony, she finds the new message from Romeo. When she finishes her reply, her client includes both an &lt;active/&gt; notification and the new Thread ID with the body of her reply:</p>
+  <p class="caption">Example 17. Contact's Client Sends Content Message</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@shakespeare.lit/orchard'
+    type='chat'&gt;
+  &lt;thread&gt;act2scene2chat2&lt;/thread&gt;
+  &lt;body&gt;
+    Hist! Romeo, hist! O, for a falconer's voice,....
+  &lt;/body&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">And so forth.</p>
+  <p class="" style="">My, these star-crossed lovers do go on, don't they?</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client that receives a chat state notification should expect that it may never receive another message or chat state notification from the other entity (e.g., because the other entity crashes or goes offline) and should plan accordingly.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The states of a chat thread may reveal information about a user's interaction with his or her computer, including his or her physical presence; such information SHOULD NOT be revealed to conversation partners who are not trusted to know such information. Client implementations MUST provide a mechanism that enables the user to disable chat state notifications if desired.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257780">12</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257830">13</a>] includes 'http://jabber.org/protocol/chatstates' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/chatstates'
+    xmlns='http://jabber.org/protocol/chatstates'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0085: http://www.jabber.org/jeps/jep-0085.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='active' type='empty'/&gt;
+  &lt;xs:element name='composing' type='empty'/&gt;
+  &lt;xs:element name='gone' type='empty'/&gt;
+  &lt;xs:element name='inactive' type='empty'/&gt;
+  &lt;xs:element name='paused' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250710">1</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2250755">2</a>. These states do not necessarily refer to the state of the client interface and certainly not to the disposition of a particular message. However, the user's involvement with the system, device, chat interface, or input interface can provide important clues regarding the user's involvement with the chat session, which should be used by the client in determining when to generate chat state notifications.</p>
+<p><a name="nt-id2256244">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256420">4</a>. An implementation may also "guess" that composing has been paused based on a change in the user's interaction with the message input interface, e.g. if the user switches window or application focus.</p>
+<p><a name="nt-id2256594">5</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2256618">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256609">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256959">8</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257026">9</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257150">10</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2257174">11</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2257780">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257830">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2005-10-05)</h4>
+<div class="indent">Clarified suggested triggers to discourage prospective notifications. (psa)
+    </div>
+<h4>Version 1.0 (2005-08-26)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.14 (2005-07-20)</h4>
+<div class="indent">Clarified terminology; specified suggested state changes; removed section on superseding JEP-0022. (psa)
+    </div>
+<h4>Version 0.13 (2005-07-19)</h4>
+<div class="indent">Further clarified business rules regarding generation of notifications. (psa)
+    </div>
+<h4>Version 0.12 (2005-07-15)</h4>
+<div class="indent">Clarified business rules regarding generation of notifications; added reference to JEP-0155; rewrote introduction; moved previous introductory text to section on superseding JEP-0022. (psa)
+    </div>
+<h4>Version 0.11 (2005-07-05)</h4>
+<div class="indent">Removed &lt;initial/&gt; state. (psa)
+    </div>
+<h4>Version 0.10 (2005-06-28)</h4>
+<div class="indent">Added optional &lt;initial/&gt; state; added business rule on repetition of notifications; added implementation note. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-28)</h4>
+<div class="indent">Made &lt;inactive/&gt; state definition consistent with &lt;paused/&gt; per list discussion; made slight adjustments to wording throughout. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-28)</h4>
+<div class="indent">Further clarified state definitions and adjusted suggested event timing. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-27)</h4>
+<div class="indent">Clarified the meaning of the &lt;gone/&gt; state; adjusted suggested timing for events. (psa)
+    </div>
+<h4>Version 0.6 (2004-02-19)</h4>
+<div class="indent">Added &lt;paused/&gt; state; defined the chat states; clarified the state chart; simplified the business rules. (psa)
+    </div>
+<h4>Version 0.5 (2003-09-18)</h4>
+<div class="indent">Clarified that 'type' must be "chat" or "groupchat" for chat state notification messages. (psa)
+    </div>
+<h4>Version 0.4 (2003-05-22)</h4>
+<div class="indent">Made Thread IDs optional; made &lt;inactive/&gt; and &lt;gone/&gt; states optional if Thread IDs are not used; removed requirement for explicit service discovery in favor of implicit discovery. (psa)
+    </div>
+<h4>Version 0.3 (2003-05-20)</h4>
+<div class="indent">Clarified terminology; added support for groupchat; added several implementation notes. (psa)
+    </div>
+<h4>Version 0.2 (2003-05-19)</h4>
+<div class="indent">General cleanup; added schema. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-19)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0093-1.1.html
+++ b/content/xep-0093-1.1.html
@@ -1,0 +1,182 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0093: Roster Item Exchange</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Roster Item Exchange">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides canonical documentation of the existing 'jabber:x:roster' namespace currently used within the Jabber community.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-02-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0093">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0093: Roster Item Exchange</h1>
+<p>This JEP provides canonical documentation of the existing 'jabber:x:roster' namespace currently used within the Jabber community.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in wide use within the Jabber community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; therefore it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0093<br>
+            Version: 1.1<br>
+            Last Updated: 2004-02-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: x-roster<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/x-roster/x-roster.xsd">http://jabber.org/protocol/x-roster/x-roster.xsd</a>&gt;<br></p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2250408">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2250495">Definition</a>
+</dt>
+<dt>3.  <a href="#sect-id2251140">Examples</a>
+</dt>
+<dt>4.  <a href="#sect-id2251152">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2251177">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2251376">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2251236">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2250408">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for sending roster items to another entity. This method makes use of the 'jabber:x:roster' namespace and has been documented variously in Internet-Drafts and elsewhere. Because this protocol is not required by <span class="ref" style="">RFC 2779</span>  [<a href="#nt-id2250446">1</a>], the 'jabber:x:roster' namespace was removed from <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250457">2</a>]. This JEP fills the void for canonical documentation.</p>
+<h2>2.
+       <a name="sect-id2250495">Definition</a>
+</h2>
+  <p class="" style="">The 'jabber:x:roster' namespace (which is not to be confused with the 'jabber:iq:roster' namespace) is used to send roster items from one Jabber entity to another. A roster item is sent by adding to the &lt;message/&gt; element an &lt;x/&gt; child scoped by the 'jabber:x:roster' namespace. This &lt;x/&gt; element MUST contain at least one &lt;item/&gt; child elements (one for each roster item to be sent).</p>
+  <p class="" style="">Each &lt;item/&gt; element may possess the following attributes:</p>
+  <ul>
+    <li>
+<span style="font-weight: bold">jid</span> -- The Jabber Identifier of the contact being sent. This attribute is REQUIRED.</li>
+    <li>
+<span style="font-weight: bold">name</span> -- A natural-language nickname for the contact. This attribute is OPTIONAL.</li>
+  </ul>
+  <p class="" style="">Each &lt;item/&gt; element MAY also contain one or more &lt;group/&gt; children specifying the natural-language name of a user-specified group, for the purpose of categorizing this contact into one or more roster groups.</p>
+<h2>3.
+       <a name="sect-id2251140">Examples</a>
+</h2>
+  <p class="caption">Example 1. A Roster Item Sent to another Entity</p>
+<div class="indent"><pre>
+&lt;message to='hamlet@denmark' from='horatio@denmark'&gt;
+  &lt;subject&gt;Visitors&lt;/subject&gt;
+  &lt;body&gt;This message contains roster items.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:roster'&gt; 
+    &lt;item jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+<h2>4.
+       <a name="sect-id2251152">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>5.
+       <a name="sect-id2251177">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2251205">3</a>].</p>
+<h2>6.
+       <a name="sect-id2251376">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'jabber:x:roster' namespace is registered in the protocol namespaces registry maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2251247">4</a>].</p>
+<h2>7.
+       <a name="sect-id2251236">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:x:roster'
+    xmlns='jabber:x:roster'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0093: http://www.jabber.org/jeps/jep-0093.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='group' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2250446">1</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p><a name="nt-id2250457">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251205">3</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2251247">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2004-02-24)</h4>
+<div class="indent">Corrected several small textual errors. (psa)
+    </div>
+<h4>Version 1.0 (2003-10-08)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Active. (psa)
+    </div>
+<h4>Version 0.1 (2003-05-22)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0100-0.10.html
+++ b/content/xep-0100-0.10.html
@@ -1,0 +1,1308 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0100: Gateway Interaction</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Gateway Interaction">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies best practices for interactions between Jabber clients and client proxy gateways to legacy IM services.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0100">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0100: Gateway Interaction</h1>
+<p>This JEP specifies best practices for interactions between Jabber clients and client proxy gateways to legacy IM services.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0100<br>
+            Version: 0.10<br>
+            Last Updated: 2005-05-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0077, JEP-0144<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases-jabber">Jabber User Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecases-jabber-register">Register</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#usecases-jabber-register-pri">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#usecases-jabber-register-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#usecases-jabber-edit">Edit Registration</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#usecases-jabber-edit-pri">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#usecases-jabber-edit-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#usecases-jabber-unregister">Unregister</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#usecases-jabber-unregister-pri">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#usecases-jabber-unregister-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#usecases-jabber-login">Log In</a>
+</dt>
+<dl>
+<dt>4.4.1.  <a href="#usecases-jabber-login-pri">Primary Flow</a>
+</dt>
+<dt>4.4.2.  <a href="#usecases-jabber-login-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.5.  <a href="#usecases-jabber-logout">Log Out</a>
+</dt>
+<dl>
+<dt>4.5.1.  <a href="#usecases-jabber-logout-pri">Primary Flow</a>
+</dt>
+<dt>4.5.2.  <a href="#usecases-jabber-logout-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.6.  <a href="#usecases-jabber-addcontact">Add Contact</a>
+</dt>
+<dl>
+<dt>4.6.1.  <a href="#usecases-jabber-addcontact-pri">Primary Flow</a>
+</dt>
+<dt>4.6.2.  <a href="#usecases-jabber-addcontact-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.7.  <a href="#usecases-jabber-deletecontact">Delete Contact</a>
+</dt>
+<dl>
+<dt>4.7.1.  <a href="#usecases-jabber-deletecontact-pri">Primary Flow</a>
+</dt>
+<dt>4.7.2.  <a href="#usecases-jabber-deletecontact-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.8.  <a href="#usecases-jabber-send">Send Message</a>
+</dt>
+<dl>
+<dt>4.8.1.  <a href="#usecases-jabber-send-pri">Primary Flow</a>
+</dt>
+<dt>4.8.2.  <a href="#usecases-jabber-send-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#usecases-legacy">Legacy User Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#usecases-legacy-add">Add Contact</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#usecases-legacy-add-pri">Primary Flow</a>
+</dt>
+<dt>5.1.2.  <a href="#usecases-legacy-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#usecases-legacy-delete">Delete Contact</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#usecases-legacy-delete-pri">Primary Flow</a>
+</dt>
+<dt>5.2.2.  <a href="#usecases-legacy-delete-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>5.3.  <a href="#usecases-legacy-send">Send Message</a>
+</dt>
+<dl>
+<dt>5.3.1.  <a href="#usecases-legacy-send-pri">Primary Flow</a>
+</dt>
+<dt>5.3.2.  <a href="#usecases-legacy-send-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#addressing">Addressing</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#addressing-gateway">Gateways</a>
+</dt>
+<dt>6.2.  <a href="#addressing-user">Users</a>
+</dt>
+<dt>6.3.  <a href="#addressing-gateway">The jabber:iq:gateway Protocol</a>
+</dt>
+</dl>
+<dt>7.  <a href="#rosters">Contact Lists</a>
+</dt>
+<dt>8.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Jabber Registrar Considerations</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">One distinguishing characteristic of Jabber technologies from their earliest days has been the existence of gateways (also called "transports") between the Jabber network and legacy instant messaging services such as AOL Instant Messenger (AIM), ICQ, MSN Messenger, and Yahoo! Instant Messenger. Surprisingly, the recommended behavior of such gateways, including the protocol elements used by a client to interact with a gateway, has never been fully documented. This JEP attempts to fill that void by codifying best practices for gateway interaction.</p>
+  <p class="" style="">Note well that this JEP defines protocol usage with regard to client proxy gateways, i.e., gateways that "masquerade" as a client on a non-Jabber IM service. Gateways that perform direct protocol translation without proxying for an account on a non-Jabber service are not addressed in this JEP. Furthermore, this JEP does not define any interaction between a gateway and the non-Jabber service, only interactions between a Jabber client and the gateway. Although what happens on the other side of the gateway is highly dependent on the nature of the legacy service, gateways should at least provide a common interface on the Jabber side of the gateway so that Jabber clients can be written in a consistent fashion.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Architectural Terms</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Gateway</td>
+      <td align="" colspan="" rowspan="">A service on the Jabber network that translates between the Jabber/XMPP protocols and the protocol used by a Legacy Service; in the context of this JEP, by "gateway" we mean a "client proxy service" that acts as a client with regard to a Legacy Service and thereby "masquerades" as a user on such a service.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber User</td>
+      <td align="" colspan="" rowspan="">A human user who has registered an account with a Jabber server; a Jabber User who wants to use a Gateway must first have also registered an account with a Legacy Service.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Legacy Service</td>
+      <td align="" colspan="" rowspan="">A non-XMPP instant messaging service.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Legacy User</td>
+      <td align="" colspan="" rowspan="">A human user who has registered an account with a Legacy Service.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Server</td>
+      <td align="" colspan="" rowspan="">An instant messaging server as defined in <span style="font-weight: bold">RFC 3921</span>
+</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The requirements defined by this JEP are captured in two sets of use cases: one set from the perspective of the Jabber User, and a smaller set from the perspective of the Legacy User who wants to interact with the Jabber User.</p>
+  <p class="" style="">The Jabber User use cases are:</p>
+  <ol start="" type="">
+    <li>Register</li>
+    <li>Edit Registration</li>
+    <li>Unregister</li>
+    <li>Log In</li>
+    <li>Log Out</li>
+    <li>Add Contact</li>
+    <li>Delete Contact</li>
+    <li>Send Message</li>
+  </ol>
+  <p class="" style="">The Legacy User use cases are:</p>
+  <ol start="" type="">
+    <li>Add Contact</li>
+    <li>Delete Contact</li>
+    <li>Send Message</li>
+  </ol>
+  <p class="" style="">While more advanced use cases (e.g., sending files and joining chat rooms) are of inherent interest, they are not covered in this JEP because registration, contact list management, and message exchange define the baseline functionality included in all gateway implementations; future JEPs may address the more advanced use cases.</p>
+<h2>4.
+       <a name="usecases-jabber">Jabber User Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecases-jabber-register">Register</a>
+</h3>
+    <p class="" style="">All existing client proxy gateways require a Jabber User to register with the Gateway before sending messages or presence through the gateway. Although strictly speaking registration is not required (e.g., a Gateway could prompt the Jabber User for credentials every time the user attempted to communicate through the gateway, or once per "session"), in practice this step is required.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="usecases-jabber-register-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ get qualified by the <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255985">1</a>] information namespace to the Gateway, and/or IQ get qualified by the <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2256008">2</a>] namespace to the Gateway's parent (the latter method is deprecated but still in use).</p>
+          <p class="caption">Example 1. User Queries Gateway Regarding Service Discovery Identity</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 2. User Queries Gateway's Parent Regarding Agent Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='romeo@montague.net/orchard'
+    to='shakespeare.lit'
+    id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="" style="">Note: Although most existing gateway implementations support only the older Agent Information protocol, it is RECOMMENDED that gateways support the Service Discovery protocol, since the former protocol is deprecated in favor of the latter. Until existing gateways are upgraded, clients SHOULD support both.</p>
+        </li>
+        <li>
+          <p class="" style="">Gateway and/or parent returns identity information to Jabber User's Client.</p>
+          <p class="caption">Example 3. Gateway Returns Service Discovery Identity</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='gateway'
+              type='aim'
+              name='AIM Gateway'/&gt;
+    &lt;feature var='jabber:iq:register'/&gt;
+    &lt;feature var='jabber:iq:time'/&gt;
+    &lt;feature var='jabber:iq:version'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 4. Gateway's Parent Returns Agent Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='shakespeare.lit'
+    id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    &lt;agent jid='aim.shakespeare.lit'&gt;
+      &lt;name&gt;AIM Gateway&lt;/name&gt;
+      &lt;service&gt;aim&lt;/service&gt;
+      &lt;transport/&gt;
+      &lt;register/&gt;
+    &lt;/agent&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="" style="">Note: Given the foregoing, a client can determine the identity of the gateway, specifically (1) that it is a gateway and (2) to which legacy service it provides a gateway.</p>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ get qualified by the <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256111">3</a>] (jabber:iq:register) namespace to Gateway.</p>
+          <p class="caption">Example 5. User Queries Gateway Regarding Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway returns IQ result to Jabber User, specifying information that is required in order to register.</p>
+          <p class="caption">Example 6. Gateway Returns Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      Please provide your AIM username and password.
+    &lt;/instructions&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:register' namespace to Gateway, containing information required to register.</p>
+          <p class="caption">Example 7. User Provides Registration Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway verifies that registration information provided by Jabber User is valid (using whatever means appropriate for the Legacy Service) and informs Jabber User of success [A1].</p>
+          <p class="caption">Example 8. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg2'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">If Gateway logged into Legacy Service in preceding step, Gateway buffers any translatable events (e.g., messages and presence) queued up for Jabber User on Legacy Service.</p></li>
+        <li>
+          <p class="" style="">Optionally, Jabber User sends IQ set qualified by the 'jabber:iq:roster' namespace to its server (see <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250257">4</a>]), containing a roster item for Gateway.</p>
+          <p class="caption">Example 9. User Creates Roster Entry</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    id='roster1'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='aim.shakespeare.lit' name='AIM Gateway'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 10. Server Response</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    to='romeo@montague.net/orchard'
+    id='roster1'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends subscription request to Jabber User (i.e., by sending a presence stanza of type "subscribe" to Jabber User's bare JID).</p>
+          <p class="caption">Example 11. Gateway Subscribes to User's Presence</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User's client SHOULD approve the subscription request (i.e., by sending a presence stanza of type "subscribed" to Gateway).</p>
+          <p class="caption">Example 12. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+          <p class="" style="">Note: As specified in <span style="font-weight: bold">RFC 3921</span>, Jabber User's server will generate a "roster push" at this point if client did not previously perform a roster set to add Gateway to user's roster (as mentioned above).</p>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends subscription request to Gateway (i.e., by sending a presence stanza of type "subscribe" to Gateway).</p>
+          <p class="caption">Example 13. Jabber User Subscribes to Gateway's Presence</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends approves subscription request (i.e., by sending a presence stanza of type "subscribed" to Jabber User's bare JID).</p>
+          <p class="caption">Example 14. Gateway Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Execute "Log In" use case.</p></li>
+        <li><p class="" style="">Gateway sends any buffered messages to Jabber User.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="usecases-jabber-register-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">User information not verified:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway returns &lt;not-acceptable/&gt; error to Jabber User. (For detailed information regarding error conditions, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256597">5</a>].)</p>
+              <p class="caption">Example 15. Gateway Informs Jabber User of Registration Error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecases-jabber-edit">Edit Registration</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the user may wish to modify his or her existing registration information (e.g., because the user has changed his or her password on the legacy IM service).</p>
+    <div class="indent">
+<h3>4.2.1 <a name="usecases-jabber-edit-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ get qualified by the 'jabber:iq:register' namespace to Gateway.</p>
+          <p class="caption">Example 16. User Queries Gateway Regarding Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='edit1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway returns IQ result to Jabber User, specifying registration information on record and including empty &lt;registered/&gt; element to signify that user is already registered.</p>
+          <p class="caption">Example 17. Gateway Returns Registration Information of Record</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;registered/&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:register' namespace to Gateway, containing all information (i.e., not just the "delta").</p>
+          <p class="caption">Example 18. User Provides Registration Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='edit2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;B4lc0ny&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway verifies that, if changed, information provided by Jabber User is still valid (using whatever means appropriate for the Legacy Service) and informs Jabber User of success [A1].</p>
+          <p class="caption">Example 19. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit2'/&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="usecases-jabber-edit-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Edit unsuccessful:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway returns &lt;not-acceptable/&gt; error to Jabber User.</p>
+              <p class="caption">Example 20. Gateway Informs Jabber User of Registration Error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;B4lc0ny&lt;/password&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecases-jabber-unregister">Unregister</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the user may choose to unregister with the Gateway, effectively ending his or her relationship with the Gateway (e.g., the user will no longer be allowed to communicate through the gateway with legacy users).</p>
+    <div class="indent">
+<h3>4.3.1 <a name="usecases-jabber-unregister-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ set in 'jabber:iq:register' namespace to Gateway, containing empty &lt;remove/&gt; element.</p>
+          <p class="caption">Example 21. User Unregisters</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='unreg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;remove/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway sends unavailable presence from Jabber User to Legacy Users and logs Jabber User out of Legacy Service.</p></li>
+        <li><p class="" style="">Gateway deletes Jabber User's information.</p></li>
+        <li>
+          <p class="" style="">Gateway sends IQ result to Jabber User.</p>
+          <p class="caption">Example 22. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='unreg1'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway cancels subscriptions.</p>
+          <p class="caption">Example 23. Gateway Cancels Subscriptions</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends unavailable presence to Jabber User.</p>
+          <p class="caption">Example 24. Gateway Logs User Out</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Jabber User's client SHOULD delete from the user's roster (1) the gateway itself, and (2) all legacy Contacts associated with the gateway.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="usecases-jabber-unregister-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="usecases-jabber-login">Log In</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the Jabber User may subsequently log in to the Gateway, effectively creating a "session" with the Gateway and enabling the Gateway to log into the Legacy Service on behalf of the user by sending the user's legacy credentials to the Legacy Service.</p>
+    <div class="indent">
+<h3>4.4.1 <a name="usecases-jabber-login-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends available presence broadcast to Server or sends directed presence to Gateway or a Legacy User.</p>
+          <p class="caption">Example 25. Jabber User Sends Available Presence</p>
+<div class="indent"><pre>
+&lt;presence/&gt;
+          </pre></div>
+          <p class="caption">Example 26. Jabber User's Server Broadcasts Available Presence</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'/&gt;
+&lt;presence from='romeo@montague.net/orchard'
+          to='aim.shakespeare.lit'/&gt;
+...
+          </pre></div>
+        </li>
+        <li><p class="" style="">Upon receiving the first presence notification stanza from Jabber User to Gateway or Legacy User, Gateway logs Jabber User into Legacy Service [A1].</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza to Jabber User expressing availability.</p>
+          <p class="caption">Example 27. Gateway Sends Presence to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Optionally, Gateway handles Legacy Service contact list; see the <a href="#rosters">Contact Lists</a> section of this document.</p></li>
+        <li>
+          <p class="" style="">Gateway forwards current presence information from Legacy Users to Jabber User, if possible mapping availability status (e.g., "away").</p>
+          <p class="caption">Example 28. Gateway Sends Presence from Legacy Users to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@aim.shakespeare.lit'
+          to='romeo@montague.net'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+&lt;/presence&gt;
+          </pre></div>
+          <p class="" style="">Note: If the Legacy Service to which the Gateway connects does not support the concept of "resources", the 'from' address of presence notification stanzas generated by a gateway SHOULD NOT include a resource identifier (i.e., they SHOULD be of the form &lt;user@host&gt; rather than &lt;user@host/resource&gt;). However, the 'from' address MAY include a resource if the Gateway determines that this is appropriate in the context of its communications with the Legacy Service.</p>
+        </li>
+        <li>
+          <p class="" style="">Gateway forwards all subsequent presence stanzas to Legacy Users (except those of type "probe" and those addressed to the Gateway itself).</p>
+          <p class="caption">Example 29. Jabber User Modifies Presence</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'&gt;
+  &lt;show&gt;dnd&lt;/show&gt;
+  &lt;status&gt;Wooing Juliet&lt;/status&gt;
+&lt;/presence&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.4.2 <a name="usecases-jabber-login-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Login fails:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway sends appropriate presence error to Jabber User (&lt;not-authorized/&gt; if password is bad, &lt;remote-server-not-found/&gt; if Legacy Service is down, etc.).</p>
+              <p class="caption">Example 30. Gateway Informs Jabber User of Failed Login</p>
+<div class="indent"><pre>
+&lt;presence to='aim.shakespeare.lit'
+          from='romeo@shakespeare.lit'&gt;
+  &lt;error code='504' type='wait'&gt;
+    &lt;remote-server-timeout
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="usecases-jabber-logout">Log Out</a>
+</h3>
+    <p class="" style="">At any time after logging in to the Gateway, the Jabber User may log out of the Gateway and thereby end his or her session on the Legacy Service. This may happen automatically when the Jabber User terminates his or her session with a Jabber server, or independently of any session on the Jabber network by manually logging out of the Gateway.</p>
+    <div class="indent">
+<h3>4.5.1 <a name="usecases-jabber-logout-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends unavailable presence broadcast to Server or sends directed presence stanza of type "unavailable" to Gateway or (if Gateway does not support directed presence) Legacy User.</p>
+          <p class="caption">Example 31. Jabber User Sends Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'/&gt;
+          </pre></div>
+          <p class="caption">Example 32. Jabber User's Server Broadcasts Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway transforms unavailable presence stanzas received from the Jabber User's server and routes them to all of the Jabber User's contacts on Legacy Service.</p></li>
+        <li><p class="" style="">Gateway logs Jabber User out of Legacy Service [A1].</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type "unavailable" to Jabber User.</p>
+          <p class="caption">Example 33. Gateway Logs User Out</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.5.2 <a name="usecases-jabber-logout-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy Service supports directed presence and Gateway receives presence stanza of type "unavailable" directed to a Legacy User:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway passes through directed unavailable presence to Legacy User.</p>
+              <p class="caption">Example 34. Jabber User Becomes Unavailable</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'/&gt;
+              </pre></div>
+              </li>
+            <li><p class="" style="">Use Case Ends.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="usecases-jabber-addcontact">Add Contact</a>
+</h3>
+    <p class="" style="">After registering with the Gateway, the Jabber User may want to add Legacy Users to his or her Jabber roster.</p>
+    <div class="indent">
+<h3>4.6.1 <a name="usecases-jabber-addcontact-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends presence stanza of type "subscribe" to Legacy User.</p>
+          <p class="caption">Example 35. Jabber User Sends Subscription Request to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+          <p class="" style="">Note: As specified in <span style="font-weight: bold">RFC 3921</span>, sending this packet will result in a "roster push" from the Server to all of the Jabber User's available resources.</p>
+        </li>
+        <li><p class="" style="">Gateway transforms subscription request and routes it to Legacy User.</p></li>
+        <li>
+          <p class="" style="">If Legacy User approves subscription request, Gateway sends presence stanza of type "subscribed" to Jabber User on behalf of Legacy User. [A1]</p>
+          <p class="caption">Example 36. Gateway Approves Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends available presence stanza to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 37. Gateway Sends Legacy User's Current Presence Information to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type "subscribe" to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 38. Gateway Sends Subscription Request to Jabber User on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends presence stanza of type "subscribed" to Legacy User.</p>
+          <p class="caption">Example 39. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.6.2 <a name="usecases-jabber-addcontact-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Legacy User denies subscription request:</p>
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway transforms subscription denial and routes it to Jabber User.</p>
+              <p class="caption">Example 40. Legacy User Denies Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribed'
+          from='juliet@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+              </pre></div>
+              </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="usecases-jabber-deletecontact">Delete Contact</a>
+</h3>
+    <p class="" style="">After adding a Legacy User to his or her Jabber roster, the Jabber User may want to delete that contact.</p>
+    <div class="indent">
+<h3>4.7.1 <a name="usecases-jabber-deletecontact-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:roster' namespace, containing subscription attribute with value of "remove".</p>
+          <p class="caption">Example 41. User Removes Roster Entry for Legacy User</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    id='remove1'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='CapuletNurse@aim.shakespeare.lit'
+          subscription='remove'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Server sends normal "roster push" to Jabber User (see <span style="font-weight: bold">RFC 3921</span>) and sends presence stanzas of type "unsubscribe", "unsubscribed", and "unavailable" to Legacy User.</p>
+          <p class="caption">Example 42. Server Sends Presence Changes to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway cleans up subscription state, informs Legacy User that Jabber User is unavailable, and MUST NOT send future changes in Jabber User's presence to Legacy User.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.7.2 <a name="usecases-jabber-deletecontact-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="usecases-jabber-send">Send Message</a>
+</h3>
+    <p class="" style="">Naturally, the Jabber User may want to exchange messages with a Legacy User. For the purposes of this JEP, we discuss one-to-one messaging only (i.e., groupchat messages, such as those defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257822">6</a>], are out of scope).</p>
+    <div class="indent">
+<h3>4.8.1 <a name="usecases-jabber-send-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends message stanza to Legacy User.</p>
+          <p class="caption">Example 43. Jabber User Sends Message to Legacy User</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard'
+         to='juliet@aim.shakespeare.lit'
+         type='chat'&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway transforms message to legacy protocol and sends to Legacy User [A1].</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.8.2 <a name="usecases-jabber-send-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy Service reports error.</p></li>
+        <li>
+          <p class="" style="">Gateway sends appropriate error to Jabber User:</p>
+          <ul>
+            <li><p class="" style="">&lt;item-not-found/&gt; -- Legacy User address is not valid.</p></li>
+            <li><p class="" style="">&lt;registration-required/&gt; -- Jabber User is not registered with Gateway.</p></li>
+            <li><p class="" style="">&lt;service-unavailable/&gt; -- Legacy User is offline and Legacy Service does not provide offline message storage.</p></li>
+            <li><p class="" style="">&lt;remote-server-not-found/&gt; -- Legacy Service cannot be reached.</p></li>
+          </ul>
+        </li>
+        <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+      </ol>
+    </div>
+  </div>
+<h2>5.
+       <a name="usecases-legacy">Legacy User Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="usecases-legacy-add">Add Contact</a>
+</h3>
+    <p class="" style="">The Legacy User may want to add the Jabber User to his or her contact list on the Legacy Service. Because the Jabber User has an account on the Legacy Service by definition, the Legacy User will actually add the Jabber User's legacy address to his or her contact list, not the Jabber User's address on the Jabber/XMPP network.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="usecases-legacy-add-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User requests subscription to Jabber User's legacy address (using legacy protocol).</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type "subscribe" to Jabber User on behalf of Legacy User (note: Gateway MUST NOT send presence stanza of type "subscribed").</p>
+          <p class="caption">Example 44. Gateway Sends Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User approves subscription request by sending presence stanza of type "subscribed" to Legacy User [A1].</p>
+          <p class="caption">Example 45. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway sends Jabber User's presence information to Legacy User.</p></li>
+        <li>
+          <p class="" style="">Jabber User's Client sends presence stanza of type "subscribe" to Legacy User.</p>
+          <p class="caption">Example 46. Jabber User Sends Subscription Request to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type "subscribed" to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 47. Gateway Approves Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends Legacy User's presence information to Jabber User.</p>
+          <p class="caption">Example 48. Gateway Sends Legacy User's Current Presence Information to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="usecases-legacy-add-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Jabber User denies subscription request:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Jabber User sends presence stanza of type "unsubscribed" to Legacy User.</p>
+              <p class="caption">Example 49. Jabber User Denies Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Gateway cleans up subscription state and MUST NOT send Jabber User's presence to Legacy User.</p></li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="usecases-legacy-delete">Delete Contact</a>
+</h3>
+    <p class="" style="">After adding the Jabber User to his or her legacy contact list, the Legacy User may want to delete the Jabber User.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="usecases-legacy-delete-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User deletes Jabber User's legacy address (using legacy protocol).</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanzas of type "unsubscribe", "unsubscribed", and "unavailable" to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 50. Gateway Cleans Up Subscription on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unavailable'
+          from='CapuletNurse@aim.shakespeare.lit'
+          from='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Jabber User's server performs defined functionality for handling presence stanzas of type "unsubscribe" and "unsubscribed" (see <span style="font-weight: bold">RFC 3921</span>).</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="usecases-legacy-delete-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="usecases-legacy-send">Send Message</a>
+</h3>
+    <p class="" style="">Naturally, the Legacy User may want to exchange messages with the Jabber User. (Here again, groupchat messages are out of scope.)</p>
+    <div class="indent">
+<h3>5.3.1 <a name="usecases-legacy-send-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User sends message to Jabber User using legacy protocol.</p></li>
+        <li>
+          <p class="" style="">Gateway transforms message and routes to Jabber User.</p>
+          <p class="caption">Example 51. Legacy User Sends Message to Jabber User</p>
+<div class="indent"><pre>
+&lt;message from='juliet@aim.shakespeare.lit'
+         to='romeo@montague.net/orchard'&gt;
+  &lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+          <p class="" style="">Note: If the Legacy Service to which the Gateway connects does not support a concept equivalent to that of Jabber "resources" as described in xmppcore;, the 'from' address of message stanzas generated by a gateway SHOULD NOT include a resource identifier (i.e., they SHOULD be of the form &lt;user@host&gt; rather than &lt;user@host/resource&gt;). However, the 'from' address MAY include a resource if the Gateway determines that this is appropriate in the context of its communications with the Legacy Service.</p>
+        </li>
+        <li><p class="" style="">Jabber User's Server delivers message or (optionally) stores it for later retrieval.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.3.2 <a name="usecases-legacy-send-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+<h2>6.
+       <a name="addressing">Addressing</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="addressing-gateway">Gateways</a>
+</h3>
+    <p class="" style="">The address of a gateway itself SHOULD be a hostname only, and that hostname SHOULD NOT be supplemented with a resource identifier when referring to the gateway's address (e.g., when storing the gateway in a roster). The hostname SHOULD be a subdomain of a primary Jabber host (e.g., icq.jabber.org might be the ICQ gateway run by the jabber.org server).</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="addressing-user">Users</a>
+</h3>
+    <p class="" style="">The Jabber Identifier corresponding to a Legacy User's address is typically of the form &lt;LegacyUserAddress@gateway.example.com&gt;, where LegacyUserAddress is the Legacy User's address on the Legacy Service and where gateway.example.com is the Jabber address of the gateway.</p>
+    <p class="" style="">Unfortunately, usernames on some Legacy Services may allow characters that are disallowed in Jabber usernames as specified by the Nodeprep profile of stringprep defined in <span style="font-weight: bold">RFC 3920</span>. For example, the usernames for a Legacy Service may be of the form &lt;user@domain&gt;, which would result in an illegal JID such as &lt;user@domain@gateway.example.com&gt;.</p>
+    <p class="" style="">There are two possible ways to solve this problem:</p>
+    <ol start="" type="">
+      <li>Use <span class="ref" style="">JID Escaping</span>  [<a href="#nt-id2258571">7</a>].</li>
+      <li>Use the older 'jabber:iq:gateway' protocol (as defined in the following section).</li>
+    </ol>
+    <p class="" style="">Gateways and clients SHOULD implement at least one of these protocols; at a minimum, it is RECOMMENDED for gateways and clients to implement the 'jabber:iq:gateway' protocol.</p>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="addressing-gateway">The jabber:iq:gateway Protocol</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:gateway' protocol performs two functions:</p>
+    <ol start="" type="">
+      <li><p class="" style="">It enables a client to determine the text for the "prompt" to show to a Jabber User when the user wants to add a legacy contact to the user's roster (e.g., "Please enter the AOL Screen Name of the person you would like to contact"), as well as the preferred name for the prompted item (e.g., "Screen Name"). To do so, the client sends an empty &lt;query/&gt; element and the gateway returns a &lt;prompt/&gt; element (the name for the prompted item) and optionally a &lt;desc/&gt; element (the text of the prompt itself).</p></li>
+      <li><p class="" style="">It enables a client to send a legacy username to the gateway and receive a properly-formatted JID in return. To do so, the client sends the legacy address to the gateway as the character data of the &lt;prompt/&gt; and the gateway returns a valid JID as the character data of the &lt;jid/&gt; element.</p></li>
+    </ol>
+    <p class="" style="">Both uses are illustrated below.</p>
+    <p class="caption">Example 52. Client Requests Prompt</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='aim.jabber.org'&gt;
+  &lt;query xmlns='jabber:iq:gateway'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 53. Gateway Returns Prompt</p>
+<div class="indent"><pre>
+  &lt;iq type='result' from='aim.jabber.org'&gt;
+    &lt;query xmlns='jabber:iq:gateway'&gt;
+      &lt;desc&gt;
+        Please enter the AOL Screen Name of the
+        person you would like to contact.
+      &lt;/desc&gt;
+      &lt;prompt&gt;Screen Name&lt;/prompt&gt;
+    &lt;/query&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following table is intended to assist implementors with mapping of gateway identities to English-language prompt names and text.</p>
+    <p class="caption">Table 2: Prompt Item Mapping (English)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Legacy Service</th>
+        <th colspan="" rowspan="">Service Discovery Identity</th>
+        <th colspan="" rowspan="">Prompt Name</th>
+        <th colspan="" rowspan="">Prompt Text</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">AOL Instant Messenger</td>
+        <td align="" colspan="" rowspan="">gateway/aim</td>
+        <td align="" colspan="" rowspan="">AOL Screen Name</td>
+        <td align="" colspan="" rowspan="">Please enter the AOL Screen Name of the person you would like to contact.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ICQ</td>
+        <td align="" colspan="" rowspan="">gateway/icq</td>
+        <td align="" colspan="" rowspan="">ICQ Number</td>
+        <td align="" colspan="" rowspan="">Please enter the ICQ Number of the person you would like to contact.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">MSN Messenger</td>
+        <td align="" colspan="" rowspan="">gateway/msn</td>
+        <td align="" colspan="" rowspan="">MSN Address</td>
+        <td align="" colspan="" rowspan="">Please enter the MSN Address of the person you would like to contact.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Yahoo! Instant Messenger</td>
+        <td align="" colspan="" rowspan="">gateway/yahoo</td>
+        <td align="" colspan="" rowspan="">Yahoo ID</td>
+        <td align="" colspan="" rowspan="">Please enter the Yahoo ID of the person you would like to contact.</td>
+      </tr>
+    </table>
+    <p class="" style="">If the client provides an 'xml:lang' attribute with the IQ-get, the gateway SHOULD return localized prompt names and text if available, or default to English if not available.</p>
+    <p class="" style="">Once the user enters a legacy username or address, the client MUST send it to the gateway as the character data of the &lt;prompt/&gt; element in an IQ-set; the gateway MUST then return a properly-formed JID based on the provided by the client.</p>
+    <p class="caption">Example 54. Client Provides Legacy Username</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='aim.jabber.org'&gt;
+  &lt;query xmlns='jabber:iq:gateway'&gt;
+      &lt;prompt&gt;Foo Bar&lt;/prompt&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 55. Gateway Returns JID</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='aim.jabber.org'&gt;
+  &lt;query xmlns='jabber:iq:gateway'&gt;
+    &lt;jid&gt;FooBar@aim.jabber.org&lt;/jid&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>7.
+       <a name="rosters">Contact Lists</a>
+</h2>
+  <p class="" style="">Some legacy services maintain server-side contact lists, which are sent to the gateway when it logs in to the legacy service on behalf of the user. The gateway MAY initiate adding of the legacy contact list items to the user's Jabber roster. Some existing gateways do this by sending a presence stanza of type "subscribed" from the legacy contact's JID (e.g., &lt;LegacyUser@gateway.jabberserver.com&gt;) to the Jabber user; unfortunately, this behavior violates the presence stanza handling rules specified in <span style="font-weight: bold">RFC 3921</span>. Therefore, a gateway SHOULD instead send the legacy contact list items to the Jabber User via the <span class="ref" style="">Roster Item Exchange</span>  [<a href="#nt-id2258967">8</a>] protocol.</p>
+<h2>8.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <p class="" style="">The following business rules apply:</p>
+  <ol start="" type="">
+    <li><p class="" style="">A client SHOULD send a <span style="font-weight: bold">Service Discovery</span> request to the gateway (and/or an <span style="font-weight: bold">Agent Information</span> request to the gateway's parent) before requesting registration information.</p></li>
+    <li><p class="" style="">A gateway SHOULD support the <span style="font-weight: bold">Service Discovery</span> protocol.</p></li>
+    <li><p class="" style="">A gateway SHOULD support the <span style="font-weight: bold">Agent Information</span> protocol, although it is deprecated.</p></li>
+    <li><p class="" style="">A gateway SHOULD map, as best it can, the legacy registration fields onto the fields defined for the 'jabber:iq:register' namespace.</p></li>
+    <li><p class="" style="">A gateway SHOULD NOT attempt to emulate offline message storage functionality for legacy services that lack such functionality.</p></li>
+    <li>
+      <p class="" style="">Existing gateway implementations do not strictly adhere to the bi-directional nature of Jabber presence notifications, since they do not broadcast presence from the gateway itself to registered users of the gateway, but rather wait for a registered user to send presence to the gateway before sending presence to the user. This sidesteps scalability challenges but may be sub-optimal; while this JEP does not require existing gateways to change their current behavior, it does RECOMMEND that they broadcast presence notifications to registered users in accordance with the standard Jabber presence model. Specifically:</p>
+      <ul>
+        <li><p class="" style="">On startup, a gateway (1) SHOULD send presence to all registered users of that gateway but (2) MAY wait to receive presence changes from each registered user.</p></li>
+        <li><p class="" style="">On shutdown, a gateway SHOULD send unavailable presence to all registered users of the gateway.</p></li>
+      </ul>
+    </li>
+  </ol>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">As defined herein, a gateway is a <span style="font-style: italic">client proxy</span>, since it "masquerades" as a user on a legacy instant messaging service. In order to act as a client proxy, the gateway logs into the user's account on the legacy service. This implies two things:</p>
+  <ul>
+    <li>The gateway must gather the legacy credentials from the user, and perhaps store them on the user's behalf.</li>
+    <li>The gateway must provide the user's credentials to the legacy service.</li>
+  </ul>
+  <p class="" style="">There are obvious security concerns with this approach. The concerns include:</p>
+  <ol start="" type="">
+    <li>The user's credentials on the legacy service may be sent in the clear from the gateway to the legacy service if the legacy service does not support channel encryption or strong authentication.</li>
+    <li>When the user informs the gateway of the user's legacy credentials, the credentials may be sent in the clear between the user's Jabber client and the user's Jabber server (if client-to-server channel encryption is not enabled) or between the user's Jabber server and the gateway (if the gateway is not in the user's "home" domain and server-to-server channel encryption is not enabled).</li>
+    <li>If the gateway stores the user's legacy credentials after registration (this is the default behavior of most or all existing gateway implementations), the user's credentials could be acquired by a malicious user if the server hosting the gateway is compromised.</li>
+  </ol>
+  <p class="" style="">There is no foreseeable solution to these concerns, since they are instrinsic to the client proxy model. Some assurance regarding the second and third concerns can be achieved if the user runs his or her own Jabber server and gateways. However, the only true solution is to move beyond the client proxy model, either by using Jabber for all IM communications or to convince legacy IM services to allow federated server-to-server communications using open protocols such as Jabber/XMPP, thus obviating the need for client proxy gateways entirely.</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259235">9</a>].</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Jabber Registrar Considerations</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259286">10</a>] shall include 'jabber:iq:gateway' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:gateway'
+    xmlns='jabber:iq:gateway'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence
+          &lt;xs:element name='desc' minOccurs='0' type='xs:string'/&gt;
+          &lt;xs:element name='prompt' type='xs:string'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element name='jid' type='xs:string'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2255985">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256008">2</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2256111">3</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2250257">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256597">5</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257822">6</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2258571">7</a>. JEP-0106: JID Escaping &lt;<a href="http://www.jabber.org/jeps/jep-0106.html">http://www.jabber.org/jeps/jep-0106.html</a>&gt;.</p>
+<p><a name="nt-id2258967">8</a>. JEP-0144: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0144.html">http://www.jabber.org/jeps/jep-0144.html</a>&gt;.</p>
+<p><a name="nt-id2259235">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259286">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2005-05-12)</h4>
+<div class="indent">Modified text regarding address transformations and added reference to JEP-0106; corrected several small errors in the text and examples. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-27)</h4>
+<div class="indent">Added specification of jabber:iq:gateway namespace; added reference to JEP-0144. (psa)
+    </div>
+<h4>Version 0.8 (2004-05-07)</h4>
+<div class="indent">Editorial review: made a number of minor textual changes and clarifications throughout; added introductory paragraph to each use case; specified that groupchat is out of scope. (psa)
+    </div>
+<h4>Version 0.7 (2004-03-31)</h4>
+<div class="indent">Cleaned up several notes, examples, and business rules based on feedback received on list. (psa)
+    </div>
+<h4>Version 0.6 (2004-03-08)</h4>
+<div class="indent">Added note about 'from' address on presence notifications and messages received through gateways from legacy users. (psa)
+    </div>
+<h4>Version 0.5 (2004-01-21)</h4>
+<div class="indent">Further specified the rationale for deprecating the "jabber:iq:gateway" protocol. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-05)</h4>
+<div class="indent">Added Edit Registration use case; modified handling of legacy contact lists to conform to RFC 3921; modified addressing rules; defined gateway startup and shutdown behavior; included XMPP error handling. (psa)
+    </div>
+<h4>Version 0.3 (2003-12-10)</h4>
+<div class="indent">Added security considerations; defined handling of legacy contact lists. (psa)
+    </div>
+<h4>Version 0.2 (2003-12-03)</h4>
+<div class="indent">Corrected some errors; clarified some ambiguities; added protocol flows. (psa)
+    </div>
+<h4>Version 0.1 (2003-06-25)</h4>
+<div class="indent">Initial version. (psa/dss)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0100-0.8.html
+++ b/content/xep-0100-0.8.html
@@ -1,0 +1,1217 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0100: Gateway Interaction</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Gateway Interaction">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies best practices for interactions between Jabber clients and client proxy gateways to legacy IM services.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-05-07">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0100">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0100: Gateway Interaction</h1>
+<p>This JEP specifies best practices for interactions between Jabber clients and client proxy gateways to legacy IM services.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0100<br>
+            Version: 0.8<br>
+            Last Updated: 2004-05-07<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0077, JEP-0093<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-glossary">Architectural Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases-jabber">Jabber User Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecases-jabber-register">Register</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#usecases-jabber-register-pri">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#usecases-jabber-register-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#usecases-jabber-edit">Edit Registration</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#usecases-jabber-edit-pri">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#usecases-jabber-edit-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#usecases-jabber-unregister">Unregister</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#usecases-jabber-unregister-pri">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#usecases-jabber-unregister-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#usecases-jabber-login">Log In</a>
+</dt>
+<dl>
+<dt>4.4.1.  <a href="#usecases-jabber-login-pri">Primary Flow</a>
+</dt>
+<dt>4.4.2.  <a href="#usecases-jabber-login-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.5.  <a href="#usecases-jabber-logout">Log Out</a>
+</dt>
+<dl>
+<dt>4.5.1.  <a href="#usecases-jabber-logout-pri">Primary Flow</a>
+</dt>
+<dt>4.5.2.  <a href="#usecases-jabber-logout-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.6.  <a href="#usecases-jabber-addcontact">Add Contact</a>
+</dt>
+<dl>
+<dt>4.6.1.  <a href="#usecases-jabber-addcontact-pri">Primary Flow</a>
+</dt>
+<dt>4.6.2.  <a href="#usecases-jabber-addcontact-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.7.  <a href="#usecases-jabber-deletecontact">Delete Contact</a>
+</dt>
+<dl>
+<dt>4.7.1.  <a href="#usecases-jabber-deletecontact-pri">Primary Flow</a>
+</dt>
+<dt>4.7.2.  <a href="#usecases-jabber-deletecontact-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.8.  <a href="#usecases-jabber-send">Send Message</a>
+</dt>
+<dl>
+<dt>4.8.1.  <a href="#usecases-jabber-send-pri">Primary Flow</a>
+</dt>
+<dt>4.8.2.  <a href="#usecases-jabber-send-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#usecases-legacy">Legacy User Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#usecases-legacy-add">Add Contact</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#usecases-legacy-add-pri">Primary Flow</a>
+</dt>
+<dt>5.1.2.  <a href="#usecases-legacy-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#usecases-legacy-delete">Delete Contact</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#usecases-legacy-delete-pri">Primary Flow</a>
+</dt>
+<dt>5.2.2.  <a href="#usecases-legacy-delete-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>5.3.  <a href="#usecases-legacy-send">Send Message</a>
+</dt>
+<dl>
+<dt>5.3.1.  <a href="#usecases-legacy-send-pri">Primary Flow</a>
+</dt>
+<dt>5.3.2.  <a href="#usecases-legacy-send-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#addressing">Addressing</a>
+</dt>
+<dt>7.  <a href="#rosters">Contact Lists</a>
+</dt>
+<dt>8.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">One distinguishing characteristic of Jabber from its earliest days has been the existence of gateways (also called &quot;transports&quot;) between the Jabber network and legacy instant messaging services such as AOL Instant Messenger (AIM), ICQ, MSN Messenger, and Yahoo! Instant Messenger. Surprisingly, the recommended behavior of such gateways, including the protocol elements used by a client to interact with a gateway, has never been fully documented. This JEP attempts to fill that void by codifying best practices for gateway interaction.</p>
+  <p class="" style="">Note well that this JEP defines protocol usage with regard to client proxy gateways, i.e., gateways that &quot;masquerade&quot; as a client on a non-Jabber IM service. Gateways that perform direct protocol translation without proxying for an account on a non-Jabber service are not addressed in this JEP. Furthermore, this JEP does not define any interaction between a gateway and the non-Jabber service, only interactions between a Jabber client and the gateway. Although what happens on the other side of the gateway is highly dependent on the nature of the legacy service, gateways should at least provide a common interface on the Jabber side of the gateway so that Jabber clients can be written in a consistent fashion.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-glossary">Architectural Terms</a>
+</h3>
+    <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Gateway</td>
+        <td align="" colspan="" rowspan="">A service on the Jabber network that translates between the Jabber/XMPP protocols and the protocol used by a Legacy Service; in the context of this JEP, by &quot;gateway&quot; we mean a &quot;client proxy service&quot; that acts as a client with regard to a Legacy Service and thereby &quot;masquerades&quot; as a user on such a service.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Jabber User</td>
+        <td align="" colspan="" rowspan="">A human user who has registered an account with a Jabber server; a Jabber User who wants to use a Gateway must first have also registered an account with a Legacy Service.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Legacy Service</td>
+        <td align="" colspan="" rowspan="">A non-XMPP instant messaging service.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Legacy User</td>
+        <td align="" colspan="" rowspan="">A human user who has registered an account with a Legacy Service.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Server</td>
+        <td align="" colspan="" rowspan="">An instant messaging server as defined in <span style="font-weight: bold">XMPP Core</span>
+</td>
+      </tr>
+    </table>
+  </div>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The requirements defined by this JEP are captured in two sets of use cases: one set from the perspective of the Jabber User, and a smaller set from the perspective of the Legacy User who wants to interact with the Jabber User.</p>
+  <p class="" style="">The Jabber User use cases are:</p>
+  <ol start="" type="">
+    <li>Register</li>
+    <li>Edit Registration</li>
+    <li>Unregister</li>
+    <li>Log In</li>
+    <li>Log Out</li>
+    <li>Add Contact</li>
+    <li>Delete Contact</li>
+    <li>Send Message</li>
+  </ol>
+  <p class="" style="">The Legacy User use cases are:</p>
+  <ol start="" type="">
+    <li>Add Contact</li>
+    <li>Delete Contact</li>
+    <li>Send Message</li>
+  </ol>
+<h2>4.
+       <a name="usecases-jabber">Jabber User Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecases-jabber-register">Register</a>
+</h3>
+    <p class="" style="">All existing client proxy gateways require a Jabber User to register with the Gateway before sending messages or presence through the gateway. Although strictly speaking registration is not required (e.g., a Gateway could prompt the Jabber User for credentials every time the user attempted to communicate through the gateway, or once per &quot;session&quot;), in practice this step is required.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="usecases-jabber-register-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ get in the <span class="ref">Service Discovery</span>  [<a href="#nt-id2602221">1</a>] information namespace to the Gateway, and/or IQ get in the <span class="ref">Agent Information</span>  [<a href="#nt-id2602242">2</a>] namespace to the Gateway's parent (the latter method is deprecated but still in use).</p>
+          <p class="caption">Example 1. User Queries Gateway Regarding Service Discovery Identity</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 2. User Queries Gateway's Parent Regarding Agent Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='shakespeare.lit'
+    id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="" style="">Note: Although most existing gateway implementations support only the older Agent Information protocol, it is RECOMMENDED that gateways support the Service Discovery protocol, since the former protocol is deprecated in favor of the latter. Until existing gateways are upgraded, clients SHOULD support both.</p>
+        </li>
+        <li>
+          <p class="" style="">Gateway and/or parent returns identity information to Jabber User's Client.</p>
+          <p class="caption">Example 3. Gateway Returns Service Discovery Identity</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='gateway'
+              type='aim'
+              name='AIM Gateway'/&gt;
+    &lt;feature var='jabber:iq:register'/&gt;
+    &lt;feature var='jabber:iq:time'/&gt;
+    &lt;feature var='jabber:iq:version'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 4. Gateway's Parent Returns Agent Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='shakespeare.lit'
+    id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    &lt;agent jid='aim.shakespeare.lit'&gt;
+      &lt;name&gt;AIM Gateway&lt;/name&gt;
+      &lt;service&gt;aim&lt;/service&gt;
+      &lt;transport/&gt;
+      &lt;register/&gt;
+    &lt;/agent&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="" style="">Note: Given the foregoing, a client can determine the identity of the gateway, specifically (1) that it is a gateway and (2) to which legacy service it provides a gateway.</p>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ get in the <span class="ref">In-Band Registration</span>  [<a href="#nt-id2602369">3</a>] (jabber:iq:register) namespace to Gateway.</p>
+          <p class="caption">Example 5. User Queries Gateway Regarding Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway returns IQ result to Jabber User, specifying information that is required in order to register.</p>
+          <p class="caption">Example 6. Gateway Returns Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      Please provide your AIM username and password.
+    &lt;/instructions&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:register' namespace to Gateway, containing information required to register.</p>
+          <p class="caption">Example 7. User Provides Registration Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway verifies that registration information provided by Jabber User is valid (using whatever means appropriate for the Legacy Service) and informs Jabber User of success [A1].</p>
+          <p class="caption">Example 8. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg2'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Optionally, Jabber User sends IQ set qualified by the 'jabber:iq:roster' namespace to its server (see <span class="ref">XMPP IM</span>  [<a href="#nt-id2602499">4</a>]), containing a roster item for Gateway.</p>
+          <p class="caption">Example 9. User Creates Roster Entry</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    id='roster1'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='aim.shakespeare.lit' name='AIM Gateway'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 10. Server Response</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    to='romeo@montague.net/orchard'
+    id='roster1'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">If Gateway logged using into Legacy Service in preceding step, Gateway buffers any translatable events (e.g., messages and presence) queued up for Jabber User on Legacy Service.</p></li>
+        <li>
+          <p class="" style="">Gateway sends subscription request to Jabber User (i.e., by sending a presence stanza of type &quot;subscribe&quot; to Jabber User's bare JID).</p>
+          <p class="caption">Example 11. Gateway Subscribes to User's Presence</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User's client SHOULD approve the subscription request (i.e., by sending a presence stanza of type &quot;subscribed&quot; to Gateway).</p>
+          <p class="caption">Example 12. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+          <p class="" style="">Note: As specified in <span style="font-weight: bold">XMPP IM</span>, Jabber User's server will generate a &quot;roster push&quot; at this point if client did not previously perform a roster set to add Gateway to user's roster (as mentioned in Step 7).</p>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends subscription request to Gateway (i.e., by sending a presence stanza of type &quot;subscribe&quot; to Gateway).</p>
+          <p class="caption">Example 13. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends approves subscription request (i.e., by sending a presence stanza of type &quot;subscribed&quot; to Jabber User's bare JID).</p>
+          <p class="caption">Example 14. Gateway Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Execute &quot;Log In&quot; use case.</p></li>
+        <li><p class="" style="">Gateway sends any buffered messages to Jabber User.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="usecases-jabber-register-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">User information not verified:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway returns &quot;Not Acceptable&quot; error to Jabber User.</p>
+              <p class="caption">Example 15. Gateway Informs Jabber User of Registration Error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecases-jabber-edit">Edit Registration</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the user may wish to modify its existing registration information (e.g., because the user has changed his or her password on the legacy IM service).</p>
+    <div class="indent">
+<h3>4.2.1 <a name="usecases-jabber-edit-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ get qualified by the 'jabber:iq:register' namespace to Gateway.</p>
+          <p class="caption">Example 16. User Queries Gateway Regarding Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='edit1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway returns IQ result to Jabber User, specifying registration information of record and including empty &lt;registered/&gt; element to signify that user is already registered.</p>
+          <p class="caption">Example 17. Gateway Returns Registration Information of Record</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;registered/&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:register' namespace to Gateway, containing all information (i.e., not just the &quot;delta&quot;).</p>
+          <p class="caption">Example 18. User Provides Registration Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='edit2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;B4lc0ny&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway verifies that, if changed, information provided by Jabber User is still valid (using whatever means appropriate for the Legacy Service) and informs Jabber User of success [A1].</p>
+          <p class="caption">Example 19. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit2'/&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="usecases-jabber-edit-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Edit unsuccessful:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway returns &quot;Not Acceptable&quot; error to Jabber User.</p>
+              <p class="caption">Example 20. Gateway Informs Jabber User of Registration Error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;B4lc0ny&lt;/password&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecases-jabber-unregister">Unregister</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the user may choose to unregister with the Gateway, effectively ending his or her relationship with the Gateway (e.g., the user will no longer be allowed to communicate through the gateway with legacy users).</p>
+    <div class="indent">
+<h3>4.3.1 <a name="usecases-jabber-unregister-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ set in 'jabber:iq:register' namespace to Gateway, containing empty &lt;remove/&gt; element.</p>
+          <p class="caption">Example 21. User Unregisters</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='unreg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;remove/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway sends unavailable presence from Jabber User to Legacy Users and logs Jabber User out of Legacy Service.</p></li>
+        <li><p class="" style="">Gateway deletes Jabber User's information.</p></li>
+        <li>
+          <p class="" style="">Gateway sends IQ result to Jabber User.</p>
+          <p class="caption">Example 22. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='unreg1'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway cancels subscriptions.</p>
+          <p class="caption">Example 23. Gateway Cancels Subscriptions</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends unavailable presence to Jabber User.</p>
+          <p class="caption">Example 24. Gateway Logs User Out</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Jabber User's client SHOULD delete from the user's roster (1) the gateway itself, and (2) all legacy cOntacts associated with the gateway.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="usecases-jabber-unregister-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="usecases-jabber-login">Log In</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the Jabber User may subsequently log in to the Gateway, effectively creating a &quot;session&quot; with the Gateway and enabling the Gateway to log into the Legacy Service on behalf of the user by sending the user's legacy credentials to the Legacy Service.</p>
+    <div class="indent">
+<h3>4.4.1 <a name="usecases-jabber-login-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends available presence broadcast to Server or sends directed presence to Gateway or a Legacy User.</p>
+          <p class="caption">Example 25. Jabber User Sends Available Presence</p>
+<div class="indent"><pre>
+&lt;presence/&gt;
+          </pre></div>
+          <p class="caption">Example 26. Jabber User's Server Broadcasts Available Presence</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'/&gt;
+&lt;presence from='romeo@montague.net/orchard'
+          to='aim.shakespeare.lit'/&gt;
+...
+          </pre></div>
+        </li>
+        <li><p class="" style="">Upon receiving first presence notification stanza from Jabber User to Gateway or Legacy User, Gateway logs Jabber User into Legacy Service [A1].</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza to Jabber User expressing availability.</p>
+          <p class="caption">Example 27. Gateway Sends Presence to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Optionally, Gateway handles Legacy Service contact list; see the <a href="#rosters">Contact Lists</a> section of this document.</p></li>
+        <li>
+          <p class="" style="">Gateway forwards current presence information from Legacy Users to Jabber User, if possible mapping availability status (e.g., &quot;away&quot;).</p>
+          <p class="caption">Example 28. Gateway Sends Presence from Legacy Users to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@aim.shakespeare.lit'
+          to='romeo@montague.net'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+&lt;/presence&gt;
+          </pre></div>
+          <p class="" style="">Note: If the Legacy Service to which the Gateway connects does not support the concept of &quot;resources&quot;, the 'from' address of presence notification stanzas generated by a gateway SHOULD NOT include a resource identifier (i.e., they SHOULD be of the form &lt;user@host&gt; rather than &lt;user@host/resource&gt;). However, the 'from' address MAY include a resource if the Gateway determines that this is appropriate in the context of its communications with the Legacy Service.</p>
+        </li>
+        <li>
+          <p class="" style="">Gateway forwards all subsequent presence stanzas to Legacy Users (except those of type &quot;probe&quot; and those addressed to the Gateway itself).</p>
+          <p class="caption">Example 29. Jabber User Modifies Presence</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'&gt;
+  &lt;show&gt;dnd&lt;/show&gt;
+  &lt;status&gt;Wooing Juliet&lt;/status&gt;
+&lt;/presence&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.4.2 <a name="usecases-jabber-login-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Login fails:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway sends appropriate presence error to Jabber User (Not Authorized&quot; if password is bad, &quot;Remote Server Timeout&quot; if Legacy Service is down, etc.).</p>
+              <p class="caption">Example 30. Gateway Informs Jabber User of Failed Login</p>
+<div class="indent"><pre>
+&lt;presence to='aim.shakespeare.lit'
+          from='romeo@shakespeare.lit'&gt;
+  &lt;error code='504' type='wait'&gt;
+    &lt;remote-server-timeout
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="usecases-jabber-logout">Log Out</a>
+</h3>
+    <p class="" style="">At any time after logging in to the Gateway, the Jabber User may log out of the Gateway and thereby end his or her session on the Legacy Service. This may happen automatically when the Jabber User terminates his or her session with a Jabber server, or independently of any session on the Jabber network by manually logging out of the Gateway.</p>
+    <div class="indent">
+<h3>4.5.1 <a name="usecases-jabber-logout-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends unavailable presence broadcast to Server or sends directed presence stanza of type &quot;unavailable&quot; to Gateway or Legacy User.</p>
+          <p class="caption">Example 31. Jabber User Sends Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'/&gt;
+          </pre></div>
+          <p class="caption">Example 32. Jabber User's Server Broadcasts Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway transforms unavailable presence stanzas received from the Jabber User's server and routes them to all of the Jabber User's contacts on Legacy Service.</p></li>
+        <li><p class="" style="">Gateway logs Jabber User out of Legacy Service [A1].</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type &quot;unavailable&quot; to Jabber User.</p>
+          <p class="caption">Example 33. Gateway Logs User Out</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.5.2 <a name="usecases-jabber-logout-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy Service supports directed presence and Gateway receives presence stanza of type &quot;unavailable&quot; directed to a Legacy User:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway passes through directed unavailable presence to Legacy User.</p>
+              <p class="caption">Example 34. Jabber User Becomes Unavailable</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'/&gt;
+              </pre></div>
+              </li>
+            <li><p class="" style="">Use Case Ends.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="usecases-jabber-addcontact">Add Contact</a>
+</h3>
+    <p class="" style="">After registering with the Gateway, the Jabber User may want to add Legacy Users to his or her Jabber roster.</p>
+    <div class="indent">
+<h3>4.6.1 <a name="usecases-jabber-addcontact-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends presence stanza of type &quot;subscribe&quot; to Legacy User.</p>
+          <p class="caption">Example 35. Jabber User Sends Subscription Request to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+          <p class="" style="">Note: As specified in <span style="font-weight: bold">XMPP IM</span>, sending this packet will result in a &quot;roster push&quot; from the Server to all of the Jabber User's available resources.</p>
+        </li>
+        <li><p class="" style="">Gateway transforms subscription request and routes it to Legacy User.</p></li>
+        <li>
+          <p class="" style="">If Legacy User approves subscription request, Gateway sends presence stanza of type &quot;subscribed&quot; to Jabber User on behalf of Legacy User. [A1]</p>
+          <p class="caption">Example 36. Gateway Approves Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends available presence stanza to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 37. Gateway Sends Legacy User's Current Presence Infromation to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type &quot;subscribe&quot; to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 38. Gateway Sends Subscription Request to Jabber User on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends presence stanza of type &quot;subscribed&quot; to Legacy User.</p>
+          <p class="caption">Example 39. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.6.2 <a name="usecases-jabber-addcontact-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Legacy User denies subscription request:</p>
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway transforms subscription denial and routes it to Jabber User.</p>
+              <p class="caption">Example 40. Legacy User Denies Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribed'
+          from='juliet@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+              </pre></div>
+              </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="usecases-jabber-deletecontact">Delete Contact</a>
+</h3>
+    <p class="" style="">After adding a Legacy User to his or her Jabber roster, the Jabber User may want to delete that contact.</p>
+    <div class="indent">
+<h3>4.7.1 <a name="usecases-jabber-deletecontact-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:roster' namespace, containing subscription attribute with value of &quot;remove&quot;.</p>
+          <p class="caption">Example 41. User Removes Roster Entry for Legacy User</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    id='remove1'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='CapuletNurse@aim.shakespeare.lit'
+          subscription='remove'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Server sends normal &quot;roster push&quot; to Jabber User (see <span style="font-weight: bold">XMPP IM</span>) and sends presence stanzas of type &quot;unsubscribe&quot;, &quot;unsubscribed&quot;, and &quot;unavailable&quot; to Legacy User.</p>
+          <p class="caption">Example 42. Server Sends Presence Changes to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway cleans up subscription state, informs Legacy User that Jabber User is unavailable, and MUST NOT send future changes in Jabber User's presence to Legacy User.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.7.2 <a name="usecases-jabber-deletecontact-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="usecases-jabber-send">Send Message</a>
+</h3>
+    <p class="" style="">Naturally, the Jabber User may want to exchange messages with a Legacy User. For the purposes of this JEP, we discuss one-to-one messaging only (i.e., groupchat messages, such as those defined in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2604208">5</a>], are out of scope).</p>
+    <div class="indent">
+<h3>4.8.1 <a name="usecases-jabber-send-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends message stanza to Legacy User.</p>
+          <p class="caption">Example 43. Jabber User Sends Message to Legacy User</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard'
+         to='juliet@aim.shakespeare.lit'
+         type='chat'&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway transforms message to legacy protocol and sends to Legacy User [A1].</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.8.2 <a name="usecases-jabber-send-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy Service reports error.</p></li>
+        <li>
+          <p class="" style="">Gateway sends appropriate error to Jabber User:</p>
+          <ul>
+            <li><p class="" style="">&quot;Not Found&quot; -- Legacy User address is not valid).</p></li>
+            <li><p class="" style="">&quot;Registration Required&quot; -- Jabber User is not registered with Gateway).</p></li>
+            <li><p class="" style="">&quot;Service Unavailable&quot; -- Legacy User is offline and Legacy Service does not provide offline message storage).</p></li>
+            <li><p class="" style="">&quot;Remote Server Error&quot; -- Legacy Service cannot be reached).</p></li>
+          </ul>
+          <p class="" style="">For mapping of these error codes to XMPP-compliant error conditions, refer to <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2604402">6</a>].</p>
+        </li>
+        <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+      </ol>
+    </div>
+  </div>
+<h2>5.
+       <a name="usecases-legacy">Legacy User Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="usecases-legacy-add">Add Contact</a>
+</h3>
+    <p class="" style="">The Legacy User may want to add the Jabber User to his or her contact list on the Legacy Service. Because the Jabber User has an account on the Legacy Service by definition, the Legacy User will actually add the Jabber User's legacy address to his or her contact list, not the Jabber User's address on the Jabber/XMPP network.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="usecases-legacy-add-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User requests subscription to Jabber User (using legacy protocol).</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type &quot;subscribe&quot; to Jabber User on behalf of Legacy User (note: Gateway MUST NOT send presence stanza of type &quot;subscribed&quot;).</p>
+          <p class="caption">Example 44. Gateway Sends Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User approves subscription request by sending presence stanza of type &quot;subscribed&quot; to Legacy User [A1].</p>
+          <p class="caption">Example 45. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway sends Jabber User's presence information to Legacy User.</p></li>
+        <li>
+          <p class="" style="">Jabber User's Client sends presence stanza of type &quot;subscribe&quot; to Legacy User.</p>
+          <p class="caption">Example 46. Jabber User Sends Subscription Request to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type &quot;subscribed&quot; to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 47. Gateway Approves Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends Legacy User's presence information to Jabber User.</p>
+          <p class="caption">Example 48. Gateway Sends Legacy User's Current Presence Information to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="usecases-legacy-add-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Jabber User denies subscription request:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Jabber User sends presence stanza of type &quot;unsubscribed&quot; to Legacy User.</p>
+              <p class="caption">Example 49. Jabber User Denies Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Gateway cleans up subscription state and MUST NOT send Jabber User's presence to Legacy User.</p></li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="usecases-legacy-delete">Delete Contact</a>
+</h3>
+    <p class="" style="">After adding the Jabber User to his or her legacy contact list, the Legacy User may want to delete the Jabber User.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="usecases-legacy-delete-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User deletes Jabber User (using legacy protocol).</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanzas of type &quot;unsubscribe&quot; and &quot;unsubscribed&quot; to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 50. Gateway Cleans Up Subscription on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unavailable'
+          from='CapuletNurse@aim.shakespeare.lit'
+          from='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Jabber User's server performs defined functionality for handling presence stanzas of type &quot;unsubscribe&quot; and &quot;unsubscribed&quot; (see <span style="font-weight: bold">XMPP IM</span>).</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="usecases-legacy-delete-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="usecases-legacy-send">Send Message</a>
+</h3>
+    <p class="" style="">Naturally, the Legacy User may want to exchange messages with the Jabber User. Here again, groupchat messages are out of scope.</p>
+    <div class="indent">
+<h3>5.3.1 <a name="usecases-legacy-send-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User sends message to Jabber User using legacy protocol.</p></li>
+        <li>
+          <p class="" style="">Gateway transforms message and routes to Jabber User.</p>
+          <p class="caption">Example 51. Legacy User Sends Message to Jabber User</p>
+<div class="indent"><pre>
+&lt;message from='juliet@aim.shakespeare.lit'
+         to='romeo@montague.net/orchard'&gt;
+  &lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+          <p class="" style="">Note: If the Legacy Service to which the Gateway connects does not support a concept equivalent to that of Jabber &quot;resources&quot; as described in <span style="font-weight: bold">XMPP Core</span>, the 'from' address of message stanzas generated by a gateway SHOULD NOT include a resource identifier (i.e., they SHOULD be of the form &lt;user@host&gt; rather than &lt;user@host/resource&gt;). However, the 'from' address MAY include a resource if the Gateway determines that this is appropriate in the context of its communications with the Legacy Service.</p>
+        </li>
+        <li><p class="" style="">Jabber User's Server delivers message or (optionally) stores it for later retrieval.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.3.2 <a name="usecases-legacy-send-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+<h2>6.
+       <a name="addressing">Addressing</a>
+</h2>
+  <p class="" style="">The address of a gateway itself SHOULD be a hostname only, and that hostname SHOULD NOT be supplemented with a resource identifier when referring to the gateway's address (e.g., when storing the gateway in a roster). The hostname SHOULD be a subdomain of a primary Jabber host (e.g., icq.jabber.org might be the ICQ gateway run by the jabber.org server).</p>
+  <p class="" style="">Usernames on legacy IM services are not necessarily compatible with Jabber usernames as specified by the Nodeprep profile of stringprep defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2605062">7</a>], and some legacy services use addresses of the form &lt;user@domain&gt;. Both of these cases must be handled by the Jabber gateway to the relevant service, as well as by the Jabber clients which interact with that gateway. There are two known cases:</p>
+  <ol start="" type="">
+    <li><p class="" style="">AOL screen names used in AIM are allowed to contain spaces, which are illegal in the node identifier portion of a Jabber Identifier. However, AOL screen names containing spaces (e.g., &quot;King Lear&quot;) are equivalent to the same screen name without spaces (&quot;KingLear&quot;); therefore, spaces in the legacy address MUST be removed when constructing a JabberID for the legacy user (e.g., &quot;KingLear@aim.shakespeare.lit&quot;).</p></li>
+    <li><p class="" style="">MSN addresses used in MSN Messenger are of the form &lt;user@domain&gt;. Because the '@' character is illegal in the node identifier portion of a Jabber Identifier, it MUST be escaped or transformed when constructing a JabberID for the legacy user. The traditional convention in the Jabber community has been to replace the '@' character with the '%' character. Although we might not design such a method today, there is no good reason to define a new method that breaks backward compatibility; therefore, the traditional substitution MUST be used.</p></li>
+  </ol>
+  <p class="" style="">There are no known issues with addresses used in legacy services other than AIM and MSN (e.g., ICQ and Yahoo).</p>
+  <p class="" style="">In the past, some gateways and clients used the undocumented 'jabber:iq:gateway' namespace to &quot;negotiate&quot; address conversion for any particular contact address on the legacy service. This use is not recommended, for several reasons:</p>
+  <ol start="" type="">
+    <li><p class="" style="">The only known issues with address mapping are those described above, so a generalized solution is not necessary.</p></li>
+    <li><p class="" style="">The jabber:iq:gateway protocol provided text for the &quot;prompt&quot; shown to the user (e.g., &quot;Please enter the AOL Screen Name of the person you would like to contact&quot;) as well as a name for the prompted item (e.g., &quot;Screen Name&quot;); however, this text is provided in English and does not take into account localization for non-English speakers or customization in particular clients, so it is better to let the client determine both the descriptive text and the prompt name based on the identity of the gateway as determined using <span style="font-weight: bold">Service Discovery</span> or <span style="font-weight: bold">Agent Information</span>.</p></li>
+  </ol>
+  <p class="" style="">Naturally, clients and gateways are free to continue using the &quot;jabber:iq:gateway&quot; protocol, which may be documented for historical purposes in a future specification.</p>
+  <p class="" style="">The following table will assist implementers with mapping of gateway identities to English-language prompt items (client developers or translators creating non-English-language interfaces should determine the localized name for these prompt items if available):</p>
+  <p class="caption">Table 2: Prompt Item Mapping (English)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Legacy Service</th>
+      <th colspan="" rowspan="">Service Discovery Identity</th>
+      <th colspan="" rowspan="">Prompt Item</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">AOL Instant Messenger</td>
+      <td align="" colspan="" rowspan="">&lt;identity category='gateway' type='aim'/&gt;</td>
+      <td align="" colspan="" rowspan="">Screen Name</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">ICQ</td>
+      <td align="" colspan="" rowspan="">&lt;identity category='gateway' type='icq'/&gt;</td>
+      <td align="" colspan="" rowspan="">UIN</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">MSN Messenger</td>
+      <td align="" colspan="" rowspan="">&lt;identity category='gateway' type='msn'/&gt;</td>
+      <td align="" colspan="" rowspan="">Address</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Yahoo! Instant Messenger</td>
+      <td align="" colspan="" rowspan="">&lt;identity category='gateway' type='yahoo'/&gt;</td>
+      <td align="" colspan="" rowspan="">ID</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="rosters">Contact Lists</a>
+</h2>
+  <p class="" style="">Some legacy services maintain server-side contact lists, which are sent to the gateway when it logs in to the legacy service on behalf of the user. The gateway MAY initiate adding of the legacy contact list items to the user's Jabber roster. Some existing gateways do this by sending a presence stanza of type &quot;subscribed&quot; from the legacy contact's JID (e.g., &lt;LegacyUser@gateway.jabberserver.com&gt;) to the Jabber user; unfortunately, this behavior violates the presence stanza handling rules specified in <span style="font-weight: bold">XMPP IM</span>. Therefore, a gateway SHOULD instead send the legacy contact list items to the Jabber User via the <span class="ref">Roster Item Exchange</span>  [<a href="#nt-id2605473">8</a>] protocol.</p>
+<h2>8.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <p class="" style="">The following business rules apply:</p>
+  <ol start="" type="">
+    <li><p class="" style="">A client SHOULD send a <span style="font-weight: bold">Service Discovery</span> request to the gateway (and/or an <span style="font-weight: bold">Agent Information</span> request to the gateway's parent) before requesting registration information.</p></li>
+    <li><p class="" style="">A gateway SHOULD support the <span style="font-weight: bold">Service Discovery</span> protocol.</p></li>
+    <li><p class="" style="">A gateway SHOULD support the <span style="font-weight: bold">Agent Information</span> protocol, although it is deprecated.</p></li>
+    <li><p class="" style="">A gateway SHOULD map, as best it can, the legacy registration fields onto the fields defined for the 'jabber:iq:register' namespace.</p></li>
+    <li><p class="" style="">A gateway SHOULD NOT attempt to emulate offline message storage functionality for legacy services that lack such functionality.</p></li>
+    <li>
+      <p class="" style="">Existing gateway implementations do not strictly adhere to the bi-directional nature of Jabber presence notifications, since they do not broadcast presence from the gateway itself to registered users of the gateway, but rather wait for a registered user to send presence to the gateway before sending presence to the user. This sidesteps scalability challenges but may be sub-optimal; while this JEP does not require existing gateways to change their current behavior, it does RECOMMEND that they broadcast presence notifications to registered users in accordance with the standard Jabber presence model. Specifically:</p>
+      <ul>
+        <li><p class="" style="">On startup, a gateway (1) SHOULD send presence to all registered users of that gateway but (2) MAY wait to receive presence changes from each registered user.</p></li>
+        <li><p class="" style="">On shutdown, a gateway SHOULD send unavailable presence to all registered users of the gateway.</p></li>
+      </ul>
+    </li>
+  </ol>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">As defined herein, a gateway is a <span style="font-style: italic">client proxy</span>, since it &quot;masquerades&quot; as a user on a legacy instant messaging service. In order to act as a client proxy, the gateway logs into the user's account on the legacy service. This implies two things:</p>
+  <ul>
+    <li>The gateway must gather the legacy credentials from the user, and perhaps store them on the user's behalf.</li>
+    <li>The gateway must provide the user's credential to the legacy service.</li>
+  </ul>
+  <p class="" style="">There are obvious security concerns with this approach. The concerns include:</p>
+  <ol start="" type="">
+    <li>The user's credentials on the legacy service may be sent in the clear from the gateway to the legacy service if the legacy service does not support channel encryption or strong authentication.</li>
+    <li>When the user informs the gateway of the user's legacy credentials, the credentials may be sent in the clear between the user's Jabber client and the user's Jabber server (if client-to-server channel encryption is not enabled) or between the user's Jabber server and the gateway (if the gateway is not in the user's &quot;home&quot; domain and server-to-server channel encryption is not enabled).</li>
+    <li>If the gateway stores the user's legacy credentials after registration (this is the default behavior of most or all existing gateway implementations), the user's credentials could be acquired by a malicious user if the server hosting the gateway is compromised.</li>
+  </ol>
+  <p class="" style="">There is no foreseeable solution to these concerns, since they are instrinsic to the client proxy model. Some assurance regarding the second and third concerns can be achieved if the user runs his or her own Jabber server and gateways. However, the only true solution is to move beyond the client proxy model, either by using Jabber for all IM communications or to convince legacy IM services to use open protocols such as Jabber/XMPP, thus making it possible to deploy secure server federation between a legacy service and Jabber/XMPP domains.</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2605791">9</a>].</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605733">10</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602221">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602242">2</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602369">3</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602499">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2604208">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604402">6</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605062">7</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2605473">8</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605791">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605733">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-05-07)</h4>
+<div class="indent">Editorial review: made a number of minor textual changes and clarifications throughout; added introductory paragraph to each use case; specified that groupchat is out of scope. (psa)
+    </div>
+<h4>Version 0.7 (2004-03-31)</h4>
+<div class="indent">Cleaned up several notes, examples, and business rules based on feedback received on list. (psa)
+    </div>
+<h4>Version 0.6 (2004-03-08)</h4>
+<div class="indent">Added note about 'from' address on presence notifications and messages received through gateways from legacy users. (psa)
+    </div>
+<h4>Version 0.5 (2004-01-21)</h4>
+<div class="indent">Further specified the rationale for deprecating the &quot;jabber:iq:gateway&quot; protocol. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-05)</h4>
+<div class="indent">Added Edit Registration use case; modified handling of legacy contact lists to conform to XMPP IM; modified addressing rules; defined gateway startup and shutdown behavior; included XMPP error handling. (psa)
+    </div>
+<h4>Version 0.3 (2003-12-10)</h4>
+<div class="indent">Added security considerations; defined handling of legacy contact lists. (psa)
+    </div>
+<h4>Version 0.2 (2003-12-03)</h4>
+<div class="indent">Corrected some errors; clarified some ambiguities; added protocol flows. (psa)
+    </div>
+<h4>Version 0.1 (2003-06-25)</h4>
+<div class="indent">Initial version. (psa/dss)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0100-0.9.html
+++ b/content/xep-0100-0.9.html
@@ -1,0 +1,1300 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0100: Gateway Interaction</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Gateway Interaction">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies best practices for interactions between Jabber clients and client proxy gateways to legacy IM services.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0100">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0100: Gateway Interaction</h1>
+<p>This JEP specifies best practices for interactions between Jabber clients and client proxy gateways to legacy IM services.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0100<br>
+            Version: 0.9<br>
+            Last Updated: 2004-10-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0077, JEP-0144<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br></p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-glossary">Architectural Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases-jabber">Jabber User Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecases-jabber-register">Register</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#usecases-jabber-register-pri">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#usecases-jabber-register-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#usecases-jabber-edit">Edit Registration</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#usecases-jabber-edit-pri">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#usecases-jabber-edit-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#usecases-jabber-unregister">Unregister</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#usecases-jabber-unregister-pri">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#usecases-jabber-unregister-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.4.  <a href="#usecases-jabber-login">Log In</a>
+</dt>
+<dl>
+<dt>4.4.1.  <a href="#usecases-jabber-login-pri">Primary Flow</a>
+</dt>
+<dt>4.4.2.  <a href="#usecases-jabber-login-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.5.  <a href="#usecases-jabber-logout">Log Out</a>
+</dt>
+<dl>
+<dt>4.5.1.  <a href="#usecases-jabber-logout-pri">Primary Flow</a>
+</dt>
+<dt>4.5.2.  <a href="#usecases-jabber-logout-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.6.  <a href="#usecases-jabber-addcontact">Add Contact</a>
+</dt>
+<dl>
+<dt>4.6.1.  <a href="#usecases-jabber-addcontact-pri">Primary Flow</a>
+</dt>
+<dt>4.6.2.  <a href="#usecases-jabber-addcontact-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.7.  <a href="#usecases-jabber-deletecontact">Delete Contact</a>
+</dt>
+<dl>
+<dt>4.7.1.  <a href="#usecases-jabber-deletecontact-pri">Primary Flow</a>
+</dt>
+<dt>4.7.2.  <a href="#usecases-jabber-deletecontact-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.8.  <a href="#usecases-jabber-send">Send Message</a>
+</dt>
+<dl>
+<dt>4.8.1.  <a href="#usecases-jabber-send-pri">Primary Flow</a>
+</dt>
+<dt>4.8.2.  <a href="#usecases-jabber-send-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#usecases-legacy">Legacy User Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#usecases-legacy-add">Add Contact</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#usecases-legacy-add-pri">Primary Flow</a>
+</dt>
+<dt>5.1.2.  <a href="#usecases-legacy-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#usecases-legacy-delete">Delete Contact</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#usecases-legacy-delete-pri">Primary Flow</a>
+</dt>
+<dt>5.2.2.  <a href="#usecases-legacy-delete-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>5.3.  <a href="#usecases-legacy-send">Send Message</a>
+</dt>
+<dl>
+<dt>5.3.1.  <a href="#usecases-legacy-send-pri">Primary Flow</a>
+</dt>
+<dt>5.3.2.  <a href="#usecases-legacy-send-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#addressing">Addressing</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#addressing-gateway">Gateways</a>
+</dt>
+<dt>6.2.  <a href="#addressing-user">Users</a>
+</dt>
+</dl>
+<dt>7.  <a href="#rosters">Contact Lists</a>
+</dt>
+<dt>8.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Jabber Registrar Considerations</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">One distinguishing characteristic of Jabber technologies from its earliest days has been the existence of gateways (also called "transports") between the Jabber network and legacy instant messaging services such as AOL Instant Messenger (AIM), ICQ, MSN Messenger, and Yahoo! Instant Messenger. Surprisingly, the recommended behavior of such gateways, including the protocol elements used by a client to interact with a gateway, has never been fully documented. This JEP attempts to fill that void by codifying best practices for gateway interaction.</p>
+  <p class="" style="">Note well that this JEP defines protocol usage with regard to client proxy gateways, i.e., gateways that "masquerade" as a client on a non-Jabber IM service. Gateways that perform direct protocol translation without proxying for an account on a non-Jabber service are not addressed in this JEP. Furthermore, this JEP does not define any interaction between a gateway and the non-Jabber service, only interactions between a Jabber client and the gateway. Although what happens on the other side of the gateway is highly dependent on the nature of the legacy service, gateways should at least provide a common interface on the Jabber side of the gateway so that Jabber clients can be written in a consistent fashion.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="terms-glossary">Architectural Terms</a>
+</h3>
+    <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Gateway</td>
+        <td align="" colspan="" rowspan="">A service on the Jabber network that translates between the Jabber/XMPP protocols and the protocol used by a Legacy Service; in the context of this JEP, by "gateway" we mean a "client proxy service" that acts as a client with regard to a Legacy Service and thereby "masquerades" as a user on such a service.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Jabber User</td>
+        <td align="" colspan="" rowspan="">A human user who has registered an account with a Jabber server; a Jabber User who wants to use a Gateway must first have also registered an account with a Legacy Service.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Legacy Service</td>
+        <td align="" colspan="" rowspan="">A non-XMPP instant messaging service.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Legacy User</td>
+        <td align="" colspan="" rowspan="">A human user who has registered an account with a Legacy Service.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Server</td>
+        <td align="" colspan="" rowspan="">An instant messaging server as defined in <span style="font-weight: bold">XMPP Core</span>
+</td>
+      </tr>
+    </table>
+  </div>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The requirements defined by this JEP are captured in two sets of use cases: one set from the perspective of the Jabber User, and a smaller set from the perspective of the Legacy User who wants to interact with the Jabber User.</p>
+  <p class="" style="">The Jabber User use cases are:</p>
+  <ol start="" type="">
+    <li>Register</li>
+    <li>Edit Registration</li>
+    <li>Unregister</li>
+    <li>Log In</li>
+    <li>Log Out</li>
+    <li>Add Contact</li>
+    <li>Delete Contact</li>
+    <li>Send Message</li>
+  </ol>
+  <p class="" style="">The Legacy User use cases are:</p>
+  <ol start="" type="">
+    <li>Add Contact</li>
+    <li>Delete Contact</li>
+    <li>Send Message</li>
+  </ol>
+<h2>4.
+       <a name="usecases-jabber">Jabber User Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecases-jabber-register">Register</a>
+</h3>
+    <p class="" style="">All existing client proxy gateways require a Jabber User to register with the Gateway before sending messages or presence through the gateway. Although strictly speaking registration is not required (e.g., a Gateway could prompt the Jabber User for credentials every time the user attempted to communicate through the gateway, or once per "session"), in practice this step is required.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="usecases-jabber-register-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ get in the <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255217">1</a>] information namespace to the Gateway, and/or IQ get in the <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2255240">2</a>] namespace to the Gateway's parent (the latter method is deprecated but still in use).</p>
+          <p class="caption">Example 1. User Queries Gateway Regarding Service Discovery Identity</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 2. User Queries Gateway's Parent Regarding Agent Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='shakespeare.lit'
+    id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="" style="">Note: Although most existing gateway implementations support only the older Agent Information protocol, it is RECOMMENDED that gateways support the Service Discovery protocol, since the former protocol is deprecated in favor of the latter. Until existing gateways are upgraded, clients SHOULD support both.</p>
+        </li>
+        <li>
+          <p class="" style="">Gateway and/or parent returns identity information to Jabber User's Client.</p>
+          <p class="caption">Example 3. Gateway Returns Service Discovery Identity</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='gateway'
+              type='aim'
+              name='AIM Gateway'/&gt;
+    &lt;feature var='jabber:iq:register'/&gt;
+    &lt;feature var='jabber:iq:time'/&gt;
+    &lt;feature var='jabber:iq:version'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 4. Gateway's Parent Returns Agent Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='shakespeare.lit'
+    id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    &lt;agent jid='aim.shakespeare.lit'&gt;
+      &lt;name&gt;AIM Gateway&lt;/name&gt;
+      &lt;service&gt;aim&lt;/service&gt;
+      &lt;transport/&gt;
+      &lt;register/&gt;
+    &lt;/agent&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="" style="">Note: Given the foregoing, a client can determine the identity of the gateway, specifically (1) that it is a gateway and (2) to which legacy service it provides a gateway.</p>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ get in the <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2255350">3</a>] (jabber:iq:register) namespace to Gateway.</p>
+          <p class="caption">Example 5. User Queries Gateway Regarding Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway returns IQ result to Jabber User, specifying information that is required in order to register.</p>
+          <p class="caption">Example 6. Gateway Returns Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;instructions&gt;
+      Please provide your AIM username and password.
+    &lt;/instructions&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:register' namespace to Gateway, containing information required to register.</p>
+          <p class="caption">Example 7. User Provides Registration Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway verifies that registration information provided by Jabber User is valid (using whatever means appropriate for the Legacy Service) and informs Jabber User of success [A1].</p>
+          <p class="caption">Example 8. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg2'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Optionally, Jabber User sends IQ set qualified by the 'jabber:iq:roster' namespace to its server (see <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2255461">4</a>]), containing a roster item for Gateway.</p>
+          <p class="caption">Example 9. User Creates Roster Entry</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    id='roster1'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='aim.shakespeare.lit' name='AIM Gateway'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+          <p class="caption">Example 10. Server Response</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    to='romeo@montague.net/orchard'
+    id='roster1'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">If Gateway logged using into Legacy Service in preceding step, Gateway buffers any translatable events (e.g., messages and presence) queued up for Jabber User on Legacy Service.</p></li>
+        <li>
+          <p class="" style="">Gateway sends subscription request to Jabber User (i.e., by sending a presence stanza of type "subscribe" to Jabber User's bare JID).</p>
+          <p class="caption">Example 11. Gateway Subscribes to User's Presence</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User's client SHOULD approve the subscription request (i.e., by sending a presence stanza of type "subscribed" to Gateway).</p>
+          <p class="caption">Example 12. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+          <p class="" style="">Note: As specified in <span style="font-weight: bold">XMPP IM</span>, Jabber User's server will generate a "roster push" at this point if client did not previously perform a roster set to add Gateway to user's roster (as mentioned in Step 7).</p>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends subscription request to Gateway (i.e., by sending a presence stanza of type "subscribe" to Gateway).</p>
+          <p class="caption">Example 13. Jabber User Subscribes to Gateway's Presence</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends approves subscription request (i.e., by sending a presence stanza of type "subscribed" to Jabber User's bare JID).</p>
+          <p class="caption">Example 14. Gateway Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Execute "Log In" use case.</p></li>
+        <li><p class="" style="">Gateway sends any buffered messages to Jabber User.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="usecases-jabber-register-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">User information not verified:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway returns "Not Acceptable" error to Jabber User.</p>
+              <p class="caption">Example 15. Gateway Informs Jabber User of Registration Error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecases-jabber-edit">Edit Registration</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the user may wish to modify its existing registration information (e.g., because the user has changed his or her password on the legacy IM service).</p>
+    <div class="indent">
+<h3>4.2.1 <a name="usecases-jabber-edit-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ get qualified by the 'jabber:iq:register' namespace to Gateway.</p>
+          <p class="caption">Example 16. User Queries Gateway Regarding Registration Requirements</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='edit1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway returns IQ result to Jabber User, specifying registration information of record and including empty &lt;registered/&gt; element to signify that user is already registered.</p>
+          <p class="caption">Example 17. Gateway Returns Registration Information of Record</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;registered/&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;ILoveJuliet&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:register' namespace to Gateway, containing all information (i.e., not just the "delta").</p>
+          <p class="caption">Example 18. User Provides Registration Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='edit2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;B4lc0ny&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway verifies that, if changed, information provided by Jabber User is still valid (using whatever means appropriate for the Legacy Service) and informs Jabber User of success [A1].</p>
+          <p class="caption">Example 19. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit2'/&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="usecases-jabber-edit-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Edit unsuccessful:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway returns "Not Acceptable" error to Jabber User.</p>
+              <p class="caption">Example 20. Gateway Informs Jabber User of Registration Error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='edit2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;RomeoMyRomeo&lt;/username&gt;
+    &lt;password&gt;B4lc0ny&lt;/password&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecases-jabber-unregister">Unregister</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the user may choose to unregister with the Gateway, effectively ending his or her relationship with the Gateway (e.g., the user will no longer be allowed to communicate through the gateway with legacy users).</p>
+    <div class="indent">
+<h3>4.3.1 <a name="usecases-jabber-unregister-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ set in 'jabber:iq:register' namespace to Gateway, containing empty &lt;remove/&gt; element.</p>
+          <p class="caption">Example 21. User Unregisters</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    to='aim.shakespeare.lit'
+    id='unreg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;remove/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway sends unavailable presence from Jabber User to Legacy Users and logs Jabber User out of Legacy Service.</p></li>
+        <li><p class="" style="">Gateway deletes Jabber User's information.</p></li>
+        <li>
+          <p class="" style="">Gateway sends IQ result to Jabber User.</p>
+          <p class="caption">Example 22. Gateway Informs Jabber User of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='aim.shakespeare.lit'
+    to='romeo@montague.net/orchard'
+    id='unreg1'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway cancels subscriptions.</p>
+          <p class="caption">Example 23. Gateway Cancels Subscriptions</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends unavailable presence to Jabber User.</p>
+          <p class="caption">Example 24. Gateway Logs User Out</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Jabber User's client SHOULD delete from the user's roster (1) the gateway itself, and (2) all legacy cOntacts associated with the gateway.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="usecases-jabber-unregister-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="usecases-jabber-login">Log In</a>
+</h3>
+    <p class="" style="">After a Jabber User has registered with a Gateway, the Jabber User may subsequently log in to the Gateway, effectively creating a "session" with the Gateway and enabling the Gateway to log into the Legacy Service on behalf of the user by sending the user's legacy credentials to the Legacy Service.</p>
+    <div class="indent">
+<h3>4.4.1 <a name="usecases-jabber-login-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends available presence broadcast to Server or sends directed presence to Gateway or a Legacy User.</p>
+          <p class="caption">Example 25. Jabber User Sends Available Presence</p>
+<div class="indent"><pre>
+&lt;presence/&gt;
+          </pre></div>
+          <p class="caption">Example 26. Jabber User's Server Broadcasts Available Presence</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'/&gt;
+&lt;presence from='romeo@montague.net/orchard'
+          to='aim.shakespeare.lit'/&gt;
+...
+          </pre></div>
+        </li>
+        <li><p class="" style="">Upon receiving first presence notification stanza from Jabber User to Gateway or Legacy User, Gateway logs Jabber User into Legacy Service [A1].</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza to Jabber User expressing availability.</p>
+          <p class="caption">Example 27. Gateway Sends Presence to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Optionally, Gateway handles Legacy Service contact list; see the <a href="#rosters">Contact Lists</a> section of this document.</p></li>
+        <li>
+          <p class="" style="">Gateway forwards current presence information from Legacy Users to Jabber User, if possible mapping availability status (e.g., "away").</p>
+          <p class="caption">Example 28. Gateway Sends Presence from Legacy Users to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@aim.shakespeare.lit'
+          to='romeo@montague.net'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+&lt;/presence&gt;
+          </pre></div>
+          <p class="" style="">Note: If the Legacy Service to which the Gateway connects does not support the concept of "resources", the 'from' address of presence notification stanzas generated by a gateway SHOULD NOT include a resource identifier (i.e., they SHOULD be of the form &lt;user@host&gt; rather than &lt;user@host/resource&gt;). However, the 'from' address MAY include a resource if the Gateway determines that this is appropriate in the context of its communications with the Legacy Service.</p>
+        </li>
+        <li>
+          <p class="" style="">Gateway forwards all subsequent presence stanzas to Legacy Users (except those of type "probe" and those addressed to the Gateway itself).</p>
+          <p class="caption">Example 29. Jabber User Modifies Presence</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'&gt;
+  &lt;show&gt;dnd&lt;/show&gt;
+  &lt;status&gt;Wooing Juliet&lt;/status&gt;
+&lt;/presence&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.4.2 <a name="usecases-jabber-login-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Login fails:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway sends appropriate presence error to Jabber User (Not Authorized" if password is bad, "Remote Server Timeout" if Legacy Service is down, etc.).</p>
+              <p class="caption">Example 30. Gateway Informs Jabber User of Failed Login</p>
+<div class="indent"><pre>
+&lt;presence to='aim.shakespeare.lit'
+          from='romeo@shakespeare.lit'&gt;
+  &lt;error code='504' type='wait'&gt;
+    &lt;remote-server-timeout
+        xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/presence&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="usecases-jabber-logout">Log Out</a>
+</h3>
+    <p class="" style="">At any time after logging in to the Gateway, the Jabber User may log out of the Gateway and thereby end his or her session on the Legacy Service. This may happen automatically when the Jabber User terminates his or her session with a Jabber server, or independently of any session on the Jabber network by manually logging out of the Gateway.</p>
+    <div class="indent">
+<h3>4.5.1 <a name="usecases-jabber-logout-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends unavailable presence broadcast to Server or sends directed presence stanza of type "unavailable" to Gateway or Legacy User.</p>
+          <p class="caption">Example 31. Jabber User Sends Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'/&gt;
+          </pre></div>
+          <p class="caption">Example 32. Jabber User's Server Broadcasts Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway transforms unavailable presence stanzas received from the Jabber User's server and routes them to all of the Jabber User's contacts on Legacy Service.</p></li>
+        <li><p class="" style="">Gateway logs Jabber User out of Legacy Service [A1].</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type "unavailable" to Jabber User.</p>
+          <p class="caption">Example 33. Gateway Logs User Out</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.5.2 <a name="usecases-jabber-logout-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy Service supports directed presence and Gateway receives presence stanza of type "unavailable" directed to a Legacy User:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway passes through directed unavailable presence to Legacy User.</p>
+              <p class="caption">Example 34. Jabber User Becomes Unavailable</p>
+<div class="indent"><pre>
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='juliet@aim.shakespeare.lit'/&gt;
+              </pre></div>
+              </li>
+            <li><p class="" style="">Use Case Ends.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="usecases-jabber-addcontact">Add Contact</a>
+</h3>
+    <p class="" style="">After registering with the Gateway, the Jabber User may want to add Legacy Users to his or her Jabber roster.</p>
+    <div class="indent">
+<h3>4.6.1 <a name="usecases-jabber-addcontact-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends presence stanza of type "subscribe" to Legacy User.</p>
+          <p class="caption">Example 35. Jabber User Sends Subscription Request to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+          <p class="" style="">Note: As specified in <span style="font-weight: bold">XMPP IM</span>, sending this packet will result in a "roster push" from the Server to all of the Jabber User's available resources.</p>
+        </li>
+        <li><p class="" style="">Gateway transforms subscription request and routes it to Legacy User.</p></li>
+        <li>
+          <p class="" style="">If Legacy User approves subscription request, Gateway sends presence stanza of type "subscribed" to Jabber User on behalf of Legacy User. [A1]</p>
+          <p class="caption">Example 36. Gateway Approves Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends available presence stanza to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 37. Gateway Sends Legacy User's Current Presence Infromation to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type "subscribe" to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 38. Gateway Sends Subscription Request to Jabber User on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User sends presence stanza of type "subscribed" to Legacy User.</p>
+          <p class="caption">Example 39. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.6.2 <a name="usecases-jabber-addcontact-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Legacy User denies subscription request:</p>
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Gateway transforms subscription denial and routes it to Jabber User.</p>
+              <p class="caption">Example 40. Legacy User Denies Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribed'
+          from='juliet@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+              </pre></div>
+              </li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="usecases-jabber-deletecontact">Delete Contact</a>
+</h3>
+    <p class="" style="">After adding a Legacy User to his or her Jabber roster, the Jabber User may want to delete that contact.</p>
+    <div class="indent">
+<h3>4.7.1 <a name="usecases-jabber-deletecontact-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends IQ set qualified by the 'jabber:iq:roster' namespace, containing subscription attribute with value of "remove".</p>
+          <p class="caption">Example 41. User Removes Roster Entry for Legacy User</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/orchard'
+    id='remove1'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='CapuletNurse@aim.shakespeare.lit'
+          subscription='remove'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Server sends normal "roster push" to Jabber User (see <span style="font-weight: bold">XMPP IM</span>) and sends presence stanzas of type "unsubscribe", "unsubscribed", and "unavailable" to Legacy User.</p>
+          <p class="caption">Example 42. Server Sends Presence Changes to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+
+&lt;presence type='unavailable'
+          from='romeo@montague.net/orchard'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway cleans up subscription state, informs Legacy User that Jabber User is unavailable, and MUST NOT send future changes in Jabber User's presence to Legacy User.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.7.2 <a name="usecases-jabber-deletecontact-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="usecases-jabber-send">Send Message</a>
+</h3>
+    <p class="" style="">Naturally, the Jabber User may want to exchange messages with a Legacy User. For the purposes of this JEP, we discuss one-to-one messaging only (i.e., groupchat messages, such as those defined in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257028">5</a>], are out of scope).</p>
+    <div class="indent">
+<h3>4.8.1 <a name="usecases-jabber-send-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">Jabber User sends message stanza to Legacy User.</p>
+          <p class="caption">Example 43. Jabber User Sends Message to Legacy User</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard'
+         to='juliet@aim.shakespeare.lit'
+         type='chat'&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway transforms message to legacy protocol and sends to Legacy User [A1].</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.8.2 <a name="usecases-jabber-send-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy Service reports error.</p></li>
+        <li>
+          <p class="" style="">Gateway sends appropriate error to Jabber User:</p>
+          <ul>
+            <li><p class="" style="">"Not Found" -- Legacy User address is not valid).</p></li>
+            <li><p class="" style="">"Registration Required" -- Jabber User is not registered with Gateway).</p></li>
+            <li><p class="" style="">"Service Unavailable" -- Legacy User is offline and Legacy Service does not provide offline message storage).</p></li>
+            <li><p class="" style="">"Remote Server Error" -- Legacy Service cannot be reached).</p></li>
+          </ul>
+          <p class="" style="">For mapping of these error codes to XMPP-compliant error conditions, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257198">6</a>].</p>
+        </li>
+        <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+      </ol>
+    </div>
+  </div>
+<h2>5.
+       <a name="usecases-legacy">Legacy User Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="usecases-legacy-add">Add Contact</a>
+</h3>
+    <p class="" style="">The Legacy User may want to add the Jabber User to his or her contact list on the Legacy Service. Because the Jabber User has an account on the Legacy Service by definition, the Legacy User will actually add the Jabber User's legacy address to his or her contact list, not the Jabber User's address on the Jabber/XMPP network.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="usecases-legacy-add-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User requests subscription to Jabber User (using legacy protocol).</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type "subscribe" to Jabber User on behalf of Legacy User (note: Gateway MUST NOT send presence stanza of type "subscribed").</p>
+          <p class="caption">Example 44. Gateway Sends Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Jabber User approves subscription request by sending presence stanza of type "subscribed" to Legacy User [A1].</p>
+          <p class="caption">Example 45. Jabber User Approves Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Gateway sends Jabber User's presence information to Legacy User.</p></li>
+        <li>
+          <p class="" style="">Jabber User's Client sends presence stanza of type "subscribe" to Legacy User.</p>
+          <p class="caption">Example 46. Jabber User Sends Subscription Request to Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribe'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends presence stanza of type "subscribed" to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 47. Gateway Approves Subscription Request on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='subscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Gateway sends Legacy User's presence information to Jabber User.</p>
+          <p class="caption">Example 48. Gateway Sends Legacy User's Current Presence Information to Jabber User</p>
+<div class="indent"><pre>
+&lt;presence from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="usecases-legacy-add-alt">Alternate Flows</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Jabber User denies subscription request:
+          <ol start="" type="">
+            <li>
+              <p class="" style="">Jabber User sends presence stanza of type "unsubscribed" to Legacy User.</p>
+              <p class="caption">Example 49. Jabber User Denies Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribed'
+          from='romeo@montague.net'
+          to='CapuletNurse@aim.shakespeare.lit'/&gt;
+              </pre></div>
+            </li>
+            <li><p class="" style="">Gateway cleans up subscription state and MUST NOT send Jabber User's presence to Legacy User.</p></li>
+            <li><p class="" style="">Use Case Ends unsuccessfully.</p></li>
+          </ol>
+        </p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="usecases-legacy-delete">Delete Contact</a>
+</h3>
+    <p class="" style="">After adding the Jabber User to his or her legacy contact list, the Legacy User may want to delete the Jabber User.</p>
+    <div class="indent">
+<h3>5.2.1 <a name="usecases-legacy-delete-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User deletes Jabber User (using legacy protocol).</p></li>
+        <li>
+          <p class="" style="">Gateway sends presence stanzas of type "unsubscribe" and "unsubscribed" to Jabber User on behalf of Legacy User.</p>
+          <p class="caption">Example 50. Gateway Cleans Up Subscription on Behalf of Legacy User</p>
+<div class="indent"><pre>
+&lt;presence type='unsubscribe'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unsubscribed'
+          from='CapuletNurse@aim.shakespeare.lit'
+          to='romeo@montague.net'/&gt;
+
+&lt;presence type='unavailable'
+          from='CapuletNurse@aim.shakespeare.lit'
+          from='romeo@montague.net/orchard'/&gt;
+          </pre></div>
+        </li>
+        <li><p class="" style="">Jabber User's server performs defined functionality for handling presence stanzas of type "unsubscribe" and "unsubscribed" (see <span style="font-weight: bold">XMPP IM</span>).</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="usecases-legacy-delete-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="usecases-legacy-send">Send Message</a>
+</h3>
+    <p class="" style="">Naturally, the Legacy User may want to exchange messages with the Jabber User. Here again, groupchat messages are out of scope.</p>
+    <div class="indent">
+<h3>5.3.1 <a name="usecases-legacy-send-pri">Primary Flow</a>
+</h3>
+      <ol start="" type="">
+        <li><p class="" style="">Legacy User sends message to Jabber User using legacy protocol.</p></li>
+        <li>
+          <p class="" style="">Gateway transforms message and routes to Jabber User.</p>
+          <p class="caption">Example 51. Legacy User Sends Message to Jabber User</p>
+<div class="indent"><pre>
+&lt;message from='juliet@aim.shakespeare.lit'
+         to='romeo@montague.net/orchard'&gt;
+  &lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;
+&lt;/message&gt;
+          </pre></div>
+          <p class="" style="">Note: If the Legacy Service to which the Gateway connects does not support a concept equivalent to that of Jabber "resources" as described in <span style="font-weight: bold">XMPP Core</span>, the 'from' address of message stanzas generated by a gateway SHOULD NOT include a resource identifier (i.e., they SHOULD be of the form &lt;user@host&gt; rather than &lt;user@host/resource&gt;). However, the 'from' address MAY include a resource if the Gateway determines that this is appropriate in the context of its communications with the Legacy Service.</p>
+        </li>
+        <li><p class="" style="">Jabber User's Server delivers message or (optionally) stores it for later retrieval.</p></li>
+        <li><p class="" style="">Use Case Ends.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>5.3.2 <a name="usecases-legacy-send-alt">Alternate Flows</a>
+</h3>
+      <p class="" style="">None.</p>
+    </div>
+  </div>
+<h2>6.
+       <a name="addressing">Addressing</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="addressing-gateway">Gateways</a>
+</h3>
+    <p class="" style="">The address of a gateway itself SHOULD be a hostname only, and that hostname SHOULD NOT be supplemented with a resource identifier when referring to the gateway's address (e.g., when storing the gateway in a roster). The hostname SHOULD be a subdomain of a primary Jabber host (e.g., icq.jabber.org might be the ICQ gateway run by the jabber.org server).</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="addressing-user">Users</a>
+</h3>
+    <p class="" style="">Usernames on legacy IM services are not necessarily compatible with Jabber usernames as specified by the Nodeprep profile of stringprep defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2257764">7</a>], and some legacy services use addresses of the form &lt;user@domain&gt;. Both of these cases must be handled by the Jabber gateway to the relevant service, as well as by the Jabber clients which interact with that gateway. There are two known cases:</p>
+    <ol start="" type="">
+      <li>AOL screen names used in AIM are allowed to contain spaces, which are illegal in the node identifier portion of a Jabber Identifier</li> 
+      <li>MSN addresses used in MSN Messenger are of the form &lt;user@domain&gt;, but the '@' character is illegal in the node identifier portion of a Jabber Identifier.</li>
+    </ol>
+    <p class="" style="">(There are no known issues with addresses used in legacy services other than AIM and MSN, e.g., ICQ and Yahoo addresses.)</p>
+    <p class="" style="">It is RECOMMENDED for client proxy gateways and the clients that interact with such gateways to use the 'jabber:iq:gateway' protocol in order to communicate how to transform legacy addresses into valid JIDs.</p>
+    <p class="" style="">The 'jabber:iq:gateway' performs two functions:</p>
+    <ol start="" type="">
+      <li><p class="" style="">It enables a client to determine the text for the "prompt" to show to a Jabber User when the user wants to add a legacy contact to the user's roster (e.g., "Please enter the AOL Screen Name of the person you would like to contact"), as well as the preferred name for the prompted item (e.g., "Screen Name"). To do so, the client sends an empty &lt;query/&gt; element and the gateway returns a &lt;prompt/&gt; element (the name for the prompted item) and optionally a &lt;desc/&gt; element (the text of the prompt itself).</p></li>
+      <li><p class="" style="">It enables a client to send a legacy username to the gateway and receive a properly-formatted JID in return. To do so, the client sends the legacy address to the gateway as the character data of the &lt;prompt/&gt; and the gateway returns a valid JID as the character data of the &lt;jid/&gt; element.</p></li>
+    </ol>
+    <p class="" style="">Both uses are illustrated below.</p>
+    <p class="caption">Example 52. Client Requests Prompt</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='aim.jabber.org'&gt;
+  &lt;query xmlns='jabber:iq:gateway'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 53. Gateway Returns Prompt</p>
+<div class="indent"><pre>
+  &lt;iq type='result' from='aim.jabber.org'&gt;
+    &lt;query xmlns='jabber:iq:gateway'&gt;
+      &lt;desc&gt;
+        Please enter the AOL Screen Name of the
+        person you would like to contact.
+      &lt;/desc&gt;
+      &lt;prompt&gt;Screen Name&lt;/prompt&gt;
+    &lt;/query&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following table is intended to assist implementors with mapping of gateway identities to English-language prompt names and text.</p>
+    <p class="caption">Table 2: Prompt Item Mapping (English)</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Legacy Service</th>
+        <th colspan="" rowspan="">Service Discovery Identity</th>
+        <th colspan="" rowspan="">Prompt Name</th>
+        <th colspan="" rowspan="">Prompt Text</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">AOL Instant Messenger</td>
+        <td align="" colspan="" rowspan="">gateway/aim</td>
+        <td align="" colspan="" rowspan="">AOL Screen Name</td>
+	<td align="" colspan="" rowspan="">Please enter the AOL Screen Name of the person you would like to contact.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ICQ</td>
+        <td align="" colspan="" rowspan="">gateway/icq</td>
+        <td align="" colspan="" rowspan="">ICQ Number</td>
+	<td align="" colspan="" rowspan="">Please enter the ICQ Number of the person you would like to contact.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">MSN Messenger</td>
+        <td align="" colspan="" rowspan="">gateway/msn</td>
+        <td align="" colspan="" rowspan="">MSN Address</td>
+	<td align="" colspan="" rowspan="">Please enter the MSN Address of the person you would like to contact.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Yahoo! Instant Messenger</td>
+        <td align="" colspan="" rowspan="">gateway/yahoo</td>
+        <td align="" colspan="" rowspan="">Yahoo ID</td>
+	<td align="" colspan="" rowspan="">Please enter the Yahoo ID of the person you would like to contact.</td>
+      </tr>
+    </table>
+    <p class="" style="">If the client provides an 'xml:lang' attribute with the IQ-get, the gateway SHOULD return localized prompt names and text if available, or default to English if not available.</p>
+    <p class="" style="">Once the user enters a legacy username or address, the client MUST send it to the gateway as the character data of the &lt;prompt/&gt; element in an IQ-set; the gateway MUST then return a properly-formed JID based on the provided by the client.</p>
+    <p class="caption">Example 54. Client Provides Legacy Username</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='aim.jabber.org'&gt;
+  &lt;query xmlns='jabber:iq:gateway'&gt;
+      &lt;prompt&gt;Foo Bar&lt;/prompt&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 55. Gateway Returns JID</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='aim.jabber.org'&gt;
+  &lt;query xmlns='jabber:iq:gateway'&gt;
+    &lt;jid&gt;FooBar@aim.jabber.org&lt;/jid&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>7.
+       <a name="rosters">Contact Lists</a>
+</h2>
+  <p class="" style="">Some legacy services maintain server-side contact lists, which are sent to the gateway when it logs in to the legacy service on behalf of the user. The gateway MAY initiate adding of the legacy contact list items to the user's Jabber roster. Some existing gateways do this by sending a presence stanza of type "subscribed" from the legacy contact's JID (e.g., &lt;LegacyUser@gateway.jabberserver.com&gt;) to the Jabber user; unfortunately, this behavior violates the presence stanza handling rules specified in <span style="font-weight: bold">XMPP IM</span>. Therefore, a gateway SHOULD instead send the legacy contact list items to the Jabber User via the <span class="ref" style="">Roster Item Exchange</span>  [<a href="#nt-id2258186">8</a>] protocol (see JEP-0144 for details).</p>
+<h2>8.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <p class="" style="">The following business rules apply:</p>
+  <ol start="" type="">
+    <li><p class="" style="">A client SHOULD send a <span style="font-weight: bold">Service Discovery</span> request to the gateway (and/or an <span style="font-weight: bold">Agent Information</span> request to the gateway's parent) before requesting registration information.</p></li>
+    <li><p class="" style="">A gateway SHOULD support the <span style="font-weight: bold">Service Discovery</span> protocol.</p></li>
+    <li><p class="" style="">A gateway SHOULD support the <span style="font-weight: bold">Agent Information</span> protocol, although it is deprecated.</p></li>
+    <li><p class="" style="">A gateway SHOULD map, as best it can, the legacy registration fields onto the fields defined for the 'jabber:iq:register' namespace.</p></li>
+    <li><p class="" style="">A gateway SHOULD NOT attempt to emulate offline message storage functionality for legacy services that lack such functionality.</p></li>
+    <li>
+      <p class="" style="">Existing gateway implementations do not strictly adhere to the bi-directional nature of Jabber presence notifications, since they do not broadcast presence from the gateway itself to registered users of the gateway, but rather wait for a registered user to send presence to the gateway before sending presence to the user. This sidesteps scalability challenges but may be sub-optimal; while this JEP does not require existing gateways to change their current behavior, it does RECOMMEND that they broadcast presence notifications to registered users in accordance with the standard Jabber presence model. Specifically:</p>
+      <ul>
+        <li><p class="" style="">On startup, a gateway (1) SHOULD send presence to all registered users of that gateway but (2) MAY wait to receive presence changes from each registered user.</p></li>
+        <li><p class="" style="">On shutdown, a gateway SHOULD send unavailable presence to all registered users of the gateway.</p></li>
+      </ul>
+    </li>
+  </ol>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">As defined herein, a gateway is a <span style="font-style: italic">client proxy</span>, since it "masquerades" as a user on a legacy instant messaging service. In order to act as a client proxy, the gateway logs into the user's account on the legacy service. This implies two things:</p>
+  <ul>
+    <li>The gateway must gather the legacy credentials from the user, and perhaps store them on the user's behalf.</li>
+    <li>The gateway must provide the user's credential to the legacy service.</li>
+  </ul>
+  <p class="" style="">There are obvious security concerns with this approach. The concerns include:</p>
+  <ol start="" type="">
+    <li>The user's credentials on the legacy service may be sent in the clear from the gateway to the legacy service if the legacy service does not support channel encryption or strong authentication.</li>
+    <li>When the user informs the gateway of the user's legacy credentials, the credentials may be sent in the clear between the user's Jabber client and the user's Jabber server (if client-to-server channel encryption is not enabled) or between the user's Jabber server and the gateway (if the gateway is not in the user's "home" domain and server-to-server channel encryption is not enabled).</li>
+    <li>If the gateway stores the user's legacy credentials after registration (this is the default behavior of most or all existing gateway implementations), the user's credentials could be acquired by a malicious user if the server hosting the gateway is compromised.</li>
+  </ol>
+  <p class="" style="">There is no foreseeable solution to these concerns, since they are instrinsic to the client proxy model. Some assurance regarding the second and third concerns can be achieved if the user runs his or her own Jabber server and gateways. However, the only true solution is to move beyond the client proxy model, either by using Jabber for all IM communications or to convince legacy IM services to use open protocols such as Jabber/XMPP, thus making it possible to deploy secure server federation between a legacy service and Jabber/XMPP domains.</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258458">9</a>].</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Jabber Registrar Considerations</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258509">10</a>] shall include 'jabber:iq:gateway' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='jabber:iq:gateway'
+    xmlns='jabber:iq:gateway'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence
+          &lt;xs:element name='desc' minOccurs='0' type='xs:string'/&gt;
+          &lt;xs:element name='prompt' type='xs:string'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element name='jid' type='xs:string'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2255217">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255240">2</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2255350">3</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2255461">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257028">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257198">6</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257764">7</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2258186">8</a>. JEP-0144: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0144.html">http://www.jabber.org/jeps/jep-0144.html</a>&gt;.</p>
+<p><a name="nt-id2258458">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258509">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2004-10-27)</h4>
+<div class="indent">Added specification of jabber:iq:gateway namespace; added reference to JEP-0144. (psa)
+    </div>
+<h4>Version 0.8 (2004-05-07)</h4>
+<div class="indent">Editorial review: made a number of minor textual changes and clarifications throughout; added introductory paragraph to each use case; specified that groupchat is out of scope. (psa)
+    </div>
+<h4>Version 0.7 (2004-03-31)</h4>
+<div class="indent">Cleaned up several notes, examples, and business rules based on feedback received on list. (psa)
+    </div>
+<h4>Version 0.6 (2004-03-08)</h4>
+<div class="indent">Added note about 'from' address on presence notifications and messages received through gateways from legacy users. (psa)
+    </div>
+<h4>Version 0.5 (2004-01-21)</h4>
+<div class="indent">Further specified the rationale for deprecating the "jabber:iq:gateway" protocol. (psa)
+    </div>
+<h4>Version 0.4 (2004-01-05)</h4>
+<div class="indent">Added Edit Registration use case; modified handling of legacy contact lists to conform to XMPP IM; modified addressing rules; defined gateway startup and shutdown behavior; included XMPP error handling. (psa)
+    </div>
+<h4>Version 0.3 (2003-12-10)</h4>
+<div class="indent">Added security considerations; defined handling of legacy contact lists. (psa)
+    </div>
+<h4>Version 0.2 (2003-12-03)</h4>
+<div class="indent">Corrected some errors; clarified some ambiguities; added protocol flows. (psa)
+    </div>
+<h4>Version 0.1 (2003-06-25)</h4>
+<div class="indent">Initial version. (psa/dss)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0106-0.2.html
+++ b/content/xep-0106-0.2.html
@@ -1,0 +1,260 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0106: JID Escaping</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="JID Escaping">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="Allow the display of Jabber Identifiers (JIDs) with characters prohibited by the Nodeprep profile of stringprep.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2003-10-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0106">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0106: JID Escaping</h1>
+<p>Allow the display of Jabber Identifiers (JIDs) with characters prohibited by the Nodeprep profile of stringprep.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0106<br>
+            Version: 0.2<br>
+            Last Updated: 2003-10-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jid#20;escaping<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2595918">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596056">Requirements</a>
+</dt>
+<dt>3.  <a href="#sect-id2596128">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2596147">Encoding Transformation</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2596232">Decoding Transformation</a>
+</dt>
+<dt>3.3.  <a href="#sect-id2596320">Discovery</a>
+</dt>
+<dt>3.4.  <a href="#sect-id2601823">Exceptions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2601871">Rules</a>
+</dt>
+<dt>5.  <a href="#sect-id2601903">Error Codes</a>
+</dt>
+<dt>6.  <a href="#sect-id2601922">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2601943">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2601964">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2595918">Introduction</a>
+</h2>
+<p class="" style="">
+<span class="ref">XMPP Core</span>  [<a href="#nt-id2595942">1</a>] defines the Nodeprep profile of stringprep (<span class="ref">RFC 3454</span>  [<a href="#nt-id2596073">2</a>]), which specifies that the following characters are invalid in the node identifier portion of a JID:</p>
+
+<ul>
+<li>All whitespace</li>
+<li>22h (&quot;)</li>
+<li>26h (&amp;)</li>
+<li>27h (')</li>
+<li>2Fh (/)</li>
+<li>3Ah (:)</li>
+<li>3Ch (&lt;)</li>
+<li>3Eh (&gt;)</li>
+<li>40h (@)</li>
+</ul>
+
+<p class="" style="">This restriction is a hardship for users who have these characters in their chosen usernames, particularly in the case of ('), which is common in names like O'Hara and D'Artagnan. The restriction is especially onerous if existing email addresses are mapped to JIDs, since some of the foregoing characters are allowed in the username portion of an email address. If (&amp;) had not been in this list, then normal XML escaping conventions could have been used, and, for example, D'Artagnan could have been rended as d&amp;apos;artagnan [sic].  Since there are good reasons for each of the prohibited characters above, another escaping mechanism is desirable.</p> 
+
+<p class="" style="">Although URL encoding (%27) was one possibility, since % is such an often-used character in JIDs (e.g, to replace @ in gateway addresses), this approach was rejected.  Future gateways SHOULD use the approach specified by this JEP, instead.</p>
+
+<h2>2.
+       <a name="sect-id2596056">Requirements</a>
+</h2>
+<ul>
+<li>Escaped JIDs MUST conform to the definition of a Jabber ID from the XMPP Core specification, including the Nodeprep profile of stringprep.  In particular this means that even after passing through Nodeprep, the JID MUST be valid, so the use of Unicode look-alikes like U+02BC (Modifier Letter Apostrophe) cannot be used.</li>
+
+<li>It MUST NOT be possible for clients to use this escaping mechanism to avoid the goal of stringprep; namely, that JIDs that look alike SHOULD have same character representation after being processed by stringprep.  Therefore, this mechanism SHOULD NOT be general-purpose, but specific to only certain characters.</li>
+
+<li>Existing JIDs that include portions of the escaping mechanism MUST continue to be valid.</li>
+
+<li>The escaping mechanism SHOULD NOT place undue strain upon server implementations; implementations that do not need to unescape SHOULD be able to ignore the escaping mechanism.</li>
+
+</ul>
+<h2>3.
+       <a name="sect-id2596128">Use Cases</a>
+</h2>
+<p class="" style="">All transformations are exactly as specified.  CASE IS SIGNIFICANT.  Lowercase was selected since Nodeprep will case fold to lowercase.</p>
+<div class="indent">
+<h3>3.1 <a name="sect-id2596147">Encoding Transformation</a>
+</h3>
+<p class="" style="">The following escaping transformations MAY be used by a conforming entity.  Typically, this will only be done by a client that is retrieving information from a user in unescaped form, or by a gateway to some external system that needs to generate a JID.</p>
+
+<ul>
+<li>&lt;space&gt; transforms to #20;</li>
+<li>&quot; transforms to #22;</li>
+<li># transforms to #23;</li>
+<li>&amp; transforms to #26;</li>
+<li>' transforms to #27;</li>
+<li>/ transforms to #2f;</li>
+<li>: transforms to #3a;</li>
+<li>&lt; transforms to #3c;</li>
+<li>&gt; transforms to #3e;</li>
+<li>@ transforms to #40;</li>
+</ul>
+
+    <p class="caption">Example 1. JID Encoding: Porthos starts a chat, typing into his client the JID d'artagnan@musketeers.bourbon.gov:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='d#27;artagnan@musketeers.bourbon.gov'
+    type='chat'&gt;
+  &lt;body&gt;And do you always forget your eyes when you run?&lt;/body&gt;
+&lt;/message&gt;</pre></div>
+</div>
+
+<div class="indent">
+<h3>3.2 <a name="sect-id2596232">Decoding Transformation</a>
+</h3>
+<p class="" style="">The opposite unescaping transformations MAY be used by a conforming entity.  Typically, this is only done by clients that want to display JIDs, and gateways that need to generate identifiers for foreign systems.</p>
+
+<ul>
+<li>#20; transforms to &lt;space&gt;</li>
+<li>#22; transforms to &quot;</li>
+<li>#23; transforms to #</li>
+<li>#26; transforms to &amp;</li>
+<li>#27; transforms to '</li>
+<li>#2f; transforms to /</li>
+<li>#3a; transforms to :</li>
+<li>#3c; transforms to &lt;</li>
+<li>#3e; transforms to &gt;</li>
+<li>#40; transforms to @</li>
+</ul>
+
+    <p class="caption">Example 2. JID Encoding: D'Artagnan the elder sends SMTP mail through a gateway:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='d#27;artagnan@gascon.fr/elder'
+    to='tréville%musketeers.bourbon.gov@smtp.jabber.org'&gt;
+  &lt;body&gt;I recommend my son to you.&lt;/body&gt;
+&lt;/message&gt;</pre></div>
+</div>
+
+<div class="indent">
+<h3>3.3 <a name="sect-id2596320">Discovery</a>
+</h3>
+<p class="" style="">If a client is going to encode identifiers for use by a gateway, the client needs to know which encoding scheme to use.  Clients MUST assume that the gateway does not support this encoding scheme, unless it discovers that the service supports the <span style="font-weight: bold">jid#20;escaping</span> [sic] feature.  Namely, if there any errors in the disco exchange, or the <span style="font-weight: bold">jid#20;escaping</span> feature is not discovered, the client SHOULD use the older escaping mechanism (@ transforms to %).</p>
+
+<p class="caption">Example 3. Client requests features</p>
+<div class="indent"><pre>
+&lt;iq
+    type='get'
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;</pre></div>
+<p class="caption">Example 4. Service responds with features</p>
+<div class="indent"><pre>
+&lt;iq
+    type='get'
+    to='porthos@musketeers.bourbon.gov/gate'
+    from='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+...
+    &lt;feature var='jid#20;escaping'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+
+</div>
+
+<div class="indent">
+<h3>3.4 <a name="sect-id2601823">Exceptions</a>
+</h3>
+<p class="" style="">In order to maintain as much backward compatibility as possible, JIDs that contain partial escape sequences, or escape sequences that are not on the list, MUST be ignored.</p>
+  <p class="caption">Example 5. Partial escape sequence</p>
+<div class="indent"><pre><span style="font-weight: bold">foo#bar</span> is not modified by escaping or unescaping transformations</pre></div>
+  <p class="caption">Example 6. Invalid escape sequence</p>
+<div class="indent"><pre><span style="font-weight: bold">foob#41;r</span> is not modified by escaping or unescaping transformations</pre></div>
+</div>
+<h2>4.
+       <a name="sect-id2601871">Rules</a>
+</h2>
+<p class="" style="">As far as the bulk of the system is concerned, an escaped JID has no special processing associated with it.  Clients SHOULD render them unescaped. Servers MAY unescape them for communication with external systems (e.g. LDAP), but only AFTER stringprep has been applied.  The unescape transformation MUST be NFKC-safe -- i.e., it must conform to Unicode normalization form KC (see Appendix B.3 of RFC 3454).  An entity MUST NOT use the unescaped version in any protocol sent to another entity, and MUST NOT use the unescaped version to compare with another JID. Note well: this JEP applies to the node identitier portion of a JID only, and MUST NOT be applied to domain identifiers or resource identifiers.</p>
+<h2>5.
+       <a name="sect-id2601903">Error Codes</a>
+</h2>
+  <p class="" style="">None defined.</p>
+<h2>6.
+       <a name="sect-id2601922">Security Considerations</a>
+</h2>
+  <p class="" style="">Entities that enforce JID escaping MUST compare unescaped versions, otherwise a JID conflict could occur.</p>
+<h2>7.
+       <a name="sect-id2601943">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602061">3</a>].</p>
+<h2>8.
+       <a name="sect-id2601964">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span style="font-weight: bold">jid#20;escaping</span> feature shall be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602008">4</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595942">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596073">2</a>. RFC 3454: Preparation of Internationalized Strings (stringprep) &lt;<a href="http://www.ietf.org/rfc/rfc3454.txt"> http://www.ietf.org/rfc/rfc3454.txt </a>&gt;.</p>
+<p>
+<a name="nt-id2602061">3</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602008">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2003-10-21)</h4>
+<div class="indent">Editorial cleanup; added security considerations. (psa)
+    </div>
+<h4>Version 0.1 (2003-07-21)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0106-0.3.html
+++ b/content/xep-0106-0.3.html
@@ -1,0 +1,325 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0106: JID Escaping</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="JID Escaping">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="Allow the display of Jabber Identifiers (JIDs) with characters prohibited by the Nodeprep profile of stringprep.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0106">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0106: JID Escaping</h1>
+<p>Allow the display of Jabber Identifiers (JIDs) with characters prohibited by the Nodeprep profile of stringprep.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0106<br>
+            Version: 0.3<br>
+            Last Updated: 2005-03-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jid#20;escaping<br></p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#encoding">Encoding Transformation</a>
+</dt>
+<dt>3.2.  <a href="#decoding">Decoding Transformation</a>
+</dt>
+<dt>3.3.  <a href="#discovery">Discovery</a>
+</dt>
+<dt>3.4.  <a href="#exceptions">Exceptions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#rules">Rules</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+<p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251364">1</a>] defines the Nodeprep profile of stringprep (<span class="ref" style="">RFC 3454</span>  [<a href="#nt-id2251323">2</a>]), which specifies that the following characters are invalid in the node identifier portion of a JID:</p>
+
+<ul>
+<li>All whitespace</li>
+<li>22h (")</li>
+<li>26h (&amp;)</li>
+<li>27h (')</li>
+<li>2Fh (/)</li>
+<li>3Ah (:)</li>
+<li>3Ch (&lt;)</li>
+<li>3Eh (&gt;)</li>
+<li>40h (@)</li>
+</ul>
+
+<p class="" style="">This restriction is a hardship for users who have these characters in their chosen usernames, particularly in the case of the ' character, which is common in names like O'Hara and D'Artagnan. The restriction is especially onerous if existing email addresses are mapped to JIDs, since some of the foregoing characters are allowed in the username portion of an email address (e.g., the characters &amp; ' / as described in sections 3.2.4 and 3.2.5 of <span class="ref" style="">RFC 2822</span>  [<a href="#nt-id2251152">3</a>]). If the &amp; character had not been in this list, then normal XML escaping conventions could have been used, and, for example, D'Artagnan could have been rendered as d&amp;apos;artagnan [sic].</p>
+<p class="" style="">Since there are good reasons for each of the prohibited characters above, another escaping mechanism is desirable. Although it might have been desirable to use URL encoding (%27), that approach was rejected since the % character is such an often-used character in JIDs (e.g, to replace the @ character in gateway addresses). Therefore, a new mechanism is described herein to escape only the foregoing characters in the node identifier portion of Jabber IDs.</p>
+
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+<p class="" style="">This JEP addresses only the following requirements:</p>
+<ol start="" type="">
+<li>The escaping mechanism shall apply to the node identitier portion of a JID only, and MUST NOT be applied to domain identifiers or resource identifiers.</li>
+<li>Escaped JIDs MUST conform to the definition of a Jabber ID from the XMPP Core specification, including the Nodeprep profile of stringprep.  In particular this means that even after passing through Nodeprep, the JID MUST be valid, so the use of Unicode look-alikes like U+02BC (Modifier Letter Apostrophe) cannot be used.</li>
+<li>It MUST NOT be possible for clients to use this escaping mechanism to avoid the goal of stringprep; namely, that JIDs that look alike SHOULD have same character representation after being processed by stringprep.  Therefore, this mechanism SHOULD NOT be general-purpose, but specific to only certain characters.</li>
+<li>Existing JIDs that include portions of the escaping mechanism MUST continue to be valid.</li>
+<li>The escaping mechanism SHOULD NOT place undue strain upon server implementations; implementations that do not need to unescape SHOULD be able to ignore the escaping mechanism.</li>
+</ol>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+<p class="" style="">All transformations are exactly as specified.  CASE IS SIGNIFICANT.  Lowercase was selected since Nodeprep will case fold to lowercase.</p>
+<div class="indent">
+<h3>3.1 <a name="encoding">Encoding Transformation</a>
+</h3>
+<p class="" style="">The following escaping transformations MAY be used by a conforming entity.  Typically, this will only be done by a client that is retrieving information from a user in unescaped form, or by a gateway to some external system (e.g., email or LDAP) that needs to generate a JID.</p>
+
+<p class="caption">Table 1: Mapping from Unescaped to Encoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+  <tr class="body">
+<th colspan="" rowspan="">Unescaped Character</th>
+<th colspan="" rowspan="">Encoded Character</th>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+<td align="" colspan="" rowspan="">#20;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">"</td>
+<td align="" colspan="" rowspan="">#22;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#</td>
+<td align="" colspan="" rowspan="">#23;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">&amp;</td>
+<td align="" colspan="" rowspan="">#26;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">'</td>
+<td align="" colspan="" rowspan="">#27;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">/</td>
+<td align="" colspan="" rowspan="">#2f;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">:</td>
+<td align="" colspan="" rowspan="">#3a;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">&lt;</td>
+<td align="" colspan="" rowspan="">#3c;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">&gt;</td>
+<td align="" colspan="" rowspan="">#3e;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">@</td>
+<td align="" colspan="" rowspan="">#40;</td>
+</tr>
+</table>
+
+    <p class="caption">Example 1. JID Encoding: Porthos starts a chat, typing into his client the JID d'artagnan@musketeers.bourbon.gov:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='d#27;artagnan@musketeers.bourbon.gov'
+    type='chat'&gt;
+  &lt;body&gt;And do you always forget your eyes when you run?&lt;/body&gt;
+&lt;/message&gt;</pre></div>
+</div>
+
+<div class="indent">
+<h3>3.2 <a name="decoding">Decoding Transformation</a>
+</h3>
+<p class="" style="">The opposite unescaping transformations MAY be used by a conforming entity.  Typically, this is only done by a client that wants to display JIDs, or by a gateways to some external system (e.g., email or LDAP) that needs to generate identifiers for foreign systems.</p>
+
+<p class="caption">Table 2: Mapping from Encoded to Decoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+  <tr class="body">
+<th colspan="" rowspan="">Encoded Character</th>
+<th colspan="" rowspan="">Decoded Character</th>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#20;</td>
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#22;</td>
+<td align="" colspan="" rowspan="">"</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#23;</td>
+<td align="" colspan="" rowspan="">#</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#26;</td>
+<td align="" colspan="" rowspan="">&amp;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#27;</td>
+<td align="" colspan="" rowspan="">'</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#2f;</td>
+<td align="" colspan="" rowspan="">/</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#3a;</td>
+<td align="" colspan="" rowspan="">:</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#3c;</td>
+<td align="" colspan="" rowspan="">&lt;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#3e;</td>
+<td align="" colspan="" rowspan="">&gt;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#40;</td>
+<td align="" colspan="" rowspan="">@</td>
+</tr>
+</table>
+
+    <p class="caption">Example 2. JID Encoding: D'Artagnan the elder sends SMTP mail through a gateway:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='d#27;artagnan@gascon.fr/elder'
+    to='tréville%musketeers.bourbon.gov@smtp.jabber.org'&gt;
+  &lt;body&gt;I recommend my son to you.&lt;/body&gt;
+&lt;/message&gt;</pre></div>
+</div>
+
+<div class="indent">
+<h3>3.3 <a name="discovery">Discovery</a>
+</h3>
+<p class="" style="">If a client is going to encode identifiers for use by a gateway, the client needs to know which encoding scheme to use. A client MUST assume that the gateway does not support this encoding scheme, unless it discovers that the service supports the <span style="font-weight: bold">jid#20;escaping</span> [sic] feature.  Namely, if there any errors in the disco exchange, or the <span style="font-weight: bold">jid#20;escaping</span> feature is not discovered, the client SHOULD use the 'jabber:iq:gateway' protocol (as specified in <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2255315">4</a>]) if the gateway supports that protocol, or use traditional escaping mechanisms (such as the transformation ofthe @ character to the % character) if support for either jid#20;escaping or jabber:iq:gateway cannot be determined.</p>
+
+<p class="caption">Example 3. Client requests features</p>
+<div class="indent"><pre>
+&lt;iq
+    type='get'
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;</pre></div>
+<p class="caption">Example 4. Service responds with features</p>
+<div class="indent"><pre>
+&lt;iq
+    type='get'
+    to='porthos@musketeers.bourbon.gov/gate'
+    from='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+...
+    &lt;feature var='jid#20;escaping'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+
+</div>
+
+<div class="indent">
+<h3>3.4 <a name="exceptions">Exceptions</a>
+</h3>
+<p class="" style="">In order to maintain as much backward compatibility as possible, JIDs that contain partial escape sequences, or escape sequences that are not on the list, MUST be ignored.</p>
+  <p class="caption">Example 5. Partial escape sequence</p>
+<div class="indent"><pre><span style="font-weight: bold">foo#bar</span> is not modified by escaping or unescaping transformations</pre></div>
+  <p class="caption">Example 6. Invalid escape sequence</p>
+<div class="indent"><pre><span style="font-weight: bold">foob#41;r</span> is not modified by escaping or unescaping transformations</pre></div>
+</div>
+<h2>4.
+       <a name="rules">Rules</a>
+</h2>
+<p class="" style="">As far as the bulk of the system is concerned, an escaped JID has no special processing associated with it.  Clients SHOULD render them unescaped. Servers MAY unescape them for communication with external systems (e.g. LDAP), but only AFTER stringprep has been applied.  The unescape transformation MUST be NFKC-safe -- i.e., it must conform to Unicode normalization form KC (see Appendix B.3 of <span style="font-weight: bold">RFC 3454</span>).  An entity MUST NOT use the unescaped version in any protocol sent to another entity, and MUST NOT use the unescaped version to compare with another JID.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Entities that enforce JID escaping MUST compare unescaped versions, otherwise a JID conflict could occur.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255462">5</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255501">6</a>] shall include the <span style="font-weight: bold">jid#20;escaping</span> [sic] feature in its registry of service discovery features.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251364">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251323">2</a>. RFC 3454: Preparation of Internationalized Strings (stringprep) &lt;<a href="http://www.ietf.org/rfc/rfc3454.txt"> http://www.ietf.org/rfc/rfc3454.txt </a>&gt;.</p>
+<p><a name="nt-id2251152">3</a>. RFC 2822: Internet Message Format &lt;<a href="http://www.ietf.org/rfc/rfc2822.txt">http://www.ietf.org/rfc/rfc2822.txt</a>&gt;.</p>
+<p><a name="nt-id2255315">4</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2255462">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255501">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-03-16)</h4>
+<div class="indent">Clarified relationship between JID escaping and traditional client proxy gateway behavior; fixed several small errors. (psa)
+    </div>
+<h4>Version 0.2 (2003-10-21)</h4>
+<div class="indent">Editorial cleanup; added security considerations. (psa)
+    </div>
+<h4>Version 0.1 (2003-07-21)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0106-0.4.html
+++ b/content/xep-0106-0.4.html
@@ -1,0 +1,343 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0106: JID Escaping</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="JID Escaping">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a mechanism that enables the display of Jabber Identifiers (JIDs) with characters prohibited by the Nodeprep profile of stringprep.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-04">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0106">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0106: JID Escaping</h1>
+<p>This JEP specifies a mechanism that enables the display of Jabber Identifiers (JIDs) with characters prohibited by the Nodeprep profile of stringprep.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0106<br>
+            Version: 0.4<br>
+            Last Updated: 2005-04-04<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jid#20;escaping<br></p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#encoding">Encoding Transformation</a>
+</dt>
+<dt>3.2.  <a href="#decoding">Decoding Transformation</a>
+</dt>
+<dt>3.3.  <a href="#discovery">Discovery</a>
+</dt>
+</dl>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#exceptions">Exceptions</a>
+</dt>
+<dt>4.2.  <a href="#processing">Processing</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+<p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251346">1</a>] defines the Nodeprep profile of stringprep (<span class="ref" style="">RFC 3454</span>  [<a href="#nt-id2251370">2</a>]), which specifies that the following characters are invalid in the node identifier portion of a JID:</p>
+
+<ul>
+<li>All whitespace</li>
+<li>22h (")</li>
+<li>26h (&amp;)</li>
+<li>27h (')</li>
+<li>2Fh (/)</li>
+<li>3Ah (:)</li>
+<li>3Ch (&lt;)</li>
+<li>3Eh (&gt;)</li>
+<li>40h (@)</li>
+</ul>
+
+<p class="" style="">This restriction is a hardship for users who have these characters in their chosen usernames, particularly in the case of the ' character, which is common in names like O'Hara and D'Artagnan. The restriction is especially onerous if existing email addresses are mapped to JIDs, since some of the foregoing characters are allowed in the username portion of an email address (e.g., the characters &amp; ' / as described in sections 3.2.4 and 3.2.5 of <span class="ref" style="">RFC 2822</span>  [<a href="#nt-id2251178">3</a>]).</p>
+<p class="" style="">If the &amp; character had not been in the foregoing list, then normal XML escaping conventions could have been used, with the result that D'Artagnan (for example) could have been rendered as D&amp;apos;artagnan [sic]. However, since there are good reasons for each of the prohibited characters shown above, another escaping mechanism is needed. Although it might have been desirable to use URL encoding (e.g., %27 for the ' character), that approach was rejected since the % character is such an often-used character in JIDs (e.g, to replace the @ character in gateway addresses). Therefore, a new mechanism is described herein to escape only the foregoing characters and only in the node identifier portion of Jabber IDs.</p>
+
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+<p class="" style="">This JEP addresses the following requirements only:</p>
+<ol start="" type="">
+<li>The escaping mechanism shall apply to the node identitier portion of a JID only, and MUST NOT be applied to domain identifiers or resource identifiers.</li>
+<li>Escaped JIDs MUST conform to the definition of a Jabber ID as specified in <span style="font-weight: bold">RFC 3920</span>, including the Nodeprep profile of stringprep.  In particular this means that even after passing through Nodeprep, the JID MUST be valid, with the result that Unicode look-alikes like U+02BC (Modifier Letter Apostrophe) cannot be used.</li>
+<li>It MUST NOT be possible for clients to use this escaping mechanism to avoid the goal of stringprep; namely, that JIDs that look alike should have same character representation after being processed by stringprep. Therefore, this mechanism SHOULD NOT be applied to any characters that are not in the list of foregoing list of characters forbidden in node identifiers.</li>
+<li>Existing JIDs that include portions of the escaping mechanism MUST continue to be valid.</li>
+<li>The escaping mechanism SHOULD NOT place undue strain upon server implementations; implementations or deployments that do not need to unescape SHOULD be able to ignore the escaping mechanism.</li>
+</ol>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+<p class="" style="">All transformations are exactly as specified.  CASE IS SIGNIFICANT.  Lowercase was selected since Nodeprep will case fold to lowercase.</p>
+<div class="indent">
+<h3>3.1 <a name="encoding">Encoding Transformation</a>
+</h3>
+<p class="" style="">The following escaping transformations MAY be used by a conforming entity.  Typically, this will be completed only by a client that is retrieving information from a user in unescaped form, or by a gateway to some external system (e.g., email or LDAP) that needs to generate a JID.</p>
+
+<p class="caption">Table 1: Mapping from Unescaped to Encoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+  <tr class="body">
+<th colspan="" rowspan="">Unescaped Character</th>
+<th colspan="" rowspan="">Encoded Character</th>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+<td align="" colspan="" rowspan="">#20;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">"</td>
+<td align="" colspan="" rowspan="">#22;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#</td>
+<td align="" colspan="" rowspan="">#23;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">&amp;</td>
+<td align="" colspan="" rowspan="">#26;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">'</td>
+<td align="" colspan="" rowspan="">#27;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">/</td>
+<td align="" colspan="" rowspan="">#2f;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">:</td>
+<td align="" colspan="" rowspan="">#3a;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">&lt;</td>
+<td align="" colspan="" rowspan="">#3c;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">&gt;</td>
+<td align="" colspan="" rowspan="">#3e;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">@</td>
+<td align="" colspan="" rowspan="">#40;</td>
+</tr>
+</table>
+
+    <p class="caption">Example 1. JID Encoding: Porthos starts a chat, typing into his client the JID d'artagnan@musketeers.bourbon.gov:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='d#27;artagnan@musketeers.bourbon.gov'
+    type='chat'&gt;
+  &lt;body&gt;And do you always forget your eyes when you run?&lt;/body&gt;
+&lt;/message&gt;</pre></div>
+</div>
+
+<div class="indent">
+<h3>3.2 <a name="decoding">Decoding Transformation</a>
+</h3>
+<p class="" style="">The opposite unescaping transformations MAY be used by a conforming entity.  Typically, this is only done by a client that wants to display JIDs, or by a gateways to some external system (e.g., email or LDAP) that needs to generate identifiers for foreign systems.</p>
+
+<p class="caption">Table 2: Mapping from Encoded to Decoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+  <tr class="body">
+<th colspan="" rowspan="">Encoded Character</th>
+<th colspan="" rowspan="">Decoded Character</th>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#20;</td>
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#22;</td>
+<td align="" colspan="" rowspan="">"</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#23;</td>
+<td align="" colspan="" rowspan="">#</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#26;</td>
+<td align="" colspan="" rowspan="">&amp;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#27;</td>
+<td align="" colspan="" rowspan="">'</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#2f;</td>
+<td align="" colspan="" rowspan="">/</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#3a;</td>
+<td align="" colspan="" rowspan="">:</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#3c;</td>
+<td align="" colspan="" rowspan="">&lt;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#3e;</td>
+<td align="" colspan="" rowspan="">&gt;</td>
+</tr>
+  <tr class="body">
+<td align="" colspan="" rowspan="">#40;</td>
+<td align="" colspan="" rowspan="">@</td>
+</tr>
+</table>
+
+    <p class="caption">Example 2. JID Encoding: D'Artagnan the elder sends SMTP mail through a gateway:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='d#27;artagnan@gascon.fr/elder'
+    to='tréville%musketeers.bourbon.gov@smtp.jabber.org'&gt;
+  &lt;body&gt;I recommend my son to you.&lt;/body&gt;
+&lt;/message&gt;</pre></div>
+</div>
+
+<div class="indent">
+<h3>3.3 <a name="discovery">Discovery</a>
+</h3>
+<p class="" style="">If an entity wants to discover whether another entity supports JID escaping, it MUST send a disco#info request to the other entity as specified in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255397">4</a>].</p>
+<p class="caption">Example 3. Client requests features</p>
+<div class="indent"><pre>
+&lt;iq
+    type='get'
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;</pre></div>
+
+<p class="" style="">If the queried entity supports JID escaping, it MUST return a <span style="font-weight: bold">jid#20;escaping</span> [sic] feature in its reply.</p>
+
+<p class="caption">Example 4. Service responds with features</p>
+<div class="indent"><pre>
+&lt;iq
+    type='get'
+    to='porthos@musketeers.bourbon.gov/gate'
+    from='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+...
+    &lt;feature var='jid#20;escaping'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+
+<p class="" style="">When a client attempts to communicate with another entity through a gateway, it needs to know which encoding mechanism to use. A client MUST assume that the gateway does not support the JID escaping mechanism unless it explicitly discovers that fact via Service Discovery as shown above. If there any errors in the service discovery exchange or if support for the <span style="font-weight: bold">jid#20;escaping</span> feature is not discovered, the client SHOULD proceed as follows:</p>
+<ol start="" type="">
+<li>If the gateway supports the 'jabber:iq:gateway' protocol (as specified in <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2255477">5</a>]), use that protocol.</li>
+<li>If the gateway does not support the 'jabber:iq:gateway' protocol, use traditional escaping mechanisms (such as the transformation of the @ character to the % character).</li>
+</ol>
+
+</div>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+<div class="indent">
+<h3>4.1 <a name="exceptions">Exceptions</a>
+</h3>
+<p class="" style="">In order to maintain as much backward compatibility as possible, JIDs that contain partial escape sequences, or escape sequences that are not on the list, MUST be ignored.</p>
+  <p class="caption">Example 5. Partial escape sequence</p>
+<div class="indent"><pre><span style="font-weight: bold">foo#bar</span> is not modified by escaping or unescaping transformations</pre></div>
+  <p class="caption">Example 6. Invalid escape sequence</p>
+<div class="indent"><pre><span style="font-weight: bold">foob#41;r</span> is not modified by escaping or unescaping transformations</pre></div>
+</div>
+<div class="indent">
+<h3>4.2 <a name="processing">Processing</a>
+</h3>
+<p class="" style="">As far as the bulk of the system is concerned, an escaped JID has no special processing associated with it.  Clients SHOULD render them unescaped. Servers MAY unescape them for communication with external systems (e.g. LDAP), but only AFTER stringprep has been applied.  The unescape transformation MUST be NFKC-safe -- i.e., it must conform to Unicode normalization form KC (see Appendix B.3 of <span style="font-weight: bold">RFC 3454</span>).  An entity MUST NOT use the unescaped version in any protocol sent to another entity, and MUST NOT use the unescaped version to compare with another JID.</p>
+</div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Entities that enforce JID escaping MUST compare unescaped versions, otherwise a JID conflict could occur.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255615">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255657">7</a>] shall include the <span style="font-weight: bold">jid#20;escaping</span> [sic] feature in its registry of service discovery features.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251346">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251370">2</a>. RFC 3454: Preparation of Internationalized Strings (stringprep) &lt;<a href="http://www.ietf.org/rfc/rfc3454.txt"> http://www.ietf.org/rfc/rfc3454.txt </a>&gt;.</p>
+<p><a name="nt-id2251178">3</a>. RFC 2822: Internet Message Format &lt;<a href="http://www.ietf.org/rfc/rfc2822.txt">http://www.ietf.org/rfc/rfc2822.txt</a>&gt;.</p>
+<p><a name="nt-id2255397">4</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255477">5</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2255615">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255657">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2005-04-04)</h4>
+<div class="indent">Corrected several small textual errors and ambiguities; slightly reorganized textual flow. (psa)
+    </div>
+<h4>Version 0.3 (2005-03-16)</h4>
+<div class="indent">Clarified relationship between JID escaping and traditional client proxy gateway behavior; fixed several small errors. (psa)
+    </div>
+<h4>Version 0.2 (2003-10-21)</h4>
+<div class="indent">Editorial cleanup; added security considerations. (psa)
+    </div>
+<h4>Version 0.1 (2003-07-21)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0106-0.5.html
+++ b/content/xep-0106-0.5.html
@@ -1,0 +1,369 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0106: JID Escaping</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="JID Escaping">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a mechanism that enables the display of Jabber Identifiers (JIDs) with characters disallowed by the Nodeprep profile of stringprep.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0106">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0106: JID Escaping</h1>
+<p>This JEP specifies a mechanism that enables the display of Jabber Identifiers (JIDs) with characters disallowed by the Nodeprep profile of stringprep.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0106<br>
+            Version: 0.5<br>
+            Last Updated: 2005-04-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jid#20;escaping<br></p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#transforms">Transformations</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#concepts">Concepts</a>
+</dt>
+<dt>3.2.  <a href="#encoding">Encoding Transformation</a>
+</dt>
+<dt>3.3.  <a href="#decoding">Decoding Transformation</a>
+</dt>
+</dl>
+<dt>4.  <a href="#discovery">Discovery</a>
+</dt>
+<dt>5.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#exceptions">Exceptions</a>
+</dt>
+<dt>5.2.  <a href="#processing">Processing</a>
+</dt>
+<dt>5.3.  <a href="#othermethods">JID Escaping vs. Older Methods</a>
+</dt>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251371">1</a>] defines the Nodeprep profile of stringprep (<span class="ref" style="">RFC 3454</span>  [<a href="#nt-id2251121">2</a>]), which specifies that the following Unicode code points are disallowed in the node identifier portion of a JID (hereafter we refer to these as "the disallowed characters"):</p>
+  <ul>
+    <li>All whitespace characters (which reduce to U+0020, also called SP)</li>
+    <li>U+0022 (")</li>
+    <li>U+0026 (&amp;)</li>
+    <li>U+0027 (')</li>
+    <li>U+002F (/)</li>
+    <li>U+003A (:)</li>
+    <li>U+003C (&lt;)</li>
+    <li>U+003E (&gt;)</li>
+    <li>U+0040 (@)</li>
+  </ul>
+  <p class="" style="">This restriction is an inconvenience for users who have one or more of the foregoing nine disallowed characters in their desired usernames, particularly in the case of the ' character, which is common in names like O'Hara and D'Artagnan. The restriction is a positive hardship if existing email addresses are mapped to JIDs, since some of the disallowed characters are allowed in the username portion of an email address (e.g., the characters &amp; ' / as described in sections 3.2.4 and 3.2.5 of <span class="ref" style="">RFC 2822</span>  [<a href="#nt-id2251237">3</a>]).</p>
+  <p class="" style="">If the &amp; character had not been in the list of disallowed characters, then normal XML escaping conventions (as specified in <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2251215">4</a>]) could have been used, with the result that D'Artagnan (for example) could have been rendered as D&amp;apos;artagnan [sic]. Since there are good reasons for each of the disallowed characters, another escaping mechanism is needed.</p>
+  <p class="" style="">It might have been desirable to use percent-encoding (e.g., %27 for the ' character) as specified in Section 2.1 of <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2250404">5</a>]. However, that approach was rejected since the % character is an often-used character in JIDs (e.g., to replace the @ character in gateway addresses) and the resulting ambiguity would have caused confusion and, most likely, misdelivered or undeliverable XML stanzas. Therefore, a new mechanism is described herein to escape only the disallowed characters and only in the node identifier portion of Jabber IDs.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>The escaping mechanism shall apply to the node identitier portion of a JID only, and MUST NOT be applied to domain identifiers or resource identifiers.</li>
+    <li>Escaped JIDs MUST conform to the definition of a Jabber ID as specified in <span style="font-weight: bold">RFC 3920</span>, including the Nodeprep profile of stringprep.  In particular this means that even after passing through Nodeprep, the JID MUST be valid, with the result that Unicode look-alikes like U+02BC (Modifier Letter Apostrophe) MUST NOT be used.</li>
+    <li>It MUST NOT be possible for clients to use this escaping mechanism to avoid the goal of stringprep; namely, that JIDs that look alike should have same character representation after being processed by stringprep. Therefore, this mechanism MUST NOT be applied to any characters other than the disallowed characters.</li>
+    <li>Existing JIDs that include portions of the escaping mechanism MUST continue to be valid.</li>
+    <li>The escaping mechanism SHOULD NOT place undue strain upon server implementations; implementations or deployments that do not need to unescape SHOULD be able to ignore the escaping mechanism.</li>
+  </ol>
+<h2>3.
+       <a name="transforms">Transformations</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="concepts">Concepts</a>
+</h3>
+    <p class="" style="">Rather than encoding a disallowed character as %hexhex as in URI syntax, this JEP specifies encoding such a character as #hexhex; where "hexhex" is the hexadecimal value of the Unicode code point in question, ignoring the leading "00" in the code point (e.g., 27 for the ' character, resulting in an encoding of #27;). Full encoding and decoding transformations for all nine disallowed characters are provided in the following sections.</p>
+    <p class="" style="">Note: All transformations are exactly as specified below. CASE IS SIGNIFICANT. Lowercase was selected since Nodeprep will case fold to lowercase for US-ASCII characters such as A, C, E, and F.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="encoding">Encoding Transformation</a>
+</h3>
+    <p class="" style="">The encoding transformations are defined in the following table. Typically, encoding is performed only by a client that is processing information provided by a human user in unescaped form, or by a gateway to some external system (e.g., email or LDAP) that needs to generate a JID.</p>
+    <p class="caption">Table 1: Mapping from Unescaped to Encoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Unescaped Character</th>
+<th colspan="" rowspan="">Encoded Character</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+<td align="" colspan="" rowspan="">#20;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">"</td>
+<td align="" colspan="" rowspan="">#22;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#</td>
+<td align="" colspan="" rowspan="">#23;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&amp;</td>
+<td align="" colspan="" rowspan="">#26;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">'</td>
+<td align="" colspan="" rowspan="">#27;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">/</td>
+<td align="" colspan="" rowspan="">#2f;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">:</td>
+<td align="" colspan="" rowspan="">#3a;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;</td>
+<td align="" colspan="" rowspan="">#3c;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&gt;</td>
+<td align="" colspan="" rowspan="">#3e;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">@</td>
+<td align="" colspan="" rowspan="">#40;</td>
+</tr>
+    </table>
+    <p class="caption">Example 1. JID Encoding: Porthos starts a chat, typing into his client the JID d'artagnan@musketeers.bourbon.gov:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='d#27;artagnan@musketeers.bourbon.gov'
+    type='chat'&gt;
+  &lt;body&gt;And do you always forget your eyes when you run?&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="decoding">Decoding Transformation</a>
+</h3>
+    <p class="" style="">The decoding transformations are defined in the following table. Typically, decoding is performed only by a client that wants to display JIDs containing encoded characters to a human user, or by a gateways to some external system (e.g., email or LDAP) that needs to generate identifiers for foreign systems.</p>
+    <p class="caption">Table 2: Mapping from Encoded to Decoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Encoded Character</th>
+<th colspan="" rowspan="">Decoded Character</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#20;</td>
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#22;</td>
+<td align="" colspan="" rowspan="">"</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#23;</td>
+<td align="" colspan="" rowspan="">#</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#26;</td>
+<td align="" colspan="" rowspan="">&amp;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#27;</td>
+<td align="" colspan="" rowspan="">'</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#2f;</td>
+<td align="" colspan="" rowspan="">/</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#3a;</td>
+<td align="" colspan="" rowspan="">:</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#3c;</td>
+<td align="" colspan="" rowspan="">&lt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#3e;</td>
+<td align="" colspan="" rowspan="">&gt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">#40;</td>
+<td align="" colspan="" rowspan="">@</td>
+</tr>
+    </table>
+    <p class="caption">Example 2. JID Encoding: D'Artagnan the elder sends SMTP mail through a gateway:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='d#27;artagnan@gascon.fr/elder'
+    to='tréville%musketeers.bourbon.gov@smtp.jabber.org'&gt;
+  &lt;body&gt;I recommend my son to you.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="discovery">Discovery</a>
+</h2>
+  <p class="" style="">If an entity needs to discover whether another entity supports JID escaping, it MUST send a disco#info request to the other entity as specified in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255555">6</a>].</p>
+  <p class="caption">Example 3. Client requests features</p>
+<div class="indent"><pre>
+&lt;iq
+    type='get'
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the queried entity supports JID escaping, it MUST return a <span style="font-weight: bold">jid#20;escaping</span> [sic] feature in its reply.</p>
+  <p class="caption">Example 4. Service responds with features</p>
+<div class="indent"><pre>
+&lt;iq
+    type='get'
+    to='porthos@musketeers.bourbon.gov/gate'
+    from='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+...
+    &lt;feature var='jid#20;escaping'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="exceptions">Exceptions</a>
+</h3>
+    <p class="" style="">In order to maintain as much backward compatibility as possible, partial escape sequences and escape sequences corresponding to characters not on the list of disallowed characters MUST be ignored.</p>
+    <p class="caption">Example 5. Partial escape sequence 1</p>
+<div class="indent"><pre><span style="font-weight: bold">the#1solution</span> is not modified by encoding or decoding transformations.</pre></div>
+    <p class="caption">Example 6. Partial escape sequence 2</p>
+<div class="indent"><pre><span style="font-weight: bold">#1;#2;#3;</span> is not modified by encoding or decoding transformations.</pre></div>
+    <p class="caption">Example 7. Invalid escape sequence 1</p>
+<div class="indent"><pre><span style="font-weight: bold">foo#ba;r</span> is not modified (to <span style="font-weight: bold">fooºr</span>) by encoding or decoding transformations.</pre></div>
+    <p class="caption">Example 8. Invalid escape sequence 2</p>
+<div class="indent"><pre><span style="font-weight: bold">foob#41;r</span> is not modified (to <span style="font-weight: bold">foobAr</span>) by encoding or decoding transformations.</pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="processing">Processing</a>
+</h3>
+    <p class="" style="">The following processing rules apply:</p>
+    <ol start="" type="">
+      <li>A client SHOULD render an encoded character as its decoded equivalent when presenting it to a human user.</li>
+      <li>A server MAY decode an encoded character for communication with external systems (e.g. LDAP), but only <span style="font-style: italic">after</span> the Nodeprep profile of stringprep has been applied.</li>
+      <li>The decoding transformation MUST be NFKC-safe -- i.e., it MUST conform to Unicode normalization form KC (see Appendix B.3 of <span style="font-weight: bold">RFC 3454</span>).</li>
+      <li>An entity MUST NOT include the unescaped or decoded version of an encoded character over the wire in any XML stanzas sent to another entity.</li>
+      <li>An entity MUST NOT use the unescaped or decoded version of an encoded character when comparing two JIDs.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="othermethods">JID Escaping vs. Older Methods</a>
+</h3>
+    <p class="" style="">When a client attempts to communicate with another entity through a gateway, it needs to know which encoding mechanism to use. A client MUST assume that the gateway does not support the JID escaping mechanism unless it explicitly discovers support via Service Discovery as shown above. If there any errors in the service discovery exchange or if support for the <span style="font-weight: bold">jid#20;escaping</span> [sic] feature is not discovered, the client SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the gateway supports the 'jabber:iq:gateway' protocol (as specified in <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2255770">7</a>]), use that protocol.</li>
+      <li>If the gateway does not support the 'jabber:iq:gateway' protocol, use customary escaping mechanisms (such as the transformation of the @ character to the % character).</li>
+    </ol>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Entities that enforce JID escaping MUST compare unescaped/decoded versions, otherwise stanzas could be directed to an incorrect JID.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255836">8</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255922">9</a>] shall include the <span style="font-weight: bold">jid#20;escaping</span> [sic] feature in its registry of service discovery features.</p>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251371">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251121">2</a>. RFC 3454: Preparation of Internationalized Strings (stringprep) &lt;<a href="http://www.ietf.org/rfc/rfc3454.txt"> http://www.ietf.org/rfc/rfc3454.txt </a>&gt;.</p>
+<p><a name="nt-id2251237">3</a>. RFC 2822: Internet Message Format &lt;<a href="http://www.ietf.org/rfc/rfc2822.txt">http://www.ietf.org/rfc/rfc2822.txt</a>&gt;.</p>
+<p><a name="nt-id2251215">4</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2250404">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2255555">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255770">7</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2255836">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255922">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2005-04-21)</h4>
+<div class="indent">Used U+00xx format for code points; added references to various RFCs; corrected terminology; cleaned up text and flow. (psa)
+    </div>
+<h4>Version 0.4 (2005-04-04)</h4>
+<div class="indent">Corrected several small textual errors and ambiguities; slightly reorganized textual flow. (psa)
+    </div>
+<h4>Version 0.3 (2005-03-16)</h4>
+<div class="indent">Clarified relationship between JID escaping and traditional client proxy gateway behavior; fixed several small errors. (psa)
+    </div>
+<h4>Version 0.2 (2003-10-21)</h4>
+<div class="indent">Editorial cleanup; added security considerations. (psa)
+    </div>
+<h4>Version 0.1 (2003-07-21)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0106-0.6.html
+++ b/content/xep-0106-0.6.html
@@ -1,0 +1,547 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0106: JID Escaping</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="JID Escaping">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a mechanism that enables the display of Jabber Identifiers (JIDs) with characters disallowed by the Nodeprep profile of stringprep.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0106">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0106: JID Escaping</h1>
+<p>This JEP specifies a mechanism that enables the display of Jabber Identifiers (JIDs) with characters disallowed by the Nodeprep profile of stringprep.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0106<br>
+            Version: 0.6<br>
+            Last Updated: 2005-05-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jid\20escaping<br></p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#discovery">Discovery</a>
+</dt>
+<dt>4.  <a href="#transforms">Transformations</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts">Concepts</a>
+</dt>
+<dt>4.2.  <a href="#encoding">Encoding Transformation</a>
+</dt>
+<dt>4.3.  <a href="#decoding">Decoding Transformation</a>
+</dt>
+</dl>
+<dt>5.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#bizrules-processing">Native Processing</a>
+</dt>
+<dt>5.2.  <a href="#bizrules-algorithm">Address Transformation Algorithm</a>
+</dt>
+<dt>5.3.  <a href="#bizrules-exceptions">Exceptions</a>
+</dt>
+<dt>5.4.  <a href="#bizrules-othermethods">JID Escaping vs. Older Methods</a>
+</dt>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#impl-email">Email Addresses</a>
+</dt>
+<dt>6.2.  <a href="#impl-sip">SIP Addresses</a>
+</dt>
+<dt>6.3.  <a href="#impl-im">IM and Presence Addresses</a>
+</dt>
+<dt>6.4.  <a href="#impl-imps">IMPS Addresses</a>
+</dt>
+<dt>6.5.  <a href="#impl-ldap">LDAP Distinguished Names</a>
+</dt>
+</dl>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251117">1</a>] defines the Nodeprep profile of stringprep (<span class="ref" style="">RFC 3454</span>  [<a href="#nt-id2251139">2</a>]), which specifies that the following nine Unicode code points are disallowed in the node identifier portion of a Jabber Identifier (hereafter we refer to these as "the disallowed characters"):</p>
+  <ul>
+    <li>All whitespace characters (which reduce to U+0020, also called SP)</li>
+    <li>U+0022 (")</li>
+    <li>U+0026 (&amp;)</li>
+    <li>U+0027 (')</li>
+    <li>U+002F (/)</li>
+    <li>U+003A (:)</li>
+    <li>U+003C (&lt;)</li>
+    <li>U+003E (&gt;)</li>
+    <li>U+0040 (@)</li>
+  </ul>
+  <p class="" style="">This restriction is an inconvenience for users who have one or more of the disallowed characters in their desired usernames, particularly in the case of the ' character, which is common in names like O'Hara and D'Artagnan. The restriction is a positive hardship if existing email addresses are mapped to JIDs, since some of the disallowed characters are allowed in the username portion of an email address (specifically, the characters &amp; ' / as described in Sections 3.2.4 and 3.2.5 of <span class="ref" style="">RFC 2822</span>  [<a href="#nt-id2251217">3</a>]).</p>
+  <p class="" style="">If the &amp; character had not been in the list of disallowed characters, then normal XML escaping conventions (as specified in <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2250382">4</a>]) could have been used, with the result that D'Artagnan (for example) could have been rendered as D&amp;apos;artagnan [sic]. Since there are good reasons for each of the disallowed characters, another escaping mechanism is needed.</p>
+  <p class="" style="">It might have been desirable to use percent-encoding (e.g., %27 for the ' character) as specified in Section 2.1 of <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2250421">5</a>]. However, that approach was rejected since the % character is an often-used character in existing JIDs (e.g., to replace the @ character in gateway addresses) and the resulting ambiguity would have caused misdelivered or undeliverable messages. Therefore, a new mechanism is described herein to escape only the disallowed characters and only in the node identifier portion of JIDs.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>The escaping mechanism shall apply to the node identitier portion of a JID only, and MUST NOT be applied to domain identifiers or resource identifiers.</li>
+    <li>Escaped JIDs MUST conform to the definition of a Jabber ID as specified in <span style="font-weight: bold">RFC 3920</span>, including the Nodeprep profile of stringprep.  In particular this means that even after passing through Nodeprep, the JID MUST be valid, with the result that Unicode look-alikes like U+02BC (Modifier Letter Apostrophe) MUST NOT be used.</li>
+    <li>It MUST NOT be possible for clients to use this escaping mechanism to avoid the goal of stringprep; namely, that JIDs that look alike should have same character representation after being processed by stringprep. Therefore, this mechanism MUST NOT be applied to any characters other than the disallowed characters.</li>
+    <li>Existing JIDs that include portions of the escaping mechanism MUST continue to be valid.</li>
+    <li>The escaping mechanism MUST NOT break commonly deployed Jabber/XMPP software implementations such as servers, components, gateways, and clients.</li>
+    <li>The escaping mechanism SHOULD NOT place undue strain upon server implementations; implementations or deployments that do not need to unescape SHOULD be able to ignore the escaping mechanism.</li>
+  </ol>
+<h2>3.
+       <a name="discovery">Discovery</a>
+</h2>
+  <p class="" style="">If an entity needs to discover whether another entity supports JID escaping, it MUST send a disco#info request to the other entity as specified in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255155">6</a>].</p>
+  <p class="caption">Example 1. Client requests features</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the queried entity supports JID escaping, it MUST return a <span style="font-weight: bold">jid\20escaping</span> [sic] feature in its reply.</p>
+  <p class="caption">Example 2. Service responds with features</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    to='porthos@musketeers.bourbon.gov/gate'
+    from='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+...
+    &lt;feature var='jid\20escaping'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="transforms">Transformations</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="concepts">Concepts</a>
+</h3>
+    <p class="" style="">This JEP specifies encoding each disallowed character as \hexhex -- where "hexhex" is the hexadecimal value of the Unicode code point in question, ignoring the leading "00" in the code point (e.g., 27 for the ' character, resulting in an encoding of \27). (Note: This escaping method is quite similar to that used for disallowed characters in LDAP distinguished names, as specified in <span class="ref" style="">RFC 2253</span>  [<a href="#nt-id2255232">7</a>].) Full encoding and decoding transformations for all nine disallowed characters are provided in the following sections. In addition, encoding and decoding transformations are shown for the \ character in case it needs to be "double-escaped" when it occurs in a non-XMPP address as part of a string that corresponds to one of the other encoded characters.</p>
+    <p class="" style="">Note: All transformations are exactly as specified below. CASE IS SIGNIFICANT. Lowercase was selected since Nodeprep will case fold to lowercase for US-ASCII characters such as A, C, E, and F.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="encoding">Encoding Transformation</a>
+</h3>
+    <p class="" style="">The encoding transformations are defined in the following table. Typically, encoding is performed only by a client that is processing information provided by a human user in unescaped form, or by a gateway to some external system (e.g., email or LDAP) that needs to generate a JID.</p>
+    <p class="caption">Table 1: Mapping from Unescaped to Encoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Unescaped Character</th>
+<th colspan="" rowspan="">Encoded Character</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+<td align="" colspan="" rowspan="">\20</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">"</td>
+<td align="" colspan="" rowspan="">\22</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&amp;</td>
+<td align="" colspan="" rowspan="">\26</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">'</td>
+<td align="" colspan="" rowspan="">\27</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">/</td>
+<td align="" colspan="" rowspan="">\2f</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">:</td>
+<td align="" colspan="" rowspan="">\3a</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;</td>
+<td align="" colspan="" rowspan="">\3c</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&gt;</td>
+<td align="" colspan="" rowspan="">\3e</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">@</td>
+<td align="" colspan="" rowspan="">\40</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\</td>
+<td align="" colspan="" rowspan="">\5c</td>
+</tr>
+    </table>
+    <p class="caption">Example 3. JID Encoding: Porthos starts a chat, typing into his client the JID d'artagnan@musketeers.bourbon.gov:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='d\27artagnan@musketeers.bourbon.gov'
+    type='chat'&gt;
+  &lt;body&gt;And do you always forget your eyes when you run?&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="decoding">Decoding Transformation</a>
+</h3>
+    <p class="" style="">The decoding transformations are defined in the following table. Typically, decoding is performed only by a client that wants to display JIDs containing encoded characters to a human user, or by a gateway to some external system (e.g., email or LDAP) that needs to generate identifiers for foreign systems.</p>
+    <p class="caption">Table 2: Mapping from Encoded to Decoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Encoded Character</th>
+<th colspan="" rowspan="">Decoded Character</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\20</td>
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\22</td>
+<td align="" colspan="" rowspan="">"</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\26</td>
+<td align="" colspan="" rowspan="">&amp;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\27</td>
+<td align="" colspan="" rowspan="">'</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\2f</td>
+<td align="" colspan="" rowspan="">/</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\3a</td>
+<td align="" colspan="" rowspan="">:</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\3c</td>
+<td align="" colspan="" rowspan="">&lt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\3e</td>
+<td align="" colspan="" rowspan="">&gt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\40</td>
+<td align="" colspan="" rowspan="">@</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\5c</td>
+<td align="" colspan="" rowspan="">\</td>
+</tr>
+    </table>
+    <p class="caption">Example 4. JID Encoding: D'Artagnan the elder sends SMTP mail through a gateway:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='d\27artagnan@gascon.fr/elder'
+    to='tréville%musketeers.bourbon.gov@smtp.example.com'&gt;
+  &lt;body&gt;I recommend my son to you.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="bizrules-processing">Native Processing</a>
+</h3>
+    <p class="" style="">The following processing rules apply to native XMPP implementations:</p>
+    <ol start="" type="">
+      <li>A client SHOULD render an encoded character as its decoded equivalent when presenting it to a human user.</li>
+      <li>A server MAY decode an encoded character for communication with external systems (e.g. LDAP), but only <span style="font-style: italic">after</span> the Nodeprep profile of stringprep has been applied.</li>
+      <li>The decoding transformation MUST be NFKC-safe -- i.e., it MUST conform to Unicode normalization form KC (see Appendix B.3 of <span style="font-weight: bold">RFC 3454</span>).</li>
+      <li>An entity MUST NOT include the unescaped or decoded version of an encoded character over the wire in any XML stanzas sent to another entity.</li>
+      <li>An entity MUST NOT use the unescaped or decoded version of an encoded character when comparing two JIDs.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="bizrules-algorithm">Address Transformation Algorithm</a>
+</h3>
+    <p class="" style="">When transforming a non-XMPP address into an XMPP address, an implementation MUST adhere to the following process:</p>
+    <ol start="" type="">
+      <li>The original address MUST first be properly decoded (e.g., according to the rules in <span style="font-weight: bold">RFC 3986</span>) before it is transformed into a JID.</li>
+      <li>Any instances of strings that correspond to encodings of the disallowed characters (e.g., the string "\27") in the original address MUST be "double-escaped" by converting the backslash character to the string "\5c".</li>
+      <li>The URI scheme component MUST be removed.</li>
+      <li>All disallowed characters in the original address MUST be properly encoded in the resulting JID (as described above).</li>
+    </ol>
+    <p class="" style="">While the fourth step should be clear from the foregoing text and the third step is necessary since XMPP addresses are not URIs, the meaning of the first and second steps may not be obvious.</p>
+    <p class="" style="">Regarding step one, many non-XMPP messaging systems use URIs to identify addresses (examples include the mailto:, sip:, sips:, im:, pres:, and wv: URI schemes) or otherwise encode an identifier (e.g., an LDAP distinguished name). Before transforming an address or identifier into a JID, it MUST first be decoded according the rules specified for that type of address or identifier in order to ensure that the proper characters are transformed.</p>
+    <p class="" style="">Regarding step two, it is possible for some non-XMPP addresses to contain strings that correspond to JID-escaped characters (e.g., "\27"). Consider a Wireless Village address of &lt;wv:\3and\2is\5@example.com&gt; -- if that addresses were directly converted into into a JID, the resulting XMPP address would be \3and\2is\5@example.com, which could be construed as :nd\2is\5@example.com if JID escaping logic is applied. Therefore the leading \ character MUST be converted to the string "\5c" during the transformation, leading to a JID of \5c3and\2is\5@example.com (which would be presented to a human user as \3and\2is\5@example.com). Escaping of the backslash character before two hexhex characters MUST NOT be performed if the string is "\5c", only if the string corresponds to the encoded representation of one ofthe disallowed characters.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="bizrules-exceptions">Exceptions</a>
+</h3>
+    <p class="" style="">In order to maintain as much backward compatibility as possible, partial escape sequences and escape sequences corresponding to characters not on the list of disallowed characters MUST be ignored.</p>
+    <p class="caption">Example 5. Partial escape sequence</p>
+<div class="indent"><pre><span style="font-weight: bold">\2plus\2is\4</span> is not modified by encoding or decoding transformations.</pre></div>
+    <p class="caption">Example 6. Invalid escape sequence 1</p>
+<div class="indent"><pre><span style="font-weight: bold">foo\bar</span> is not modified (to <span style="font-weight: bold">fooºr</span>) by encoding or decoding transformations.</pre></div>
+    <p class="caption">Example 7. Invalid escape sequence 2</p>
+<div class="indent"><pre><span style="font-weight: bold">foob\41r</span> is not modified (to <span style="font-weight: bold">foobAr</span>) by encoding or decoding transformations.</pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="bizrules-othermethods">JID Escaping vs. Older Methods</a>
+</h3>
+    <p class="" style="">When a client attempts to communicate with another entity through a gateway, it needs to know which encoding mechanism to use. A client MUST assume that the gateway does not support the JID escaping mechanism unless it explicitly discovers support for the <span style="font-weight: bold">jid\20escaping</span> [sic] feature via Service Discovery as shown above. If there any errors in the service discovery exchange or if support for JID escaping is not discovered, the client SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the gateway supports the 'jabber:iq:gateway' protocol (as specified in <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2255970">8</a>]), use that protocol.</li>
+      <li>If the gateway does not support the 'jabber:iq:gateway' protocol, use customary escaping mechanisms (such as transformation of the @ character to the % character).</li>
+    </ol>
+  </div>
+<h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">In order to assist implementors, this section describes specific mappings between JIDs and addresses or identifiers used in the following standardized protocols:</p>
+  <ul>
+    <li>Mailboxes and the mailto: URI scheme as used in email.</li>
+    <li>The sip: and sips: URI schemes as used in SIP/SIMPLE.</li>
+    <li>The im: and pres: URI schemes.</li>
+    <li>The wv: URI scheme as used in Wireless Village (IMPS).</li>
+    <li>LDAP distinguished names.</li>
+  </ul>
+  <div class="indent">
+<h3>6.1 <a name="impl-email">Email Addresses</a>
+</h3>
+    <p class="" style="">The address format for an Internet mailbox is specified in <span style="font-weight: bold">RFC 2822</span>. The identifier of interest in this context is the "addr-spec" address and more particularly the "dot-atom" rule specified in Section 3.2.4, i.e., the email address shorn of angle brackets, display names, comments, quoted strings, and the like. Because some deployments of XMPP messaging systems may want to re-use existing email addresses as JIDs, it is helpful to define how to transform an email address into a JID.</p>
+    <p class="" style="">In general, it is straightforward to transform an email address (i.e., a "dot-atom") into a JID, since traditional email addresses allow US-ASCII characters only rather than the nearly full range of Unicode code points allowed in a JID.  [<a href="#nt-id2256067">9</a>] However, there are three characters allowed in the local-part of an email address that are not allowed in the node identifier portion of a JID: namely, the characters &amp; ' / as described in Sections 3.2.4 and 3.2.5 of <span style="font-weight: bold">RFC 2822</span>. In order to transform these characters, a compliant implementation MUST use the methods specified herein.</p>
+    <p class="caption">Example 8. An Email Address Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 9. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 10. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="" style="">(Note: Because the backslash character is forbidden in the "dot-atom" construction, an email address should not contain a string that corresponds to one of the encoded characters specified in the <a href="#transforms">Transformations</a> section of this document; therefore, no such examples are shown; see below under <a href="#impl-imps">IMPS Addresses</a>.)</p>
+    <p class="" style="">An email address may also exist in the form of a mailto: URI as specified in <span class="ref" style="">RFC 2368</span>  [<a href="#nt-id2256160">10</a>]. Before transforming a mailto: URI into a JID, it MUST be URL-decoded and all headers MUST be removed, leaving a mailbox identifier, as shown in the following example.</p>
+    <p class="caption">Example 11. A mailto: URI Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+mailto:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com?subject=that%20is%20crazy%21
+    </pre></div>
+    <p class="caption">Example 12. The Resulting Mailbox</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 13. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 14. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="impl-sip">SIP Addresses</a>
+</h3>
+    <p class="" style="">As specified in <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2256225">11</a>], a SIP address (i.e., a sip: or sips: URI) can be quite complex if URI parameters or headers are included. However, a basic SIP address (the combination of the optional "userinfo" and required "hostport" constructions) is essentially similar to an email address (e.g., the same characters &amp; ' / allowed in an email address but disallowed in an XMPP node identifier are also allowed in a basic SIP address).</p>
+    <p class="caption">Example 15. A Basic sip: URI Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+sip:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com
+    </pre></div>
+    <p class="caption">Example 16. The URL-Decoded Address</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 17. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 18. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="impl-im">IM and Presence Addresses</a>
+</h3>
+    <p class="" style="">The im: and pres: URI schemes are specified in <span class="ref" style="">RFC 3860</span>  [<a href="#nt-id2256304">12</a>] and <span class="ref" style="">RFC 3859</span>  [<a href="#nt-id2256324">13</a>] respectively. With the exception of headers, an im: or pres: URI is simply a mailbox (as specified in <span style="font-weight: bold">RFC 2822</span>) prepended with the im: or pres: scheme. Thus a basic IM or PRES address (not including optional headers) is essentially similar to an email address (e.g., the same characters &amp; ' / allowed in an email address but disallowed in an XMPP node identifier are also allowed in a basic IM or PRES address).</p>
+    <p class="caption">Example 19. A Basic im: URI Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+im:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com
+    </pre></div>
+    <p class="caption">Example 20. The URL-Decoded Address</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 21. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 22. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="impl-imps">IMPS Addresses</a>
+</h3>
+    <p class="" style="">The Instant Messaging and Presence Service (IMPS) protocol was originally defined by the Wireless Village consortium and is now maintained by the <span class="ref" style="">Open Mobile Alliance (OMA)</span>  [<a href="#nt-id2256397">14</a>]. An IMPS address is formatted as a wv: URI, as specified in <span class="ref" style="">WV Client-Server Protocol v1.1</span>  [<a href="#nt-id2256426">15</a>]. A basic address (not including a private resource) is of the form &lt;wv:user-id@domain&gt; and an address with a private resource is of the form &lt;wv:user-id/resource@domain&gt;.</p>
+    <p class="" style="">The "User-ID" construction is either a mobile phone number (beginning with "+1" for international numbers and a digit for national numbers) or an "Internet-Identity". An "Internet-Identity" may contain any US-ASCII character other than / @ + SP TAB and thus may include the following characters that are disallowed in the node identifier portion of a JID: " &amp; ' / : &lt; &gt; (which characters MUST be escaped when transforming an IMPS address into a JID). However, some of those characters are also reserved in URI syntax (namely the &amp; ' / characters) so those characters will be found in encoded form within a wv: URI.</p>
+    <p class="caption">Example 23. A Basic wv: URI Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+wv:here%27s_a_wild_%26_%2Fcr%zy%2F_address_for%3A%3Cwv%3E%28%22IMPS%22%29@example.com
+    </pre></div>
+    <p class="caption">Example 24. The URL-Decoded Address</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address_for:&lt;wv&gt;("IMPS")@example.com
+    </pre></div>
+    <p class="caption">Example 25. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address_for\3a\3cwv\3e(\22IMPS\22)@example.com
+    </pre></div>
+    <p class="caption">Example 26. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address_for:&lt;wv&gt;("IMPS")@example.com
+    </pre></div>
+    <p class="" style="">Unlike the foregoing address types, IMPS addresses are allowed to contain backslashes. This implies that it is possible for an IMPS address to contain a string that corresponds to one of the encoded character representations for code points that are disallowed in XMPP node identifiers. And example would be the IMPS address &lt;wv:\3and\2is\5@example.com&gt;, where the string "\3a" could be interpreted as the : character if that IMPS address is directly converted into a JID. Therefore, the leading \ character MUST be transformed to "\5c" in order to avoid possible ambiguity. Thus the transformed JID would be &lt;\5c3and\2is\5@example.com&gt;, which would be presented to a user as &lt;\3and\2is\5@example.com&gt;.</p>
+    <p class="" style="">If an IMPS address contains a private resource, a gateway between XMPP and IMPS should process the resource and append it to the end of the JID; however, such gateway behavior is out of scope for this JEP.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="impl-ldap">LDAP Distinguished Names</a>
+</h3>
+    <p class="" style="">Within the Lightweight Directory Access Protocol (see <span class="ref" style="">RFC 2251</span>  [<a href="#nt-id2256564">16</a>]), a "distinguished name" (DN) is a hierarchically-organized string representation that uniquely identifies a user, system, or organization. It is possible that some messaging systems use LDAP distinguished names to identify entities that can communicate using the system (e.g., this is reputed to be the case for certain releases of the Lotus Sametime system sold by IBM), and in any case it may be helpful to transform an LDAP distinguished name into an XMPP address for identification or addressing purposes.</p>
+    <p class="" style="">As previously mentioned, a UTF-8 string representation of LDAP distinguished names is specified in <span style="font-weight: bold">RFC 2253</span>. This representation specifies that the characters , + " \ &lt; &gt; ; are to be escaped with the backslash character (e.g., the string "\," would be used to escape the , character) and that any other non-US-ASCII characters are to be escaped using a string of the form "\xx".</p>
+    <p class="" style="">The following example shows a distinguished name (and transformations thereof) for a person whose common name is "D'Artagnan Saint-André" and who is associated with an organization called "Example &amp; Company, Inc." whose domain name is "example.com":</p>
+    <p class="caption">Example 27. A Distinguished Name</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-André,O=Example &amp; Company, Inc.,DC=example,DC=com
+    </pre></div>
+    <p class="caption">Example 28. UTF-8 Representation of Distinguished Name</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-Andr\E9,O=Example &amp;amp; Company\, Inc.,DC=example,DC=com
+    </pre></div>
+    <p class="" style="">This example assumes that the specified user is identified with a gateway running at st.example.com (note that the backslash escaping the , character in the organization name is removed during the transformation).</p>
+    <p class="caption">Example 29. The Transformed JID</p>
+<div class="indent"><pre>
+CN=D\27Artagnan\20Saint-Andr\E9,O=Example\20\26\20Company,\20Inc.,DC=example,DC=com@st.example.com
+    </pre></div>
+    <p class="caption">Example 30. The JID as Presented to a User</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-André,O=Example &amp; Company, Inc.,DC=example,DC=com@st.example.com
+    </pre></div>
+    <p class="" style="">Naturally, a more intelligent gateway could use the Domain Components to construct a more readable JID, such as &lt;D\27Artagnan\20Saint-André@example.com&gt;; however, such gateway behavior is out of scope for this JEP.</p>
+  </div>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">An entity that performs JID escaping MUST NOT compare unescaped/decoded versions, otherwise messages and other information could be directed to an entity other than the intended recipient.</p>
+  <p class="" style="">An entity that transforms a non-XMPP address into a JID MUST follow the algorithm specified in the <a href="#bizrules-algorithm">Address Transformation Algorithm</a> section of this document, otherwise messages and other information could be directed to an entity other than the intended recipient.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256871">17</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256919">18</a>] shall include the <span style="font-weight: bold">jid\20escaping</span> [sic] feature in its registry of service discovery features.</p>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251117">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251139">2</a>. RFC 3454: Preparation of Internationalized Strings (stringprep) &lt;<a href="http://www.ietf.org/rfc/rfc3454.txt"> http://www.ietf.org/rfc/rfc3454.txt </a>&gt;.</p>
+<p><a name="nt-id2251217">3</a>. RFC 2822: Internet Message Format &lt;<a href="http://www.ietf.org/rfc/rfc2822.txt">http://www.ietf.org/rfc/rfc2822.txt</a>&gt;.</p>
+<p><a name="nt-id2250382">4</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2250421">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2255155">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255232">7</a>. RFC 2253: Lightweight Directory Access Protocol (v3): UTF-8 String Representation of Distinguished Names &lt;<a href="http://www.ietf.org/rfc/rfc2253.txt">http://www.ietf.org/rfc/rfc2253.txt</a>&gt;.</p>
+<p><a name="nt-id2255970">8</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2256067">9</a>. This specification does not cover recent efforts to define internationalized email addresses.</p>
+<p><a name="nt-id2256160">10</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p><a name="nt-id2256225">11</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256304">12</a>. RFC 3860: Common Profile for Instant Messaging (CPIM) &lt;<a href="http://www.ietf.org/rfc/rfc3860.txt">http://www.ietf.org/rfc/rfc3860.txt</a>&gt;.</p>
+<p><a name="nt-id2256324">13</a>. RFC 3859: Common Profile for Presence (CPP) &lt;<a href="http://www.ietf.org/rfc/rfc3859.txt">http://www.ietf.org/rfc/rfc3859.txt</a>&gt;.</p>
+<p><a name="nt-id2256397">14</a>. The Open Mobile Alliance is the focal point for the development of mobile service enabler specifications, which support the creation of interoperable end-to-end mobile services. For further information, see &lt;<a href="http://www.openmobilealliance.org/">http://www.openmobilealliance.org/</a>&gt;.</p>
+<p><a name="nt-id2256426">15</a>. Wireless Village Client-Server Protocol v1.1 &lt;<a href="http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html">http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html</a>&gt;.</p>
+<p><a name="nt-id2256564">16</a>. RFC 2251: Lightweight Directory Access Protocol (v3) &lt;<a href="http://www.ietf.org/rfc/rfc2251.txt">http://www.ietf.org/rfc/rfc2251.txt</a>&gt;.</p>
+<p><a name="nt-id2256871">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256919">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-05-06)</h4>
+<div class="indent">Changed format from #xx; to \xx per list discussion; added extensive implementation notes. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-21)</h4>
+<div class="indent">Changed to U+00xx format for code points; added references to various RFCs; corrected terminology; cleaned up text and flow. (psa)
+    </div>
+<h4>Version 0.4 (2005-04-04)</h4>
+<div class="indent">Corrected several small textual errors and ambiguities; slightly reorganized textual flow. (psa)
+    </div>
+<h4>Version 0.3 (2005-03-16)</h4>
+<div class="indent">Clarified relationship between JID escaping and traditional client proxy gateway behavior; fixed several small errors. (psa)
+    </div>
+<h4>Version 0.2 (2003-10-21)</h4>
+<div class="indent">Editorial cleanup; added security considerations. (psa)
+    </div>
+<h4>Version 0.1 (2003-07-21)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0106-0.7.html
+++ b/content/xep-0106-0.7.html
@@ -1,0 +1,623 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0106: JID Escaping</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="JID Escaping">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a mechanism that enables the display of Jabber Identifiers (JIDs) with characters disallowed by the Nodeprep profile of stringprep.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-08">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0106">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0106: JID Escaping</h1>
+<p>This JEP specifies a mechanism that enables the display of Jabber Identifiers (JIDs) with characters disallowed by the Nodeprep profile of stringprep.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0106<br>
+            Version: 0.7<br>
+            Last Updated: 2005-05-08<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jid\20escaping<br></p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#discovery">Discovery</a>
+</dt>
+<dt>4.  <a href="#transforms">Transformations</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts">Concepts</a>
+</dt>
+<dt>4.2.  <a href="#encoding">Encoding Transformation</a>
+</dt>
+<dt>4.3.  <a href="#decoding">Decoding Transformation</a>
+</dt>
+</dl>
+<dt>5.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#bizrules-processing">Native Processing</a>
+</dt>
+<dt>5.2.  <a href="#bizrules-algorithm">Address Transformation Algorithm</a>
+</dt>
+<dt>5.3.  <a href="#bizrules-exceptions">Exceptions</a>
+</dt>
+<dt>5.4.  <a href="#bizrules-othermethods">JID Escaping vs. Older Methods</a>
+</dt>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#impl-email">Email Addresses</a>
+</dt>
+<dt>6.2.  <a href="#impl-sip">SIP Addresses</a>
+</dt>
+<dt>6.3.  <a href="#impl-im">IM and Presence Addresses</a>
+</dt>
+<dt>6.4.  <a href="#impl-imps">IMPS Addresses</a>
+</dt>
+<dt>6.5.  <a href="#impl-ldap">LDAP Distinguished Names</a>
+</dt>
+</dl>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251129">1</a>] defines the Nodeprep profile of stringprep (<span class="ref" style="">RFC 3454</span>  [<a href="#nt-id2251154">2</a>]), which specifies that the following nine Unicode code points are disallowed in the node identifier portion of a Jabber Identifier (hereafter we refer to these as "the disallowed characters"):</p>
+  <ul>
+    <li>All whitespace characters (which reduce to U+0020, also called SP)</li>
+    <li>U+0022 (")</li>
+    <li>U+0026 (&amp;)</li>
+    <li>U+0027 (')</li>
+    <li>U+002F (/)</li>
+    <li>U+003A (:)</li>
+    <li>U+003C (&lt;)</li>
+    <li>U+003E (&gt;)</li>
+    <li>U+0040 (@)</li>
+  </ul>
+  <p class="" style="">This restriction is an inconvenience for users who have one or more of the disallowed characters in their desired usernames, particularly in the case of the ' character, which is common in names like O'Hara and D'Artagnan. The restriction is a positive hardship if existing email addresses are mapped to JIDs, since some of the disallowed characters are allowed in the username portion of an email address (specifically, the characters &amp; ' / as described in Sections 3.2.4 and 3.2.5 of <span class="ref" style="">RFC 2822</span>  [<a href="#nt-id2251236">3</a>]).</p>
+  <p class="" style="">If the &amp; character had not been in the list of disallowed characters, then normal XML escaping conventions (as specified in <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2250394">4</a>]) could have been used, with the result that D'Artagnan (for example) could have been rendered as D&amp;apos;artagnan [sic]. Since there are good reasons for each of the disallowed characters, another escaping mechanism is needed.</p>
+  <p class="" style="">It might have been desirable to use percent-encoding (e.g., %27 for the ' character) as specified in Section 2.1 of <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2250436">5</a>]. However, that approach was rejected since the % character is an often-used character in existing JIDs (e.g., to replace the @ character in gateway addresses) and the resulting ambiguity would have caused misdelivered or undeliverable messages. Therefore, a new mechanism is described herein to escape only the disallowed characters and only in the node identifier portion of JIDs.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>The escaping mechanism shall apply to the node identitier portion of a JID only, and MUST NOT be applied to domain identifiers or resource identifiers.</li>
+    <li>Escaped JIDs MUST conform to the definition of a Jabber ID as specified in <span style="font-weight: bold">RFC 3920</span>, including the Nodeprep profile of stringprep.  In particular this means that even after passing through Nodeprep, the JID MUST be valid, with the result that Unicode look-alikes like U+02BC (Modifier Letter Apostrophe) MUST NOT be used.</li>
+    <li>It MUST NOT be possible for clients to use this escaping mechanism to avoid the goal of stringprep; namely, that JIDs that look alike should have same character representation after being processed by stringprep. Therefore, this mechanism MUST NOT be applied to any characters other than the disallowed characters.</li>
+    <li>Existing JIDs that include portions of the escaping mechanism MUST continue to be valid.</li>
+    <li>The escaping mechanism MUST NOT break commonly deployed Jabber/XMPP software implementations such as servers, components, gateways, and clients.</li>
+    <li>The escaping mechanism SHOULD NOT place undue strain upon server implementations; implementations or deployments that do not need to unescape SHOULD be able to ignore the escaping mechanism.</li>
+  </ol>
+<h2>3.
+       <a name="discovery">Discovery</a>
+</h2>
+  <p class="" style="">If an entity needs to discover whether another entity supports JID escaping, it MUST send a disco#info request to the other entity as specified in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255165">6</a>].</p>
+  <p class="caption">Example 1. Client requests features</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the queried entity supports JID escaping, it MUST return a <span style="font-weight: bold">jid\20escaping</span> [sic] feature in its reply.</p>
+  <p class="caption">Example 2. Service responds with features</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    to='porthos@musketeers.bourbon.gov/gate'
+    from='irc.shakespeare.lit'
+    id='info1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+...
+    &lt;feature var='jid\20escaping'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="transforms">Transformations</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="concepts">Concepts</a>
+</h3>
+    <p class="" style="">This JEP specifies encoding each disallowed character as \hexhex -- where "hexhex" is the hexadecimal value of the Unicode code point in question, ignoring the leading "00" in the code point (e.g., 27 for the ' character, resulting in an encoding of \27). (Note: This escaping method is quite similar to that used for disallowed characters in LDAP distinguished names, as specified in <span class="ref" style="">RFC 2253</span>  [<a href="#nt-id2255244">7</a>].) Full encoding and decoding transformations for all nine disallowed characters are provided in the following sections. In addition, encoding and decoding transformations are shown for the \ character in case it needs to be "double-escaped" when it occurs in a non-XMPP address as part of a string that corresponds to one of the other encoded characters.</p>
+    <p class="" style="">Note: All transformations are exactly as specified below. CASE IS SIGNIFICANT. Lowercase was selected since Nodeprep will case fold to lowercase for US-ASCII characters such as A, C, E, and F.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="encoding">Encoding Transformation</a>
+</h3>
+    <p class="" style="">The encoding transformations are defined in the following table. Typically, encoding is performed only by a client that is processing information provided by a human user in unescaped form, or by a gateway to some external system (e.g., email or LDAP) that needs to generate a JID.</p>
+    <p class="caption">Table 1: Mapping from Unescaped to Encoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Unescaped Character</th>
+<th colspan="" rowspan="">Encoded Character</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+<td align="" colspan="" rowspan="">\20</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">"</td>
+<td align="" colspan="" rowspan="">\22</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&amp;</td>
+<td align="" colspan="" rowspan="">\26</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">'</td>
+<td align="" colspan="" rowspan="">\27</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">/</td>
+<td align="" colspan="" rowspan="">\2f</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">:</td>
+<td align="" colspan="" rowspan="">\3a</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&lt;</td>
+<td align="" colspan="" rowspan="">\3c</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">&gt;</td>
+<td align="" colspan="" rowspan="">\3e</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">@</td>
+<td align="" colspan="" rowspan="">\40</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\</td>
+<td align="" colspan="" rowspan="">\5c</td>
+</tr>
+    </table>
+    <p class="caption">Example 3. JID Encoding: Porthos starts a chat, typing into his client the JID d'artagnan@musketeers.bourbon.gov:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='porthos@musketeers.bourbon.gov/gate'
+    to='d\27artagnan@musketeers.bourbon.gov'
+    type='chat'&gt;
+  &lt;body&gt;And do you always forget your eyes when you run?&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="decoding">Decoding Transformation</a>
+</h3>
+    <p class="" style="">The decoding transformations are defined in the following table. Typically, decoding is performed only by a client that wants to display JIDs containing encoded characters to a human user, or by a gateway to some external system (e.g., email or LDAP) that needs to generate identifiers for foreign systems.</p>
+    <p class="caption">Table 2: Mapping from Encoded to Decoded Characters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Encoded Character</th>
+<th colspan="" rowspan="">Decoded Character</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\20</td>
+<td align="" colspan="" rowspan="">&lt;space&gt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\22</td>
+<td align="" colspan="" rowspan="">"</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\26</td>
+<td align="" colspan="" rowspan="">&amp;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\27</td>
+<td align="" colspan="" rowspan="">'</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\2f</td>
+<td align="" colspan="" rowspan="">/</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\3a</td>
+<td align="" colspan="" rowspan="">:</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\3c</td>
+<td align="" colspan="" rowspan="">&lt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\3e</td>
+<td align="" colspan="" rowspan="">&gt;</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\40</td>
+<td align="" colspan="" rowspan="">@</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan="">\5c</td>
+<td align="" colspan="" rowspan="">\</td>
+</tr>
+    </table>
+    <p class="caption">Example 4. JID Encoding: D'Artagnan the elder sends SMTP mail through a gateway:</p>
+<div class="indent"><pre>
+&lt;message 
+    from='d\27artagnan@gascon.fr/elder'
+    to='tréville%musketeers.bourbon.gov@smtp.example.com'&gt;
+  &lt;body&gt;I recommend my son to you.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="bizrules-processing">Native Processing</a>
+</h3>
+    <p class="" style="">The following processing rules apply to native XMPP implementations:</p>
+    <ol start="" type="">
+      <li>A client SHOULD render an encoded character as its decoded equivalent when presenting it to a human user.</li>
+      <li>A server MAY decode an encoded character for communication with external systems (e.g. LDAP), but only <span style="font-style: italic">after</span> the Nodeprep profile of stringprep has been applied.</li>
+      <li>The decoding transformation MUST be NFKC-safe -- i.e., it MUST conform to Unicode normalization form KC (see Appendix B.3 of <span style="font-weight: bold">RFC 3454</span>).</li>
+      <li>An entity MUST NOT include the unescaped or decoded version of an encoded character over the wire in any XML stanzas sent to another entity.</li>
+      <li>An entity MUST NOT use the unescaped or decoded version of an encoded character when comparing two JIDs.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="bizrules-algorithm">Address Transformation Algorithm</a>
+</h3>
+    <p class="" style="">When transforming a non-XMPP address into an XMPP address, an implementation MUST adhere to the following process:</p>
+    <ol start="" type="">
+      <li>The original address MUST first be properly decoded (e.g., according to the rules in <span style="font-weight: bold">RFC 3986</span>) before it is transformed into a JID.</li>
+      <li>Any instances of strings that correspond to encodings of the disallowed characters (e.g., the string "\27") in the original address MUST be "double-escaped" by converting the backslash character to the string "\5c".</li>
+      <li>The URI scheme component MUST be removed.</li>
+      <li>All disallowed characters in the original address MUST be properly encoded in the resulting JID (as described above).</li>
+    </ol>
+    <p class="" style="">While the fourth step should be clear from the foregoing text and the third step is necessary since XMPP addresses are not URIs, the meaning of the first and second steps may not be obvious.</p>
+    <p class="" style="">Regarding step one, many non-XMPP messaging systems use URIs to identify addresses (examples include the mailto:, sip:, sips:, im:, pres:, and wv: URI schemes) or otherwise encode an identifier (e.g., an LDAP distinguished name). Before transforming an address or identifier into a JID, it MUST first be decoded according the rules specified for that type of address or identifier in order to ensure that the proper characters are transformed.</p>
+    <p class="" style="">Regarding step two, it is possible for some non-XMPP addresses to contain strings that correspond to JID-escaped characters (e.g., "\27"). Consider a Wireless Village address of &lt;wv:\3and\2is\5@example.com&gt; -- if that addresses were directly converted into into a JID, the resulting XMPP address would be \3and\2is\5@example.com, which could be construed as :nd\2is\5@example.com if JID escaping logic is applied. Therefore the leading \ character MUST be converted to the string "\5c" during the transformation, leading to a JID of \5c3and\2is\5@example.com (which would be presented to a human user as \3and\2is\5@example.com). Escaping of the backslash character before two hexhex characters MUST NOT be performed if the string is "\5c", only if the string corresponds to the encoded representation of one ofthe disallowed characters.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="bizrules-exceptions">Exceptions</a>
+</h3>
+    <p class="" style="">In order to maintain as much backward compatibility as possible, partial escape sequences and escape sequences corresponding to characters not on the list of disallowed characters MUST be ignored.</p>
+    <p class="caption">Example 5. Partial escape sequence</p>
+<div class="indent"><pre><span style="font-weight: bold">\2plus\2is\4</span> is not modified by encoding or decoding transformations.</pre></div>
+    <p class="caption">Example 6. Invalid escape sequence 1</p>
+<div class="indent"><pre><span style="font-weight: bold">foo\bar</span> is not modified (to <span style="font-weight: bold">fooºr</span>) by encoding or decoding transformations.</pre></div>
+    <p class="caption">Example 7. Invalid escape sequence 2</p>
+<div class="indent"><pre><span style="font-weight: bold">foob\41r</span> is not modified (to <span style="font-weight: bold">foobAr</span>) by encoding or decoding transformations.</pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="bizrules-othermethods">JID Escaping vs. Older Methods</a>
+</h3>
+    <p class="" style="">When a client attempts to communicate with another entity through a gateway, it needs to know which encoding mechanism to use. A client MUST assume that the gateway does not support the JID escaping mechanism unless it explicitly discovers support for the <span style="font-weight: bold">jid\20escaping</span> [sic] feature via Service Discovery as shown above. If there any errors in the service discovery exchange or if support for JID escaping is not discovered, the client SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the gateway supports the 'jabber:iq:gateway' protocol (as specified in <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2255986">8</a>]), use that protocol.</li>
+      <li>If the gateway does not support the 'jabber:iq:gateway' protocol, use customary escaping mechanisms (such as transformation of the @ character to the % character).</li>
+    </ol>
+  </div>
+<h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">In order to assist implementors, this section describes specific mappings between JIDs and addresses or identifiers used in the following standardized protocols:</p>
+  <ul>
+    <li>Mailboxes and the mailto: URI scheme as used in email.</li>
+    <li>The sip: and sips: URI schemes as used in SIP/SIMPLE.</li>
+    <li>The im: and pres: URI schemes.</li>
+    <li>The wv: URI scheme as used in Wireless Village (IMPS).</li>
+    <li>LDAP distinguished names.</li>
+  </ul>
+  <div class="indent">
+<h3>6.1 <a name="impl-email">Email Addresses</a>
+</h3>
+    <p class="" style="">The address format for an Internet mailbox is specified in <span style="font-weight: bold">RFC 2822</span>. The identifier of interest in this context is the "addr-spec" address and more particularly the "dot-atom" rule specified in Section 3.2.4, i.e., the email address shorn of angle brackets, display names, comments, quoted strings, and the like. Because some deployments of XMPP messaging systems may want to re-use existing email addresses as JIDs, it is helpful to define how to transform an email address into a JID.</p>
+    <p class="" style="">In general, it is straightforward to transform an email address (i.e., a "dot-atom") into a JID, since traditional email addresses allow US-ASCII characters only rather than the nearly full range of Unicode code points allowed in a JID.  [<a href="#nt-id2256076">9</a>] However, there are three characters allowed in the local-part of an email address that are not allowed in the node identifier portion of a JID: namely, the characters &amp; ' / as described in Sections 3.2.4 and 3.2.5 of <span style="font-weight: bold">RFC 2822</span>. In order to transform these characters, a compliant implementation MUST use the methods specified herein.</p>
+    <p class="caption">Example 8. An Email Address Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 9. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 10. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="" style="">(Note: Because the backslash character is forbidden in the "dot-atom" construction, an email address should not contain a string that corresponds to one of the encoded characters specified in the <a href="#transforms">Transformations</a> section of this document; therefore, no such examples are shown; see below under <a href="#impl-imps">IMPS Addresses</a>.)</p>
+    <p class="" style="">An email address may also exist in the form of a mailto: URI as specified in <span class="ref" style="">RFC 2368</span>  [<a href="#nt-id2256171">10</a>]. Before transforming a mailto: URI into a JID, it MUST be URL-decoded and all headers MUST be removed, leaving a mailbox identifier, as shown in the following example.</p>
+    <p class="caption">Example 11. A mailto: URI Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+mailto:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com?subject=that%20is%20crazy%21
+    </pre></div>
+    <p class="caption">Example 12. The Resulting Mailbox</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 13. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 14. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="" style="">The foregoing examples showed how to transform an email address or mailto: URI into a JID. However, it also may be necessary to convert a JID into an email address or mailto: URI, as shown in the following example.</p>
+    <p class="caption">Example 15. User Enters Address, Including Disallowed Characters</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 16. Client Transforms Address Using JID Escaping</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 17. Application Converts Escaped JID to Mailbox</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 18. Application Converts Mailbox to mailto: URI</p>
+<div class="indent"><pre>
+mailto:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="impl-sip">SIP Addresses</a>
+</h3>
+    <p class="" style="">As specified in <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2256316">11</a>], a SIP address (i.e., a sip: or sips: URI) can be quite complex if URI parameters or headers are included. However, a basic SIP address (the combination of the optional "userinfo" and required "hostport" constructions) is essentially similar to an email address (e.g., the same characters &amp; ' / allowed in an email address but disallowed in an XMPP node identifier are also allowed in a basic SIP address).</p>
+    <p class="caption">Example 19. A Basic sip: URI Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+sip:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com
+    </pre></div>
+    <p class="caption">Example 20. The URL-Decoded Address</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 21. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 22. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="" style="">The foregoing example showed how to transform a sip: or sips: URI into a JID. However, it also may be necessary to convert a JID into a sip: or sips: URI, as shown in the following example.</p>
+    <p class="caption">Example 23. User Enters Address, Including Disallowed Characters</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 24. Client Transforms Address Using JID Escaping</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 25. Application Converts Escaped JID to sip: URI</p>
+<div class="indent"><pre>
+sip:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="impl-im">IM and Presence Addresses</a>
+</h3>
+    <p class="" style="">The im: and pres: URI schemes are specified in <span class="ref" style="">RFC 3860</span>  [<a href="#nt-id2256386">12</a>] and <span class="ref" style="">RFC 3859</span>  [<a href="#nt-id2256408">13</a>] respectively. With the exception of headers, an im: or pres: URI is simply a mailbox (as specified in <span style="font-weight: bold">RFC 2822</span>) prepended with the im: or pres: scheme. Thus a basic IM or PRES address (not including optional headers) is essentially similar to an email address (e.g., the same characters &amp; ' / allowed in an email address but disallowed in an XMPP node identifier are also allowed in a basic IM or PRES address).</p>
+    <p class="caption">Example 26. A Basic im: URI Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+im:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com
+    </pre></div>
+    <p class="caption">Example 27. The URL-Decoded Address</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 28. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 29. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="" style="">The foregoing example showed how to transform an im: or pres: URI into a JID. However, it also may be necessary to convert a JID into an im: or pres: URI, as shown in the following example.</p>
+    <p class="caption">Example 30. User Enters Address, Including Disallowed Characters</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address@example.com
+    </pre></div>
+    <p class="caption">Example 31. Client Transforms Address Using JID Escaping</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address@example.com
+    </pre></div>
+    <p class="caption">Example 32. Application Converts Escaped JID to pres: URI</p>
+<div class="indent"><pre>
+pres:here%27s_a_wild_%26_%2Fcr%zy%2F_address@example.com
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="impl-imps">IMPS Addresses</a>
+</h3>
+    <p class="" style="">The Instant Messaging and Presence Service (IMPS) protocol was originally defined by the Wireless Village consortium and is now maintained by the <span class="ref" style="">Open Mobile Alliance (OMA)</span>  [<a href="#nt-id2256514">14</a>]. An IMPS address is formatted as a wv: URI, as specified in <span class="ref" style="">WV Client-Server Protocol v1.1</span>  [<a href="#nt-id2256538">15</a>]. A basic address (not including a private resource) is of the form &lt;wv:user-id@domain&gt; and an address with a private resource is of the form &lt;wv:user-id/resource@domain&gt;.</p>
+    <p class="" style="">The "User-ID" construction is either a mobile phone number (beginning with "+1" for international numbers and a digit for national numbers) or an "Internet-Identity". An "Internet-Identity" may contain any US-ASCII character other than / @ + SP TAB and thus may include the following characters that are disallowed in the node identifier portion of a JID: " &amp; ' / : &lt; &gt; (which characters MUST be escaped when transforming an IMPS address into a JID). However, some of those characters are also reserved in URI syntax (namely the &amp; ' / characters) so those characters will be found in encoded form within a wv: URI.</p>
+    <p class="caption">Example 33. A Basic wv: URI Containing JID-Disallowed Characters</p>
+<div class="indent"><pre>
+wv:here%27s_a_wild_%26_%2Fcr%zy%2F_address_for%3A%3Cwv%3E%28%22IMPS%22%29@example.com
+    </pre></div>
+    <p class="caption">Example 34. The URL-Decoded Address</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address_for:&lt;wv&gt;("IMPS")@example.com
+    </pre></div>
+    <p class="caption">Example 35. The Transformed JID</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address_for\3a\3cwv\3e(\22IMPS\22)@example.com
+    </pre></div>
+    <p class="caption">Example 36. The JID as Presented to a User</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address_for:&lt;wv&gt;("IMPS")@example.com
+    </pre></div>
+    <p class="" style="">Unlike the foregoing address types, IMPS addresses are allowed to contain backslashes. This implies that it is possible for an IMPS address to contain a string that corresponds to one of the encoded character representations for code points that are disallowed in XMPP node identifiers. An example would be the IMPS address &lt;wv:\3and\2is\5@example.com&gt;, where the string "\3a" could be interpreted as the : character if that IMPS address is directly converted into a JID. Therefore, the leading \ character MUST be transformed to "\5c" in order to avoid possible ambiguity. Thus the transformed JID would be &lt;\5c3and\2is\5@example.com&gt;, which would be presented to a user as &lt;\3and\2is\5@example.com&gt;.</p>
+    <p class="" style="">If an IMPS address contains a private resource, a gateway between XMPP and IMPS should process the resource and append it to the end of the JID; however, such gateway behavior is out of scope for this JEP.</p>
+    <p class="" style="">The foregoing example showed how to transform a wv: URI into a JID. However, it also may be necessary to convert a JID into a wv: URI, as shown in the following example.</p>
+    <p class="caption">Example 37. User Enters Address, Including Disallowed Characters</p>
+<div class="indent"><pre>
+here's_a_wild_&amp;_/cr%zy/_address_for:&lt;wv&gt;("IMPS")@example.com
+    </pre></div>
+    <p class="caption">Example 38. Client Transforms Address Using JID Escaping</p>
+<div class="indent"><pre>
+here\27s_a_wild_\26_\2fcr%zy\2f_address_for\3a\3cwv\3e(\22IMPS\22)@example.com
+    </pre></div>
+    <p class="caption">Example 39. Application Converts Escaped JID to wv: URI</p>
+<div class="indent"><pre>
+wv:here%27s_a_wild_%26_%2Fcr%zy%2F_address_for%3A%3Cwv%3E%28%22IMPS%22%29@example.com
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="impl-ldap">LDAP Distinguished Names</a>
+</h3>
+    <p class="" style="">Within the Lightweight Directory Access Protocol (see <span class="ref" style="">RFC 2251</span>  [<a href="#nt-id2256710">16</a>]), a "distinguished name" (DN) is a hierarchically-organized string representation that uniquely identifies a user, system, or organization. It is possible that some messaging systems use LDAP distinguished names to identify entities that can communicate using the system (e.g., this is reputed to be the case for certain releases of the Lotus Sametime system sold by IBM), and in any case it may be helpful to transform an LDAP distinguished name into an XMPP address for identification or addressing purposes.</p>
+    <p class="" style="">As previously mentioned, a UTF-8 string representation of LDAP distinguished names is specified in <span style="font-weight: bold">RFC 2253</span>. This representation specifies that the characters , + " \ &lt; &gt; ; are to be escaped with the backslash character (e.g., the string "\," would be used to escape the , character) and that any other non-US-ASCII characters are to be escaped using a string of the form "\xx".</p>
+    <p class="" style="">The following example shows a distinguished name (and transformations thereof) for a person whose common name is "D'Artagnan Saint-André" and who is associated with an organization called "Example &amp; Company, Inc." whose domain name is "example.com":</p>
+    <p class="caption">Example 40. A Distinguished Name</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-André,O=Example &amp; Company, Inc.,DC=example,DC=com
+    </pre></div>
+    <p class="caption">Example 41. UTF-8 Representation of Distinguished Name</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-Andr\E9,O=Example &amp;amp; Company\, Inc.,DC=example,DC=com
+    </pre></div>
+    <p class="" style="">This example assumes that the specified user is identified with a gateway running at st.example.com (note that the backslash escaping the , character in the organization name is removed during the transformation).</p>
+    <p class="caption">Example 42. The Transformed JID</p>
+<div class="indent"><pre>
+CN=D\27Artagnan\20Saint-Andr\E9,O=Example\20\26\20Company,\20Inc.,DC=example,DC=com@st.example.com
+    </pre></div>
+    <p class="caption">Example 43. The JID as Presented to a User</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-André,O=Example &amp; Company, Inc.,DC=example,DC=com@st.example.com
+    </pre></div>
+    <p class="" style="">Naturally, a more intelligent gateway could use the Domain Components to construct a more readable JID, such as &lt;D\27Artagnan\20Saint-André@example.com&gt;; however, such gateway behavior is out of scope for this JEP.</p>
+    <p class="" style="">The foregoing example showed how to transform an LDAP distinguished name into a JID. However, it also may be necessary to convert a JID into an LDAP distinguished name, as shown in the following example.</p>
+    <p class="caption">Example 44. User Enters Address, Including Disallowed Characters</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-Andr&amp;#xe9;,O=Example &amp;amp; Company, Inc.,DC=example,DC=com@st.example.com
+    </pre></div>
+    <p class="caption">Example 45. Client Transforms Address Using JID Escaping</p>
+<div class="indent"><pre>
+CN=D\27Artagnan\20Saint-Andr\E9,O=Example\20\26\20Company,\20Inc.,DC=example,DC=com@st.example.com
+    </pre></div>
+    <p class="caption">Example 46. Application Converts Escaped JID to UTF-8 Representation of LDAP Distinguished Name</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-Andr\E9,O=Example &amp;amp; Company\, Inc.,DC=example,DC=com
+    </pre></div>
+    <p class="caption">Example 47. Application Converts UTF-8 Representation to LDAP Distinguished Name</p>
+<div class="indent"><pre>
+CN=D'Artagnan Saint-André,O=Example &amp; Company, Inc.,DC=example,DC=com
+    </pre></div>
+  </div>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">An entity that performs JID escaping MUST NOT compare unescaped/decoded versions, otherwise messages and other information could be directed to an entity other than the intended recipient.</p>
+  <p class="" style="">An entity that transforms a non-XMPP address into a JID MUST follow the algorithm specified in the <a href="#bizrules-algorithm">Address Transformation Algorithm</a> section of this document, otherwise messages and other information could be directed to an entity other than the intended recipient.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256929">17</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256977">18</a>] shall include the <span style="font-weight: bold">jid\20escaping</span> [sic] feature in its registry of service discovery features.</p>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251129">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251154">2</a>. RFC 3454: Preparation of Internationalized Strings (stringprep) &lt;<a href="http://www.ietf.org/rfc/rfc3454.txt"> http://www.ietf.org/rfc/rfc3454.txt </a>&gt;.</p>
+<p><a name="nt-id2251236">3</a>. RFC 2822: Internet Message Format &lt;<a href="http://www.ietf.org/rfc/rfc2822.txt">http://www.ietf.org/rfc/rfc2822.txt</a>&gt;.</p>
+<p><a name="nt-id2250394">4</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2250436">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2255165">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255244">7</a>. RFC 2253: Lightweight Directory Access Protocol (v3): UTF-8 String Representation of Distinguished Names &lt;<a href="http://www.ietf.org/rfc/rfc2253.txt">http://www.ietf.org/rfc/rfc2253.txt</a>&gt;.</p>
+<p><a name="nt-id2255986">8</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2256076">9</a>. This specification does not cover recent efforts to define internationalized email addresses.</p>
+<p><a name="nt-id2256171">10</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p><a name="nt-id2256316">11</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256386">12</a>. RFC 3860: Common Profile for Instant Messaging (CPIM) &lt;<a href="http://www.ietf.org/rfc/rfc3860.txt">http://www.ietf.org/rfc/rfc3860.txt</a>&gt;.</p>
+<p><a name="nt-id2256408">13</a>. RFC 3859: Common Profile for Presence (CPP) &lt;<a href="http://www.ietf.org/rfc/rfc3859.txt">http://www.ietf.org/rfc/rfc3859.txt</a>&gt;.</p>
+<p><a name="nt-id2256514">14</a>. The Open Mobile Alliance is the focal point for the development of mobile service enabler specifications, which support the creation of interoperable end-to-end mobile services. For further information, see &lt;<a href="http://www.openmobilealliance.org/">http://www.openmobilealliance.org/</a>&gt;.</p>
+<p><a name="nt-id2256538">15</a>. Wireless Village Client-Server Protocol v1.1 &lt;<a href="http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html">http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html</a>&gt;.</p>
+<p><a name="nt-id2256710">16</a>. RFC 2251: Lightweight Directory Access Protocol (v3) &lt;<a href="http://www.ietf.org/rfc/rfc2251.txt">http://www.ietf.org/rfc/rfc2251.txt</a>&gt;.</p>
+<p><a name="nt-id2256929">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256977">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2005-05-08)</h4>
+<div class="indent">Added examples of transforming JIDs to non-XMPP address formats. (psa)
+    </div>
+<h4>Version 0.6 (2005-05-06)</h4>
+<div class="indent">Changed format from #xx; to \xx per list discussion; added extensive implementation notes. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-21)</h4>
+<div class="indent">Changed to U+00xx format for code points; added references to various RFCs; corrected terminology; cleaned up text and flow. (psa)
+    </div>
+<h4>Version 0.4 (2005-04-04)</h4>
+<div class="indent">Corrected several small textual errors and ambiguities; slightly reorganized textual flow. (psa)
+    </div>
+<h4>Version 0.3 (2005-03-16)</h4>
+<div class="indent">Clarified relationship between JID escaping and traditional client proxy gateway behavior; fixed several small errors. (psa)
+    </div>
+<h4>Version 0.2 (2003-10-21)</h4>
+<div class="indent">Editorial cleanup; added security considerations. (psa)
+    </div>
+<h4>Version 0.1 (2003-07-21)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0107-0.6.html
+++ b/content/xep-0107-0.6.html
@@ -1,0 +1,438 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0107: User Mood</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Mood">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Ralph Meijer">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about user moods.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0107">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0107: User Mood</h1>
+<p>This JEP defines a protocol for communicating information about user moods.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0107<br>
+            Version: 0.6<br>
+            Last Updated: 2004-09-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: mood<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Ralph Meijer</h3>
+<p class="indent">
+        Email: ralphm@ik.nu<br>
+        JID: ralphm@ik.nu</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#protocol-pubsub">Pubsub</a>
+</dt>
+<dt>2.2.  <a href="#protocol-message">Message</a>
+</dt>
+</dl>
+<dt>3.  <a href="#moods">Mood Values</a>
+</dt>
+<dt>4.  <a href="#wv-mapping">Mapping to Wireless Village Moods</a>
+</dt>
+<dt>5.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines an extension mechanism for capturing &quot;extended presence&quot; data about user moods.</p>
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about user moods is provided by the user and propagated on the network by the user's client. The information is structured via a &lt;mood/&gt; element that is qualified by the 'http://jabber.org/protocol/mood' namespace. The mood itself is provided as the XML character data of the &lt;value/&gt; child of the &lt;mood/&gt; element, which is REQUIRED. The user MAY also specify a natural-language description of, or reason for, the mood in the &lt;text/&gt; child of the &lt;mood/&gt; element, which is OPTIONAL.</p>
+  <p class="" style="">The &lt;mood/&gt; element SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596230">1</a>] but MAY be provided in a message as well. Because mood information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+  <div class="indent">
+<h3>2.1 <a name="protocol-pubsub">Pubsub</a>
+</h3>
+    <p class="" style="">If the user wishes to publish his mood to all of those who are subscribed to his mood information, the user SHOULD use publish-subscribe.</p>
+    <p class="caption">Example 1. User Publishes Mood</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='juliet@capulet.com/balcony' 
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/juliet-mood'&gt;
+      &lt;item id='current'&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;value&gt;annoyed&lt;/value&gt;
+          &lt;text&gt;curse my nurse!&lt;/text&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The mood is then delivered to all subscribers:</p>
+    <p class="caption">Example 2. Mood is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message 
+    from='pubsub.shakespeare.lit' 
+    to='romeo@montague.net/orchard'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/juliet-mood'&gt;
+      &lt;item id='current'&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;value&gt;annoyed&lt;/value&gt;
+          &lt;text&gt;curse my nurse!&lt;/text&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2596325">2</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message 
+    from='pubsub.shakespeare.lit' 
+    to='romeo@montague.net/orchard'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/juliet-mood'&gt;
+      &lt;item id='current'&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;value&gt;annoyed&lt;/value&gt;
+          &lt;text&gt;curse my nurse!&lt;/text&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="protocol-message">Message</a>
+</h3>
+    <p class="" style="">A user MAY also provide a mood extension in a specific message, in order to lend a defined emotional tone to the message.</p>
+    <p class="caption">Example 4. User Provides Mood in Message</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard'
+         to='juliet@capulet.com/balcony'
+         type='chat'&gt;
+  &lt;body&gt;A thousand times good night!&lt;/body&gt;
+  &lt;mood xmlns='http://jabber.org/protocol/mood'/&gt;
+    &lt;value&gt;sad&lt;/value&gt;
+  &lt;/mood&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The &lt;mood/&gt; element could even contain a URL reference structured according to the <span class="ref">Out-of-Band Data</span>  [<a href="#nt-id2596313">3</a>] protocol:</p>
+    <p class="caption">Example 5. User Provides Mood and URL in Message</p>
+<div class="indent"><pre>
+&lt;message from='ralphm@ik.nu/work'
+         to='stpeter@jabber.org/home'
+         type='chat'&gt;
+  &lt;body&gt;Cool!&lt;/body&gt;
+  &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+    &lt;value&gt;happy&lt;/value&gt;
+    &lt;text&gt;Yay, the mood JEP has been published!&lt;/text&gt;
+    &lt;x xmlns='jabber:x:oob'&gt;
+      &lt;url&gt;http://www.jabber.org/jeps/jep-0107.html&lt;/url&gt;
+    &lt;/x&gt;
+  &lt;/mood&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="moods">Mood Values</a>
+</h2>
+  <p class="" style="">There exist various theories of human affect, mood, and emotion, including those promulgated by Frijda  [<a href="#nt-id2595843">4</a>], Ortony et al.  [<a href="#nt-id2595851">5</a>], and Wierzbicka  [<a href="#nt-id2595859">6</a>]. The taxonomy provided here mostly follows the Affective Knowledge Representation that has been defined by Lisetti  [<a href="#nt-id2595871">7</a>] in an effort to harmonize the prevailing theories in this area. Furthermore, the taxonomy provided here includes a number of physical states in addition to moods, and also takes into account the specific context of instant messaging, including work done by other standards development organizations (e.g., the Wireless Village specifications contributed to the <span class="ref">Open Mobile Alliance (OMA)</span>  [<a href="#nt-id2595761">8</a>]) and instant messaging service providers (e.g., ICQ).</p>
+  <p class="" style="">The mood values defined in this taxonomy are as follows:</p>
+  <ul>
+    <li>afraid</li>
+    <li>amazed</li>
+    <li>angry</li>
+    <li>annoyed</li>
+    <li>anxious</li>
+    <li>ashamed</li>
+    <li>bored</li>
+    <li>brave</li>
+    <li>calm</li>
+    <li>cold</li>
+    <li>confused</li>
+    <li>contented</li>
+    <li>cranky</li>
+    <li>curious</li>
+    <li>depressed</li>
+    <li>disappointed</li>
+    <li>disgusted</li>
+    <li>distracted</li>
+    <li>embarrassed</li>
+    <li>excited</li>
+    <li>flirtatious</li>
+    <li>frustrated</li>
+    <li>grumpy</li>
+    <li>guilty</li>
+    <li>happy</li>
+    <li>hot</li>
+    <li>humbled</li>
+    <li>humiliated</li>
+    <li>hungry</li>
+    <li>hurt</li>
+    <li>impressed</li>
+    <li>in_awe</li>
+    <li>in_love</li>
+    <li>indignant</li>
+    <li>interested</li>
+    <li>invincible</li>
+    <li>jealous</li>
+    <li>lonely</li>
+    <li>mean</li>
+    <li>moody</li>
+    <li>nervous</li>
+    <li>neutral</li>
+    <li>offended</li>
+    <li>playful</li>
+    <li>proud</li>
+    <li>relieved</li>
+    <li>remorseful</li>
+    <li>restless</li>
+    <li>sad</li>
+    <li>sarcastic</li>
+    <li>serious</li>
+    <li>shocked</li>
+    <li>shy</li>
+    <li>sick</li>
+    <li>sleepy</li>
+    <li>stressed</li>
+    <li>surprised</li>
+    <li>thirsty</li>
+    <li>worried</li>
+  </ul>
+<h2>4.
+       <a name="wv-mapping">Mapping to Wireless Village Moods</a>
+</h2>
+  <p class="" style="">The Wireless Village (now &quot;IMPS&quot;) specifications for mobile instant messaging define a number of presence attributes, encapsulated in the &quot;StatusMood&quot; information element  [<a href="#nt-id2602344">9</a>]. The following values are defined for StatusMood in Wireless Village, all of which map one-to-one from Wireless Village to the same values (albeit lowercase) in Jabber:</p>
+  <ul>
+    <li>ANGRY</li>
+    <li>ANXIOUS</li>
+    <li>ASHAMED</li>
+    <li>BORED</li>
+    <li>EXCITED</li>
+    <li>HAPPY</li>
+    <li>IN_LOVE</li>
+    <li>INVINCIBLE</li>
+    <li>JEALOUS</li>
+    <li>SAD</li>
+    <li>SLEEPY</li>
+  </ul>
+  <p class="" style="">The full range of moods defined herein is richer than that defined in Wireless Village; no mapping is provided by this specification for mood values that are not present in Wireless Village, and any such mapping is the responsibility of a gateway between the two systems.</p>
+<h2>5.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">The XML character data values of the &lt;value/&gt; elements is not intended to be presented to a human user and thus there is no special reason to include an 'xml:lang' attribute unless the sender includes a &lt;text/&gt; element as well (as explained in <span class="ref">RFC 2277</span>  [<a href="#nt-id2602557">10</a>], &quot;internationalization is for humans&quot;). It is the responsibility of the receiving application to provide localized text strings associated with the XML character data values defined herein, or some other appropriate presentation (e.g., graphical images that represent the mood).</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Because user moods may be published to a large number of pubsub subscribers, users should take care in approving subscribers and in characterizing their current moods.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602527">11</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602683">12</a>] shall add the 'http://jabber.org/protocol/mood' namespace to its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/mood'
+    xmlns='http://jabber.org/protocol/mood'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='mood'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='text' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element ref='value'&gt;
+          &lt;xs:simpleType&gt;
+            &lt;xs:restriction base='xs:NCName'&gt;
+              &lt;xs:enumeration value='afraid'/&gt;
+              &lt;xs:enumeration value='amazed'/&gt;
+              &lt;xs:enumeration value='angry'/&gt;
+              &lt;xs:enumeration value='annoyed'/&gt;
+              &lt;xs:enumeration value='anxious'/&gt;
+              &lt;xs:enumeration value='ashamed'/&gt;
+              &lt;xs:enumeration value='bored'/&gt;
+              &lt;xs:enumeration value='brave'/&gt;
+              &lt;xs:enumeration value='calm'/&gt;
+              &lt;xs:enumeration value='cold'/&gt;
+              &lt;xs:enumeration value='confused'/&gt;
+              &lt;xs:enumeration value='contented'/&gt;
+              &lt;xs:enumeration value='cranky'/&gt;
+              &lt;xs:enumeration value='curious'/&gt;
+              &lt;xs:enumeration value='depressed'/&gt;
+              &lt;xs:enumeration value='disappointed'/&gt;
+              &lt;xs:enumeration value='disgusted'/&gt;
+              &lt;xs:enumeration value='distracted'/&gt;
+              &lt;xs:enumeration value='embarrassed'/&gt;
+              &lt;xs:enumeration value='excited'/&gt;
+              &lt;xs:enumeration value='flirtatious'/&gt;
+              &lt;xs:enumeration value='frustrated'/&gt;
+              &lt;xs:enumeration value='grumpy'/&gt;
+              &lt;xs:enumeration value='guilty'/&gt;
+              &lt;xs:enumeration value='happy'/&gt;
+              &lt;xs:enumeration value='hot'/&gt;
+              &lt;xs:enumeration value='humbled'/&gt;
+              &lt;xs:enumeration value='humiliated'/&gt;
+              &lt;xs:enumeration value='hungry'/&gt;
+              &lt;xs:enumeration value='hurt'/&gt;
+              &lt;xs:enumeration value='impressed'/&gt;
+              &lt;xs:enumeration value='in_awe'/&gt;
+              &lt;xs:enumeration value='in_love'/&gt;
+              &lt;xs:enumeration value='indignant'/&gt;
+              &lt;xs:enumeration value='interested'/&gt;
+              &lt;xs:enumeration value='invincible'/&gt;
+              &lt;xs:enumeration value='jealous'/&gt;
+              &lt;xs:enumeration value='lonely'/&gt;
+              &lt;xs:enumeration value='mean'/&gt;
+              &lt;xs:enumeration value='moody'/&gt;
+              &lt;xs:enumeration value='nervous'/&gt;
+              &lt;xs:enumeration value='neutral'/&gt;
+              &lt;xs:enumeration value='offended'/&gt;
+              &lt;xs:enumeration value='playful'/&gt;
+              &lt;xs:enumeration value='proud'/&gt;
+              &lt;xs:enumeration value='relieved'/&gt;
+              &lt;xs:enumeration value='remorseful'/&gt;
+              &lt;xs:enumeration value='restless'/&gt;
+              &lt;xs:enumeration value='sad'/&gt;
+              &lt;xs:enumeration value='sarcastic'/&gt;
+              &lt;xs:enumeration value='serious'/&gt;
+              &lt;xs:enumeration value='shocked'/&gt;
+              &lt;xs:enumeration value='shy'/&gt;
+              &lt;xs:enumeration value='sick'/&gt;
+              &lt;xs:enumeration value='sleepy'/&gt;
+              &lt;xs:enumeration value='stressed'/&gt;
+              &lt;xs:enumeration value='surprised'/&gt;
+              &lt;xs:enumeration value='thirsty'/&gt;
+              &lt;xs:enumeration value='worried'/&gt;
+            &lt;/xs:restriction&gt;
+          &lt;/xs:simpleType&gt;
+        &lt;/xs:element&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596230">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596325">2</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596313">3</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595843">4</a>. Frijda, N. 1986. <span style="font-weight: bold">The Emotions</span>. New York: Cambridge University Press.</p>
+<p>
+<a name="nt-id2595851">5</a>. Ortony, A., Clore, G., and Collins, A. 1988. <span style="font-weight: bold">The Cognitive Structure of Emotions</span>. Hillsdale, NJ:  Erlbaum.</p>
+<p>
+<a name="nt-id2595859">6</a>. Wierzbicka, A. 1992. Defining Emotion Concepts. <span style="font-weight: bold">Cognitive Science</span> 16: 539-581.</p>
+<p>
+<a name="nt-id2595871">7</a>. Lisetti, C. 2002. Personality, Affect, and Emotion Taxonomy for Socially Intelligent Agents. In <span style="font-weight: bold">Proceedings of FLAIRS 2002</span>. Menlo Park, CA: AAAI Press.</p>
+<p>
+<a name="nt-id2595761">8</a>. The Open Mobile Alliance is the focal point for the development of mobile service enabler specifications, which support the creation of interoperable end-to-end mobile services. For further information, see &lt;<a href="http://www.openmobilealliance.org/">http://www.openmobilealliance.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602344">9</a>. The Wireless Village Initiative: Presence Attributes v1.1 (WV-029); for further information, visit &lt;<a href="http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html">http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602557">10</a>. RFC 2277: IETF Policy on Character Sets and Languages &lt;<a href="http://www.ietf.org/rfc/rfc2277.txt">http://www.ietf.org/rfc/rfc2277.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602527">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602683">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2004-09-15)</h4>
+<div class="indent">Added internationalization considerations. (psa)
+    </div>
+<h4>Version 0.5 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.4 (2004-02-19)</h4>
+<div class="indent">Minor fixes to text and schema. (psa)
+    </div>
+<h4>Version 0.3 (2003-08-01)</h4>
+<div class="indent">Added more moods. (psa)
+    </div>
+<h4>Version 0.2 (2003-07-23)</h4>
+<div class="indent">Expanded the information format; changed primary container to use pubsub. (psa)
+    </div>
+<h4>Version 0.1 (2003-07-22)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0108-0.4.html
+++ b/content/xep-0108-0.4.html
@@ -1,0 +1,544 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0108: User Activity</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Activity">
+<meta name="DC.Creator" content="Ralph Meijer">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about user activities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0108">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0108: User Activity</h1>
+<p>This JEP defines a protocol for communicating information about user activities.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0108<br>
+            Version: 0.4<br>
+            Last Updated: 2004-09-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: activity<br>
+</p>
+<h2>Author Information</h2>
+<h3>Ralph Meijer</h3>
+<p class="indent">
+        Email: ralphm@ik.nu<br>
+        JID: ralphm@ik.nu</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>3.  <a href="#activities">Activity Values</a>
+</dt>
+<dt>4.  <a href="#rpid-mapping">Mapping to RPID</a>
+</dt>
+<dt>5.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines an extension mechanism for capturing &quot;extended presence&quot; data about user activities, above and beyond availability as defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2596134">1</a>] (e.g., the 'away', 'extended away', and 'dnd' values of the &lt;show/&gt; child of the &lt;presence/&gt; stanza).</p>
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about user activities is provided by the user and propagated on the network by the user's client. The information is structured by means of an &lt;activity/&gt; element that is qualified by the 'http://jabber.org/protocol/activity' namespace. The activity itself is provided as the XML character data of the REQUIRED &lt;general/&gt; and OPTIONAL &lt;specific&gt; children of the &lt;activity/&gt; element. The user MAY also specify a natural-language description of the activity in the OPTIONAL &lt;text/&gt; child of the &lt;activity/&gt; element.</p>
+  <p class="" style="">The &lt;activity/&gt; element SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596111">2</a>]. Because activity information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+  <p class="caption">Example 1. User Publishes Activity</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='juliet@capulet.com/balcony' 
+    to='pubsub.shakespeare.lit' 
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/juliet-activity'&gt;
+      &lt;item id='current'&gt;
+        &lt;activity xmlns='http://jabber.org/protocol/activity'&gt;
+          &lt;general&gt;relaxing&lt;/general&gt;
+          &lt;specific&gt;partying&lt;/specific&gt;
+          &lt;text&gt;My nurse's birthday!&lt;/text&gt;
+        &lt;/activity&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The activity is then delivered to all subscribers:</p>
+    <p class="caption">Example 2. Activity is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message 
+    from='pubsub.shakespeare.lit' 
+    to='romeo@montague.net/orchard'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/juliet-activity'&gt;
+      &lt;item id='current'&gt;
+        &lt;activity xmlns='http://jabber.org/protocol/activity'&gt;
+          &lt;general&gt;relaxing&lt;/general&gt;
+          &lt;specific&gt;partying&lt;/specific&gt;
+          &lt;text&gt;My nurse's birthday!&lt;/text&gt;
+        &lt;/activity&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2596291">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message 
+    from='pubsub.shakespeare.lit' 
+    to='romeo@montague.net/orchard'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/juliet-activity'&gt;
+      &lt;item id='current'&gt;
+        &lt;activity xmlns='http://jabber.org/protocol/activity'&gt;
+          &lt;general&gt;relaxing&lt;/general&gt;
+          &lt;specific&gt;partying&lt;/specific&gt;
+          &lt;text&gt;My nurse's birthday!&lt;/text&gt;
+        &lt;/activity&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+<h2>3.
+       <a name="activities">Activity Values</a>
+</h2>
+  <p class="" style="">Each activity has a REQUIRED &lt;general/&gt; category and an OPTIONAL &lt;specific/&gt; instance. One can understand each specifier as '[user] is [activity]' (e.g., 'Juliet is partying'), where the relevant value is the most specific activity provided (e.g., specifically &quot;partying&quot; rather than generally &quot;relaxing&quot;). The optional &lt;text/&gt; element MAY be used to provide further details about the activity.</p>
+  <p class="" style="">The activity values defined in this taxonomy are as follows, where the first indentation level is the general category and the second indentation level is the specific instance:</p>
+
+  <ul>
+
+    <li>doing_chores
+      <ul>
+        <li>buying_groceries</li>
+        <li>cleaning</li>
+        <li>cooking</li>
+        <li>doing_maintenance</li>
+        <li>doing_the_dishes</li>
+        <li>doing_the_laundry</li>
+        <li>gardening</li>
+        <li>running_an_errand</li>
+        <li>walking_the_dog</li>
+      </ul>
+    </li>
+
+    <li>drinking
+      <ul>
+        <li>having_a_beer</li>
+        <li>having_coffee</li>
+        <li>having_tea</li>
+      </ul>
+    </li>
+
+    <li>eating
+      <ul>
+        <li>having_a_snack</li>
+        <li>having_breakfast</li>
+        <li>having_dinner</li>
+        <li>having_lunch</li>
+      </ul>
+    </li>
+
+    <li>exercising
+      <ul>
+        <li>cycling</li>
+        <li>hiking</li>
+        <li>jogging</li>
+        <li>playing_sports</li>
+        <li>running</li>
+        <li>skiing</li>
+        <li>swimming</li>
+        <li>working_out</li>
+      </ul>
+    </li>
+
+    <li>grooming
+      <ul>
+        <li>at_the_spa</li>
+        <li>brushing_teeth</li>
+        <li>getting_a_haircut</li>
+        <li>shaving</li>
+        <li>taking_a_bath</li>
+        <li>taking_a_shower</li>
+      </ul>
+    </li>
+  
+    <li>having_appointment</li>
+
+    <li>inactive
+      <ul>
+        <li>day_off</li>
+        <li>hanging_out</li>
+        <li>on_vacation</li>
+        <li>scheduled_holiday</li>
+        <li>sleeping</li>
+      </ul>
+    </li>
+
+    <li>relaxing
+      <ul>
+        <li>gaming</li>
+        <li>going_out</li>
+        <li>partying</li>
+        <li>reading</li>
+        <li>rehearsing</li>
+        <li>shopping</li>
+        <li>socializing</li>
+        <li>sunbathing</li>
+        <li>watching_tv</li>
+        <li>watching_a_movie</li>
+      </ul>
+    </li>
+
+    <li>talking
+      <ul>
+        <li>on_the_phone</li>
+        <li>in_real_life</li>
+      </ul>
+    </li>
+
+    <li>traveling
+      <ul>
+        <li>commuting</li>
+        <li>cycling</li>
+        <li>driving</li>
+        <li>in_a_car</li>
+        <li>on_a_bus</li>
+        <li>on_a_plane</li>
+        <li>on_a_train</li>
+        <li>on_a_trip</li>
+        <li>walking</li>
+      </ul>
+    </li>
+
+    <li>working
+      <ul>
+        <li>coding</li>
+        <li>in_a_meeting</li>
+        <li>reading</li>
+        <li>studying</li>
+        <li>writing</li>
+      </ul>
+    </li>
+
+  </ul>
+
+  <p class="" style="">In addition, the &lt;specific/&gt; element can take a value of &quot;other&quot; in order to handle activities not defined herein.  [<a href="#nt-id2602110">4</a>]</p>
+
+<h2>4.
+       <a name="rpid-mapping">Mapping to RPID</a>
+</h2>
+  <p class="" style="">The <span class="ref">draft-ietf-simple-rpid</span>  [<a href="#nt-id2602242">5</a>] Internet-Draft published within the IETF's SIMPLE Working Group defines several extensions to the <span class="ref">Presence Information Data Format (PIDF) </span>  [<a href="#nt-id2602267">6</a>] for so-called &quot;rich presence&quot;. One such extension is the &lt;activity/&gt; element (see Section 4.2), which &quot;describes what the presentity is currently doing&quot;. The following table shows a mapping from the defined RPID activity values to the Jabber values defined herein.</p>
+  <p class="caption">Table 1: RPID-to-Jabber mappings</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">RPID &lt;activity/&gt;</th>
+      <th colspan="" rowspan="">Jabber &lt;general/&gt;</th>
+      <th colspan="" rowspan="">Jabber &lt;specific/&gt;</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">appointment</td>
+      <td align="center" colspan="" rowspan="">having_appointment</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">available</td>
+      <td align="center" colspan="2" rowspan=""> [<a href="#nt-id2602289">7</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">away</td>
+      <td align="center" colspan="2" rowspan=""> [<a href="#nt-id2602323">8</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">busy</td>
+      <td align="center" colspan="2" rowspan=""> [<a href="#nt-id2602358">9</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">holiday</td>
+      <td align="center" colspan="" rowspan="">inactive</td>
+      <td align="center" colspan="" rowspan="">scheduled_holiday</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">in-transit</td>
+      <td align="center" colspan="" rowspan="">traveling</td>
+      <td align="center" colspan="" rowspan=""> [<a href="#nt-id2602446">10</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">meal</td>
+      <td align="center" colspan="" rowspan="">eating</td>
+      <td align="center" colspan="" rowspan=""> [<a href="#nt-id2602487">11</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">meeting</td>
+      <td align="center" colspan="" rowspan="">working</td>
+      <td align="center" colspan="" rowspan="">in_a_meeting</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">on-the-phone</td>
+      <td align="center" colspan="" rowspan="">talking</td>
+      <td align="center" colspan="" rowspan="">on_the_phone</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">permanent-absence</td>
+      <td align="center" colspan="2" rowspan=""> [<a href="#nt-id2602590">12</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">sleeping</td>
+      <td align="center" colspan="" rowspan="">inactive</td>
+      <td align="center" colspan="" rowspan="">sleeping</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">steering</td>
+      <td align="center" colspan="" rowspan="">traveling</td>
+      <td align="center" colspan="" rowspan="">driving</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">travel</td>
+      <td align="center" colspan="" rowspan="">traveling</td>
+      <td align="center" colspan="" rowspan="">on_a_trip</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">vacation</td>
+      <td align="center" colspan="" rowspan="">inactive</td>
+      <td align="center" colspan="" rowspan="">on_vacation</td>
+    </tr>
+  </table>
+  <p class="" style="">The full range of activities defined herein is considerably richer than that defined in RPID; no mapping to RPID is provided by this specification for activity values that are not present in RPID, and any such mapping is the responsibility of a gateway between the two systems.</p>
+<h2>5.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">The XML character data values of the &lt;general/&gt; and &lt;specific/&gt; elements are not intended to be presented to a human user and thus there is no special reason to include an 'xml:lang' attribute unless the sender includes a &lt;text/&gt; element as well (as explained in <span class="ref">RFC 2277</span>  [<a href="#nt-id2602923">14</a>], &quot;internationalization is for humans&quot;). It is the responsibility of the receiving application to provide localized text strings associated with the XML character data values defined herein, or some other appropriate presentation (e.g., graphical images that represent the appropriate activities).</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Because user activities may be published to a large number of pubsub subscribers, users should take care in approving subscribers and in characterizing their current activities.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602893">15</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603050">16</a>] shall add the 'http://jabber.org/protocol/activity' namespace to its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/activity'
+    xmlns='http://jabber.org/protocol/activity'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='activity'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='general' minOccurs='1'/&gt;
+        &lt;xs:element ref='specific' minOccurs='0'/&gt;
+        &lt;xs:element name='text' minOccurs='0' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='general'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:NCName'&gt;
+        &lt;xs:enumeration value='doing_chores'/&gt;
+        &lt;xs:enumeration value='drinking'/&gt;
+        &lt;xs:enumeration value='eating'/&gt;
+        &lt;xs:enumeration value='exercising'/&gt;
+        &lt;xs:enumeration value='grooming'/&gt;
+        &lt;xs:enumeration value='having_appointment'/&gt;
+        &lt;xs:enumeration value='inactive'/&gt;
+        &lt;xs:enumeration value='relaxing'/&gt;
+        &lt;xs:enumeration value='talking'/&gt;
+        &lt;xs:enumeration value='traveling'/&gt;
+        &lt;xs:enumeration value='working'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='specific'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:NCName'&gt;
+        &lt;xs:enumeration value='at_the_spa'/&gt;
+        &lt;xs:enumeration value='brushing_teeth'/&gt;
+        &lt;xs:enumeration value='buying_groceries'/&gt;
+        &lt;xs:enumeration value='cleaning'/&gt;
+        &lt;xs:enumeration value='coding'/&gt;
+        &lt;xs:enumeration value='commuting'/&gt;
+        &lt;xs:enumeration value='cooking'/&gt;
+        &lt;xs:enumeration value='cycling'/&gt;
+        &lt;xs:enumeration value='day_off'/&gt;
+        &lt;xs:enumeration value='doing_maintenance'/&gt;
+        &lt;xs:enumeration value='doing_the_dishes'/&gt;
+        &lt;xs:enumeration value='doing_the_laundry'/&gt;
+        &lt;xs:enumeration value='driving'/&gt;
+        &lt;xs:enumeration value='flying'/&gt;
+        &lt;xs:enumeration value='gaming'/&gt;
+        &lt;xs:enumeration value='gardening'/&gt;
+        &lt;xs:enumeration value='getting_a_haircut'/&gt;
+        &lt;xs:enumeration value='going_out'/&gt;
+        &lt;xs:enumeration value='hanging_out'/&gt;
+        &lt;xs:enumeration value='having_a_beer'/&gt;
+        &lt;xs:enumeration value='having_a_snack'/&gt;
+        &lt;xs:enumeration value='having_breakfast'/&gt;
+        &lt;xs:enumeration value='having_coffee'/&gt;
+        &lt;xs:enumeration value='having_dinner'/&gt;
+        &lt;xs:enumeration value='having_lunch'/&gt;
+        &lt;xs:enumeration value='having_tea'/&gt;
+        &lt;xs:enumeration value='hiking'/&gt;
+        &lt;xs:enumeration value='in_a_car'/&gt;
+        &lt;xs:enumeration value='in_a_meeting'/&gt;
+        &lt;xs:enumeration value='in_real_life'/&gt;
+        &lt;xs:enumeration value='jogging'/&gt;
+        &lt;xs:enumeration value='on_a_bus'/&gt;
+        &lt;xs:enumeration value='on_a_plane'/&gt;
+        &lt;xs:enumeration value='on_a_train'/&gt;
+        &lt;xs:enumeration value='on_a_trip'/&gt;
+        &lt;xs:enumeration value='on_the_phone'/&gt;
+        &lt;xs:enumeration value='on_vacation'/&gt;
+        &lt;xs:enumeration value='other'/&gt;
+        &lt;xs:enumeration value='partying'/&gt;
+        &lt;xs:enumeration value='playing_sports'/&gt;
+        &lt;xs:enumeration value='reading'/&gt;
+        &lt;xs:enumeration value='reading'/&gt;
+        &lt;xs:enumeration value='rehearsing'/&gt;
+        &lt;xs:enumeration value='running'/&gt;
+        &lt;xs:enumeration value='running_an_errand'/&gt;
+        &lt;xs:enumeration value='scheduled_holiday'/&gt;
+        &lt;xs:enumeration value='shaving'/&gt;
+        &lt;xs:enumeration value='shopping'/&gt;
+        &lt;xs:enumeration value='skiing'/&gt;
+        &lt;xs:enumeration value='sleeping'/&gt;
+        &lt;xs:enumeration value='socializing'/&gt;
+        &lt;xs:enumeration value='studying'/&gt;
+        &lt;xs:enumeration value='sunbathing'/&gt;
+        &lt;xs:enumeration value='swimming'/&gt;
+        &lt;xs:enumeration value='taking_a_bath'/&gt;
+        &lt;xs:enumeration value='taking_a_shower'/&gt;
+        &lt;xs:enumeration value='walking'/&gt;
+        &lt;xs:enumeration value='walking_the_dog'/&gt;
+        &lt;xs:enumeration value='watching_tv'/&gt;
+        &lt;xs:enumeration value='watching_a_movie'/&gt;
+        &lt;xs:enumeration value='working_out'/&gt;
+        &lt;xs:enumeration value='writing'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596134">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596111">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596291">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602110">4</a>. In the absence of a &lt;text/&gt; element, the recipient is free to draw whatever conclusions he or she may like regarding the nature of the &quot;other&quot; activity. Naturally, emoticons can be provided as the XML character data of the &lt;text/&gt; element. ;-)</p>
+<p>
+<a name="nt-id2602242">5</a>. draft-ietf-simple-rpid &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-simple-rpid-04.txt">http://www.ietf.org/internet-drafts/draft-ietf-simple-rpid-04.txt</a>&gt;. Work in progress.</p>
+<p>
+<a name="nt-id2602267">6</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602289">7</a>. In XMPP, &quot;available&quot; is not an activity, but an availability state captured by means of a &lt;presence/&gt; stanza with no &lt;show/&gt; child (see <span style="font-weight: bold">XMPP IM</span>).</p>
+<p>
+<a name="nt-id2602323">8</a>. In XMPP, &quot;away&quot; is not an activity, but an availability state captured by means of a &lt;presence/&gt; stanza with a &lt;show&gt;away&lt;/show&gt; child (see <span style="font-weight: bold">XMPP IM</span>).</p>
+<p>
+<a name="nt-id2602358">9</a>. In XMPP, &quot;busy&quot; is not an activity, but an availability state captured by means of a &lt;presence/&gt; stanza with &lt;show&gt;dnd&lt;/show&gt; child (see <span style="font-weight: bold">XMPP IM</span>). Alternatively, the RPID &quot;busy&quot; activity could map to any number of more specific Jabber activities as defined herein.</p>
+<p>
+<a name="nt-id2602446">10</a>. Appropriate specific values in the &quot;traveling&quot; category would be &quot;in_a_car&quot;, &quot;on_a_bus&quot;, and &quot;on_a_train&quot;.</p>
+<p>
+<a name="nt-id2602487">11</a>. The &quot;eating&quot; category can be further specified by &quot;having_a_snack&quot;, &quot;having_breakfast&quot;, &quot;having_lunch&quot;, or &quot;having_dinner&quot;.</p>
+<p>
+<a name="nt-id2602590">12</a>. In XMPP, &quot;permanent absence&quot; is not an activity, but instead would be sent to a contact via the &lt;gone/&gt; stanza error (see <span class="ref">XMPP Core</span>  [<a href="#nt-id2602707">13</a>]).</p>
+<p>
+<a name="nt-id2602707">13</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602923">14</a>. RFC 2277: IETF Policy on Character Sets and Languages &lt;<a href="http://www.ietf.org/rfc/rfc2277.txt">http://www.ietf.org/rfc/rfc2277.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602893">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603050">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2004-09-15)</h4>
+<div class="indent">Added internationalization considerations. (psa)
+    </div>
+<h4>Version 0.3 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.2 (2004-02-19)</h4>
+<div class="indent">Minor text and schema changes; added RPID mapping. (psa)
+    </div>
+<h4>Version 0.1 (2003-07-22)</h4>
+<div class="indent">Initial version. (rm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0111-0.5.html
+++ b/content/xep-0111-0.5.html
@@ -1,0 +1,342 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0111: TINS</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="TINS">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="A Transport for Initiating and Negotiating Sessions (TINS) using SDP over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-04-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0111">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0111: TINS</h1>
+<p>A Transport for Initiating and Negotiating Sessions (TINS) using SDP over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0111<br>
+            Version: 0.5<br>
+            Last Updated: 2004-04-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2327, RFC 3261<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: tins<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#discovery">Discovering Support</a>
+</dt>
+<dt>5.  <a href="#examples">Examples</a>
+</dt>
+<dl><dt>5.1.  <a href="#examples-call">Negotiating A Voice Call</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>9.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schema-tins">tins</a>
+</dt>
+<dt>9.2.  <a href="#schema-sdp">sdp</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Session Description Protocol (SDP) provides a mechanism for describing multimedia sessions that are advertised and negotiated over the Internet. This document describes how to use SDP to build a framework for media stream/session initiation and negotiation between Jabber entities. In particular, SDP (as specified in <span class="ref">RFC 2327</span>  [<a href="#nt-id2596157">1</a>]) over XMPP (as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2596170">2</a>]) is used to provide a semantics for signalling call setup that is similar to the semantics provided by the Session Initiation Protocol as defined in <span class="ref">RFC 3261</span>  [<a href="#nt-id2596211">3</a>]. The resulting mechanism is called the &quot;Transport for Initiating and Negotiating Sessions&quot; or TINS.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable a Jabber entity to negotiate an out-of-band multimedia session with another Jabber entity.</li>
+    <li>Enable a Jabber entity to negotiate an out-of-band multimedia session with a non-Jabber entity through a gateway.</li>
+    <li>Maximize interoperability with existing gateways and devices by using standard Internet protocols.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">The approach taken herein is to send pure <span style="font-weight: bold">Session Description Protocol (SDP)</span>. While earlier versions of this document used <span class="ref">Session Description and Capability Negotiation (SDPng)</span>  [<a href="#nt-id2596151">4</a>] (an XML representation of SDP), SDPng is a more experimental technology; by contrast, SDP is a stable RFC and there is broad support for it by existing gateways and devices. The use of SDP rather than SDPng thus enables the Jabber community to implement solutions that are deployable on the Internet today.</p>
+  <p class="" style="">The container element used in this protocol is the &lt;tins/&gt; element qualified by the 'http://jabber.org/protocol/tins' namespace. The &lt;tins/&gt; element SHOULD be included as the child of a &lt;message/&gt; stanza only (&lt;iq/&gt; stanzas SHOULD NOT be used because <span class="ref">RFC 3261</span>  [<a href="#nt-id2596224">5</a>] allows entities to send multiple results in response to a SIP request, which does not map to the syntax of the &lt;iq/&gt; stanza as defined in <span style="font-weight: bold">XMPP Core</span>). In order to track the structure of the TINS &quot;conversation&quot;, the &lt;thread/&gt; child of &lt;message/&gt; MAY be used.</p>
+  <p class="" style="">The &lt;tins/&gt; element MUST possess a 'method' attribute, whose value SHOULD be either an IANA-registered value for SIP method (or 'result', as described below). The following SIP methods will probably be used most frequently in TINS interactions:</p>
+  <ul>
+    <li><p class="" style="">INVITE -- Used to invite the target user to an out-of-band session.  The content inside the &lt;tins/&gt; element MAY be SDP descriptions of the connection types offered.  If a session is already established for this transaction, the new INVITE serves as a renegotiation of session parameters.</p></li>
+    <li><p class="" style="">ACK -- Used by the initiator to tell the invitee that an out-of-band session has been established.</p></li>
+    <li><p class="" style="">BYE -- Either side of the conversation decides to terminate the transaction.  This message SHOULD cause all resources associated with this transaction to be freed, and any associated network connections to be terminated.</p></li>
+  </ul>
+  <p class="" style="">The SDP data itself is included as the XML character data of an &lt;sdp/&gt; child of the &lt;tins/&gt; element, qualifed by the 'urn:ietf:rfc:2327' namespace (this is consistent with <span class="ref">RFC 2648</span>  [<a href="#nt-id2601924">6</a>]). Any restricted XML characters in the SDP data (i.e., &amp; ' &lt; &gt; &quot;) MUST be properly escaped when contained in the XML character data of the &lt;sdp/&gt; element (for example, the ' character MUST be escaped to &amp;apos;). It is the responsibility of the Jabber recipient or translating gateway to unescape these restricted characters. Note: the &lt;sdp/&gt; element is qualified by a separate namespace because it may be desirable for TINS to support other formats (such as SDPng) in the future; these can then be added without changing the XML schema for TINS.</p>
+  <p class="" style="">The request stanza MAY include header information or Internet metadata such as that defined by RFC 3261; specification of the preferred method for including such information will be provided in a separate document. The request stanza MAY also include multicast addresses as specified in <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2601883">7</a>].</p>
+  <p class="" style="">In reply to a request, the receiver MUST send zero or more replies, with the value of the 'method' attribute set to a value of &quot;result&quot; and the value of the 'code' attribute set to one of the valid SIP response codes as specified in Section 21 of RFC 3261.</p>
+<h2>4.
+       <a name="discovery">Discovering Support</a>
+</h2>
+  <p class="" style="">Before initiating a TINS negotiation, a Jabber entity SHOULD determine that the target entity supports the 'http://jabber.org/protocol/tins' namespace. Such discovery SHOULD occur by means of <span class="ref">Service Discovery</span>  [<a href="#nt-id2602039">8</a>], either directly by querying the target entity or indirectly by means of <span class="ref">Entity Capabilities</span>  [<a href="#nt-id2601964">9</a>]. If the target entity is a non-Jabber entity that is contacted through a gateway, the gateway itself SHOULD reply to service discovery queries on behalf of the non-Jabber entity and SHOULD insert a client capabilities extension into the presence stanzas it generates on behalf of the non-Jabber entity.</p>
+  <p class="" style="">If a Jabber entity receives, or a gateway handles, an IQ stanza containing a &lt;tins/&lt; element qualified by the 'http://jabber.org/protocol/tins' namespace but does not understand the TINS protocol, it MUST return a &quot;Service Unavailable&quot; error (see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602011">10</a>] for error syntax).</p>
+<h2>5.
+       <a name="examples">Examples</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="examples-call">Negotiating A Voice Call</a>
+</h3>
+    <p class="" style="">The following XMPP stanzas could be used to initiate a voice call. The 'from' addresses will usually be added by the XMPP server or relevant gateway, but are shown here for the sake of clarity.</p>
+    <p class="caption">Example 1. Step 1: A sends an invite to B</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins01'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='INVITE' xmlns='http://jabber.org/protocol/tins'&gt;
+    &lt;sdp xmlns='urn:ietf:rfc:2327'&gt;
+      v=0
+      o=A@example.com 98765432 IN IP4 192.168.1.1
+      s=TINS questions
+      i=Let&amp;apos;s talk about TINS
+      e=A@example.com
+      p=+1-303-555-1212
+      c=IN IP4 192.168.1.1/127
+      t=3288361865 0
+      a=recvonly
+      m=audio 7800 RTP/AVP 0
+    &lt;/sdp&gt;
+  &lt;/tins&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 2. Step 2: B tells A that it is trying</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins01'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result'
+        code='100'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 3. Step 3: B tells A that it is ringing</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins01'&gt;
+  &lt;tins method='result'
+        code='180'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 4. Step 4: B sends an updated description to A</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins02'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result' 
+        code='200'
+        xmlns='http://jabber.org/protocol/tins'&gt;
+    &lt;sdp xmlns='urn:ietf:rfc:2327'&gt;
+      v=0
+      o=A@example.com 98765432 IN IP4 192.168.1.2
+      s=TINS questions
+      i=Let&amp;apos;s talk about TINS
+      e=A@example.com
+      p=+1-303-555-1212
+      c=IN IP4 192.168.1.2/127
+      t=3288361865 0
+      a=recvonly
+      m=audio 7800 RTP/AVP 0
+      a=recvonly
+      m=audio 9410 RTP/AVP 0
+    &lt;/sdp&gt;
+  &lt;/tins&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 5. Step 5: A sends an acknowledgement to B</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins02'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='ACK' xmlns='http://jabber.org/protocol/tins'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 6. Step 6: B hangs up</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins03'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='BYE' xmlns='http://jabber.org/protocol/tins'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 7. Step 7: A acknowledges the hang up</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins03'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result'
+        code='200'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <p class="" style=""><span style="font-style: italic">More examples to follow.</span></p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">TINS is subject to the same security considerations as XMPP, particularly with regard to authentication and channel encryption; for details, refer to <span style="font-weight: bold">XMPP Core</span>.</p>
+  <p class="" style="">This document does not describe how the media protocols (e.g. RTP) traverse firewalls and NATs.</p>
+  <p class="" style="">There is no general-purpose way to ensure that media protocol connections are associated with the in-band TINS conversation.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602336">11</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">Upon advancement of this JEP to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602274">12</a>] shall add the 'http://jabber.org/protocol/tins' namespace to its registry of protocol namespaces.</p>
+<h2>9.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schema-tins">tins</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/tins'
+    xmlns='http://jabber.org/protocol/tins'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='tins'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='code' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='method' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schema-sdp">sdp</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='urn:ietf:rfc:2327'
+    xmlns='urn:ietf:rfc:2327'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='sdp' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596157">1</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596170">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596211">3</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596151">4</a>. Session Description and Capability Negotiation (SDPng) &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-sdpng-07.txt">http://www.ietf.org/internet-drafts/draft-ietf-mmusic-sdpng-07.txt</a>&gt;. Work in progress.</p>
+<p>
+<a name="nt-id2596224">5</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601924">6</a>. RFC 2648: A URN Namespace for IETF Documents &lt;<a href="http://www.ietf.org/rfc/rfc2648.txt">http://www.ietf.org/rfc/rfc2648.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601883">7</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602039">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601964">9</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602011">10</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602336">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602274">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2004-04-05)</h4>
+<div class="indent">Changed &lt;iq/&gt; to &lt;message/&gt; given probability of multiple SIP responses. (psa)
+    </div>
+<h4>Version 0.4 (2004-03-16)</h4>
+<div class="indent">Specified that the &lt;sdp/&gt; element is in a separate namespace and that the same mechanism could be used for other content schemes in the future. (psa)
+    </div>
+<h4>Version 0.3 (2004-03-15)</h4>
+<div class="indent">Replaced SDPng with SDP; added sections for Requirements, Protocol, and Discovering Support; added XML schema. (psa/jjh)
+    </div>
+<h4>Version 0.2 (2003-07-29)</h4>
+<div class="indent">Converted to JEP format. (psa)
+    </div>
+<h4>Version 0.1 (2003-02-21)</h4>
+<div class="indent">Internet-Draft version published as draft-hildebrand-xmpp-sdpng-00. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0111-0.6.html
+++ b/content/xep-0111-0.6.html
@@ -1,0 +1,405 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0111: TINS</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="TINS">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="A Transport for Initiating and Negotiating Sessions (TINS) using SDP over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0111">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0111: TINS</h1>
+<p>A Transport for Initiating and Negotiating Sessions (TINS) using SDP over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0111<br>
+            Version: 0.6<br>
+            Last Updated: 2004-10-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2327, RFC 3261<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: tins<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#discovery">Discovering Support</a>
+</dt>
+<dt>5.  <a href="#examples">Examples</a>
+</dt>
+<dl><dt>5.1.  <a href="#examples-call">Negotiating a Voice Call</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>9.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schema-tins">tins</a>
+</dt>
+<dt>9.2.  <a href="#schema-sdp">sdp</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Session Description Protocol (SDP) provides a mechanism for describing multimedia sessions that are advertised and negotiated over the Internet. This document describes how to use SDP to build a framework for media stream/session initiation and negotiation between Jabber entities. In particular, SDP (as specified in <span class="ref">RFC 2327</span>  [<a href="#nt-id2596267">1</a>]) over XMPP (as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2596298">2</a>]) is used to provide a semantics for signalling call setup that is similar to the semantics provided by the Session Initiation Protocol as defined in <span class="ref">RFC 3261</span>  [<a href="#nt-id2596321">3</a>]. The resulting mechanism is called the &quot;Transport for Initiating and Negotiating Sessions&quot; or TINS.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable a Jabber entity to negotiate an out-of-band multimedia session with another Jabber entity.</li>
+    <li>Enable a Jabber entity to negotiate an out-of-band multimedia session with a non-Jabber entity through a gateway.</li>
+    <li>Maximize interoperability with existing gateways and devices by using standard Internet protocols.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">The approach taken herein is to send pure <span style="font-weight: bold">Session Description Protocol (SDP)</span>. While earlier versions of this document used <span class="ref">Session Description and Capability Negotiation (SDPng)</span>  [<a href="#nt-id2601881">4</a>] (an XML representation of SDP), SDPng is a more experimental technology; by contrast, SDP is a stable RFC and there is broad support for it by existing gateways and devices. The use of SDP rather than SDPng thus enables the Jabber community to implement solutions that are deployable on the Internet today.</p>
+  <p class="" style="">The container element used in this protocol is the &lt;tins/&gt; element qualified by the 'http://jabber.org/protocol/tins' namespace. The &lt;tins/&gt; element SHOULD be included as the child of a &lt;message/&gt; stanza only (&lt;iq/&gt; stanzas SHOULD NOT be used because <span style="font-weight: bold">RFC 3261</span> allows entities to send multiple results in response to a SIP request, which does not map to the syntax of the &lt;iq/&gt; stanza as defined in <span style="font-weight: bold">XMPP Core</span>). In order to track the structure of the TINS &quot;conversation&quot;, the &lt;thread/&gt; child of &lt;message/&gt; MAY be used.</p>
+  <p class="" style="">The &lt;tins/&gt; element MUST possess a 'method' attribute, whose value SHOULD be either an IANA-registered value for a SIP method or 'result', as described below. The following SIP methods will probably be used most frequently in TINS interactions:</p>
+  <ul>
+    <li><p class="" style="">INVITE -- Used to invite the target user to an out-of-band session.  The content inside the &lt;tins/&gt; element MAY be SDP descriptions of the connection types offered.  If a session is already established for this transaction, the new INVITE serves as a renegotiation of session parameters.</p></li>
+    <li><p class="" style="">ACK -- Used by the initiator to tell the invitee that an out-of-band session has been established.</p></li>
+    <li><p class="" style="">BYE -- Either side of the conversation decides to terminate the transaction.  This message SHOULD cause all resources associated with this transaction to be freed, and any associated network connections to be terminated.</p></li>
+  </ul>
+  <p class="" style="">The SDP data itself is included as the XML character data of an &lt;sdp/&gt; child of the &lt;tins/&gt; element, qualifed by the 'urn:ietf:rfc:2327' namespace (this is consistent with <span class="ref">RFC 2648</span>  [<a href="#nt-id2602040">5</a>]). Any restricted XML characters in the SDP data (i.e., &amp; ' &lt; &gt; &quot;) MUST be properly escaped when contained in the XML character data of the &lt;sdp/&gt; element (for example, the ' character MUST be escaped to &amp;apos;). It is the responsibility of the Jabber recipient or translating gateway to unescape these restricted characters. (Note: The &lt;sdp/&gt; element is qualified by a separate namespace because it may be desirable for TINS to support other formats (such as SDPng) in the future; these can then be added without changing the XML schema for TINS.)</p>
+  <p class="" style="">The request stanza MAY also include either or both of the following:</p>
+  <ul>
+    <li>Header information or Internet metadata (such as that defined by RFC 3261) in the format specified by <span class="ref">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2602004">6</a>].</li>
+    <li>Multicast addresses as specified by <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602130">7</a>].</li>
+  </ul>
+  <p class="" style="">In reply to a request, the receiver MUST send zero or more replies, with the value of the 'method' attribute set to a value of &quot;result&quot; and the value of the 'code' attribute set to one of the valid SIP response codes as specified in Section 21 of RFC 3261.</p>
+<h2>4.
+       <a name="discovery">Discovering Support</a>
+</h2>
+  <p class="" style="">Before initiating a TINS negotiation, a Jabber entity SHOULD determine that the target entity supports the 'http://jabber.org/protocol/tins' namespace. Such discovery SHOULD occur by means of <span class="ref">Service Discovery</span>  [<a href="#nt-id2602098">8</a>], either directly by querying the target entity or indirectly by means of <span class="ref">Entity Capabilities</span>  [<a href="#nt-id2602120">9</a>]. If the target entity is a non-Jabber entity that is contacted through a gateway, the gateway itself SHOULD reply to service discovery queries on behalf of the non-Jabber entity and SHOULD insert a client capabilities extension into the presence stanzas it generates on behalf of the non-Jabber entity.</p>
+  <p class="" style="">If a Jabber entity receives, or a gateway handles, an IQ stanza containing a &lt;tins/&gt; element qualified by the 'http://jabber.org/protocol/tins' namespace but does not understand the TINS protocol, it MUST return a &quot;Service Unavailable&quot; error (see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602178">10</a>] for error syntax).</p>
+<h2>5.
+       <a name="examples">Examples</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="examples-call">Negotiating a Voice Call</a>
+</h3>
+    <p class="" style="">The following XMPP stanzas could be used to initiate a voice call. The 'from' addresses will usually be added by the XMPP server or relevant gateway, but are shown here for the sake of clarity. Note the inclusion of SHIM headers and extended addresses.</p>
+    <p class="caption">Example 1. Step 1: A sends an invite to B</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins01'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='INVITE' xmlns='http://jabber.org/protocol/tins'&gt;
+    &lt;sdp xmlns='urn:ietf:rfc:2327'&gt;
+      v=0
+      o=A@example.com 98765432 IN IP4 192.168.1.1
+      s=TINS questions
+      i=Let&amp;apos;s talk about TINS
+      e=A@example.com
+      p=+1-303-555-1212
+      c=IN IP4 192.168.1.1/127
+      t=3288361865 0
+      a=recvonly
+      m=audio 7800 RTP/AVP 0
+    &lt;/sdp&gt;
+  &lt;/tins&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 2. Step 2: B tells A that it is trying</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins01'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result'
+        code='100'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 3. Step 3: B tells A that it is ringing</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins01'&gt;
+  &lt;tins method='result'
+        code='180'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 4. Step 4: B sends an updated description to A</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins02'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result' 
+        code='200'
+        xmlns='http://jabber.org/protocol/tins'&gt;
+    &lt;sdp xmlns='urn:ietf:rfc:2327'&gt;
+      v=0
+      o=A@example.com 98765432 IN IP4 192.168.1.2
+      s=TINS questions
+      i=Let&amp;apos;s talk about TINS
+      e=A@example.com
+      p=+1-303-555-1212
+      c=IN IP4 192.168.1.2/127
+      t=3288361865 0
+      a=recvonly
+      m=audio 7800 RTP/AVP 0
+      a=recvonly
+      m=audio 9410 RTP/AVP 0
+    &lt;/sdp&gt;
+  &lt;/tins&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 5. Step 5: A sends an acknowledgement to B</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins02'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='ACK' xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 6. Step 6: B hangs up</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins03'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='BYE' xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 7. Step 7: A acknowledges the hang up</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins03'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result'
+        code='200'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <p class="" style=""><span style="font-style: italic">More examples to follow.</span></p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">TINS is subject to the same security considerations as XMPP, particularly with regard to authentication and channel encryption; for details, refer to <span style="font-weight: bold">XMPP Core</span>.</p>
+  <p class="" style="">This document does not describe how the media protocols (e.g. RTP) traverse firewalls and NATs.</p>
+  <p class="" style="">There is no general-purpose way to ensure that media protocol connections are associated with the in-band TINS conversation.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602539">11</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602477">12</a>] shall include 'http://jabber.org/protocol/tins' in its registry of protocol namespaces.</p>
+<h2>9.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schema-tins">tins</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/tins'
+    xmlns='http://jabber.org/protocol/tins'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='tins'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='code' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='method' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schema-sdp">sdp</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='urn:ietf:rfc:2327'
+    xmlns='urn:ietf:rfc:2327'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='sdp' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596267">1</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596298">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596321">3</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601881">4</a>. Session Description and Capability Negotiation (SDPng) &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-sdpng-07.txt">http://www.ietf.org/internet-drafts/draft-ietf-mmusic-sdpng-07.txt</a>&gt;. Work in progress.</p>
+<p>
+<a name="nt-id2602040">5</a>. RFC 2648: A URN Namespace for IETF Documents &lt;<a href="http://www.ietf.org/rfc/rfc2648.txt">http://www.ietf.org/rfc/rfc2648.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602004">6</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602130">7</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602098">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602120">9</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602178">10</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602539">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602477">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2004-10-26)</h4>
+<div class="indent">Added extended addresses and SHIM headers to examples in order to illustrate the use of JEP-0033 and JEP-0121. (psa/jjh)
+    </div>
+<h4>Version 0.5 (2004-04-05)</h4>
+<div class="indent">Changed &lt;iq/&gt; to &lt;message/&gt; given probability of multiple SIP responses. (psa/jjh)
+    </div>
+<h4>Version 0.4 (2004-03-16)</h4>
+<div class="indent">Specified that the &lt;sdp/&gt; element is in a separate namespace and that the same mechanism could be used for other content schemes in the future. (psa/jjh)
+    </div>
+<h4>Version 0.3 (2004-03-15)</h4>
+<div class="indent">Replaced SDPng with SDP; added sections for Requirements, Protocol, and Discovering Support; added XML schema. (psa/jjh)
+    </div>
+<h4>Version 0.2 (2003-07-29)</h4>
+<div class="indent">Converted to JEP format. (psa)
+    </div>
+<h4>Version 0.1 (2003-02-21)</h4>
+<div class="indent">Internet-Draft version published as draft-hildebrand-xmpp-sdpng-00. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0111-0.7.html
+++ b/content/xep-0111-0.7.html
@@ -1,0 +1,421 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS)</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="A Transport for Initiating and Negotiating Sessions (TINS)">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a SIP-compatible transport for initiating and negotiating sessions using SDP over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0111">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS)</h1>
+<p>This JEP defines a SIP-compatible transport for initiating and negotiating sessions using SDP over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0111<br>
+            Version: 0.7<br>
+            Last Updated: 2005-05-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2327, RFC 3261<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: tins<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/A%20Transport%20for%20Initiating%20and%20Negotiating%20Sessions%20(TINS)%20(JEP-0111)">http://wiki.jabber.org/index.php/A Transport for Initiating and Negotiating Sessions (TINS) (JEP-0111)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#discovery">Discovering Support</a>
+</dt>
+<dt>5.  <a href="#examples">Examples</a>
+</dt>
+<dl><dt>5.1.  <a href="#examples-call">Negotiating a Voice Call</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schema-tins">tins</a>
+</dt>
+<dt>9.2.  <a href="#schema-sdp">sdp</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2250537">1</a>]) provides a mechanism for describing multimedia sessions that are advertised and negotiated over the Internet. The "Transport for Initiating and Negotiating Sessions" (TINS) specified herein describes how to use SDP to build a framework for media stream/session initiation and negotiation between entities that natively support XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250562">2</a>]).
+     [<a href="#nt-id2251707">3</a>] 
+  In particular, TINS provides an XMPP representation of standard session management semantics such as those provided by the Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250615">5</a>]). As a result, native XMPP clients that support TINS can negotiate out-of-band multimedia sessions (e.g., use of the Real-Time Transport Protocol or RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2250776">6</a>]) and XMPP services that support TINS can easily interoperate with SIP services through gateways.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable an XMPP entity to negotiate an out-of-band multimedia session with another XMPP entity.</li>
+    <li>Enable an XMPP entity to negotiate an out-of-band multimedia session with a non-XMPP entity through a gateway.</li>
+    <li>Maximize interoperability with existing gateways and devices by using standard Internet protocols.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">TINS exchanges are completed by sending &lt;message/&gt; stanzas containing a child &lt;tins/&gt; element qualified by the 'http://jabber.org/protocol/tins' namespace. 
+     [<a href="#nt-id2250650">7</a>]
+   In order to track the structure of the TINS "conversation", the &lt;thread/&gt; child of &lt;message/&gt; MAY also be included. The &lt;tins/&gt; element MUST possess a 'method' attribute, whose value SHOULD be either an IANA-registered value for a SIP method or "result", as described below. The following SIP methods will probably be used most frequently in TINS interactions:</p>
+  <ul>
+    <li><p class="" style="">INVITE -- Used to invite the target user to an out-of-band session.  The content inside the &lt;tins/&gt; element MAY be SDP descriptions of the connection types offered.  If a session is already established for this transaction, the new INVITE serves as a renegotiation of session parameters.</p></li>
+    <li><p class="" style="">ACK -- Used by the initiator to tell the invitee that an out-of-band session has been established.</p></li>
+    <li><p class="" style="">BYE -- Used by either side of the conversation to terminate the transaction.  This message SHOULD cause all resources associated with this transaction to be freed, and any associated network connections to be terminated.</p></li>
+  </ul>
+  <p class="" style="">The SDP data itself is included as the XML character data of an &lt;sdp/&gt; child of the &lt;tins/&gt; element, qualifed by the 'urn:ietf:rfc:2327' namespace (this is consistent with <span class="ref" style="">RFC 2648</span>  [<a href="#nt-id2256237">8</a>]). 
+     [<a href="#nt-id2256226">9</a>]
+  Any restricted XML characters in the SDP data (i.e., &amp; ' &lt; &gt; ") MUST be properly escaped when contained in the XML character data of the &lt;sdp/&gt; element (for example, the ' character MUST be escaped to &amp;apos;). It is the responsibility of the XMPP recipient or translating gateway to unescape these restricted characters for processing.</p>
+  <p class="" style="">The request stanza MAY also include either or both of the following:</p>
+  <ul>
+    <li>Header information or Internet metadata (such as that defined by <span style="font-weight: bold">RFC 3261</span>) in the format specified by <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2256286">10</a>].</li>
+    <li>Multicast addresses as specified by <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2256310">11</a>].</li>
+  </ul>
+  <p class="" style="">In reply to a request, the receiver MUST send zero or more replies, with the value of the 'method' attribute set to a value of "result" and the value of the 'code' attribute set to one of the valid SIP response codes as specified in Section 21 of <span style="font-weight: bold">RFC 3261</span>.</p>
+<h2>4.
+       <a name="discovery">Discovering Support</a>
+</h2>
+  <p class="" style="">Before initiating a TINS negotiation, an XMPP entity SHOULD determine that the target entity supports the 'http://jabber.org/protocol/tins' namespace. Such discovery SHOULD occur by means of <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256366">12</a>], either directly by querying the target entity or indirectly by means of <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256389">13</a>]. If the target entity is a non-XMPP entity that is contacted through a gateway, the gateway itself SHOULD reply to service discovery queries on behalf of the non-XMPP entity and SHOULD insert a client capabilities extension into the presence stanzas it generates on behalf of the non-XMPP entity.</p>
+  <p class="" style="">If an XMPP entity receives, or a gateway handles, a &lt;message/&gt; stanza containing a &lt;tins/&gt; element qualified by the 'http://jabber.org/protocol/tins' namespace but it does not understand the TINS protocol, it SHOULD either silently ignore it or return a &lt;service-unavailable/&gt; error (see <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256427">14</a>] for error syntax).</p>
+<h2>5.
+       <a name="examples">Examples</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="examples-call">Negotiating a Voice Call</a>
+</h3>
+    <p class="" style="">The following XMPP stanzas could be used to initiate a voice call. The 'from' addresses will usually be added by the XMPP server or relevant gateway, but are shown here for the sake of clarity. Note the inclusion of SHIM headers and extended addresses.</p>
+    <p class="caption">Example 1. Step 1: A sends an invite to B</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins01'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='INVITE' xmlns='http://jabber.org/protocol/tins'&gt;
+    &lt;sdp xmlns='urn:ietf:rfc:2327'&gt;
+      v=0
+      o=A@example.com 98765432 IN IP4 192.168.1.1
+      s=TINS questions
+      i=Let&amp;apos;s talk about TINS
+      e=A@example.com
+      p=+1-303-555-1212
+      c=IN IP4 192.168.1.1/127
+      t=3288361865 0
+      a=recvonly
+      m=audio 7800 RTP/AVP 0
+    &lt;/sdp&gt;
+  &lt;/tins&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 2. Step 2: B tells A that it is trying</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins01'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result'
+        code='100'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 3. Step 3: B tells A that it is ringing</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins01'&gt;
+  &lt;tins method='result'
+        code='180'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 4. Step 4: B sends an updated description to A</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins02'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result' 
+        code='200'
+        xmlns='http://jabber.org/protocol/tins'&gt;
+    &lt;sdp xmlns='urn:ietf:rfc:2327'&gt;
+      v=0
+      o=A@example.com 98765432 IN IP4 192.168.1.2
+      s=TINS questions
+      i=Let&amp;apos;s talk about TINS
+      e=A@example.com
+      p=+1-303-555-1212
+      c=IN IP4 192.168.1.2/127
+      t=3288361865 0
+      a=recvonly
+      m=audio 7800 RTP/AVP 0
+      a=recvonly
+      m=audio 9410 RTP/AVP 0
+    &lt;/sdp&gt;
+  &lt;/tins&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 5. Step 5: A sends an acknowledgement to B</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins02'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='ACK' xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 6. Step 6: B hangs up</p>
+<div class="indent"><pre>
+&lt;message
+    from='B@example.com/laptop' 
+    to='A@example.com/work' 
+    id='tins03'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='BYE' xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 7. Step 7: A acknowledges the hang up</p>
+<div class="indent"><pre>
+&lt;message
+    from='A@example.com/work' 
+    to='B@example.com/laptop' 
+    id='tins03'&gt;
+  &lt;thread&gt;1234@hostA.example.com&lt;/thread&gt;
+  &lt;tins method='result'
+        code='200'
+        xmlns='http://jabber.org/protocol/tins'/&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Via'&gt;SIP/2.0/UDP tins.example.com;branch=z9hG4bK776asdhds&lt;/header&gt;
+    &lt;header name='Call-ID'&gt;a84b4c76e66710@tins.example.com&lt;/header&gt;
+    &lt;header name='CSeq'&gt;314159 INVITE&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='bcc' jid='compliance.example.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <p class="" style=""><span style="font-style: italic">More examples to follow.</span></p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">TINS is subject to the same security considerations as XMPP, particularly with regard to authentication and channel encryption; for details, refer to <span style="font-weight: bold">RFC 3920</span>.</p>
+  <p class="" style="">This document does not describe how the media protocols (e.g. RTP) traverse firewalls and NATs.</p>
+  <p class="" style="">There is no general-purpose way to ensure that media protocol connections are associated with the in-band TINS conversation.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250379">15</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256850">16</a>] shall include 'http://jabber.org/protocol/tins' in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schema-tins">tins</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/tins'
+    xmlns='http://jabber.org/protocol/tins'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='urn:ietf:rfc:2327'/&gt;
+
+  &lt;xs:element name='tins'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:sdp='urn:ietf:rfc:2327'&gt;
+        &lt;xs:element ref='sdp:sdp'/&gt;
+        &lt;xs:any namespace='##other'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='code' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='method' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schema-sdp">sdp</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='urn:ietf:rfc:2327'
+    xmlns='urn:ietf:rfc:2327'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='sdp' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250537">1</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2250562">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251707">3</a>. The approach taken herein is to send pure SDP. While earlier versions of this document used <span class="ref" style="">Session Description and Capability Negotiation (SDPng)</span>  [<a href="#nt-id2250583">4</a>] (an XML representation of SDP), SDPng is a more experimental technology; by contrast, SDP is a stable protocol and there is broad support for it by existing gateways and devices. The use of SDP rather than SDPng thus enables the Jabber/XMPP community to implement solutions that are deployable on the Internet today.</p>
+<p><a name="nt-id2250583">4</a>. Session Description and Capability Negotiation (SDPng) &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-sdpng-09.txt">http://www.ietf.org/internet-drafts/draft-ietf-mmusic-sdpng-09.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250615">5</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2250776">6</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2250650">7</a>. While it may seem that the semantics of &lt;iq/&gt; stanzas are more appropriate, <span style="font-weight: bold">RFC 3261</span> allows entities to send multiple results in response to a SIP request, which does not map to the syntax of the &lt;iq/&gt; stanza as defined in <span style="font-weight: bold">RFC 3920</span>.</p>
+<p><a name="nt-id2256237">8</a>. RFC 2648: A URN Namespace for IETF Documents &lt;<a href="http://www.ietf.org/rfc/rfc2648.txt">http://www.ietf.org/rfc/rfc2648.txt</a>&gt;.</p>
+<p><a name="nt-id2256226">9</a>. The &lt;sdp/&gt; element is qualified by a separate namespace because it may be desirable for TINS to support other formats (such as SDPng) in the future; these can then be added without changing the XML schema for TINS.</p>
+<p><a name="nt-id2256286">10</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2256310">11</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2256366">12</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256389">13</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256427">14</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2250379">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256850">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2005-05-12)</h4>
+<div class="indent">Corrected several errors in the text and schemas. (psa)
+    </div>
+<h4>Version 0.6 (2004-10-26)</h4>
+<div class="indent">Added extended addresses and SHIM headers to examples in order to illustrate the use of JEP-0033 and JEP-0121. (psa/jjh)
+    </div>
+<h4>Version 0.5 (2004-04-05)</h4>
+<div class="indent">Changed &lt;iq/&gt; to &lt;message/&gt; given probability of multiple SIP responses. (psa/jjh)
+    </div>
+<h4>Version 0.4 (2004-03-16)</h4>
+<div class="indent">Specified that the &lt;sdp/&gt; element is in a separate namespace and that the same mechanism could be used for other content schemes in the future. (psa/jjh)
+    </div>
+<h4>Version 0.3 (2004-03-15)</h4>
+<div class="indent">Replaced SDPng with SDP; added sections for Requirements, Protocol, and Discovering Support; added XML schema. (psa/jjh)
+    </div>
+<h4>Version 0.2 (2003-07-29)</h4>
+<div class="indent">Converted to JEP format. (psa)
+    </div>
+<h4>Version 0.1 (2003-02-21)</h4>
+<div class="indent">Internet-Draft version published as draft-hildebrand-xmpp-sdpng-00. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0112-0.5.html
+++ b/content/xep-0112-0.5.html
@@ -1,0 +1,292 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0112: User Physical Location</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Physical Location">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="A protocol for communicating information about the current physical location of a user.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-05-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0112">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0112: User Physical Location</h1>
+<p>A protocol for communicating information about the current physical location of a user.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. Final voting results should be available within several weeks.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0112<br>
+            Version: 0.5<br>
+            Last Updated: 2004-05-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: physloc<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>3.  <a href="#usage">Usage</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>6.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines an extension mechanism for capturing &quot;extended presence&quot; information about a user's current physical location. The information structures defined herein are intended to provide a semi-structured format for describing a location that may change fairly frequently (e.g., one's location on a campus or in a large building) in situations where the user or application does not possess, or does not wish to communicate, detailed latitude/longitude data of the type defined in <span class="ref">User Geolocation</span>  [<a href="#nt-id2596136">1</a>].</p> 
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the user's location is provided by the user and propagated on the network by the user's client. The information is structured by means of an &lt;physloc/&gt; element that is qualified by the 'http://jabber.org/protocol/physloc' namespace. The location information itself is provided as the XML character data of the following children of the &lt;physloc/&gt; element:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Description</th>
+<th colspan="" rowspan="">Example</th>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;country/&gt;</td>
+<td align="" colspan="" rowspan="">The nation where the user is located</td>
+<td align="" colspan="" rowspan="">USA</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;region/&gt;</td>
+<td align="" colspan="" rowspan="">An administrative region of the nation, such as a state or province</td>
+<td align="" colspan="" rowspan="">New York</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;locality/&gt;</td>
+<td align="" colspan="" rowspan="">A locality within the administrative region, such as a town or city</td>
+<td align="" colspan="" rowspan="">New York City</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;area/&gt;</td>
+<td align="" colspan="" rowspan="">A named area such as a campus or neighborhood</td>
+<td align="" colspan="" rowspan="">Central Park</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;street/&gt;</td>
+<td align="" colspan="" rowspan="">A thoroughfare within the locality, or a crossing of two thoroughfares</td>
+<td align="" colspan="" rowspan="">34th and Broadway</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;building/&gt;</td>
+<td align="" colspan="" rowspan="">A specific building on a street or in an area</td>
+<td align="" colspan="" rowspan="">The Empire State Building</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;floor/&gt;</td>
+<td align="" colspan="" rowspan="">A particular floor in a building</td>
+<td align="" colspan="" rowspan="">102</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;room/&gt;</td>
+<td align="" colspan="" rowspan="">A particular room in a building</td>
+<td align="" colspan="" rowspan="">Observatory</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;text/&gt;</td>
+<td align="" colspan="" rowspan="">A catch-all element that captures any other information about the user's location</td>
+<td align="" colspan="" rowspan="">Northwest corner of the lobby</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;url/&gt;</td>
+<td align="" colspan="" rowspan="">A URL that describes the current location</td>
+<td align="" colspan="" rowspan="">A MaqQuest page</td>
+</tr>
+  </table>
+<h2>3.
+       <a name="usage">Usage</a>
+</h2>
+  <p class="" style="">The &lt;physloc/&gt; information SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2601978">2</a>]. Because physical location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+  <p class="caption">Example 1. User Publishes Address</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/laptop'
+    to='pubsub.jabber.org'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/stpeter-loc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The location information is then delivered to all subscribers:</p>
+  <p class="caption">Example 2. Activity is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='jer@jabber.org/silver'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/stpeter-physloc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+  </pre></div>
+  <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2601963">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+  <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='jer@jabber.org/silver'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/stpeter-physloc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. A user SHOULD take care in approving subscribers and in characterizing his or her current physical location.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602152">4</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602111">5</a>] shall add the 'http://jabber.org/protocol/physloc' namespace to its registry of protocol namespaces.</p>
+  </div>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/physloc'
+    xmlns='http://jabber.org/protocol/physloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='physloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:element name='country' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='region' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='locality' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='area' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='street' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='building' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='floor' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='room' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='text' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='url' minOccurs='0' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596136">1</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601978">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601963">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602152">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602111">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2004-05-11)</h4>
+<div class="indent">Changed root element, namespace, and shortname to physloc to prevent conflict with JEP-0033. (psa)
+    </div>
+<h4>Version 0.4 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Revived JEP upon modifications to JEP-0080; changed root element, namespace, and shortname to 'address'. (psa)
+    </div>
+<h4>Version 0.2 (2003-08-21)</h4>
+<div class="indent">Removed 'current' from title; changed shortname to 'location'; changed 'freetext' to 'text'; made several other small fixes. (psa)
+    </div>
+<h4>Version 0.1 (2003-08-20)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0112-0.6.html
+++ b/content/xep-0112-0.6.html
@@ -1,0 +1,404 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0112: User Physical Location</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Physical Location">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the current physical location of a Jabber entity.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0112">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0112: User Physical Location</h1>
+<p>This JEP defines a protocol for communicating information about the current physical location of a Jabber entity.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. Final voting results should be available within several weeks.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0112<br>
+            Version: 0.6<br>
+            Last Updated: 2004-10-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: physloc<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>3.  <a href="#usage">Usage</a>
+</dt>
+<dt>4.  <a href="#mapping">Mapping to Other Formats</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines an extension mechanism for capturing &quot;extended presence&quot; information about a user's current physical location. The information structures defined herein are intended to provide a format for describing a location or address that may change fairly frequently (e.g., one's location on a campus or in a large building) in situations where the user or application does not possess, or does not wish to communicate, detailed latitude/longitude data of the type defined in <span class="ref">User Geolocation</span>  [<a href="#nt-id2596158">1</a>].</p> 
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the user's location is provided by the user and propagated on the network by the user's client. The information is structured by means of an &lt;physloc/&gt; element that is qualified by the 'http://jabber.org/protocol/physloc' namespace. The location information itself is provided as the XML character data of the following children of the &lt;physloc/&gt; element:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Description</th>
+<th colspan="" rowspan="">Example</th>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;country/&gt;</td>
+<td align="" colspan="" rowspan="">The nation where the user is located</td>
+<td align="" colspan="" rowspan="">USA</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;region/&gt;</td>
+<td align="" colspan="" rowspan="">An administrative region of the nation, such as a state or province</td>
+<td align="" colspan="" rowspan="">New York</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;locality/&gt;</td>
+<td align="" colspan="" rowspan="">A locality within the administrative region, such as a town or city</td>
+<td align="" colspan="" rowspan="">New York City</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;area/&gt;</td>
+<td align="" colspan="" rowspan="">A named area such as a campus or neighborhood</td>
+<td align="" colspan="" rowspan="">Central Park</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;street/&gt;</td>
+<td align="" colspan="" rowspan="">A thoroughfare within the locality, or a crossing of two thoroughfares</td>
+<td align="" colspan="" rowspan="">34th and Broadway</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;building/&gt;</td>
+<td align="" colspan="" rowspan="">A specific building on a street or in an area</td>
+<td align="" colspan="" rowspan="">The Empire State Building</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;floor/&gt;</td>
+<td align="" colspan="" rowspan="">A particular floor in a building</td>
+<td align="" colspan="" rowspan="">102</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;room/&gt;</td>
+<td align="" colspan="" rowspan="">A particular room in a building</td>
+<td align="" colspan="" rowspan="">Observatory</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;text/&gt;</td>
+<td align="" colspan="" rowspan="">A catch-all element that captures any other information about the user's location</td>
+<td align="" colspan="" rowspan="">Northwest corner of the lobby</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;url/&gt;</td>
+<td align="" colspan="" rowspan="">A URL that describes the current location</td>
+<td align="" colspan="" rowspan="">A MaqQuest page</td>
+</tr>
+  </table>
+<h2>3.
+       <a name="usage">Usage</a>
+</h2>
+  <p class="" style="">The &lt;physloc/&gt; information SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602016">2</a>]. Because physical location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+  <p class="caption">Example 1. User Publishes Address</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/laptop'
+    to='pubsub.jabber.org'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/stpeter-loc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The location information is then delivered to all subscribers:</p>
+  <p class="caption">Example 2. Activity is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='jer@jabber.org/silver'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/stpeter-physloc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+  </pre></div>
+  <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602001">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+  <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='jer@jabber.org/silver'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/stpeter-physloc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>4.
+       <a name="mapping">Mapping to Other Formats</a>
+</h2>
+  <p class="" style="">There are many XML data formats for physical location or address information. It is beyond the scope of this JEP to provide a mapping from the extension defined herein to every such format. However, it would be valuable to provide a mapping from the Jabber/XMPP format to the formats used in other presence or extended presence protocols. The two main protocols of interest are:</p>
+  <ol start="" type="">
+    <li><p class="" style="">The Wireless Village (now &quot;IMPS&quot;) specifications for mobile instant messaging; these specifications define a presence attribute for address information as encapsulated in the IMPS &quot;Address&quot; element  [<a href="#nt-id2602086">4</a>].</p></li>
+    <li><p class="" style="">The SIP-based SIMPLE specifications; the IETF's GEOPRIV Working Group has defined an extension to the IETF's <span class="ref">Presence Information Data Format (PIDF) </span>  [<a href="#nt-id2602219">5</a>] for location information, as specified in <span class="ref">A Presence-based GEOPRIV Location Object Format</span>  [<a href="#nt-id2602242">6</a>] (also known as &quot;PIDF-LO&quot;).</p></li>
+  </ol>
+  <p class="caption">Table 2: Mapping Jabber Physical Location to IMPS and PIDF-LO</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jabber/XMPP</th>
+      <th colspan="" rowspan="">Wireless Village / IMPS</th>
+      <th colspan="" rowspan="">SIMPLE (PIDF-LO)</th>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;country/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Country/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;country/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;region/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;A1/&gt; and/or &lt;A2/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;locality/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;City/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;A3/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;area/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;NamedArea/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;A4/&gt; and/or &lt;A5/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;street/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Street/&gt;
+         [<a href="#nt-id2602397">7</a>]
+      </td>
+      <td align="center" colspan="" rowspan="">&lt;A6/&gt; 
+         [<a href="#nt-id2602428">8</a>] 
+      </td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;building/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Building/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;LMK/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;floor/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;FLR/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;room/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;text/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;FreeTextLocation/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;LOC/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;url/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;Accuracy/&gt;
+         [<a href="#nt-id2602688">9</a>]
+      </td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;NAM/&gt;
+         [<a href="#nt-id2602748">10</a>]
+      </td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;PC/&gt;
+         [<a href="#nt-id2602797">11</a>] 
+      </td>
+    </tr>
+  </table>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. A user SHOULD take care in approving subscribers and in characterizing his or her current physical location.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602960">12</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602909">13</a>] shall add the 'http://jabber.org/protocol/physloc' namespace to its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/physloc'
+    xmlns='http://jabber.org/protocol/physloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='physloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:element name='country' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='region' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='locality' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='area' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='street' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='building' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='floor' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='room' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='text' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='url' minOccurs='0' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596158">1</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602016">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602001">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602086">4</a>. The Wireless Village Initiative: Presence Attributes v1.1 (WV-029); for further information, visit &lt;<a href="http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html">http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602219">5</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602242">6</a>. A Presence-based GEOPRIV Location Object Format &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-geopriv-pidf-lo-03.txt">http://www.ietf.org/internet-drafts/draft-ietf-geopriv-pidf-lo-03.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602397">7</a>. The IMPS specification also enables one to define an intersection (e.g., &quot;Broadway and 34th Street&quot;) as the combination of a &lt;Crossing1/&lt; element (e.g., &quot;Broadway&quot;) and a &lt;Crossing2/&lt; element (e.g., &quot;34th Street&quot;). To map from IMPS to Jabber, an application SHOULD map such a combination to one Jabber/XMPP &lt;street/&gt; element.</p>
+<p>
+<a name="nt-id2602428">8</a>. The PIDF-LO format provides information elements for much more granular control over a traditional street address; in PIDF-LO the &lt;A6/&gt; element is the street name only, and further information is provided in distinct elements for a leading street direction (e.g., &quot;N&quot;), trailing street suffix (e.g., &quot;SW&quot;), street suffix (e.g., &quot;Avenue&quot;), house number (e.g., &quot;909&quot;), and house number suffix (e.g., &quot;1/2&quot;). To map from PIDF-LO to Jabber, an application SHOULD construct the complete street address from the PIDF-LO elements (&lt;A6/&gt;, &lt;PRD/&gt;, &lt;POD/&gt;, &lt;STS/&gt;, &lt;HNO/&gt;, and &lt;HNS/&gt;) and map the result to one Jabber/XMPP &lt;street/&gt; element.</p>
+<p>
+<a name="nt-id2602688">9</a>. This element provides accuracy in meters. The geolocation protocol defined in JEP-0080 specifies such an element for Jabber/XMPP, which SHOULD be used when mapping from IMPS to Jabber.</p>
+<p>
+<a name="nt-id2602748">10</a>. This element provides a name for the location, e.g., a certain store in a building. This SHOULD be mapped to the Jabber/XMPP &lt;text/&gt; element.</p>
+<p>
+<a name="nt-id2602797">11</a>. This element provides a postal code. Because the Jabber/XMPP format is intended for casual use by humans rather than for postal delivery, it does not include an element for postal code; the PIDF-LO &lt;PC/&gt; element MAY be mapped to the Jabber/XMPP &lt;text/&gt; element.</p>
+<p>
+<a name="nt-id2602960">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602909">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2004-10-05)</h4>
+<div class="indent">Defined mappings to Wireless Village and SIMPLE. (psa)
+    </div>
+<h4>Version 0.5 (2004-05-11)</h4>
+<div class="indent">Changed root element, namespace, and shortname to physloc to prevent conflict with JEP-0033. (psa)
+    </div>
+<h4>Version 0.4 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Revived JEP upon modifications to JEP-0080; changed root element, namespace, and shortname to 'address'. (psa)
+    </div>
+<h4>Version 0.2 (2003-08-21)</h4>
+<div class="indent">Removed 'current' from title; changed shortname to 'location'; changed 'freetext' to 'text'; made several other small fixes. (psa)
+    </div>
+<h4>Version 0.1 (2003-08-20)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0112-0.7.html
+++ b/content/xep-0112-0.7.html
@@ -1,0 +1,418 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0112: User Physical Location</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Physical Location">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the current physical location of a Jabber entity.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-10">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0112">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0112: User Physical Location</h1>
+<p>This JEP defines a protocol for communicating information about the current physical location of a Jabber entity.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0112<br>
+            Version: 0.7<br>
+            Last Updated: 2004-10-10<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: physloc<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>3.  <a href="#usage">Usage</a>
+</dt>
+<dt>4.  <a href="#mapping">Mapping to Other Formats</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines an extension mechanism for capturing &quot;extended presence&quot; information about a user's current physical location. The information structures defined herein are intended to provide a format for describing a location or address that may change fairly frequently (e.g., one's location on a campus or in a large building) in situations where the user or application does not possess, or does not wish to communicate, detailed latitude/longitude data of the type defined in <span class="ref">User Geolocation</span>  [<a href="#nt-id2596197">1</a>].</p> 
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the user's location is provided by the user and propagated on the network by the user's client. The information is structured by means of an &lt;physloc/&gt; element that is qualified by the 'http://jabber.org/protocol/physloc' namespace. The location information itself is provided as the XML character data of the following children of the &lt;physloc/&gt; element:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Description</th>
+<th colspan="" rowspan="">Example</th>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;country/&gt;</td>
+<td align="" colspan="" rowspan="">The nation where the user is located</td>
+<td align="" colspan="" rowspan="">USA</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;region/&gt;</td>
+<td align="" colspan="" rowspan="">An administrative region of the nation, such as a state or province</td>
+<td align="" colspan="" rowspan="">New York</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;locality/&gt;</td>
+<td align="" colspan="" rowspan="">A locality within the administrative region, such as a town or city</td>
+<td align="" colspan="" rowspan="">New York City</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;area/&gt;</td>
+<td align="" colspan="" rowspan="">A named area such as a campus or neighborhood</td>
+<td align="" colspan="" rowspan="">Central Park</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;street/&gt;</td>
+<td align="" colspan="" rowspan="">A thoroughfare within the locality, or a crossing of two thoroughfares</td>
+<td align="" colspan="" rowspan="">34th and Broadway</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;building/&gt;</td>
+<td align="" colspan="" rowspan="">A specific building on a street or in an area</td>
+<td align="" colspan="" rowspan="">The Empire State Building</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;floor/&gt;</td>
+<td align="" colspan="" rowspan="">A particular floor in a building</td>
+<td align="" colspan="" rowspan="">102</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;room/&gt;</td>
+<td align="" colspan="" rowspan="">A particular room in a building</td>
+<td align="" colspan="" rowspan="">Observatory</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;postalcode/&gt;</td>
+<td align="" colspan="" rowspan="">A code used for postal delivery</td>
+<td align="" colspan="" rowspan="">10027</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;text/&gt;</td>
+<td align="" colspan="" rowspan="">A catch-all element that captures any other information about the user's location</td>
+<td align="" colspan="" rowspan="">Northwest corner of the lobby</td>
+</tr>
+  </table>
+<h2>3.
+       <a name="usage">Usage</a>
+</h2>
+  <p class="" style="">The &lt;physloc/&gt; information SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602054">2</a>]. Because physical location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+  <p class="caption">Example 1. User Publishes Address</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/laptop'
+    to='pubsub.jabber.org'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/stpeter-loc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The location information is then delivered to all subscribers:</p>
+  <p class="caption">Example 2. Activity is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='jer@jabber.org/silver'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/stpeter-physloc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+  </pre></div>
+  <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602039">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+  <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='jer@jabber.org/silver'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/stpeter-physloc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>4.
+       <a name="mapping">Mapping to Other Formats</a>
+</h2>
+  <p class="" style="">There are many XML data formats for physical location or address information. It is beyond the scope of this JEP to provide a mapping from the extension defined herein to every such format. However, it would be valuable to provide a mapping from the Jabber/XMPP format to the formats used in other presence or extended presence protocols. The two main protocols of interest are:</p>
+  <ol start="" type="">
+    <li><p class="" style="">The Wireless Village (now &quot;IMPS&quot;) specifications for mobile instant messaging; these specifications define a presence attribute for address information as encapsulated in the IMPS &quot;Address&quot; element  [<a href="#nt-id2602124">4</a>].</p></li>
+    <li><p class="" style="">The SIP-based SIMPLE specifications; the IETF's GEOPRIV Working Group has defined an extension to the IETF's <span class="ref">Presence Information Data Format (PIDF) </span>  [<a href="#nt-id2602257">5</a>] for location information, as specified in <span class="ref">A Presence-based GEOPRIV Location Object Format</span>  [<a href="#nt-id2602280">6</a>] (also known as &quot;PIDF-LO&quot;).</p></li>
+  </ol>
+  <p class="" style="">The following table also maps the format defined herein to the vCard XML format specified in <span class="ref">vcard-temp</span>  [<a href="#nt-id2602185">7</a>].</p>
+  <p class="caption">Table 2: Mapping Jabber Physical Location to IMPS, PIDF-LO, and vCard</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jabber/XMPP</th>
+      <th colspan="" rowspan="">Wireless Village / IMPS</th>
+      <th colspan="" rowspan="">SIMPLE (PIDF-LO)</th>
+      <th colspan="" rowspan="">vCard XML</th>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;country/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Country/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;country/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;CTRY/&gt;
+         [<a href="#nt-id2602337">8</a>]
+      </td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;region/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;A1/&gt; and/or &lt;A2/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;REGION/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;locality/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;City/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;A3/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;LOCALITY/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;area/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;NamedArea/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;A4/&gt; and/or &lt;A5/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;street/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Street/&gt;
+         [<a href="#nt-id2602533">9</a>]
+      </td>
+      <td align="center" colspan="" rowspan="">&lt;A6/&gt; 
+         [<a href="#nt-id2602564">10</a>] 
+      </td>
+      <td align="center" colspan="" rowspan="">&lt;STREET/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;building/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Building/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;LMK/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;floor/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;FLR/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;room/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;postalcode/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;PC/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;PCODE/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;text/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;FreeTextLocation/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;LOC/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;EXTADR/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;Accuracy/&gt;
+         [<a href="#nt-id2602897">11</a>]
+      </td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;NAM/&gt;
+         [<a href="#nt-id2602969">12</a>]
+      </td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+  </table>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. A user SHOULD take care in approving subscribers and in characterizing his or her current physical location.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603140">13</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603089">14</a>] shall add the 'http://jabber.org/protocol/physloc' namespace to its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/physloc'
+    xmlns='http://jabber.org/protocol/physloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='physloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:element name='country' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='region' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='locality' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='area' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='street' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='building' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='floor' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='room' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='text' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='url' minOccurs='0' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596197">1</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602054">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602039">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602124">4</a>. The Wireless Village Initiative: Presence Attributes v1.1 (WV-029); for further information, visit &lt;<a href="http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html">http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602257">5</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602280">6</a>. A Presence-based GEOPRIV Location Object Format &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-geopriv-pidf-lo-03.txt">http://www.ietf.org/internet-drafts/draft-ietf-geopriv-pidf-lo-03.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602185">7</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602337">8</a>. As noted in JEP-0054, the XML vCard format defined in draft-dawson-vcard-xml-dtd-01 specified a &lt;COUNTRY/&gt; element rather than a &lt;CTRY/&gt; element; refer to JEP-0054 for details.</p>
+<p>
+<a name="nt-id2602533">9</a>. The IMPS specification also enables one to define an intersection (e.g., &quot;Broadway and 34th Street&quot;) as the combination of a &lt;Crossing1/&gt; element (e.g., &quot;Broadway&quot;) and a &lt;Crossing2/&gt; element (e.g., &quot;34th Street&quot;). To map from IMPS to Jabber, an application SHOULD map such a combination to one Jabber/XMPP &lt;street/&gt; element.</p>
+<p>
+<a name="nt-id2602564">10</a>. The PIDF-LO format provides information elements for much more granular control over a traditional street address; in PIDF-LO the &lt;A6/&gt; element is the street name only, and further information is provided in distinct elements for a leading street direction (e.g., &quot;N&quot;), trailing street suffix (e.g., &quot;SW&quot;), street suffix (e.g., &quot;Avenue&quot;), house number (e.g., &quot;909&quot;), and house number suffix (e.g., &quot;1/2&quot;). To map from PIDF-LO to Jabber, an application SHOULD construct the complete street address from the PIDF-LO elements (&lt;A6/&gt;, &lt;PRD/&gt;, &lt;POD/&gt;, &lt;STS/&gt;, &lt;HNO/&gt;, and &lt;HNS/&gt;) and map the result to one Jabber/XMPP &lt;street/&gt; element.</p>
+<p>
+<a name="nt-id2602897">11</a>. This element provides accuracy in meters. The geolocation protocol defined in JEP-0080 specifies such an element for Jabber/XMPP, which SHOULD be used when mapping from IMPS to Jabber.</p>
+<p>
+<a name="nt-id2602969">12</a>. This element provides a name for the location, e.g., a certain store in a building. This SHOULD be mapped to the Jabber/XMPP &lt;text/&gt; element.</p>
+<p>
+<a name="nt-id2603140">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603089">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2004-10-10)</h4>
+<div class="indent">Added &lt;postalcode/&gt; element; removed &lt;url/&gt; element (unnecessary given the existence of jabber:x:oob); defined mapping to vCard. (psa)
+    </div>
+<h4>Version 0.6 (2004-10-05)</h4>
+<div class="indent">Defined mappings to Wireless Village and SIMPLE. (psa)
+    </div>
+<h4>Version 0.5 (2004-05-11)</h4>
+<div class="indent">Changed root element, namespace, and shortname to physloc to prevent conflict with JEP-0033. (psa)
+    </div>
+<h4>Version 0.4 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Revived JEP upon modifications to JEP-0080; changed root element, namespace, and shortname to 'address'. (psa)
+    </div>
+<h4>Version 0.2 (2003-08-21)</h4>
+<div class="indent">Removed 'current' from title; changed shortname to 'location'; changed 'freetext' to 'text'; made several other small fixes. (psa)
+    </div>
+<h4>Version 0.1 (2003-08-20)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0112-0.8.html
+++ b/content/xep-0112-0.8.html
@@ -1,0 +1,430 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0112: User Physical Location</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Physical Location">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the current physical location of a Jabber entity.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0112">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0112: User Physical Location</h1>
+<p>This JEP defines a protocol for communicating information about the current physical location of a Jabber entity.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0112<br>
+            Version: 0.8<br>
+            Last Updated: 2004-10-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: physloc<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>3.  <a href="#usage">Usage</a>
+</dt>
+<dt>4.  <a href="#mapping">Mapping to Other Formats</a>
+</dt>
+<dt>5.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines an extension mechanism for capturing &quot;extended presence&quot; information about a user's current physical location. The information structures defined herein are intended to provide a format for describing a location or address that may change fairly frequently (e.g., one's location on a campus or in a large building) in situations where the user or application does not possess, or does not wish to communicate, detailed latitude/longitude data of the type defined in <span class="ref">User Geolocation</span>  [<a href="#nt-id2596218">1</a>].</p> 
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">Information about the user's location is provided by the user and propagated on the network by the user's client. The information is structured by means of an &lt;physloc/&gt; element that is qualified by the 'http://jabber.org/protocol/physloc' namespace. The location information itself is provided as the XML character data of the following children of the &lt;physloc/&gt; element:</p>
+  <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+<th colspan="" rowspan="">Element</th>
+<th colspan="" rowspan="">Description</th>
+<th colspan="" rowspan="">Example</th>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;country/&gt;</td>
+<td align="" colspan="" rowspan="">The nation where the user is located</td>
+<td align="" colspan="" rowspan="">USA</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;region/&gt;</td>
+<td align="" colspan="" rowspan="">An administrative region of the nation, such as a state or province</td>
+<td align="" colspan="" rowspan="">New York</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;locality/&gt;</td>
+<td align="" colspan="" rowspan="">A locality within the administrative region, such as a town or city</td>
+<td align="" colspan="" rowspan="">New York City</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;area/&gt;</td>
+<td align="" colspan="" rowspan="">A named area such as a campus or neighborhood</td>
+<td align="" colspan="" rowspan="">Central Park</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;street/&gt;</td>
+<td align="" colspan="" rowspan="">A thoroughfare within the locality, or a crossing of two thoroughfares</td>
+<td align="" colspan="" rowspan="">34th and Broadway</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;building/&gt;</td>
+<td align="" colspan="" rowspan="">A specific building on a street or in an area</td>
+<td align="" colspan="" rowspan="">The Empire State Building</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;floor/&gt;</td>
+<td align="" colspan="" rowspan="">A particular floor in a building</td>
+<td align="" colspan="" rowspan="">102</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;room/&gt;</td>
+<td align="" colspan="" rowspan="">A particular room in a building</td>
+<td align="" colspan="" rowspan="">Observatory</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;postalcode/&gt;</td>
+<td align="" colspan="" rowspan="">A code used for postal delivery</td>
+<td align="" colspan="" rowspan="">10027</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">&lt;text/&gt;</td>
+<td align="" colspan="" rowspan="">A catch-all element that captures any other information about the user's location</td>
+<td align="" colspan="" rowspan="">Northwest corner of the lobby</td>
+</tr>
+  </table>
+<h2>3.
+       <a name="usage">Usage</a>
+</h2>
+  <p class="" style="">The &lt;physloc/&gt; information SHOULD be communicated by means of <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602076">2</a>]. Because physical location information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+  <p class="caption">Example 1. User Publishes Address</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/laptop'
+    to='pubsub.jabber.org'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/stpeter-loc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'
+                 xml:lang='en'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The location information is then delivered to all subscribers:</p>
+  <p class="caption">Example 2. Activity is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='jer@jabber.org/silver'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/stpeter-physloc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'
+                 xml:lang='en'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+  </pre></div>
+  <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602062">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+  <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='jer@jabber.org/silver'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/stpeter-physloc'&gt;
+      &lt;item id='current'&gt;
+        &lt;physloc xmlns='http://jabber.org/protocol/physloc'
+                 xml:lang='en'&gt;
+          &lt;country&gt;Austria&lt;/country&gt;
+          &lt;locality&gt;Vienna&lt;/locality&gt;
+          &lt;building&gt;Vienna International Centre&lt;/building&gt;
+          &lt;text&gt;At IETF 57&lt;/text&gt;
+        &lt;/physloc&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='stpeter@jabber.org'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>4.
+       <a name="mapping">Mapping to Other Formats</a>
+</h2>
+  <p class="" style="">There are many XML data formats for physical location or address information. It is beyond the scope of this JEP to provide a mapping from the extension defined herein to every such format. However, it would be valuable to provide a mapping from the Jabber/XMPP format to the formats used in other presence or extended presence protocols. The two main protocols of interest are:</p>
+  <ol start="" type="">
+    <li><p class="" style="">The Wireless Village (now &quot;IMPS&quot;) specifications for mobile instant messaging; these specifications define a presence attribute for address information as encapsulated in the IMPS &quot;Address&quot; element  [<a href="#nt-id2602144">4</a>].</p></li>
+    <li><p class="" style="">The SIP-based SIMPLE specifications; the IETF's GEOPRIV Working Group has defined an extension to the IETF's <span class="ref">Presence Information Data Format (PIDF) </span>  [<a href="#nt-id2602280">5</a>] for location information, as specified in <span class="ref">A Presence-based GEOPRIV Location Object Format</span>  [<a href="#nt-id2602303">6</a>] (also known as &quot;PIDF-LO&quot;).</p></li>
+  </ol>
+  <p class="" style="">The following table also maps the format defined herein to the vCard XML format specified in <span class="ref">vcard-temp</span>  [<a href="#nt-id2602208">7</a>].</p>
+  <p class="caption">Table 2: Mapping Jabber Physical Location to IMPS, PIDF-LO, and vCard</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jabber/XMPP</th>
+      <th colspan="" rowspan="">Wireless Village / IMPS</th>
+      <th colspan="" rowspan="">SIMPLE (PIDF-LO)</th>
+      <th colspan="" rowspan="">vCard XML</th>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;country/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Country/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;country/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;CTRY/&gt;
+         [<a href="#nt-id2602361">8</a>]
+      </td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;region/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;A1/&gt; and/or &lt;A2/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;REGION/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;locality/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;City/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;A3/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;LOCALITY/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;area/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;NamedArea/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;A4/&gt; and/or &lt;A5/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;street/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Street/&gt;
+         [<a href="#nt-id2602556">9</a>]
+      </td>
+      <td align="center" colspan="" rowspan="">&lt;A6/&gt; 
+         [<a href="#nt-id2602587">10</a>] 
+      </td>
+      <td align="center" colspan="" rowspan="">&lt;STREET/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;building/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;Building/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;LMK/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;floor/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;FLR/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;room/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;postalcode/&gt;</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;PC/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;PCODE/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">&lt;text/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;FreeTextLocation/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;LOC/&gt;</td>
+      <td align="center" colspan="" rowspan="">&lt;EXTADR/&gt;</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;Accuracy/&gt;
+         [<a href="#nt-id2602920">11</a>]
+      </td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+    <tr class="body">
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">--</td>
+      <td align="center" colspan="" rowspan="">&lt;NAM/&gt;
+         [<a href="#nt-id2602992">12</a>]
+      </td>
+      <td align="center" colspan="" rowspan="">--</td>
+    </tr>
+  </table>
+<h2>5.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Because the character data contained in most &lt;physloc/&gt; child elements is intended to be readable by humans, the &lt;physloc/&gt; element SHOULD possess an 'xml:lang' attribute specifying the natural language of such character data.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is imperative to control access to location information, at least by default. Imagine that a stalker got unauthorized access to this information, with enough accuracy and timeliness to be able to find the target person. This scenario could lead to loss of life, so please take access control checks seriously. A user SHOULD take care in approving subscribers and in characterizing his or her current physical location.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603189">13</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603137">14</a>] shall add the 'http://jabber.org/protocol/physloc' namespace to its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/physloc'
+    xmlns='http://jabber.org/protocol/physloc'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='physloc'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='0'&gt;
+        &lt;xs:element name='country' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='region' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='locality' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='area' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='street' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='building' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='floor' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='room' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='text' minOccurs='0' type='xs:string'/&gt;
+        &lt;xs:element name='url' minOccurs='0' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596218">1</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602076">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602062">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602144">4</a>. The Wireless Village Initiative: Presence Attributes v1.1 (WV-029); for further information, visit &lt;<a href="http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html">http://www.openmobilealliance.org/tech/affiliates/wv/wvindex.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602280">5</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602303">6</a>. A Presence-based GEOPRIV Location Object Format &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-geopriv-pidf-lo-03.txt">http://www.ietf.org/internet-drafts/draft-ietf-geopriv-pidf-lo-03.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602208">7</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602361">8</a>. As noted in JEP-0054, the XML vCard format defined in draft-dawson-vcard-xml-dtd-01 specified a &lt;COUNTRY/&gt; element rather than a &lt;CTRY/&gt; element; refer to JEP-0054 for details.</p>
+<p>
+<a name="nt-id2602556">9</a>. The IMPS specification also enables one to define an intersection (e.g., &quot;Broadway and 34th Street&quot;) as the combination of a &lt;Crossing1/&gt; element (e.g., &quot;Broadway&quot;) and a &lt;Crossing2/&gt; element (e.g., &quot;34th Street&quot;). To map from IMPS to Jabber, an application SHOULD map such a combination to one Jabber/XMPP &lt;street/&gt; element.</p>
+<p>
+<a name="nt-id2602587">10</a>. The PIDF-LO format provides information elements for much more granular control over a traditional street address; in PIDF-LO the &lt;A6/&gt; element is the street name only, and further information is provided in distinct elements for a leading street direction (e.g., &quot;N&quot;), trailing street suffix (e.g., &quot;SW&quot;), street suffix (e.g., &quot;Avenue&quot;), house number (e.g., &quot;909&quot;), and house number suffix (e.g., &quot;1/2&quot;). To map from PIDF-LO to Jabber, an application SHOULD construct the complete street address from the PIDF-LO elements (&lt;A6/&gt;, &lt;PRD/&gt;, &lt;POD/&gt;, &lt;STS/&gt;, &lt;HNO/&gt;, and &lt;HNS/&gt;) and map the result to one Jabber/XMPP &lt;street/&gt; element.</p>
+<p>
+<a name="nt-id2602920">11</a>. This element provides accuracy in meters. The geolocation protocol defined in JEP-0080 specifies such an element for Jabber/XMPP, which SHOULD be used when mapping from IMPS to Jabber.</p>
+<p>
+<a name="nt-id2602992">12</a>. This element provides a name for the location, e.g., a certain store in a building. This SHOULD be mapped to the Jabber/XMPP &lt;text/&gt; element.</p>
+<p>
+<a name="nt-id2603189">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603137">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-10-12)</h4>
+<div class="indent">Added internationalization considerations. (psa)
+    </div>
+<h4>Version 0.7 (2004-10-10)</h4>
+<div class="indent">Added &lt;postalcode/&gt; element; removed &lt;url/&gt; element (unnecessary given the existence of jabber:x:oob); defined mapping to vCard. (psa)
+    </div>
+<h4>Version 0.6 (2004-10-05)</h4>
+<div class="indent">Defined mappings to Wireless Village and SIMPLE. (psa)
+    </div>
+<h4>Version 0.5 (2004-05-11)</h4>
+<div class="indent">Changed root element, namespace, and shortname to physloc to prevent conflict with JEP-0033. (psa)
+    </div>
+<h4>Version 0.4 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Revived JEP upon modifications to JEP-0080; changed root element, namespace, and shortname to 'address'. (psa)
+    </div>
+<h4>Version 0.2 (2003-08-21)</h4>
+<div class="indent">Removed 'current' from title; changed shortname to 'location'; changed 'freetext' to 'text'; made several other small fixes. (psa)
+    </div>
+<h4>Version 0.1 (2003-08-20)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0114-1.3.html
+++ b/content/xep-0114-1.3.html
@@ -1,0 +1,594 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0114: Jabber Component Protocol</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jabber Component Protocol">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP documents the existing protocol used for communication between servers and &quot;external&quot; components over the Jabber network.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-07-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0114">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0114: Jabber Component Protocol</h1>
+<p>This JEP documents the existing protocol used for communication between servers and &quot;external&quot; components over the Jabber network.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in wide use within the Jabber community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; therefore it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0114<br>
+            Version: 1.3<br>
+            Last Updated: 2004-07-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: component<br>
+        Schema for jabber:component:accept: &lt;<a href="http://jabber.org/protocol/component/accept.xsd">http://jabber.org/protocol/component/accept.xsd</a>&gt;<br>
+        Schema for jabber:component:connect: &lt;<a href="http://jabber.org/protocol/component/connect.xsd">http://jabber.org/protocol/component/connect.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2596032">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596055">Concepts</a>
+</dt>
+<dt>3.  <a href="#sect-id2596119">Details</a>
+</dt>
+<dt>4.  <a href="#sect-id2595835">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2595857">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2595719">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2595769">XML Schemas</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#sect-id2602084">jabber:component:accept</a>
+</dt>
+<dt>7.2.  <a href="#sect-id2602096">jabber:component:connect</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2596032">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber network has long included a wire protocol that enables trusted components to connect to Jabber servers. While this component protocol is minimal and will probably be superseded by a more comprehensive component protocol at some point, informational documentation of the existing protocol would be helpful for component and server developers. This JEP provides such documentation.</p>
+<h2>2.
+       <a name="sect-id2596055">Concepts</a>
+</h2>
+  <p class="" style="">Traditionally there have been two basic kinds of server-side components: &quot;internal components&quot; (which utilize the internal API of a server, in the past particularly the <span class="ref">jabberd</span>  [<a href="#nt-id2596173">1</a>] server) and &quot;external components&quot; (which communicate with a server over a wire protocol and therefore are not tied to any particular server implementation). The wire component protocol in use today enables an external component to connect to a server (with proper configuration and authentication) and to send and receive XML stanzas through the server. There are two connection methods: &quot;accept&quot; and &quot;connect&quot;. When the &quot;accept&quot; method is used, the server waits for connections from components and accepts them when they are initiated by a component. When the &quot;connect&quot; method is used, the server initiates the connection to a component. The &quot;accept&quot; method is by far the most common method, but both are documented herein. (In the past, there has been one other connection method for external components: &quot;execute&quot;. However, this method is obsolete and is not documented herein.)</p>
+  <p class="" style="">An external component is called &quot;trusted&quot; because it authenticates with a server using authentication credentials that include a shared secret. This secret is commonly specified in the configuration files used by the server and component, but could be provided at runtime on the command line or extracted from a database. An external component is commonly trusted to do things that clients cannot, such as write 'from' addresses for the server's domain(s). Some server may also allow components to send packets that are used by the server's internal protocol (e.g., &lt;log/&gt; and &lt;xdb/&gt; packets in the jabberd 1.x series); however, those internal protocols are out of scope for this JEP.</p>
+<h2>3.
+       <a name="sect-id2596119">Details</a>
+</h2>
+  <p class="" style="">The main difference between the jabber:component:* namespaces and the 'jabber:client' or 'jabber:server' namespace is authentication. External components do not use the older <span class="ref">Non-SASL Authentication</span>  [<a href="#nt-id2596152">2</a>] protocol (i.e., the 'jabber:iq:auth' namespace), nor do they (yet) use SASL authentication as defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2596290">3</a>] (although a future component protocol would most likely use SASL). Instead, they use a special &lt;handshake/&gt; element whose CDATA contains credentials for the component's session with the server. The protocol flow is as follows:</p>
+    <p class="caption">Example 1. Stream Negotiation and Authentication</p>
+<div class="indent"><pre>
+
+C: Component sends stream header to server
+
+&lt;stream:stream
+    xmlns='jabber:component:accept'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    to='shakespeare.lit'&gt;
+
+S: Server replies with stream header, including StreamID
+
+&lt;stream:stream
+    xmlns:stream='http://etherx.jabber.org/streams'
+    xmlns='jabber:component:accept'
+    from='shakespeare.lit'
+    id='3BF96D32'&gt;
+
+C: Component sends handshake element
+
+&lt;handshake&gt;aaee83c26aeeafcbabeabfcbcd50df997e0a2a1e&lt;/handshake&gt;
+
+S: Server sends empty handshake element to acknowledge success
+
+&lt;handshake/&gt;
+    </pre></div>
+    <p class="" style="">If the credentials supplied by the initiator are not valid, the receiver MUST close the stream and the underlying TCP connection.</p>
+    <p class="" style="">The handshake value is always supplied by the initiator. Thus for jabber:component:accept connections, the handshake value is provided by the component, whereas for jabber:component:connect connections, the handshake value is provided by the server.</p>
+    <p class="" style="">The CDATA of the handshake element is computed according to the following algorithm:</p>
+    <ol start="" type="">
+      <li>Concatenate the Stream ID received from the server with the shared secret (if necessary, characters that map to predefined XML entities MUST be escaped according to the rules defined in section 4.6 of the XML specification, and any non-ASCII characters MUST be encoded according to the encoding of XML streams as specified in <span style="font-weight: bold">XMPP Core</span>, i.e., UTF-8 as defined in <span class="ref">RFC 3269</span>  [<a href="#nt-id2596266">4</a>]).</li>
+      <li>Hash the concatenated string according to the SHA1 algorithm, i.e., SHA1( concat (sid, password)).</li>
+      <li>Ensure that the hash output is in hexadecimal format, not binary or base64.</li>
+      <li>Convert the hash output to all lowercase characters.</li>
+    </ol>
+    <p class="" style="">Once authenticated, the component can send stanzas through the server and receive stanzas from the server. All stanzas sent to the server MUST possess a 'from' attribute and a 'to' attribute, as in the 'jabber:server' namespace. The domain identifier portion of the JID contained in the 'from' attribute MUST match the hostname of the component. However, this is the only restriction on 'from' addresses, and the component MAY send stanzas from any user at its hostname.</p>
+<h2>4.
+       <a name="sect-id2595835">Security Considerations</a>
+</h2>
+  <p class="" style="">Given that an external component is trusted to write 'from' addresses for any user at the component's hostname, server administrators SHOULD make sure that they in fact do trust the component software.</p>
+<h2>5.
+       <a name="sect-id2595857">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2595742">5</a>]</p>
+<h2>6.
+       <a name="sect-id2595719">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'jabber:component:accept' and 'jabber:component:connect' namespaces shall be registered with <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2595789">6</a>] as a result of this JEP.</p>
+<h2>7.
+       <a name="sect-id2595769">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="sect-id2602084">jabber:component:accept</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='jabber:component:accept'
+    xmlns='jabber:component:accept'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0114: http://www.jabber.org/jeps/jep-0114.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='handshake' type='xs:string'/&gt;
+
+  &lt;xs:element name='message'&gt;
+     &lt;xs:complexType&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+            &lt;xs:element ref='subject'/&gt;
+            &lt;xs:element ref='body'/&gt;
+            &lt;xs:element ref='thread'/&gt;
+          &lt;/xs:choice&gt;
+          &lt;xs:any     namespace='##other'
+                      minOccurs='0'
+                      maxOccurs='unbounded'/&gt;
+          &lt;xs:element ref='error'
+                      minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:attribute name='from'
+                      type='xs:string'
+                      use='required'/&gt;
+        &lt;xs:attribute name='id'
+                      type='xs:NMTOKEN'
+                      use='optional'/&gt;
+        &lt;xs:attribute name='to'
+                      type='xs:string'
+                      use='required'/&gt;
+        &lt;xs:attribute name='type' use='optional' default='normal'&gt;
+          &lt;xs:simpleType&gt;
+            &lt;xs:restriction base='xs:NCName'&gt;
+              &lt;xs:enumeration value='chat'/&gt;
+              &lt;xs:enumeration value='error'/&gt;
+              &lt;xs:enumeration value='groupchat'/&gt;
+              &lt;xs:enumeration value='headline'/&gt;
+              &lt;xs:enumeration value='normal'/&gt;
+            &lt;/xs:restriction&gt;
+          &lt;/xs:simpleType&gt;
+        &lt;/xs:attribute&gt;
+        &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+     &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subject'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='thread' type='xs:NMTOKEN'/&gt;
+
+  &lt;xs:element name='presence'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+          &lt;xs:element ref='show'/&gt;
+          &lt;xs:element ref='status'/&gt;
+          &lt;xs:element ref='priority'/&gt;
+        &lt;/xs:choice&gt;
+        &lt;xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='error'
+                    minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='type' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='subscribe'/&gt;
+            &lt;xs:enumeration value='subscribed'/&gt;
+            &lt;xs:enumeration value='unsubscribe'/&gt;
+            &lt;xs:enumeration value='unsubscribed'/&gt;
+            &lt;xs:enumeration value='unavailable'/&gt;
+            &lt;xs:enumeration value='probe'/&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='show'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:NCName'&gt;
+        &lt;xs:enumeration value='away'/&gt;
+        &lt;xs:enumeration value='chat'/&gt;
+        &lt;xs:enumeration value='dnd'/&gt;
+        &lt;xs:enumeration value='xa'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='priority' type='xs:byte'/&gt;
+
+  &lt;xs:element name='iq'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+        &lt;xs:element ref='error'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='required'/&gt;
+      &lt;xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='get'/&gt;
+            &lt;xs:enumeration value='set'/&gt;
+            &lt;xs:enumeration value='result'/&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='error'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence  xmlns:err='urn:ietf:params:xml:ns:xmpp-streams'&gt;
+        &lt;xs:group   ref='err:stanzaErrorGroup'/&gt;
+        &lt;xs:element ref='err:text'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='code' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='cancel'/&gt;
+            &lt;xs:enumeration value='continue'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+            &lt;xs:enumeration value='auth'/&gt;
+            &lt;xs:enumeration value='wait'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="sect-id2602096">jabber:component:connect</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='jabber:component:connect'
+    xmlns='jabber:component:connect'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0114: http://www.jabber.org/jeps/jep-0114.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='handshake' type='xs:string'/&gt;
+
+  &lt;xs:element name='message'&gt;
+     &lt;xs:complexType&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+            &lt;xs:element ref='subject'/&gt;
+            &lt;xs:element ref='body'/&gt;
+            &lt;xs:element ref='thread'/&gt;
+          &lt;/xs:choice&gt;
+          &lt;xs:any     namespace='##other'
+                      minOccurs='0'
+                      maxOccurs='unbounded'/&gt;
+          &lt;xs:element ref='error'
+                      minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:attribute name='from'
+                      type='xs:string'
+                      use='required'/&gt;
+        &lt;xs:attribute name='id'
+                      type='xs:NMTOKEN'
+                      use='optional'/&gt;
+        &lt;xs:attribute name='to'
+                      type='xs:string'
+                      use='required'/&gt;
+        &lt;xs:attribute name='type' use='optional' default='normal'&gt;
+          &lt;xs:simpleType&gt;
+            &lt;xs:restriction base='xs:NCName'&gt;
+              &lt;xs:enumeration value='chat'/&gt;
+              &lt;xs:enumeration value='error'/&gt;
+              &lt;xs:enumeration value='groupchat'/&gt;
+              &lt;xs:enumeration value='headline'/&gt;
+              &lt;xs:enumeration value='normal'/&gt;
+            &lt;/xs:restriction&gt;
+          &lt;/xs:simpleType&gt;
+        &lt;/xs:attribute&gt;
+        &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+     &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subject'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='thread' type='xs:NMTOKEN'/&gt;
+
+  &lt;xs:element name='presence'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+          &lt;xs:element ref='show'/&gt;
+          &lt;xs:element ref='status'/&gt;
+          &lt;xs:element ref='priority'/&gt;
+        &lt;/xs:choice&gt;
+        &lt;xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='error'
+                    minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='type' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='subscribe'/&gt;
+            &lt;xs:enumeration value='subscribed'/&gt;
+            &lt;xs:enumeration value='unsubscribe'/&gt;
+            &lt;xs:enumeration value='unsubscribed'/&gt;
+            &lt;xs:enumeration value='unavailable'/&gt;
+            &lt;xs:enumeration value='probe'/&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='show'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:NCName'&gt;
+        &lt;xs:enumeration value='away'/&gt;
+        &lt;xs:enumeration value='chat'/&gt;
+        &lt;xs:enumeration value='dnd'/&gt;
+        &lt;xs:enumeration value='xa'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='priority' type='xs:byte'/&gt;
+
+  &lt;xs:element name='iq'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+        &lt;xs:element ref='error'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='required'/&gt;
+      &lt;xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='get'/&gt;
+            &lt;xs:enumeration value='set'/&gt;
+            &lt;xs:enumeration value='result'/&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='error'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence  xmlns:err='urn:ietf:params:xml:ns:xmpp-streams'&gt;
+        &lt;xs:group   ref='err:stanzaErrorGroup'/&gt;
+        &lt;xs:element ref='err:text'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='code' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='cancel'/&gt;
+            &lt;xs:enumeration value='continue'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+            &lt;xs:enumeration value='auth'/&gt;
+            &lt;xs:enumeration value='wait'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596173">1</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596152">2</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596290">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596266">4</a>. RFC 3269: UTF-8, a transformation format of ISO 10646 &lt;<a href="http://www.ietf.org/rfc/rfc3269.txt">http://www.ietf.org/rfc/rfc3269.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595742">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2595789">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.3 (2004-07-21)</h4>
+<div class="indent">Removed reference to UTF-16; further modified schema to track XMPP specifications. (psa)
+    </div>
+<h4>Version 1.2 (2004-03-01)</h4>
+<div class="indent">Modified schema to track XMPP specifications. (psa)
+    </div>
+<h4>Version 1.1 (2004-01-06)</h4>
+<div class="indent">Added schema. (psa)
+    </div>
+<h4>Version 1.0 (2003-10-08)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Active. (psa)
+    </div>
+<h4>Version 0.1 (2003-08-26)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0114-1.4.html
+++ b/content/xep-0114-1.4.html
@@ -1,0 +1,601 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0114: Jabber Component Protocol</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jabber Component Protocol">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP documents the existing protocol used for communication between servers and &quot;external&quot; components over the Jabber network.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0114">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0114: Jabber Component Protocol</h1>
+<p>This JEP documents the existing protocol used for communication between servers and &quot;external&quot; components over the Jabber network.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in wide use within the Jabber community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; therefore it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0114<br>
+            Version: 1.4<br>
+            Last Updated: 2004-11-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: component<br>
+        Schema for jabber:component:accept: &lt;<a href="http://jabber.org/protocol/component/accept.xsd">http://jabber.org/protocol/component/accept.xsd</a>&gt;<br>
+        Schema for jabber:component:connect: &lt;<a href="http://jabber.org/protocol/component/connect.xsd">http://jabber.org/protocol/component/connect.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2596146">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596171">Concepts</a>
+</dt>
+<dt>3.  <a href="#sect-id2596236">Details</a>
+</dt>
+<dt>4.  <a href="#sect-id2602016">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2602063">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2602078">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2602098">XML Schemas</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#sect-id2602139">jabber:component:accept</a>
+</dt>
+<dt>7.2.  <a href="#sect-id2602146">jabber:component:connect</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2596146">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber network has long included a wire protocol that enables trusted components to connect to Jabber servers. While this component protocol is minimal and will probably be superseded by a more comprehensive component protocol at some point, informational documentation of the existing protocol would be helpful for component and server developers. This JEP provides such documentation.</p>
+<h2>2.
+       <a name="sect-id2596171">Concepts</a>
+</h2>
+  <p class="" style="">Traditionally there have been two basic kinds of server-side components: &quot;internal components&quot; (which utilize the internal API of a server, in the past particularly the <span class="ref">jabberd</span>  [<a href="#nt-id2596290">1</a>] server) and &quot;external components&quot; (which communicate with a server over a wire protocol and therefore are not tied to any particular server implementation). The wire component protocol in use today enables an external component to connect to a server (with proper configuration and authentication) and to send and receive XML stanzas through the server. There are two connection methods: &quot;accept&quot; and &quot;connect&quot;. When the &quot;accept&quot; method is used, the server waits for connections from components and accepts them when they are initiated by a component. When the &quot;connect&quot; method is used, the server initiates the connection to a component. The &quot;accept&quot; method is by far the most common method, but both are documented herein. (In the past, there has been one other connection method for external components: &quot;execute&quot;. However, this method is obsolete and is not documented herein.)</p>
+  <p class="" style="">An external component is called &quot;trusted&quot; because it authenticates with a server using authentication credentials that include a shared secret. This secret is commonly specified in the configuration files used by the server and component, but could be provided at runtime on the command line or extracted from a database. An external component is commonly trusted to do things that clients cannot, such as write 'from' addresses for the server's domain(s). Some server may also allow components to send packets that are used by the server's internal protocol (e.g., &lt;log/&gt; and &lt;xdb/&gt; packets in the jabberd 1.x series); however, those internal protocols are out of scope for this JEP.</p>
+<h2>3.
+       <a name="sect-id2596236">Details</a>
+</h2>
+  <p class="" style="">The main difference between the jabber:component:* namespaces and the 'jabber:client' or 'jabber:server' namespace is authentication. External components do not use the older <span class="ref">Non-SASL Authentication</span>  [<a href="#nt-id2596268">2</a>] protocol (i.e., the 'jabber:iq:auth' namespace), nor do they (yet) use SASL authentication as defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2596406">3</a>] (although a future component protocol would most likely use SASL). Instead, they use a special &lt;handshake/&gt; element whose XML character data specifies credentials for the component's session with the server. The protocol flow for stream negotiation and authentication using jabber:component:accept is as follows:</p>
+    <p class="caption">Example 1. Component sends stream header to server</p>
+<div class="indent"><pre>
+&lt;stream:stream
+    xmlns='jabber:component:accept'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    to='plays.shakespeare.lit'&gt;
+    </pre></div>
+    <p class="" style="">Note: In the 'jabber:component:accept' namespace, the value of the 'to' address is the component name, not the server name;  [<a href="#nt-id2596330">4</a>] this enables the server to determine whether it will service a component of that name (e.g., based on server configuration or some other implementation-specific mechanism). If so, the server MUST reply with a stream header.</p>
+    <p class="caption">Example 2. Server replies with stream header, including StreamID</p>
+<div class="indent"><pre>
+&lt;stream:stream
+    xmlns:stream='http://etherx.jabber.org/streams'
+    xmlns='jabber:component:accept'
+    from='plays.shakespeare.lit'
+    id='3BF96D32'&gt;
+    </pre></div>
+    <p class="" style="">If the server will not service that component name, it MUST return a stream error (e.g., &lt;conflict/&gt; or &lt;host-unknown/&gt;); see <span style="font-weight: bold">XMPP Core</span> for details regarding stream error syntax.</p> 
+    <p class="" style="">After receiving the stream header reply from the server, the component MUST send a &lt;handshake/&gt; element with appropriate contents.  [<a href="#nt-id2596381">5</a>]</p>
+    <p class="caption">Example 3. Component sends handshake element</p>
+<div class="indent"><pre>
+&lt;handshake&gt;aaee83c26aeeafcbabeabfcbcd50df997e0a2a1e&lt;/handshake&gt;
+    </pre></div>
+    <p class="" style="">The XML character data of the handshake element is computed according to the following algorithm:</p>
+    <ol start="" type="">
+      <li>Concatenate the Stream ID received from the server with the shared secret (if necessary, characters that map to predefined XML entities MUST be escaped according to the rules defined in section 4.6 of the XML specification, and any non-ASCII characters MUST be encoded according to the encoding of XML streams as specified in <span style="font-weight: bold">XMPP Core</span>, i.e., UTF-8 as defined in <span class="ref">RFC 3269</span>  [<a href="#nt-id2602042">6</a>]).</li>
+      <li>Hash the concatenated string according to the SHA1 algorithm, i.e., SHA1( concat (sid, password)).</li>
+      <li>Ensure that the hash output is in hexadecimal format, not binary or base64.</li>
+      <li>Convert the hash output to all lowercase characters.</li>
+    </ol>
+    <p class="" style="">If the credentials supplied by the initiator are not valid, the receiver MUST close the stream and the underlying TCP connection, and SHOULD return a &lt;not-authorized/&gt; stream error.</p>
+    <p class="" style="">If the credentials are acceptable, the receiving application (in this case the server) MUST return an empty &lt;handshake/&gt; element.</p> 
+    <p class="caption">Example 4. Server sends empty handshake element to acknowledge success</p>
+<div class="indent"><pre>
+&lt;handshake/&gt;
+    </pre></div>
+    <p class="" style="">Once authenticated, the component can send stanzas through the server and receive stanzas from the server. All stanzas sent to the server MUST possess a 'from' attribute and a 'to' attribute, as in the 'jabber:server' namespace. The domain identifier portion of the JID contained in the 'from' attribute MUST match the hostname of the component. However, this is the only restriction on 'from' addresses, and the component MAY send stanzas from any user at its hostname.</p>
+<h2>4.
+       <a name="sect-id2602016">Security Considerations</a>
+</h2>
+  <p class="" style="">Given that an external component is trusted to write 'from' addresses for any user at the component's hostname, server administrators SHOULD make sure that they in fact do trust the component software.</p>
+<h2>5.
+       <a name="sect-id2602063">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602180">7</a>]</p>
+<h2>6.
+       <a name="sect-id2602078">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The 'jabber:component:accept' and 'jabber:component:connect' namespaces shall be registered with <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602119">8</a>] as a result of this JEP.</p>
+<h2>7.
+       <a name="sect-id2602098">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="sect-id2602139">jabber:component:accept</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='jabber:component:accept'
+    xmlns='jabber:component:accept'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0114: http://www.jabber.org/jeps/jep-0114.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='handshake' type='xs:string'/&gt;
+
+  &lt;xs:element name='message'&gt;
+     &lt;xs:complexType&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+            &lt;xs:element ref='subject'/&gt;
+            &lt;xs:element ref='body'/&gt;
+            &lt;xs:element ref='thread'/&gt;
+          &lt;/xs:choice&gt;
+          &lt;xs:any     namespace='##other'
+                      minOccurs='0'
+                      maxOccurs='unbounded'/&gt;
+          &lt;xs:element ref='error'
+                      minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:attribute name='from'
+                      type='xs:string'
+                      use='required'/&gt;
+        &lt;xs:attribute name='id'
+                      type='xs:NMTOKEN'
+                      use='optional'/&gt;
+        &lt;xs:attribute name='to'
+                      type='xs:string'
+                      use='required'/&gt;
+        &lt;xs:attribute name='type' use='optional' default='normal'&gt;
+          &lt;xs:simpleType&gt;
+            &lt;xs:restriction base='xs:NCName'&gt;
+              &lt;xs:enumeration value='chat'/&gt;
+              &lt;xs:enumeration value='error'/&gt;
+              &lt;xs:enumeration value='groupchat'/&gt;
+              &lt;xs:enumeration value='headline'/&gt;
+              &lt;xs:enumeration value='normal'/&gt;
+            &lt;/xs:restriction&gt;
+          &lt;/xs:simpleType&gt;
+        &lt;/xs:attribute&gt;
+        &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+     &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subject'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='thread' type='xs:NMTOKEN'/&gt;
+
+  &lt;xs:element name='presence'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+          &lt;xs:element ref='show'/&gt;
+          &lt;xs:element ref='status'/&gt;
+          &lt;xs:element ref='priority'/&gt;
+        &lt;/xs:choice&gt;
+        &lt;xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='error'
+                    minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='type' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='subscribe'/&gt;
+            &lt;xs:enumeration value='subscribed'/&gt;
+            &lt;xs:enumeration value='unsubscribe'/&gt;
+            &lt;xs:enumeration value='unsubscribed'/&gt;
+            &lt;xs:enumeration value='unavailable'/&gt;
+            &lt;xs:enumeration value='probe'/&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='show'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:NCName'&gt;
+        &lt;xs:enumeration value='away'/&gt;
+        &lt;xs:enumeration value='chat'/&gt;
+        &lt;xs:enumeration value='dnd'/&gt;
+        &lt;xs:enumeration value='xa'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='priority' type='xs:byte'/&gt;
+
+  &lt;xs:element name='iq'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+        &lt;xs:element ref='error'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='required'/&gt;
+      &lt;xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='get'/&gt;
+            &lt;xs:enumeration value='set'/&gt;
+            &lt;xs:enumeration value='result'/&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='error'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence  xmlns:err='urn:ietf:params:xml:ns:xmpp-streams'&gt;
+        &lt;xs:group   ref='err:stanzaErrorGroup'/&gt;
+        &lt;xs:element ref='err:text'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='code' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='cancel'/&gt;
+            &lt;xs:enumeration value='continue'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+            &lt;xs:enumeration value='auth'/&gt;
+            &lt;xs:enumeration value='wait'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="sect-id2602146">jabber:component:connect</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:xml='http://www.w3.org/XML/1998/namespace'
+    targetNamespace='jabber:component:connect'
+    xmlns='jabber:component:connect'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0114: http://www.jabber.org/jeps/jep-0114.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='handshake' type='xs:string'/&gt;
+
+  &lt;xs:element name='message'&gt;
+     &lt;xs:complexType&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+            &lt;xs:element ref='subject'/&gt;
+            &lt;xs:element ref='body'/&gt;
+            &lt;xs:element ref='thread'/&gt;
+          &lt;/xs:choice&gt;
+          &lt;xs:any     namespace='##other'
+                      minOccurs='0'
+                      maxOccurs='unbounded'/&gt;
+          &lt;xs:element ref='error'
+                      minOccurs='0'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:attribute name='from'
+                      type='xs:string'
+                      use='required'/&gt;
+        &lt;xs:attribute name='id'
+                      type='xs:NMTOKEN'
+                      use='optional'/&gt;
+        &lt;xs:attribute name='to'
+                      type='xs:string'
+                      use='required'/&gt;
+        &lt;xs:attribute name='type' use='optional' default='normal'&gt;
+          &lt;xs:simpleType&gt;
+            &lt;xs:restriction base='xs:NCName'&gt;
+              &lt;xs:enumeration value='chat'/&gt;
+              &lt;xs:enumeration value='error'/&gt;
+              &lt;xs:enumeration value='groupchat'/&gt;
+              &lt;xs:enumeration value='headline'/&gt;
+              &lt;xs:enumeration value='normal'/&gt;
+            &lt;/xs:restriction&gt;
+          &lt;/xs:simpleType&gt;
+        &lt;/xs:attribute&gt;
+        &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+     &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='subject'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='thread' type='xs:NMTOKEN'/&gt;
+
+  &lt;xs:element name='presence'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+          &lt;xs:element ref='show'/&gt;
+          &lt;xs:element ref='status'/&gt;
+          &lt;xs:element ref='priority'/&gt;
+        &lt;/xs:choice&gt;
+        &lt;xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='error'
+                    minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='type' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='subscribe'/&gt;
+            &lt;xs:enumeration value='subscribed'/&gt;
+            &lt;xs:enumeration value='unsubscribe'/&gt;
+            &lt;xs:enumeration value='unsubscribed'/&gt;
+            &lt;xs:enumeration value='unavailable'/&gt;
+            &lt;xs:enumeration value='probe'/&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='show'&gt;
+    &lt;xs:simpleType&gt;
+      &lt;xs:restriction base='xs:NCName'&gt;
+        &lt;xs:enumeration value='away'/&gt;
+        &lt;xs:enumeration value='chat'/&gt;
+        &lt;xs:enumeration value='dnd'/&gt;
+        &lt;xs:enumeration value='xa'/&gt;
+      &lt;/xs:restriction&gt;
+    &lt;/xs:simpleType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='status'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='priority' type='xs:byte'/&gt;
+
+  &lt;xs:element name='iq'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:any     namespace='##other'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+        &lt;xs:element ref='error'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='from'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:NMTOKEN'
+                    use='required'/&gt;
+      &lt;xs:attribute name='to'
+                    type='xs:string'
+                    use='required'/&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='get'/&gt;
+            &lt;xs:enumeration value='set'/&gt;
+            &lt;xs:enumeration value='result'/&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute ref='xml:lang' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='error'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence  xmlns:err='urn:ietf:params:xml:ns:xmpp-streams'&gt;
+        &lt;xs:group   ref='err:stanzaErrorGroup'/&gt;
+        &lt;xs:element ref='err:text'
+                    minOccurs='0'
+                    maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='code' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='type' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='cancel'/&gt;
+            &lt;xs:enumeration value='continue'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+            &lt;xs:enumeration value='auth'/&gt;
+            &lt;xs:enumeration value='wait'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596290">1</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596268">2</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596406">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596330">4</a>. In the 'jabber:component:connect' namespace, the server would set the 'from' attribute to the component name.</p>
+<p>
+<a name="nt-id2596381">5</a>. The handshake value is always supplied by the initiator. Thus for jabber:component:accept connections, the handshake value is provided by the component, whereas for jabber:component:connect connections, the handshake value is provided by the server.</p>
+<p>
+<a name="nt-id2602042">6</a>. RFC 3269: UTF-8, a transformation format of ISO 10646 &lt;<a href="http://www.ietf.org/rfc/rfc3269.txt">http://www.ietf.org/rfc/rfc3269.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602180">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602119">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.4 (2004-11-05)</h4>
+<div class="indent">Corrected error regarding to and from attributes. (psa)
+    </div>
+<h4>Version 1.3 (2004-07-21)</h4>
+<div class="indent">Removed reference to UTF-16; further modified schema to track XMPP specifications. (psa)
+    </div>
+<h4>Version 1.2 (2004-03-01)</h4>
+<div class="indent">Modified schema to track XMPP specifications. (psa)
+    </div>
+<h4>Version 1.1 (2004-01-06)</h4>
+<div class="indent">Added schema. (psa)
+    </div>
+<h4>Version 1.0 (2003-10-08)</h4>
+<div class="indent">Per a vote of the Jabber Council, changed status to Active. (psa)
+    </div>
+<h4>Version 0.1 (2003-08-26)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0115-1.0.html
+++ b/content/xep-0115-1.0.html
@@ -1,0 +1,382 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0115: Entity Capabilities</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Entity Capabilities">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for broadcasting and discovering client, device, or generic entity capabilities in a way that minimizes network impact.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0115">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0115: Entity Capabilities</h1>
+<p>This JEP defines a protocol for broadcasting and discovering client, device, or generic entity capabilities in a way that minimizes network impact.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0115<br>
+            Version: 1.0<br>
+            Last Updated: 2004-08-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: caps<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/caps/caps.xsd">http://jabber.org/protocol/caps/caps.xsd</a>&gt;<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#assumptions">Assumptions</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#advertise">Advertising Capabilities</a>
+</dt>
+<dt>4.2.  <a href="#discover">Discovering Capabilities</a>
+</dt>
+<dt>4.3.  <a href="#sendmsg">Sending Messages to Unsubscribed Entities</a>
+</dt>
+</dl>
+<dt>5.  <a href="#optimizations">Server Optimizations</a>
+</dt>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#error">Error Codes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">It is often desirable for a Jabber/XMPP application (commonly but not necessarily a client) to take different actions depending on the capabilities of another application from which it receives presence information. Examples include:</p>
+    <ul>
+      <li>Showing a different set of icons depending on the capabilities of other clients.</li>
+      <li>Not sending <span class="ref">XHTML-IM</span>  [<a href="#nt-id2596242">1</a>] content to plaintext clients such as cell phones.</li> 
+      <li>Allowing the initiation of Voice over IP (VoIP) sessions only to clients that support VoIP.</li>
+      <li>Not showing a &quot;Send a File&quot; button if another user's client does not support <span class="ref">File Transfer</span>  [<a href="#nt-id2596279">2</a>].</li>
+    </ul>
+    <p class="" style="">Recently, some existing Jabber clients have begun sending <span class="ref">Software Version</span>  [<a href="#nt-id2596310">3</a>] requests to each entity from which they receive presence.  That solution is impractical on a larger scale, particularly for users or applications with large rosters. This JEP proposes a more robust and scalable solution: namely, a presence-based mechanism for exchanging information about entity capabilities.  [<a href="#nt-id2596155">4</a>]</p>
+  <h2>2.
+       <a name="assumptions">Assumptions</a>
+</h2>
+    <p class="" style="">This JEP makes several assumptions:</p>
+    <ul>
+      <li>The type of client I am using is of interest to the people on my roster.</li>
+      <li>Clients for the people on my roster might want to make user interface decisions based on my capabilities.</li>
+      <li>Different instances of the same client (including version) have the same base capabilities.</li>
+      <li>Some clients will have bundles of functionality that can be enabled and disabled.</li>
+      <li>One instance of a given client may not know about all of the possible bundles of functionality that can be enabled and disabled (for example, plugins written to a client SDK).</li>
+      <li>Members of a community tend to cluster around a small set of clients.  More specifically, multiple people in my roster use the same client, and they upgrade versions relatively slowly (commonly a few times a year, perhaps once a week at most, certainly not once a minute).</li>
+      <li>Some clients are running against servers without server-to-server connectivity enabled, and without access to the Internet via HTTP.</li>
+      <li>Conversations are possible between users who not on each other's roster.</li>
+      <li>Client capabilities may change over the course of a session, due to features being enabled and disabled.</li>
+    </ul>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">The protocol defined herein addresses the following requirements:</p>
+    <ol start="" type="">
+      <li>Clients MUST be able to participate even if they support only <span class="ref">XMPP Core</span>  [<a href="#nt-id2601908">5</a>], <span class="ref">XMPP IM</span>  [<a href="#nt-id2601929">6</a>], and <span class="ref">Service Discovery</span>  [<a href="#nt-id2601951">7</a>].</li>
+      <li>Clients MUST be able to participate even if they are on networks without connectivity to other XMPP servers, services offering specialized XMPP extensions, or HTTP servers. [<a href="#nt-id2601813">8</a>]</li>
+      <li>Clients MUST be able to retrieve information without querying each user.</li>
+      <li>Since presence is normally broadcasted to many users, the byte size of the proposed extension MUST be as small as possible.</li>
+      <li>It MUST be possible to write a <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2601871">10</a>] implementation that passes the given information along.</li>
+      <li>It MUST be possible to publish a change in capabilities within a single session.</li>
+      <li>Server infrastructure above and beyond that defined in <span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span> MUST NOT be required for this approach to work, although additional server infrastructure MAY be used for optimization purposes.</li>
+    </ol>
+  <h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="advertise">Advertising Capabilities</a>
+</h3>
+      <p class="" style="">Each time a conformant client sends presence, it annotates that presence with an element that specifies the client type, the version of that client, and which feature bundles (if any) are currently enabled. Unless the server optimizations shown later are being used, the client MUST send this with every presence change (except for unavailable presence) to enable existing servers to remember the last presence for use in responding to probes. The client MUST send the <span style="font-weight: bold">'node'</span> and <span style="font-weight: bold">'ver'</span> attributes.</p>
+      <p class="" style="">In addition, the client MAY send an <span style="font-weight: bold">'ext'</span> attribute (short for &quot;extensions&quot;) if it has one or more feature bundles to advertise. A feature bundle is any non-standard addition or extension to the core application, such as a client plugin. If more than one feature bundle is advertised, the value of the <span style="font-weight: bold">'ext'</span> attribute MUST be a space-separated list of bundle names.  [<a href="#nt-id2602031">11</a>] The client MUST NOT send an <span style="font-weight: bold">'ext'</span> attribute if there are no interesting non-core features enabled. The names of the feature bundles MUST NOT be used for semantic purposes: they are merely identifiers that will be used in other use cases. If a feature bundle changes in any way (e.g., a user installs an updated version of a client plugin), the application MUST change the bundle name.</p>
+      <p class="" style="">The values of the <span style="font-weight: bold">'node'</span>, <span style="font-weight: bold">'ver'</span>, and <span style="font-weight: bold">'ext'</span> attributes MUST NOT contain the '#' character, since that character is used as a separator in the <a href="#discover">Discovering Capabilities</a> use case.</p>
+
+      <p class="caption">Example 1. Annotated presence sent</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://exodus.jabberstudio.org/caps'
+     ver='0.9'/&gt;
+&lt;/presence&gt;
+</pre></div>
+      <p class="caption">Example 2. Annotated presence sent, with feature extensions</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://exodus.jabberstudio.org/caps'
+     ver='0.9'
+     ext='tins ftrans xhtml'/&gt;
+&lt;/presence&gt;
+</pre></div>
+    </div>
+
+    <div class="indent">
+<h3>4.2 <a name="discover">Discovering Capabilities</a>
+</h3>
+      <p class="" style="">Once someone on my roster knows what client I am using, they need to be able to figure out what features are supported by that client.  The client that received the annotated presence sends a <span style="font-weight: bold">disco#info</span> request (as defined in <span style="font-weight: bold">JEP-0030: Service Discovery</span>) to <span style="font-style: italic">exactly</span> one of the users that sent a particular combination of <span style="font-weight: bold">node</span> and <span style="font-weight: bold">ver</span>. If the requestor has received the same annotation from multiple JIDs, the requestor SHOULD pick a random JID from that list to which the requestor will send the <span style="font-weight: bold">disco#info</span> request.</p>
+
+      <p class="" style="">The <span style="font-weight: bold">disco#info</span> request is sent to a JID + node combination that consists of the chosen <span style="font-weight: bold">&lt;user@host/resource&gt;</span> JID and a service discovery <span style="font-weight: bold">node</span> that is constructed as follows: concatenate (1) the value of the caps <span style="font-weight: bold">'node'</span> attribute, (2) the &quot;#&quot; character, and (3) the version number specified in the caps <span style="font-weight: bold">'ver'</span> attribute.</p>
+
+      <p class="caption">Example 3. Disco#info request for client#version</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='randomuser1@capulet.com/resource'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#0.9'/&gt;
+&lt;/iq&gt;
+</pre></div>
+      
+      <p class="" style="">Subsequent requests MAY be made to determine the info for each extension. These requests MUST be sent to a random <span style="font-weight: bold">&lt;user@host/resource&gt;</span> JID that sent a caps annotation that included a particular <span style="font-weight: bold">node</span>/<span style="font-weight: bold">ext</span> combination. The <span style="font-weight: bold">disco#info</span> request shall be sent to a JID + node combination that consists of the chosen JID and a service discovery <span style="font-weight: bold">node</span> that is constructed as follows: concatenate (1) the value of the caps <span style="font-weight: bold">'node'</span> attribute, (2) the &quot;#&quot; character, and (3) the extension name specified by one of the space-separated names in the caps <span style="font-weight: bold">'ext'</span> attribute. The requestor SHOULD try to use different JIDs for each of these requests, as well as for the first request.</p>
+      
+      <p class="caption">Example 4. Disco#info requests for client#extension</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='randomuser2@capulet.com/resource'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#tins'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='get' to='randomuser3@capulet.com/resource'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#ftrans'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='get' to='randomuser4@capulet.com/resource'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#xhtml'/&gt;
+&lt;/iq&gt;
+</pre></div>
+
+      <p class="" style="">All of the responses to the <span style="font-weight: bold">disco#info</span> queries SHOULD be cached. If a particular entity cannot store the responses, it SHOULD NOT make the requests. An entity SHOULD NOT make the service discovery requests unless the information is required for some local functionality. An entity MUST NOT ever make a request to another entity that has the same version of the same application as the requesting entity, except for extensions that are not supported by the requestor's installation (e.g., one &quot;Exodus 0.9&quot; client MUST NOT query another &quot;Exodus 0.9&quot; client unless the second client has advertised an extension or plugin that the first client does not have).</p>
+    </div>
+
+    <div class="indent">
+<h3>4.3 <a name="sendmsg">Sending Messages to Unsubscribed Entities</a>
+</h3>
+      <p class="" style="">If an application sends message to an entity from which it has not received presence, it MAY choose to append a capabilities annotation to <span style="font-style: italic">only</span> the first message sent to that entity within a particular conversation thread or &quot;session&quot;. The application MUST NOT append a capabilities annotation to later messages and MUST NOT send the annotation to entities from which it has received presence. Also, an application MUST NOT send the capabilities annotation to entities which are in a user's roster (or equivalent entity store, as in a gateway) with subscription='both' or subscription='to' (since presence would have been received from these entities if they were online).</p>
+      
+      <p class="caption">Example 5. Message including capabilities</p>
+<div class="indent"><pre>
+&lt;message to='romeo@example.net' 
+         from='juliet@example.com/balcony'&gt;
+  &lt;thread&gt;thread1&lt;/thread&gt;
+  &lt;body&gt;Art thou not Romeo, and a Montague?&lt;/example&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://exodus.jabberstudio.org/caps'
+     ver='0.9'
+     ext='xhtml'/&gt;
+&lt;/message&gt;
+</pre></div>
+      
+      <p class="" style="">If the recipient responds to one of these annotated messages, the first message back in the other direction SHOULD be annotated with capabilities.</p>
+      <p class="caption">Example 6. Response message including capabilities</p>
+<div class="indent"><pre>
+&lt;message from='romeo@example.net/orchard' 
+         to='juliet@example.com/balcony'&gt;
+  &lt;thread&gt;thread1&lt;/example&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/example&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://exodus.jabberstudio.org/caps'
+     ver='0.9'/&gt;
+&lt;/message&gt;
+</pre></div>
+      <p class="" style="">Alternatively, unsubscribed entities MAY send directed presence to each other, for which the same rules apply as listed above for messages.</p>
+    </div>
+  <h2>5.
+       <a name="optimizations">Server Optimizations</a>
+</h2>
+    <p class="" style="">A server that is managing an entity's session MAY choose to optimize traffic through the server. In this case, the server MAY strip off redundant capabilities annotations. Because of this, receivers of annotations MUST NOT expect an annotation on every presence packet they receive. If the server wants to perform this traffic optimization, it MUST ensure that the first presence each subscriber receives contains the annotation. The server MUST also ensure that any changes in the annotation (typically in the <span style="font-weight: bold">'ext'</span> attribute) are sent to all subscribers.</p>
+
+      <p class="" style="">A client MAY query the server using <span style="font-weight: bold">disco#info</span> to determine if the server supports the <span style="font-weight: bold">'http://jabber.org/protocol/caps'</span> feature. If so, the server MUST perform the optimization delineated above, and the client MAY choose to only send the capabilities annotation on the first presence packet, as well as whenever its capabilities change.</p>
+
+      <p class="caption">Example 7. Disco#info request for server optimization</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/caps'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <p class="" style="">If capabilities information has not been received from another entity, an application MUST assume that the other entity does not support capabilities.</p>
+  <h2>7.
+       <a name="error">Error Codes</a>
+</h2>
+    <p class="" style="">No application-specific error codes are defined by this document. See <span style="font-weight: bold">JEP-0030: Service Discovery</span> for a list of potential service discovery error codes.</p>
+  <h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Use of the protocol specified in this JEP might make some client-specific forms of attack slightly easier, since the attacker could more easily determine the type of client being used. However, since most clients respond to <span style="font-weight: bold">jabber:iq:version</span> requests without performing access control checks, there is no new vulnerability. Entities that wish to restrict access to capabilities information SHOULD use the privacy lists protocol defined in <span style="font-weight: bold">XMPP IM</span> to define appropriate communications blocking (e.g., an entity MAY choose to allow IQ requests only from &quot;trusted&quot; entities, such as those with whom it has a subscription of &quot;both&quot;).</p>
+    <p class="" style="">It is possible (though unlikely) for a bad actor or rogue application to poison other entities by providing incorrect information in response to disco#info requests. To guard against such poisoning, a requesting entity MAY send disco#info requests to multiple entities that match the same <span style="font-weight: bold">node</span>/<span style="font-weight: bold">ver</span> or <span style="font-weight: bold">node</span>/<span style="font-weight: bold">ext</span> combination and then compare the results to ensure consistency. The requesting entity SHOULD NOT send the same request to more than five entities and MUST ensure that the entities are truly different by not sending the same request to multiple entities for which the &lt;user@host&gt; portion matches.</p>
+  <h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602874">13</a>]. </p>
+  <h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <p class="" style="">Upon advancement of this JEP to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602813">14</a>] shall add <span style="font-weight: bold">'http://jabber.org/protocol/caps'</span> to its registries of protocol namespaces and service discovery features.</p>
+    <p class="" style="">If it is useful or interesting, the Registrar may also provide registration of the URIs to be used in the <span style="font-weight: bold">'node'</span> attribute, but since these URIs can be scoped according to well-defined existing rules, this is not necessary.</p>
+  <h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/caps'
+    xmlns='http://jabber.org/protocol/caps'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0115: http://www.jabber.org/jeps/jep-0115.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='c'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='ext' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='node' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='ver' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596242">1</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596279">2</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596310">3</a>. JEP-0092: Software Version &lt;<a href="http://www.jabber.org/jeps/jep-0092.html">http://www.jabber.org/jeps/jep-0092.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596155">4</a>. This proposal is not limited to clients, and could be used by any entity that exchanges presence with another entity, e.g., a gateway. However, this JEP uses the example of clients throughout.</p>
+<p>
+<a name="nt-id2601908">5</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601929">6</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601951">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601813">8</a>. These first two requirements effectively eliminated <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2601834">9</a>] as a possible implementation of entity capabilities.</p>
+<p>
+<a name="nt-id2601834">9</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601871">10</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602031">11</a>. While it might be objected that a space-separated list is not structured data, space-separated lists of attribute values are recommended by <span class="ref">XML 1.0</span>  [<a href="#nt-id2602138">12</a>].</p>
+<p>
+<a name="nt-id2602138">12</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p>
+<a name="nt-id2602874">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602813">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2004-08-01)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.7 (2004-06-29)</h4>
+<div class="indent">Added several items to the Security Considerations; clarified naming requirements regarding 'node', 'ver', and 'ext' attributes. (jjh/psa)
+    </div>
+<h4>Version 0.6 (2004-04-25)</h4>
+<div class="indent">Made a number of editorial adjustments. (psa)
+    </div>
+<h4>Version 0.5 (2004-01-05)</h4>
+<div class="indent">Specified that the protocol can be used whenever presence is used (e.g., by gateways); improved the XML schema; made several editorial adjustments. (psa)
+    </div>
+<h4>Version 0.4 (2003-09-04)</h4>
+<div class="indent">IQ gets must be to a resource, since they are intended to go to a particular session. (jjh)
+    </div>
+<h4>Version 0.3 (2003-09-02)</h4>
+<div class="indent">Servers MUST strip extras changed to MAY, due to implementer feedback. (jjh)
+    </div>
+<h4>Version 0.2 (2003-08-28)</h4>
+<div class="indent">Add more clarifying assumptions and requirements, make
+        it clear that clients don't have to send capabilities every
+        time if the server is optimizing. (jjh)
+    </div>
+<h4>Version 0.1 (2003-08-27)</h4>
+<div class="indent">Initial version. (jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.10.html
+++ b/content/xep-0116-0.10.html
@@ -1,0 +1,1279 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0116<br>
+            Version: 0.10<br>
+            Last Updated: 2006-07-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, RFC 2104, RFC 2409, RFC 3526, RFC 3548, xml-c14n, JEP-0004, JEP-0020, JEP-0030, JEP-0068, JEP-0155<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Encrypted%20Sessions%20(JEP-0116)">http://wiki.jabber.org/index.php/Encrypted Sessions (JEP-0116)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:dizzyd@jabber.org">dizzyd@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:dizzyd@jabber.org">dizzyd@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#personae">Dramatis Personae</a>
+</dt>
+<dt>3.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>4.  <a href="#init">Online ESession Negotiation</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#init-online-request">ESession Request</a>
+</dt>
+<dt>4.2.  <a href="#init-online-bobprep">Diffie-Hellman Preparation (Bob)</a>
+</dt>
+<dt>4.3.  <a href="#init-keys">Generating Session Keys</a>
+</dt>
+<dt>4.4.  <a href="#init-hide">Hiding Identity</a>
+</dt>
+<dt>4.5.  <a href="#init-online-response">ESession Response</a>
+</dt>
+<dt>4.6.  <a href="#init-online-aliceprep">Diffie-Hellman Preparation (Alice)</a>
+</dt>
+<dt>4.7.  <a href="#init-online-bobid">Verifying Bob's Identity</a>
+</dt>
+<dt>4.8.  <a href="#init-online-complete">ESession Completion</a>
+</dt>
+</dl>
+<dt>5.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#exchange-separate">Encryptable Content</a>
+</dt>
+<dt>5.2.  <a href="#exchange-encrypt">Encryption</a>
+</dt>
+<dt>5.3.  <a href="#exchange-send">Sending an Encrypted Stanza</a>
+</dt>
+<dt>5.4.  <a href="#exchange-decrypt">Decryption</a>
+</dt>
+</dl>
+<dt>6.  <a href="#rekey">Re-Key Exchange</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#rekey-init">Re-Key Initiation</a>
+</dt>
+<dt>6.2.  <a href="#rekey-accept">Re-Key Acceptance</a>
+</dt>
+<dt>6.3.  <a href="#rekey-publish">Publishing Old MAC Values</a>
+</dt>
+</dl>
+<dt>7.  <a href="#terminate">ESession Termination</a>
+</dt>
+<dt>8.  <a href="#sign">Signature Generation and Verification</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#sign-normal">XML Normalization</a>
+</dt>
+<dt>8.2.  <a href="#sign-hash">Hash</a>
+</dt>
+<dt>8.3.  <a href="#sign-calc">Generation</a>
+</dt>
+<dl>
+<dt>8.3.1.  <a href="#sign-rsa-gen">RSA</a>
+</dt>
+<dt>8.3.2.  <a href="#sign-dsa-gen">DSA</a>
+</dt>
+</dl>
+<dt>8.4.  <a href="#sign-format">Signature Format</a>
+</dt>
+<dl>
+<dt>8.4.1.  <a href="#sign-rsa-format">RSA</a>
+</dt>
+<dt>8.4.2.  <a href="#sign-dsa-format">DSA</a>
+</dt>
+</dl>
+<dt>8.5.  <a href="#sign-calc">Verification</a>
+</dt>
+<dl>
+<dt>8.5.1.  <a href="#sign-rsa-verify">RSA</a>
+</dt>
+<dt>8.5.2.  <a href="#sign-dsa-verify">DSA</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#sec-prng">Random Numbers</a>
+</dt>
+<dt>9.2.  <a href="#sec-rekey">Re-Keying Limits</a>
+</dt>
+<dt>9.3.  <a href="#sec-keys">Verifying Keys</a>
+</dt>
+<dt>9.4.  <a href="#sec-replay">Replay Attacks</a>
+</dt>
+<dt>9.5.  <a href="#sec-unencrypted">Unencrypted ESessions</a>
+</dt>
+<dt>9.6.  <a href="#sec-storage">Storage</a>
+</dt>
+<dt>9.7.  <a href="#sec-general">Extra Responsabilities of Implementors</a>
+</dt>
+<dt>9.8.  <a href="#sec-mandatory">Mandatory to Implement Technologies</a>
+</dt>
+<dl>
+<dt>9.8.1.  <a href="#sec-mandatory-encryption">Block Cipher Algorithms</a>
+</dt>
+<dt>9.8.2.  <a href="#sec-mandatory-sign">Key Signing Algorithms</a>
+</dt>
+<dt>9.8.3.  <a href="#sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</dt>
+<dt>9.8.4.  <a href="#sec-mandatory-hash">Hash Algorithms</a>
+</dt>
+<dt>9.8.5.  <a href="#sec-mandatory-compress">Compression Algorithms</a>
+</dt>
+</dl>
+</dl>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#registrar-ns">Namespaces</a>
+</dt>
+<dt>11.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>12.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>13.  <a href="#open">Open Issues</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#open-tothink">To Think About</a>
+</dt>
+<dt>13.2.  <a href="#open-todo">To Do</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">End-to-end encryption is a desirable feature for any communication technology. Ideally, such a technology would design encryption in from the beginning and would forbid unencrypted communications. Realistically, most communication technologies have not been designed in that manner, and Jabber/XMPP technologies are no exception. In particular, the original Jabber technologies developed in 1999 did not include end-to-end encryption by default. PGP-based encryption of message bodies and signing of presence information was added as an extension to the core protocols in the year 2000; this extension is documented in <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2259828">1</a>]. When the core protocols were formalized within the Internet Standards Process by the IETF's XMPP Working Group in 2003, a different extension was defined using S/MIME-based signing and encryption of CPIM-formatted messages (see <span class="ref" style="">RFC 3862</span>  [<a href="#nt-id2259858">2</a>]) and PIDF-formatted presence information (see <span class="ref" style="">RFC 3863</span>  [<a href="#nt-id2259880">3</a>]); this extension is specified in <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2259900">4</a>].</p>
+  <p class="" style="">For reasons described in <span class="ref" style="">Cryptographic Design of Encrypted Sessions</span>  [<a href="#nt-id2259932">5</a>], the foregoing proposals (and others not mentioned) have not been widely implemented and deployed. This is unfortunate, since an open communication protocol needs to enable end-to-end encryption in order to be seriously considered for deployment by a broad range of users.</p>
+  <p class="" style="">This proposal describes a different approach to end-to-end encryption for use by entities that communicate using XMPP. The requirements and the consequent cryptographic design that underpin this protocol are described in <span style="font-weight: bold">Cryptographic Design of Encrypted Sessions</span>. The basic concept is that of an encrypted session which acts as a secure tunnel between two endpoints. Once the tunnel is established, the content of each one-to-one XML stanza exchanged between the endpoints will be encrypted and then transmitted within a "wrapper" stanza.</p>
+<h2>2.
+       <a name="personae">Dramatis Personae</a>
+</h2>
+  <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+  <ol start="1" type="">
+    <li>"Alice" is the name of the initiator of the ESession. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+    <li>"Bob" is the name of the other participant in the ESession started by Alice. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    <li>"Aunt Tillie" the archetypal typical user (i.e. non-technical, with only very limited knowledge of how to use a computer, and averse to performing any procedures that are not familiar).</li>
+  </ol>
+  <p class="" style="">While Alice and Bob are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an ESession.</p>
+<h2>3.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">Before attempting to engage in an ESession with Bob, Alice SHOULD discover whether he supports this protocol, using either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260047">6</a>] or the presence-based profile of <span style="font-weight: bold">JEP-0030</span> specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2260072">7</a>].</p>
+  <p class="" style="">The normal course of events is for Alice to authenticate with her server, retrieve her roster (see <span style="font-weight: bold">RFC 3921</span>), send initial presence to her server, and then receive presence information from all the contacts in her roster. If the presence information she receives from some contacts does not include capabilities data (per <span style="font-weight: bold">JEP-0115</span>), Alice SHOULD then send a service discovery information ("disco#info") request to each of those contacts (in accordance with <span style="font-weight: bold">JEP-0030</span>). Such initial service discovery stanzas MUST NOT be considered part of encrypted communication sessions for the purposes of this JEP, since they perform a "bootstrapping" function that is a prerequisite to encrypted communications. The disco#info request sent from Alice to Bob might look as follows:</p>
+  <p class="caption">Example 1. Alice Queries Bob for ESession Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com/laptop'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Bob sends a disco#info reply and he supports the protocol defined herein, then he MUST include a service discovery feature variable of "http://jabber.org/protocol/esession".</p>
+  <p class="caption">Example 2. Bob Returns disco#info Data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='bob@example.com/laptop'
+    to='alice@example.org/pda'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='client' type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/esession'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="init">Online ESession Negotiation</a>
+</h2>
+    <p class="" style="">The process for establishing a secure session over an insecure transport is essentially a negotiation of various ESession algorithms and other parameters, combined with a translation into XMPP syntax of the <span style="font-weight: bold">SIGMA</span> approach to key exchange (see <span style="font-weight: bold">Cryptographic Design of Encrypted Sessions</span>).</p>
+    <p class="" style="">If Alice believes Bob may be online then she SHOULD use the protocol specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2260185">8</a>] and in this section to negotiate the ESession options and the keys.</p>
+    <p class="" style="">Note: If Alice believes Bob is offline then she SHOULD NOT use this negotiation protocol. However, she MAY use the protocol specified in <span style="font-weight: bold">Offline Encrypted Sessions</span> to establish the ESession options and keys. Alternatively, she MAY send stanzas without encryption - in which case her client MUST make absolutely clear to her that the stanzas will not be protected and give her the option not to send the stanzas.</p>
+    <p class="" style="">Note: In any case, Alice MUST NOT initiate a new ESession with Bob if she already has one established with him.</p>
+    <div class="indent">
+<h3>4.1 <a name="init-online-request">ESession Request</a>
+</h3>
+      <p class="" style="">In addition to the "accept", "logging" and "secure" fields specified in <span style="font-weight: bold">Chat Session Negotiation</span>, Alice MUST send to Bob each of the ESession options (see list below) that she is willing to use, in her order of preference (see <a href="#sec-mandatory">Mandatory to Implement Technologies</a>). Note: Alice SHOULD NOT include a "reason" field since Aunt Tillie may not be aware the ESession request is <span style="font-style: italic">not</span> encrypted.</p>
+      <ol start="" type="">
+        <li><p class="" style="">The list of Modular Exponential (MODP) group numbers (as specified in <span class="ref" style="">RFC 2409</span>  [<a href="#nt-id2260286">9</a>] or <span class="ref" style="">RFC 3526</span>  [<a href="#nt-id2260276">10</a>]) that MAY be used for Diffie-Hellman key exchange (valid group numbers include 1,2,3,4,5,14,15,16,17 and 18)</p></li>
+        <li><p class="" style="">Symmetric block cipher algorithm names</p></li>
+        <li><p class="" style="">Hash algorithm names</p></li>
+        <li><p class="" style="">Signature algorithm names</p></li>
+        <li><p class="" style="">Compression algorithm names</p></li>
+        <li><p class="" style="">The list of stanza types that MAY be encrypted and decrypted</p></li>
+        <li><p class="" style="">Whether or not the other entity MUST send the fingerprint (PKID) of its public signature-verification key instead of the full key  [<a href="#nt-id2260366">11</a>]</p></li>
+        <li><p class="" style="">The different versions of this protocol that are supported  [<a href="#nt-id2260381">12</a>]</p></li>
+        <li><p class="" style="">The minimum number of stanzas that MUST be exchanged before an entity MAY initiate a key re-exchange (1 - every stanza, 100 - every hundred stanzas). Note: This value MUST be less than 2<span class="super" style="">32</span> (see <a href="#sec-rekey">Re-Keying Limits</a>)</p></li>
+      </ol>
+      <p class="" style="">Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). For each MODP group that Alice specifies she MUST perform the following computations to calculate her Diffie-Hellman keys (where n is the number of bits per cipher block for the block cipher algorithm with the largest block size out of those she specified):</p>
+      <ol start="" type="">
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      </ol>
+      <p class="" style="">Alice MUST send all her calculated values of e to Bob (in the same order as the associated MODP groups are being sent). She MUST also specify randomly generated Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2260508">13</a>]) value of N<span class="sub" style="">A</span> (her ESession ID).</p>
+      <p class="caption">Example 3. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='form' xmlns='jabber:x:data'&gt;
+      &lt;field type="hidden" var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="accept"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="logging"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="secure"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="modp"&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="crypt_algs"&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="hash_algs"&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="sign_algs"&gt;
+        &lt;option&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;dsa&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="compress"&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-multi" var="stanzas"&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="pk_hash"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="ver"&gt;
+        &lt;option&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;1.2&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="text-single" var="rekey_freq"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="my_nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="keys"&gt;
+        &lt;value&gt; ** Base64 encoded value of e5 ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded value of e14 ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded value of e2 ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='drop' condition='deliver' value='stored'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">If Bob does not support one or more of the options in each ESession field, then he SHOULD return a &lt;feature-not-implemented/&gt; error (but he MAY return no error if, for example, he does not want to reveal his presence to Alice for whatever reason):</p>
+      <p class="caption">Example 4. Bob Informs Alice that Her Options Are Not Supported</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='bob@example.com/laptop'
+         to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    ...
+  &lt;/feature&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-options xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">Either Bob or Alice MAY attempt to initiate a new ESession after any error during the negotiation process. However, both MUST consider the previous negotiation to have failed and MUST discard any information learned through the previous negotiation.</p>
+      <p class="" style="">If Bob is unwilling to start an ESession, but he <span style="font-style: italic">is</span> ready to initiate a one-to-one chat session with Alice (see <span style="font-weight: bold">Chat Session Negotiation</span>), then he SHOULD accept the Chat Session and terminate the ESession negotiation by <span style="font-style: italic">not</span> including a 'nonce' field in his response.</p>
+      <p class="caption">Example 5. Bob Accepts Chat Session</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="init-online-bobprep">Diffie-Hellman Preparation (Bob)</a>
+</h3>
+      <p class="" style="">If Bob supports one or more of each of Alice's ESession options and is willing to start an ESession with Alice, then he MUST select one of the options from each of the ESession fields he received from Alice including one hash algorithm ("HASH"), and one of the MODP groups and Alice's corresponding value of e (see <span class="ref" style="">RFC 3766</span>  [<a href="#nt-id2250626">14</a>] or <span style="font-weight: bold">RFC 3526</span> for recommendations regarding balancing the sizes of symmetric cipher blocks and Diffie-Hellman moduli).</p>
+      <p class="" style="">Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). Bob SHOULD return a &lt;feature-not-implemented/&gt; error unless: 1 &lt; e &lt; p - 1</p>
+      <p class="" style="">Bob MUST then perform the following computations (where n is the number of bits per cipher block for the selected block cipher algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate a random number N<span class="sub" style="">B</span> (his ESession ID)</p></li>
+        <li><p class="" style="">Generate an n-bit random number C<span class="sub" style="">A</span> (the block cipher counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the block counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Calculate K = HASH(e<span class="super" style="">y</span> mod p) (the shared secret)</p></li>
+      </ol>
+    </div>
+
+    <div class="indent">
+<h3>4.3 <a name="init-keys">Generating Session Keys</a>
+</h3>
+      <p class="" style="">Bob MUST use the shared secret ("K") and the selected hash algorithm ("HASH") to generate two sets of three keys, one set for each direction of the ESession.</p>
+      <p class="" style="">For stanzas that Alice will send to Bob, the keys are calculated as:</p>
+      <ol start="" type="">
+        <li><p class="" style="">Encryption key KC<span class="sub" style="">A</span> = HASH(K, 0)</p></li>
+        <li><p class="" style="">Integrity key KM<span class="sub" style="">A</span> = HASH(K, 2)</p></li>
+        
+        <li><p class="" style="">SIGMA key KS<span class="sub" style="">A</span> = HASH(K, 4)</p></li>
+      </ol>
+      <p class="" style="">For stanzas that Bob will send to Alice the keys are calculated as:</p>
+      <ol start="4" type="">
+        <li><p class="" style="">Encryption key KC<span class="sub" style="">B</span> = HASH(K, 1)</p></li>
+        <li><p class="" style="">Integrity key KM<span class="sub" style="">B</span> = HASH(K, 3)</p></li>
+        <li><p class="" style="">SIGMA key KS<span class="sub" style="">B</span> = HASH(K, 5)</p></li>
+      </ol>
+      <p class="" style="">Once the sets of keys have been calculated the value of K MUST be securely destroyed.</p>
+      <p class="" style="">Note: As many bits of key data as are needed for each key MUST be taken from the least significant bits of the hash output. When negotiating a hash, entities MUST ensure that the hash output is no shorter than the required key data. For algorithms with variable-length keys the maximum length (up to the hash output length) SHOULD be used.</p>
+    </div>
+
+    <div class="indent">
+<h3>4.4 <a name="init-hide">Hiding Identity</a>
+</h3>
+      <p class="" style="">Bob MUST perform the following steps before he can prove his identity to Alice while protecting it from third parties.</p>
+      <ol start="" type="">
+        <li><p class="" style="">Select pubKey<span class="sub" style="">B</span>, the public key Alice should use to authenticate his signature with the signature algorithm he selected ("SIGN").</p></li>
+        <li>
+<p class="" style="">Set form<span class="sub" style="">B</span> to the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the reponse data form he will send back to Alice (including his responses for all the fields he received from Alice).</p>
+            <p class="" style="">Bob MUST encapsulate the Base64 encoded values of C<span class="sub" style="">A</span> and Alice's N<span class="sub" style="">A</span> in two new 'counter' and 'nonce' fields and add them to form<span class="sub" style="">B</span>. Note: The 'pk_hash' field specifies whether or not Alice MUST send the fingerprint (PKID) of her public signature-verification key instead of her full key. Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Alice. Note: Bob MUST place his Base64 encoded values of N<span class="sub" style="">B</span> and d in the 'my_nonce' and 'keys' fields. Bob MUST NOT return Alice's values of e.</p>
+</li>
+        <li>
+<p class="" style="">Concatenate Alice's ESession ID, Bob's ESession ID, d, pubKey<span class="sub" style="">B</span> and form<span class="sub" style="">B</span>, and calculate the HMAC (as defined in Section 2 of <span class="ref" style="">RFC 2104</span>  [<a href="#nt-id2261374">15</a>]) of the resulting byte string using the selected hash algorithm ("HASH") and the key KS<span class="sub" style="">B</span>.</p>
+            <p class="caption"></p>
+<div class="indent"><pre>mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})</pre></div>
+</li>
+        <li>
+<p class="" style="">Calculate sign<span class="sub" style="">B</span>, the signature of the HMAC result using his private signature key that corresponds to pubKey<span class="sub" style="">B</span></p>
+            <p class="caption"></p>
+<div class="indent"><pre>sign<span class="sub" style="">B</span> = SIGN(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)</pre></div>
+</li>
+        <li>
+<p class="" style="">If the value of the 'pk_hash' field that Alice sent Bob was true then Bob SHOULD set pubKey<span class="sub" style="">B</span> to the key's fingerprint</p>
+            <p class="caption"></p>
+<div class="indent"><pre>if (pk_hash) pubKey<span class="sub" style="">B</span> = HASH(pubKey<span class="sub" style="">B</span>)</pre></div>
+</li>
+        <li>
+<p class="" style="">Concatenate pubKey<span class="sub" style="">B</span> and sign<span class="sub" style="">B</span> and encrypt the resulting byte string with the agreed algorithm ("CIPHER") in counter mode (see <span class="ref" style=""> Recommendation for Block Cipher Modes of Operation</span>  [<a href="#nt-id2261596">16</a>]), using the encryption key KC<span class="sub" style="">B</span> and block counter C<span class="sub" style="">B</span>. Note: C<span class="sub" style="">B</span> MUST be incremented by 1 for each encrypted block or partial block (i.e. C<span class="sub" style="">B</span> = (C<span class="sub" style="">B</span> + 1) mod 2<span class="super" style="">n</span>, where n is the number of bits per cipher block for the agreed block cipher algorithm).</p>
+            <p class="caption"></p>
+<div class="indent"><pre>ID<span class="sub" style="">B</span> = CIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})</pre></div>
+</li>
+        <li>
+<p class="" style="">Calculate the HMAC of the encrypted identity (ID<span class="sub" style="">B</span>) and the value of Bob's block cipher counter C<span class="sub" style="">B</span> <span style="font-style: italic">before</span> the encryption above using the selected hash algorithm ("HASH") and the integrity key KM<span class="sub" style="">B</span>.</p>
+            <p class="caption"></p>
+<div class="indent"><pre>M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)</pre></div>
+</li>
+      </ol>
+    </div>
+
+    <div class="indent">
+<h3>4.5 <a name="init-online-response">ESession Response</a>
+</h3>
+    <p class="" style="">Bob responds to Alice by sending her form<span class="sub" style="">B</span>.</p>
+    <p class="caption">Example 6. Bob Responds to Alice (4-Message Negotiation)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="sign_algs"&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pk_hash"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="ver"&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="my_nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="keys"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded block counter ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob prefers the RECOMMENDED 3-message ESession negotiation, where Alice's identity is protected from active attacks instead of his own, then he should encapsulate the Base64 encoded values of ID<span class="sub" style="">B</span> and M<span class="sub" style="">B</span> in data form fields ('identity' and 'mac'), and append the new fields to form<span class="sub" style="">B</span> before sending it to Alice.</p>
+    <p class="caption">Example 7. Bob Responds to Alice (3-Message Negotiation)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="sign_algs"&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pk_hash"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="ver"&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="my_nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="keys"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded block counter ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="identity"&gt;
+        &lt;value&gt; ** Encrypted identity ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="mac"&gt;
+        &lt;value&gt; ** Integrity of identity ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+
+    <div class="indent">
+<h3>4.6 <a name="init-online-aliceprep">Diffie-Hellman Preparation (Alice)</a>
+</h3>
+      <p class="" style="">After Alice receives Bob's response, she MUST use the value of d and the ESession options specified in Bob's response to perform the following steps (where p and g are the constants associated with the selected MODP group, HASH is the selected hash algorithm, and n is the number of bits per cipher block for the agreed block cipher algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob if she is not prepared to support any of the ESession options specified by Bob (if any of the options were not included in her initial ESession request)</p></li>
+        <li><p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob unless: 1 &lt; d &lt; p - 1</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the block counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Select her values of x and e that correspond to the selected MODP group (from all the values of x and e she calculated previously)</p></li>
+        <li><p class="" style="">Calculate K = HASH(d<span class="super" style="">x</span> mod p) (the shared secret)</p></li>
+        <li><p class="" style="">Generate the session keys (KC<span class="sub" style="">A</span>, KM<span class="sub" style="">A</span>, KS<span class="sub" style="">A</span>, KC<span class="sub" style="">B</span>, KM<span class="sub" style="">B</span> and KS<span class="sub" style="">B</span>) in the same way as Bob did (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.7 <a name="init-online-bobid">Verifying Bob's Identity</a>
+</h3>
+      <p class="" style="">If Bob included 'identity' and 'mac' fields in his response then Alice MUST also perform the following steps:</p>
+      <ol start="1" type="">
+        <li>
+<p class="" style="">Calculate the HMAC of the encrypted identity (ID<span class="sub" style="">B</span>) and the value of Bob's block cipher counter using HASH and the integrity key KM<span class="sub" style="">B</span>.</p>
+            <p class="caption"></p>
+<div class="indent"><pre>M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)</pre></div>
+</li>
+        <li><p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob unless the value of M<span class="sub" style="">B</span> she calculated matches the one she received in the 'mac' field</p></li>
+        <li>
+<p class="" style="">Obtain pubKey<span class="sub" style="">B</span> and sign<span class="sub" style="">B</span> by decrypting ID<span class="sub" style="">B</span> with the agreed symmetric block cipher algorithm ("DECIPHER") in counter mode, using the encryption key KC<span class="sub" style="">B</span> and block counter C<span class="sub" style="">B</span>. Note: C<span class="sub" style="">B</span> MUST be incremented by 1 for each encrypted block or partial block (i.e. C<span class="sub" style="">B</span> = (C<span class="sub" style="">B</span> + 1) mod 2<span class="super" style="">n</span>, where n is the number of bits per cipher block for the agreed block cipher algorithm).</p>
+            <p class="caption"></p>
+<div class="indent"><pre>{pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>} = DECIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)</pre></div>
+</li>
+        <li><p class="" style="">If the value of the 'pk_hash' field she sent to Bob in her <a href="#init-online-request">ESession Request</a> was true, then Alice SHOULD change the value of pubKey<span class="sub" style="">B</span> to be her copy of the public key whose HASH matches the value of pubKey<span class="sub" style="">B</span> that she received from Bob. Note: If she cannot find a copy of the public key then Alice MUST terminate the ESession. She MAY then request a new ESession with the 'pk_hash' field set to false.</p></li>
+        <li><p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob unless she can confirm (or has previously confirmed) that pubKey<span class="sub" style="">B</span> really is Bob's public key, for examples, via secure out-of-band communication, or through a third-party authority (see <a href="#sec-keys">Verifying Keys</a>).</p></li>
+        <li><p class="" style="">Set the value of form<span class="sub" style="">B</span> to be the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the form she received from Bob without any 'identity' or 'mac' fields.</p></li>
+        <li>
+<p class="" style="">Concatenate Alice's ESession ID, Bob's ESession ID, d, pubKey<span class="sub" style="">B</span> and form<span class="sub" style="">B</span>, and calculate the HMAC of the resulting byte string using HASH and the key KS<span class="sub" style="">B</span>.</p>
+            <p class="caption"></p>
+<div class="indent"><pre>mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})</pre></div>
+</li>
+        <li>
+<p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob unless she can use pubKey<span class="sub" style="">B</span> with the selected signature verification algorithm ("VERIFY") to confirm that sign<span class="sub" style="">B</span> is the signature of the HMAC result (see <a href="#sign">Signature Verification</a>).</p>
+            <p class="caption"></p>
+<div class="indent"><pre>VERIFY(sign<span class="sub" style="">B</span>, pubKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)</pre></div>
+</li>
+      </ol>
+    </div>
+
+    <div class="indent">
+<h3>4.8 <a name="init-online-complete">ESession Completion</a>
+</h3>
+      <p class="" style="">Alice MUST then prove her identity to Bob while protecting it from third parties. She MUST perform the steps equivalent to those Bob performed above (see <a href="#init-hide">Hiding Identity</a> for a more detailed description). Alice's calculations are summarised below (pay attention to the order of N<span class="sub" style="">B</span> and N<span class="sub" style="">A</span> when calculating mac<span class="sub" style="">A</span>). Note: form<span class="sub" style="">A</span> is the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the <a href="#init-online-request">ESession Request</a> data form that she sent to Bob previously.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>})</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>sign<span class="sub" style="">A</span> = SIGN(signKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>if (pk_hash) pubKey<span class="sub" style="">A</span> = HASH(pubKey<span class="sub" style="">A</span>)</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>ID<span class="sub" style="">A</span> = CIPHER(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>})</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)</pre></div>
+
+      <p class="" style="">Alice MUST send the Base64 encoded values of N<span class="sub" style="">B</span>, ID<span class="sub" style="">A</span> and M<span class="sub" style="">A</span> to Bob. If Alice has already confirmed Bob's identity (i.e. if Bob included 'identity' and 'mac' fields in his response), then she MAY also send encrypted content (see <a href="#exchange">Exchanging Stanzas</a>) in the same stanza as the proof of her identity.</p>
+      <p class="caption">Example 8. Alice Sends Bob Her Identity</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="nonce"&gt;&lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="identity"&gt;&lt;value&gt; ** Encrypted identity ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="mac"&gt;&lt;value&gt; ** Integrity of identity ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">If Alice also includes a &lt;terminate/&gt; element (see <a href="#terminate">ESession Termination</a>) within the &lt;encrypted/&gt; element then the ESession is terminated immediately. Note: This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified) and offers several significant advantages over non-session approaches - including perfect forward secrecy.</p>
+      <p class="" style="">After receiving Alice's identity Bob MUST verify it by performing steps equivalent to those described in the section <a href="#init-online-bobid">Verifying Bob's Identity</a> above. Some of Bob's calculations are summarised below (pay attention to the order of N<span class="sub" style="">B</span> and N<span class="sub" style="">A</span> when calculating mac<span class="sub" style="">A</span>). Note: form<span class="sub" style="">A</span> is the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the <a href="#init-online-request">ESession Request</a> data form (the <span style="font-style: italic">first</span> form) that Alice sent him. Note: If Bob sends an error to Alice then he SHOULD ignore any encrypted content he received in the stanza.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>{pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>} = DECIPHER(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>})</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>VERIFY(sign<span class="sub" style="">A</span>, pubKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)</pre></div>
+      <p class="" style="">If Alice has already confirmed Bob's identity (i.e. if Bob included 'identity' and 'mac' fields in his response above), then the ESession negotiation is complete.</p>
+      <p class="" style="">Otherwise, one more step is necessary. Bob MUST send Alice the Base64 encoded values of N<span class="sub" style="">A</span>, ID<span class="sub" style="">B</span> and M<span class="sub" style="">B</span> that he calculated previously (see <a href="#init-hide">Hiding Identity</a>). Note: He MAY also send encrypted content (see <a href="#exchange">Exchanging Stanzas</a>) in the same stanza.</p>
+      <p class="caption">Example 9. Bob Sends Alice His Identity</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="nonce"&gt;&lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="identity"&gt;&lt;value&gt; ** Encrypted identity ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="mac"&gt;&lt;value&gt; ** Integrity of identity ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">After receiving Bob's identity Alice MUST verify it by performing steps described in the section <a href="#init-online-bobid">Verifying Bob's Identity</a> above. Note: If Alice sends an error to Bob then she SHOULD ignore any encrypted content she received in the stanza.</p>
+    </div>
+<h2>5.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="exchange-separate">Encryptable Content</a>
+</h3>
+    <p class="" style="">Once ESession negotiation is complete, Alice and Bob MUST exchange only encrypted forms of the one-to-one stanza types they agreed upon (e.g., &lt;message/&gt; and &lt;iq/&gt; stanzas).</p>
+    <p class="" style="">Either Alice or Bob MAY send encrypted stanzas. Here we describe the process where Alice sends Bob an encrypted stanza. She MUST only encrypt the XML content that would normally be ignored by the intermediate servers. She MUST NOT encrypt stanza wrapper elements or <span style="font-weight: bold">Advanced Message Processing</span> elements.</p>
+  <p class="caption">Example 10. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+
+  <p class="caption">Example 11. XML Content to be Encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+</pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="exchange-encrypt">Encryption</a>
+</h3>
+
+    <p class="" style="">Alice MUST perform the following steps to encrypt the XML content. Note: if there is no XML content to be encrypted (e.g. if this is an empty <a href="#rekey">Re-Keying</a> or <a href="#terminate">Termination</a> stanza), then C<span class="sub" style="">A</span> MUST be incremented by 1 (see below), and only the last two steps (normalization and MAC calculation) should be performed.</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Serialize the XML content she wishes to send into an array of UTF-8 bytes, m.  [<a href="#nt-id2263527">17</a>]</p></li>
+      <li>
+        <p class="" style="">Compress m using the negotiated algorithm. If a compression algorithm other than 'none' was agreed, the compression context is typically initialized after key exchange and passed from one stanza to the next, with only a partial flush at the end of each stanza.  [<a href="#nt-id2263546">18</a>]</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = compress(m)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Encrypt the data with the agreed algorithm in counter mode, using the encryption key KC<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented by 1 for each encrypted block or partial block (i.e. C<span class="sub" style="">A</span> = (C<span class="sub" style="">A</span> + 1) mod 2<span class="super" style="">n</span>, where n is the number of bits per cipher block for the agreed block cipher algorithm). Note: if the block cipher algorithm 'none' was agreed (see <a href="#sec-unencrypted">Unencrypted ESessions</a>) then encryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1 (for replay protection).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_final = encrypt(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Alice MUST now create the <a href="#sign-normal">Normalized</a> XML <span style="font-style: italic">content</span> of the &lt;encrypted/&gt; XML element. If there is encrypted XML content, the XML MUST include the Base64 encoded value of m_final wrapped in a &lt;data/&gt; element. Note: the &lt;encrypted/&gt; element MAY also contain one &lt;terminate/&gt; element (see <a href="#terminate">Termination</a>), one &lt;key/&gt; element and one or more &lt;old/&gt; elements (see <a href="#rekey">Re-Keying</a>).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_content = '&lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;'</pre></div>
+      </li>
+      <li>
+        <p class="" style="">The XML content and the value of Alice's block cipher counter C<span class="sub" style="">A</span> <span style="font-style: italic">before</span> the data was encrypted, are now processed through the HMAC algorithm, along with the agreed hash algorithm ("HASH") and the integrity key KM<span class="sub" style="">A</span>.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>a_mac = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+    </ol>
+
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="exchange-send">Sending an Encrypted Stanza</a>
+</h3>
+    <p class="" style="">Before sending the stanza to Bob, Alice MUST wrap m_content and the Base64 encoded value of a_mac (wrapped in a &lt;mac/&gt; element) inside an &lt;encrypted/&gt; element and insert it into the stanza in place of the original content. There MUST NOT be more than one &lt;encrypted/&gt; element per stanza.</p>
+    <p class="caption">Example 12. Message Stanza with Encrypted Content</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="exchange-decrypt">Decryption</a>
+</h3>
+
+    <p class="" style="">When Bob receives the stanza from Alice, he extracts and Base64 decodes the values of m_final and a_mac from the content and performs the following steps.</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Remove the &lt;mac/&gt; element from the &lt;encrypted/&gt; element and <a href="#sign-normal">Normalize</a> the remaining XML <span style="font-style: italic">content</span>. Calculate the Message Authentication Code (MAC) for the content.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>b_mac = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Verify that b_mac and a_mac match. If they are not identical, the content has been tampered with and Bob MUST terminate the ESession, he MAY send a &lt;not-acceptable/&gt; error to Alice.  [<a href="#nt-id2263901">19</a>]</p>
+      </li>
+      <li>
+        <p class="" style="">Decrypt m_final using the agreed algorithm, KC<span class="sub" style="">A</span> and C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented by 1 for each decrypted block (see <a href="#exchange-encrypt">Encryption</a>). Note: if the block cipher algorithm 'none' was agreed decryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = decrypt(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_final)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Decompress m_compressed using the negotiated algorithm (usually 'none').</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m = decompress(m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Replace the &lt;encrypted/&gt; element in the serialized XML stanza with m and feed the stanza into an XML parser. If the parser returns an XML format error then Bob MUST terminate the ESession, he MAY send a &lt;not-acceptable/&gt; error to Alice.  [<a href="#nt-id2264075">20</a>]</p>
+      </li>
+    </ol>
+  </div>
+  <h2>6.
+       <a name="rekey">Re-Key Exchange</a>
+</h2>
+<p class="" style="">Once an attacker has discovered an encryption key it could be used to decrypt all stanzas within a session, including stanzas that were intercepted <span style="font-style: italic">before</span> the key was discovered. To reduce the window of vulnerability, both Alice and Bob SHOULD change their values of x and y and re-exchange the encryption key as regularly as possible. They MUST also destroy all copies of keys as soon as they are no longer needed.</p>
+<p class="" style="">Note: Although most entities are capable of re-keying after each stanza, clients running in constrained runtime environments may require a few seconds to re-key. During ESession negotiation these clients MAY negotiate the minimum number of stanzas to be exchanged between re-keys at the cost of a larger window of vulnerability. Entities MUST NOT initiate key re-exchanges more frequently than the agreed limit.</p>
+
+  <div class="indent">
+<h3>6.1 <a name="rekey-init">Re-Key Initiation</a>
+</h3>
+    <p class="" style="">Either Alice or Bob MAY initiate a key re-exchange. Here we describe the process initiated by Alice. First she MUST calculate new values for the encryption parameters:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1, where n is the number of bits per cipher block for the agreed block cipher algorithm)</p></li>
+      <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the new shared secret)</p></li>
+      <li><p class="" style="">Calculate KC<span class="sub" style="">A</span>, KM<span class="sub" style="">A</span>, KC<span class="sub" style="">B</span>, KM<span class="sub" style="">B</span> from K (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">To avoid extra stanzas, the new value of e SHOULD be sent to Bob along with an encrypted stanza. Note: Alice MUST NOT use the new KC<span class="sub" style="">A</span> and KM<span class="sub" style="">A</span> to encrypt this stanza or to calculate the MAC. However, she MUST use them when sending subsequent stanzas.</p>
+    <p class="" style="">Note: There is no need for Alice to provide a signature because the calculation of the MAC includes the new value of e, see <a href="#exchange">Exchanging Stanzas</a>).</p>
+    <p class="caption">Example 13. Alice Sends Re-Key Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;key&gt; ** Base64 encoded value of new e ** &lt;/key&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Bob may not receive the new key before he sends his next stanzas (they may cross in transit). So, before destroying her old values of KC<span class="sub" style="">B</span> and KM<span class="sub" style="">B</span>, Alice MUST wait until either she receives a stanza encrypted with the new key, or a reasonable time has passed (60 seconds should cover a network round-trip and calculations by a constrained client). Similarly she MUST wait before destroying her old value of x, in case Bob sends two stanzas before receiving Alice's new key (the first stanza might include a re-key).</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="rekey-accept">Re-Key Acceptance</a>
+</h3>
+    <p class="" style="">After Bob has received a stanza with a new value of e, has confirmed it is greater than one, and has decrypted the stanza with the old value of KC<span class="sub" style="">A</span>, he MUST securely destroy all copies of KC<span class="sub" style="">A</span> and KC<span class="sub" style="">B</span> and perform the following calculations with the new value of e:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p</p></li>
+      <li><p class="" style="">Calculate KC<span class="sub" style="">A</span>, KM<span class="sub" style="">A</span>, KC<span class="sub" style="">B</span>, KM<span class="sub" style="">B</span> from K (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">He MUST use these new values to encrypt and decrypt all subsequent stanzas.  [<a href="#nt-id2264438">21</a>]</p>
+    <p class="" style="">The next time Bob sends Alice a stanza he MUST specify the number of rekeys he has received from her since he sent her his last stanza. He does that by setting the 'rekeys' attribute of the &lt;data/&gt; element. Note: The default value of the 'rekeys' attribute is zero.</p>
+    <p class="caption">Example 14. Bob's First Stanza After Receiving a Re-Key</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data rekeys='1'&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Alice receives the stanza from Bob she MUST use the 'rekeys' attribute to decide which of her values of KC<span class="sub" style="">B</span> and KM<span class="sub" style="">B</span> (or x) she should use to decrypt the stanza - otherwise she would not know if Bob received her rekey(s) before he sent the stanza. Once she is sure Bob has received her rekey(s) she MUST discard all her older values of KC<span class="sub" style="">B</span>, KM<span class="sub" style="">B</span> and x.</p>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="rekey-publish">Publishing Old MAC Values</a>
+</h3>
+    <p class="" style="">Once the expired MAC keys have been published, anyone could create valid arbitrary stanzas with them. This prevents anyone being able to prove the authenticity of a transcript of the ESession in the future.</p>
+    <p class="" style="">Either entity MAY publish old values of KM<span class="sub" style="">A</span> and/or KM<span class="sub" style="">B</span> within any encrypted stanza as long as it knows that all the stanzas that MAY use the old values have been received and validated. Note: A 'man-in-the-middle' could delay the delivery of stanzas indefinitely. So, before Alice publishes KM<span class="sub" style="">A</span> (and KM<span class="sub" style="">B</span>), she MUST wait until she has both sent a re-key to Bob and received a stanza from Bob encrypted with her new key. (She MAY also publish KM<span class="sub" style="">B</span> after she has received a re-key from Bob.)</p>
+    <p class="caption">Example 15. Publishing Expired MAC Keys</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Entities SHOULD ignore any &lt;old/&gt; elements they receive.</p>
+  </div>
+  <h2>7.
+       <a name="terminate">ESession Termination</a>
+</h2>
+    <p class="" style="">Either entity MAY terminate an ESession at any time. Entities MUST terminate all open ESessions before they go offline. To terminate an ESession Alice MUST send a stanza to Bob including a &lt;terminate/&gt; element with content "1"  [<a href="#nt-id2264646">22</a>]. Note: She MAY publish old values of KM<span class="sub" style="">A</span> and/or KM<span class="sub" style="">B</span> within her termination stanza as long as she is sure all the stanzas that MAY use the old values have been received and validated (see <a href="#rekey-publish">Publishing Old MAC Values</a>). She MUST then securely destroy all keys associated with the ESession.</p>
+    <p class="caption">Example 16. Alice Terminates an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Bob receives a termination stanza he MUST verify the MAC (to be sure he received all the stanzas Alice sent him during the ESession) and immediately send a termination stanza back to Alice. Note: He MAY publish <span style="font-style: italic">any</span> old values of KM<span class="sub" style="">A</span> or KM<span class="sub" style="">B</span> within the termination stanza. He MUST then securely destroy all keys associated with the ESession.</p>
+    <p class="caption">Example 17. Bob Confirms ESession Termination</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Alice receives the stanza she MUST verify the MAC to be sure she received all the stanzas Bob sent her during the ESession. Once an entity has sent a termination stanza it MUST NOT send another stanza within the ESession.</p>
+  <h2>8.
+       <a name="sign">Signature Generation and Verification</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="sign-normal">XML Normalization</a>
+</h3>
+    <p class="" style="">Before the signature or MAC of a block of XML is generated or verified, all character data <span style="font-style: italic">between</span> all elements MUST be removed and the XML MUST be converted to canonical form (see <span class="ref" style="">Canonical XML</span>  [<a href="#nt-id2264807">23</a>]).</p>
+    <p class="" style="">All the XML this protocol requires to be signed or MACed is very simple, so in this case, canonicalization SHOULD only require the following changes:</p>
+    <ul>
+      <li>Set attribute value delimiters to quotation marks (i.e. simply replace all single quotes in the serialized XML with double quotes)</li>
+      <li>Impose lexicographic order on the attributes of "field" elements (i.e. ensure "type" is before "var")</li>
+    </ul>
+    <p class="" style="">Implementations MAY conceivably also need to make the following changes. Note: Empty elements and special characters SHOULD NOT appear in the signed or MACed XML specified in this protocol.</p>
+    <ul>
+      <li>Ensure there are no character references</li>
+      <li>Convert empty elements to start-end tag pairs</li>
+      <li>Ensure there is no whitespace except for single spaces before attributes</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="sign-hash">Hash</a>
+</h3>
+    <p class="" style="">Before the signature or MAC of a block of XML is generated or verified, the agreed hash algorithm MUST be used to generate the hash of the normalized XML.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>m_hash = HASH(m_content)</pre></div>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="sign-calc">Generation</a>
+</h3>
+    <p class="" style="">The signature generation depends on the type of private key being used.</p>
+    <div class="indent">
+<h3>8.3.1 <a name="sign-rsa-gen">RSA</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>signature_rsa = rsa_sign(rsa_private_key, m_hash, hashOID)</pre></div>
+      <p class="" style="">The multiprecision integer signature_rsa is the signature (see <span class="ref" style="">RFC 3447</span>  [<a href="#nt-id2264931">24</a>]).</p>
+    </div>
+    <div class="indent">
+<h3>8.3.2 <a name="sign-dsa-gen">DSA</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>sig_dsa_r, sig_dsa_s = dsa_sign(dsa_private_key, m_hash)</pre></div>
+      <p class="" style="">The multiprecision integers sig_dsa_r and sig_dsa_s are the signature (see <span class="ref" style="">Digital Signature Standard</span>  [<a href="#nt-id2264985">25</a>]).</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="sign-format">Signature Format</a>
+</h3>
+    <p class="" style="">The signature formats are the same for all public key formats. All integers are stored in big-endian byte order.</p>
+    <div class="indent">
+<h3>8.4.1 <a name="sign-rsa-format">RSA</a>
+</h3>
+      <p class="" style="">Base64 encoding of the signature_rsa multiprecision integer (without any header or length prefix).</p>
+    </div>
+    <div class="indent">
+<h3>8.4.2 <a name="sign-dsa-format">DSA</a>
+</h3>
+      <p class="" style="">Base64 encoding of the following structure:</p>
+      <ul>
+        <li>number of bytes in sig_dsa_r (2-byte integer)</li>
+        <li>sig_dsa_r</li>
+        <li>number of bytes in sig_dsa_s (2-byte integer)</li>
+        <li>sig_dsa_s</li>
+      </ul>
+    </div>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="sign-calc">Verification</a>
+</h3>
+    <p class="" style="">The signature verification depends on the type of public key being used.</p>
+    <div class="indent">
+<h3>8.5.1 <a name="sign-rsa-verify">RSA</a>
+</h3>
+      <p class="" style="">The rsa_modulus and rsa_public_exponent multiprecision integers are extracted from the other entity's authenticated public key. The signature_rsa multiprecision integer is the signature received from the other entity.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>boolean = rsa_verify(signature_rsa, m_hash, hashOID, rsa_modulus, rsa_public_exponent)</pre></div>
+    </div>
+    <div class="indent">
+<h3>8.5.2 <a name="sign-dsa-verify">DSA</a>
+</h3>
+      <p class="" style="">The dsa_p, dsa_q, dsa_g and dsa_y multiprecision integers are extracted from the other entity's authenticated public key. The sig_dsa_r and sig_dsa_s multiprecision integers are the signature received from the other entity.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>boolean = dsa_verify(sig_dsa_r, sig_dsa_s, m_hash, dsa_p, dsa_q, dsa_g, dsa_y)</pre></div>
+    </div>
+  </div>
+  <h2>9.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="sec-prng">Random Numbers</a>
+</h3>
+    <p class="" style="">Weak pseudo-random number generators (PRNG) enable successful attacks. Implementors MUST use a cryptographically strong PRNG to generate all random numbers (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2265164">26</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="sec-rekey">Re-Keying Limits</a>
+</h3>
+    <p class="" style="">After a key exchange an entity MUST NOT exchange a total of 2<span class="super" style="">32</span> encrypted blocks before it initiates a key re-exchange (see <span class="ref" style="">RFC 4344</span>  [<a href="#nt-id2265211">27</a>]). Note: This limitation also ensures the same key and counter values are never used to encrypt two different blocks using counter mode (thus preventing simple attacks).</p>
+    <p class="" style="">In order to reduce the Perfect Forward Secrecy window of vulnerability, after an extended period of activity, entities SHOULD either re-key or terminate the ESession.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="sec-keys">Verifying Keys</a>
+</h3>
+    <p class="" style="">The trust system outlined in this document is based on Alice trusting that the public key presented by Bob is <span style="font-style: italic">actually</span> Bob's key (and vice versa). Determining this trust may be done in a variety of ways depending on the entities' support for different public key (certificate) formats, signing algorithms and signing authorities. For instance, if Bob publishes a PGP/GPG public key, Alice MAY verify that his key is signed by another key that she knows to be good. Or, if Bob provides an X.509 certificate, she MAY check that his key has been signed by a Certificate Authority that she trusts.</p>
+    <p class="" style="">When trust cannot be achieved automatically, methods that are not transparent to the users may be employed. For example, Bob could communicate the SHA-256 fingerprint of his public key to Alice via secure out-of-band communication (e.g. face-to-face). This would enable Alice to confirm that the public key she receives in-band is valid. Note however that very few people bother to verify fingerprints in this way. So this method is exceptionally vulnerable to 'man-in-the-middle' attacks. In order to reduce the window of vulnerability, an entity SHOULD remember the fingerprints of all user-validated public keys and alert the user in the future if ever the fingerprint(s) it stored for an entity do not match any of the received public keys.</p>
+    <p class="" style="">Alternatively Alice and Bob could agree a shared secret via secure out-of-band communication, Bob could then use it to create an HMAC of his public key that only Alice could verify.</p>
+    <p class="" style="">Note: If no keys are acceptable to Alice (because Alice has never verified any of the keys, and because either the keys are not signed, or Alice does not support the signature algorithms of the keys, or she cannot parse the certificate formats, or she does not recognise the authorities that signed the keys) then, although the ESession can still be encrypted, she cannot be sure she is communicating with Bob.</p>
+  </div>
+  <div class="indent">
+<h3>9.4 <a name="sec-replay">Replay Attacks</a>
+</h3>
+    <p class="" style="">The block cipher counters maintained implicitly by Alice and Bob (C<span class="sub" style="">A</span> and C<span class="sub" style="">B</span>) prevent stanzas being replayed within any ESession. They ensure that the MAC will be different for all stanzas, even if the HMAC key and the content of the stanza are identical.</p>
+    <p class="" style="">Alice and Bob MUST ensure that the value of e or d they provide when negotiating each online ESession is unique. This prevents complete online ESessions being replayed.</p>
+  </div>
+  <div class="indent">
+<h3>9.5 <a name="sec-unencrypted">Unencrypted ESessions</a>
+</h3>
+    <p class="" style="">Organisations with full disclosure policies may require entities to disable encryption to enable the logging of all messages on their server. Unencrypted ESessions meet all the <a href="#reqs-sec">Security Requirements</a> except for Confidentiality. Unencrypted ESessions enable Alice to to confirm <span style="font-style: italic">securely</span> with Bob that both client-server connections are secure. i.e. that the value of the 'secure' option (as specified in <span style="font-weight: bold">Chat Session Negotiation</span>) has not been tampered with.</p>
+  </div>
+  <div class="indent">
+<h3>9.6 <a name="sec-storage">Storage</a>
+</h3>
+    <p class="" style="">If either entity stores a (re-encrypted) transcript of an ESession for future consultation then the Perfect Forward Secrecy offered by this protocol is lost. If the negotiated value of the 'logging' <span style="font-weight: bold">Chat Session Negotiation</span> field is false the entities SHOULD NOT store any part of the ESession content (not even in encrypted form).</p>
+  </div>
+  <div class="indent">
+<h3>9.7 <a name="sec-general">Extra Responsabilities of Implementors</a>
+</h3>
+    <p class="" style="">Cryptography plays only a small part in an entity's security. Even if it implements this protocol perfectly it may still be vulnerable to other attacks. For examples, an implementation might store ESession keys on swap space or save private keys to a file in cleartext! Implementors MUST take very great care when developing applications with secure technologies.</p>
+  </div>
+  <div class="indent">
+<h3>9.8 <a name="sec-mandatory">Mandatory to Implement Technologies</a>
+</h3>
+    <p class="" style="">An implementation of ESession MUST support the Diffie-Hellman Key Agreement and HMAC algorithms. Note: The parameter names mentioned below are related to secure shell; see <span style="font-weight: bold">SSH Transport Layer Encryption Modes</span> for block cipher algorithm details; see the <span class="ref" style="">IANA Secure Shell Protocol Parameters Registry</span>  [<a href="#nt-id2265474">28</a>] for other names.</p>
+    <div class="indent">
+<h3>9.8.1 <a name="sec-mandatory-encryption">Block Cipher Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following block cipher algorithm:</p>
+      <ul>
+        <li>aes128-ctr (see <span class="ref" style="">Advanced Encryption Standard</span>  [<a href="#nt-id2265522">29</a>])</li>
+      </ul>
+      <p class="" style="">The block length of an block cipher algorithm's cipher SHOULD be at least 128 bits. An implementation of ESession MAY also support the following block cipher algorithms:</p>
+      <ul>
+        <li>aes256-ctr</li>
+        <li>aes192-ctr</li>
+        <li>twofish256-ctr (see <span class="ref" style="">Twofish</span>  [<a href="#nt-id2265566">30</a>])</li>
+        <li>twofish192-ctr</li>
+        <li>twofish128-ctr</li>
+        <li>serpent256-ctr (see <span class="ref" style="">Serpent</span>  [<a href="#nt-id2265601">31</a>])</li>
+        <li>serpent192-ctr</li>
+        <li>serpent128-ctr</li>
+        <li>none (no encryption, only signing)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>9.8.2 <a name="sec-mandatory-sign">Key Signing Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following signing algorithm:</p>
+      <ul>
+        <li>rsa (see <span style="font-weight: bold">RFC 3447</span>)</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following signing algorithm:</p>
+      <ul>
+        <li>dsa (see <span style="font-weight: bold">Digital Signature Standard</span>)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>9.8.3 <a name="sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following public key formats:</p>
+      <ul>
+        <li>ssh-rsa</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following public key formats:</p>
+      <ul>
+        <li>ssh-dss</li>
+        <li>x509v3-sign-rsa (see <span class="ref" style="">X.509 Authentication in SSH2</span>  [<a href="#nt-id2265719">32</a>])</li>
+        <li>x509v3-sign-dss</li>
+        <li>pgp-sign-rsa</li>
+        <li>pgp-sign-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession MAY also support the following public key formats:</p>
+      <ul>
+        <li>spki-sign-rsa</li>
+        <li>spki-sign-dss</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>9.8.4 <a name="sec-mandatory-hash">Hash Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following hash algorithm:</p>
+      <ul>
+        <li>sha256 (see <span class="ref" style="">Secure Hash Standard</span>  [<a href="#nt-id2265795">33</a>])</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following hash algorithm (sha1 and md5 are NOT RECOMMENDED):</p>
+      <ul>
+        <li>whirlpool (see <span class="ref" style="">Whirlpool</span>  [<a href="#nt-id2265839">34</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>9.8.5 <a name="sec-mandatory-compress">Compression Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following compression algorithm:</p>
+      <ul>
+        <li>none (no compression, the output MUST be the same as the input)</li>
+      </ul>
+      <p class="" style="">Support for other algorithms is NOT RECOMMENDED since compression partially defeats the <a href="#reqs-repudiate">Repudiability</a> requirement of this JEP by making it more difficult for a third party (with some knowledge of the plaintext) to modify a transcript of an encrypted session in a meaningful way. However, encrypted content is pseudo-random and cannot be compressed, so, in those cases where bandwidth is severely constrained, an implementation of ESession MAY support the following algorithms to compress content before it is encrypted:</p>
+      <ul>
+        <li>lzw (see <span class="ref" style="">Standard ECMA-151</span>  [<a href="#nt-id2265909">35</a>])</li>
+        <li>zlib (see <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2265934">36</a>])</li>
+      </ul>
+    </div>
+  </div>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2265975">37</a>]. </p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2266062">38</a>] shall register the following namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/esession</li>
+      <li>http://jabber.org/protocol/esession#init</li>
+      <li>http://jabber.org/protocol/esession#error</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2266083">39</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in <span style="font-style: italic">both</span> Encrypted Sessions and Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field
+      var='match_resource'
+      type='text-single'
+      label='Target resource for offline ESessions'/&gt;
+  &lt;field
+      var='modp'
+      type='list-single'
+      label='MODP group number'/&gt;
+  &lt;field
+      var='crypt_algs'
+      type='list-single'
+      label='Symmetric block cipher options'/&gt;
+  &lt;field
+      var='hash_algs'
+      type='list-single'
+      label='Hash algorithm options'/&gt;
+  &lt;field
+      var='sign_algs'
+      type='list-single'
+      label='Signature algorithm options'/&gt;
+  &lt;field
+      var='compress'
+      type='list-single'
+      label='Compression algorithm options'/&gt;
+  &lt;field
+      var='stanzas'
+      type='list-multi'
+      label='Stanzas types to encrypt'/&gt;
+  &lt;field
+      var='pk_hash'
+      type='boolean'
+      label='Respond with public key fingerprint'/&gt;
+  &lt;field
+      var='ver'
+      type='list-single'
+      label='Supported versions of JEP-0116'/&gt;
+  &lt;field
+      var='rekey_freq'
+      type='text-single'
+      label='Minimum number of stanzas between key exchanges'/&gt;
+  &lt;field
+      var='keys'
+      type='hidden'
+      label='Diffie-Hellman keys'/&gt;
+  &lt;field
+      var='my_nonce'
+      type='hidden'
+      label='ESession ID of Sender'/&gt;
+  &lt;field
+      var='expires'
+      type='hidden'
+      label='Expiry time of offline ESession options'/&gt;
+  &lt;field
+      var='nonce'
+      type='hidden'
+      label='ESession ID of Receiver'/&gt;
+  &lt;field
+      var='counter'
+      type='hidden'
+      label='Initial block counter'/&gt;
+  &lt;field
+      var='pkids'
+      type='list-single'
+      label='Public key IDs'/&gt;
+  &lt;field
+      var='signs'
+      type='list-single'
+      label='Data form signatures'/&gt;
+&lt;/form_type&gt;
+
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;jep&gt;JEP-0155&lt;/jep&gt;
+  ...
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>13.
+       <a name="open">Open Issues</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="open-tothink">To Think About</a>
+</h3>
+    <ol start="" type="">
+      <li>Standardise on the X.509 public key and signature formats?</li>
+      <li>What challenges exist to make the OTR Gaim Plugin use this protocol natively when talking to Jabber entities? Can these be mitigated by 'non-critical' protocol changes?</li>
+      <li>Would anything in this protocol (e.g., its dependency on in-order stanza delivery) prevent an XMPP entity using it to exchange encrypted messages and presence with a user of a non-XMPP messaging system, assuming that the gateway both supports this protocol and is compatible with a purpose-built security plugin on the other user's client (e.g. a Gaim plugin connects to the gateway via a non-XMPP network)?</li>
+      <li>Could use <span class="ref" style="">Flexible Offline Message Retrieval</span>  [<a href="#nt-id2266197">40</a>] (FOMR) instead of AMP to prevent any offline ESessions Bob can't decrypt being delivered to him. (Each &lt;item/&gt; that corresponds to an ESession message would have to contain a &lt;ESessionID/&gt; child, to allow Bob to discover which of his stored values of y was used to encrypt the message.)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="open-todo">To Do</a>
+</h3>
+    <ol start="" type="">
+      <li>Ask the authors of AMP to explain how to achieve the match_resource functionality to be specified in JEP-0187.</li>
+      <li>Define names for X.509 SubjectPublicKeyInfo public key formats (different to X.509 certificates). This format must be used when keys are distributed within session negotiation.</li>
+      <li>Add non-repudiable signing option</li>
+      <li>Perhaps the JEP needs to specify more carefully how block counters are handled between messages, especially in the event of partial blocks?</li>
+      <li>Give examples of specific errors and discuss error scenarios throughout document (e.g., what should Bob do if he is not offline and he receives an offline key exchange stanza?).</li>
+      <li>Update Dependencies list</li>
+      <li>Define an <span style="font-style: italic">optional</span> protocol that would allow Alice to store values of N<span class="sub" style="">A</span> and x (and the PKIDs she trusts) 'securely' on her own server (before she goes offline).</li>
+    </ol>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2259828">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2259858">2</a>. RFC 3862: Common Presence and Instant Messaging (CPIM): Message Format &lt;<a href="http://www.ietf.org/rfc/rfc3862.txt">http://www.ietf.org/rfc/rfc3862.txt</a>&gt;.</p>
+<p><a name="nt-id2259880">3</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p><a name="nt-id2259900">4</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2259932">5</a>. JEP-0188: Cryptographic Design of Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0188.html">http://www.jabber.org/jeps/jep-0188.html</a>&gt;.</p>
+<p><a name="nt-id2260047">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260072">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2260185">8</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2260286">9</a>. RFC 2409: The Internet Key Exchange (IKE) &lt;<a href="http://www.ietf.org/rfc/rfc2409.txt">http://www.ietf.org/rfc/rfc2409.txt</a>&gt;.</p>
+<p><a name="nt-id2260276">10</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p><a name="nt-id2260366">11</a>. If the entity already possesses one of the other entity's public keys then it is RECOMMENDED that only the fingerprint is requested from the other entity - since this saves bandwidth.</p>
+<p><a name="nt-id2260381">12</a>. This version of this document describes version 1.0 of this protocol.</p>
+<p><a name="nt-id2260508">13</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2250626">14</a>. RFC 3766: Determining Strengths For Public Keys Used For Exchanging Symmetric Keys &lt;<a href="http://www.ietf.org/rfc/rfc3766.txt">http://www.ietf.org/rfc/rfc3766.txt</a>&gt;.</p>
+<p><a name="nt-id2261374">15</a>. RFC 2104: HMAC: Keyed-Hashing for Message Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2104.txt">http://www.ietf.org/rfc/rfc2104.txt</a>&gt;.</p>
+<p><a name="nt-id2261596">16</a>. Recommendation for Block Cipher Modes of Operation: Federal Information Processing Standards Publication 800-38a &lt;<a href="http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf">http://csrc.nist.gov/publications/ nistpubs/800-38a/sp800-38a.pdf</a>&gt;.</p>
+<p><a name="nt-id2263527">17</a>. Although counter mode encryption requires no padding, implementations MAY still disguise the length of m by appending a random number of white-space characters.</p>
+<p><a name="nt-id2263546">18</a>. If Bob were to receive a stanza out-of-order, then he would fail to decrypt the stanza and be forced to terminate the ESession.</p>
+<p><a name="nt-id2263901">19</a>. If Bob were to receive a stanza out-of-order, then the MACs would not match because the values of C<span class="sub" style="">A</span> would not be synchronized.</p>
+<p><a name="nt-id2264075">20</a>. Bob MUST NOT send a stream error to his server since intermediate entities are not responsible for encoded content.</p>
+<p><a name="nt-id2264438">21</a>. If an entity fails to receive any stanza that includes a new key in the correct order, then it will fail to decrypt the next stanza it receives and be forced to terminate the ESession.</p>
+<p><a name="nt-id2264646">22</a>. Content is specified for the &lt;terminate/&gt; element to facilitate <a href="#sign-normal">XML Normalization</a>.</p>
+<p><a name="nt-id2264807">23</a>. Canonical XML 1.0 &lt;<a href="http://www.w3.org/TR/xml-c14n">http://www.w3.org/TR/xml-c14n</a>&gt;.</p>
+<p><a name="nt-id2264931">24</a>. RFC 3447: Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography Specifications Version 2.1 &lt;<a href="http://www.ietf.org/rfc/rfc3447.txt">http://www.ietf.org/rfc/rfc3447.txt</a>&gt;.</p>
+<p><a name="nt-id2264985">25</a>. Digital Signature Standard: Federal Information Processing Standards Publication 186  &lt;<a href="http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf">http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf</a>&gt;.</p>
+<p><a name="nt-id2265164">26</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2265211">27</a>. RFC 4344: SSH Transport Layer Encryption Modes &lt;<a href="http://www.ietf.org/rfc/rfc4344.txt">http://www.ietf.org/rfc/rfc4344.txt</a>&gt;.</p>
+<p><a name="nt-id2265474">28</a>. IANA registry of parameters related to secure shell &lt;<a href="http://www.iana.org/assignments/ssh-parameters">http://www.iana.org/assignments/ssh-parameters</a>&gt;.</p>
+<p><a name="nt-id2265522">29</a>. Advanced Encryption Standard: Federal Information Processing Standards Publication 197 &lt;<a href="http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf">http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf</a>&gt;.</p>
+<p><a name="nt-id2265566">30</a>. The Twofish Block Cipher &lt;<a href="http://www.schneier.com/twofish.html">http://www.schneier.com/twofish.html</a>&gt;.</p>
+<p><a name="nt-id2265601">31</a>. The Serpent Block Cipher &lt;<a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">http://www.cl.cam.ac.uk/~rja14/serpent.html</a>&gt;.</p>
+<p><a name="nt-id2265719">32</a>. X.509 Authentication in SSH2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-03.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-03.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2265795">33</a>. Secure Hash Standard: Federal Information Processing Standards Publication 180-2  &lt;<a href="http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf">http://csrc.nist.gov/publications/fips/fips180-2/fips186-2withchangenotice.pdf</a>&gt;.</p>
+<p><a name="nt-id2265839">34</a>. The Whirlpool Hash Function &lt;<a href="http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html">http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html</a>&gt;.</p>
+<p><a name="nt-id2265909">35</a>. Standard ECMA-151: Data Compression for Information Interchange - Adaptive Coding with Embedded Dictionary - DLCZ Algorithm &lt;<a href="http://www.ecma-international.org/publications/standards/Ecma-151.htm">http://www.ecma-international.org/publications/standards/Ecma-151.htm</a>&gt;.</p>
+<p><a name="nt-id2265934">36</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2265975">37</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2266062">38</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2266083">39</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2266197">40</a>. JEP-0013: Flexible Offline Message Retrieval &lt;<a href="http://www.jabber.org/jeps/jep-0013.html">http://www.jabber.org/jeps/jep-0013.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2006-07-18)</h4>
+<div class="indent">Added Upgradability requirement; added expires field to offline options; updated in line with latest version of PEP; moved some content to new JEPs (0187, 0188 and 0189) (ip)
+    </div>
+<h4>Version 0.9 (2005-11-29)</h4>
+<div class="indent">Modified protocol in line with SIGMA: added Identity Protection requirement, no pre-indication of acceptable keys, send multiple values of e with ESession request, offline options published via SPPS, added LZW compression (ip)
+    </div>
+<h4>Version 0.8 (2005-09-27)</h4>
+<div class="indent">Added diagramatic synopses; Added match_resource field; replaced req_mac and kid fields with prev_hash; Alice specifies initial counter (doubles as nonce); many other improvements (ip)
+    </div>
+<h4>Version 0.7 (2005-08-26)</h4>
+<div class="indent">Simplified XML normalization; added Synopsis and Efficiency requirement; defined signature formats (ip)
+    </div>
+<h4>Version 0.6 (2005-08-12)</h4>
+<div class="indent">Extended termination procedure; added object encryption/signing requirement and special case; clarified expired MAC publishing; added Flexible Offline Message Retrieval to Open Issues. (ip)
+    </div>
+<h4>Version 0.5 (2005-08-10)</h4>
+<div class="indent">Added flexibility requirement; added late signature of initial request; added termination MAC. (ip)
+    </div>
+<h4>Version 0.4 (2005-08-09)</h4>
+<div class="indent">Added (offline) replay protection; required offline Created header; compression is NOT RECOMMENDED; added second set of offline options for subscribers; added JIDs to session key generation; unencrypted sessions; added secure option; sign whole data form; HMAC whole &lt;encrypted/&gt; element; added ESession termination; option to distribute public keys within session negotiation; added Integrity requirement; several clarifications (ip)
+    </div>
+<h4>Version 0.3 (2005-08-02)</h4>
+<div class="indent">Restored status to Experimental; complete rewrite; new Introduction, Background, Requirements and Security Considerations; new OTR-inspired protocol; JEP-0155-based negotiation; counter mode encryption; more secure hashes; offline sessions; re-keying; mac publishing; preliminary key and options publishing protocol. (ip/psa)
+    </div>
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.2.html
+++ b/content/xep-0116-0.2.html
@@ -1,0 +1,705 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="Note: This proposal has been retracted by the author.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-07-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>Note: This proposal has been retracted by the author.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This JEP has been retracted by the author(s). Implementation of the protocol described herein is not recommended. Developers desiring similar functionality should implement the protocol that supersedes this one (if any).</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Retracted<br>
+            Type: Standards Track<br>
+            Number: 0116<br>
+            Version: 0.2<br>
+            Last Updated: 2004-07-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br>
+</p>
+<h2>Author Information</h2>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2595915">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596035">References</a>
+</dt>
+<dt>3.  <a href="#sect-id2596285">Characters</a>
+</dt>
+<dt>4.  <a href="#sect-id2596155">Prerequisites</a>
+</dt>
+<dt>5.  <a href="#sect-id2601836">Negotiating the ESession</a>
+</dt>
+<dt>6.  <a href="#sect-id2602874">Exchanging Messages</a>
+</dt>
+<dt>7.  <a href="#sect-id2603297">Public Key Algorithms</a>
+</dt>
+<dt>8.  <a href="#sect-id2603333">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#sect-id2603352">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#sect-id2603370">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#sect-id2603382">Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#sect-id2603444">Field Standardization</a>
+</dt>
+</dl>
+<dt>11.  <a href="#sect-id2603503">XML Schemas</a>
+</dt>
+<dt>12.  <a href="#sect-id2603529">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2595915">Introduction</a>
+</h2>
+    <p class="" style="">This JEP describes a lightweight protocol which allows two Jabber endpoints 
+      to create a secure tunnel between them, called an &quot;ESession&quot;. Once the tunnel is
+      established, all packets between the endpoints will be
+      compressed, encrypted, and transmitted in a &quot;wrapper&quot; protocol
+      element. Steps are taken to ensure that packets exchanged are
+      in the order they were transmitted, were not tampered with, and
+      cannot be replayed at a later time. 
+    </p>
+
+    <p class="" style="">Traditionally, creating an end-to-end encrypted session between
+    two Jabber endpoints has required the use of a PKI system such as
+    PGP or GPG (see, for example, <span class="ref">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2596077">1</a>]). Integrating with PGP/GPG
+    is problematic due to a lack of solid SDKs. Typical
+    integration with this system requires spawning the PGP/GPG client
+    as a child process and passing data back and forth over some
+    mixture of IPC (such as shared memory or redirected stin/stdout).
+    Additionally, there are efficiency issues with using PKI-based
+    encryption and signatures for every message.  Finally, the way in
+    which the PGP/GPG integration is currently used is susceptible to
+    replay attacks. Given these issues, a protocol is needed which:
+      <ul>
+        <li>Utilizes widely available, in-process, cryptographic
+          primitives</li>
+        <li>Prevents replay attacks</li>
+        <li>Minimizes client processing requirements, per packet</li>
+      </ul>
+    </p>
+
+    <p class="" style="">There exist other Internet protocols which exhibit these
+    characteristics and that are based on standard cryptographic
+    techniques. One of these is SSH
+    (Secure Shell).  The transport protocol used in SSH is
+    flexible, relatively simple to implement and, most importantly,
+    proven. For these reasons, SSH was chosen as the <span style="font-style: italic">conceptual model</span> for this
+    end-to-end encryption proposal. This proposal builds on the
+    key-exchange, replay protection, and cipher processing models
+    that are outlined in the SSH transport protocol.</p>
+  <h2>2.
+       <a name="sect-id2596035">References</a>
+</h2>
+    <p class="" style="">This JEP is built on a broad foundation of well-researched
+    cryptographic techniques (by authors who have far more experience
+    in the crypto sciences than the current author). While this JEP provides
+    all the necessary information to implement the protocol described
+    herein, it is <span style="font-style: italic">strongly</span> recommended that developers also
+    spend some time perusing the following documents, in order to achieve
+    a more perfect understanding of the theories behind this protocol.
+    </p>
+    <ul>
+      <li>
+<span class="ref">RFC 2412</span>  [<a href="#nt-id2596184">2</a>] (especially Appendices C, D, and E)</li>
+      <li>
+<span class="ref">RFC 3526</span>  [<a href="#nt-id2596209">3</a>]</li>
+      <li>
+<span class="ref">SSH Transport Layer Protocol</span>  [<a href="#nt-id2596238">4</a>]</li>
+      <li>
+<span class="ref">SSH Protocol Architecture</span>  [<a href="#nt-id2596261">5</a>] (especially Section 4)</li>
+    </ul>
+    <p class="" style="">In addition, this proposal depends on the following Jabber Enhancement Proposals for syntax within XML streams:</p>
+    <ul>
+      <li>
+<span class="ref">Data Forms</span>  [<a href="#nt-id2596296">6</a>]</li>
+      <li>
+<span class="ref">Feature Negotiation</span>  [<a href="#nt-id2601776">7</a>]</li>
+      <li>
+<span class="ref">Service Discovery</span>  [<a href="#nt-id2601796">8</a>]</li>
+      <li>
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2601819">9</a>]</li>
+    </ul>
+  <h2>3.
+       <a name="sect-id2596285">Characters</a>
+</h2>
+    <p class="" style="">This JEP introduces a few characters to help the reader follow
+    the necessary exchanges:
+      <ol start="1" type="">
+	<li>&quot;Alice&quot; is the name of the initiator of the sample
+	ESession. Within the scope of this JEP, her fully-qualified
+	  JID is: alice@host/res.</li>
+	<li>&quot;Bob&quot; is the name of the other participant in the
+	ESession started by Alice. Within the scope of this JEP, his
+	  fully-qualified JID is: bob@host/res.</li>
+      </ol>
+      For the sake of brevity, both Alice's and Bob's JIDs will be abbrievated in
+      the protocol snippets to just be &quot;alice&quot; and &quot;bob&quot;,
+      respectively. However, ALL packets exchanged for ESession
+      purposes MUST be addressed to a fully-qualified JID.
+    </p>
+    <p class="" style="">
+      Note that while Alice and Bob are introduced as &quot;end-users&quot;, they are simply 
+      meant to be an example of Jabber entities. Any directly addressable Jabber
+      entity may participate in an ESession.
+    </p>
+  <h2>4.
+       <a name="sect-id2596155">Prerequisites</a>
+</h2>
+    <p class="" style="">
+      Alice (alice@host/res) wants to establish an encrypted session
+      with Bob (bob@host/res). Before she can do so, she MUST
+      determine that he supports the ESession protocol. This SHOULD be
+      done using the disco protocol to ensure he supports the
+      &quot;http://jabber.org/protocol/esession&quot; namespace. Once this
+      determination has been made, she can begin the process of
+      establishing an ESession.
+    </p>
+  <h2>5.
+       <a name="sect-id2601836">Negotiating the ESession</a>
+</h2>
+    <p class="" style="">
+      The establishment of an ESession is based on the SSH transport
+      mechanism for establishing a secure session over an insecure
+      transport (refer to &quot;SSH Transport Layer Protocol&quot; for more information). Like SSH,
+      ESession uses a Diffie-Hellman (DH) key exchange algorithm with
+      SHA-1 as the hashing algorithm. The first packet is the initial
+      part of the DH exchange, so Alice must perform the following
+      steps to prepare:
+    </p>
+    <ol start="1" type="">
+      <li><p class="" style="">
+	Select a Modular Exponential (MODP) Diffie-Hellman
+	group (these are defined in RFC 3526). Each MODP group defines a series of constants,
+	including a prime (which we will refer to as &quot;DH_PRIME&quot;) and
+	a generator (which we will refer to as
+	&quot;DH_GEN&quot;). Additionally, a third parameter (&quot;DH_GROUPORDER&quot;)
+	is derived from DH_PRIME and DH_GEN. The value of DH_GROUPORDER
+	is (DH_PRIME - 1) / 2.
+      </p></li>
+      <li><p class="" style="">Generate a random number &quot;x&quot; (where 1 &lt; x &lt;
+      DH_GROUPORDER). Implementors MUST use a cryptographically
+      strong, pseudo-random number generator.</p></li>
+      <li><p class="" style="">Calculate &quot;e&quot; = DH_GEN ^ (x mod DH_PRIME)</p></li>
+    </ol>
+    <p class="" style="">
+      Alice then sends &quot;e&quot; to Bob as a part of the initial exchange
+      request to start an ESession. Alice includes an identifier of
+      the MODP group that she used, so that Bob will be able to work
+      off the same DH parameters. Finally, she specifies the cipher,
+      key, and message authentication code (MAC) algorithms that she is willing to use, in the order
+      of preference. </p>
+    <p class="caption">Example 1. Request for ESession</p>
+<div class="indent"><pre>
+&lt;iq from='alice' to='bob' type='set' id='es1'&gt;
+  &lt;esession xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;start&gt;
+      &lt;features xmlns='http://jabber.org/protocol/feature-neg'&gt;
+	&lt;x xmlns='jabber:x:data'&gt;
+          &lt;field type='hidden' var='FORM_TYPE'&gt;
+            &lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt; 
+          &lt;/field&gt;
+	  &lt;field type='list-single' var='cipher-algo'&gt;
+	    &lt;option&gt;&lt;value&gt;3des-cbc&lt;/value&gt;&lt;/option&gt;
+	    &lt;option&gt;&lt;value&gt;blowfish-cbc&lt;/value&gt;&lt;/option&gt;
+	    &lt;option&gt;&lt;value&gt;twofish128-cbc&lt;/value&gt;&lt;/option&gt;
+	    &lt;option&gt;&lt;value&gt;aes128-cbc&lt;/value&gt;&lt;/option&gt;
+	  &lt;/field&gt;
+	  &lt;field type='list-single' var='key-algo'&gt;
+	    &lt;option&gt;&lt;value&gt;esession-dss&lt;/value&gt;&lt;/option&gt;
+	    &lt;option&gt;&lt;value&gt;esession-rsa&lt;/value&gt;&lt;/option&gt;
+	  &lt;/field&gt;
+	  &lt;field type='list-single' var='mac-algo'&gt;
+	    &lt;option&gt;&lt;value&gt;hmac-sha1&lt;/value&gt;&lt;/option&gt;
+	    &lt;option&gt;&lt;value&gt;hmac-sha1-96&lt;/value&gt;&lt;/option&gt;
+	  &lt;/field&gt;
+	&lt;/x&gt;
+      &lt;/features&gt;
+      &lt;e modp='MODP-5'&gt; ** value of &quot;e&quot;, encoded as a hexadecimal string ** &lt;/e&gt;
+    &lt;/start&gt;
+  &lt;/esession&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="" style="">When Bob receives the request for the ESession, he must examine
+      the available algorithms and the selected MODP group. If none of
+      these parameters meets his requirements for security or Bob is unwilling to negotiate an ESession, he
+      MUST return an IQ type='error'. However, if Bob is willing to start an
+      ESession with Alice, he MUST select one algorithm each from the list of cipher, key, and MAC
+      algorithms that Alice provided, and perform the
+      following computations (using the MODP parameters provided by
+      Alice):</p>
+    <ol start="4" type="">
+      <li><p class="" style="">Verify that (1 &lt; e &lt; DH_PRIME - 1)</p></li>
+      <li><p class="" style="">Generate a random number &quot;y&quot; (where 0 &lt; y &lt; DH_GROUPORDER)</p></li>
+      <li><p class="" style="">Calculate &quot;f&quot; = DH_GEN ^ (y mod DH_GROUPORDER)</p></li>
+      <li><p class="" style="">Verify that (1 &lt; f &lt; DH_PRIME - 1)</p></li>
+      <li><p class="" style="">Calculate &quot;K&quot; = e ^ (y mod DH_PRIME). K represents
+      the base key material used to derive the actual keys for
+      encryption and integrity checking</p></li>
+      <li>
+<p class="" style="">Compute a session identifier (SID) by computing the SHA-1
+        hash of the following values  [<a href="#nt-id2595752">10</a>]:</p>
+        <p class="caption">Table 1: SID Hash Inputs</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+            <th colspan="" rowspan="">Data</th>
+            <th colspan="" rowspan="">Datatype</th>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Bob's public key (base64 encoded)</td>
+            <td align="" colspan="" rowspan="">string</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Value of &quot;e&quot;</td>
+            <td align="" colspan="" rowspan="">mpint</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Value of &quot;f&quot;</td>
+            <td align="" colspan="" rowspan="">mpint</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Value of &quot;K&quot;</td>
+            <td align="" colspan="" rowspan="">mpint</td>
+          </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Name of the selected cipher-algo</td>
+	    <td align="" colspan="" rowspan="">string</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Name of the selected key-algo</td>
+	    <td align="" colspan="" rowspan="">string</td>
+	  </tr>
+	  <tr class="body">
+	    <td align="" colspan="" rowspan="">Name of the selected mac-algo</td>
+	    <td align="" colspan="" rowspan="">string</td>
+	  </tr>
+        </table>
+        <p class="" style="">Note that &quot;e&quot;, &quot;f&quot; and &quot;K&quot; are hashed as raw multiple-precision
+          integers, encoded according to the &quot;mpint&quot; type defined in the 
+          &quot;SSH Protocol Architecture&quot; specification.
+        </p>
+
+      </li>
+      <li><p class="" style="">Compute signature (&quot;SIG&quot;) of the session identifier. To
+      complete this step, Bob must select a key algorithm from the list
+      Alice provided and use that to create a signed message digest of
+      the SID. Alice will use this message digest, in conjunction with
+      Bob's public key, to verify that the value of &quot;f&quot; which she
+      receives from Bob was actually generated by Bob, and was not
+      tampered with.</p></li>
+    </ol>
+
+    <p class="" style="">Bob now sends &quot;f&quot;, &quot;SIG&quot; and his public key to Alice, along
+    with his choices for the required algorithms.</p>
+
+    <p class="caption">Example 2. Response to ESession request</p>
+<div class="indent"><pre>
+&lt;iq from='bob' to='alice' type='result' id='es1'&gt;
+  &lt;esession xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;starting&gt;
+      &lt;features xmlns='http://jabber.org/protocol/feature-neg'&gt;
+	&lt;x xmlns='jabber:x:data'&gt;
+	  &lt;field var='cipher-algo'&gt;&lt;value&gt;blowfish-cbc&lt;/value&gt;&lt;/field&gt;
+	  &lt;field var='key-algo'&gt;&lt;value&gt;esession-dss&lt;/value&gt;&lt;/field&gt;
+	  &lt;field var='mac-algo'&gt;&lt;value&gt;hmac-sha1&lt;/value&gt;&lt;/field&gt;
+	&lt;/x&gt;
+      &lt;/features&gt;
+      &lt;f&gt; ** value of &quot;f&quot;, encoded as a hexadecimal string ** &lt;/f&gt;
+      &lt;sig&gt; ** value of SIG, Base64 encoded ** &lt;/sig&gt;
+      &lt;public-key type='dsa'&gt; ** Base64 encoded DSA public key ** &lt;/public-key&gt;
+    &lt;/starting&gt;
+  &lt;/esession&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="" style="">On receipt of the IQ-result, Alice now needs to verify the &quot;f&quot;
+    value provided by Bob. She performs the following
+    computations:</p>
+    <ol start="11" type="">
+      <li><p class="" style="">Verify that (1 &lt; f &lt; DH_PRIME-1)</p></li>
+      <li><p class="" style="">Calculate &quot;K&quot; where K = f ^ (x mod DH_PRIME).</p></li>
+      <li><p class="" style="">Compute SID (session id) exactly as Bob did above in Step 9.</p></li>
+      <li><p class="" style="">Verify the signed message digest (&quot;SIG&quot;) that Bob
+      provided, using his public key and SID.</p></li>
+    </ol>
+
+    <p class="" style="">At this point, Alice can be certain that the &quot;f&quot; value in the
+    IQ-result was actually generated by Bob, and in turn, can trust
+    that she has the same value for &quot;K&quot; that Bob does. This entire
+    trust system is based on Alice trusting that the public key
+    presented by Bob is <span style="font-style: italic">actually</span> Bob's key.  Depending on the
+    public key algorithm selected, determining this trust can be done
+    in a variety of ways. For instance, if PGP/GPG is in use Alice may
+    verify that Bob's key is signed by another key she knows to be
+    good. Or if they are using an X.509-based algorithm, she may
+    check that Bob's key has been signed by a trusted Certificate Authority (CA).</p>
+
+    <p class="" style="">With the Diffie-Helman negotiation complete and verified, Alice
+    and Bob can generate two sets of key data, one for each direction
+    of the ESession. For data that Alice will send to Bob (Alice -&gt;
+    Bob), the keys are calculated as:</p>
+    <ol start="15" type="">
+      <li><p class="" style="">IV (cipher vector) K-I1 = SHA-1(K, &quot;A&quot;, SID)</p></li>
+      <li><p class="" style="">Encryption Key K-E1 = SHA-1(K, &quot;C&quot;, SID)</p></li>
+      <li><p class="" style="">Integrity Key K-M1 = SHA-1(K, &quot;E&quot;, SID)</p></li>
+    </ol>
+    <p class="" style="">For data that Bob will send to Alice (Bob -&gt; Alice) the keys are calculated as:</p>
+    <ol start="18" type="">
+      <li><p class="" style="">IV (cipher vector) K-I2 = SHA-1(K, &quot;B&quot;, SID)</p></li>
+      <li><p class="" style="">Encryption Key K-E2 = SHA-1(K, &quot;D&quot;, SID)</p></li>
+      <li><p class="" style="">Integrity Key K-M2 = SHA-1(K, &quot;F&quot;, SID)</p></li>
+    </ol>
+
+    <p class="" style="">As described in the &quot;SSH Transport Layer Protocol&quot; specification (Section 5.2), key data
+    MUST be taken from the beginning of the hash output. 192 bits (24
+    bytes) SHOULD be used for algorithms with variable-length
+    keys. For other algorithms, as many bytes as are needed are taken
+    from the beginning of the hash value.  If the key length in longer
+    than the output of the hash, the key is extended by computing a
+    hash of the concatenation of K and H and the entire key so far,
+    and appending the resulting bytes (as many as the hash generates)
+    to the key.  This process is repeated until enough key material is
+    available; the key is taken from the beginning of this
+    value  [<a href="#nt-id2602709">11</a>]. In other words:
+      <p class="caption"></p>
+<div class="indent"><pre>
+        K-E1_1 = SHA-1(K, X, SID)   (X is e.g. &quot;A&quot;)
+        K-E1_2 = SHA-1(K, K1)
+        K-E1_3 = SHA-1(K, K1, K2)
+        ...
+        K-E1 = K-E1_1 || K-E1_2 || K-E1_3 || ...
+      </pre></div>
+    </p>
+
+    <p class="" style="">Note that for each key generated, the following inputs should be passed
+    into the SHA-1 hash function, using the formats specified below:
+      <p class="caption">Table 2: Key Hash Inputs</p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+            <th colspan="" rowspan="">Data</th>
+            <th colspan="" rowspan="">Datatype</th>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">The value of &quot;K&quot;, as calculated above</td>
+            <td align="" colspan="" rowspan="">mpint</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Literal value of &quot;A&quot;, &quot;B&quot;, etc.</td>
+            <td align="" colspan="" rowspan="">character (single-byte)</td>
+          </tr>
+          <tr class="body">
+            <td align="" colspan="" rowspan="">Value of &quot;SID&quot; (an output of another SHA-1 digest)</td>
+            <td align="" colspan="" rowspan="">raw SHA-1 digest</td>
+          </tr>
+        </table>
+    </p>
+    
+    <p class="" style="">With these keys computed and algorithms agreed upon, ESession
+    negotiation is now complete. From this point forward, Alice and
+    Bob MUST only exchange encrypted forms of directed &lt;message/&gt; and
+    &lt;iq/&gt; stanzas. Presence stanzas SHOULD NOT be encrypted, since
+    they are typically relayed by the server, which does not have the
+    key.</p>
+
+    <p class="" style="">Each side will now start a counter (&quot;C&quot;) which will be
+    incremented with each packet sent and received. This counter is used to prevent
+    replay attacks by ensuring that the MAC for a given packet never
+    repeats, even if the content of the packet is identical.</p>
+  <h2>6.
+       <a name="sect-id2602874">Exchanging Messages</a>
+</h2>
+    <p class="" style="">When Alice wants to send Bob a &lt;message/&gt; (such as the one in
+    Example 3) she will now take the following steps:</p>
+
+      <ol start="1" type="">
+        <li><p class="" style="">Construct the packet she wishes to send, and serialize
+        this packet (&quot;m&quot;).</p></li>
+      </ol>
+    <p class="caption">Example 3. Message to be encrypted</p>
+<div class="indent"><pre>
+&lt;message from='alice' to='bob' type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;/message&gt;
+</pre></div>
+    <ol start="2" type="">
+      <li>
+        <p class="" style="">Compress the serialization using the ZLIB compression format defined in <span class="ref">RFC 1950</span>  [<a href="#nt-id2603045">12</a>]. This
+          is a required step due to the large amount of repeated data
+          inherent in XML. Typically, the compression context will be
+          initialized after key exchange and is passed from one packet
+          to the next, with only a partial flush being performed at
+          the end of the packet.</p>
+        <p class="" style="">
+<p class="caption"></p>
+<div class="indent"><pre>m_compressed = zlib-compress(m)</pre></div>
+</p>
+      </li>
+      <li>
+        <p class="" style="">Random bytes of padding are now appended to the compressed
+        serialization, with the following constraints:
+          <ul>
+            <li>The total length of the compressed serialization and
+              the padding is a multiple of the cipher block
+              size.</li>
+            <li>There MUST NOT be more than 255 bytes of padding.</li> 
+            <li>The last block of data (as determined by cipher block size)
+              MUST only contain padding
+               [<a href="#nt-id2602999">13</a>].
+            </li>
+            <li>The last <span style="font-style: italic">byte</span> of padding must indicate how
+            many bytes of padding there are in total. The recipient
+            will use this to remove the padding after decryption, but
+            before feeding the data into the decompressor.</li>
+          </ul>
+        </p>
+        <p class="" style="">
+<p class="caption"></p>
+<div class="indent"><pre>m_padded = m_compressed + padding</pre></div>
+</p>
+      </li>
+      <li>
+        <p class="" style="">The resulting data from Step 3 is now processed through the
+        selected MAC algorithm (&quot;mac-algo&quot;), along with the MAC key
+        (&quot;K-M1&quot;) and the current value of the packet counter
+        (&quot;C&quot;).</p>
+        <p class="" style="">
+<p class="caption"></p>
+<div class="indent"><pre>m_mac = mac-algo(K-M1, C, m_padded)</pre></div>
+</p>
+      </li>
+      <li>
+        <p class="" style="">Finally, the data from Step 3 will be encrypted with the
+        selected algorithm (&quot;cipher-algo&quot;), using the encryption
+        key.</p>
+        <p class="" style="">
+<p class="caption"></p>
+<div class="indent"><pre>m_final = cipher-algo-encrypt(K-E1, m_padded)</pre></div>
+</p>
+      </li>
+    </ol>
+
+    <p class="" style="">Alice will now wrap m_mac and m_final in a &lt;message/&gt; packet and
+    transmit it directly to Bob's address (fully-qualified):</p>
+
+    <p class="caption">Example 4. Encrypted message</p>
+<div class="indent"><pre>
+&lt;message from='alice' to='bob' 
+	 xmlns:enc='http://jabber.org/protocol/esession#data'&gt;
+  &lt;enc:data&gt; ** base64 encoded m_final ** &lt;/enc:data&gt;
+  &lt;enc:mac&gt; ** base64 encoded m_mac ** &lt;/enc:mac&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    <p class="" style="">When Bob recieves the packet from Alice, he will extract the
+    m_final and m_mac from the message and perform the following
+    steps:</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Decrypt m_final using the selected cipher and K-M1</p>
+        <p class="" style="">
+<p class="caption"></p>
+<div class="indent"><pre>r_padded = cipher-algo-decrypt(K-E1, m_final)</pre></div>
+</p>
+      </li>
+      <li>
+        <p class="" style="">Calculate the MAC for the decrypted data</p>
+        <p class="" style="">
+<p class="caption"></p>
+<div class="indent"><pre>r_mac = mac-algo(K-M1, C, r_padded)</pre></div>
+</p>
+      </li>
+      <li>
+        <p class="" style="">Compare r_mac and m_mac; they MUST match. If they do not
+        match, the message has been tampered with and SHOULD be
+        bounced with a Bad Request error. Additionally, Bob
+        MUST invalidate the ESession (since if a packet was
+        dropped or delivered out of order, it will be impossible to
+        recover the contents, as ZLIB stream would be in an
+        inconsistent state).</p>
+
+        <p class="" style="">
+<p class="caption"></p>
+<div class="indent"><pre>assert(r_mac == m_mac)</pre></div>
+</p>
+      </li>
+      <li>Strip off &quot;n&quot; bytes of padding, determined by the last byte
+      in the decrypted data.
+        <p class="caption"></p>
+<div class="indent"><pre>n = last-byte-of(r_padded)</pre></div>
+        <p class="caption"></p>
+<div class="indent"><pre>r_compressed = left(r_padded, len(r_padded) - n)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Decompress r_padded via ZLIB</p>
+        <p class="" style="">
+<p class="caption"></p>
+<div class="indent"><pre>r = zlib-decompress(r_padded)</pre></div>
+</p>
+      </li>
+      <li>
+        <p class="" style="">Bob will now take r and feed it into an XML parser to
+        transform the raw bytes into a useable, parsed XML form.</p>
+      </li>
+    </ol>
+  <h2>7.
+       <a name="sect-id2603297">Public Key Algorithms</a>
+</h2>
+    <p class="" style="">ESession supports two public key algorithms initially:
+      <ul>
+        <li>esession-dss: a Digital Signature Standard [FIPS-186]
+          based signature and verification key</li>
+        <li>esession-rsa: a RSA (PKCS-1) bases signature and
+          verification key</li>
+      </ul>
+    </p>
+  <h2>8.
+       <a name="sect-id2603333">Security Considerations</a>
+</h2>
+    <p class="" style="">To follow.</p>
+  <h2>9.
+       <a name="sect-id2603352">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603470">14</a>]. </p>
+  <h2>10.
+       <a name="sect-id2603370">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>10.1 <a name="sect-id2603382">Namespaces</a>
+</h3>
+      <p class="" style="">Upon approval of this JEP, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603419">15</a>] shall register the following namespaces:</p>
+      <ul>
+        <li>'http://jabber.org/protocol/esession'</li>
+        <li>'http://jabber.org/protocol/esession#data'</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>10.2 <a name="sect-id2603444">Field Standardization</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall reserve the following fields within the scope of Data Forms used for ESession negotation:</p>
+      <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field 
+      var='cipher-algo'
+      type='list-single'
+      label='Cipher algorithm options'/&gt;
+  &lt;field 
+      var='key-algo'
+      type='list-single'
+      label='Public key algorithm options'/&gt;
+  &lt;field 
+      var='mac-algo'
+      type='list-single'
+      label='Message authentication code algorithm options'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+  <h2>11.
+       <a name="sect-id2603503">XML Schemas</a>
+</h2>
+    <p class="" style="">To follow.</p>
+  <h2>12.
+       <a name="sect-id2603529">Open Issues</a>
+</h2>
+    <ol start="" type="">
+      <li>Address encoding issues.</li>
+      <li>Specify how to handle namespaces.</li>
+      <li>Specify that clients should use multiple XML parser instances to guard against presence of non-well-formed XML (not checked by server).</li>
+      <li>Address offline message handling, if any.</li>
+      <li>Define session tear-down.</li>
+      <li>Discuss public key algorithms and formats in greater detail.</li>
+    </ol>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596077">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596184">2</a>. RFC 2412: The OAKLEY Key Determination Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2412.txt">http://www.ietf.org/rfc/rfc2412.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596209">3</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596238">4</a>. SSH Transport Layer Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-17.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-17.txt</a>&gt;. Work in progress.</p>
+<p>
+<a name="nt-id2596261">5</a>. SSH Protocol Architecture &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-15.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-15.txt</a>&gt;. Work in progress.</p>
+<p>
+<a name="nt-id2596296">6</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601776">7</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601796">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601819">9</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595752">10</a>. The SID must NEVER be transmitted between Alice and Bob;
+          they should both be able to derive the same value.</p>
+<p>
+<a name="nt-id2602709">11</a>. As noted in &quot;SSH Transport Layer Protocol&quot;, this process will lose entropy if the amount of
+    entropy in K is larger than the internal state size of
+    SHA-1.</p>
+<p>
+<a name="nt-id2603045">12</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602999">13</a>. This helps protect against attacks on the last
+                cipher block, since it will contain only random
+                data</p>
+<p>
+<a name="nt-id2603470">14</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603419">15</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial Version (diz)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.3.html
+++ b/content/xep-0116-0.3.html
@@ -1,0 +1,1169 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-08-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0116<br>
+            Version: 0.3<br>
+            Last Updated: 2005-08-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2409, RFC 2631, RFC 3526, JEP-0004, JEP-0020, JEP-0030, JEP-0068, JEP-0155<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>3.1.  <a href="#terms-personae">Dramatis Personae</a>
+</dt></dl>
+<dt>4.  <a href="#reqs">Requirements</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#reqs-sec">Security Requirements</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#reqs-encrypt">Encryption</a>
+</dt>
+<dt>4.1.2.  <a href="#reqs-forward">Perfect Forward Security</a>
+</dt>
+<dt>4.1.3.  <a href="#reqs-auth">Authentication</a>
+</dt>
+<dt>4.1.4.  <a href="#reqs-repudiate">Repudiability</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#reqs-xmpp">Application Requirements</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#reqs-generality">Generality</a>
+</dt>
+<dt>4.2.2.  <a href="#reqs-implement">Implementability</a>
+</dt>
+<dt>4.2.3.  <a href="#reqs-usable">Usability</a>
+</dt>
+<dt>4.2.4.  <a href="#reqs-usable">Interoperability</a>
+</dt>
+<dt>4.2.5.  <a href="#reqs-offline">Offline sessions</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>6.  <a href="#init">ESession Initiation</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#init-online">Online Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>6.1.1.  <a href="#init-request">Esession Request</a>
+</dt>
+<dt>6.1.2.  <a href="#init-prep">Diffie-Hellman Preparation (Bob)</a>
+</dt>
+<dt>6.1.3.  <a href="#init-response">Esession Response</a>
+</dt>
+<dt>6.1.4.  <a href="#init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</dt>
+<dt>6.1.5.  <a href="#init-complete">Diffie-Hellman Completion</a>
+</dt>
+</dl>
+<dt>6.2.  <a href="#init-offline">Offline Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>6.2.1.  <a href="#init-publish">Publishing Esession Options</a>
+</dt>
+<dt>6.2.2.  <a href="#init-start">Requesting Offline Esession Options</a>
+</dt>
+<dt>6.2.3.  <a href="#init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</dt>
+<dt>6.2.4.  <a href="#init-start">Starting an Offline Esession</a>
+</dt>
+<dt>6.2.5.  <a href="#init-start">Accepting an Offline Esession</a>
+</dt>
+</dl>
+<dt>6.3.  <a href="#init-keys">Generating Initial Session Keys</a>
+</dt>
+</dl>
+<dt>7.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dt>8.  <a href="#rekey">Re-Key Exchange</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#rekey-init">Re-Key Initiation</a>
+</dt>
+<dt>8.2.  <a href="#rekey-accept">Re-Key Acceptance</a>
+</dt>
+<dt>8.3.  <a href="#rekey-publish">Publishing Old Values of K-M</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#sec-prng">Verifying Keys</a>
+</dt>
+<dt>9.2.  <a href="#sec-rekey">Re-Keying Limits</a>
+</dt>
+<dt>9.3.  <a href="#sec-keys">Verifying Keys</a>
+</dt>
+<dt>9.4.  <a href="#sec-general">Extra Responsabilities of Implementors</a>
+</dt>
+<dt>9.5.  <a href="#sec-mandatory">Mandatory to Implement Technologies</a>
+</dt>
+<dl>
+<dt>9.5.1.  <a href="#sec-mandatory-encryption">Encryption Algorithms</a>
+</dt>
+<dt>9.5.2.  <a href="#sec-mandatory-sign">Key Signing Algorithms</a>
+</dt>
+<dt>9.5.3.  <a href="#sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</dt>
+<dt>9.5.4.  <a href="#sec-mandatory-hash">Hash Algorithms</a>
+</dt>
+<dt>9.5.5.  <a href="#sec-mandatory-compress">Compression Algorithms</a>
+</dt>
+</dl>
+</dl>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#registrar-ns">Namespaces</a>
+</dt>
+<dt>11.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>12.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>13.  <a href="#keys">Public Key Publication and Retrieval</a>
+</dt>
+<dt>14.  <a href="#open">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">End-to-end encryption is a desirable feature for any communication technology. Ideally, such a technology would design encryption in from the beginning and would forbid unencrypted communications. Realistically, most communication technologies have not been designed in that manner, and Jabber/XMPP technologies are no exception. In particular, the original Jabber technologies developed in 1999 did not include end-to-end encryption by default. PGP-based encryption of message bodies and signing of presence information was added as an extension to the core protocols in the year 2000; this extension is documented in <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2250515">1</a>]. When the core protocols were formalized within the Internet Standards Process by the IETF's XMPP Working Group in 2003, a different extension was defined using S/MIME-based signing and encryption of CPIM-formatted messages (see <span class="ref" style="">RFC 3862</span>  [<a href="#nt-id2250681">2</a>]) and PIDF-formatted presence information (see <span class="ref" style="">RFC 3863</span>  [<a href="#nt-id2250702">3</a>]); this extension is specified in <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2250725">4</a>].</p>
+  <p class="" style="">For reasons described more fully below, the foregoing proposals (and others not mentioned) have not been widely implemented and deployed. This is unfortunate, since an open communication protocol needs to enable end-to-end encryption in order to be seriously considered for deployment by a broad range of users. This proposal describes a different approach to end-to-end encryption for use by entities that communicate using XMPP. The approach taken herein essentially translates the semantics of the secure shell protocol (SSH) into the syntax of XMPP, with some adjustments that reflect reports of security issues with SHA-1 and insights gleaned from implementation of "off-the-record" (OTR) communication in the Gaim encryption plugin as described in <span class="ref" style="">Off-the-Record Communication</span>  [<a href="#nt-id2250769">5</a>]. The result is a protocol for encrypted sessions or "ESessions".</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">As specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250545">6</a>], XMPP is an XML streaming protocol that enables the near-real-time exchange of XML fragments between any two (or more) network endpoints. To date, the main application built on top of the core XML streaming layer is instant messaging (IM) and presence, the base extensions for which are specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250575">7</a>]. There are three first-level elements of XML streams (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;); each of these "XML stanza" types has different semantics, which can complicate the task of defining a generalized approach to end-to-end encryption for XMPP. In addition, XML stanzas can be extended (via properly-namespaced child elements) for a wide variety of functionality. The chosen approach should enable encryption of several complete XML elements rather than only parts thereof (e.g., only the XML character data of the message &lt;body/&gt; element as in <span style="font-weight: bold">JEP-0027</span>).</p>
+  <p class="" style="">XMPP is a session-oriented communication technology: normally, a client authenticates with a server and maintains a long-lived connection that defines the client's XMPP session. Such stream-level sessions are secured via channel encryption using Transport Level Security (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2250626">8</a>]), as specified in Section 5 of <span style="font-weight: bold">RFC 3920</span>. However, there is no guarantee that all hops will implement or enforce channel encryption (or that intermediate routers are trustworthy), which makes end-to-end encryption desirable.</p>
+  <p class="" style="">The session metaphor also applies to communication between endpoints: for instance, in IM applications, most instant messaging exchanges occur in bursts within limited time periods (e.g., two people may send a fairly large number of messages during a five-minute chat and then not exchange messages again for hours or even days). The XML stanzas exchanged during such a session may not be limited to &lt;message/&gt; stanzas; for instance, the session may be triggered by a change in one of the parties' presence status (e.g., changing from away to available) and the session may involve the exchange of &lt;iq/&gt; stanzas (e.g., to transfer a file as specified in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2255633">9</a>]). Endpoints may want to encrypt the stanzas they send to each other in such a way that the stanzas cannot be understood by untrusted mediating entities (such as servers) except to the extent required to understand the necessary routing information. (One complicating factor is that routing information may include not only the stanza's 'to', 'from', 'type, and 'id' attributes, but also <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255661">10</a>] and <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2255682">11</a>] data extensions.)</p>
+  <p class="" style="">The foregoing XMPP communications exist in the context of a one-to-one communication session between two entities. However, several forms of XMPP communication exist outside the context of one-to-one communication sessions:</p>
+  <ul>
+    <li>Many-to-many sessions, such as a text conference in a chatroom as specified in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255715">12</a>].</li>
+    <li>One-to-many "broadcast", such as undirected presence stanzas sent from one user to many contacts (see <span style="font-weight: bold">RFC 3921</span>) and data syndication implemented using <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2255744">13</a>].</li>
+    <li>One-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</li>
+  </ul>
+  <p class="" style="">Ideally, any technology for end-to-end encryption in XMPP could be extended to cover these scenarios as well as one-to-one communication sessions. However, for both many-to-many sessions and one-to-many broadcast are are deemed out of scope for this JEP. Offline communications are handled via a simple extension to the protocol for one-to-one sessions between two entities that are online simultaneously (see below).</p>
+  <p class="" style="">Because XMPP is a session-oriented communication technology, encryption schemes that are appropriate for less dynamic technologies may not be appropriate for XMPP, and XMPP may be able to take advantage of encryption approaches that are not feasible for less dynamic technologies. In particular, existing approaches to encryption of Internet communications have generally assumed that the "thing" to be encrypted has a stable identity or is best understood as a standalone object (e.g., a file or email message); the term "object encryption" well captures this assumption. Both <span style="font-weight: bold">JEP-0027</span> and <span style="font-weight: bold">RFC 3923</span> assume that XMPP communications are more like the exchange of email messages than they are like an interactive session -- while <span style="font-weight: bold">JEP-0027</span> uses "old-style" PGP object encryption and <span style="font-weight: bold">RFC 3923</span> uses "new-style" S/MIME object encryption, both specify the use of object encryption. </p>
+  <p class="" style="">However, the session-oriented nature of XMPP may imply that the focus should be on "session encryption" rather than "object encryption". The paradigm for XMPP encryption may be something closer to the widely-deployed Secure Shell technology (see <span class="ref" style="">SSH Protocol Architecture</span>  [<a href="#nt-id2255874">14</a>] and <span class="ref" style="">SSH Transport Layer Protocol</span>  [<a href="#nt-id2255845">15</a>]) than to traditional encryption of files and standalone email messages. In many ways, Secure Shell (or, more generally, opportunistic security) is the conceptual model for the current proposal.</p>
+  <p class="" style="">Therefore, this JEP specifies a method for encrypted sessions ("ESessions") that takes advantage of the inherent possibilities and strengths of session encryption as opposed to object encryption. The basic concept is that of an encrypted session which acts as a secure tunnel between two endpoints. Once the tunnel is established, all one-to-one XML stanzas exchanged between the endpoints will be encrypted and then transmitted within a "wrapper" protocol element.</p>
+<h2>3.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="terms-personae">Dramatis Personae</a>
+</h3>
+    <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+    <ol start="1" type="">
+      <li>"Alice" is the name of the initiator of the ESession. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+      <li>"Bob" is the name of the other participant in the ESession started by Alice. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    </ol>
+    <p class="" style="">While Alice and Bob are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an Esession.</p>
+  </div>
+<h2>4.
+       <a name="reqs">Requirements</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="reqs-sec">Security Requirements</a>
+</h3>
+    <p class="" style="">This JEP stipulates the following security requirements for end-to-end encryption of XMPP communications:</p>
+    <ul>
+      <li>Encryption</li>
+      <li>Perfect forward security</li>
+      <li>Authentication</li>
+      <li>Repudiability</li>
+    </ul>
+    <p class="" style="">Each of these requirements is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="reqs-encrypt">Encryption</a>
+</h3>
+      <p class="" style="">The one-to-one XML stanzas exchanged between two entities MUST NOT be understandable to any other entity that might intercept the communications.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="reqs-forward">Perfect Forward Security</a>
+</h3>
+      <p class="" style="">The encrypted communication MUST NOT be revealed even if a system compromise occurs in the future (e.g., Steve steals Bob's computer).</p>
+    </div>
+    <div class="indent">
+<h3>4.1.3 <a name="reqs-auth">Authentication</a>
+</h3>
+      <p class="" style="">Each party to a conversation MUST know that the other party is who he says he is (Alice must be able to know that Bob really is Bob, and vice versa).</p>
+    </div>
+    <div class="indent">
+<h3>4.1.4 <a name="reqs-repudiate">Repudiability</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be able to repudiate any stanza that occurs within an Esession. After an Esession has finished, it SHOULD NOT be possible to <span style="font-style: italic">prove cryptographically</span> that any transcript has not been modified by a third party.  [<a href="#nt-id2256200">16</a>]</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="reqs-xmpp">Application Requirements</a>
+</h3>
+    <p class="" style="">In addition to the foregoing security profile, this JEP also stipulates the following application-specific requirements for encrypted communication in the context of Jabber/XMPP technologies:</p>
+    <ol start="" type="">
+      <li>Generality</li>
+      <li>Implementability</li>
+      <li>Usability</li>
+      <li>Interoperability</li>
+      <li>Offline "sessions"</li>
+    </ol>
+    <p class="" style="">Each of these is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.2.1 <a name="reqs-generality">Generality</a>
+</h3>
+      <p class="" style="">The solution should be generally applicable to any XML stanza type (&lt;message/&gt;, &lt;presence/&gt;, &lt;iq/&gt;) sent between two entities. It is deemed acceptable for now if the solution does not apply to many-to-many stanzas (e.g., groupchat messages sent within the context of multi-user chat) or one-to-many stanzas (e.g., presence "broadcasts" and pubsub notifications); end-to-end encryption of such stanzas may require separate solutions or extensions to the one-to-one session solution.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="reqs-implement">Implementability</a>
+</h3>
+      <p class="" style="">The only good security technology is an implemented security technology. The solution should be one that typical client developers can implemented in a relatively straightforward and consistent fashion.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="reqs-usable">Usability</a>
+</h3>
+      <p class="" style="">The requirement of usability takes implementability one step further by stipulating that the solution must be one that organizations can deploy and humans can use with 100% transparency (like https:). Experience has shown that: solutions requiring a full public key infrastructure do not get widely deployed, and solutions requiring any user action are not widely used. We can do better.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.4 <a name="reqs-usable">Interoperability</a>
+</h3>
+      <p class="" style="">Ideally, it would be possible for an XMPP user to exchange encrypted messages (and, potentially, presence information) with users of non-XMPP messaging systems.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.5 <a name="reqs-offline">Offline sessions</a>
+</h3>
+      <p class="" style="">Ideally, it should be possible to encrypt one-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</p>
+    </div>
+  </div>
+<h2>5.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">Before attempting to engage in an ESession with Bob, Alice SHOULD discover whether he supports this protocol, using either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256401">17</a>] or the presence-based profile of <span style="font-weight: bold">JEP-0030</span> specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256424">18</a>].</p>
+  <p class="" style="">The normal course of events is for Alice to authenticate with her server, retrieve her roster (see <span style="font-weight: bold">RFC 3921</span>), send initial presence to her server, and then receive presence information from all the contacts in her roster. If the presence information she receives from some contacts does not include capabilities data (per <span style="font-weight: bold">JEP-0115</span>), Alice SHOULD then send a service discovery information ("disco#info") request to each of those contacts (in accordance with <span style="font-weight: bold">JEP-0030</span>). Such initial service discovery stanzas MUST NOT be considered part of encrypted communication sessions for the purposes of this JEP, since they perform a "bootstrapping" function that is a prerequisite to encrypted communications. The disco#info request sent from Alice to Bob might look as follows:</p>
+  <p class="caption">Example 1. Alice Queries Bob for Esession Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq from='alice@example.org/pda'
+    to='bob@example.com/laptop'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Bob sends a disco#info reply and he supports the protocol defined herein, then he MUST include a service discovery feature variable of "http://jabber.org/protocol/esession".</p>
+  <p class="caption">Example 2. Bob Returns disco#info Data</p>
+<div class="indent"><pre>
+&lt;iq from='bob@example.com/laptop'
+    from='alice@example.org/pda'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='client' type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/esession'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="init">ESession Initiation</a>
+</h2>
+  <p class="" style="">The process for establishing an ESession is essentially a translation into XMPP syntax of the SSH transport mechanism for establishing a secure session over an insecure transport (see <span style="font-weight: bold">SSH Transport Layer Protocol</span>). Specifically, as in SSH, ESession uses a Diffie-Hellman key exchange algorithm (see <span class="ref" style="">RFC 2631</span>  [<a href="#nt-id2256523">19</a>]) in the initial negotation (although, as we shall see, it does not use SHA-1 as the hashing algorithm).</p>
+  <p class="" style="">When Alice wishes to establish an ESession with Bob, Alice may choose between two different methods of performing the initial Diffie-Hellman key exchange, depending on whether Bob is online or not.</p>
+
+  <div class="indent">
+<h3>6.1 <a name="init-online">Online Diffie-Hellman Key Exchange</a>
+</h3>
+    <p class="" style="">If Alice believes Bob may be online then she SHOULD retrieve Bob's long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) and then use the protocol specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2256586">20</a>] to negotiate the initial Diffie-Hellman key. In this aggressive exchange the first two messages negotiate policy, swap Diffie-Hellman public values and the ancillary data necessary for the exchange and authentication. The second message also authenticates the responder. The third message authenticates the initiator and exchanges the final Diffie-Hellman public value.</p>
+    <div class="indent">
+<h3>6.1.1 <a name="init-request">Esession Request</a>
+</h3>
+      <p class="" style="">Alice MUST provide information about each of the Esession options (algorithms etc.) that she is willing to use, in her order of preference (see the <a href="#sec-mandatory">Mandatory to Implement Technologies</a> section of this document for further information):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">The list of Modular Exponential (MODP) group numbers (as specified in <span class="ref" style="">RFC 2409</span>  [<a href="#nt-id2256653">21</a>] or <span class="ref" style="">RFC 3526</span>  [<a href="#nt-id2256677">22</a>]) she is willing to use for Diffie-Hellman key exchange (valid group numbers include 1,2,3,4,5,14,15,16,17 and 18)</p></li>
+        <li><p class="" style="">Stanza symmetric encryption algorithm names</p></li>
+        <li><p class="" style="">Hash algorithm names</p></li>
+        <li><p class="" style="">Compression algorithm names</p></li>
+        <li><p class="" style="">The list of stanza types she is willing to encrypt and decrypt</p></li>
+        <li><p class="" style="">The minimum number of stanzas that MUST be exchanged before an entity MAY initiate a key re-exchange (1 - every stanza, 100 - every hundred stanzas). This value MUST be less than 2<span class="super" style="">32</span> (see <a href="#sec-rekey">Re-Keying Limits</a>)</p></li>
+        <li><p class="" style="">The Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256771">23</a>]) SHA-256 fingerprint (PKID) of each of Bob's public signature-verification keys that she found acceptable (see <a href="#sec-keys">Verifying Keys</a>)</p></li>
+      </ol>
+    <p class="caption">Example 3. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com'
+         id='es1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field var='modp' type='list-single'&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;1&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field var='encryption_algorithms' type='list-single'&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field var='hash_algorithms' type='list-single'&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field var='compression' type='list-single'&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;zlib&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field var='stanzas' type='list-multi'&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field var='max_rekey_freq' type='text-single'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='publickey_ids' type='list-multi'&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob does not support one or more of the options in each Esession field (except the 'publickey_ids' field), then he SHOULD return a &lt;feature-not-implemented/&gt; error (but he MAY return no error if, for example, he does not want to reveal his presence to Alice for whatever reason):</p>
+    <p class="caption">Example 4. Bob Informs Alice that Her Options Are Not Supported</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='bob@example.com/laptop'
+         to='alice@example.org/pda'
+         id='es1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Either Bob or Alice MAY attempt to initiate a new ESession after any error during the initiation process. However, both MUST consider the previous negotiation to have failed and MUST discard any information learned through the previous negotiation.</p>
+    </div>
+    <div class="indent">
+<h3>6.1.2 <a name="init-prep">Diffie-Hellman Preparation (Bob)</a>
+</h3>
+      <p class="" style="">If Bob is willing to start an ESession with Alice, he SHOULD retrieve Alice's long-term public signature-verification keys. He MUST select one of the options from each of the Esession fields he received from Alice including one of the MODP groups (see the Conclusion of <span class="ref" style="">RFC 3766</span>  [<a href="#nt-id2256878">24</a>] for recommendations regarding balancing the sizes of symmetric cipher blocks and Diffie-Hellman moduli). Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p).</p>
+      <p class="" style="">Bob MUST then perform the following computations (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n-1 random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d</p></li>
+        <li><p class="" style="">If Alice selected one or more of his public keys, and if Bob has access to a long-lived private signing key that corresponds to one of those keys (note that the keys may only be accessible to another of Bob's clients), calculate the signature of d using the selected private key</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.1.3 <a name="init-response">Esession Response</a>
+</h3>
+    <p class="" style="">Bob responds to Alice specifying the Esession options he selected. Note: The value of the 'max_rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Alice. Instead of providing the PKID of his public key that he selected, Bob MUST specify the Base64 encoded SHA-256 fingerprint (PKID) of each of Alice's public signature-verification keys that he finds acceptable (see <a href="#sec-keys">Verifying Keys</a>). Note: The submited values for the 'publickey_ids' field do not correspond to the options he received.</p>
+    <p class="" style="">Bob also includes C<span class="sub" style="">A</span>, the value of d and the signature of d (if it was possible to create one), all Base64 encoded.</p>
+    <p class="caption">Example 5. Bob Responds to Alice</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop'
+         to='alice@example.org/pda'
+         id='es1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field var='modp'&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='encryption_algorithms'&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='hash_algorithms'&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='compression'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='stanzas'&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='max_rekey_freq'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='publickey_ids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;key kid=' ** KID ** '&gt; ** base64 encoded value of d ** &lt;/key&gt;
+    &lt;sign pkid=' ** PKID ** '&gt; ** base64 encoded signature of d ** &lt;/sign&gt;
+    &lt;counter&gt; ** base64 encoded initial counter value ** &lt;/counter&gt;
+  &lt;/init&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Alice provided a PKID but Bob did not provide a signature then she MAY send a failure notice to Bob. If Bob provided an invalid signature then she MUST send a failure notice to Bob.</p>
+    <p class="caption">Example 6. Alice Signals that ESession Negotiation Failed (Unacceptable Signature)</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         id='es2'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-signature xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    </div>
+    <div class="indent">
+<h3>6.1.4 <a name="init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</h3>
+      <p class="" style="">After verifying Bob's signature, Alice can be certain that the value of d was actually generated by Bob. Alice MUST use the value of d and the Esession options specified in Bob's response to perform the following steps (where n is the number of bits per encryption block for the agreed encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value she received from Bob</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span></p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">If Bob selected one or more of her public keys, and if Alice has access to a long-lived private signing key that corresponds to one of those keys, calculate the signature of e using the selected private key</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (this is the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.1.5 <a name="init-complete">Diffie-Hellman Completion</a>
+</h3>
+    <p class="" style="">Alice then completes the Diffie-Hellman negotiation by sending Bob the value of e and the signature of e (if it was possible to create one), both Base64 encoded. Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza as the Diffie-Hellman completion.</p>
+    <p class="caption">Example 7. Alice Completes Diffie-Hellman Negotitation</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;key kid=' ** KID ** '&gt; ** base64 encoded value of e ** &lt;/key&gt;
+    &lt;sign pkid=' ** PKID ** '&gt; ** base64 encoded signature of e ** &lt;/sign&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob provided a PKID but Alice did not provide a valid signature, then he MUST ignore any encrypted content in the stanza and send a failure notice to Alice.</p>
+    <p class="" style="">If no error occurs, Bob MUST calculate K = e<span class="super" style="">y</span> mod p (the shared secret). Alice and Bob then have the same value for K and the key exchange is complete.</p>
+    </div>
+  </div>
+
+
+
+<div class="indent">
+<h3>6.2 <a name="init-offline">Offline Diffie-Hellman Key Exchange</a>
+</h3>
+
+  <p class="" style="">As described below, offline negotiation of an ESession is in essence a special case of the online negotiation flow.</p>
+
+    <div class="indent">
+<h3>6.2.1 <a name="init-publish">Publishing Esession Options</a>
+</h3>
+      <p class="" style="">Just before Bob goes offline he SHOULD:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Select a MODP group (that defines the constants p and g)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1, where n is the largest number of bits per encryption block for the encryption algorithms he is willing to use)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d</p></li>
+      </ol>
+      <p class="" style="">Bob SHOULD publish d and the KID along with information about each of the Esession options he is willing to use (see <a href="#init-request">Esession Request</a>) through his own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>) or a similar protocol (out of scope for this JEP). Note: The single specified MODP group MUST be the one he used to generate d. The list of stanza types he is willing to decrypt MUST NOT include the value 'iq'. It is also RECOMMENDED that he includes a list of his public signature-verification keys and the corresponding signatures of d.</p>
+      <p class="" style=""><span style="font-style: italic">Note: This publishing protocol is highly preliminary and depends on a separate proposal.</span></p>
+
+      <p class="caption">Example 8. Bob Publishes His Esession Options</p>
+<div class="indent"><pre>
+&lt;iq from='bob@example.com/laptop'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='modp'&gt;
+        &lt;value&gt;2&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='encryption_algorithms'&gt;
+        &lt;value&gt;aes256-ctr&lt;/value&gt;
+        &lt;value&gt;twofish256-ctr&lt;/value&gt;
+        &lt;value&gt;aes128-ctr&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='hash_algorithms'&gt;
+        &lt;value&gt;whirlpool&lt;/value&gt;
+        &lt;value&gt;sha256&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='compression'&gt;
+        &lt;value&gt;none&lt;/value&gt;
+        &lt;value&gt;zlib&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='stanzas'&gt;
+        &lt;value&gt;message&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='max_rekey_freq'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='publickey_ids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='sign'&gt;
+        &lt;value&gt; ** base64 encoded signature of d ** &lt;/value&gt;
+        &lt;value&gt; ** base64 encoded signature of d ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">Bob MUST store the secret value of y that he used to calculate d in a secure way so that he can retrieve it when he next comes online. Note: Bob should idealy be able to access the value of y even if he comes online with a different client on a different machine, otherwise he will not be able to decrypt the stanzas sent to him while he was offline.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.2 <a name="init-start">Requesting Offline Esession Options</a>
+</h3>
+      <p class="" style="">If Alice believes Bob is offline then she SHOULD request his Esession options and his long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) from his server.</p>
+      <p class="caption">Example 9. Alice asks Bob's Server for his Esession Options</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If, after receiving Bob's Esession options and public keys, Alice is unable to verify any of Bob's Esession signatures then she MAY decide to proceed no further, since she cannot be sure who will be able to decrypt her stanzas.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.3 <a name="init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</h3>
+      <p class="" style="">Alice MUST select one of the options from each of Bob's Esession fields. If she cannot support any of the options in a field (except the public key and signature fields) then she MUST not send encrypted stanzas to Bob while he is offline.</p>
+      <p class="" style="">Alice MUST use the value of d and the MODP group specified in Bob's Esession options to perform the following steps (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n-1 random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the counter for stanzas sent from Bob to Alice - in case Bob comes online before Alice terminates the Esession)</p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate signatures of e using each of her long-lived private signing keys</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the shared secret)</p></li>
+      </ol>
+
+    </div>
+    <div class="indent">
+<h3>6.2.4 <a name="init-start">Starting an Offline Esession</a>
+</h3>
+      <p class="" style="">Alice then sends Bob all the signatures of e, the value of e and C<span class="sub" style="">A</span> (all Base64 encoded). She also specifies which of his Esession options she selected. Note: The value of the 'max_rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Bob. Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza.</p>
+      <p class="caption">Example 10. Alice Establishes an ESession Without Negotiation</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;key kid=' ** KID ** '&gt; ** base64 encoded value of e ** &lt;/key&gt;
+    &lt;sign pkid=' ** PKID ** '&gt; ** base64 encoded signature of e ** &lt;/sign&gt;
+    &lt;sign pkid=' ** PKID ** '&gt; ** base64 encoded signature of e ** &lt;/sign&gt;
+    &lt;counter&gt; ** base64 encoded initial counter value ** &lt;/counter&gt;
+    &lt;x xmlns='jabber:x:data'&gt;
+      &lt;field var='modp'&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='encryption_algorithms'&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='hash_algorithms'&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='compression'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='max_rekey_freq'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='stanzas'&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+      <p class="" style="">Alice can assume that she and Bob have the same value for K and that the key exchange is complete.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.5 <a name="init-start">Accepting an Offline Esession</a>
+</h3>
+      <p class="" style="">When Bob comes online and receives the key exchange stanza from Alice then he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Request Alice's public keys and, if possible, confirm that one of her signatures matches her value of e (if he is unable to verify any of her signatures then he MAY decide to proceed no further, since he cannot be sure who started the Esession)</p></li>
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value he received from Alice</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (in case Alice has not yet terminated the Esession)</p></li>
+        <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="indent">
+<h3>6.3 <a name="init-keys">Generating Initial Session Keys</a>
+</h3>
+    <p class="" style="">Whichever method Alice used to perform the Diffie-Hellman key exchange (online or offline), once it is complete, then before Alice and Bob can start encrypting and decrypting stanzas they must both use the agreed hash algorithm ("HASH") to generate two sets of key data, one for each direction of the ESession.</p>
+    <p class="" style="">For stanzas that Alice will send to Bob, the keys are calculated as:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">A</span> = HASH(K, "A")</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">A</span> = HASH(K-E<span class="sub" style="">A</span>, "C")  [<a href="#nt-id2258073">25</a>]</p></li>
+    </ol>
+    <p class="" style="">For stanzas that Bob will send to Alice the keys are calculated as:</p>
+    <ol start="4" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">B</span> = HASH(K, "B")</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">B</span> = HASH(K-E<span class="sub" style="">B</span>, "D")</p></li>
+    </ol>
+    <p class="" style="">Once the two sets of key data have been calculated the value of K MUST be securely destroyed.</p>
+    <p class="" style="">As many bytes of key data as are needed MUST be taken from the beginning of the hash output. When negotiating a hash, entities MUST ensure that the hash output is no shorter than the required key data. For algorithms with variable-length keys the maximum length (up to the hash output length) SHOULD be used.</p>
+
+    <p class="" style="">With these keys computed and the algorithms agreed upon, ESession initiation is now complete. From this point forward, Alice and Bob MUST exchange only encrypted forms of the one-to-one stanza types they agreed upon (e.g., &lt;message/&gt; and &lt;iq/&gt; stanzas).</p>
+  </div>
+<h2>7.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+
+  <p class="" style="">Once an Esession has been established, whenever Alice wants to send Bob an encrypted stanza she MUST only encrypt the XML content that would normally be ignored by the intermediate servers.</p>
+
+  <p class="caption">Example 11. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop' type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Store'&gt;false&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+
+  <p class="caption">Example 12. XML Content to be encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+</pre></div>
+
+    <p class="" style="">Alice MUST perform the following steps to encrypt the XML content.</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Serialize the XML content she wishes to send into an array of UTF-8 bytes, m.  [<a href="#nt-id2258282">26</a>]</p></li>
+      <li>
+        <p class="" style="">If compression was agreed upon, compress m using the negotiated algorithm. Typically, the compression context will be initialized after key exchange and is passed from one stanza to the next, with only a partial flush being performed at the end of the stanza. Note this means if Bob receives a stanza out-of-order, then he will fail to decrypt the stanza and be forced to terminate the Esession.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = compress(m)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Encrypt the data with the agreed algorithm in counter mode, using the encryption key K-E<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented for each encrypted block, and if C<span class="sub" style="">A</span>=2<span class="super" style="">n</span>-1 (where n is the number of bits per encryption block for the agreed encryption algorithm) then C<span class="sub" style="">A</span> MUST be "incremented" to 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_final = encrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">The encrypted data and the value of Alice's encryption block counter C<span class="sub" style="">A</span> <span style="font-style: italic">before</span> the data was encrypted, are now processed through the HMAC algorithm (as defined in Section 2 of <span class="ref" style="">RFC 2104</span>  [<a href="#nt-id2258436">27</a>]), along with the agreed hash algorithm ("HASH") and the integrity key K-M<span class="sub" style="">A</span>.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>a_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_final, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+    </ol>
+    <p class="" style="">Note: C<span class="sub" style="">A</span> and C<span class="sub" style="">B</span> prevent replay attacks by ensuring that the Message Authentication Code (MAC) for a given stanza never repeats, even if the content of the stanza is identical.</p>
+
+    <p class="" style="">Alice MUST now create an &lt;encrypted/&gt; XML element using a_mac, m_final and Bob's KID (the one that corresponds to the value of d used to encrypt the data). She MUST insert the element into the stanza in place of the original content and send it to Bob. There MUST NOT be more than one &lt;encrypted/&gt; element per stanza.</p>
+
+    <p class="caption">Example 13. Stanza with Encrypted Content</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule condition='match-resource' value='exact' action='error'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Store'&gt;false&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    <p class="" style="">When Bob receives the stanza from Alice, he extracts the values of m_final and a_mac from the content and performs the following steps. Note: Alice may not have received Bob's last re-key (see <a href="#rekey">Re-Keying</a>) before sending the stanza. So Bob MUST ensure he uses the values of K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> that correspond to his KID that Alice sent him in this stanza (and the current value of e that Alice sent him previously).</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Calculate the MAC for the encrypted data.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>b_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_final, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Verify that b_mac and a_mac match. If they are not identical, the encrypted content has been tampered with and Bob MUST terminate the ESession by sending an error to Alice. Note: If Bob receives a stanza out-of-order, then the MACs will not match because the values of C<span class="sub" style="">A</span> are not synchronized.</p>
+      </li>
+      <li>
+        <p class="" style="">Decrypt m_final using the agreed algorithm, K-E<span class="sub" style="">A</span> and C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented for each decrypted block, and if C<span class="sub" style="">A</span>=2<span class="super" style="">n</span>-1 (where n is the number of bits per encryption block for the agreed encryption algorithm) then C<span class="sub" style="">A</span> MUST be "incremented" to 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = decrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_final)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">If compression was agreed upon, decompress m_compressed using the negotiated algorithm.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m = decompress(m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Replace the &lt;encrypted/&gt; element in the serialized XML stanza with m and feed the stanza into an XML parser. If the parser returns an XML format error then Bob MUST terminate the ESession by sending an error to Alice.</p>
+      </li>
+    </ol>
+  <h2>8.
+       <a name="rekey">Re-Key Exchange</a>
+</h2>
+<p class="" style="">Once an attacker has discovered an encryption key it could be used to decrypt all stanzas within a session, including stanzas that were intercepted <span style="font-style: italic">before</span> the key was discovered. To reduce the window of vulnerability, both Alice and Bob SHOULD change their values of x and y and re-exchange the encryption key as regularly as possible. They MUST also destroy all copies of keys as soon as they are no longer needed.</p>
+<p class="" style="">Note: Although most entities are capable of re-keying after each stanza, clients running in constrained runtime environments may require a few seconds to re-key. During Esession initiation these clients MAY negotiate the minimum number of stanzas to be exchanged between re-keys at the cost of a larger window of vulnerability. Entities MUST NOT initiate key re-exchanges more frequently than the agreed limit.</p>
+
+  <div class="indent">
+<h3>8.1 <a name="rekey-init">Re-Key Initiation</a>
+</h3>
+    <p class="" style="">Either Alice or Bob MAY initiate a key re-exchange. Here we describe the process initiated by Alice. First she MUST calculate new values for the encryption parameters:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1, where n is the number of bits per encryption block for the agreed encryption algorithm)</p></li>
+      <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+      <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the new shared secret)</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Initial Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">To avoid extra stanzas, the new value of e SHOULD be sent to Bob along with an encrypted stanza. Note: Alice MUST NOT use the new K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> to encrypt this stanza or to calculate the MAC. However, she MUST use them when sending subsequent stanzas.</p>
+    <p class="" style="">There is no need for Alice to provide a signature for e because the calculation of the MAC MUST include the new value of e (a_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_final, C<span class="sub" style="">A</span>, e), see <a href="#exchange">Exchanging Stanzas</a>).</p>
+    <p class="caption">Example 14. Alice Sends Re-Key Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** base64 encoded m_final ** &lt;/data&gt;
+    &lt;key kid=' ** KID ** '&gt; ** base64 encoded value of new e ** &lt;/key&gt;
+    &lt;mac&gt; ** base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Bob may not receive the new key before he sends his next stanzas (they may cross in transit). So, before destroying her old values of K-E<span class="sub" style="">B</span> and K-M<span class="sub" style="">B</span>, Alice MUST wait until either she receives a stanza encrypted with the new key, or a reasonable time has passed (60 seconds should cover a network round-trip and calculations by a constrained client). Similarly she MUST wait before destroying her old value of x, in case Bob sends two stanzas before receiving Alice's new key (the first stanza might include a re-key).</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="rekey-accept">Re-Key Acceptance</a>
+</h3>
+    <p class="" style="">After Bob receives a stanza with a new value of e and he has decrypted the stanza with the old value of K-E<span class="sub" style="">A</span>, he MUST securely destroy all copies of K-E<span class="sub" style="">A</span> and K-E<span class="sub" style="">B</span> and perform the following calculations with the new value of e:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Initial Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">He MUST use these new values to encrypt and decrypt all subsequent stanzas.</p>
+    <p class="" style="">Note: If an entity fails to receive any stanza that includes a new key in the correct order, then it will fail to decrypt the next stanza it receives and be forced to terminate the Esession.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="rekey-publish">Publishing Old Values of K-M</a>
+</h3>
+    <p class="" style="">Either entity MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> as part of any encrypted stanza as long as it knows that all the stanzas that MAY use the old values have been received and validated. It MUST wait until it has received either a re-key or a stanza encrypted with a newer key from the other entity.</p>
+    <p class="" style="">Once the expired MAC keys have been published, anyone could create valid arbitrary stanzas with them. This prevents anyone being able to prove the authenticity of a transcript of the Esession in the future.</p>
+    <p class="caption">Example 15. Publishing Expired MAC Keys</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** base64 encoded a_mac ** &lt;/mac&gt;
+    &lt;old&gt; ** base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;old&gt; ** base64 encoded old MAC key ** &lt;/old&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Entities MUST ignore any &lt;old/&gt; elements they receive.</p>
+  </div>
+  <h2>9.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="sec-prng">Verifying Keys</a>
+</h3>
+    <p class="" style="">Weak pseudo-random number generators (PRNG) enable successful attacks. Implementors MUST use a cryptographically strong PRNG to generate all random numbers (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2259334">28</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="sec-rekey">Re-Keying Limits</a>
+</h3>
+    <p class="" style="">After a key exchange an entity MUST NOT exchange a total of 2<span class="super" style="">32</span> encrypted blocks before it initiates a key re-exchange (see <span class="ref" style="">SSH Transport Layer Encryption Modes</span>  [<a href="#nt-id2259384">29</a>]).</p>
+    <p class="" style="">Note: This policy also ensures the same key and counter values are never used to encrypt two different blocks using counter mode. This is necessary to prevent simple attacks.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="sec-keys">Verifying Keys</a>
+</h3>
+    <p class="" style="">The trust system outlined herein is based on Alice trusting that the public key presented by Bob is <span style="font-style: italic">actually</span> Bob's key. Determining this trust may be done in a variety of ways depending on the entities' support for different public key (certificate) formats, signing algorithms and signing authorities. For instance, if Bob publishes a PGP/GPG public key, Alice MAY verify that his key is signed by another key that she knows to be good. Or, if Bob provides an X.509 certificate, she MAY check that his key has been signed by a Certificate Authority that she trusts.</p>
+    <p class="" style="">When trust cannot be achieved automatically, methods that are not transparent to the users may be employed. For example, Bob could communicate the SHA-256 fingerprint of his public key to Alice via secure out-of-band communication (e.g. face-to-face). This would enable Alice to confirm that the public key she receives in-band is valid. Note however that very few people bother to verify fingerprints in this way. So this method is exceptionally vulnerable to 'man-in-the-middle' attacks. In order to reduce the window of vulnerability, an entity SHOULD remember the fingerprints of all user-validated public keys and alert the user in the future if ever the fingerprint(s) it stored for an entity do not match any of the received public keys.</p>
+    <p class="" style="">Alternatively Alice and Bob could agree a shared secret via secure out-of-band communication, Bob could then use it to create an HMAC of his public key that only Alice could verify.</p>
+    <p class="" style="">Note: If no keys are acceptable to Alice (because Alice has never verified any of the keys, and because either the keys are not signed, or Alice does not support the signature algorithms of the keys, or she cannot parse the certificate formats, or she does not recognise the authorities that signed the keys) then, although the Esession can still be encrypted, she cannot be sure she is communicating with Bob.</p>
+  </div>
+  <div class="indent">
+<h3>9.4 <a name="sec-general">Extra Responsabilities of Implementors</a>
+</h3>
+    <p class="" style="">Cryptography plays only a small part in an entity's security. Even if it implements this protocol perfectly it may still be vulnerable to other attacks. For example, an implementation might save private keys to a file in cleartext! Implementors MUST take very great care when developing applications with secure technologies.</p>
+  </div>
+  <div class="indent">
+<h3>9.5 <a name="sec-mandatory">Mandatory to Implement Technologies</a>
+</h3>
+    <p class="" style="">Note: The security parameter names mentioned below are related to secure shell; see <span style="font-weight: bold">SSH Transport Layer Encryption Modes</span> for encryption algorithm details; see the <span class="ref" style="">IANA Secure Shell Protocol Parameters</span>  [<a href="#nt-id2259544">30</a>] for other names.</p>
+    <div class="indent">
+<h3>9.5.1 <a name="sec-mandatory-encryption">Encryption Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following encryption algorithm:</p>
+      <ul>
+        <li>aes128-ctr (see <span class="ref" style="">Advanced Encryption Standard</span>  [<a href="#nt-id2259592">31</a>])</li>
+      </ul>
+      <p class="" style="">The block length of an encryption algorithm's cipher SHOULD be at least 128 bits. Other compliant algorithm names include:</p>
+      <ul>
+        <li>aes256-ctr</li>
+        <li>aes192-ctr</li>
+        <li>twofish256-ctr (see <span class="ref" style="">Twofish</span>  [<a href="#nt-id2259636">32</a>])</li>
+        <li>twofish192-ctr</li>
+        <li>twofish128-ctr</li>
+        <li>serpent256-ctr (see <span class="ref" style="">Serpent</span>  [<a href="#nt-id2259670">33</a>])</li>
+        <li>serpent192-ctr</li>
+        <li>serpent128-ctr</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>9.5.2 <a name="sec-mandatory-sign">Key Signing Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following signing algorithms:</p>
+      <ul>
+        <li>rsa (see <span class="ref" style="">RFC 2437</span>  [<a href="#nt-id2259721">34</a>])</li>
+        <li>dss (see <span class="ref" style="">Digital Signature Standard</span>  [<a href="#nt-id2259744">35</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>9.5.3 <a name="sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following public key formats:</p>
+      <ul>
+        <li>ssh-rsa</li>
+        <li>ssh-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following public key formats:</p>
+      <ul>
+        <li>x509v3-sign-rsa (see <span class="ref" style="">X.509 Authentication in SSH2</span>  [<a href="#nt-id2259808">36</a>])</li>
+        <li>x509v3-sign-dss</li>
+        <li>pgp-sign-rsa</li>
+        <li>pgp-sign-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession MAY also support the following public key formats:</p>
+      <ul>
+        <li>spki-sign-rsa</li>
+        <li>spki-sign-dss</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>9.5.4 <a name="sec-mandatory-hash">Hash Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following hash algorithms (sha1 and md5 are NOT RECOMMENDED):</p>
+      <ul>
+        <li>sha256 (see <span class="ref" style="">Secure Hash Standard</span>  [<a href="#nt-id2259887">37</a>])</li>
+        <li>whirlpool (see <span class="ref" style="">Whirlpool</span>  [<a href="#nt-id2259916">38</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>9.5.5 <a name="sec-mandatory-compress">Compression Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following compression algorithm:</p>
+      <ul>
+        <li>none (no compression)</li>
+      </ul>
+      <p class="" style="">It is RECOMMENDED that an implementation of ESession also support the following compression algorithm:</p>
+      <ul>
+        <li>zlib (see <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2259971">39</a>])</li>
+      </ul>
+    </div>
+  </div>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260012">40</a>]. </p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260060">41</a>] shall register the following namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/esession</li>
+      <li>http://jabber.org/protocol/esession#init</li>
+      <li>http://jabber.org/protocol/esession#error</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall reserve the following fields within the scope of Data Forms used for ESession negotation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field
+      var='modp'
+      type='list-single'
+      label='MODP group number'/&gt;
+  &lt;field
+      var='encryption_algorithms'
+      type='list-single'
+      label='Symmetric block cipher options'/&gt;
+  &lt;field
+      var='hash_algorithms'
+      type='list-single'
+      label='Hash algorithm options'/&gt;
+  &lt;field
+      var='compression'
+      type='list-single'
+      label='Compression algorithm options'/&gt;
+  &lt;field
+      var='stanzas'
+      type='list-multi'
+      label='Stanzas types to encrypt'/&gt;
+  &lt;field
+      var='max_rekey_freq'
+      type='text-single'
+      label='Minimum number of stanzas between key exchanges'/&gt;
+  &lt;field
+      var='publickey_ids'
+      type='list-multi'
+      label='Public key IDs'/&gt;
+  &lt;field
+      var='kid'
+      type='text-single'
+      label='Diffie-Hellman key ID'/&gt;
+  &lt;field
+      var='key'
+      type='text-single'
+      label='Diffie-Hellman key'/&gt;
+  &lt;field
+      var='sign'
+      type='list-multi'
+      label='Diffie-Hellman key signatures'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>13.
+       <a name="keys">Public Key Publication and Retrieval</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is highly preliminary and will probably be specified in a separate proposal.</span></p>
+  <p class="" style="">Entities SHOULD publish their long-term public signature-verification keys through their own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>).</p>
+
+  <p class="caption">Example 16. Entity Publishes Public Keys to Server</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='alice@example.org/pda'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="" style="">Before initiating an ESession, if Bob does not already possess one of Alice's signature-verification keys, he SHOULD retrieve them from Alice's server.</p>
+  <p class="caption">Example 17. Bob Requests Public Keys from Alice's Server</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="caption">Example 18. Server Returns Public Keys</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='alice@example.org'
+    to='bob@example.com/laptop'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Bob should examine all the public keys and identify which ones are acceptable (see <a href="#sec-keys">Verifying Keys</a>).</p>
+<h2>14.
+       <a name="open">Open Issues</a>
+</h2>
+  <ol start="" type="">
+    <li>Specify that entities should use multiple XML parser instances to guard against presence of non-well-formed XML (not checked by server).</li>
+    <li>Define session tear-down (entities SHOULD do this automatically after some period of inactivity).</li>
+    <li>Give examples of specific errors and discuss error scenarios (e.g. What should Bob do if he is not offline and he receives an offline key exchange stanza?) throughout document.</li>
+    <li>Discuss signature formats in greater detail.</li>
+    <li>Discuss in-order processing.</li>
+    <li>Discuss the risk of Bob divulging his presence status if anyone can monitor changes to his offline DH key. (Can access be limited to people who are subscribing to his presence?)</li>
+    <li>Specify that stanzas should be cached (for a few seconds) and resent in any new session that is established as a result of an error in the old session?</li>
+    <li>Examine potential use of a SID in key calculations (see SSH/OTR).</li>
+    <li>Separate public key publishing into a disco item for each key?</li>
+    <li>Should entities signs the whole init element (instead of just the value of d or e (see OTR)?</li>
+    <li>Should entities HMAC the whole encrypted element - the KID as well as the encrpted data etc (see OTR)?</li>
+    <li>Could the protocol approximate SSH or IPsec even more closely without losing the benefits of OTR?</li>
+  </ol>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250515">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2250681">2</a>. RFC 3862: Common Presence and Instant Messaging (CPIM): Message Format &lt;<a href="http://www.ietf.org/rfc/rfc3862.txt">http://www.ietf.org/rfc/rfc3862.txt</a>&gt;.</p>
+<p><a name="nt-id2250702">3</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p><a name="nt-id2250725">4</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2250769">5</a>. Off-the-Record Communication, or, Why Not to Use PGP &lt;<a href="http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf">http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf</a>&gt;.</p>
+<p><a name="nt-id2250545">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250575">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250626">8</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2255633">9</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2255661">10</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255682">11</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2255715">12</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255744">13</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2255874">14</a>. SSH Protocol Architecture &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2255845">15</a>. SSH Transport Layer Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256200">16</a>. Naturally, it is possible that Alice or Bob may retain cleartext versions of the exchanged communications; however, that threat is out of scope for this JEP.</p>
+<p><a name="nt-id2256401">17</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256424">18</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256523">19</a>. RFC 2631: Diffie-Hellman Key Agreement Method &lt;<a href="http://www.ietf.org/rfc/rfc2631.txt">http://www.ietf.org/rfc/rfc2631.txt</a>&gt;.</p>
+<p><a name="nt-id2256586">20</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2256653">21</a>. RFC 2409: The Internet Key Exchange (IKE) &lt;<a href="http://www.ietf.org/rfc/rfc2409.txt">http://www.ietf.org/rfc/rfc2409.txt</a>&gt;.</p>
+<p><a name="nt-id2256677">22</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p><a name="nt-id2256771">23</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256878">24</a>. RFC 3766: Determining Strengths For Public Keys Used For Exchanging Symmetric Keys &lt;<a href="http://www.ietf.org/rfc/rfc3766.txt">http://www.ietf.org/rfc/rfc3766.txt</a>&gt;.</p>
+<p><a name="nt-id2258073">25</a>. K-M<span class="sub" style="">A</span> is a hash of K-E<span class="sub" style="">A</span> (not K) to ensure that if an attacker recovers the decryption key she will not be able to cryptographically convince anyone that it was not her who created the stanza.</p>
+<p><a name="nt-id2258282">26</a>. Although counter mode encryption requires no padding, implementations MAY still disguise the length of m by appending a random number of white-space characters.</p>
+<p><a name="nt-id2258436">27</a>. RFC 2104: HMAC: Keyed-Hashing for Message Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2104.txt">http://www.ietf.org/rfc/rfc2104.txt</a>&gt;.</p>
+<p><a name="nt-id2259334">28</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2259384">29</a>. SSH Transport Layer Encryption Modes &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2259544">30</a>. IANA registry of parameters related to secure shell &lt;<a href="http://www.iana.org/assignments/ssh-parameters">http://www.iana.org/assignments/ssh-parameters</a>&gt;.</p>
+<p><a name="nt-id2259592">31</a>. Advanced Encryption Standard: Federal Information Processing Standards Publication 197 &lt;<a href="http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf">http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf</a>&gt;.</p>
+<p><a name="nt-id2259636">32</a>. The Twofish Block Cipher &lt;<a href="http://www.schneier.com/twofish.html">http://www.schneier.com/twofish.html</a>&gt;.</p>
+<p><a name="nt-id2259670">33</a>. The Serpent Block Cipher &lt;<a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">http://www.cl.cam.ac.uk/~rja14/serpent.html</a>&gt;.</p>
+<p><a name="nt-id2259721">34</a>. RFC 2437: PKCS #1: RSA Cryptography Specifications Version 2.0 &lt;<a href="http://www.ietf.org/rfc/rfc2437.txt">http://www.ietf.org/rfc/rfc2437.txt</a>&gt;.</p>
+<p><a name="nt-id2259744">35</a>. Digital Signature Standard: Federal Information Processing Standards Publication 186  &lt;<a href="http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf">http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf</a>&gt;.</p>
+<p><a name="nt-id2259808">36</a>. X.509 Authentication in SSH2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2259887">37</a>. Secure Hash Standard: Federal Information Processing Standards Publication 180-2  &lt;<a href="http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf">http://csrc.nist.gov/publications/fips/fips180-2/fips186-2withchangenotice.pdf</a>&gt;.</p>
+<p><a name="nt-id2259916">38</a>. The Whirlpool Hash Function &lt;<a href="http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html">http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html</a>&gt;.</p>
+<p><a name="nt-id2259971">39</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2260012">40</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260060">41</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-08-02)</h4>
+<div class="indent">Changed status from Retracted to Experimental; complete rewrite; new Introduction, Background, Requirements and Security Considerations; new OTR-inspired protocol; JEP-0155-based negotiation; counter mode encryption; more secure hashes; offline sessions; re-keying; mac publishing; preliminary key and options publishing protocol. (ip/psa)
+    </div>
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.4.html
+++ b/content/xep-0116-0.4.html
@@ -1,0 +1,1419 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0116<br>
+            Version: 0.4<br>
+            Last Updated: 2004-08-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2409, RFC 2631, RFC 3526, JEP-0004, JEP-0020, JEP-0030, JEP-0068, JEP-0155<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>3.1.  <a href="#terms-personae">Dramatis Personae</a>
+</dt></dl>
+<dt>4.  <a href="#reqs">Requirements</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#reqs-sec">Security Requirements</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#reqs-encrypt">Confidentiality</a>
+</dt>
+<dt>4.1.2.  <a href="#reqs-integrity">Integrity</a>
+</dt>
+<dt>4.1.3.  <a href="#reqs-replay">Replay Protection</a>
+</dt>
+<dt>4.1.4.  <a href="#reqs-forward">Perfect Forward Secrecy</a>
+</dt>
+<dt>4.1.5.  <a href="#reqs-auth">Authentication</a>
+</dt>
+<dt>4.1.6.  <a href="#reqs-repudiate">Repudiability</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#reqs-xmpp">Application Requirements</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#reqs-generality">Generality</a>
+</dt>
+<dt>4.2.2.  <a href="#reqs-implement">Implementability</a>
+</dt>
+<dt>4.2.3.  <a href="#reqs-usable">Usability</a>
+</dt>
+<dt>4.2.4.  <a href="#reqs-usable">Interoperability</a>
+</dt>
+<dt>4.2.5.  <a href="#reqs-offline">Offline Sessions</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>6.  <a href="#init">ESession Initiation</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#init-online">Online Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>6.1.1.  <a href="#init-request">Esession Request</a>
+</dt>
+<dt>6.1.2.  <a href="#init-prep">Diffie-Hellman Preparation (Bob)</a>
+</dt>
+<dt>6.1.3.  <a href="#init-response">Esession Response</a>
+</dt>
+<dt>6.1.4.  <a href="#init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</dt>
+<dt>6.1.5.  <a href="#init-complete">Diffie-Hellman Completion</a>
+</dt>
+</dl>
+<dt>6.2.  <a href="#init-offline">Offline Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>6.2.1.  <a href="#init-publish">Publishing Esession Options</a>
+</dt>
+<dt>6.2.2.  <a href="#init-offreq">Requesting Offline Esession Options</a>
+</dt>
+<dt>6.2.3.  <a href="#init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</dt>
+<dt>6.2.4.  <a href="#init-start">Starting an Offline Esession</a>
+</dt>
+<dt>6.2.5.  <a href="#init-accept">Accepting Offline Esessions</a>
+</dt>
+</dl>
+<dt>6.3.  <a href="#init-keys">Generating Session Keys</a>
+</dt>
+</dl>
+<dt>7.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#exchange-separate">Encryptable Content</a>
+</dt>
+<dt>7.2.  <a href="#exchange-encrypt">Encryption</a>
+</dt>
+<dt>7.3.  <a href="#exchange-send">Sending an Encrypted Stanza</a>
+</dt>
+<dt>7.4.  <a href="#exchange-decrypt">Decryption</a>
+</dt>
+</dl>
+<dt>8.  <a href="#rekey">Re-Key Exchange</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#rekey-init">Re-Key Initiation</a>
+</dt>
+<dt>8.2.  <a href="#rekey-accept">Re-Key Acceptance</a>
+</dt>
+<dt>8.3.  <a href="#rekey-publish">Publishing Old MAC Values</a>
+</dt>
+</dl>
+<dt>9.  <a href="#terminate">Esession Termination</a>
+</dt>
+<dt>10.  <a href="#sign">Signature Generation</a>
+</dt>
+<dl><dt>10.1.  <a href="#sign-canon">Canonical Form (Informative)</a>
+</dt></dl>
+<dt>11.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#sec-prng">Random Numbers</a>
+</dt>
+<dt>11.2.  <a href="#sec-rekey">Re-Keying Limits</a>
+</dt>
+<dt>11.3.  <a href="#sec-keys">Verifying Keys</a>
+</dt>
+<dt>11.4.  <a href="#sec-replay">Replay Attacks</a>
+</dt>
+<dt>11.5.  <a href="#sec-unencrypted">Unencrypted Esessions</a>
+</dt>
+<dt>11.6.  <a href="#sec-storage">Storage</a>
+</dt>
+<dt>11.7.  <a href="#sec-general">Extra Responsabilities of Implementors</a>
+</dt>
+<dt>11.8.  <a href="#sec-mandatory">Mandatory to Implement Technologies</a>
+</dt>
+<dl>
+<dt>11.8.1.  <a href="#sec-mandatory-encryption">Encryption Algorithms</a>
+</dt>
+<dt>11.8.2.  <a href="#sec-mandatory-sign">Key Signing Algorithms</a>
+</dt>
+<dt>11.8.3.  <a href="#sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</dt>
+<dt>11.8.4.  <a href="#sec-mandatory-hash">Hash Algorithms</a>
+</dt>
+<dt>11.8.5.  <a href="#sec-mandatory-compress">Compression Algorithms</a>
+</dt>
+</dl>
+</dl>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#registrar-ns">Namespaces</a>
+</dt>
+<dt>13.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>14.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>15.  <a href="#keys">Public Key Publication and Retrieval</a>
+</dt>
+<dt>16.  <a href="#open">Open Issues</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#open-tothink">To Think About</a>
+</dt>
+<dt>16.2.  <a href="#open-todo">To Do</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">End-to-end encryption is a desirable feature for any communication technology. Ideally, such a technology would design encryption in from the beginning and would forbid unencrypted communications. Realistically, most communication technologies have not been designed in that manner, and Jabber/XMPP technologies are no exception. In particular, the original Jabber technologies developed in 1999 did not include end-to-end encryption by default. PGP-based encryption of message bodies and signing of presence information was added as an extension to the core protocols in the year 2000; this extension is documented in <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2250540">1</a>]. When the core protocols were formalized within the Internet Standards Process by the IETF's XMPP Working Group in 2003, a different extension was defined using S/MIME-based signing and encryption of CPIM-formatted messages (see <span class="ref" style="">RFC 3862</span>  [<a href="#nt-id2250707">2</a>]) and PIDF-formatted presence information (see <span class="ref" style="">RFC 3863</span>  [<a href="#nt-id2250728">3</a>]); this extension is specified in <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2250750">4</a>].</p>
+  <p class="" style="">For reasons described more fully below, the foregoing proposals (and others not mentioned) have not been widely implemented and deployed. This is unfortunate, since an open communication protocol needs to enable end-to-end encryption in order to be seriously considered for deployment by a broad range of users. This proposal describes a different approach to end-to-end encryption for use by entities that communicate using XMPP. The approach taken herein essentially translates the semantics of the secure shell protocol (SSH) into the syntax of XMPP, with some adjustments that reflect reports of security issues with SHA-1 and insights gleaned from implementation of "off-the-record" (OTR) communication in the Gaim encryption plugin as described in <span class="ref" style="">Off-the-Record Communication</span>  [<a href="#nt-id2250564">5</a>]. The result is a protocol for encrypted sessions or "ESessions".</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">As specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250599">6</a>], XMPP is an XML streaming protocol that enables the near-real-time exchange of XML fragments between any two (or more) network endpoints. To date, the main application built on top of the core XML streaming layer is instant messaging (IM) and presence, the base extensions for which are specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250626">7</a>]. There are three first-level elements of XML streams (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;); each of these "XML stanza" types has different semantics, which can complicate the task of defining a generalized approach to end-to-end encryption for XMPP. In addition, XML stanzas can be extended (via properly-namespaced child elements) for a wide variety of functionality. The chosen approach should enable encryption of several complete XML elements rather than only parts thereof (e.g., only the XML character data of the message &lt;body/&gt; element as in <span style="font-weight: bold">JEP-0027</span>).</p>
+  <p class="" style="">XMPP is a session-oriented communication technology: normally, a client authenticates with a server and maintains a long-lived connection that defines the client's XMPP session. Such stream-level sessions are secured via channel encryption using Transport Level Security (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2250679">8</a>]), as specified in Section 5 of <span style="font-weight: bold">RFC 3920</span>. However, there is no guarantee that all hops will implement or enforce channel encryption (or that intermediate routers are trustworthy), which makes end-to-end encryption desirable.</p>
+  <p class="" style="">The session metaphor also applies to communication between endpoints: for instance, in IM applications, most instant messaging exchanges occur in bursts within limited time periods (e.g., two people may send a fairly large number of messages during a five-minute chat and then not exchange messages again for hours or even days). The XML stanzas exchanged during such a session may not be limited to &lt;message/&gt; stanzas; for instance, the session may be triggered by a change in one of the parties' presence status (e.g., changing from away to available) and the session may involve the exchange of &lt;iq/&gt; stanzas (e.g., to transfer a file as specified in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2255670">9</a>]). Endpoints may want to encrypt the stanzas they send to each other in such a way that the stanzas cannot be understood by untrusted mediating entities (such as servers) except to the extent required to understand the necessary routing information. (One complicating factor is that routing information may include not only the stanza's 'to', 'from', 'type, and 'id' attributes, but also <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255693">10</a>] extensions.)</p>
+  <p class="" style="">The foregoing XMPP communications exist in the context of a one-to-one communication session between two entities. However, several forms of XMPP communication exist outside the context of one-to-one communication sessions:</p>
+  <ul>
+    <li>Many-to-many sessions, such as a text conference in a chatroom as specified in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255730">11</a>].</li>
+    <li>One-to-many "broadcast", such as undirected presence stanzas sent from one user to many contacts (see <span style="font-weight: bold">RFC 3921</span>) and data syndication implemented using <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2255760">12</a>].</li>
+    <li>One-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</li>
+  </ul>
+  <p class="" style="">Ideally, any technology for end-to-end encryption in XMPP could be extended to cover these scenarios as well as one-to-one communication sessions. However, for both many-to-many sessions and one-to-many broadcast are are deemed out of scope for this JEP. Offline communications are handled via a simple extension to the protocol for one-to-one sessions between two entities that are online simultaneously (see below).</p>
+  <p class="" style="">Because XMPP is a session-oriented communication technology, encryption schemes that are appropriate for less dynamic technologies may not be appropriate for XMPP. XMPP, with its guaranteed in-order delivery of XML stanzas, may be able to take advantage of encryption approaches that are not feasible for less dynamic technologies. In particular, existing approaches to encryption of Internet communications have generally assumed that the "thing" to be encrypted has a stable identity or is best understood as a standalone object (e.g., a file or email message); the term "object encryption" well captures this assumption. Both <span style="font-weight: bold">JEP-0027</span> and <span style="font-weight: bold">RFC 3923</span> assume that XMPP communications are more like the exchange of email messages than they are like an interactive session -- while <span style="font-weight: bold">JEP-0027</span> uses "old-style" PGP object encryption and <span style="font-weight: bold">RFC 3923</span> uses "new-style" S/MIME object encryption, both specify the use of object encryption. </p>
+  <p class="" style="">However, the session-oriented nature of XMPP may imply that the focus should be on "session encryption" rather than "object encryption". The paradigm for XMPP encryption may be something closer to the widely-deployed Secure Shell technology (see <span class="ref" style="">SSH Protocol Architecture</span>  [<a href="#nt-id2255837">13</a>] and <span class="ref" style="">SSH Transport Layer Protocol</span>  [<a href="#nt-id2255862">14</a>]) than to traditional encryption of files and standalone email messages. In many ways, Secure Shell (or, more generally, opportunistic security) is the conceptual model for the current proposal.</p>
+  <p class="" style="">Therefore, this JEP specifies a method for encrypted sessions ("ESessions") that takes advantage of the inherent possibilities and strengths of session encryption as opposed to object encryption. The basic concept is that of an encrypted session which acts as a secure tunnel between two endpoints. Once the tunnel is established, all one-to-one XML stanzas exchanged between the endpoints will be encrypted and then transmitted within a "wrapper" protocol element.</p>
+<h2>3.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="terms-personae">Dramatis Personae</a>
+</h3>
+    <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+    <ol start="1" type="">
+      <li>"Alice" is the name of the initiator of the ESession. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+      <li>"Bob" is the name of the other participant in the ESession started by Alice. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    </ol>
+    <p class="" style="">While Alice and Bob are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an Esession.</p>
+  </div>
+<h2>4.
+       <a name="reqs">Requirements</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="reqs-sec">Security Requirements</a>
+</h3>
+    <p class="" style="">This JEP stipulates the following security requirements for end-to-end encryption of XMPP communications:</p>
+    <ul>
+      <li>Confidentiality</li>
+      <li>Integrity</li>
+      <li>Replay protection</li>
+      <li>Perfect forward secrecy</li>
+      <li>Authentication</li>
+      <li>Repudiability</li>
+    </ul>
+    <p class="" style="">Each of these requirements is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="reqs-encrypt">Confidentiality</a>
+</h3>
+      <p class="" style="">The one-to-one XML stanzas exchanged between two entities MUST NOT be understandable to any other entity that might intercept the communications.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="reqs-integrity">Integrity</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be sure that the content of the XML stanzas they receive has not been changed by any other entity.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.3 <a name="reqs-replay">Replay Protection</a>
+</h3>
+      <p class="" style="">Alice or Bob MUST be able to identify and reject any communications that are copies of their previous communications resent by another entity.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.4 <a name="reqs-forward">Perfect Forward Secrecy</a>
+</h3>
+      <p class="" style="">The encrypted communication MUST NOT be revealed even if long-lived keys are compromised in the future (e.g., Steve steals Bob's computer).</p>
+    </div>
+    <div class="indent">
+<h3>4.1.5 <a name="reqs-auth">Authentication</a>
+</h3>
+      <p class="" style="">Each party to a conversation MUST know that the other party is who he says he is (Alice must be able to know that Bob really is Bob, and vice versa).  [<a href="#nt-id2256098">15</a>]</p>
+    </div>
+    <div class="indent">
+<h3>4.1.6 <a name="reqs-repudiate">Repudiability</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be able to repudiate any stanza that occurs within an Esession. After an Esession has finished, it SHOULD NOT be possible to <span style="font-style: italic">prove cryptographically</span> that any transcript has not been modified by a third party.  [<a href="#nt-id2256126">16</a>]</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="reqs-xmpp">Application Requirements</a>
+</h3>
+    <p class="" style="">In addition to the foregoing security profile, this JEP also stipulates the following application-specific requirements for encrypted communication in the context of Jabber/XMPP technologies:</p>
+    <ul>
+      <li>Generality</li>
+      <li>Implementability</li>
+      <li>Usability</li>
+      <li>Interoperability</li>
+      <li>Offline "sessions"</li>
+    </ul>
+    <p class="" style="">Each of these is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.2.1 <a name="reqs-generality">Generality</a>
+</h3>
+      <p class="" style="">The solution should be generally applicable to any XML stanza type (&lt;message/&gt;, &lt;presence/&gt;, &lt;iq/&gt;) sent between two entities. It is deemed acceptable for now if the solution does not apply to many-to-many stanzas (e.g., groupchat messages sent within the context of multi-user chat) or one-to-many stanzas (e.g., presence "broadcasts" and pubsub notifications); end-to-end encryption of such stanzas may require separate solutions or extensions to the one-to-one session solution.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="reqs-implement">Implementability</a>
+</h3>
+      <p class="" style="">The only good security technology is an implemented security technology. The solution should be one that typical client developers can implemented in a relatively straightforward and consistent fashion.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="reqs-usable">Usability</a>
+</h3>
+      <p class="" style="">The requirement of usability takes implementability one step further by stipulating that the solution must be one that organizations can deploy and humans can use with 100% transparency (like https:). Experience has shown that: solutions requiring a full public key infrastructure do not get widely deployed, and solutions requiring any user action are not widely used. We can do better.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.4 <a name="reqs-usable">Interoperability</a>
+</h3>
+      <p class="" style="">Ideally, it would be possible for an XMPP user to exchange encrypted messages (and, potentially, presence information) with users of non-XMPP messaging systems.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.5 <a name="reqs-offline">Offline Sessions</a>
+</h3>
+      <p class="" style="">Ideally, it should be possible to encrypt one-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</p>
+    </div>
+  </div>
+<h2>5.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">Before attempting to engage in an ESession with Bob, Alice SHOULD discover whether he supports this protocol, using either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256322">17</a>] or the presence-based profile of <span style="font-weight: bold">JEP-0030</span> specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256345">18</a>].</p>
+  <p class="" style="">The normal course of events is for Alice to authenticate with her server, retrieve her roster (see <span style="font-weight: bold">RFC 3921</span>), send initial presence to her server, and then receive presence information from all the contacts in her roster. If the presence information she receives from some contacts does not include capabilities data (per <span style="font-weight: bold">JEP-0115</span>), Alice SHOULD then send a service discovery information ("disco#info") request to each of those contacts (in accordance with <span style="font-weight: bold">JEP-0030</span>). Such initial service discovery stanzas MUST NOT be considered part of encrypted communication sessions for the purposes of this JEP, since they perform a "bootstrapping" function that is a prerequisite to encrypted communications. The disco#info request sent from Alice to Bob might look as follows:</p>
+  <p class="caption">Example 1. Alice Queries Bob for Esession Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com/laptop'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Bob sends a disco#info reply and he supports the protocol defined herein, then he MUST include a service discovery feature variable of "http://jabber.org/protocol/esession".</p>
+  <p class="caption">Example 2. Bob Returns disco#info Data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='bob@example.com/laptop'
+    to='alice@example.org/pda'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='client' type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/esession'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="init">ESession Initiation</a>
+</h2>
+  <p class="" style="">The process for establishing an ESession is essentially a translation into XMPP syntax of the SSH transport mechanism for establishing a secure session over an insecure transport (see <span style="font-weight: bold">SSH Transport Layer Protocol</span>). Specifically, as in SSH, ESession uses a Diffie-Hellman key exchange algorithm (see <span class="ref" style="">RFC 2631</span>  [<a href="#nt-id2256444">19</a>]) in the initial negotation (although, as we shall see, it does not use SHA-1 as the hashing algorithm).</p>
+  <p class="" style="">When Alice wishes to establish an ESession with Bob, Alice may choose between two different methods of performing the initial Diffie-Hellman key exchange, depending on whether Bob is online or not. Note: Alice MUST NOT initiate a new Esession with Bob if she already has one established with him.</p>
+
+  <div class="indent">
+<h3>6.1 <a name="init-online">Online Diffie-Hellman Key Exchange</a>
+</h3>
+    <p class="" style="">If Alice believes Bob may be online then she SHOULD retrieve Bob's long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) and then use the protocol specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2256508">20</a>] to negotiate the initial Diffie-Hellman key. In this aggressive exchange the first two messages negotiate policy, swap Diffie-Hellman public values and the ancillary data necessary for the exchange and authentication. The second message also authenticates the responder. The third message authenticates the initiator and exchanges the final Diffie-Hellman public value.</p>
+    <div class="indent">
+<h3>6.1.1 <a name="init-request">Esession Request</a>
+</h3>
+      <p class="" style="">Alice MUST specify each of the Esession options (algorithms etc.) she is willing to use, in her order of preference (see <a href="#sec-mandatory">Mandatory to Implement Technologies</a>):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">The list of Modular Exponential (MODP) group numbers (as specified in <span class="ref" style="">RFC 2409</span>  [<a href="#nt-id2256574">21</a>] or <span class="ref" style="">RFC 3526</span>  [<a href="#nt-id2256597">22</a>]) she is willing to use for Diffie-Hellman key exchange (valid group numbers include 1,2,3,4,5,14,15,16,17 and 18)</p></li>
+        <li><p class="" style="">Stanza symmetric encryption algorithm names</p></li>
+        <li><p class="" style="">Hash algorithm names</p></li>
+        <li><p class="" style="">Compression algorithm names</p></li>
+        <li><p class="" style="">The list of stanza types she is willing to encrypt and decrypt</p></li>
+        <li><p class="" style="">Whether or not both entities MUST be connected securely to their servers (see Section 5 of <span style="font-weight: bold">RFC 3920</span>)</p></li>
+        <li><p class="" style="">The minimum number of stanzas that MUST be exchanged before an entity MAY initiate a key re-exchange (1 - every stanza, 100 - every hundred stanzas). This value MUST be less than 2<span class="super" style="">32</span> (see <a href="#sec-rekey">Re-Keying Limits</a>)</p></li>
+        <li><p class="" style="">The Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256705">23</a>]) SHA-256 fingerprint (PKID) of each of Bob's public signature-verification keys that she found acceptable (see <a href="#sec-keys">Verifying Keys</a>)</p></li>
+      </ol>
+    <p class="caption">Example 3. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='form' xmlns='jabber:x:data'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='logging'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field type='list-single' var='modp'&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;1&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='crypt_algs'&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='hash_algs'&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='compress'&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='stanzas'&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='secure'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='rekey_freq'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='accept_pkids'&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob does not support one or more of the options in each Esession field (except the 'accept_pkids' field), then he SHOULD return a &lt;feature-not-implemented/&gt; error (but he MAY return no error if, for example, he does not want to reveal his presence to Alice for whatever reason):</p>
+    <p class="caption">Example 4. Bob Informs Alice that Her Options Are Not Supported</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='bob@example.com/laptop'
+         to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    ...
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Either Bob or Alice MAY attempt to initiate a new ESession after any error during the initiation process. However, both MUST consider the previous negotiation to have failed and MUST discard any information learned through the previous negotiation.</p>
+    </div>
+    <div class="indent">
+<h3>6.1.2 <a name="init-prep">Diffie-Hellman Preparation (Bob)</a>
+</h3>
+      <p class="" style="">If Bob is willing to start an ESession with Alice, he SHOULD retrieve Alice's long-term public signature-verification keys. He MUST select one of the options from each of the Esession fields he received from Alice including one of the MODP groups (see <span class="ref" style="">RFC 3766</span>  [<a href="#nt-id2256863">24</a>] or <span style="font-weight: bold">RFC 3526</span> for recommendations regarding balancing the sizes of symmetric cipher blocks and Diffie-Hellman moduli). Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). Bob MUST then perform the following computations (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n-1 random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.1.3 <a name="init-response">Esession Response</a>
+</h3>
+    <p class="" style="">Bob responds to Alice specifying the Esession options he selected.</p>
+    <p class="" style="">If Bob is willing to start an ESession with Alice, then instead of providing the PKID of his public key that he selected, Bob MUST specify the Base64 encoded SHA-256 fingerprint (PKID) of each of Alice's public signature-verification keys that he finds acceptable (see <a href="#sec-keys">Verifying Keys</a>). Note: The submited values for the 'accept_pkids' field do not correspond to the options he received. The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Alice.</p>
+    <p class="" style="">In addition to the fields he received from Alice, Bob MUST include the KID and the Base64 encoded values of d and C<span class="sub" style="">A</span>. If Alice selected one or more of his public keys, and if Bob has access to a long-lived private signing key that corresponds to one of those keys  [<a href="#nt-id2257034">25</a>], then he MUST also include the PKID. Otherwise (for example, if Bob is unable to publish keys to his server or if Alice is unable to access keys published via his server  [<a href="#nt-id2257042">26</a>]), Bob MAY include one of his Base64 encoded public keys. In either case, Bob MUST include the Base64 encoded signature (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+    <p class="" style="">However, if Bob is ready to initiate a one-to-one chat session with Alice (see <span style="font-weight: bold">Chat Session Negotiation</span>) but he is unwilling to start an ESession, then he SHOULD terminate the Esession negotiation by not specifying any of the five extra values in his response.</p>
+    <p class="caption">Example 5. Bob Responds to Alice (with Public Key)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      ...
+      &lt;field var='modp'&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='hash_algs'&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='compress'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='stanzas'&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='secure'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='accept_pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field var='counter'&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkey'&gt;
+        &lt;value&gt; ** Base64 encoded public key ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 6. Bob Responds to Alice (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+      &lt;field var='counter'&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Alice provided a PKID but Bob did not provide a signature then she MAY send a failure notice to him. If Bob sent Alice a public key but she could not verify it belongs to him via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then she SHOULD send a failure notice to him. If Bob provided an invalid signature (see <a href="#sign">Signature Generation</a>) then she MUST send a failure notice to him.</p>
+    <p class="caption">Example 7. Alice Signals that ESession Negotiation Failed (Unacceptable Signature)</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='alice@example.org/pda'
+         to='bob@example.com/laptop'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-signature xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.4 <a name="init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</h3>
+      <p class="" style="">After verifying Bob's signature, Alice can be certain that the value of d was actually generated by Bob. Alice MUST use the value of d and the Esession options specified in Bob's response to perform the following steps (where n is the number of bits per encryption block for the agreed encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value she received from Bob</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span></p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (this is the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.1.5 <a name="init-complete">Diffie-Hellman Completion</a>
+</h3>
+    <p class="" style="">Alice then completes the Diffie-Hellman negotiation by sending Bob the KID and the Base64 encoded value of e. If Bob selected one or more of her public keys, and if Alice has access to a long-lived private signing key that corresponds to one of those keys, then she MUST also include the PKID. Otherwise, Alice MAY include one of her Base64 encoded public keys (see <a href="#init-response">Esession Response</a> example). In either case, Alice MUST include the Base64 encoded signature (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+    <p class="" style="">Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza as the Diffie-Hellman completion.</p>
+    <p class="caption">Example 8. Alice Completes Diffie-Hellman Negotitation (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x xmlns='jabber:x:data'&gt;
+      &lt;field var='kid'&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='key'&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='pkids'&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='signs'&gt;&lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob provided a PKID but Alice did not provide a signature then he MAY send a failure notice to her. If Alice sent Bob a public key but he could not verify it belongs to her via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then he SHOULD send a failure notice to her. If Alice provided an invalid signature (see <a href="#sign">Signature Generation</a>) then he MUST send a failure notice to her. If Bob sends a failure notice then he SHOULD ignore any encrypted content in the stanza.</p>
+    <p class="" style="">If no error occurs, Bob MUST calculate K = e<span class="super" style="">y</span> mod p (the shared secret). Alice and Bob then have the same value for K and the key exchange is complete.</p>
+    </div>
+  </div>
+
+
+
+<div class="indent">
+<h3>6.2 <a name="init-offline">Offline Diffie-Hellman Key Exchange</a>
+</h3>
+
+  <p class="" style="">As described below, offline negotiation of an Esession is in essence a special case of online negotiation. Bob MAY publish a set of Esession options just before he goes offline to allow entities that subscribe to his presence to initiate Esessions and send encrypted stanzas to him while he is offline. He MAY also publish <span style="font-style: italic">another</span> similar set of relatively long-lived  [<a href="#nt-id2257592">27</a>] Esession options that any entity MAY use for the same purpose.</p>
+
+    <div class="indent">
+<h3>6.2.1 <a name="init-publish">Publishing Esession Options</a>
+</h3>
+      <p class="" style="">In order to publish either set of his offline Esession options Bob MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1, where n is the largest number of bits per encryption block for the encryption algorithms he is willing to use)</p></li>
+        <li><p class="" style="">Select a MODP group (that defines the constants p and g)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d (typically by calculating a hash of d, since this KID SHOULD be unique across all Esessions)</p></li>
+        <li><p class="" style="">Store the values of y and d and the KID in a secure way, so that he can retrieve them when he comes back online (idealy even if that is using a different client and/or a different machine)</p></li>
+        <li><p class="" style="">Publish each of the Esession options he is willing to use (see <a href="#init-request">Esession Request</a>) including the value of d and the KID. He SHOULD do this through his own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>) or a similar protocol (out of scope for this JEP).</p></li>
+      </ol>
+      <p class="" style="">Note: The single specified MODP group MUST be the one Bob used to generate d. The list of stanza types he is willing to decrypt MUST NOT include the value 'iq'. Bob MUST also include the list of the PKIDs of all his public signature-verification keys that he can sign for, and the corresponding list of Base64 encoded signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style=""><span style="font-style: italic">Note: This publishing protocol is highly preliminary and depends on a separate proposal.</span></p>
+      <p class="caption">Example 9. Bob Publishes His Esession Options for His Subscribers</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info-subscription'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field var='modp'&gt;
+        &lt;value&gt;2&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;
+        &lt;value&gt;aes256-ctr&lt;/value&gt;
+        &lt;value&gt;twofish256-ctr&lt;/value&gt;
+        &lt;value&gt;aes128-ctr&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='hash_algs'&gt;
+        &lt;value&gt;whirlpool&lt;/value&gt;
+        &lt;value&gt;sha256&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='compress'&gt;
+        &lt;value&gt;none&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='stanzas'&gt;
+        &lt;value&gt;message&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='secure'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">Bob MAY publish his Esession options for all entities using the same protocol except for the 'xmlns' and 'node' attributes of the &lt;query/&gt; element:</p>
+      <p class="caption">Example 10. Bob Publishes His Esession Options for All Entities</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.2 <a name="init-offreq">Requesting Offline Esession Options</a>
+</h3>
+      <p class="" style="">If Alice believes Bob is offline she SHOULD request his Esession options and his long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) from his server.</p>
+      <p class="" style="">If Alice is subscribing to Bob's presence she MUST request his Esession Options exclusively for subscribers.</p>
+      <p class="caption">Example 11. Alice asks Bob's Server for his Esession Options (Subscribers)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If Alice is not subscribing to Bob's presence (or if Bob has no Esession Options exclusively for subscribers) she MUST use the following request instead.</p>
+      <p class="caption">Example 12. Alice asks Bob's Server for his Esession Options (All Entities)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If, after receiving Bob's public keys and Esession options, Alice is unable to verify any of Bob's signatures (see <a href="#sign">Signature Generation</a>) then she MAY decide to proceed no further, since she cannot be sure who will be able to decrypt her stanzas.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.3 <a name="init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</h3>
+      <p class="" style="">Alice MUST select one of the options from each of Bob's Esession fields. If she cannot support any of the options in a field (except the 'pkids' and 'signs' fields) then she MUST not send encrypted stanzas to Bob while he is offline.</p>
+      <p class="" style="">Alice MUST use the value of d and the MODP group specified in Bob's Esession options to perform the following steps (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n-1 random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the counter for stanzas sent from Bob to Alice - in case Bob comes online before Alice terminates the Esession)</p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.2.4 <a name="init-start">Starting an Offline Esession</a>
+</h3>
+      <p class="" style="">Alice then sends Bob the KID and the Base64 encoded values of e and C<span class="sub" style="">A</span>. She SHOULD also include the list of the PKIDs of all her public signature-verification keys that she can sign for, and the corresponding list of Base64 encoded signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style="">She also specifies which of Bob's Esession options she selected. Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Bob.</p>
+      <p class="" style="">Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza.</p>
+      <p class="caption">Example 13. Alice Establishes an ESession Without Negotiation</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com' type='chat'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x xmlns='jabber:x:data'&gt;
+      &lt;field var='logging'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='modp'&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='hash_algs'&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='compress'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='stanzas'&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='secure'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='counter'&gt;&lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='kid'&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='key'&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+      <p class="" style="">Alice can assume that she and Bob have the same value for K and that the key exchange is complete.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.5 <a name="init-accept">Accepting Offline Esessions</a>
+</h3>
+      <p class="" style="">When Bob comes online he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Retrieve the two sets of Esession options he MAY have published (see <a href="#init-publish">Publishing Esession Options</a>)</p></li>
+        <li>
+<p class="" style="">Ensure he is no longer publishing offline Esession options exclusively for entities that are subscribing to his presence</p>
+            <p class="caption">Example 14. Bob Stops Publishing His Esession Options</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+        </li>
+        <li><p class="" style="">Retrieve any values of y, d and KID that he stored before going offline, and destroy in a secure way any persistently stored copies that correspond to Esession options exclusively for subscribers</p></li>
+        <li><p class="" style="">Confirm those values of d and KID match the published values. They may not match if, for example, he went offline using a different client and/or a different machine. Note: if they do not match then he cannot decrypt any offline Esessions he receives.</p></li>
+      </ol>
+      <p class="" style="">When Bob receives a key exchange stanza from Alice then he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Confirm that the KID he received from Alice matches one of the KIDs he published</p></li>
+        <li><p class="" style="">Confirm that he can support all the Esession options he received from Alice</p></li>
+        <li><p class="" style="">Confirm that he has not already received a key exchange stanza from Alice with the same value of e since he came online (see <a href="#sec-replay">Replay Attacks</a>)</p></li>
+        <li><p class="" style="">Request Alice's public keys and, if possible, verify one of her signatures (see <a href="#sign">Signature Generation</a>; if he is unable to verify any of her signatures then he MAY decide to proceed no further, since he cannot be sure who started the Esession)</p></li>
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value he received from Alice</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (in case Alice has not yet terminated the Esession)</p></li>
+        <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="indent">
+<h3>6.3 <a name="init-keys">Generating Session Keys</a>
+</h3>
+    <p class="" style="">Whichever method Alice used to perform the Diffie-Hellman key exchange (online or offline), once it is complete, then before Alice and Bob can start encrypting and decrypting stanzas they MUST both use the agreed hash algorithm ("HASH") and their full JIDs to generate two pairs of keys, one for each direction of the ESession. Note: JID<span class="sub" style="">B</span> MUST be Bob's bare JID throughout an offline Esession, even if he comes online in the middle of the Esession and the key is re-exchanged.</p>
+    <p class="" style="">For stanzas that Alice will send to Bob, the keys are calculated as:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">A</span> = HASH(K-E<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)  [<a href="#nt-id2258540">28</a>]</p></li>
+    </ol>
+    <p class="" style="">For stanzas that Bob will send to Alice the keys are calculated as:</p>
+    <ol start="4" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">B</span> = HASH(K-E<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)</p></li>
+    </ol>
+    <p class="" style="">Once the two pairs of keys have been calculated the value of K MUST be securely destroyed.</p>
+    <p class="" style="">As many bytes of key data as are needed MUST be taken from the beginning of the hash output. When negotiating a hash, entities MUST ensure that the hash output is no shorter than the required key data. For algorithms with variable-length keys the maximum length (up to the hash output length) SHOULD be used.</p>
+
+    <p class="" style="">With these keys computed and the algorithms agreed upon, ESession initiation is now complete. From this point forward, Alice and Bob MUST exchange only encrypted forms of the one-to-one stanza types they agreed upon (e.g., &lt;message/&gt; and &lt;iq/&gt; stanzas).</p>
+  </div>
+<h2>7.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="exchange-separate">Encryptable Content</a>
+</h3>
+    <p class="" style="">Once an Esession has been established, whenever Alice wants to send Bob an encrypted stanza she MUST only encrypt the XML content that would normally be ignored by the intermediate servers. She MUST NOT encrypt stanza wrapper elements or <span style="font-weight: bold">Advanced Message Processing</span> elements.</p>
+    <p class="" style="">If this is an offline Esession then Alice SHOULD include a 'Created' SHIM header in the encrypted content. Bob SHOULD trust this header and ignore the unencrypted <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2258738">29</a>] element inserted by his server.</p>
+
+  <p class="caption">Example 15. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+  &lt;amp per-hop='true' xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+
+  <p class="caption">Example 16. XML Content to be Encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+  &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+&lt;/headers&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+</pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="exchange-encrypt">Encryption</a>
+</h3>
+
+    <p class="" style="">Alice MUST perform the following steps to encrypt the XML content.</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Serialize the XML content she wishes to send into an array of UTF-8 bytes, m.  [<a href="#nt-id2258791">30</a>]</p></li>
+      <li>
+        <p class="" style="">Compress m using the negotiated algorithm. If a compression algorithm other than 'none' was agreed, the compression context is typically initialized after key exchange and passed from one stanza to the next, with only a partial flush at the end of each stanza.  [<a href="#nt-id2258811">31</a>]</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = compress(m)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Encrypt the data with the agreed algorithm in counter mode, using the encryption key K-E<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented for each encrypted block or partial block, and if C<span class="sub" style="">A</span>=2<span class="super" style="">n</span>-1 (where n is the number of bits per encryption block for the agreed encryption algorithm) then C<span class="sub" style="">A</span> MUST be "incremented" to 1. Note: if the encryption algorithm 'none' was agreed (see <a href="#sec-unencrypted">Unencrypted Esessions</a>) encryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_final = encrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Alice MUST now create the XML <span style="font-style: italic">content</span> of the &lt;encrypted/&gt; XML element (with no CDATA between any of the elements) in canonical form (see <span class="ref" style="">Canonical XML</span>  [<a href="#nt-id2258960">32</a>]). The XML SHOULD include the Base64 encoded value of m_final, and Bob's KID (the one that corresponds to the value of d she used to encrypt the data). It MAY also contain one &lt;key/&gt; element and one or more &lt;old/&gt; elements (see <a href="#rekey">Re-Keying</a>).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_content = '&lt;data kid=" ** KID ** "&gt; ** Base64 encoded m_final ** &lt;/data&gt;'</pre></div>
+      </li>
+      <li>
+        <p class="" style="">The XML content and the value of Alice's encryption block counter C<span class="sub" style="">A</span> <span style="font-style: italic">before</span> the data was encrypted, are now processed through the HMAC algorithm (as defined in Section 2 of <span class="ref" style="">RFC 2104</span>  [<a href="#nt-id2259026">33</a>]), along with the agreed hash algorithm ("HASH") and the integrity key K-M<span class="sub" style="">A</span>.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>a_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+    </ol>
+
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="exchange-send">Sending an Encrypted Stanza</a>
+</h3>
+    <p class="" style="">Before sending the stanza to Bob, Alice MUST wrap m_content and the Base64 encoded value of a_mac (wrapped in a &lt;mac/&gt; element) inside an &lt;encrypted/&gt; element and insert it into the stanza in place of the original content. There MUST NOT be more than one &lt;encrypted/&gt; element per stanza.</p>
+    <p class="caption">Example 17. Message Stanza with Encrypted Content</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp per-hop='true' xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="exchange-decrypt">Decryption</a>
+</h3>
+
+    <p class="" style="">When Bob receives the stanza from Alice, he extracts and Base64 decodes the values of m_final and a_mac from the content and performs the following steps. Note: Alice may not have received Bob's last re-key (see <a href="#rekey">Re-Keying</a>) before sending the stanza. So Bob MUST ensure he uses the values of K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> that correspond to his KID that Alice specified with the 'kid' attribute of the &lt;data/&gt; element in the stanza he received (and the current value of e that Alice sent him previously).</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Remove the &lt;mac/&gt; element from the &lt;encrypted/&gt; element and convert the remaining XML <span style="font-style: italic">content</span> into canonical form (with no CDATA between any of the elements, see <span style="font-weight: bold">Canonical XML</span>). Calculate the Message Authentication Code (MAC) for the content.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>b_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Verify that b_mac and a_mac match. If they are not identical, the content has been tampered with and Bob MUST terminate the ESession by sending an error to Alice.  [<a href="#nt-id2259217">34</a>]</p>
+      </li>
+      <li>
+        <p class="" style="">Decrypt m_final using the agreed algorithm, K-E<span class="sub" style="">A</span> and C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented for each decrypted block, and if C<span class="sub" style="">A</span>=2<span class="super" style="">n</span>-1 (where n is the number of bits per encryption block for the agreed encryption algorithm) then C<span class="sub" style="">A</span> MUST be "incremented" to 1. Note: if the encryption algorithm 'none' was agreed decryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = decrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_final)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Decompress m_compressed using the negotiated algorithm (usually 'none').</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m = decompress(m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Replace the &lt;encrypted/&gt; element in the serialized XML stanza with m and feed the stanza into an XML parser. If the parser returns an XML format error then Bob MUST terminate the ESession by sending an error to Alice.  [<a href="#nt-id2259370">35</a>]</p>
+      </li>
+    </ol>
+  </div>
+  <h2>8.
+       <a name="rekey">Re-Key Exchange</a>
+</h2>
+<p class="" style="">Once an attacker has discovered an encryption key it could be used to decrypt all stanzas within a session, including stanzas that were intercepted <span style="font-style: italic">before</span> the key was discovered. To reduce the window of vulnerability, both Alice and Bob SHOULD change their values of x and y and re-exchange the encryption key as regularly as possible. They MUST also destroy all copies of keys as soon as they are no longer needed.</p>
+<p class="" style="">Note: Although most entities are capable of re-keying after each stanza, clients running in constrained runtime environments may require a few seconds to re-key. During Esession initiation these clients MAY negotiate the minimum number of stanzas to be exchanged between re-keys at the cost of a larger window of vulnerability. Entities MUST NOT initiate key re-exchanges more frequently than the agreed limit.</p>
+
+  <div class="indent">
+<h3>8.1 <a name="rekey-init">Re-Key Initiation</a>
+</h3>
+    <p class="" style="">Either Alice or Bob MAY initiate a key re-exchange. Here we describe the process initiated by Alice. First she MUST calculate new values for the encryption parameters:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1, where n is the number of bits per encryption block for the agreed encryption algorithm)</p></li>
+      <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+      <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the new shared secret)</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">To avoid extra stanzas, the new value of e SHOULD be sent to Bob along with an encrypted stanza. Note: Alice MUST NOT use the new K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> to encrypt this stanza or to calculate the MAC. However, she MUST use them when sending subsequent stanzas.</p>
+    <p class="" style="">Note: There is no need for Alice to provide a signature because the calculation of the MAC includes the new value of e, see <a href="#exchange">Exchanging Stanzas</a>).</p>
+    <p class="caption">Example 18. Alice Sends Re-Key Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;key kid=' ** KID ** '&gt; ** Base64 encoded value of new e ** &lt;/key&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Bob may not receive the new key before he sends his next stanzas (they may cross in transit). So, before destroying her old values of K-E<span class="sub" style="">B</span> and K-M<span class="sub" style="">B</span>, Alice MUST wait until either she receives a stanza encrypted with the new key, or a reasonable time has passed (60 seconds should cover a network round-trip and calculations by a constrained client). Similarly she MUST wait before destroying her old value of x, in case Bob sends two stanzas before receiving Alice's new key (the first stanza might include a re-key).</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="rekey-accept">Re-Key Acceptance</a>
+</h3>
+    <p class="" style="">After Bob receives a stanza with a new value of e and he has decrypted the stanza with the old value of K-E<span class="sub" style="">A</span>, he MUST securely destroy all copies of K-E<span class="sub" style="">A</span> and K-E<span class="sub" style="">B</span> and perform the following calculations with the new value of e:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">He MUST use these new values to encrypt and decrypt all subsequent stanzas.  [<a href="#nt-id2259794">36</a>]</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="rekey-publish">Publishing Old MAC Values</a>
+</h3>
+    <p class="" style="">Either entity MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> as part of any encrypted stanza as long as it knows that all the stanzas that MAY use the old values have been received and validated. It MUST wait until it has received either a re-key or a stanza encrypted with a newer key from the other entity.</p>
+    <p class="" style="">Once the expired MAC keys have been published, anyone could create valid arbitrary stanzas with them. This prevents anyone being able to prove the authenticity of a transcript of the Esession in the future.</p>
+    <p class="caption">Example 19. Publishing Expired MAC Keys</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Entities SHOULD ignore any &lt;old/&gt; elements they receive.</p>
+  </div>
+  <h2>9.
+       <a name="terminate">Esession Termination</a>
+</h2>
+    <p class="" style="">Either entity MAY terminate an Esession at any time by securely destroying all keys associated with the Esession and sending a termination stanza to the other entity.</p>
+    <p class="caption">Example 20. Alice Terminates an Esession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;end xmlns='http://jabber.org/protocol/esession#end'/&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When the other entity receives a termination stanza it MUST destroy all keys associated with the Esession.</p>
+  <h2>10.
+       <a name="sign">Signature Generation</a>
+</h2>
+    <p class="" style="">Before the signature of a block of XML is calculated, all CDATA between all elements must be removed and the XML MUST be converted to canonical form (see <span style="font-weight: bold">Canonical XML</span>).</p>
+  <div class="indent">
+<h3>10.1 <a name="sign-canon">Canonical Form (Informative)</a>
+</h3>
+    <ul>
+      <li>Encoded in UTF-8</li>
+      <li>Line breaks normalized to ASCII 10</li>
+      <li>Attribute values are normalized, as if by a validating processor</li>
+      <li>Character references are replaced</li>
+      <li>CDATA sections are replaced with their character content</li>
+      <li>Empty elements are converted to start-end tag pairs</li>
+      <li>All whitespace in character content is retained (excluding characters removed during line feed normalization)</li>
+      <li>Normalization of whitespace in start and end tags</li>
+      <li>Attribute value delimiters are set to quotation marks (double quotes)</li>
+      <li>Special characters in attribute values and character content are replaced by character references (&amp;amp;, &amp;lt;, &amp;gt;, &amp;quot;, &amp;#xD;, &amp;#xA;, &amp;#x9;)</li>
+      <li>Lexicographic order is imposed on the namespace declarations (always first) and attributes of each element</li>
+    </ul>
+
+  </div>
+  <h2>11.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="sec-prng">Random Numbers</a>
+</h3>
+    <p class="" style="">Weak pseudo-random number generators (PRNG) enable successful attacks. Implementors MUST use a cryptographically strong PRNG to generate all random numbers (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2260038">37</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="sec-rekey">Re-Keying Limits</a>
+</h3>
+    <p class="" style="">After a key exchange an entity MUST NOT exchange a total of 2<span class="super" style="">32</span> encrypted blocks before it initiates a key re-exchange (see <span class="ref" style="">SSH Transport Layer Encryption Modes</span>  [<a href="#nt-id2260088">38</a>]). Note: This limitation also ensures the same key and counter values are never used to encrypt two different blocks using counter mode (thus preventing simple attacks).</p>
+    <p class="" style="">In order to reduce the Perfect Forward Secrecy window of vulnerability, after an extended period of activity, entities SHOULD either re-key or terminate the Esession.</p>
+  </div>
+  <div class="indent">
+<h3>11.3 <a name="sec-keys">Verifying Keys</a>
+</h3>
+    <p class="" style="">The trust system outlined in this document is based on Alice trusting that the public key presented by Bob is <span style="font-style: italic">actually</span> Bob's key (and vice versa). Determining this trust may be done in a variety of ways depending on the entities' support for different public key (certificate) formats, signing algorithms and signing authorities. For instance, if Bob publishes a PGP/GPG public key, Alice MAY verify that his key is signed by another key that she knows to be good. Or, if Bob provides an X.509 certificate, she MAY check that his key has been signed by a Certificate Authority that she trusts.</p>
+    <p class="" style="">When trust cannot be achieved automatically, methods that are not transparent to the users may be employed. For example, Bob could communicate the SHA-256 fingerprint of his public key to Alice via secure out-of-band communication (e.g. face-to-face). This would enable Alice to confirm that the public key she receives in-band is valid. Note however that very few people bother to verify fingerprints in this way. So this method is exceptionally vulnerable to 'man-in-the-middle' attacks. In order to reduce the window of vulnerability, an entity SHOULD remember the fingerprints of all user-validated public keys and alert the user in the future if ever the fingerprint(s) it stored for an entity do not match any of the received public keys.</p>
+    <p class="" style="">Alternatively Alice and Bob could agree a shared secret via secure out-of-band communication, Bob could then use it to create an HMAC of his public key that only Alice could verify.</p>
+    <p class="" style="">Note: If no keys are acceptable to Alice (because Alice has never verified any of the keys, and because either the keys are not signed, or Alice does not support the signature algorithms of the keys, or she cannot parse the certificate formats, or she does not recognise the authorities that signed the keys) then, although the Esession can still be encrypted, she cannot be sure she is communicating with Bob.</p>
+  </div>
+  <div class="indent">
+<h3>11.4 <a name="sec-replay">Replay Attacks</a>
+</h3>
+    <p class="" style="">The encryption block counters maintained implicitly by Alice and Bob (C<span class="sub" style="">A</span> and C<span class="sub" style="">B</span>) prevent stanzas being replayed within any Esession. They ensure that the MAC will be different for all stanzas, even if the HMAC key and the content of the stanza are identical.</p>
+    <p class="" style="">Alice and Bob MUST ensure that the value of e or d they provide when negotiating each online Esession is unique. This prevents complete online Esessions being replayed.</p>
+    <p class="" style="">Since Bob supplies the same value of d for all offline Esessions, to prevent complete offline Esessions being replayed to him, he MUST take care to securely store <span style="font-style: italic">new</span> values (or destroy existing values) of y and KID whenever he goes offline (see <a href="#init-publish">Publishing Esession Options</a>). Also, when Bob next comes online, he MUST remember all the values of e he receives in offline Esession initiation stanzas, and reject any offline Esessions that specify a value of e he has already received (see <a href="#init-accept">Accepting an Offline Esession</a>).</p>
+  </div>
+  <div class="indent">
+<h3>11.5 <a name="sec-unencrypted">Unencrypted Esessions</a>
+</h3>
+    <p class="" style="">Organisations with full disclosure policies may require entities to disable encryption to enable the logging of all messages on their server. Unencrypted Esessions meet all the <a href="#reqs-sec">Security Requirements</a> except for Confidentiality. This enables Alice to use the 'secure' Esession option to confirm securely with Bob that both client-server connections are secure.</p>
+  </div>
+  <div class="indent">
+<h3>11.6 <a name="sec-storage">Storage</a>
+</h3>
+    <p class="" style="">If either entity stores a (re-encrypted) transcript of an Esession for future consultation then the Perfect Forward Secrecy offered by this protocol is lost. If the negotiated value of the 'logging' <span style="font-weight: bold">Chat Session Negotiation</span> field is false the entities SHOULD NOT store any part of the Esession content (not even in encrypted form).</p>
+  </div>
+  <div class="indent">
+<h3>11.7 <a name="sec-general">Extra Responsabilities of Implementors</a>
+</h3>
+    <p class="" style="">Cryptography plays only a small part in an entity's security. Even if it implements this protocol perfectly it may still be vulnerable to other attacks. For examples, an implementation might store Esession keys on swap space or save private keys to a file in cleartext! Implementors MUST take very great care when developing applications with secure technologies.</p>
+  </div>
+  <div class="indent">
+<h3>11.8 <a name="sec-mandatory">Mandatory to Implement Technologies</a>
+</h3>
+    <p class="" style="">An implementation of ESession MUST support the Diffie-Hellman Key Agreement and HMAC algorithms. Note: The parameter names mentioned below are related to secure shell; see <span style="font-weight: bold">SSH Transport Layer Encryption Modes</span> for encryption algorithm details; see the <span class="ref" style="">IANA Secure Shell Protocol Parameters</span>  [<a href="#nt-id2260374">39</a>] for other names.</p>
+    <div class="indent">
+<h3>11.8.1 <a name="sec-mandatory-encryption">Encryption Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following encryption algorithm:</p>
+      <ul>
+        <li>aes128-ctr (see <span class="ref" style="">Advanced Encryption Standard</span>  [<a href="#nt-id2260422">40</a>])</li>
+      </ul>
+      <p class="" style="">The block length of an encryption algorithm's cipher SHOULD be at least 128 bits. An implementation of ESession MAY also support the following encryption algorithms:</p>
+      <ul>
+        <li>aes256-ctr</li>
+        <li>aes192-ctr</li>
+        <li>twofish256-ctr (see <span class="ref" style="">Twofish</span>  [<a href="#nt-id2260467">41</a>])</li>
+        <li>twofish192-ctr</li>
+        <li>twofish128-ctr</li>
+        <li>serpent256-ctr (see <span class="ref" style="">Serpent</span>  [<a href="#nt-id2260500">42</a>])</li>
+        <li>serpent192-ctr</li>
+        <li>serpent128-ctr</li>
+        <li>none (no encryption, only signing)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.8.2 <a name="sec-mandatory-sign">Key Signing Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following signing algorithms:</p>
+      <ul>
+        <li>rsa (see <span class="ref" style="">RFC 2437</span>  [<a href="#nt-id2260552">43</a>])</li>
+        <li>dss (see <span class="ref" style="">Digital Signature Standard</span>  [<a href="#nt-id2260574">44</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.8.3 <a name="sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following public key formats:</p>
+      <ul>
+        <li>ssh-rsa</li>
+        <li>ssh-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following public key formats:</p>
+      <ul>
+        <li>x509v3-sign-rsa (see <span class="ref" style="">X.509 Authentication in SSH2</span>  [<a href="#nt-id2260642">45</a>])</li>
+        <li>x509v3-sign-dss</li>
+        <li>pgp-sign-rsa</li>
+        <li>pgp-sign-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession MAY also support the following public key formats:</p>
+      <ul>
+        <li>spki-sign-rsa</li>
+        <li>spki-sign-dss</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.8.4 <a name="sec-mandatory-hash">Hash Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following hash algorithm:</p>
+      <ul>
+        <li>sha256 (see <span class="ref" style="">Secure Hash Standard</span>  [<a href="#nt-id2260721">46</a>])</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following hash algorithm (sha1 and md5 are NOT RECOMMENDED):</p>
+      <ul>
+        <li>whirlpool (see <span class="ref" style="">Whirlpool</span>  [<a href="#nt-id2260757">47</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.8.5 <a name="sec-mandatory-compress">Compression Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following compression algorithm:</p>
+      <ul>
+        <li>none (no compression, the output MUST be the same as the input)</li>
+      </ul>
+      <p class="" style="">Support for other algorithms is NOT RECOMMENDED since compression partially defeats the <a href="#reqs-repudiate">Repudiability</a> requirement of this JEP by making it more difficult for a third party (with some knowledge of the plaintext) to modify a transcript of an encrypted session in a meaningful way. However, encrypted content is pseudo-random and cannot be compressed, so, in those cases where bandwidth is severely constrained, an implementation of ESession MAY support the following algorithm to compress content before it is encrypted:</p>
+      <ul>
+        <li>zlib (see <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2260831">48</a>])</li>
+      </ul>
+    </div>
+  </div>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260909">49</a>]. </p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="registrar-ns">Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260925">50</a>] shall register the following namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/esession</li>
+      <li>http://jabber.org/protocol/esession#init</li>
+      <li>http://jabber.org/protocol/esession#end</li>
+      <li>http://jabber.org/protocol/esession#error</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall reserve the following fields within the scope of Data Forms used for ESession negotation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field
+      var='modp'
+      type='list-single'
+      label='MODP group number'/&gt;
+  &lt;field
+      var='crypt_algs'
+      type='list-single'
+      label='Symmetric block cipher options'/&gt;
+  &lt;field
+      var='hash_algs'
+      type='list-single'
+      label='Hash algorithm options'/&gt;
+  &lt;field
+      var='compress'
+      type='list-single'
+      label='Compression algorithm options'/&gt;
+  &lt;field
+      var='stanzas'
+      type='list-multi'
+      label='Stanzas types to encrypt'/&gt;
+  &lt;field
+      var='secure'
+      type='boolean'
+      label='Require encrypted client-server streams'/&gt;
+  &lt;field
+      var='rekey_freq'
+      type='text-single'
+      label='Minimum number of stanzas between key exchanges'/&gt;
+  &lt;field
+      var='accept_pkids'
+      type='list-multi'
+      label='Acceptable public key IDs'/&gt;
+  &lt;field
+      var='counter'
+      type='hidden'
+      label='Initial block counter'/&gt;
+  &lt;field
+      var='kid'
+      type='hidden'
+      label='Diffie-Hellman key ID'/&gt;
+  &lt;field
+      var='key'
+      type='hidden'
+      label='Diffie-Hellman key'/&gt;
+  &lt;field
+      var='pkey'
+      type='hidden'
+      label='Public key'/&gt;
+  &lt;field
+      var='pkids'
+      type='list-single'
+      label='Public key IDs'/&gt;
+  &lt;field
+      var='signs'
+      type='list-single'
+      label='Data form signatures'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>14.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>15.
+       <a name="keys">Public Key Publication and Retrieval</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is highly preliminary and will be specified in a separate proposal before this document reaches draft status.</span></p>
+  <p class="" style="">Entities SHOULD publish their long-term public signature-verification keys to all entities through their own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>).</p>
+
+  <p class="caption">Example 21. Entity Publishes Public Keys to Server</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='dp1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="" style="">Before initiating an ESession, if Bob does not already possess one of Alice's signature-verification keys, he SHOULD retrieve them from Alice's server.</p>
+  <p class="caption">Example 22. Bob Requests Public Keys from Alice's Server</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="caption">Example 23. Server Returns Public Keys</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='alice@example.org'
+    to='bob@example.com/laptop'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Bob should examine all the public keys and identify which ones are acceptable (see <a href="#sec-keys">Verifying Keys</a>).</p>
+<h2>16.
+       <a name="open">Open Issues</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="open-tothink">To Think About</a>
+</h3>
+    <ol start="" type="">
+      <li>Define an optional protocol that would allow Bob to store y (and the PKIDs he trusts) 'securely' on his own server (before he goes offline). If Bob prefers not to use this protocol (because local storage is more secure), what should he do when he receives an offline Esession if he is <span style="font-style: italic">unable to retrieve the value of y</span> that he stored before going offline (e.g., if he went offline using a different client and/or a different machine)?</li>
+      <li>What challenges exist to make the OTR Gaim Plugin use this protocol natively when talking to Jabber entities? Can these be mitigated by 'non-critical' protocol changes?</li>
+      <li>Would it be possible for an XMPP entity to exchange encrypted messages and presence with a user of a non-XMPP messaging system, assuming that the gateway both supports this protocol and is compatible with a purpose-built security plugin on the other user's client (e.g. a Gaim plugin connects to the gateway via a non-XMPP network)?</li>
+      <li>Could the protocol approximate SSH (or IPsec) more closely without losing the benefits of OTR?</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>16.2 <a name="open-todo">To Do</a>
+</h3>
+    <ol start="" type="">
+      <li>Perhaps the JEP needs to specify more carefully how block counters are handled between messages, especially in the event of partial blocks?</li>
+      <li>Define names for X.509 SubjectPublicKeyInfo public key formats (different to X.509 certificates). This format must be used when keys are distributed within session initiation.</li>
+      <li>Discuss signature formats in greater detail.</li>
+      <li>Give examples of specific errors and discuss error scenarios throughout document (e.g., what should Bob do if he is not offline and he receives an offline key exchange stanza?).</li>
+      <li>Separate public key publishing into another JEP. Should there be a disco item for each key?</li>
+    </ol>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250540">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2250707">2</a>. RFC 3862: Common Presence and Instant Messaging (CPIM): Message Format &lt;<a href="http://www.ietf.org/rfc/rfc3862.txt">http://www.ietf.org/rfc/rfc3862.txt</a>&gt;.</p>
+<p><a name="nt-id2250728">3</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p><a name="nt-id2250750">4</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2250564">5</a>. Off-the-Record Communication, or, Why Not to Use PGP &lt;<a href="http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf">http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf</a>&gt;.</p>
+<p><a name="nt-id2250599">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250626">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250679">8</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2255670">9</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2255693">10</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255730">11</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255760">12</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2255837">13</a>. SSH Protocol Architecture &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2255862">14</a>. SSH Transport Layer Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256098">15</a>. The reliable association between an entity and its public keys is beyond the scope of this JEP.</p>
+<p><a name="nt-id2256126">16</a>. Naturally, it is possible that Alice or Bob may retain cleartext versions of the exchanged communications; however, that threat is out of scope for this JEP.</p>
+<p><a name="nt-id2256322">17</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256345">18</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256444">19</a>. RFC 2631: Diffie-Hellman Key Agreement Method &lt;<a href="http://www.ietf.org/rfc/rfc2631.txt">http://www.ietf.org/rfc/rfc2631.txt</a>&gt;.</p>
+<p><a name="nt-id2256508">20</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2256574">21</a>. RFC 2409: The Internet Key Exchange (IKE) &lt;<a href="http://www.ietf.org/rfc/rfc2409.txt">http://www.ietf.org/rfc/rfc2409.txt</a>&gt;.</p>
+<p><a name="nt-id2256597">22</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p><a name="nt-id2256705">23</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256863">24</a>. RFC 3766: Determining Strengths For Public Keys Used For Exchanging Symmetric Keys &lt;<a href="http://www.ietf.org/rfc/rfc3766.txt">http://www.ietf.org/rfc/rfc3766.txt</a>&gt;.</p>
+<p><a name="nt-id2257034">25</a>. The private signing keys may only be accessible to another of Bob's clients.</p>
+<p><a name="nt-id2257042">26</a>. Some servers may not support public key publishing.</p>
+<p><a name="nt-id2257592">27</a>. The more often Bob changes his published Esession options, the shorter the Perfect Forward Secrecy window of vulnerability. However, whenever he changes them he divulges his presence to all the entities that are monitoring them.</p>
+<p><a name="nt-id2258540">28</a>. K-M<span class="sub" style="">A</span> is a hash of K-E<span class="sub" style="">A</span> (not K) to ensure that if an attacker recovers the decryption key she will not be able to cryptographically convince anyone that it was not her who created the stanza.</p>
+<p><a name="nt-id2258738">29</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2258791">30</a>. Although counter mode encryption requires no padding, implementations MAY still disguise the length of m by appending a random number of white-space characters.</p>
+<p><a name="nt-id2258811">31</a>. If Bob were to receive a stanza out-of-order, then he would fail to decrypt the stanza and be forced to terminate the Esession.</p>
+<p><a name="nt-id2258960">32</a>. Canonical XML 1.0 &lt;<a href="http://www.w3.org/TR/xml-c14n">http://www.w3.org/TR/xml-c14n</a>&gt;.</p>
+<p><a name="nt-id2259026">33</a>. RFC 2104: HMAC: Keyed-Hashing for Message Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2104.txt">http://www.ietf.org/rfc/rfc2104.txt</a>&gt;.</p>
+<p><a name="nt-id2259217">34</a>. If Bob were to receive a stanza out-of-order, then the MACs would not match because the values of C<span class="sub" style="">A</span> would not be synchronized.</p>
+<p><a name="nt-id2259370">35</a>. Bob MUST NOT send a stream error to his server since intermediate entities are not responsible for encoded content.</p>
+<p><a name="nt-id2259794">36</a>. If an entity fails to receive any stanza that includes a new key in the correct order, then it will fail to decrypt the next stanza it receives and be forced to terminate the Esession.</p>
+<p><a name="nt-id2260038">37</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2260088">38</a>. SSH Transport Layer Encryption Modes &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2260374">39</a>. IANA registry of parameters related to secure shell &lt;<a href="http://www.iana.org/assignments/ssh-parameters">http://www.iana.org/assignments/ssh-parameters</a>&gt;.</p>
+<p><a name="nt-id2260422">40</a>. Advanced Encryption Standard: Federal Information Processing Standards Publication 197 &lt;<a href="http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf">http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf</a>&gt;.</p>
+<p><a name="nt-id2260467">41</a>. The Twofish Block Cipher &lt;<a href="http://www.schneier.com/twofish.html">http://www.schneier.com/twofish.html</a>&gt;.</p>
+<p><a name="nt-id2260500">42</a>. The Serpent Block Cipher &lt;<a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">http://www.cl.cam.ac.uk/~rja14/serpent.html</a>&gt;.</p>
+<p><a name="nt-id2260552">43</a>. RFC 2437: PKCS #1: RSA Cryptography Specifications Version 2.0 &lt;<a href="http://www.ietf.org/rfc/rfc2437.txt">http://www.ietf.org/rfc/rfc2437.txt</a>&gt;.</p>
+<p><a name="nt-id2260574">44</a>. Digital Signature Standard: Federal Information Processing Standards Publication 186  &lt;<a href="http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf">http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf</a>&gt;.</p>
+<p><a name="nt-id2260642">45</a>. X.509 Authentication in SSH2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2260721">46</a>. Secure Hash Standard: Federal Information Processing Standards Publication 180-2  &lt;<a href="http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf">http://csrc.nist.gov/publications/fips/fips180-2/fips186-2withchangenotice.pdf</a>&gt;.</p>
+<p><a name="nt-id2260757">47</a>. The Whirlpool Hash Function &lt;<a href="http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html">http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html</a>&gt;.</p>
+<p><a name="nt-id2260831">48</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2260909">49</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260925">50</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2004-08-09)</h4>
+<div class="indent">Added (offline) replay protection; required offline Created header; compression is NOT RECOMMENDED; added second set of offline options for subscribers; added JIDs to session key generation; unencrypted sessions; added 'secure' option; sign whole data form; HMAC whole &lt;encrypted/&gt; element; added Esession termination; option to distribute public keys within session initiation; added Integrity requirement; several clarifications (ip)
+    </div>
+<h4>Version 0.3 (2005-08-02)</h4>
+<div class="indent">Restored status to Experimental; complete rewrite; new Introduction, Background, Requirements and Security Considerations; new OTR-inspired protocol; JEP-0155-based negotiation; counter mode encryption; more secure hashes; offline sessions; re-keying; mac publishing; preliminary key and options publishing protocol. (ip/psa)
+    </div>
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.5.html
+++ b/content/xep-0116-0.5.html
@@ -1,0 +1,1446 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-10">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0116<br>
+            Version: 0.5<br>
+            Last Updated: 2004-08-10<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2104, RFC 2409, RFC 3526, RFC 3548, xml-c14n, JEP-0004, JEP-0020, JEP-0030, JEP-0068, JEP-0079, JEP-0155<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>3.1.  <a href="#terms-personae">Dramatis Personae</a>
+</dt></dl>
+<dt>4.  <a href="#reqs">Requirements</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#reqs-sec">Security Requirements</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#reqs-encrypt">Confidentiality</a>
+</dt>
+<dt>4.1.2.  <a href="#reqs-integrity">Integrity</a>
+</dt>
+<dt>4.1.3.  <a href="#reqs-replay">Replay Protection</a>
+</dt>
+<dt>4.1.4.  <a href="#reqs-forward">Perfect Forward Secrecy</a>
+</dt>
+<dt>4.1.5.  <a href="#reqs-auth">Authentication</a>
+</dt>
+<dt>4.1.6.  <a href="#reqs-repudiate">Repudiability</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#reqs-xmpp">Application Requirements</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#reqs-generality">Generality</a>
+</dt>
+<dt>4.2.2.  <a href="#reqs-implement">Implementability</a>
+</dt>
+<dt>4.2.3.  <a href="#reqs-usable">Usability</a>
+</dt>
+<dt>4.2.4.  <a href="#reqs-flexible">Flexibility</a>
+</dt>
+<dt>4.2.5.  <a href="#reqs-usable">Interoperability</a>
+</dt>
+<dt>4.2.6.  <a href="#reqs-offline">Offline Sessions</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>6.  <a href="#init">ESession Initiation</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#init-online">Online Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>6.1.1.  <a href="#init-request">Esession Request</a>
+</dt>
+<dt>6.1.2.  <a href="#init-prep">Diffie-Hellman Preparation (Bob)</a>
+</dt>
+<dt>6.1.3.  <a href="#init-response">Esession Response</a>
+</dt>
+<dt>6.1.4.  <a href="#init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</dt>
+<dt>6.1.5.  <a href="#init-complete">Diffie-Hellman Completion</a>
+</dt>
+</dl>
+<dt>6.2.  <a href="#init-offline">Offline Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>6.2.1.  <a href="#init-publish">Publishing Esession Options</a>
+</dt>
+<dt>6.2.2.  <a href="#init-offreq">Requesting Offline Esession Options</a>
+</dt>
+<dt>6.2.3.  <a href="#init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</dt>
+<dt>6.2.4.  <a href="#init-start">Starting an Offline Esession</a>
+</dt>
+<dt>6.2.5.  <a href="#init-accept">Accepting Offline Esessions</a>
+</dt>
+</dl>
+<dt>6.3.  <a href="#init-keys">Generating Session Keys</a>
+</dt>
+</dl>
+<dt>7.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#exchange-separate">Encryptable Content</a>
+</dt>
+<dt>7.2.  <a href="#exchange-encrypt">Encryption</a>
+</dt>
+<dt>7.3.  <a href="#exchange-send">Sending an Encrypted Stanza</a>
+</dt>
+<dt>7.4.  <a href="#exchange-decrypt">Decryption</a>
+</dt>
+</dl>
+<dt>8.  <a href="#rekey">Re-Key Exchange</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#rekey-init">Re-Key Initiation</a>
+</dt>
+<dt>8.2.  <a href="#rekey-accept">Re-Key Acceptance</a>
+</dt>
+<dt>8.3.  <a href="#rekey-publish">Publishing Old MAC Values</a>
+</dt>
+</dl>
+<dt>9.  <a href="#terminate">Esession Termination</a>
+</dt>
+<dt>10.  <a href="#sign">Signature Generation</a>
+</dt>
+<dl><dt>10.1.  <a href="#sign-canon">Canonical Form (Informative)</a>
+</dt></dl>
+<dt>11.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#sec-prng">Random Numbers</a>
+</dt>
+<dt>11.2.  <a href="#sec-rekey">Re-Keying Limits</a>
+</dt>
+<dt>11.3.  <a href="#sec-keys">Verifying Keys</a>
+</dt>
+<dt>11.4.  <a href="#sec-replay">Replay Attacks</a>
+</dt>
+<dt>11.5.  <a href="#sec-unencrypted">Unencrypted Esessions</a>
+</dt>
+<dt>11.6.  <a href="#sec-storage">Storage</a>
+</dt>
+<dt>11.7.  <a href="#sec-offline">Offline Esessions</a>
+</dt>
+<dt>11.8.  <a href="#sec-general">Extra Responsabilities of Implementors</a>
+</dt>
+<dt>11.9.  <a href="#sec-mandatory">Mandatory to Implement Technologies</a>
+</dt>
+<dl>
+<dt>11.9.1.  <a href="#sec-mandatory-encryption">Encryption Algorithms</a>
+</dt>
+<dt>11.9.2.  <a href="#sec-mandatory-sign">Key Signing Algorithms</a>
+</dt>
+<dt>11.9.3.  <a href="#sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</dt>
+<dt>11.9.4.  <a href="#sec-mandatory-hash">Hash Algorithms</a>
+</dt>
+<dt>11.9.5.  <a href="#sec-mandatory-compress">Compression Algorithms</a>
+</dt>
+</dl>
+</dl>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#registrar-ns">Namespaces</a>
+</dt>
+<dt>13.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>14.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>15.  <a href="#keys">Public Key Publication and Retrieval</a>
+</dt>
+<dt>16.  <a href="#open">Open Issues</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#open-tothink">To Think About</a>
+</dt>
+<dt>16.2.  <a href="#open-todo">To Do</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">End-to-end encryption is a desirable feature for any communication technology. Ideally, such a technology would design encryption in from the beginning and would forbid unencrypted communications. Realistically, most communication technologies have not been designed in that manner, and Jabber/XMPP technologies are no exception. In particular, the original Jabber technologies developed in 1999 did not include end-to-end encryption by default. PGP-based encryption of message bodies and signing of presence information was added as an extension to the core protocols in the year 2000; this extension is documented in <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2250669">1</a>]. When the core protocols were formalized within the Internet Standards Process by the IETF's XMPP Working Group in 2003, a different extension was defined using S/MIME-based signing and encryption of CPIM-formatted messages (see <span class="ref" style="">RFC 3862</span>  [<a href="#nt-id2250627">2</a>]) and PIDF-formatted presence information (see <span class="ref" style="">RFC 3863</span>  [<a href="#nt-id2250650">3</a>]); this extension is specified in <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2250694">4</a>].</p>
+  <p class="" style="">For reasons described more fully below, the foregoing proposals (and others not mentioned) have not been widely implemented and deployed. This is unfortunate, since an open communication protocol needs to enable end-to-end encryption in order to be seriously considered for deployment by a broad range of users. This proposal describes a different approach to end-to-end encryption for use by entities that communicate using XMPP. The approach taken herein essentially translates the semantics of the secure shell protocol (SSH) into the syntax of XMPP, with some adjustments that reflect reports of security issues with SHA-1 and insights gleaned from implementation of "off-the-record" (OTR) communication in the Gaim encryption plugin as described in <span class="ref" style="">Off-the-Record Communication</span>  [<a href="#nt-id2250454">5</a>]. The result is a protocol for encrypted sessions or "ESessions".</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">As specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250486">6</a>], XMPP is an XML streaming protocol that enables the near-real-time exchange of XML fragments between any two (or more) network endpoints. To date, the main application built on top of the core XML streaming layer is instant messaging (IM) and presence, the base extensions for which are specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250514">7</a>]. There are three first-level elements of XML streams (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;); each of these "XML stanza" types has different semantics, which can complicate the task of defining a generalized approach to end-to-end encryption for XMPP. In addition, XML stanzas can be extended (via properly-namespaced child elements) for a wide variety of functionality. The chosen approach should enable encryption of several complete XML elements rather than only parts thereof (e.g., only the XML character data of the message &lt;body/&gt; element as in <span style="font-weight: bold">JEP-0027</span>).</p>
+  <p class="" style="">XMPP is a session-oriented communication technology: normally, a client authenticates with a server and maintains a long-lived connection that defines the client's XMPP session. Such stream-level sessions are secured via channel encryption using Transport Level Security (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2255652">8</a>]), as specified in Section 5 of <span style="font-weight: bold">RFC 3920</span>. However, there is no guarantee that all hops will implement or enforce channel encryption (or that intermediate routers are trustworthy), which makes end-to-end encryption desirable.</p>
+  <p class="" style="">The session metaphor also applies to communication between endpoints: for instance, in IM applications, most instant messaging exchanges occur in bursts within limited time periods (e.g., two people may send a fairly large number of messages during a five-minute chat and then not exchange messages again for hours or even days). The XML stanzas exchanged during such a session may not be limited to &lt;message/&gt; stanzas; for instance, the session may be triggered by a change in one of the parties' presence status (e.g., changing from away to available) and the session may involve the exchange of &lt;iq/&gt; stanzas (e.g., to transfer a file as specified in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2255699">9</a>]). Endpoints may want to encrypt the stanzas they send to each other in such a way that the stanzas cannot be understood by untrusted mediating entities (such as servers) except to the extent required to understand the necessary routing information. (One complicating factor is that routing information may include not only the stanza's 'to', 'from', 'type, and 'id' attributes, but also <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255721">10</a>] extensions.)</p>
+  <p class="" style="">The foregoing XMPP communications exist in the context of a one-to-one communication session between two entities. However, several forms of XMPP communication exist outside the context of one-to-one communication sessions:</p>
+  <ul>
+    <li>Many-to-many sessions, such as a text conference in a chatroom as specified in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255756">11</a>].</li>
+    <li>One-to-many "broadcast", such as undirected presence stanzas sent from one user to many contacts (see <span style="font-weight: bold">RFC 3921</span>) and data syndication implemented using <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2255786">12</a>].</li>
+    <li>One-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</li>
+  </ul>
+  <p class="" style="">Ideally, any technology for end-to-end encryption in XMPP could be extended to cover these scenarios as well as one-to-one communication sessions. However, both many-to-many sessions and one-to-many broadcast are deemed out of scope for this JEP. Offline communications are handled via a simple extension to the protocol for one-to-one sessions between two entities that are online simultaneously (see below).</p>
+  <p class="" style="">Because XMPP is a session-oriented communication technology, encryption schemes that are appropriate for less dynamic technologies may not be appropriate for XMPP. XMPP, with its in-order delivery of XML stanzas, is able to take advantage of encryption approaches that are not feasible for less dynamic technologies. In particular, existing approaches to encryption of Internet communications have generally assumed that the "thing" to be encrypted has a stable identity or is best understood as a standalone object (e.g., a file or email message); the term "object encryption" well captures this assumption. Both <span style="font-weight: bold">JEP-0027</span> and <span style="font-weight: bold">RFC 3923</span> assume that XMPP communications are more like the exchange of email messages than they are like an interactive session -- while <span style="font-weight: bold">JEP-0027</span> uses "old-style" PGP object encryption and <span style="font-weight: bold">RFC 3923</span> uses "new-style" S/MIME object encryption, both specify the use of object encryption. </p>
+  <p class="" style="">However, the session-oriented nature of XMPP may imply that the focus should be on "session encryption" rather than "object encryption". The paradigm for XMPP encryption may be something closer to the widely-deployed Secure Shell technology (see <span class="ref" style="">SSH Protocol Architecture</span>  [<a href="#nt-id2255916">13</a>] and <span class="ref" style="">SSH Transport Layer Protocol</span>  [<a href="#nt-id2255889">14</a>]) than to traditional encryption of files and standalone email messages. In many ways, Secure Shell (or, more specifically, OTR) is the conceptual model for the current proposal.</p>
+  <p class="" style="">Therefore, this JEP specifies a method for encrypted sessions ("ESessions") that takes advantage of the inherent possibilities and strengths of session encryption as opposed to object encryption. The basic concept is that of an encrypted session which acts as a secure tunnel between two endpoints. Once the tunnel is established, the content of all one-to-one XML stanzas exchanged between the endpoints will be encrypted and then transmitted within a "wrapper" protocol element.</p>
+<h2>3.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="terms-personae">Dramatis Personae</a>
+</h3>
+    <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+    <ol start="1" type="">
+      <li>"Alice" is the name of the initiator of the ESession. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+      <li>"Bob" is the name of the other participant in the ESession started by Alice. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    </ol>
+    <p class="" style="">While Alice and Bob are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an Esession.</p>
+  </div>
+<h2>4.
+       <a name="reqs">Requirements</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="reqs-sec">Security Requirements</a>
+</h3>
+    <p class="" style="">This JEP stipulates the following security requirements for end-to-end encryption of XMPP communications:</p>
+    <ul>
+      <li>Confidentiality</li>
+      <li>Integrity</li>
+      <li>Replay protection</li>
+      <li>Perfect forward secrecy</li>
+      <li>Authentication</li>
+      <li>Repudiability</li>
+    </ul>
+    <p class="" style="">Each of these requirements is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="reqs-encrypt">Confidentiality</a>
+</h3>
+      <p class="" style="">The one-to-one XML stanzas exchanged between two entities MUST NOT be understandable to any other entity that might intercept the communications.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="reqs-integrity">Integrity</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be sure that no other entity may change the content of the XML stanzas they exchange, or remove or insert stanzas into the Esession undetected.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.3 <a name="reqs-replay">Replay Protection</a>
+</h3>
+      <p class="" style="">Alice or Bob MUST be able to identify and reject any communications that are copies of their previous communications resent by another entity.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.4 <a name="reqs-forward">Perfect Forward Secrecy</a>
+</h3>
+      <p class="" style="">The encrypted communication MUST NOT be revealed even if long-lived keys are compromised in the future (e.g., Steve steals Bob's computer).</p>
+    </div>
+    <div class="indent">
+<h3>4.1.5 <a name="reqs-auth">Authentication</a>
+</h3>
+      <p class="" style="">Each party to a conversation MUST know that the other party is who he says he is (Alice must be able to know that Bob really is Bob, and vice versa).  [<a href="#nt-id2256127">15</a>]</p>
+    </div>
+    <div class="indent">
+<h3>4.1.6 <a name="reqs-repudiate">Repudiability</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be able to repudiate any stanza that occurs within an Esession. After an Esession has finished, it SHOULD NOT be possible to <span style="font-style: italic">prove cryptographically</span> that any transcript has not been modified by a third party.  [<a href="#nt-id2256154">16</a>]</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="reqs-xmpp">Application Requirements</a>
+</h3>
+    <p class="" style="">In addition to the foregoing security profile, this JEP also stipulates the following application-specific requirements for encrypted communication in the context of Jabber/XMPP technologies:</p>
+    <ul>
+      <li>Generality</li>
+      <li>Implementability</li>
+      <li>Usability</li>
+      <li>Flexability</li>
+      <li>Interoperability</li>
+      <li>Offline "sessions"</li>
+    </ul>
+    <p class="" style="">Each of these is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.2.1 <a name="reqs-generality">Generality</a>
+</h3>
+      <p class="" style="">The solution should be generally applicable to any XML stanza type (&lt;message/&gt;, &lt;presence/&gt;, &lt;iq/&gt;) sent between two entities. It is deemed acceptable for now if the solution does not apply to many-to-many stanzas (e.g., groupchat messages sent within the context of multi-user chat) or one-to-many stanzas (e.g., presence "broadcasts" and pubsub notifications); end-to-end encryption of such stanzas may require separate solutions or extensions to the one-to-one session solution.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="reqs-implement">Implementability</a>
+</h3>
+      <p class="" style="">The only good security technology is an implemented security technology. The solution should be one that typical client developers can implement in a relatively straightforward and consistent fashion.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="reqs-usable">Usability</a>
+</h3>
+      <p class="" style="">The requirement of usability takes implementability one step further by stipulating that the solution must be one that organizations may deploy and humans may use with 100% transparency (with the ease-of-use of https:). Experience has shown that: solutions requiring a full public key infrastructure do not get widely deployed, and solutions requiring any user action are not widely used. We can do better.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.4 <a name="reqs-flexible">Flexibility</a>
+</h3>
+      <p class="" style="">The solution should be compatible with existing (and future) cryptographic algorithms and identity certification schemes (including X.509 and PGP).</p>
+    </div>
+    <div class="indent">
+<h3>4.2.5 <a name="reqs-usable">Interoperability</a>
+</h3>
+      <p class="" style="">Ideally, it would be possible for an XMPP user to exchange encrypted messages (and, potentially, presence information) with users of non-XMPP messaging systems.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.6 <a name="reqs-offline">Offline Sessions</a>
+</h3>
+      <p class="" style="">Ideally, it should be possible to encrypt one-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</p>
+    </div>
+  </div>
+<h2>5.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">Before attempting to engage in an ESession with Bob, Alice SHOULD discover whether he supports this protocol, using either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256373">17</a>] or the presence-based profile of <span style="font-weight: bold">JEP-0030</span> specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256395">18</a>].</p>
+  <p class="" style="">The normal course of events is for Alice to authenticate with her server, retrieve her roster (see <span style="font-weight: bold">RFC 3921</span>), send initial presence to her server, and then receive presence information from all the contacts in her roster. If the presence information she receives from some contacts does not include capabilities data (per <span style="font-weight: bold">JEP-0115</span>), Alice SHOULD then send a service discovery information ("disco#info") request to each of those contacts (in accordance with <span style="font-weight: bold">JEP-0030</span>). Such initial service discovery stanzas MUST NOT be considered part of encrypted communication sessions for the purposes of this JEP, since they perform a "bootstrapping" function that is a prerequisite to encrypted communications. The disco#info request sent from Alice to Bob might look as follows:</p>
+  <p class="caption">Example 1. Alice Queries Bob for Esession Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com/laptop'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Bob sends a disco#info reply and he supports the protocol defined herein, then he MUST include a service discovery feature variable of "http://jabber.org/protocol/esession".</p>
+  <p class="caption">Example 2. Bob Returns disco#info Data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='bob@example.com/laptop'
+    to='alice@example.org/pda'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='client' type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/esession'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="init">ESession Initiation</a>
+</h2>
+  <p class="" style="">The process for establishing an ESession is essentially a translation into XMPP syntax of the SSH transport mechanism for establishing a secure session over an insecure transport (see <span style="font-weight: bold">SSH Transport Layer Protocol</span>). Specifically, as in SSH, ESession uses a Diffie-Hellman key exchange algorithm (see <span class="ref" style="">RFC 2631</span>  [<a href="#nt-id2256494">19</a>]) in the initial negotation (although, as we shall see, it does not use SHA-1 as the hashing algorithm).</p>
+  <p class="" style="">When Alice wishes to establish an ESession with Bob, Alice may choose between two different methods of performing the initial Diffie-Hellman key exchange, depending on whether Bob is online or not. Note: Alice MUST NOT initiate a new Esession with Bob if she already has one established with him.</p>
+
+  <div class="indent">
+<h3>6.1 <a name="init-online">Online Diffie-Hellman Key Exchange</a>
+</h3>
+    <p class="" style="">If Alice believes Bob may be online then she SHOULD retrieve Bob's long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) and then use the protocol specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2256559">20</a>] to negotiate the initial Diffie-Hellman key. In this aggressive exchange the first two messages negotiate policy, swap Diffie-Hellman public values and the ancillary data necessary for the exchange and authentication. The second message also authenticates the responder. The third message authenticates the initiator and exchanges the final Diffie-Hellman public value.</p>
+    <div class="indent">
+<h3>6.1.1 <a name="init-request">Esession Request</a>
+</h3>
+      <p class="" style="">Alice MUST specify each of the Esession options (algorithms etc.) she is willing to use, in her order of preference (see <a href="#sec-mandatory">Mandatory to Implement Technologies</a>):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">The list of Modular Exponential (MODP) group numbers (as specified in <span class="ref" style="">RFC 2409</span>  [<a href="#nt-id2256625">21</a>] or <span class="ref" style="">RFC 3526</span>  [<a href="#nt-id2256648">22</a>]) she is willing to use for Diffie-Hellman key exchange (valid group numbers include 1,2,3,4,5,14,15,16,17 and 18)</p></li>
+        <li><p class="" style="">Stanza symmetric encryption algorithm names</p></li>
+        <li><p class="" style="">Hash algorithm names</p></li>
+        <li><p class="" style="">Compression algorithm names</p></li>
+        <li><p class="" style="">The list of stanza types she is willing to encrypt and decrypt</p></li>
+        <li><p class="" style="">Whether or not both entities MUST be connected securely to their servers (see Section 5 of <span style="font-weight: bold">RFC 3920</span>)</p></li>
+        <li><p class="" style="">The minimum number of stanzas that MUST be exchanged before an entity MAY initiate a key re-exchange (1 - every stanza, 100 - every hundred stanzas). This value MUST be less than 2<span class="super" style="">32</span> (see <a href="#sec-rekey">Re-Keying Limits</a>)</p></li>
+        <li><p class="" style="">The Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256756">23</a>]) SHA-256 fingerprint (PKID) of each of Bob's public signature-verification keys that she found acceptable (see <a href="#sec-keys">Verifying Keys</a>)</p></li>
+      </ol>
+    <p class="caption">Example 3. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='form' xmlns='jabber:x:data'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='logging'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field type='list-single' var='modp'&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;1&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='crypt_algs'&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='hash_algs'&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='compress'&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='stanzas'&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='secure'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='rekey_freq'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='accept_pkids'&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob does not support one or more of the options in each Esession field (except the 'accept_pkids' field), then he SHOULD return a &lt;feature-not-implemented/&gt; error (but he MAY return no error if, for example, he does not want to reveal his presence to Alice for whatever reason):</p>
+    <p class="caption">Example 4. Bob Informs Alice that Her Options Are Not Supported</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='bob@example.com/laptop'
+         to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    ...
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Either Bob or Alice MAY attempt to initiate a new ESession after any error during the initiation process. However, both MUST consider the previous negotiation to have failed and MUST discard any information learned through the previous negotiation.</p>
+    </div>
+    <div class="indent">
+<h3>6.1.2 <a name="init-prep">Diffie-Hellman Preparation (Bob)</a>
+</h3>
+      <p class="" style="">If Bob is willing to start an ESession with Alice, he SHOULD retrieve Alice's long-term public signature-verification keys. He MUST select one of the options from each of the Esession fields he received from Alice including one of the MODP groups (see <span class="ref" style="">RFC 3766</span>  [<a href="#nt-id2256913">24</a>] or <span style="font-weight: bold">RFC 3526</span> for recommendations regarding balancing the sizes of symmetric cipher blocks and Diffie-Hellman moduli). Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). Bob MUST then perform the following computations (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n-1 random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.1.3 <a name="init-response">Esession Response</a>
+</h3>
+    <p class="" style="">Bob responds to Alice specifying the Esession options he selected.</p>
+    <p class="" style="">If Bob is willing to start an ESession with Alice, then instead of providing the PKID of his public key that he selected, Bob MUST specify the Base64 encoded SHA-256 fingerprint (PKID) of each of Alice's public signature-verification keys that he finds acceptable (see <a href="#sec-keys">Verifying Keys</a>). Note: The submited values for the 'accept_pkids' field do not correspond to the options he received. The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Alice.</p>
+    <p class="" style="">In addition to the fields he received from Alice, Bob MUST include the KID and the Base64 encoded values of d and C<span class="sub" style="">A</span>. If Alice selected one or more of his public keys, and if Bob has access to a long-lived private signing key that corresponds to one of those keys  [<a href="#nt-id2257220">25</a>], then he MUST also include the PKID. Otherwise (for example, if Bob is unable to publish keys to his server or if Alice is unable to access keys published via his server  [<a href="#nt-id2257228">26</a>]), Bob MAY include one of his Base64 encoded public keys. In either case, Bob MUST include the Base64 encoded signature (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+    <p class="" style="">However, if Bob is ready to initiate a one-to-one chat session with Alice (see <span style="font-weight: bold">Chat Session Negotiation</span>) but he is unwilling to start an ESession, then he SHOULD terminate the Esession negotiation by not specifying any of the five extra values in his response.</p>
+    <p class="caption">Example 5. Bob Responds to Alice (with Public Key)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      ...
+      &lt;field var='modp'&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='hash_algs'&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='compress'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='stanzas'&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='secure'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='accept_pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field var='counter'&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkey'&gt;
+        &lt;value&gt; ** Base64 encoded public key ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 6. Bob Responds to Alice (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+      &lt;field var='counter'&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Alice provided a PKID but Bob did not provide a signature then she MAY send a failure notice to him. If Bob sent Alice a public key but she could not verify it belongs to him via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then she SHOULD send a failure notice to him. If Bob provided an invalid signature (see <a href="#sign">Signature Generation</a>) then she MUST send a failure notice to him.</p>
+    <p class="caption">Example 7. Alice Signals that ESession Negotiation Failed (Unacceptable Signature)</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='alice@example.org/pda'
+         to='bob@example.com/laptop'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-signature xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.4 <a name="init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</h3>
+      <p class="" style="">After verifying Bob's signature, Alice can be certain that the value of d was actually generated by Bob. Alice MUST use the value of d and the Esession options specified in Bob's response to perform the following steps (where n is the number of bits per encryption block for the agreed encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value she received from Bob</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span></p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (this is the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.1.5 <a name="init-complete">Diffie-Hellman Completion</a>
+</h3>
+    <p class="" style="">Alice then completes the Diffie-Hellman negotiation by sending Bob the KID and the Base64 encoded value of e. If Bob selected one or more of her public keys, and if Alice has access to a long-lived private signing key that corresponds to one of those keys, then she MUST also include the PKID. Otherwise, Alice MAY include one of her Base64 encoded public keys (see <a href="#init-response">Esession Response</a> example). In either case, Alice MUST include the Base64 encoded signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form from her initial Esession request and of the <span style="font-style: italic">content</span> of this data form (excluding the 'signs' field).</p>
+    <p class="" style="">Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza as the Diffie-Hellman completion.</p>
+    <p class="caption">Example 8. Alice Completes Diffie-Hellman Negotitation (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x xmlns='jabber:x:data'&gt;
+      &lt;field var='kid'&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='key'&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='pkids'&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='req_sign'&gt;&lt;value&gt; ** Base64 encoded signature of her previous form ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='signs'&gt;&lt;value&gt; ** Base64 encoded signature of this form ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob provided a PKID but Alice did not provide a signature then he MAY send a failure notice to her. If Alice sent Bob a public key but he could not verify it belongs to her via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then he SHOULD send a failure notice to her. If Alice provided an invalid signature (see <a href="#sign">Signature Generation</a>) then he MUST send a failure notice to her. If Bob sends a failure notice then he SHOULD ignore any encrypted content in the stanza.</p>
+    <p class="" style="">If no error occurs, Bob MUST calculate K = e<span class="super" style="">y</span> mod p (the shared secret). Alice and Bob then have the same value for K and the key exchange is complete.</p>
+    </div>
+  </div>
+
+
+
+<div class="indent">
+<h3>6.2 <a name="init-offline">Offline Diffie-Hellman Key Exchange</a>
+</h3>
+  <p class="" style="">As described below, offline negotiation of an Esession is in essence a special case of online negotiation. Bob MAY publish a set of Esession options just before he goes offline (see <a href="#sec-offline">Offline Esessions</a> Security Considerations) to allow entities that subscribe to his presence to initiate Esessions and send encrypted stanzas to him while he is offline. He MAY also publish <span style="font-style: italic">another</span> similar set of relatively long-lived  [<a href="#nt-id2256934">27</a>] Esession options that any entity MAY use for the same purpose.</p>
+    <div class="indent">
+<h3>6.2.1 <a name="init-publish">Publishing Esession Options</a>
+</h3>
+      <p class="" style="">In order to publish either set of his offline Esession options Bob MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1, where n is the largest number of bits per encryption block for the encryption algorithms he is willing to use)</p></li>
+        <li><p class="" style="">Select a MODP group (that defines the constants p and g)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d (typically by calculating a hash of d, since this KID SHOULD be unique across all Esessions)</p></li>
+        <li><p class="" style="">Store the values of y and d and the KID in a secure way, so that he can retrieve them when he comes back online (idealy even if that is using a different client and/or a different machine)</p></li>
+        <li><p class="" style="">Publish each of the Esession options he is willing to use (see <a href="#init-request">Esession Request</a>) including the value of d and the KID. He SHOULD do this through his own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>) or a similar protocol (out of scope for this JEP).</p></li>
+      </ol>
+      <p class="" style="">Note: The single specified MODP group MUST be the one Bob used to generate d. The list of stanza types he is willing to decrypt MUST NOT include the value 'iq'. Bob MUST also include the list of the PKIDs of all his public signature-verification keys that he can sign for, and the corresponding list of Base64 encoded signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style=""><span style="font-style: italic">Note: This publishing protocol is highly preliminary and depends on a separate proposal.</span></p>
+      <p class="caption">Example 9. Bob Publishes His Esession Options for His Subscribers</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info-subscription'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field var='modp'&gt;
+        &lt;value&gt;2&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;
+        &lt;value&gt;aes256-ctr&lt;/value&gt;
+        &lt;value&gt;twofish256-ctr&lt;/value&gt;
+        &lt;value&gt;aes128-ctr&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='hash_algs'&gt;
+        &lt;value&gt;whirlpool&lt;/value&gt;
+        &lt;value&gt;sha256&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='compress'&gt;
+        &lt;value&gt;none&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='stanzas'&gt;
+        &lt;value&gt;message&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='secure'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">Bob MAY publish his Esession options for all entities using the same protocol except for the 'xmlns' and 'node' attributes of the &lt;query/&gt; element:</p>
+      <p class="caption">Example 10. Bob Publishes His Esession Options for All Entities</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.2 <a name="init-offreq">Requesting Offline Esession Options</a>
+</h3>
+      <p class="" style="">If Alice believes Bob is offline she SHOULD request his Esession options and his long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) from his server.</p>
+      <p class="" style="">If Alice is subscribing to Bob's presence she MUST request his Esession Options exclusively for subscribers.</p>
+      <p class="caption">Example 11. Alice asks Bob's Server for his Esession Options (Subscribers)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If Alice is not subscribing to Bob's presence (or if Bob has no Esession Options exclusively for subscribers) she MUST use the following request instead.</p>
+      <p class="caption">Example 12. Alice asks Bob's Server for his Esession Options (All Entities)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If, after receiving Bob's public keys and Esession options, Alice is unable to verify any of Bob's signatures (see <a href="#sign">Signature Generation</a>) then she MAY decide to proceed no further, since she cannot be sure who will be able to decrypt her stanzas.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.3 <a name="init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</h3>
+      <p class="" style="">Alice MUST select one of the options from each of Bob's Esession fields. If she cannot support any of the options in a field (except the 'pkids' and 'signs' fields) then she MUST not send encrypted stanzas to Bob while he is offline.</p>
+      <p class="" style="">Alice MUST use the value of d and the MODP group specified in Bob's Esession options to perform the following steps (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n-1 random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the counter for stanzas sent from Bob to Alice - in case Bob comes online before Alice terminates the Esession)</p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.2.4 <a name="init-start">Starting an Offline Esession</a>
+</h3>
+      <p class="" style="">Alice then sends Bob the KID and the Base64 encoded values of e and C<span class="sub" style="">A</span>. She SHOULD also include the list of the PKIDs of all her public signature-verification keys that she can sign for, and the corresponding list of Base64 encoded signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style="">She also specifies which of Bob's Esession options she selected. Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Bob.</p>
+      <p class="" style="">Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza.</p>
+      <p class="caption">Example 13. Alice Establishes an ESession Without Negotiation</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com' type='chat'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x xmlns='jabber:x:data'&gt;
+      &lt;field var='logging'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='modp'&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='hash_algs'&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='compress'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='stanzas'&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='secure'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='counter'&gt;&lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='kid'&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='key'&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+      <p class="" style="">Alice can assume that she and Bob have the same value for K and that the key exchange is complete.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.5 <a name="init-accept">Accepting Offline Esessions</a>
+</h3>
+      <p class="" style="">When Bob comes online he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Retrieve the two sets of Esession options he MAY have published (see <a href="#init-publish">Publishing Esession Options</a>)</p></li>
+        <li>
+<p class="" style="">Ensure he is no longer publishing offline Esession options exclusively for entities that are subscribing to his presence</p>
+            <p class="caption">Example 14. Bob Stops Publishing His Esession Options</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+        </li>
+        <li><p class="" style="">Retrieve any values of y, d and KID that he stored before going offline, and destroy in a secure way any persistently stored copies that correspond to Esession options exclusively for subscribers</p></li>
+        <li><p class="" style="">Confirm those values of d and KID match the published values. They may not match if, for example, he went offline using a different client and/or a different machine. Note: if they do not match then he cannot decrypt any offline Esessions he receives.</p></li>
+      </ol>
+      <p class="" style="">When Bob receives a key exchange stanza from Alice then he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Confirm that the KID he received from Alice matches one of the KIDs he published</p></li>
+        <li><p class="" style="">Confirm that he can support all the Esession options he received from Alice</p></li>
+        <li><p class="" style="">Confirm that he has not already received a key exchange stanza from Alice with the same value of e since he came online (see <a href="#sec-replay">Replay Attacks</a>)</p></li>
+        <li><p class="" style="">Request Alice's public keys and, if possible, verify one of her signatures (see <a href="#sign">Signature Generation</a>; if he is unable to verify any of her signatures then he MAY decide to proceed no further, since he cannot be sure who started the Esession)</p></li>
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value he received from Alice</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (in case Alice has not yet terminated the Esession)</p></li>
+        <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="indent">
+<h3>6.3 <a name="init-keys">Generating Session Keys</a>
+</h3>
+    <p class="" style="">Whichever method Alice used to perform the Diffie-Hellman key exchange (online or offline), once it is complete, then before Alice and Bob can start encrypting and decrypting stanzas they MUST both use the agreed hash algorithm ("HASH") and their full JIDs to generate two pairs of keys, one for each direction of the ESession. Note: JID<span class="sub" style="">B</span> MUST be Bob's bare JID throughout an offline Esession, even if he comes online in the middle of the Esession and the key is re-exchanged.</p>
+    <p class="" style="">For stanzas that Alice will send to Bob, the keys are calculated as:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">A</span> = HASH(K-E<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)  [<a href="#nt-id2258876">28</a>]</p></li>
+    </ol>
+    <p class="" style="">For stanzas that Bob will send to Alice the keys are calculated as:</p>
+    <ol start="4" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">B</span> = HASH(K-E<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)</p></li>
+    </ol>
+    <p class="" style="">Once the two pairs of keys have been calculated the value of K MUST be securely destroyed.</p>
+    <p class="" style="">As many bytes of key data as are needed MUST be taken from the beginning of the hash output. When negotiating a hash, entities MUST ensure that the hash output is no shorter than the required key data. For algorithms with variable-length keys the maximum length (up to the hash output length) SHOULD be used.</p>
+
+    <p class="" style="">With these keys computed and the algorithms agreed upon, ESession initiation is now complete. From this point forward, Alice and Bob MUST exchange only encrypted forms of the one-to-one stanza types they agreed upon (e.g., &lt;message/&gt; and &lt;iq/&gt; stanzas).</p>
+  </div>
+<h2>7.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="exchange-separate">Encryptable Content</a>
+</h3>
+    <p class="" style="">Once an Esession has been established, whenever Alice wants to send Bob an encrypted stanza she MUST only encrypt the XML content that would normally be ignored by the intermediate servers. She MUST NOT encrypt stanza wrapper elements or <span style="font-weight: bold">Advanced Message Processing</span> elements.</p>
+    <p class="" style="">If this is an offline Esession then Alice SHOULD include a 'Created' SHIM header in the encrypted content. Bob SHOULD trust this header and ignore the unencrypted <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2259075">29</a>] element inserted by his server.</p>
+
+  <p class="caption">Example 15. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+  &lt;amp per-hop='true' xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+
+  <p class="caption">Example 16. XML Content to be Encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+  &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+&lt;/headers&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+</pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="exchange-encrypt">Encryption</a>
+</h3>
+
+    <p class="" style="">Alice MUST perform the following steps to encrypt the XML content.</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Serialize the XML content she wishes to send into an array of UTF-8 bytes, m.  [<a href="#nt-id2259128">30</a>]</p></li>
+      <li>
+        <p class="" style="">Compress m using the negotiated algorithm. If a compression algorithm other than 'none' was agreed, the compression context is typically initialized after key exchange and passed from one stanza to the next, with only a partial flush at the end of each stanza.  [<a href="#nt-id2259147">31</a>]</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = compress(m)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Encrypt the data with the agreed algorithm in counter mode, using the encryption key K-E<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented for each encrypted block or partial block, and if C<span class="sub" style="">A</span>=2<span class="super" style="">n</span>-1 (where n is the number of bits per encryption block for the agreed encryption algorithm) then C<span class="sub" style="">A</span> MUST be "incremented" to 1. Note: if the encryption algorithm 'none' was agreed (see <a href="#sec-unencrypted">Unencrypted Esessions</a>) encryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_final = encrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Alice MUST now create the XML <span style="font-style: italic">content</span> of the &lt;encrypted/&gt; XML element (with no CDATA between any of the elements) in canonical form (see <span class="ref" style="">Canonical XML</span>  [<a href="#nt-id2259296">32</a>]). The XML SHOULD include the Base64 encoded value of m_final, and Bob's KID (the one that corresponds to the value of d she used to encrypt the data). It MAY also contain one &lt;key/&gt; element and one or more &lt;old/&gt; elements (see <a href="#rekey">Re-Keying</a>).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_content = '&lt;data kid=" ** KID ** "&gt; ** Base64 encoded m_final ** &lt;/data&gt;'</pre></div>
+      </li>
+      <li>
+        <p class="" style="">The XML content and the value of Alice's encryption block counter C<span class="sub" style="">A</span> <span style="font-style: italic">before</span> the data was encrypted, are now processed through the HMAC algorithm (as defined in Section 2 of <span class="ref" style="">RFC 2104</span>  [<a href="#nt-id2259362">33</a>]), along with the agreed hash algorithm ("HASH") and the integrity key K-M<span class="sub" style="">A</span>.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>a_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+    </ol>
+
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="exchange-send">Sending an Encrypted Stanza</a>
+</h3>
+    <p class="" style="">Before sending the stanza to Bob, Alice MUST wrap m_content and the Base64 encoded value of a_mac (wrapped in a &lt;mac/&gt; element) inside an &lt;encrypted/&gt; element and insert it into the stanza in place of the original content. There MUST NOT be more than one &lt;encrypted/&gt; element per stanza.</p>
+    <p class="caption">Example 17. Message Stanza with Encrypted Content</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp per-hop='true' xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="exchange-decrypt">Decryption</a>
+</h3>
+
+    <p class="" style="">When Bob receives the stanza from Alice, he extracts and Base64 decodes the values of m_final and a_mac from the content and performs the following steps. Note: Alice may not have received Bob's last re-key (see <a href="#rekey">Re-Keying</a>) before sending the stanza. So Bob MUST ensure he uses the values of K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> that correspond to his KID that Alice specified with the 'kid' attribute of the &lt;data/&gt; element in the stanza he received (and the current value of e that Alice sent him previously).</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Remove the &lt;mac/&gt; element from the &lt;encrypted/&gt; element and convert the remaining XML <span style="font-style: italic">content</span> into canonical form (with no CDATA between any of the elements, see <span style="font-weight: bold">Canonical XML</span>). Calculate the Message Authentication Code (MAC) for the content.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>b_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Verify that b_mac and a_mac match. If they are not identical, the content has been tampered with and Bob MUST terminate the ESession by sending an error to Alice.  [<a href="#nt-id2259554">34</a>]</p>
+      </li>
+      <li>
+        <p class="" style="">Decrypt m_final using the agreed algorithm, K-E<span class="sub" style="">A</span> and C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented for each decrypted block, and if C<span class="sub" style="">A</span>=2<span class="super" style="">n</span>-1 (where n is the number of bits per encryption block for the agreed encryption algorithm) then C<span class="sub" style="">A</span> MUST be "incremented" to 1. Note: if the encryption algorithm 'none' was agreed decryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = decrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_final)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Decompress m_compressed using the negotiated algorithm (usually 'none').</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m = decompress(m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Replace the &lt;encrypted/&gt; element in the serialized XML stanza with m and feed the stanza into an XML parser. If the parser returns an XML format error then Bob MUST terminate the ESession by sending an error to Alice.  [<a href="#nt-id2259706">35</a>]</p>
+      </li>
+    </ol>
+  </div>
+  <h2>8.
+       <a name="rekey">Re-Key Exchange</a>
+</h2>
+<p class="" style="">Once an attacker has discovered an encryption key it could be used to decrypt all stanzas within a session, including stanzas that were intercepted <span style="font-style: italic">before</span> the key was discovered. To reduce the window of vulnerability, both Alice and Bob SHOULD change their values of x and y and re-exchange the encryption key as regularly as possible. They MUST also destroy all copies of keys as soon as they are no longer needed.</p>
+<p class="" style="">Note: Although most entities are capable of re-keying after each stanza, clients running in constrained runtime environments may require a few seconds to re-key. During Esession initiation these clients MAY negotiate the minimum number of stanzas to be exchanged between re-keys at the cost of a larger window of vulnerability. Entities MUST NOT initiate key re-exchanges more frequently than the agreed limit.</p>
+
+  <div class="indent">
+<h3>8.1 <a name="rekey-init">Re-Key Initiation</a>
+</h3>
+    <p class="" style="">Either Alice or Bob MAY initiate a key re-exchange. Here we describe the process initiated by Alice. First she MUST calculate new values for the encryption parameters:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1, where n is the number of bits per encryption block for the agreed encryption algorithm)</p></li>
+      <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+      <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the new shared secret)</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">To avoid extra stanzas, the new value of e SHOULD be sent to Bob along with an encrypted stanza. Note: Alice MUST NOT use the new K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> to encrypt this stanza or to calculate the MAC. However, she MUST use them when sending subsequent stanzas.</p>
+    <p class="" style="">Note: There is no need for Alice to provide a signature because the calculation of the MAC includes the new value of e, see <a href="#exchange">Exchanging Stanzas</a>).</p>
+    <p class="caption">Example 18. Alice Sends Re-Key Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;key kid=' ** KID ** '&gt; ** Base64 encoded value of new e ** &lt;/key&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Bob may not receive the new key before he sends his next stanzas (they may cross in transit). So, before destroying her old values of K-E<span class="sub" style="">B</span> and K-M<span class="sub" style="">B</span>, Alice MUST wait until either she receives a stanza encrypted with the new key, or a reasonable time has passed (60 seconds should cover a network round-trip and calculations by a constrained client). Similarly she MUST wait before destroying her old value of x, in case Bob sends two stanzas before receiving Alice's new key (the first stanza might include a re-key).</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="rekey-accept">Re-Key Acceptance</a>
+</h3>
+    <p class="" style="">After Bob receives a stanza with a new value of e and he has decrypted the stanza with the old value of K-E<span class="sub" style="">A</span>, he MUST securely destroy all copies of K-E<span class="sub" style="">A</span> and K-E<span class="sub" style="">B</span> and perform the following calculations with the new value of e:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">He MUST use these new values to encrypt and decrypt all subsequent stanzas.  [<a href="#nt-id2260131">36</a>]</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="rekey-publish">Publishing Old MAC Values</a>
+</h3>
+    <p class="" style="">Either entity MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> as part of any encrypted stanza as long as it knows that all the stanzas that MAY use the old values have been received and validated. It MUST wait until it has received either a re-key or a stanza encrypted with a newer key from the other entity.</p>
+    <p class="" style="">Once the expired MAC keys have been published, anyone could create valid arbitrary stanzas with them. This prevents anyone being able to prove the authenticity of a transcript of the Esession in the future.</p>
+    <p class="caption">Example 19. Publishing Expired MAC Keys</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data kid=' ** KID ** '&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Entities SHOULD ignore any &lt;old/&gt; elements they receive.</p>
+  </div>
+  <h2>9.
+       <a name="terminate">Esession Termination</a>
+</h2>
+    <p class="" style="">Either entity MAY terminate an Esession at any time. Before terminating a session Alice MUST calculate the MAC of her encryption block counter C<span class="sub" style="">A</span>, using the agreed hash algorithm ("HASH") and her integrity key K-M<span class="sub" style="">A</span>.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>a_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>)</pre></div>
+    <p class="" style="">She MUST then securely destroy all keys associated with the Esession and send a termination stanza to Bob.</p>
+    <p class="caption">Example 20. Alice Terminates an Esession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;end xmlns='http://jabber.org/protocol/esession#end'&gt;
+      &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/end&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Bob receives a termination stanza he MUST verify the MAC and then destroy all keys associated with the Esession.</p>
+  <h2>10.
+       <a name="sign">Signature Generation</a>
+</h2>
+    <p class="" style="">Before the signature of a block of XML is calculated, all CDATA between all elements must be removed and the XML MUST be converted to canonical form (see <span style="font-weight: bold">Canonical XML</span>).</p>
+  <div class="indent">
+<h3>10.1 <a name="sign-canon">Canonical Form (Informative)</a>
+</h3>
+    <ul>
+      <li>Encoded in UTF-8</li>
+      <li>Line breaks normalized to ASCII 10</li>
+      <li>Attribute values are normalized, as if by a validating processor</li>
+      <li>Character references are replaced</li>
+      <li>CDATA sections are replaced with their character content</li>
+      <li>Empty elements are converted to start-end tag pairs</li>
+      <li>All whitespace in character content is retained (excluding characters removed during line feed normalization)</li>
+      <li>Normalization of whitespace in start and end tags</li>
+      <li>Attribute value delimiters are set to quotation marks (double quotes)</li>
+      <li>Special characters in attribute values and character content are replaced by character references (&amp;amp;, &amp;lt;, &amp;gt;, &amp;quot;, &amp;#xD;, &amp;#xA;, &amp;#x9;)</li>
+      <li>Lexicographic order is imposed on the namespace declarations (always first) and attributes of each element</li>
+    </ul>
+
+  </div>
+  <h2>11.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="sec-prng">Random Numbers</a>
+</h3>
+    <p class="" style="">Weak pseudo-random number generators (PRNG) enable successful attacks. Implementors MUST use a cryptographically strong PRNG to generate all random numbers (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2260428">37</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="sec-rekey">Re-Keying Limits</a>
+</h3>
+    <p class="" style="">After a key exchange an entity MUST NOT exchange a total of 2<span class="super" style="">32</span> encrypted blocks before it initiates a key re-exchange (see <span class="ref" style="">SSH Transport Layer Encryption Modes</span>  [<a href="#nt-id2260477">38</a>]). Note: This limitation also ensures the same key and counter values are never used to encrypt two different blocks using counter mode (thus preventing simple attacks).</p>
+    <p class="" style="">In order to reduce the Perfect Forward Secrecy window of vulnerability, after an extended period of activity, entities SHOULD either re-key or terminate the Esession.</p>
+  </div>
+  <div class="indent">
+<h3>11.3 <a name="sec-keys">Verifying Keys</a>
+</h3>
+    <p class="" style="">The trust system outlined in this document is based on Alice trusting that the public key presented by Bob is <span style="font-style: italic">actually</span> Bob's key (and vice versa). Determining this trust may be done in a variety of ways depending on the entities' support for different public key (certificate) formats, signing algorithms and signing authorities. For instance, if Bob publishes a PGP/GPG public key, Alice MAY verify that his key is signed by another key that she knows to be good. Or, if Bob provides an X.509 certificate, she MAY check that his key has been signed by a Certificate Authority that she trusts.</p>
+    <p class="" style="">When trust cannot be achieved automatically, methods that are not transparent to the users may be employed. For example, Bob could communicate the SHA-256 fingerprint of his public key to Alice via secure out-of-band communication (e.g. face-to-face). This would enable Alice to confirm that the public key she receives in-band is valid. Note however that very few people bother to verify fingerprints in this way. So this method is exceptionally vulnerable to 'man-in-the-middle' attacks. In order to reduce the window of vulnerability, an entity SHOULD remember the fingerprints of all user-validated public keys and alert the user in the future if ever the fingerprint(s) it stored for an entity do not match any of the received public keys.</p>
+    <p class="" style="">Alternatively Alice and Bob could agree a shared secret via secure out-of-band communication, Bob could then use it to create an HMAC of his public key that only Alice could verify.</p>
+    <p class="" style="">Note: If no keys are acceptable to Alice (because Alice has never verified any of the keys, and because either the keys are not signed, or Alice does not support the signature algorithms of the keys, or she cannot parse the certificate formats, or she does not recognise the authorities that signed the keys) then, although the Esession can still be encrypted, she cannot be sure she is communicating with Bob.</p>
+  </div>
+  <div class="indent">
+<h3>11.4 <a name="sec-replay">Replay Attacks</a>
+</h3>
+    <p class="" style="">The encryption block counters maintained implicitly by Alice and Bob (C<span class="sub" style="">A</span> and C<span class="sub" style="">B</span>) prevent stanzas being replayed within any Esession. They ensure that the MAC will be different for all stanzas, even if the HMAC key and the content of the stanza are identical.</p>
+    <p class="" style="">Alice and Bob MUST ensure that the value of e or d they provide when negotiating each online Esession is unique. This prevents complete online Esessions being replayed.</p>
+    <p class="" style="">Since Bob supplies the same value of d for all offline Esessions, to prevent complete offline Esessions being replayed to him, he MUST take care to securely store <span style="font-style: italic">new</span> values (or destroy existing values) of y and KID whenever he goes offline (see <a href="#init-publish">Publishing Esession Options</a>). Also, when Bob next comes online, he MUST remember all the values of e he receives in offline Esession initiation stanzas, and reject any offline Esessions that specify a value of e he has already received (see <a href="#init-accept">Accepting an Offline Esession</a>).</p>
+  </div>
+  <div class="indent">
+<h3>11.5 <a name="sec-unencrypted">Unencrypted Esessions</a>
+</h3>
+    <p class="" style="">Organisations with full disclosure policies may require entities to disable encryption to enable the logging of all messages on their server. Unencrypted Esessions meet all the <a href="#reqs-sec">Security Requirements</a> except for Confidentiality. This enables Alice to use the 'secure' Esession option to confirm securely with Bob that both client-server connections are secure.</p>
+  </div>
+  <div class="indent">
+<h3>11.6 <a name="sec-storage">Storage</a>
+</h3>
+    <p class="" style="">If either entity stores a (re-encrypted) transcript of an Esession for future consultation then the Perfect Forward Secrecy offered by this protocol is lost. If the negotiated value of the 'logging' <span style="font-weight: bold">Chat Session Negotiation</span> field is false the entities SHOULD NOT store any part of the Esession content (not even in encrypted form).</p>
+  </div>
+  <div class="indent">
+<h3>11.7 <a name="sec-offline">Offline Esessions</a>
+</h3>
+    <p class="" style="">Bob MAY decide not to support Offline Esessions since they are significantly less secure than online Esessions. The Perfect Forward Secrecy window of vulnerability is much longer. More seriously, Bob MUST store his private Diffie-Hellman key, y, to local disk or to a server (perhaps symmetrically encrypted with a password). It is <span style="font-style: italic">really</span> hard to securely erase something from a disk. Note: If Bob does not support Offline Esessions then, while he is offline, Alice will probably send him completely unprotected messages!</p>
+  </div>
+  <div class="indent">
+<h3>11.8 <a name="sec-general">Extra Responsabilities of Implementors</a>
+</h3>
+    <p class="" style="">Cryptography plays only a small part in an entity's security. Even if it implements this protocol perfectly it may still be vulnerable to other attacks. For examples, an implementation might store Esession keys on swap space or save private keys to a file in cleartext! Implementors MUST take very great care when developing applications with secure technologies.</p>
+  </div>
+  <div class="indent">
+<h3>11.9 <a name="sec-mandatory">Mandatory to Implement Technologies</a>
+</h3>
+    <p class="" style="">An implementation of ESession MUST support the Diffie-Hellman Key Agreement and HMAC algorithms. Note: The parameter names mentioned below are related to secure shell; see <span style="font-weight: bold">SSH Transport Layer Encryption Modes</span> for encryption algorithm details; see the <span class="ref" style="">IANA Secure Shell Protocol Parameters</span>  [<a href="#nt-id2260791">39</a>] for other names.</p>
+    <div class="indent">
+<h3>11.9.1 <a name="sec-mandatory-encryption">Encryption Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following encryption algorithm:</p>
+      <ul>
+        <li>aes128-ctr (see <span class="ref" style="">Advanced Encryption Standard</span>  [<a href="#nt-id2260839">40</a>])</li>
+      </ul>
+      <p class="" style="">The block length of an encryption algorithm's cipher SHOULD be at least 128 bits. An implementation of ESession MAY also support the following encryption algorithms:</p>
+      <ul>
+        <li>aes256-ctr</li>
+        <li>aes192-ctr</li>
+        <li>twofish256-ctr (see <span class="ref" style="">Twofish</span>  [<a href="#nt-id2260884">41</a>])</li>
+        <li>twofish192-ctr</li>
+        <li>twofish128-ctr</li>
+        <li>serpent256-ctr (see <span class="ref" style="">Serpent</span>  [<a href="#nt-id2260917">42</a>])</li>
+        <li>serpent192-ctr</li>
+        <li>serpent128-ctr</li>
+        <li>none (no encryption, only signing)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.9.2 <a name="sec-mandatory-sign">Key Signing Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following signing algorithms:</p>
+      <ul>
+        <li>rsa (see <span class="ref" style="">RFC 2437</span>  [<a href="#nt-id2260969">43</a>])</li>
+        <li>dss (see <span class="ref" style="">Digital Signature Standard</span>  [<a href="#nt-id2260991">44</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.9.3 <a name="sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following public key formats:</p>
+      <ul>
+        <li>ssh-rsa</li>
+        <li>ssh-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following public key formats:</p>
+      <ul>
+        <li>x509v3-sign-rsa (see <span class="ref" style="">X.509 Authentication in SSH2</span>  [<a href="#nt-id2261059">45</a>])</li>
+        <li>x509v3-sign-dss</li>
+        <li>pgp-sign-rsa</li>
+        <li>pgp-sign-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession MAY also support the following public key formats:</p>
+      <ul>
+        <li>spki-sign-rsa</li>
+        <li>spki-sign-dss</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.9.4 <a name="sec-mandatory-hash">Hash Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following hash algorithm:</p>
+      <ul>
+        <li>sha256 (see <span class="ref" style="">Secure Hash Standard</span>  [<a href="#nt-id2261138">46</a>])</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following hash algorithm (sha1 and md5 are NOT RECOMMENDED):</p>
+      <ul>
+        <li>whirlpool (see <span class="ref" style="">Whirlpool</span>  [<a href="#nt-id2261174">47</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.9.5 <a name="sec-mandatory-compress">Compression Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following compression algorithm:</p>
+      <ul>
+        <li>none (no compression, the output MUST be the same as the input)</li>
+      </ul>
+      <p class="" style="">Support for other algorithms is NOT RECOMMENDED since compression partially defeats the <a href="#reqs-repudiate">Repudiability</a> requirement of this JEP by making it more difficult for a third party (with some knowledge of the plaintext) to modify a transcript of an encrypted session in a meaningful way. However, encrypted content is pseudo-random and cannot be compressed, so, in those cases where bandwidth is severely constrained, an implementation of ESession MAY support the following algorithm to compress content before it is encrypted:</p>
+      <ul>
+        <li>zlib (see <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2261248">48</a>])</li>
+      </ul>
+    </div>
+  </div>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261326">49</a>]. </p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="registrar-ns">Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261342">50</a>] shall register the following namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/esession</li>
+      <li>http://jabber.org/protocol/esession#init</li>
+      <li>http://jabber.org/protocol/esession#end</li>
+      <li>http://jabber.org/protocol/esession#error</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall reserve the following fields within the scope of Data Forms used for ESession negotation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field
+      var='modp'
+      type='list-single'
+      label='MODP group number'/&gt;
+  &lt;field
+      var='crypt_algs'
+      type='list-single'
+      label='Symmetric block cipher options'/&gt;
+  &lt;field
+      var='hash_algs'
+      type='list-single'
+      label='Hash algorithm options'/&gt;
+  &lt;field
+      var='compress'
+      type='list-single'
+      label='Compression algorithm options'/&gt;
+  &lt;field
+      var='stanzas'
+      type='list-multi'
+      label='Stanzas types to encrypt'/&gt;
+  &lt;field
+      var='secure'
+      type='boolean'
+      label='Require encrypted client-server streams'/&gt;
+  &lt;field
+      var='rekey_freq'
+      type='text-single'
+      label='Minimum number of stanzas between key exchanges'/&gt;
+  &lt;field
+      var='accept_pkids'
+      type='list-multi'
+      label='Acceptable public key IDs'/&gt;
+  &lt;field
+      var='counter'
+      type='hidden'
+      label='Initial block counter'/&gt;
+  &lt;field
+      var='kid'
+      type='hidden'
+      label='Diffie-Hellman key ID'/&gt;
+  &lt;field
+      var='key'
+      type='hidden'
+      label='Diffie-Hellman key'/&gt;
+  &lt;field
+      var='pkey'
+      type='hidden'
+      label='Public key'/&gt;
+  &lt;field
+      var='pkids'
+      type='list-single'
+      label='Public key IDs'/&gt;
+  &lt;field
+      var='signs'
+      type='list-single'
+      label='Data form signatures'/&gt;
+  &lt;field
+      var='req_sign'
+      type='hidden'
+      label='Signature of initial request data form'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>14.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>15.
+       <a name="keys">Public Key Publication and Retrieval</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is highly preliminary and will be specified in a separate proposal before this document reaches draft status.</span></p>
+  <p class="" style="">Entities SHOULD publish their long-term public signature-verification keys to all entities through their own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>).</p>
+
+  <p class="caption">Example 21. Entity Publishes Public Keys to Server</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='dp1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="" style="">Before initiating an ESession, if Bob does not already possess one of Alice's signature-verification keys, he SHOULD retrieve them from Alice's server.</p>
+  <p class="caption">Example 22. Bob Requests Public Keys from Alice's Server</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="caption">Example 23. Server Returns Public Keys</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='alice@example.org'
+    to='bob@example.com/laptop'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Bob should examine all the public keys and identify which ones are acceptable (see <a href="#sec-keys">Verifying Keys</a>).</p>
+<h2>16.
+       <a name="open">Open Issues</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="open-tothink">To Think About</a>
+</h3>
+    <ol start="" type="">
+      <li>Define an optional protocol that would allow Bob to store y (and the PKIDs he trusts) 'securely' on his own server (before he goes offline). If Bob prefers not to use this protocol (because local storage is more secure), what should he do when he receives an offline Esession if he is <span style="font-style: italic">unable to retrieve the value of y</span> that he stored before going offline (e.g., if he went offline using a different client and/or a different machine)?</li>
+      <li>What challenges exist to make the OTR Gaim Plugin use this protocol natively when talking to Jabber entities? Can these be mitigated by 'non-critical' protocol changes?</li>
+      <li>Would it be possible for an XMPP entity to exchange encrypted messages and presence with a user of a non-XMPP messaging system, assuming that the gateway both supports this protocol and is compatible with a purpose-built security plugin on the other user's client (e.g. a Gaim plugin connects to the gateway via a non-XMPP network)?</li>
+      <li>Could the protocol approximate SSH (or IPsec) more closely without losing the benefits of OTR?</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>16.2 <a name="open-todo">To Do</a>
+</h3>
+    <ol start="" type="">
+      <li>Perhaps the JEP needs to specify more carefully how block counters are handled between messages, especially in the event of partial blocks?</li>
+      <li>Define names for X.509 SubjectPublicKeyInfo public key formats (different to X.509 certificates). This format must be used when keys are distributed within session initiation.</li>
+      <li>Discuss signature formats in greater detail.</li>
+      <li>Give examples of specific errors and discuss error scenarios throughout document (e.g., what should Bob do if he is not offline and he receives an offline key exchange stanza?).</li>
+      <li>Separate public key publishing into another JEP. Should there be a disco item for each key?</li>
+      <li>Update Dependencies list</li>
+    </ol>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250669">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2250627">2</a>. RFC 3862: Common Presence and Instant Messaging (CPIM): Message Format &lt;<a href="http://www.ietf.org/rfc/rfc3862.txt">http://www.ietf.org/rfc/rfc3862.txt</a>&gt;.</p>
+<p><a name="nt-id2250650">3</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p><a name="nt-id2250694">4</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2250454">5</a>. Off-the-Record Communication, or, Why Not to Use PGP &lt;<a href="http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf">http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf</a>&gt;.</p>
+<p><a name="nt-id2250486">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250514">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255652">8</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2255699">9</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2255721">10</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255756">11</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255786">12</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2255916">13</a>. SSH Protocol Architecture &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2255889">14</a>. SSH Transport Layer Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256127">15</a>. The reliable association between an entity and its public keys is beyond the scope of this JEP.</p>
+<p><a name="nt-id2256154">16</a>. Naturally, it is possible that Alice or Bob may retain cleartext versions of the exchanged communications; however, that threat is out of scope for this JEP.</p>
+<p><a name="nt-id2256373">17</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256395">18</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256494">19</a>. RFC 2631: Diffie-Hellman Key Agreement Method &lt;<a href="http://www.ietf.org/rfc/rfc2631.txt">http://www.ietf.org/rfc/rfc2631.txt</a>&gt;.</p>
+<p><a name="nt-id2256559">20</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2256625">21</a>. RFC 2409: The Internet Key Exchange (IKE) &lt;<a href="http://www.ietf.org/rfc/rfc2409.txt">http://www.ietf.org/rfc/rfc2409.txt</a>&gt;.</p>
+<p><a name="nt-id2256648">22</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p><a name="nt-id2256756">23</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256913">24</a>. RFC 3766: Determining Strengths For Public Keys Used For Exchanging Symmetric Keys &lt;<a href="http://www.ietf.org/rfc/rfc3766.txt">http://www.ietf.org/rfc/rfc3766.txt</a>&gt;.</p>
+<p><a name="nt-id2257220">25</a>. The private signing keys may only be accessible to another of Bob's clients.</p>
+<p><a name="nt-id2257228">26</a>. Some servers may not support public key publishing.</p>
+<p><a name="nt-id2256934">27</a>. The more often Bob changes his published Esession options, the shorter the Perfect Forward Secrecy window of vulnerability. However, whenever he changes them he divulges his presence to all the entities that are monitoring them.</p>
+<p><a name="nt-id2258876">28</a>. K-M<span class="sub" style="">A</span> is a hash of K-E<span class="sub" style="">A</span> (not K) to ensure that if an attacker recovers the decryption key she will not be able to cryptographically convince anyone that it was not her who created the stanza.</p>
+<p><a name="nt-id2259075">29</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2259128">30</a>. Although counter mode encryption requires no padding, implementations MAY still disguise the length of m by appending a random number of white-space characters.</p>
+<p><a name="nt-id2259147">31</a>. If Bob were to receive a stanza out-of-order, then he would fail to decrypt the stanza and be forced to terminate the Esession.</p>
+<p><a name="nt-id2259296">32</a>. Canonical XML 1.0 &lt;<a href="http://www.w3.org/TR/xml-c14n">http://www.w3.org/TR/xml-c14n</a>&gt;.</p>
+<p><a name="nt-id2259362">33</a>. RFC 2104: HMAC: Keyed-Hashing for Message Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2104.txt">http://www.ietf.org/rfc/rfc2104.txt</a>&gt;.</p>
+<p><a name="nt-id2259554">34</a>. If Bob were to receive a stanza out-of-order, then the MACs would not match because the values of C<span class="sub" style="">A</span> would not be synchronized.</p>
+<p><a name="nt-id2259706">35</a>. Bob MUST NOT send a stream error to his server since intermediate entities are not responsible for encoded content.</p>
+<p><a name="nt-id2260131">36</a>. If an entity fails to receive any stanza that includes a new key in the correct order, then it will fail to decrypt the next stanza it receives and be forced to terminate the Esession.</p>
+<p><a name="nt-id2260428">37</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2260477">38</a>. SSH Transport Layer Encryption Modes &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2260791">39</a>. IANA registry of parameters related to secure shell &lt;<a href="http://www.iana.org/assignments/ssh-parameters">http://www.iana.org/assignments/ssh-parameters</a>&gt;.</p>
+<p><a name="nt-id2260839">40</a>. Advanced Encryption Standard: Federal Information Processing Standards Publication 197 &lt;<a href="http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf">http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf</a>&gt;.</p>
+<p><a name="nt-id2260884">41</a>. The Twofish Block Cipher &lt;<a href="http://www.schneier.com/twofish.html">http://www.schneier.com/twofish.html</a>&gt;.</p>
+<p><a name="nt-id2260917">42</a>. The Serpent Block Cipher &lt;<a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">http://www.cl.cam.ac.uk/~rja14/serpent.html</a>&gt;.</p>
+<p><a name="nt-id2260969">43</a>. RFC 2437: PKCS #1: RSA Cryptography Specifications Version 2.0 &lt;<a href="http://www.ietf.org/rfc/rfc2437.txt">http://www.ietf.org/rfc/rfc2437.txt</a>&gt;.</p>
+<p><a name="nt-id2260991">44</a>. Digital Signature Standard: Federal Information Processing Standards Publication 186  &lt;<a href="http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf">http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf</a>&gt;.</p>
+<p><a name="nt-id2261059">45</a>. X.509 Authentication in SSH2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2261138">46</a>. Secure Hash Standard: Federal Information Processing Standards Publication 180-2  &lt;<a href="http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf">http://csrc.nist.gov/publications/fips/fips180-2/fips186-2withchangenotice.pdf</a>&gt;.</p>
+<p><a name="nt-id2261174">47</a>. The Whirlpool Hash Function &lt;<a href="http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html">http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html</a>&gt;.</p>
+<p><a name="nt-id2261248">48</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2261326">49</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261342">50</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2004-08-10)</h4>
+<div class="indent">Added Flexibility requirement; added late signature of initial request; added termination MAC. (ip)
+    </div>
+<h4>Version 0.4 (2004-08-09)</h4>
+<div class="indent">Added (offline) replay protection; required offline Created header; compression is NOT RECOMMENDED; added second set of offline options for subscribers; added JIDs to session key generation; unencrypted sessions; added secure option; sign whole data form; HMAC whole &lt;encrypted/&gt; element; added Esession termination; option to distribute public keys within session initiation; added Integrity requirement; several clarifications (ip)
+    </div>
+<h4>Version 0.3 (2005-08-02)</h4>
+<div class="indent">Restored status to Experimental; complete rewrite; new Introduction, Background, Requirements and Security Considerations; new OTR-inspired protocol; JEP-0155-based negotiation; counter mode encryption; more secure hashes; offline sessions; re-keying; mac publishing; preliminary key and options publishing protocol. (ip/psa)
+    </div>
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.6.html
+++ b/content/xep-0116-0.6.html
@@ -1,0 +1,1478 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0116<br>
+            Version: 0.6<br>
+            Last Updated: 2004-08-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2104, RFC 2409, RFC 3526, RFC 3548, xml-c14n, JEP-0004, JEP-0020, JEP-0030, JEP-0068, JEP-0079, JEP-0155<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>3.1.  <a href="#terms-personae">Dramatis Personae</a>
+</dt></dl>
+<dt>4.  <a href="#reqs">Requirements</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#reqs-sec">Security Requirements</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#reqs-encrypt">Confidentiality</a>
+</dt>
+<dt>4.1.2.  <a href="#reqs-integrity">Integrity</a>
+</dt>
+<dt>4.1.3.  <a href="#reqs-replay">Replay Protection</a>
+</dt>
+<dt>4.1.4.  <a href="#reqs-forward">Perfect Forward Secrecy</a>
+</dt>
+<dt>4.1.5.  <a href="#reqs-auth">Authentication</a>
+</dt>
+<dt>4.1.6.  <a href="#reqs-repudiate">Repudiability</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#reqs-xmpp">Application Requirements</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#reqs-generality">Generality</a>
+</dt>
+<dt>4.2.2.  <a href="#reqs-implement">Implementability</a>
+</dt>
+<dt>4.2.3.  <a href="#reqs-usable">Usability</a>
+</dt>
+<dt>4.2.4.  <a href="#reqs-flexible">Flexibility</a>
+</dt>
+<dt>4.2.5.  <a href="#reqs-usable">Interoperability</a>
+</dt>
+<dt>4.2.6.  <a href="#reqs-offline">Offline Sessions</a>
+</dt>
+<dt>4.2.7.  <a href="#reqs-offline">Object Encryption</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>6.  <a href="#init">ESession Initiation</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#init-online">Online Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>6.1.1.  <a href="#init-request">Esession Request</a>
+</dt>
+<dt>6.1.2.  <a href="#init-prep">Diffie-Hellman Preparation (Bob)</a>
+</dt>
+<dt>6.1.3.  <a href="#init-response">Esession Response</a>
+</dt>
+<dt>6.1.4.  <a href="#init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</dt>
+<dt>6.1.5.  <a href="#init-complete">Diffie-Hellman Completion</a>
+</dt>
+</dl>
+<dt>6.2.  <a href="#init-offline">Offline Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>6.2.1.  <a href="#init-publish">Publishing Esession Options</a>
+</dt>
+<dt>6.2.2.  <a href="#init-offreq">Requesting Offline Esession Options</a>
+</dt>
+<dt>6.2.3.  <a href="#init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</dt>
+<dt>6.2.4.  <a href="#init-start">Starting an Offline Esession</a>
+</dt>
+<dt>6.2.5.  <a href="#init-accept">Accepting Offline Esessions</a>
+</dt>
+</dl>
+<dt>6.3.  <a href="#init-keys">Generating Session Keys</a>
+</dt>
+</dl>
+<dt>7.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#exchange-separate">Encryptable Content</a>
+</dt>
+<dt>7.2.  <a href="#exchange-encrypt">Encryption</a>
+</dt>
+<dt>7.3.  <a href="#exchange-send">Sending an Encrypted Stanza</a>
+</dt>
+<dt>7.4.  <a href="#exchange-decrypt">Decryption</a>
+</dt>
+</dl>
+<dt>8.  <a href="#rekey">Re-Key Exchange</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#rekey-init">Re-Key Initiation</a>
+</dt>
+<dt>8.2.  <a href="#rekey-accept">Re-Key Acceptance</a>
+</dt>
+<dt>8.3.  <a href="#rekey-publish">Publishing Old MAC Values</a>
+</dt>
+</dl>
+<dt>9.  <a href="#terminate">Esession Termination</a>
+</dt>
+<dt>10.  <a href="#sign">Signature Generation</a>
+</dt>
+<dl><dt>10.1.  <a href="#sign-canon">Canonical Form (Informative)</a>
+</dt></dl>
+<dt>11.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#sec-prng">Random Numbers</a>
+</dt>
+<dt>11.2.  <a href="#sec-rekey">Re-Keying Limits</a>
+</dt>
+<dt>11.3.  <a href="#sec-keys">Verifying Keys</a>
+</dt>
+<dt>11.4.  <a href="#sec-replay">Replay Attacks</a>
+</dt>
+<dt>11.5.  <a href="#sec-unencrypted">Unencrypted Esessions</a>
+</dt>
+<dt>11.6.  <a href="#sec-storage">Storage</a>
+</dt>
+<dt>11.7.  <a href="#sec-offline">Offline Esessions</a>
+</dt>
+<dt>11.8.  <a href="#sec-general">Extra Responsabilities of Implementors</a>
+</dt>
+<dt>11.9.  <a href="#sec-mandatory">Mandatory to Implement Technologies</a>
+</dt>
+<dl>
+<dt>11.9.1.  <a href="#sec-mandatory-encryption">Encryption Algorithms</a>
+</dt>
+<dt>11.9.2.  <a href="#sec-mandatory-sign">Key Signing Algorithms</a>
+</dt>
+<dt>11.9.3.  <a href="#sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</dt>
+<dt>11.9.4.  <a href="#sec-mandatory-hash">Hash Algorithms</a>
+</dt>
+<dt>11.9.5.  <a href="#sec-mandatory-compress">Compression Algorithms</a>
+</dt>
+</dl>
+</dl>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#registrar-ns">Namespaces</a>
+</dt>
+<dt>13.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>14.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>15.  <a href="#keys">Public Key Publication and Retrieval</a>
+</dt>
+<dt>16.  <a href="#open">Open Issues</a>
+</dt>
+<dl>
+<dt>16.1.  <a href="#open-tothink">To Think About</a>
+</dt>
+<dt>16.2.  <a href="#open-todo">To Do</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">End-to-end encryption is a desirable feature for any communication technology. Ideally, such a technology would design encryption in from the beginning and would forbid unencrypted communications. Realistically, most communication technologies have not been designed in that manner, and Jabber/XMPP technologies are no exception. In particular, the original Jabber technologies developed in 1999 did not include end-to-end encryption by default. PGP-based encryption of message bodies and signing of presence information was added as an extension to the core protocols in the year 2000; this extension is documented in <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2250561">1</a>]. When the core protocols were formalized within the Internet Standards Process by the IETF's XMPP Working Group in 2003, a different extension was defined using S/MIME-based signing and encryption of CPIM-formatted messages (see <span class="ref" style="">RFC 3862</span>  [<a href="#nt-id2250690">2</a>]) and PIDF-formatted presence information (see <span class="ref" style="">RFC 3863</span>  [<a href="#nt-id2250427">3</a>]); this extension is specified in <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2250447">4</a>].</p>
+  <p class="" style="">For reasons described more fully below, the foregoing proposals (and others not mentioned) have not been widely implemented and deployed. This is unfortunate, since an open communication protocol needs to enable end-to-end encryption in order to be seriously considered for deployment by a broad range of users. This proposal describes a different approach to end-to-end encryption for use by entities that communicate using XMPP. The approach taken herein essentially translates the semantics of the secure shell protocol (SSH) into the syntax of XMPP, with some adjustments that reflect reports of security issues with SHA-1 and insights gleaned from implementation of "off-the-record" (OTR) communication in the Gaim encryption plugin as described in <span class="ref" style="">Off-the-Record Communication</span>  [<a href="#nt-id2250491">5</a>]. The result is a protocol for encrypted sessions or "ESessions".</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">As specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250516">6</a>], XMPP is an XML streaming protocol that enables the near-real-time exchange of XML fragments between any two (or more) network endpoints. To date, the main application built on top of the core XML streaming layer is instant messaging (IM) and presence, the base extensions for which are specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250550">7</a>]. There are three first-level elements of XML streams (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;); each of these "XML stanza" types has different semantics, which can complicate the task of defining a generalized approach to end-to-end encryption for XMPP. In addition, XML stanzas can be extended (via properly-namespaced child elements) for a wide variety of functionality. The chosen approach should enable encryption of several complete XML elements rather than only parts thereof (e.g., only the XML character data of the message &lt;body/&gt; element as in <span style="font-weight: bold">JEP-0027</span>).</p>
+  <p class="" style="">XMPP is a session-oriented communication technology: normally, a client authenticates with a server and maintains a long-lived connection that defines the client's XMPP session. Such stream-level sessions are secured via channel encryption using Transport Level Security (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2255679">8</a>]), as specified in Section 5 of <span style="font-weight: bold">RFC 3920</span>. However, there is no guarantee that all hops will implement or enforce channel encryption (or that intermediate routers are trustworthy), which makes end-to-end encryption desirable.</p>
+  <p class="" style="">The session metaphor also applies to communication between endpoints: for instance, in IM applications, most instant messaging exchanges occur in bursts within limited time periods (e.g., two people may send a fairly large number of messages during a five-minute chat and then not exchange messages again for hours or even days). The XML stanzas exchanged during such a session may not be limited to &lt;message/&gt; stanzas; for instance, the session may be triggered by a change in one of the parties' presence status (e.g., changing from away to available) and the session may involve the exchange of &lt;iq/&gt; stanzas (e.g., to transfer a file as specified in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2255726">9</a>]). Endpoints may want to encrypt the stanzas they send to each other in such a way that the stanzas cannot be understood by untrusted mediating entities (such as servers) except to the extent required to understand the necessary routing information. (One complicating factor is that routing information may include not only the stanza's 'to', 'from', 'type, and 'id' attributes, but also <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255754">10</a>] extensions.)</p>
+  <p class="" style="">The foregoing XMPP communications exist in the context of a one-to-one communication session between two entities. However, several forms of XMPP communication exist outside the context of one-to-one communication sessions:</p>
+  <ul>
+    <li>Many-to-many sessions, such as a text conference in a chatroom as specified in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255788">11</a>].</li>
+    <li>One-to-many "broadcast", such as undirected presence stanzas sent from one user to many contacts (see <span style="font-weight: bold">RFC 3921</span>) and data syndication implemented using <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2255818">12</a>].</li>
+    <li>One-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</li>
+  </ul>
+  <p class="" style="">Ideally, any technology for end-to-end encryption in XMPP could be extended to cover these scenarios as well as one-to-one communication sessions. However, both many-to-many sessions and one-to-many broadcast are deemed out of scope for this JEP. Offline communications are handled via a simple extension to the protocol for one-to-one sessions between two entities that are online simultaneously (see below).</p>
+  <p class="" style="">Because XMPP is a session-oriented communication technology, encryption schemes that are appropriate for less dynamic technologies may not be appropriate for XMPP. XMPP, with its in-order delivery of XML stanzas, is able to take advantage of encryption approaches that are not feasible for less dynamic technologies. In particular, existing approaches to encryption of Internet communications have generally assumed that the "thing" to be encrypted has a stable identity or is best understood as a standalone object (e.g., a file or email message); the term "object encryption" well captures this assumption. Both <span style="font-weight: bold">JEP-0027</span> and <span style="font-weight: bold">RFC 3923</span> assume that XMPP communications are more like the exchange of email messages than they are like an interactive session -- while <span style="font-weight: bold">JEP-0027</span> uses "old-style" PGP object encryption and <span style="font-weight: bold">RFC 3923</span> uses "new-style" S/MIME object encryption, both specify the use of object encryption. </p>
+  <p class="" style="">However, the session-oriented nature of XMPP may imply that the focus should be on "session encryption" rather than "object encryption". The paradigm for XMPP encryption may be something closer to the widely-deployed Secure Shell technology (see <span class="ref" style="">SSH Protocol Architecture</span>  [<a href="#nt-id2255908">13</a>] and <span class="ref" style="">SSH Transport Layer Protocol</span>  [<a href="#nt-id2255934">14</a>]) than to traditional encryption of files and standalone email messages. In many ways, Secure Shell (or, more specifically, OTR) is the conceptual model for the current proposal.</p>
+  <p class="" style="">Therefore, this JEP specifies a method for encrypted sessions ("ESessions") that takes advantage of the inherent possibilities and strengths of session encryption as opposed to object encryption. The basic concept is that of an encrypted session which acts as a secure tunnel between two endpoints. Once the tunnel is established, the content of all one-to-one XML stanzas exchanged between the endpoints will be encrypted and then transmitted within a "wrapper" protocol element.</p>
+<h2>3.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="terms-personae">Dramatis Personae</a>
+</h3>
+    <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+    <ol start="1" type="">
+      <li>"Alice" is the name of the initiator of the ESession. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+      <li>"Bob" is the name of the other participant in the ESession started by Alice. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    </ol>
+    <p class="" style="">While Alice and Bob are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an Esession.</p>
+  </div>
+<h2>4.
+       <a name="reqs">Requirements</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="reqs-sec">Security Requirements</a>
+</h3>
+    <p class="" style="">This JEP stipulates the following security requirements for end-to-end encryption of XMPP communications:</p>
+    <ul>
+      <li>Confidentiality</li>
+      <li>Integrity</li>
+      <li>Replay protection</li>
+      <li>Perfect forward secrecy</li>
+      <li>Authentication</li>
+      <li>Repudiability</li>
+    </ul>
+    <p class="" style="">Each of these requirements is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="reqs-encrypt">Confidentiality</a>
+</h3>
+      <p class="" style="">The one-to-one XML stanzas exchanged between two entities MUST NOT be understandable to any other entity that might intercept the communications.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="reqs-integrity">Integrity</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be sure that no other entity may change the content of the XML stanzas they exchange, or remove or insert stanzas into the Esession undetected.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.3 <a name="reqs-replay">Replay Protection</a>
+</h3>
+      <p class="" style="">Alice or Bob MUST be able to identify and reject any communications that are copies of their previous communications resent by another entity.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.4 <a name="reqs-forward">Perfect Forward Secrecy</a>
+</h3>
+      <p class="" style="">The encrypted communication MUST NOT be revealed even if long-lived keys are compromised in the future (e.g., Steve steals Bob's computer).</p>
+    </div>
+    <div class="indent">
+<h3>4.1.5 <a name="reqs-auth">Authentication</a>
+</h3>
+      <p class="" style="">Each party to a conversation MUST know that the other party is who he says he is (Alice must be able to know that Bob really is Bob, and vice versa).  [<a href="#nt-id2256157">15</a>]</p>
+    </div>
+    <div class="indent">
+<h3>4.1.6 <a name="reqs-repudiate">Repudiability</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be able to repudiate any stanza that occurs within an Esession. After an Esession has finished, it SHOULD NOT be possible to <span style="font-style: italic">prove cryptographically</span> that any transcript has not been modified by a third party.  [<a href="#nt-id2256184">16</a>]</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="reqs-xmpp">Application Requirements</a>
+</h3>
+    <p class="" style="">In addition to the foregoing security profile, this JEP also stipulates the following application-specific requirements for encrypted communication in the context of Jabber/XMPP technologies:</p>
+    <ul>
+      <li>Generality</li>
+      <li>Implementability</li>
+      <li>Usability</li>
+      <li>Flexibility</li>
+      <li>Interoperability</li>
+      <li>Offline "sessions"</li>
+      <li>Object encryption</li>
+    </ul>
+    <p class="" style="">Each of these is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.2.1 <a name="reqs-generality">Generality</a>
+</h3>
+      <p class="" style="">The solution should be generally applicable to any XML stanza type (&lt;message/&gt;, &lt;presence/&gt;, &lt;iq/&gt;) sent between two entities. It is deemed acceptable for now if the solution does not apply to many-to-many stanzas (e.g., groupchat messages sent within the context of multi-user chat) or one-to-many stanzas (e.g., presence "broadcasts" and pubsub notifications); end-to-end encryption of such stanzas may require separate solutions or extensions to the one-to-one session solution.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="reqs-implement">Implementability</a>
+</h3>
+      <p class="" style="">The only good security technology is an implemented security technology. The solution should be one that typical client developers can implement in a relatively straightforward and consistent fashion.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="reqs-usable">Usability</a>
+</h3>
+      <p class="" style="">The requirement of usability takes implementability one step further by stipulating that the solution must be one that organizations may deploy and humans may use with 100% transparency (with the ease-of-use of https:). Experience has shown that: solutions requiring a full public key infrastructure do not get widely deployed, and solutions requiring any user action are not widely used. We can do better.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.4 <a name="reqs-flexible">Flexibility</a>
+</h3>
+      <p class="" style="">The solution should be compatible with existing (and future) cryptographic algorithms and identity certification schemes (including X.509 and PGP).</p>
+    </div>
+    <div class="indent">
+<h3>4.2.5 <a name="reqs-usable">Interoperability</a>
+</h3>
+      <p class="" style="">Ideally, it would be possible for an XMPP user to exchange encrypted messages (and, potentially, presence information) with users of non-XMPP messaging systems.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.6 <a name="reqs-offline">Offline Sessions</a>
+</h3>
+      <p class="" style="">Ideally, it should be possible to encrypt one-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</p>
+    </div>
+    <div class="indent">
+<h3>4.2.7 <a name="reqs-offline">Object Encryption</a>
+</h3>
+      <p class="" style="">For cases where a session is not desired, it should be possible to encrypt, sign and send a single stanza in isolation, so-called "object encryption".</p>
+    </div>
+  </div>
+<h2>5.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">Before attempting to engage in an ESession with Bob, Alice SHOULD discover whether he supports this protocol, using either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256432">17</a>] or the presence-based profile of <span style="font-weight: bold">JEP-0030</span> specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256454">18</a>].</p>
+  <p class="" style="">The normal course of events is for Alice to authenticate with her server, retrieve her roster (see <span style="font-weight: bold">RFC 3921</span>), send initial presence to her server, and then receive presence information from all the contacts in her roster. If the presence information she receives from some contacts does not include capabilities data (per <span style="font-weight: bold">JEP-0115</span>), Alice SHOULD then send a service discovery information ("disco#info") request to each of those contacts (in accordance with <span style="font-weight: bold">JEP-0030</span>). Such initial service discovery stanzas MUST NOT be considered part of encrypted communication sessions for the purposes of this JEP, since they perform a "bootstrapping" function that is a prerequisite to encrypted communications. The disco#info request sent from Alice to Bob might look as follows:</p>
+  <p class="caption">Example 1. Alice Queries Bob for Esession Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com/laptop'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Bob sends a disco#info reply and he supports the protocol defined herein, then he MUST include a service discovery feature variable of "http://jabber.org/protocol/esession".</p>
+  <p class="caption">Example 2. Bob Returns disco#info Data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='bob@example.com/laptop'
+    to='alice@example.org/pda'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='client' type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/esession'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="init">ESession Initiation</a>
+</h2>
+  <p class="" style="">The process for establishing an ESession is essentially a translation into XMPP syntax of the SSH transport mechanism for establishing a secure session over an insecure transport (see <span style="font-weight: bold">SSH Transport Layer Protocol</span>). Specifically, as in SSH, ESession uses a Diffie-Hellman key exchange algorithm (see <span class="ref" style="">RFC 2631</span>  [<a href="#nt-id2256554">19</a>]) in the initial negotation (although, as we shall see, it does not use SHA-1 as the hashing algorithm).</p>
+  <p class="" style="">When Alice wishes to establish an ESession with Bob, Alice may choose between two different methods of performing the initial Diffie-Hellman key exchange, depending on whether Bob is online or not. Note: Alice MUST NOT initiate a new Esession with Bob if she already has one established with him.</p>
+
+  <div class="indent">
+<h3>6.1 <a name="init-online">Online Diffie-Hellman Key Exchange</a>
+</h3>
+    <p class="" style="">If Alice believes Bob may be online then she SHOULD retrieve Bob's long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) and then use the protocol specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2256618">20</a>] to negotiate the initial Diffie-Hellman key. In this aggressive exchange the first two messages negotiate policy, swap Diffie-Hellman public values and the ancillary data necessary for the exchange and authentication. The second message also authenticates the responder. The third message authenticates the initiator and exchanges the final Diffie-Hellman public value.</p>
+    <div class="indent">
+<h3>6.1.1 <a name="init-request">Esession Request</a>
+</h3>
+      <p class="" style="">Alice MUST specify each of the Esession options (algorithms etc.) she is willing to use, in her order of preference (see <a href="#sec-mandatory">Mandatory to Implement Technologies</a>):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">The list of Modular Exponential (MODP) group numbers (as specified in <span class="ref" style="">RFC 2409</span>  [<a href="#nt-id2256684">21</a>] or <span class="ref" style="">RFC 3526</span>  [<a href="#nt-id2256707">22</a>]) she is willing to use for Diffie-Hellman key exchange (valid group numbers include 1,2,3,4,5,14,15,16,17 and 18)</p></li>
+        <li><p class="" style="">Stanza symmetric encryption algorithm names</p></li>
+        <li><p class="" style="">Hash algorithm names</p></li>
+        <li><p class="" style="">Compression algorithm names</p></li>
+        <li><p class="" style="">The list of stanza types she is willing to encrypt and decrypt</p></li>
+        <li><p class="" style="">Whether or not both entities MUST be connected securely to their servers (see Section 5 of <span style="font-weight: bold">RFC 3920</span>)</p></li>
+        <li><p class="" style="">The minimum number of stanzas that MUST be exchanged before an entity MAY initiate a key re-exchange (1 - every stanza, 100 - every hundred stanzas). This value MUST be less than 2<span class="super" style="">32</span> (see <a href="#sec-rekey">Re-Keying Limits</a>)</p></li>
+        <li><p class="" style="">The Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256815">23</a>]) SHA-256 fingerprint (PKID) of each of Bob's public signature-verification keys that she found acceptable (see <a href="#sec-keys">Verifying Keys</a>)</p></li>
+      </ol>
+    <p class="caption">Example 3. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='form' xmlns='jabber:x:data'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='logging'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field type='list-single' var='modp'&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;1&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='crypt_algs'&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='hash_algs'&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='compress'&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='stanzas'&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='secure'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='rekey_freq'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='accept_pkids'&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob does not support one or more of the options in each Esession field (except the 'accept_pkids' field), then he SHOULD return a &lt;feature-not-implemented/&gt; error (but he MAY return no error if, for example, he does not want to reveal his presence to Alice for whatever reason):</p>
+    <p class="caption">Example 4. Bob Informs Alice that Her Options Are Not Supported</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='bob@example.com/laptop'
+         to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    ...
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Either Bob or Alice MAY attempt to initiate a new ESession after any error during the initiation process. However, both MUST consider the previous negotiation to have failed and MUST discard any information learned through the previous negotiation.</p>
+    </div>
+    <div class="indent">
+<h3>6.1.2 <a name="init-prep">Diffie-Hellman Preparation (Bob)</a>
+</h3>
+      <p class="" style="">If Bob is willing to start an ESession with Alice, he SHOULD retrieve Alice's long-term public signature-verification keys. He MUST select one of the options from each of the Esession fields he received from Alice including one of the MODP groups (see <span class="ref" style="">RFC 3766</span>  [<a href="#nt-id2256972">24</a>] or <span style="font-weight: bold">RFC 3526</span> for recommendations regarding balancing the sizes of symmetric cipher blocks and Diffie-Hellman moduli). Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). Bob MUST then perform the following computations (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n-1 random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.1.3 <a name="init-response">Esession Response</a>
+</h3>
+    <p class="" style="">Bob responds to Alice specifying the Esession options he selected.</p>
+    <p class="" style="">If Bob is willing to start an ESession with Alice, then instead of providing the PKID of his public key that he selected, Bob MUST specify the Base64 encoded SHA-256 fingerprint (PKID) of each of Alice's public signature-verification keys that he finds acceptable (see <a href="#sec-keys">Verifying Keys</a>). Note: The submited values for the 'accept_pkids' field do not correspond to the options he received. The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Alice.</p>
+    <p class="" style="">In addition to the fields he received from Alice, Bob MUST include the KID and the Base64 encoded values of d and C<span class="sub" style="">A</span>. If Alice selected one or more of his public keys, and if Bob has access to a long-lived private signing key that corresponds to one of those keys  [<a href="#nt-id2257143">25</a>], then he MUST also include the PKID. Otherwise (for example, if Bob is unable to publish keys to his server or if Alice is unable to access keys published via his server  [<a href="#nt-id2257150">26</a>]), Bob MAY include one of his Base64 encoded public keys. In either case, Bob MUST include the Base64 encoded signature (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+    <p class="" style="">However, if Bob is ready to initiate a one-to-one chat session with Alice (see <span style="font-weight: bold">Chat Session Negotiation</span>) but he is unwilling to start an ESession, then he SHOULD terminate the Esession negotiation by not specifying any of the five extra values in his response.</p>
+    <p class="caption">Example 5. Bob Responds to Alice (with Public Key)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      ...
+      &lt;field var='modp'&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='hash_algs'&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='compress'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='stanzas'&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='secure'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='accept_pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field var='counter'&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkey'&gt;
+        &lt;value&gt; ** Base64 encoded public key ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 6. Bob Responds to Alice (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+      &lt;field var='counter'&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Alice provided a PKID but Bob did not provide a signature then she MAY send a failure notice to him. If Bob sent Alice a public key but she could not verify it belongs to him via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then she SHOULD send a failure notice to him. If Bob provided an invalid signature (see <a href="#sign">Signature Generation</a>) then she MUST send a failure notice to him.</p>
+    <p class="caption">Example 7. Alice Signals that ESession Negotiation Failed (Unacceptable Signature)</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='alice@example.org/pda'
+         to='bob@example.com/laptop'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-signature xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.4 <a name="init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</h3>
+      <p class="" style="">After verifying Bob's signature, Alice can be certain that the value of d was actually generated by Bob. Alice MUST use the value of d and the Esession options specified in Bob's response to perform the following steps (where n is the number of bits per encryption block for the agreed encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value she received from Bob</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span></p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (this is the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.1.5 <a name="init-complete">Diffie-Hellman Completion</a>
+</h3>
+    <p class="" style="">Alice then completes the Diffie-Hellman negotiation by sending Bob the KID and the Base64 encoded value of e. If Bob selected one or more of her public keys, and if Alice has access to a long-lived private signing key that corresponds to one of those keys, then she MUST also include the PKID. Otherwise, Alice MAY include one of her Base64 encoded public keys (see <a href="#init-response">Esession Response</a> example). In either case, Alice MUST include the Base64 encoded signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form from her initial Esession request and of the <span style="font-style: italic">content</span> of this data form (excluding the 'signs' field).</p>
+    <p class="" style="">Alice MAY also send encrypted content (see <a href="#exchange">Exchanging Stanzas</a>) in the same stanza as the Diffie-Hellman completion. Note: If she also includes a &lt;terminate/&gt; element (see <a href="#terminate">Esession Termination</a>) within the &lt;encrypted/&gt; element then the Esession is terminated immediately. This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified).</p>
+    <p class="caption">Example 8. Alice Completes Diffie-Hellman Negotitation (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x xmlns='jabber:x:data'&gt;
+      &lt;field var='kid'&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='key'&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='pkids'&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='req_sign'&gt;&lt;value&gt; ** Base64 encoded signature of her previous form ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='signs'&gt;&lt;value&gt; ** Base64 encoded signature of this form ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob provided a PKID but Alice did not provide a signature then he MAY send a failure notice to her. If Alice sent Bob a public key but he could not verify it belongs to her via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then he SHOULD send a failure notice to her. If Alice provided an invalid signature (see <a href="#sign">Signature Generation</a>) then he MUST send a failure notice to her. If Bob sends a failure notice then he SHOULD ignore any encrypted content in the stanza.</p>
+    <p class="" style="">If no error occurs, Bob MUST calculate K = e<span class="super" style="">y</span> mod p (the shared secret). Alice and Bob then have the same value for K and the key exchange is complete.</p>
+    </div>
+  </div>
+
+
+
+<div class="indent">
+<h3>6.2 <a name="init-offline">Offline Diffie-Hellman Key Exchange</a>
+</h3>
+  <p class="" style="">As described below, offline negotiation of an Esession is in essence a special case of online negotiation. Bob MAY publish a set of Esession options just before he goes offline (see <a href="#sec-offline">Offline Esessions</a> Security Considerations) to allow entities that subscribe to his presence to initiate Esessions and send encrypted stanzas to him while he is offline. He MAY also publish <span style="font-style: italic">another</span> similar set of relatively long-lived  [<a href="#nt-id2257591">27</a>] Esession options that any entity MAY use for the same purpose.</p>
+    <div class="indent">
+<h3>6.2.1 <a name="init-publish">Publishing Esession Options</a>
+</h3>
+      <p class="" style="">In order to publish either set of his offline Esession options Bob MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1, where n is the largest number of bits per encryption block for the encryption algorithms he is willing to use)</p></li>
+        <li><p class="" style="">Select a MODP group (that defines the constants p and g)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d (typically by calculating a hash of d, since this KID SHOULD be unique across all Esessions)</p></li>
+        <li><p class="" style="">Store the values of y and d and the KID in a secure way, so that he can retrieve them when he comes back online (idealy even if that is using a different client and/or a different machine)</p></li>
+        <li><p class="" style="">Publish each of the Esession options he is willing to use (see <a href="#init-request">Esession Request</a>) including the value of d and the KID. He SHOULD do this through his own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>) or a similar protocol (out of scope for this JEP).</p></li>
+      </ol>
+      <p class="" style="">Note: The single specified MODP group MUST be the one Bob used to generate d. The list of stanza types he is willing to decrypt MUST NOT include the value 'iq'. Bob MUST also include the list of the PKIDs of all his public signature-verification keys that he can sign for, and the corresponding list of Base64 encoded signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style=""><span style="font-style: italic">Note: This publishing protocol is highly preliminary and depends on a separate proposal.</span></p>
+      <p class="caption">Example 9. Bob Publishes His Esession Options for His Subscribers</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info-subscription'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+      &lt;field var='modp'&gt;
+        &lt;value&gt;2&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;
+        &lt;value&gt;aes256-ctr&lt;/value&gt;
+        &lt;value&gt;twofish256-ctr&lt;/value&gt;
+        &lt;value&gt;aes128-ctr&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='hash_algs'&gt;
+        &lt;value&gt;whirlpool&lt;/value&gt;
+        &lt;value&gt;sha256&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='compress'&gt;
+        &lt;value&gt;none&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='stanzas'&gt;
+        &lt;value&gt;message&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='secure'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='kid'&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='key'&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">Bob MAY publish his Esession options for all entities using the same protocol except for the 'xmlns' and 'node' attributes of the &lt;query/&gt; element:</p>
+      <p class="caption">Example 10. Bob Publishes His Esession Options for All Entities</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.2 <a name="init-offreq">Requesting Offline Esession Options</a>
+</h3>
+      <p class="" style="">If Alice believes Bob is offline she SHOULD request his Esession options and his long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) from his server.</p>
+      <p class="" style="">If Alice is subscribing to Bob's presence she MUST request his Esession Options exclusively for subscribers.</p>
+      <p class="caption">Example 11. Alice asks Bob's Server for his Esession Options (Subscribers)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If Alice is not subscribing to Bob's presence (or if Bob has no Esession Options exclusively for subscribers) she MUST use the following request instead.</p>
+      <p class="caption">Example 12. Alice asks Bob's Server for his Esession Options (All Entities)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If, after receiving Bob's public keys and Esession options, Alice is unable to verify any of Bob's signatures (see <a href="#sign">Signature Generation</a>) then she MAY decide to proceed no further, since she cannot be sure who will be able to decrypt her stanzas.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.3 <a name="init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</h3>
+      <p class="" style="">Alice MUST select one of the options from each of Bob's Esession fields. If she cannot support any of the options in a field (except the 'pkids' and 'signs' fields) then she MUST not send encrypted stanzas to Bob while he is offline.</p>
+      <p class="" style="">Alice MUST use the value of d and the MODP group specified in Bob's Esession options to perform the following steps (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n-1 random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the counter for stanzas sent from Bob to Alice - in case Bob comes online before Alice terminates the Esession)</p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>6.2.4 <a name="init-start">Starting an Offline Esession</a>
+</h3>
+      <p class="" style="">Alice then sends Bob the KID and the Base64 encoded values of e and C<span class="sub" style="">A</span>. She SHOULD also include the list of the PKIDs of all her public signature-verification keys that she can sign for, and the corresponding list of Base64 encoded signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style="">She also specifies which of Bob's Esession options she selected. Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Bob.</p>
+      <p class="" style="">Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza. Note: If she also includes a &lt;terminate/&gt; element (see <a href="#terminate">Esession Termination</a>) within the &lt;encrypted/&gt; element then the Esession is terminated immediately. This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified).</p>
+      <p class="caption">Example 13. Alice Establishes an ESession Without Negotiation</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com' type='chat'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x xmlns='jabber:x:data'&gt;
+      &lt;field var='logging'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='modp'&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='crypt_algs'&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='hash_algs'&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='compress'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='rekey_freq'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='stanzas'&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='secure'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='counter'&gt;&lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='kid'&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='key'&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var='pkids'&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='signs'&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+      <p class="" style="">Alice can assume that she and Bob have the same value for K and that the key exchange is complete.</p>
+    </div>
+    <div class="indent">
+<h3>6.2.5 <a name="init-accept">Accepting Offline Esessions</a>
+</h3>
+      <p class="" style="">When Bob comes online he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Retrieve the two sets of Esession options he MAY have published (see <a href="#init-publish">Publishing Esession Options</a>)</p></li>
+        <li>
+<p class="" style="">Ensure he is no longer publishing offline Esession options exclusively for entities that are subscribing to his presence</p>
+            <p class="caption">Example 14. Bob Stops Publishing His Esession Options</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+        </li>
+        <li><p class="" style="">Retrieve any values of y, d and KID that he stored before going offline, and destroy in a secure way any persistently stored copies that correspond to Esession options exclusively for subscribers</p></li>
+        <li><p class="" style="">Confirm those values of d and KID match the published values. They may not match if, for example, he went offline using a different client and/or a different machine. Note: if they do not match then he cannot decrypt any offline Esessions he receives.</p></li>
+      </ol>
+      <p class="" style="">When Bob receives a key exchange stanza from Alice then he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Confirm that the KID he received from Alice matches one of the KIDs he published</p></li>
+        <li><p class="" style="">Confirm that he can support all the Esession options he received from Alice</p></li>
+        <li><p class="" style="">Confirm that he has not already received a key exchange stanza from Alice with the same value of e since he came online (see <a href="#sec-replay">Replay Attacks</a>)</p></li>
+        <li><p class="" style="">Request Alice's public keys and, if possible, verify one of her signatures (see <a href="#sign">Signature Generation</a>; if he is unable to verify any of her signatures then he MAY decide to proceed no further, since he cannot be sure who started the Esession)</p></li>
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value he received from Alice</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> + 2<span class="super" style="">n-1</span> (in case Alice has not yet terminated the Esession)</p></li>
+        <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="indent">
+<h3>6.3 <a name="init-keys">Generating Session Keys</a>
+</h3>
+    <p class="" style="">Whichever method Alice used to perform the Diffie-Hellman key exchange (online or offline), once it is complete, then before Alice and Bob can start encrypting and decrypting stanzas they MUST both use the agreed hash algorithm ("HASH") and their full JIDs to generate two pairs of keys, one for each direction of the ESession. Note: JID<span class="sub" style="">B</span> MUST be Bob's bare JID throughout an offline Esession, even if he comes online in the middle of the Esession and the key is re-exchanged.</p>
+    <p class="" style="">For stanzas that Alice will send to Bob, the keys are calculated as:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">A</span> = HASH(K-E<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)  [<a href="#nt-id2258694">28</a>]</p></li>
+    </ol>
+    <p class="" style="">For stanzas that Bob will send to Alice the keys are calculated as:</p>
+    <ol start="4" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">B</span> = HASH(K-E<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)</p></li>
+    </ol>
+    <p class="" style="">Once the two pairs of keys have been calculated the value of K MUST be securely destroyed.</p>
+    <p class="" style="">As many bytes of key data as are needed MUST be taken from the beginning of the hash output. When negotiating a hash, entities MUST ensure that the hash output is no shorter than the required key data. For algorithms with variable-length keys the maximum length (up to the hash output length) SHOULD be used.</p>
+
+    <p class="" style="">With these keys computed and the algorithms agreed upon, ESession initiation is now complete. From this point forward, Alice and Bob MUST exchange only encrypted forms of the one-to-one stanza types they agreed upon (e.g., &lt;message/&gt; and &lt;iq/&gt; stanzas).</p>
+  </div>
+<h2>7.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="exchange-separate">Encryptable Content</a>
+</h3>
+    <p class="" style="">Once an Esession has been established, whenever Alice wants to send Bob an encrypted stanza she MUST only encrypt the XML content that would normally be ignored by the intermediate servers. She MUST NOT encrypt stanza wrapper elements or <span style="font-weight: bold">Advanced Message Processing</span> elements.</p>
+    <p class="" style="">If this is an offline Esession then Alice SHOULD include a 'Created' SHIM header in the encrypted content. Bob SHOULD trust this header and ignore the unencrypted <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2258893">29</a>] element inserted by his server.</p>
+
+  <p class="caption">Example 15. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+  &lt;amp per-hop='true' xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+
+  <p class="caption">Example 16. XML Content to be Encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+  &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+&lt;/headers&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+</pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="exchange-encrypt">Encryption</a>
+</h3>
+
+    <p class="" style="">Alice MUST perform the following steps to encrypt the XML content. Note: if there is no XML content to be encrypted (e.g. if this is an empty <a href="#rekey">Re-Keying</a> or <a href="#terminate">Termination</a> stanza), then C<span class="sub" style="">A</span> MUST be incremented by 1 (see below), and only the last two steps (canonicalization and MAC calculation) should be performed.</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Serialize the XML content she wishes to send into an array of UTF-8 bytes, m.  [<a href="#nt-id2258970">30</a>]</p></li>
+      <li>
+        <p class="" style="">Compress m using the negotiated algorithm. If a compression algorithm other than 'none' was agreed, the compression context is typically initialized after key exchange and passed from one stanza to the next, with only a partial flush at the end of each stanza.  [<a href="#nt-id2258990">31</a>]</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = compress(m)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Encrypt the data with the agreed algorithm in counter mode, using the encryption key K-E<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented for each encrypted block or partial block, and if C<span class="sub" style="">A</span>=2<span class="super" style="">n</span>-1 (where n is the number of bits per encryption block for the agreed encryption algorithm) then C<span class="sub" style="">A</span> MUST be "incremented" to 1. Note: if the encryption algorithm 'none' was agreed (see <a href="#sec-unencrypted">Unencrypted Esessions</a>) then encryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_final = encrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Alice MUST now create the XML <span style="font-style: italic">content</span> of the &lt;encrypted/&gt; XML element (with no CDATA between any of the elements) in canonical form (see <span class="ref" style="">Canonical XML</span>  [<a href="#nt-id2259139">32</a>]). The XML MUST include Bob's KID (the one that corresponds to the value of d she used to encrypt the data) wrapped in a &lt;kid/&gt; element and, if there is XML content, the Base64 encoded value of m_final wrapped in a &lt;data/&gt; element. Note: it MAY also contain one &lt;terminate/&gt; element (see <a href="#terminate">Termination</a>), one &lt;key/&gt; element and one or more &lt;old/&gt; elements (see <a href="#rekey">Re-Keying</a>).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_content = '&lt;kid&gt; ** KID ** &lt;/kid&gt;&lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;'</pre></div>
+      </li>
+      <li>
+        <p class="" style="">The XML content and the value of Alice's encryption block counter C<span class="sub" style="">A</span> <span style="font-style: italic">before</span> the data was encrypted, are now processed through the HMAC algorithm (as defined in Section 2 of <span class="ref" style="">RFC 2104</span>  [<a href="#nt-id2259212">33</a>]), along with the agreed hash algorithm ("HASH") and the integrity key K-M<span class="sub" style="">A</span>.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>a_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+    </ol>
+
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="exchange-send">Sending an Encrypted Stanza</a>
+</h3>
+    <p class="" style="">Before sending the stanza to Bob, Alice MUST wrap m_content and the Base64 encoded value of a_mac (wrapped in a &lt;mac/&gt; element) inside an &lt;encrypted/&gt; element and insert it into the stanza in place of the original content. There MUST NOT be more than one &lt;encrypted/&gt; element per stanza.</p>
+    <p class="caption">Example 17. Message Stanza with Encrypted Content</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp per-hop='true' xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="exchange-decrypt">Decryption</a>
+</h3>
+
+    <p class="" style="">When Bob receives the stanza from Alice, he extracts and Base64 decodes the values of m_final and a_mac from the content and performs the following steps. Note: Alice may not have received Bob's last re-key (see <a href="#rekey">Re-Keying</a>) before sending the stanza. So Bob MUST ensure he uses the values of K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> that correspond to his KID that Alice specified in the &lt;kid/&gt; element of the stanza he received (and the current value of e that Alice sent him previously).</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Remove the &lt;mac/&gt; element from the &lt;encrypted/&gt; element and convert the remaining XML <span style="font-style: italic">content</span> into canonical form (with no CDATA between any of the elements, see <span style="font-weight: bold">Canonical XML</span>). Calculate the Message Authentication Code (MAC) for the content.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>b_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Verify that b_mac and a_mac match. If they are not identical, the content has been tampered with and Bob MUST terminate the ESession by sending an error to Alice.  [<a href="#nt-id2259408">34</a>]</p>
+      </li>
+      <li>
+        <p class="" style="">Decrypt m_final using the agreed algorithm, K-E<span class="sub" style="">A</span> and C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented for each decrypted block, and if C<span class="sub" style="">A</span>=2<span class="super" style="">n</span>-1 (where n is the number of bits per encryption block for the agreed encryption algorithm) then C<span class="sub" style="">A</span> MUST be "incremented" to 1. Note: if the encryption algorithm 'none' was agreed decryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = decrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_final)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Decompress m_compressed using the negotiated algorithm (usually 'none').</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m = decompress(m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Replace the &lt;encrypted/&gt; element in the serialized XML stanza with m and feed the stanza into an XML parser. If the parser returns an XML format error then Bob MUST terminate the ESession by sending an error to Alice.  [<a href="#nt-id2259560">35</a>]</p>
+      </li>
+    </ol>
+  </div>
+  <h2>8.
+       <a name="rekey">Re-Key Exchange</a>
+</h2>
+<p class="" style="">Once an attacker has discovered an encryption key it could be used to decrypt all stanzas within a session, including stanzas that were intercepted <span style="font-style: italic">before</span> the key was discovered. To reduce the window of vulnerability, both Alice and Bob SHOULD change their values of x and y and re-exchange the encryption key as regularly as possible. They MUST also destroy all copies of keys as soon as they are no longer needed.</p>
+<p class="" style="">Note: Although most entities are capable of re-keying after each stanza, clients running in constrained runtime environments may require a few seconds to re-key. During Esession initiation these clients MAY negotiate the minimum number of stanzas to be exchanged between re-keys at the cost of a larger window of vulnerability. Entities MUST NOT initiate key re-exchanges more frequently than the agreed limit.</p>
+
+  <div class="indent">
+<h3>8.1 <a name="rekey-init">Re-Key Initiation</a>
+</h3>
+    <p class="" style="">Either Alice or Bob MAY initiate a key re-exchange. Here we describe the process initiated by Alice. First she MUST calculate new values for the encryption parameters:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1, where n is the number of bits per encryption block for the agreed encryption algorithm)</p></li>
+      <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+      <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the new shared secret)</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">To avoid extra stanzas, the new value of e SHOULD be sent to Bob along with an encrypted stanza. Note: Alice MUST NOT use the new K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> to encrypt this stanza or to calculate the MAC. However, she MUST use them when sending subsequent stanzas.</p>
+    <p class="" style="">Note: There is no need for Alice to provide a signature because the calculation of the MAC includes the new value of e, see <a href="#exchange">Exchanging Stanzas</a>).</p>
+    <p class="caption">Example 18. Alice Sends Re-Key Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;key kid=' ** KID ** '&gt; ** Base64 encoded value of new e ** &lt;/key&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Bob may not receive the new key before he sends his next stanzas (they may cross in transit). So, before destroying her old values of K-E<span class="sub" style="">B</span> and K-M<span class="sub" style="">B</span>, Alice MUST wait until either she receives a stanza encrypted with the new key, or a reasonable time has passed (60 seconds should cover a network round-trip and calculations by a constrained client). Similarly she MUST wait before destroying her old value of x, in case Bob sends two stanzas before receiving Alice's new key (the first stanza might include a re-key).</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="rekey-accept">Re-Key Acceptance</a>
+</h3>
+    <p class="" style="">After Bob receives a stanza with a new value of e and he has decrypted the stanza with the old value of K-E<span class="sub" style="">A</span>, he MUST securely destroy all copies of K-E<span class="sub" style="">A</span> and K-E<span class="sub" style="">B</span> and perform the following calculations with the new value of e:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">He MUST use these new values to encrypt and decrypt all subsequent stanzas.  [<a href="#nt-id2259985">36</a>]</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="rekey-publish">Publishing Old MAC Values</a>
+</h3>
+    <p class="" style="">Once the expired MAC keys have been published, anyone could create valid arbitrary stanzas with them. This prevents anyone being able to prove the authenticity of a transcript of the Esession in the future.</p>
+    <p class="" style="">Either entity MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> within any encrypted stanza as long as it knows that all the stanzas that MAY use the old values have been received and validated. Note: A 'man-in-the-middle' could delay the delivery of stanzas indefinitely. So, before Alice publishes K-M<span class="sub" style="">A</span> (and K-M<span class="sub" style="">B</span>), she MUST wait until she has both sent a re-key to Bob and received a stanza from Bob encrypted with her new key. (She MAY also publish K-M<span class="sub" style="">B</span> after she has received a re-key from Bob.)</p>
+    <p class="caption">Example 19. Publishing Expired MAC Keys</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Entities SHOULD ignore any &lt;old/&gt; elements they receive.</p>
+  </div>
+  <h2>9.
+       <a name="terminate">Esession Termination</a>
+</h2>
+    <p class="" style="">Either entity MAY terminate an Esession at any time. To terminate a session Alice MUST send a stanza to Bob including a &lt;terminate/&gt; element. Note: She MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> within her termination stanza as long as she is sure all the stanzas that MAY use the old values have been received and validated (see <a href="#rekey-publish">Publishing Old MAC Values</a>). She MUST then securely destroy all keys associated with the Esession.</p>
+    <p class="caption">Example 20. Alice Terminates an Esession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;terminate/&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Bob receives a termination stanza he MUST verify the MAC (to be sure he received all the stanzas Alice sent him during the Esession) and, if the stanza was sent to him while he was online, immediately send a termination stanza back to Alice. Note: He MAY publish <span style="font-style: italic">any</span> old values of K-M<span class="sub" style="">A</span> or K-M<span class="sub" style="">B</span> within the termination stanza. He MUST then securely destroy all keys associated with the Esession.</p>
+    <p class="caption">Example 21. Bob Confirms Esession Termination</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;terminate/&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Alice receives the stanza she MUST verify the MAC to be sure she received all the stanzas Bob sent her during the Esession. Once an entity has sent a termination stanza it MUST NOT send another stanza within the Esession.</p>
+  <h2>10.
+       <a name="sign">Signature Generation</a>
+</h2>
+    <p class="" style="">Before the signature of a block of XML is calculated, all CDATA between all elements must be removed and the XML MUST be converted to canonical form (see <span style="font-weight: bold">Canonical XML</span>).</p>
+  <div class="indent">
+<h3>10.1 <a name="sign-canon">Canonical Form (Informative)</a>
+</h3>
+    <ul>
+      <li>Encoded in UTF-8</li>
+      <li>Line breaks normalized to ASCII 10</li>
+      <li>Attribute values are normalized, as if by a validating processor</li>
+      <li>Character references are replaced</li>
+      <li>CDATA sections are replaced with their character content</li>
+      <li>Empty elements are converted to start-end tag pairs</li>
+      <li>All whitespace in character content is retained (excluding characters removed during line feed normalization)</li>
+      <li>Normalization of whitespace in start and end tags</li>
+      <li>Attribute value delimiters are set to quotation marks (double quotes)</li>
+      <li>Special characters in attribute values and character content are replaced by character references (&amp;amp;, &amp;lt;, &amp;gt;, &amp;quot;, &amp;#xD;, &amp;#xA;, &amp;#x9;)</li>
+      <li>Lexicographic order is imposed on the namespace declarations (always first) and attributes of each element</li>
+    </ul>
+
+  </div>
+  <h2>11.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="sec-prng">Random Numbers</a>
+</h3>
+    <p class="" style="">Weak pseudo-random number generators (PRNG) enable successful attacks. Implementors MUST use a cryptographically strong PRNG to generate all random numbers (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2260343">37</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="sec-rekey">Re-Keying Limits</a>
+</h3>
+    <p class="" style="">After a key exchange an entity MUST NOT exchange a total of 2<span class="super" style="">32</span> encrypted blocks before it initiates a key re-exchange (see <span class="ref" style="">SSH Transport Layer Encryption Modes</span>  [<a href="#nt-id2260392">38</a>]). Note: This limitation also ensures the same key and counter values are never used to encrypt two different blocks using counter mode (thus preventing simple attacks).</p>
+    <p class="" style="">In order to reduce the Perfect Forward Secrecy window of vulnerability, after an extended period of activity, entities SHOULD either re-key or terminate the Esession.</p>
+  </div>
+  <div class="indent">
+<h3>11.3 <a name="sec-keys">Verifying Keys</a>
+</h3>
+    <p class="" style="">The trust system outlined in this document is based on Alice trusting that the public key presented by Bob is <span style="font-style: italic">actually</span> Bob's key (and vice versa). Determining this trust may be done in a variety of ways depending on the entities' support for different public key (certificate) formats, signing algorithms and signing authorities. For instance, if Bob publishes a PGP/GPG public key, Alice MAY verify that his key is signed by another key that she knows to be good. Or, if Bob provides an X.509 certificate, she MAY check that his key has been signed by a Certificate Authority that she trusts.</p>
+    <p class="" style="">When trust cannot be achieved automatically, methods that are not transparent to the users may be employed. For example, Bob could communicate the SHA-256 fingerprint of his public key to Alice via secure out-of-band communication (e.g. face-to-face). This would enable Alice to confirm that the public key she receives in-band is valid. Note however that very few people bother to verify fingerprints in this way. So this method is exceptionally vulnerable to 'man-in-the-middle' attacks. In order to reduce the window of vulnerability, an entity SHOULD remember the fingerprints of all user-validated public keys and alert the user in the future if ever the fingerprint(s) it stored for an entity do not match any of the received public keys.</p>
+    <p class="" style="">Alternatively Alice and Bob could agree a shared secret via secure out-of-band communication, Bob could then use it to create an HMAC of his public key that only Alice could verify.</p>
+    <p class="" style="">Note: If no keys are acceptable to Alice (because Alice has never verified any of the keys, and because either the keys are not signed, or Alice does not support the signature algorithms of the keys, or she cannot parse the certificate formats, or she does not recognise the authorities that signed the keys) then, although the Esession can still be encrypted, she cannot be sure she is communicating with Bob.</p>
+  </div>
+  <div class="indent">
+<h3>11.4 <a name="sec-replay">Replay Attacks</a>
+</h3>
+    <p class="" style="">The encryption block counters maintained implicitly by Alice and Bob (C<span class="sub" style="">A</span> and C<span class="sub" style="">B</span>) prevent stanzas being replayed within any Esession. They ensure that the MAC will be different for all stanzas, even if the HMAC key and the content of the stanza are identical.</p>
+    <p class="" style="">Alice and Bob MUST ensure that the value of e or d they provide when negotiating each online Esession is unique. This prevents complete online Esessions being replayed.</p>
+    <p class="" style="">Since Bob supplies the same value of d for all offline Esessions, to prevent complete offline Esessions being replayed to him, he MUST take care to securely store <span style="font-style: italic">new</span> values (or destroy existing values) of y and KID whenever he goes offline (see <a href="#init-publish">Publishing Esession Options</a>). Also, when Bob next comes online, he MUST remember all the values of e he receives in offline Esession initiation stanzas, and reject any offline Esessions that specify a value of e he has already received (see <a href="#init-accept">Accepting an Offline Esession</a>).</p>
+  </div>
+  <div class="indent">
+<h3>11.5 <a name="sec-unencrypted">Unencrypted Esessions</a>
+</h3>
+    <p class="" style="">Organisations with full disclosure policies may require entities to disable encryption to enable the logging of all messages on their server. Unencrypted Esessions meet all the <a href="#reqs-sec">Security Requirements</a> except for Confidentiality. This enables Alice to use the 'secure' Esession option to confirm securely with Bob that both client-server connections are secure.</p>
+  </div>
+  <div class="indent">
+<h3>11.6 <a name="sec-storage">Storage</a>
+</h3>
+    <p class="" style="">If either entity stores a (re-encrypted) transcript of an Esession for future consultation then the Perfect Forward Secrecy offered by this protocol is lost. If the negotiated value of the 'logging' <span style="font-weight: bold">Chat Session Negotiation</span> field is false the entities SHOULD NOT store any part of the Esession content (not even in encrypted form).</p>
+  </div>
+  <div class="indent">
+<h3>11.7 <a name="sec-offline">Offline Esessions</a>
+</h3>
+    <p class="" style="">Bob MAY decide not to support Offline Esessions since they are significantly less secure than online Esessions. The Perfect Forward Secrecy window of vulnerability is much longer. More seriously, Bob MUST store his private Diffie-Hellman key, y, to local disk or to a server (perhaps symmetrically encrypted with a password). It is <span style="font-style: italic">really</span> hard to securely erase something from a disk. Note: If Bob does not support Offline Esessions then, while he is offline, Alice will probably send him completely unprotected messages!</p>
+  </div>
+  <div class="indent">
+<h3>11.8 <a name="sec-general">Extra Responsabilities of Implementors</a>
+</h3>
+    <p class="" style="">Cryptography plays only a small part in an entity's security. Even if it implements this protocol perfectly it may still be vulnerable to other attacks. For examples, an implementation might store Esession keys on swap space or save private keys to a file in cleartext! Implementors MUST take very great care when developing applications with secure technologies.</p>
+  </div>
+  <div class="indent">
+<h3>11.9 <a name="sec-mandatory">Mandatory to Implement Technologies</a>
+</h3>
+    <p class="" style="">An implementation of ESession MUST support the Diffie-Hellman Key Agreement and HMAC algorithms. Note: The parameter names mentioned below are related to secure shell; see <span style="font-weight: bold">SSH Transport Layer Encryption Modes</span> for encryption algorithm details; see the <span class="ref" style="">IANA Secure Shell Protocol Parameters</span>  [<a href="#nt-id2260714">39</a>] for other names.</p>
+    <div class="indent">
+<h3>11.9.1 <a name="sec-mandatory-encryption">Encryption Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following encryption algorithm:</p>
+      <ul>
+        <li>aes128-ctr (see <span class="ref" style="">Advanced Encryption Standard</span>  [<a href="#nt-id2260762">40</a>])</li>
+      </ul>
+      <p class="" style="">The block length of an encryption algorithm's cipher SHOULD be at least 128 bits. An implementation of ESession MAY also support the following encryption algorithms:</p>
+      <ul>
+        <li>aes256-ctr</li>
+        <li>aes192-ctr</li>
+        <li>twofish256-ctr (see <span class="ref" style="">Twofish</span>  [<a href="#nt-id2260807">41</a>])</li>
+        <li>twofish192-ctr</li>
+        <li>twofish128-ctr</li>
+        <li>serpent256-ctr (see <span class="ref" style="">Serpent</span>  [<a href="#nt-id2260840">42</a>])</li>
+        <li>serpent192-ctr</li>
+        <li>serpent128-ctr</li>
+        <li>none (no encryption, only signing)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.9.2 <a name="sec-mandatory-sign">Key Signing Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following signing algorithm:</p>
+      <ul>
+        <li>rsa (see <span class="ref" style="">RFC 2437</span>  [<a href="#nt-id2260892">43</a>])</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following signing algorithm:</p>
+      <ul>
+        <li>dss (see <span class="ref" style="">Digital Signature Standard</span>  [<a href="#nt-id2260928">44</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.9.3 <a name="sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following public key formats:</p>
+      <ul>
+        <li>ssh-rsa</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following public key formats:</p>
+      <ul>
+        <li>ssh-dss</li>
+        <li>x509v3-sign-rsa (see <span class="ref" style="">X.509 Authentication in SSH2</span>  [<a href="#nt-id2261032">45</a>])</li>
+        <li>x509v3-sign-dss</li>
+        <li>pgp-sign-rsa</li>
+        <li>pgp-sign-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession MAY also support the following public key formats:</p>
+      <ul>
+        <li>spki-sign-rsa</li>
+        <li>spki-sign-dss</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.9.4 <a name="sec-mandatory-hash">Hash Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following hash algorithm:</p>
+      <ul>
+        <li>sha256 (see <span class="ref" style="">Secure Hash Standard</span>  [<a href="#nt-id2261073">46</a>])</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following hash algorithm (sha1 and md5 are NOT RECOMMENDED):</p>
+      <ul>
+        <li>whirlpool (see <span class="ref" style="">Whirlpool</span>  [<a href="#nt-id2261110">47</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>11.9.5 <a name="sec-mandatory-compress">Compression Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following compression algorithm:</p>
+      <ul>
+        <li>none (no compression, the output MUST be the same as the input)</li>
+      </ul>
+      <p class="" style="">Support for other algorithms is NOT RECOMMENDED since compression partially defeats the <a href="#reqs-repudiate">Repudiability</a> requirement of this JEP by making it more difficult for a third party (with some knowledge of the plaintext) to modify a transcript of an encrypted session in a meaningful way. However, encrypted content is pseudo-random and cannot be compressed, so, in those cases where bandwidth is severely constrained, an implementation of ESession MAY support the following algorithm to compress content before it is encrypted:</p>
+      <ul>
+        <li>zlib (see <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2261229">48</a>])</li>
+      </ul>
+    </div>
+  </div>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261237">49</a>]. </p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="registrar-ns">Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261281">50</a>] shall register the following namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/esession</li>
+      <li>http://jabber.org/protocol/esession#init</li>
+      <li>http://jabber.org/protocol/esession#error</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall reserve the following fields within the scope of Data Forms used for ESession negotation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field
+      var='modp'
+      type='list-single'
+      label='MODP group number'/&gt;
+  &lt;field
+      var='crypt_algs'
+      type='list-single'
+      label='Symmetric block cipher options'/&gt;
+  &lt;field
+      var='hash_algs'
+      type='list-single'
+      label='Hash algorithm options'/&gt;
+  &lt;field
+      var='compress'
+      type='list-single'
+      label='Compression algorithm options'/&gt;
+  &lt;field
+      var='stanzas'
+      type='list-multi'
+      label='Stanzas types to encrypt'/&gt;
+  &lt;field
+      var='secure'
+      type='boolean'
+      label='Require encrypted client-server streams'/&gt;
+  &lt;field
+      var='rekey_freq'
+      type='text-single'
+      label='Minimum number of stanzas between key exchanges'/&gt;
+  &lt;field
+      var='accept_pkids'
+      type='list-multi'
+      label='Acceptable public key IDs'/&gt;
+  &lt;field
+      var='counter'
+      type='hidden'
+      label='Initial block counter'/&gt;
+  &lt;field
+      var='kid'
+      type='hidden'
+      label='Diffie-Hellman key ID'/&gt;
+  &lt;field
+      var='key'
+      type='hidden'
+      label='Diffie-Hellman key'/&gt;
+  &lt;field
+      var='pkey'
+      type='hidden'
+      label='Public key'/&gt;
+  &lt;field
+      var='pkids'
+      type='list-single'
+      label='Public key IDs'/&gt;
+  &lt;field
+      var='signs'
+      type='list-single'
+      label='Data form signatures'/&gt;
+  &lt;field
+      var='req_sign'
+      type='hidden'
+      label='Signature of initial request data form'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>14.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>15.
+       <a name="keys">Public Key Publication and Retrieval</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is highly preliminary and will be specified in a separate proposal before this document reaches draft status.</span></p>
+  <p class="" style="">Entities SHOULD publish their long-term public signature-verification keys to all entities through their own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>).</p>
+
+  <p class="caption">Example 22. Entity Publishes Public Keys to Server</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='dp1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="" style="">Before initiating an ESession, if Bob does not already possess one of Alice's signature-verification keys, he SHOULD retrieve them from Alice's server.</p>
+  <p class="caption">Example 23. Bob Requests Public Keys from Alice's Server</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="caption">Example 24. Server Returns Public Keys</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='alice@example.org'
+    to='bob@example.com/laptop'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Bob should examine all the public keys and identify which ones are acceptable (see <a href="#sec-keys">Verifying Keys</a>).</p>
+<h2>16.
+       <a name="open">Open Issues</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="open-tothink">To Think About</a>
+</h3>
+    <ol start="" type="">
+      <li>Object signing is relatively inefficient if the same message will be sent to many entities (borderline one-to-many)</li>
+      <li>What challenges exist to make the OTR Gaim Plugin use this protocol natively when talking to Jabber entities? Can these be mitigated by 'non-critical' protocol changes?</li>
+      <li>Would anything in this protocol (e.g., its dependency on in-order stanza delivery) prevent an XMPP entity using it to exchange encrypted messages and presence with a user of a non-XMPP messaging system, assuming that the gateway both supports this protocol and is compatible with a purpose-built security plugin on the other user's client (e.g. a Gaim plugin connects to the gateway via a non-XMPP network)?</li>
+      <li>Could the protocol approximate SSH (or IPsec) more closely without losing the benefits of OTR?</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>16.2 <a name="open-todo">To Do</a>
+</h3>
+    <ol start="" type="">
+      <li>Perhaps the JEP needs to specify more carefully how block counters are handled between messages, especially in the event of partial blocks?</li>
+      <li>Define names for X.509 SubjectPublicKeyInfo public key formats (different to X.509 certificates). This format must be used when keys are distributed within session initiation.</li>
+      <li>Discuss signature formats in greater detail.</li>
+      <li>Give examples of specific errors and discuss error scenarios throughout document (e.g., what should Bob do if he is not offline and he receives an offline key exchange stanza?).</li>
+      <li>Update Dependencies list</li>
+      <li>Separate public key publishing into another JEP. Should there be a disco item for each key?</li>
+      <li>Define an optional protocol that would allow Bob to store y (and the PKIDs he trusts) 'securely' on his own server (before he goes offline). After going online Bob should retrieve the values of y that he stored before going offline (if any), and then use <span class="ref" style="">Flexible Offline Message Retrieval</span>  [<a href="#nt-id2261605">51</a>] to prevent any offline Esessions he can't decrypt being delivered to him (Each &lt;item/&gt; that corresponds to an Esession message MUST contain a &lt;kid/&gt; child. This allows Bob to discover which of his KIDs was used to encrypt the message. <span style="font-style: italic">N.B. This requires a new server feature, only Jive and XCP support FOMR!</span>). Bob SHOULD NOT request messages whose KID does not correspond to one of the values of y he retrieved. This is most likely to occur if he prefered not to store y on his server (because local storage is more secure), and he went offline using a different client and/or a different machine.</li>
+    </ol>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250561">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2250690">2</a>. RFC 3862: Common Presence and Instant Messaging (CPIM): Message Format &lt;<a href="http://www.ietf.org/rfc/rfc3862.txt">http://www.ietf.org/rfc/rfc3862.txt</a>&gt;.</p>
+<p><a name="nt-id2250427">3</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p><a name="nt-id2250447">4</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2250491">5</a>. Off-the-Record Communication, or, Why Not to Use PGP &lt;<a href="http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf">http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf</a>&gt;.</p>
+<p><a name="nt-id2250516">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250550">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255679">8</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2255726">9</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2255754">10</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255788">11</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255818">12</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2255908">13</a>. SSH Protocol Architecture &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2255934">14</a>. SSH Transport Layer Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256157">15</a>. The reliable association between an entity and its public keys is beyond the scope of this JEP.</p>
+<p><a name="nt-id2256184">16</a>. Naturally, it is possible that Alice or Bob may retain cleartext versions of the exchanged communications; however, that threat is out of scope for this JEP.</p>
+<p><a name="nt-id2256432">17</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256454">18</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256554">19</a>. RFC 2631: Diffie-Hellman Key Agreement Method &lt;<a href="http://www.ietf.org/rfc/rfc2631.txt">http://www.ietf.org/rfc/rfc2631.txt</a>&gt;.</p>
+<p><a name="nt-id2256618">20</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2256684">21</a>. RFC 2409: The Internet Key Exchange (IKE) &lt;<a href="http://www.ietf.org/rfc/rfc2409.txt">http://www.ietf.org/rfc/rfc2409.txt</a>&gt;.</p>
+<p><a name="nt-id2256707">22</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p><a name="nt-id2256815">23</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256972">24</a>. RFC 3766: Determining Strengths For Public Keys Used For Exchanging Symmetric Keys &lt;<a href="http://www.ietf.org/rfc/rfc3766.txt">http://www.ietf.org/rfc/rfc3766.txt</a>&gt;.</p>
+<p><a name="nt-id2257143">25</a>. The private signing keys may only be accessible to another of Bob's clients.</p>
+<p><a name="nt-id2257150">26</a>. Some servers may not support public key publishing.</p>
+<p><a name="nt-id2257591">27</a>. The more often Bob changes his published Esession options, the shorter the Perfect Forward Secrecy window of vulnerability. However, whenever he changes them he divulges his presence to all the entities that are monitoring them.</p>
+<p><a name="nt-id2258694">28</a>. K-M<span class="sub" style="">A</span> is a hash of K-E<span class="sub" style="">A</span> (not K) to ensure that if an attacker recovers the decryption key she will not be able to cryptographically convince anyone that it was not her who created the stanza.</p>
+<p><a name="nt-id2258893">29</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2258970">30</a>. Although counter mode encryption requires no padding, implementations MAY still disguise the length of m by appending a random number of white-space characters.</p>
+<p><a name="nt-id2258990">31</a>. If Bob were to receive a stanza out-of-order, then he would fail to decrypt the stanza and be forced to terminate the Esession.</p>
+<p><a name="nt-id2259139">32</a>. Canonical XML 1.0 &lt;<a href="http://www.w3.org/TR/xml-c14n">http://www.w3.org/TR/xml-c14n</a>&gt;.</p>
+<p><a name="nt-id2259212">33</a>. RFC 2104: HMAC: Keyed-Hashing for Message Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2104.txt">http://www.ietf.org/rfc/rfc2104.txt</a>&gt;.</p>
+<p><a name="nt-id2259408">34</a>. If Bob were to receive a stanza out-of-order, then the MACs would not match because the values of C<span class="sub" style="">A</span> would not be synchronized.</p>
+<p><a name="nt-id2259560">35</a>. Bob MUST NOT send a stream error to his server since intermediate entities are not responsible for encoded content.</p>
+<p><a name="nt-id2259985">36</a>. If an entity fails to receive any stanza that includes a new key in the correct order, then it will fail to decrypt the next stanza it receives and be forced to terminate the Esession.</p>
+<p><a name="nt-id2260343">37</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2260392">38</a>. SSH Transport Layer Encryption Modes &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2260714">39</a>. IANA registry of parameters related to secure shell &lt;<a href="http://www.iana.org/assignments/ssh-parameters">http://www.iana.org/assignments/ssh-parameters</a>&gt;.</p>
+<p><a name="nt-id2260762">40</a>. Advanced Encryption Standard: Federal Information Processing Standards Publication 197 &lt;<a href="http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf">http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf</a>&gt;.</p>
+<p><a name="nt-id2260807">41</a>. The Twofish Block Cipher &lt;<a href="http://www.schneier.com/twofish.html">http://www.schneier.com/twofish.html</a>&gt;.</p>
+<p><a name="nt-id2260840">42</a>. The Serpent Block Cipher &lt;<a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">http://www.cl.cam.ac.uk/~rja14/serpent.html</a>&gt;.</p>
+<p><a name="nt-id2260892">43</a>. RFC 2437: PKCS #1: RSA Cryptography Specifications Version 2.0 &lt;<a href="http://www.ietf.org/rfc/rfc2437.txt">http://www.ietf.org/rfc/rfc2437.txt</a>&gt;.</p>
+<p><a name="nt-id2260928">44</a>. Digital Signature Standard: Federal Information Processing Standards Publication 186  &lt;<a href="http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf">http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf</a>&gt;.</p>
+<p><a name="nt-id2261032">45</a>. X.509 Authentication in SSH2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2261073">46</a>. Secure Hash Standard: Federal Information Processing Standards Publication 180-2  &lt;<a href="http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf">http://csrc.nist.gov/publications/fips/fips180-2/fips186-2withchangenotice.pdf</a>&gt;.</p>
+<p><a name="nt-id2261110">47</a>. The Whirlpool Hash Function &lt;<a href="http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html">http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html</a>&gt;.</p>
+<p><a name="nt-id2261229">48</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2261237">49</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261281">50</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2261605">51</a>. JEP-0013: Flexible Offline Message Retrieval &lt;<a href="http://www.jabber.org/jeps/jep-0013.html">http://www.jabber.org/jeps/jep-0013.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2004-08-12)</h4>
+<div class="indent">Extended termination procedure; added object encryption/signing requirement and special case; clarified expired MAC publishing; added Flexible Offline Message Retrieval to Open Issues. (ip)
+    </div>
+<h4>Version 0.5 (2004-08-10)</h4>
+<div class="indent">Added flexibility requirement; added late signature of initial request; added termination MAC. (ip)
+    </div>
+<h4>Version 0.4 (2004-08-09)</h4>
+<div class="indent">Added (offline) replay protection; required offline Created header; compression is NOT RECOMMENDED; added second set of offline options for subscribers; added JIDs to session key generation; unencrypted sessions; added secure option; sign whole data form; HMAC whole &lt;encrypted/&gt; element; added Esession termination; option to distribute public keys within session initiation; added Integrity requirement; several clarifications (ip)
+    </div>
+<h4>Version 0.3 (2005-08-02)</h4>
+<div class="indent">Restored status to Experimental; complete rewrite; new Introduction, Background, Requirements and Security Considerations; new OTR-inspired protocol; JEP-0155-based negotiation; counter mode encryption; more secure hashes; offline sessions; re-keying; mac publishing; preliminary key and options publishing protocol. (ip/psa)
+    </div>
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.7.html
+++ b/content/xep-0116-0.7.html
@@ -1,0 +1,1756 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-08-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0116<br>
+            Version: 0.7<br>
+            Last Updated: 2005-08-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2104, RFC 2409, RFC 3526, RFC 3548, xml-c14n, JEP-0004, JEP-0020, JEP-0030, JEP-0068, JEP-0079, JEP-0155<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>3.1.  <a href="#terms-personae">Dramatis Personae</a>
+</dt></dl>
+<dt>4.  <a href="#reqs">Requirements</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#reqs-sec">Security Requirements</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#reqs-encrypt">Confidentiality</a>
+</dt>
+<dt>4.1.2.  <a href="#reqs-integrity">Integrity</a>
+</dt>
+<dt>4.1.3.  <a href="#reqs-replay">Replay Protection</a>
+</dt>
+<dt>4.1.4.  <a href="#reqs-forward">Perfect Forward Secrecy</a>
+</dt>
+<dt>4.1.5.  <a href="#reqs-auth">Authentication</a>
+</dt>
+<dt>4.1.6.  <a href="#reqs-repudiate">Repudiability</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#reqs-xmpp">Application Requirements</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#reqs-generality">Generality</a>
+</dt>
+<dt>4.2.2.  <a href="#reqs-implement">Implementability</a>
+</dt>
+<dt>4.2.3.  <a href="#reqs-usable">Usability</a>
+</dt>
+<dt>4.2.4.  <a href="#reqs-efficient">Efficiency</a>
+</dt>
+<dt>4.2.5.  <a href="#reqs-flexible">Flexibility</a>
+</dt>
+<dt>4.2.6.  <a href="#reqs-usable">Interoperability</a>
+</dt>
+<dt>4.2.7.  <a href="#reqs-offline">Offline Sessions</a>
+</dt>
+<dt>4.2.8.  <a href="#reqs-offline">Object Encryption</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>6.  <a href="#synopsis">Synopsis of a Complete Esession</a>
+</dt>
+<dt>7.  <a href="#init">ESession Initiation</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#init-online">Online Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#init-request">Esession Request</a>
+</dt>
+<dt>7.1.2.  <a href="#init-prep">Diffie-Hellman Preparation (Bob)</a>
+</dt>
+<dt>7.1.3.  <a href="#init-response">Esession Response</a>
+</dt>
+<dt>7.1.4.  <a href="#init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</dt>
+<dt>7.1.5.  <a href="#init-complete">Diffie-Hellman Completion</a>
+</dt>
+</dl>
+<dt>7.2.  <a href="#init-offline">Offline Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>7.2.1.  <a href="#init-publish">Publishing Esession Options</a>
+</dt>
+<dt>7.2.2.  <a href="#init-offreq">Requesting Offline Esession Options</a>
+</dt>
+<dt>7.2.3.  <a href="#init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</dt>
+<dt>7.2.4.  <a href="#init-start">Starting an Offline Esession</a>
+</dt>
+<dt>7.2.5.  <a href="#init-accept">Accepting Offline Esessions</a>
+</dt>
+</dl>
+<dt>7.3.  <a href="#init-keys">Generating Session Keys</a>
+</dt>
+</dl>
+<dt>8.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#exchange-separate">Encryptable Content</a>
+</dt>
+<dt>8.2.  <a href="#exchange-encrypt">Encryption</a>
+</dt>
+<dt>8.3.  <a href="#exchange-send">Sending an Encrypted Stanza</a>
+</dt>
+<dt>8.4.  <a href="#exchange-decrypt">Decryption</a>
+</dt>
+</dl>
+<dt>9.  <a href="#rekey">Re-Key Exchange</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#rekey-init">Re-Key Initiation</a>
+</dt>
+<dt>9.2.  <a href="#rekey-accept">Re-Key Acceptance</a>
+</dt>
+<dt>9.3.  <a href="#rekey-publish">Publishing Old MAC Values</a>
+</dt>
+</dl>
+<dt>10.  <a href="#terminate">Esession Termination</a>
+</dt>
+<dt>11.  <a href="#sign">Signature Generation and Verification</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#sign-normal">XML Normalization</a>
+</dt>
+<dt>11.2.  <a href="#sign-hash">Hash</a>
+</dt>
+<dt>11.3.  <a href="#sign-calc">Generation</a>
+</dt>
+<dl>
+<dt>11.3.1.  <a href="#sign-rsa-gen">RSA</a>
+</dt>
+<dt>11.3.2.  <a href="#sign-dsa-gen">DSA</a>
+</dt>
+</dl>
+<dt>11.4.  <a href="#sign-format">Signature Format</a>
+</dt>
+<dl>
+<dt>11.4.1.  <a href="#sign-rsa-format">RSA</a>
+</dt>
+<dt>11.4.2.  <a href="#sign-dsa-format">DSA</a>
+</dt>
+</dl>
+<dt>11.5.  <a href="#sign-calc">Verification</a>
+</dt>
+<dl>
+<dt>11.5.1.  <a href="#sign-rsa-verify">RSA</a>
+</dt>
+<dt>11.5.2.  <a href="#sign-dsa-verify">DSA</a>
+</dt>
+</dl>
+</dl>
+<dt>12.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#sec-prng">Random Numbers</a>
+</dt>
+<dt>12.2.  <a href="#sec-rekey">Re-Keying Limits</a>
+</dt>
+<dt>12.3.  <a href="#sec-keys">Verifying Keys</a>
+</dt>
+<dt>12.4.  <a href="#sec-replay">Replay Attacks</a>
+</dt>
+<dt>12.5.  <a href="#sec-unencrypted">Unencrypted Esessions</a>
+</dt>
+<dt>12.6.  <a href="#sec-storage">Storage</a>
+</dt>
+<dt>12.7.  <a href="#sec-offline">Offline Esessions</a>
+</dt>
+<dt>12.8.  <a href="#sec-general">Extra Responsabilities of Implementors</a>
+</dt>
+<dt>12.9.  <a href="#sec-mandatory">Mandatory to Implement Technologies</a>
+</dt>
+<dl>
+<dt>12.9.1.  <a href="#sec-mandatory-encryption">Encryption Algorithms</a>
+</dt>
+<dt>12.9.2.  <a href="#sec-mandatory-sign">Key Signing Algorithms</a>
+</dt>
+<dt>12.9.3.  <a href="#sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</dt>
+<dt>12.9.4.  <a href="#sec-mandatory-hash">Hash Algorithms</a>
+</dt>
+<dt>12.9.5.  <a href="#sec-mandatory-compress">Compression Algorithms</a>
+</dt>
+</dl>
+</dl>
+<dt>13.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#registrar-ns">Namespaces</a>
+</dt>
+<dt>14.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>15.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>16.  <a href="#keys">Public Key Publication and Retrieval</a>
+</dt>
+<dt>17.  <a href="#open">Open Issues</a>
+</dt>
+<dl>
+<dt>17.1.  <a href="#open-tothink">To Think About</a>
+</dt>
+<dt>17.2.  <a href="#open-todo">To Do</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">End-to-end encryption is a desirable feature for any communication technology. Ideally, such a technology would design encryption in from the beginning and would forbid unencrypted communications. Realistically, most communication technologies have not been designed in that manner, and Jabber/XMPP technologies are no exception. In particular, the original Jabber technologies developed in 1999 did not include end-to-end encryption by default. PGP-based encryption of message bodies and signing of presence information was added as an extension to the core protocols in the year 2000; this extension is documented in <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2250608">1</a>]. When the core protocols were formalized within the Internet Standards Process by the IETF's XMPP Working Group in 2003, a different extension was defined using S/MIME-based signing and encryption of CPIM-formatted messages (see <span class="ref" style="">RFC 3862</span>  [<a href="#nt-id2250638">2</a>]) and PIDF-formatted presence information (see <span class="ref" style="">RFC 3863</span>  [<a href="#nt-id2250659">3</a>]); this extension is specified in <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2250680">4</a>].</p>
+  <p class="" style="">For reasons described more fully below, the foregoing proposals (and others not mentioned) have not been widely implemented and deployed. This is unfortunate, since an open communication protocol needs to enable end-to-end encryption in order to be seriously considered for deployment by a broad range of users. This proposal describes a different approach to end-to-end encryption for use by entities that communicate using XMPP. The approach taken herein essentially translates the semantics of the secure shell protocol (SSH) into the syntax of XMPP, with some adjustments that reflect reports of security issues with SHA-1 and insights gleaned from implementation of "off-the-record" (OTR) communication in the Gaim encryption plugin as described in <span class="ref" style="">Off-the-Record Communication</span>  [<a href="#nt-id2250724">5</a>]. The result is a protocol for encrypted sessions or "ESessions".</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">As specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250754">6</a>], XMPP is an XML streaming protocol that enables the near-real-time exchange of XML fragments between any two (or more) network endpoints. To date, the main application built on top of the core XML streaming layer is instant messaging (IM) and presence, the base extensions for which are specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2255716">7</a>]. There are three first-level elements of XML streams (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;); each of these "XML stanza" types has different semantics, which can complicate the task of defining a generalized approach to end-to-end encryption for XMPP. In addition, XML stanzas can be extended (via properly-namespaced child elements) for a wide variety of functionality. The chosen approach should enable encryption of several complete XML elements rather than only parts thereof (e.g., only the XML character data of the message &lt;body/&gt; element as in <span style="font-weight: bold">JEP-0027</span>).</p>
+  <p class="" style="">XMPP is a session-oriented communication technology: normally, a client authenticates with a server and maintains a long-lived connection that defines the client's XMPP session. Such stream-level sessions are secured via channel encryption using Transport Level Security (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2255767">8</a>]), as specified in Section 5 of <span style="font-weight: bold">RFC 3920</span>. However, there is no guarantee that all hops will implement or enforce channel encryption (or that intermediate routers are trustworthy), which makes end-to-end encryption desirable.</p>
+  <p class="" style="">The session metaphor also applies to communication between endpoints: for instance, in IM applications, most instant messaging exchanges occur in bursts within limited time periods (e.g., two people may send a fairly large number of messages during a five-minute chat and then not exchange messages again for hours or even days). The XML stanzas exchanged during such a session may not be limited to &lt;message/&gt; stanzas; for instance, the session may be triggered by a change in one of the parties' presence status (e.g., changing from away to available) and the session may involve the exchange of &lt;iq/&gt; stanzas (e.g., to transfer a file as specified in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2255816">9</a>]). Endpoints may want to encrypt the stanzas they send to each other in such a way that the stanzas cannot be understood by untrusted mediating entities (such as servers) except to the extent required to understand the necessary routing information. (One complicating factor is that routing information may include not only the stanza's 'to', 'from', 'type, and 'id' attributes, but also <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2255837">10</a>] extensions.)</p>
+  <p class="" style="">The foregoing XMPP communications exist in the context of a one-to-one communication session between two entities. However, several forms of XMPP communication exist outside the context of one-to-one communication sessions:</p>
+  <ul>
+    <li>Many-to-many sessions, such as a text conference in a chatroom as specified in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255872">11</a>].</li>
+    <li>One-to-many "broadcast", such as undirected presence stanzas sent from one user to many contacts (see <span style="font-weight: bold">RFC 3921</span>) and data syndication implemented using <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2255901">12</a>].</li>
+    <li>One-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</li>
+  </ul>
+  <p class="" style="">Ideally, any technology for end-to-end encryption in XMPP could be extended to cover these scenarios as well as one-to-one communication sessions. However, both many-to-many sessions and one-to-many broadcast are deemed out of scope for this JEP. Offline communications are handled via a simple extension to the protocol for one-to-one sessions between two entities that are online simultaneously (see below).</p>
+  <p class="" style="">Because XMPP is a session-oriented communication technology, encryption schemes that are appropriate for less dynamic technologies may not be appropriate for XMPP. XMPP, with its in-order delivery of XML stanzas, is able to take advantage of encryption approaches that are not feasible for less dynamic technologies. In particular, existing approaches to encryption of Internet communications have generally assumed that the "thing" to be encrypted has a stable identity or is best understood as a standalone object (e.g., a file or email message); the term "object encryption" well captures this assumption. Both <span style="font-weight: bold">JEP-0027</span> and <span style="font-weight: bold">RFC 3923</span> assume that XMPP communications are more like the exchange of email messages than they are like an interactive session -- while <span style="font-weight: bold">JEP-0027</span> uses "old-style" PGP object encryption and <span style="font-weight: bold">RFC 3923</span> uses "new-style" S/MIME object encryption, both specify the use of object encryption. </p>
+  <p class="" style="">However, the session-oriented nature of XMPP may imply that the focus should be on "session encryption" rather than "object encryption". The paradigm for XMPP encryption may be something closer to the widely-deployed Secure Shell technology (see <span class="ref" style="">SSH Protocol Architecture</span>  [<a href="#nt-id2256032">13</a>] and <span class="ref" style="">SSH Transport Layer Protocol</span>  [<a href="#nt-id2256004">14</a>]) than to traditional encryption of files and standalone email messages. In many ways, Secure Shell (or, more specifically, OTR) is the conceptual model for the current proposal.</p>
+  <p class="" style="">Therefore, this JEP specifies a method for encrypted sessions ("ESessions") that takes advantage of the inherent possibilities and strengths of session encryption as opposed to object encryption. The basic concept is that of an encrypted session which acts as a secure tunnel between two endpoints. Once the tunnel is established, the content of all one-to-one XML stanzas exchanged between the endpoints will be encrypted and then transmitted within a "wrapper" protocol element.</p>
+<h2>3.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="terms-personae">Dramatis Personae</a>
+</h3>
+    <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+    <ol start="1" type="">
+      <li>"Alice" is the name of the initiator of the ESession. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+      <li>"Bob" is the name of the other participant in the ESession started by Alice. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    </ol>
+    <p class="" style="">While Alice and Bob are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an Esession.</p>
+  </div>
+<h2>4.
+       <a name="reqs">Requirements</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="reqs-sec">Security Requirements</a>
+</h3>
+    <p class="" style="">This JEP stipulates the following security requirements for end-to-end encryption of XMPP communications:</p>
+    <ul>
+      <li>Confidentiality</li>
+      <li>Integrity</li>
+      <li>Replay protection</li>
+      <li>Perfect forward secrecy</li>
+      <li>Authentication</li>
+      <li>Repudiability</li>
+    </ul>
+    <p class="" style="">Each of these requirements is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="reqs-encrypt">Confidentiality</a>
+</h3>
+      <p class="" style="">The one-to-one XML stanzas exchanged between two entities MUST NOT be understandable to any other entity that might intercept the communications.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="reqs-integrity">Integrity</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be sure that no other entity may change the content of the XML stanzas they exchange, or remove or insert stanzas into the Esession undetected.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.3 <a name="reqs-replay">Replay Protection</a>
+</h3>
+      <p class="" style="">Alice or Bob MUST be able to identify and reject any communications that are copies of their previous communications resent by another entity.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.4 <a name="reqs-forward">Perfect Forward Secrecy</a>
+</h3>
+      <p class="" style="">The encrypted communication MUST NOT be revealed even if long-lived keys are compromised in the future (e.g., Steve steals Bob's computer).</p>
+    </div>
+    <div class="indent">
+<h3>4.1.5 <a name="reqs-auth">Authentication</a>
+</h3>
+      <p class="" style="">Each party to a conversation MUST know that the other party is who he says he is (Alice must be able to know that Bob really is Bob, and vice versa).  [<a href="#nt-id2256242">15</a>]</p>
+    </div>
+    <div class="indent">
+<h3>4.1.6 <a name="reqs-repudiate">Repudiability</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be able to repudiate any stanza that occurs within an Esession. After an Esession has finished, it SHOULD NOT be possible to <span style="font-style: italic">prove cryptographically</span> that any transcript has not been modified by a third party.  [<a href="#nt-id2256270">16</a>]</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="reqs-xmpp">Application Requirements</a>
+</h3>
+    <p class="" style="">In addition to the foregoing security profile, this JEP also stipulates the following application-specific requirements for encrypted communication in the context of Jabber/XMPP technologies:</p>
+    <ul>
+      <li>Generality</li>
+      <li>Implementability</li>
+      <li>Usability</li>
+      <li>Efficiency</li>
+      <li>Flexibility</li>
+      <li>Interoperability</li>
+      <li>Offline "sessions"</li>
+      <li>Object encryption</li>
+    </ul>
+    <p class="" style="">Each of these is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.2.1 <a name="reqs-generality">Generality</a>
+</h3>
+      <p class="" style="">The solution should be generally applicable to any XML stanza type (&lt;message/&gt;, &lt;presence/&gt;, &lt;iq/&gt;) sent between two entities. It is deemed acceptable for now if the solution does not apply to many-to-many stanzas (e.g., groupchat messages sent within the context of multi-user chat) or one-to-many stanzas (e.g., presence "broadcasts" and pubsub notifications); end-to-end encryption of such stanzas may require separate solutions or extensions to the one-to-one session solution.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="reqs-implement">Implementability</a>
+</h3>
+      <p class="" style="">The only good security technology is an implemented security technology. The solution should be one that typical client developers can implement in a relatively straightforward and interoperable fashion.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="reqs-usable">Usability</a>
+</h3>
+      <p class="" style="">The requirement of usability takes implementability one step further by stipulating that the solution must be one that organizations may deploy and humans may use with 100% transparency (with the ease-of-use of https:). Experience has shown that: solutions requiring a full public key infrastructure do not get widely deployed, and solutions requiring any user action are not widely used. We can do better.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.4 <a name="reqs-efficient">Efficiency</a>
+</h3>
+      <p class="" style="">Cryptographic operations are highly CPU intensive, particularly public key and Diffie-Hellman operations. Cryptographic data structures can be relatively large especially public keys and certificates. The solution should perform efficiently even when CPU and network bandwidth are constrained.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.5 <a name="reqs-flexible">Flexibility</a>
+</h3>
+      <p class="" style="">The solution should be compatible with existing (and future) cryptographic algorithms and identity certification schemes (including X.509 and PGP).</p>
+    </div>
+    <div class="indent">
+<h3>4.2.6 <a name="reqs-usable">Interoperability</a>
+</h3>
+      <p class="" style="">Ideally, it would be possible for an XMPP user to exchange encrypted messages (and, potentially, presence information) with users of non-XMPP messaging systems.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.7 <a name="reqs-offline">Offline Sessions</a>
+</h3>
+      <p class="" style="">Ideally, it should be possible to encrypt one-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</p>
+    </div>
+    <div class="indent">
+<h3>4.2.8 <a name="reqs-offline">Object Encryption</a>
+</h3>
+      <p class="" style="">For cases where a session is not desired, it should be possible to encrypt, sign and send a single stanza in isolation, so-called "object encryption".</p>
+    </div>
+  </div>
+<h2>5.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">Before attempting to engage in an ESession with Bob, Alice SHOULD discover whether he supports this protocol, using either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256534">17</a>] or the presence-based profile of <span style="font-weight: bold">JEP-0030</span> specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256557">18</a>].</p>
+  <p class="" style="">The normal course of events is for Alice to authenticate with her server, retrieve her roster (see <span style="font-weight: bold">RFC 3921</span>), send initial presence to her server, and then receive presence information from all the contacts in her roster. If the presence information she receives from some contacts does not include capabilities data (per <span style="font-weight: bold">JEP-0115</span>), Alice SHOULD then send a service discovery information ("disco#info") request to each of those contacts (in accordance with <span style="font-weight: bold">JEP-0030</span>). Such initial service discovery stanzas MUST NOT be considered part of encrypted communication sessions for the purposes of this JEP, since they perform a "bootstrapping" function that is a prerequisite to encrypted communications. The disco#info request sent from Alice to Bob might look as follows:</p>
+  <p class="caption">Example 1. Alice Queries Bob for Esession Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com/laptop'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Bob sends a disco#info reply and he supports the protocol defined herein, then he MUST include a service discovery feature variable of "http://jabber.org/protocol/esession".</p>
+  <p class="caption">Example 2. Bob Returns disco#info Data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='bob@example.com/laptop'
+    to='alice@example.org/pda'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='client' type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/esession'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="synopsis">Synopsis of a Complete Esession</a>
+</h2>
+    <p class="" style="">To initiate an Esession Alice sends Bob her preferences. Bob's public key IDs come from her database of verified public keys. Her other preferences are typically the same for all Esessions.</p>
+    <p class="caption">Example 3. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='form' xmlns='jabber:x:data'&gt;
+      &lt;field type="hidden" var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="accept"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="logging"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="modp"&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;1&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="crypt_algs"&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="hash_algs"&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="compress"&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-multi" var="stanzas"&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="secure"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="text-single" var="rekey_freq"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-multi" var="accept_pkids"&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    <p class="" style="">Bob replies to Alice with his preferences from the options she sent him and his half of the shared encryption key.</p>
+    <p class="caption">Example 4. Bob Accepts Esession</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="accept_pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="kid"&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="key"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    <p class="" style="">Alice sends her first encrypted stanza to Bob along with her half of the shared encryption key.</p>
+    <p class="caption">Example 5. Alice Completes Esession Negotiation and Sends Her First Encrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="kid"&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="key"&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pkids"&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="req_mac"&gt;&lt;value&gt; ** Base64 encoded MAC of her previous form ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="signs"&gt;&lt;value&gt; ** signature of this form ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    <p class="caption">Example 6. Bob sends Alice an Encrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda' type='chat'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+
+
+...
+    </pre></div>
+
+    <p class="caption">Example 7. Alice Terminates the Esession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    <p class="caption">Example 8. Bob Confirms Termination</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+<h2>7.
+       <a name="init">ESession Initiation</a>
+</h2>
+  <p class="" style="">The process for establishing an ESession is essentially a translation into XMPP syntax of the SSH transport mechanism for establishing a secure session over an insecure transport (see <span style="font-weight: bold">SSH Transport Layer Protocol</span>). Specifically, as in SSH, ESession uses a Diffie-Hellman key exchange algorithm (see <span class="ref" style="">RFC 2631</span>  [<a href="#nt-id2250251">19</a>]) in the initial negotation (although, as we shall see, it does not use SHA-1 as the hashing algorithm).</p>
+  <p class="" style="">When Alice wishes to establish an ESession with Bob, Alice may choose between two different methods of performing the initial Diffie-Hellman key exchange, depending on whether Bob is online or not. Note: Alice MUST NOT initiate a new Esession with Bob if she already has one established with him.</p>
+
+  <div class="indent">
+<h3>7.1 <a name="init-online">Online Diffie-Hellman Key Exchange</a>
+</h3>
+    <p class="" style="">If Alice believes Bob may be online then she SHOULD retrieve Bob's long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) and then use the protocol specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2257011">20</a>] to negotiate the initial Diffie-Hellman key. In this aggressive exchange the first two messages negotiate policy, swap Diffie-Hellman public values and the ancillary data necessary for the exchange and authentication. The second message also authenticates the responder. The third message authenticates the initiator and exchanges the final Diffie-Hellman public value.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="init-request">Esession Request</a>
+</h3>
+      <p class="" style="">In addition to the "accept" and "logging" fields specified in <span style="font-weight: bold">Chat Session Negotiation</span>, Alice MUST specify each of the Esession options (algorithms etc.) she is willing to use, in her order of preference (see <a href="#sec-mandatory">Mandatory to Implement Technologies</a>). Note: Alice SHOULD NOT include a "reason" field since Aunt Tillie may not be aware the Esession request is not encrypted.</p>
+      <ol start="1" type="">
+        <li><p class="" style="">The list of Modular Exponential (MODP) group numbers (as specified in <span class="ref" style="">RFC 2409</span>  [<a href="#nt-id2257085">21</a>] or <span class="ref" style="">RFC 3526</span>  [<a href="#nt-id2257108">22</a>]) she is willing to use for Diffie-Hellman key exchange (valid group numbers include 1,2,3,4,5,14,15,16,17 and 18)</p></li>
+        <li><p class="" style="">Stanza symmetric encryption algorithm names</p></li>
+        <li><p class="" style="">Hash algorithm names</p></li>
+        <li><p class="" style="">Compression algorithm names</p></li>
+        <li><p class="" style="">The list of stanza types she is willing to encrypt and decrypt</p></li>
+        <li><p class="" style="">Whether or not both entities MUST be connected securely to their servers (see Section 5 of <span style="font-weight: bold">RFC 3920</span>)</p></li>
+        <li><p class="" style="">The minimum number of stanzas that MUST be exchanged before an entity MAY initiate a key re-exchange (1 - every stanza, 100 - every hundred stanzas). This value MUST be less than 2<span class="super" style="">32</span> (see <a href="#sec-rekey">Re-Keying Limits</a>)</p></li>
+        <li><p class="" style="">The Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2257215">23</a>]) SHA-256 fingerprint (PKID) of each of Bob's public signature-verification keys that she found acceptable (see <a href="#sec-keys">Verifying Keys</a>). Note: Alice SHOULD facilitate <a href="#sign-normal">XML Normalization</a> by <span style="font-style: italic">not</span> including an empty "accept_pkids" field.</p></li>
+      </ol>
+    <p class="caption">Example 9. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='form' xmlns='jabber:x:data'&gt;
+      &lt;field type="hidden" var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="accept"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="logging"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="modp"&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;1&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="crypt_algs"&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="hash_algs"&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="compress"&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-multi" var="stanzas"&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="secure"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="text-single" var="rekey_freq"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-multi" var="accept_pkids"&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='drop' condition='deliver' value='stored'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob does not support one or more of the options in each Esession field (except the 'accept_pkids' field), then he SHOULD return a &lt;feature-not-implemented/&gt; error (but he MAY return no error if, for example, he does not want to reveal his presence to Alice for whatever reason):</p>
+    <p class="caption">Example 10. Bob Informs Alice that Her Options Are Not Supported</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='bob@example.com/laptop'
+         to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    ...
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Either Bob or Alice MAY attempt to initiate a new ESession after any error during the initiation process. However, both MUST consider the previous negotiation to have failed and MUST discard any information learned through the previous negotiation.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="init-prep">Diffie-Hellman Preparation (Bob)</a>
+</h3>
+      <p class="" style="">If Bob is willing to start an ESession with Alice, he SHOULD retrieve Alice's long-term public signature-verification keys. He MUST select one of the options from each of the Esession fields he received from Alice including one of the MODP groups (see <span class="ref" style="">RFC 3766</span>  [<a href="#nt-id2257355">24</a>] or <span style="font-weight: bold">RFC 3526</span> for recommendations regarding balancing the sizes of symmetric cipher blocks and Diffie-Hellman moduli). Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). Bob MUST then perform the following computations (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the block counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.1.3 <a name="init-response">Esession Response</a>
+</h3>
+    <p class="" style="">Bob responds to Alice specifying the Esession options he selected.</p>
+    <p class="" style="">If Bob is willing to start an ESession with Alice, then instead of providing the PKID of his public key that he selected, Bob MUST specify the Base64 encoded SHA-256 fingerprint (PKID) of each of Alice's public signature-verification keys that he finds acceptable (see <a href="#sec-keys">Verifying Keys</a>). Note: The values Bob submits in the "accept_pkids" field are not selected from the options he received.</p>
+    <p class="" style="">Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Alice.</p>
+    <p class="" style="">In addition to the fields he received from Alice, Bob MUST include his KID and the Base64 encoded values of d and C<span class="sub" style="">A</span>. If Alice selected one or more of his public keys, and if Bob has access to a long-lived private signing key that corresponds to one of those keys  [<a href="#nt-id2257572">25</a>], then he MUST also include the PKID. Otherwise (for example, if Bob is unable to publish keys to his server or if Alice is unable to access keys published via his server  [<a href="#nt-id2257580">26</a>]), Bob MAY include one of his Base64 encoded public keys. In either case, Bob MUST include the signature (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+    <p class="" style="">Note: Bob SHOULD facilitate <a href="#sign-normal">XML Normalization</a> by <span style="font-style: italic">not</span> including empty "accept_pkids", "pkids" or "signs" fields.</p>
+    <p class="" style="">However, if Bob is unwilling to start an ESession, but he is ready to initiate a one-to-one chat session with Alice (see <span style="font-weight: bold">Chat Session Negotiation</span>), then he SHOULD terminate the Esession negotiation by not specifying any of the five extra values in his response.</p>
+    <p class="caption">Example 11. Bob Responds to Alice (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="accept_pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="kid"&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="key"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 12. Bob Responds to Alice (with Public Key)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="kid"&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="key"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pkey"&gt;
+        &lt;value&gt; ** Base64 encoded public key ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Alice provided a PKID but Bob did not provide a signature then she MAY send a failure notice to him. If Bob sent Alice a public key but she could not verify it belongs to him via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then she SHOULD send a failure notice to him. If Bob provided an invalid signature (see <a href="#sign">Signature Verification</a>) then she MUST send a failure notice to him.</p>
+    <p class="caption">Example 13. Alice Signals that ESession Negotiation Failed (Unacceptable Signature)</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='alice@example.org/pda'
+         to='bob@example.com/laptop'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-signature xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.4 <a name="init-prep2">Diffie-Hellman Preparation (Alice)</a>
+</h3>
+      <p class="" style="">After verifying Bob's signature, Alice can be certain that the value of d was actually generated by Bob. Alice MUST use the value of d and the Esession options specified in Bob's response to perform the following steps (where n is the number of bits per encryption block for the agreed encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value she received from Bob</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span></p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (this is the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.1.5 <a name="init-complete">Diffie-Hellman Completion</a>
+</h3>
+    <p class="" style="">Alice then completes the Diffie-Hellman negotiation by sending Bob the KID and the Base64 encoded value of e. If Bob selected one or more of her public keys, and if Alice has access to a long-lived private signing key that corresponds to one of those keys, then she MUST also include the PKID. Otherwise, Alice MAY include one of her Base64 encoded public keys (see the <a href="#init-response">Esession Response</a> example).</p>
+    <p class="" style="">In either case, Alice MUST include the signature (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field). She MUST also include the Base64 encoded MAC of the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the data form from her <span style="font-style: italic">initial</span> Esession request. The calculation of the MAC MUST be the same as for the content of encrypted stanzas, including C<span class="sub" style="">A</span> (see <a href="#exchange-encrypt">Encryption</a>).</p>
+    <p class="" style="">Note: Alice SHOULD facilitate <a href="#sign-normal">XML Normalization</a> by <span style="font-style: italic">not</span> including empty "pkids" or "signs" fields.</p>
+    <p class="" style="">Alice MAY also send encrypted content (see <a href="#exchange">Exchanging Stanzas</a>) in the same stanza as the Diffie-Hellman completion. Note: If she also includes a &lt;terminate/&gt; element (see <a href="#terminate">Esession Termination</a>) within the &lt;encrypted/&gt; element then the Esession is terminated immediately. This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified).</p>
+    <p class="caption">Example 14. Alice Completes Diffie-Hellman Negotitation (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="kid"&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="key"&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pkids"&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="req_mac"&gt;&lt;value&gt; ** Base64 encoded MAC of her previous form ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="signs"&gt;&lt;value&gt; ** signature of this form ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob provided a PKID but Alice did not provide a signature then he MAY send a failure notice to her. If Alice sent Bob a public key but he could not verify it belongs to her via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then he SHOULD send a failure notice to her. If Alice provided an invalid signature (see <a href="#sign">Signature Verification</a>) or an invalid MAC then he MUST send a failure notice to her. If Bob sends a failure notice then he SHOULD ignore any encrypted content in the stanza.</p>
+    <p class="" style="">If no error occurs, Bob MUST calculate K = e<span class="super" style="">y</span> mod p (the shared secret). Alice and Bob then have the same value for K and the key exchange is complete.</p>
+    </div>
+  </div>
+
+
+
+<div class="indent">
+<h3>7.2 <a name="init-offline">Offline Diffie-Hellman Key Exchange</a>
+</h3>
+  <p class="" style="">As described below, offline negotiation of an Esession is in essence a special case of online negotiation. Bob MAY publish a set of Esession options just before he goes offline (see <a href="#sec-offline">Offline Esessions</a> Security Considerations) to allow entities that subscribe to his presence to initiate Esessions and send encrypted stanzas to him while he is offline. He MAY also publish <span style="font-style: italic">another</span> similar set of relatively long-lived  [<a href="#nt-id2258090">27</a>] Esession options that any entity MAY use for the same purpose.</p>
+    <div class="indent">
+<h3>7.2.1 <a name="init-publish">Publishing Esession Options</a>
+</h3>
+      <p class="" style="">In order to publish either set of his offline Esession options Bob MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1, where n is the largest number of bits per encryption block for the encryption algorithms he is willing to use)</p></li>
+        <li><p class="" style="">Select a MODP group (that defines the constants p and g)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for d (typically by calculating a hash of d, since this KID SHOULD be unique across all Esessions)</p></li>
+        <li><p class="" style="">Store the values of y and d and the KID in a secure way, so that he can retrieve them when he comes back online (idealy even if that is using a different client and/or a different machine)</p></li>
+        <li><p class="" style="">Publish each of the Esession options he is willing to use (see <a href="#init-request">Esession Request</a>) including the value of d and the KID. He SHOULD do this through his own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>) or a similar protocol (out of scope for this JEP).</p></li>
+      </ol>
+      <p class="" style="">Note: The single specified MODP group MUST be the one Bob used to generate d. The list of stanza types he is willing to decrypt MUST NOT include the value 'iq'. Bob MUST also include the list of the PKIDs of all his public signature-verification keys that he can sign for, and the corresponding list of signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style=""><span style="font-style: italic">Note: This publishing protocol is highly preliminary and depends on a separate proposal.</span></p>
+      <p class="caption">Example 15. Bob Publishes His Esession Options for His Subscribers</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info-subscription'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="logging"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="modp"&gt;
+        &lt;value&gt;2&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;
+        &lt;value&gt;aes256-ctr&lt;/value&gt;
+        &lt;value&gt;twofish256-ctr&lt;/value&gt;
+        &lt;value&gt;aes128-ctr&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="hash_algs"&gt;
+        &lt;value&gt;whirlpool&lt;/value&gt;
+        &lt;value&gt;sha256&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="compress"&gt;
+        &lt;value&gt;none&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="stanzas"&gt;
+        &lt;value&gt;message&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="secure"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="kid"&gt;
+        &lt;value&gt; ** KID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="key"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">Bob MAY publish his Esession options for all entities using the same protocol except for the 'xmlns' and 'node' attributes of the &lt;query/&gt; element:</p>
+      <p class="caption">Example 16. Bob Publishes His Esession Options for All Entities</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.2.2 <a name="init-offreq">Requesting Offline Esession Options</a>
+</h3>
+      <p class="" style="">If Alice believes Bob is offline she SHOULD request his Esession options and his long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) from his server.</p>
+      <p class="" style="">If Alice is subscribing to Bob's presence she MUST request his Esession Options exclusively for subscribers.</p>
+      <p class="caption">Example 17. Alice asks Bob's Server for his Esession Options (Subscribers)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If Alice is not subscribing to Bob's presence (or if Bob has no Esession Options exclusively for subscribers) she MUST use the following request instead.</p>
+      <p class="caption">Example 18. Alice asks Bob's Server for his Esession Options (All Entities)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If, after receiving Bob's public keys and Esession options, Alice is unable to verify any of Bob's signatures (see <a href="#sign">Signature Verification</a>) then she MAY decide to proceed no further, since she cannot be sure who will be able to decrypt her stanzas.</p>
+    </div>
+    <div class="indent">
+<h3>7.2.3 <a name="init-prep3">Diffie-Hellman Preparation (Offline)</a>
+</h3>
+      <p class="" style="">Alice MUST select one of the options from each of Bob's Esession fields. If she cannot support any of the options in a field (except the 'pkids' and 'signs' fields) then she MUST not send encrypted stanzas to Bob while he is offline.</p>
+      <p class="" style="">Alice MUST use the value of d and the MODP group specified in Bob's Esession options to perform the following steps (where n is the number of bits per encryption block for the selected encryption algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n random bits (C<span class="sub" style="">A</span> is the encryption block counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the block counter for stanzas sent from Bob to Alice  [<a href="#nt-id2258514">28</a>])</p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.2.4 <a name="init-start">Starting an Offline Esession</a>
+</h3>
+      <p class="" style="">Alice then sends Bob the KID and the Base64 encoded values of e and C<span class="sub" style="">A</span>. She SHOULD also include the list of the PKIDs of all her public signature-verification keys that she can sign for, and the corresponding list of signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style="">She also specifies which of Bob's Esession options she selected. Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Bob.</p>
+      <p class="" style="">Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza. Note: If she also includes a &lt;terminate/&gt; element (see <a href="#terminate">Esession Termination</a>) within the &lt;encrypted/&gt; element then the Esession is terminated immediately. This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified).</p>
+      <p class="caption">Example 19. Alice Establishes an ESession Without Negotiation</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com' type='chat'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="counter"&gt;&lt;value&gt; ** Base64 encoded initial counter value ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="kid"&gt;&lt;value&gt; ** KID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="key"&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+      <p class="" style="">Alice can assume that she and Bob have the same value for K and that the key exchange is complete.</p>
+    </div>
+    <div class="indent">
+<h3>7.2.5 <a name="init-accept">Accepting Offline Esessions</a>
+</h3>
+      <p class="" style="">When Bob comes online he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Retrieve the two sets of Esession options he MAY have published (see <a href="#init-publish">Publishing Esession Options</a>)</p></li>
+        <li>
+<p class="" style="">Ensure he is no longer publishing offline Esession options exclusively for entities that are subscribing to his presence</p>
+            <p class="caption">Example 20. Bob Stops Publishing His Esession Options</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+        </li>
+        <li><p class="" style="">Retrieve any values of y, d and KID that he stored before going offline, and destroy in a secure way any persistently stored copies that correspond to Esession options exclusively for subscribers</p></li>
+        <li><p class="" style="">Confirm those values of d and KID match the published values. They may not match if, for example, he went offline using a different client and/or a different machine. Note: if they do not match then he cannot decrypt any offline Esessions he receives.</p></li>
+      </ol>
+      <p class="" style="">When Bob receives a key exchange stanza from Alice then he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Confirm that the KID he received from Alice matches one of the KIDs he published</p></li>
+        <li><p class="" style="">Confirm that he can support all the Esession options he received from Alice</p></li>
+        <li><p class="" style="">Confirm that he has not already received a key exchange stanza from Alice with the same value of e since he came online (see <a href="#sec-replay">Replay Attacks</a>)</p></li>
+        <li><p class="" style="">Request Alice's public keys and, if possible, verify one of her signatures (see <a href="#sign">Signature Verification</a>; if he is unable to verify any of her signatures then he MAY decide to proceed no further, since he cannot be sure who started the Esession)</p></li>
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value he received from Alice</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (in case Alice has not yet terminated the Esession)</p></li>
+        <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="indent">
+<h3>7.3 <a name="init-keys">Generating Session Keys</a>
+</h3>
+    <p class="" style="">Whichever method Alice used to perform the Diffie-Hellman key exchange (online or offline), once it is complete, then before Alice and Bob can start encrypting and decrypting stanzas they MUST both use the agreed hash algorithm ("HASH") and their full JIDs to generate two pairs of keys, one for each direction of the ESession. Note: JID<span class="sub" style="">B</span> MUST be Bob's bare JID throughout an offline Esession, even if he comes online in the middle of the Esession and the key is re-exchanged.</p>
+    <p class="" style="">For stanzas that Alice will send to Bob, the keys are calculated as:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">A</span> = HASH(K-E<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)  [<a href="#nt-id2259069">29</a>]</p></li>
+    </ol>
+    <p class="" style="">For stanzas that Bob will send to Alice the keys are calculated as:</p>
+    <ol start="4" type="">
+      <li><p class="" style="">Encryption key K-E<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">B</span> = HASH(K-E<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)</p></li>
+    </ol>
+    <p class="" style="">Once the two pairs of keys have been calculated the value of K MUST be securely destroyed.</p>
+    <p class="" style="">As many bytes of key data as are needed MUST be taken from the beginning of the hash output. When negotiating a hash, entities MUST ensure that the hash output is no shorter than the required key data. For algorithms with variable-length keys the maximum length (up to the hash output length) SHOULD be used.</p>
+
+    <p class="" style="">With these keys computed and the algorithms agreed upon, ESession initiation is now complete. From this point forward, Alice and Bob MUST exchange only encrypted forms of the one-to-one stanza types they agreed upon (e.g., &lt;message/&gt; and &lt;iq/&gt; stanzas).</p>
+  </div>
+<h2>8.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="exchange-separate">Encryptable Content</a>
+</h3>
+    <p class="" style="">Once an Esession has been established, whenever Alice wants to send Bob an encrypted stanza she MUST only encrypt the XML content that would normally be ignored by the intermediate servers. She MUST NOT encrypt stanza wrapper elements or <span style="font-weight: bold">Advanced Message Processing</span> elements.</p>
+    <p class="" style="">If this is an offline Esession then Alice SHOULD include a 'Created' SHIM header in the encrypted content. Bob SHOULD trust this header and ignore the unencrypted <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2259267">30</a>] element inserted by his server.</p>
+
+  <p class="caption">Example 21. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+
+  <p class="caption">Example 22. XML Content to be Encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+  &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+&lt;/headers&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+</pre></div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="exchange-encrypt">Encryption</a>
+</h3>
+
+    <p class="" style="">Alice MUST perform the following steps to encrypt the XML content. Note: if there is no XML content to be encrypted (e.g. if this is an empty <a href="#rekey">Re-Keying</a> or <a href="#terminate">Termination</a> stanza), then C<span class="sub" style="">A</span> MUST be incremented by 1 (see below), and only the last two steps (normalization and MAC calculation) should be performed.</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Serialize the XML content she wishes to send into an array of UTF-8 bytes, m.  [<a href="#nt-id2259343">31</a>]</p></li>
+      <li>
+        <p class="" style="">Compress m using the negotiated algorithm. If a compression algorithm other than 'none' was agreed, the compression context is typically initialized after key exchange and passed from one stanza to the next, with only a partial flush at the end of each stanza.  [<a href="#nt-id2259362">32</a>]</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = compress(m)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Encrypt the data with the agreed algorithm in counter mode (see <span class="ref" style=""> Recommendation for Block Cipher Modes of Operation</span>  [<a href="#nt-id2259405">33</a>]), using the encryption key K-E<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented by 1 for each encrypted block or partial block (i.e. C<span class="sub" style="">A</span> = (C<span class="sub" style="">A</span> + 1) mod 2<span class="super" style="">n</span>, where n is the number of bits per encryption block for the agreed encryption algorithm). Note: if the encryption algorithm 'none' was agreed (see <a href="#sec-unencrypted">Unencrypted Esessions</a>) then encryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1 (for replay protection).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_final = encrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Alice MUST now create the <a href="#sign-normal">Normalized</a> XML <span style="font-style: italic">content</span> of the &lt;encrypted/&gt; XML element. The XML MUST include Bob's KID (the one that corresponds to the value of d she used to encrypt the data) wrapped in a &lt;kid/&gt; element and, if there is XML content, the Base64 encoded value of m_final wrapped in a &lt;data/&gt; element. Note: it MAY also contain one &lt;terminate/&gt; element (see <a href="#terminate">Termination</a>), one &lt;key/&gt; element and one or more &lt;old/&gt; elements (see <a href="#rekey">Re-Keying</a>).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_content = '&lt;kid&gt; ** KID ** &lt;/kid&gt;&lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;'</pre></div>
+      </li>
+      <li>
+        <p class="" style="">The XML content and the value of Alice's encryption block counter C<span class="sub" style="">A</span> <span style="font-style: italic">before</span> the data was encrypted, are now processed through the HMAC algorithm (as defined in Section 2 of <span class="ref" style="">RFC 2104</span>  [<a href="#nt-id2259595">34</a>]), along with the agreed hash algorithm ("HASH") and the integrity key K-M<span class="sub" style="">A</span>.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>a_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+    </ol>
+
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="exchange-send">Sending an Encrypted Stanza</a>
+</h3>
+    <p class="" style="">Before sending the stanza to Bob, Alice MUST wrap m_content and the Base64 encoded value of a_mac (wrapped in a &lt;mac/&gt; element) inside an &lt;encrypted/&gt; element and insert it into the stanza in place of the original content. There MUST NOT be more than one &lt;encrypted/&gt; element per stanza.</p>
+    <p class="caption">Example 23. Message Stanza with Encrypted Content</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="exchange-decrypt">Decryption</a>
+</h3>
+
+    <p class="" style="">When Bob receives the stanza from Alice, he extracts and Base64 decodes the values of m_final and a_mac from the content and performs the following steps. Note: Alice may not have received Bob's last re-key (see <a href="#rekey">Re-Keying</a>) before sending the stanza. So Bob MUST ensure he uses the values of K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> that correspond to his KID that Alice specified in the &lt;kid/&gt; element of the stanza he received (and the current value of e that Alice sent him previously).</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Remove the &lt;mac/&gt; element from the &lt;encrypted/&gt; element and <a href="#sign-normal">Normalize</a> the remaining XML <span style="font-style: italic">content</span>. Calculate the Message Authentication Code (MAC) for the content.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>b_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Verify that b_mac and a_mac match. If they are not identical, the content has been tampered with and Bob MUST terminate the ESession by sending an error to Alice.  [<a href="#nt-id2259786">35</a>]</p>
+      </li>
+      <li>
+        <p class="" style="">Decrypt m_final using the agreed algorithm, K-E<span class="sub" style="">A</span> and C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented by 1 for each decrypted block (see <a href="#exchange-encrypt">Encryption</a>). Note: if the encryption algorithm 'none' was agreed decryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = decrypt(K-E<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_final)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Decompress m_compressed using the negotiated algorithm (usually 'none').</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m = decompress(m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Replace the &lt;encrypted/&gt; element in the serialized XML stanza with m and feed the stanza into an XML parser. If the parser returns an XML format error then Bob MUST terminate the ESession by sending an error to Alice.  [<a href="#nt-id2259916">36</a>]</p>
+      </li>
+    </ol>
+  </div>
+  <h2>9.
+       <a name="rekey">Re-Key Exchange</a>
+</h2>
+<p class="" style="">Once an attacker has discovered an encryption key it could be used to decrypt all stanzas within a session, including stanzas that were intercepted <span style="font-style: italic">before</span> the key was discovered. To reduce the window of vulnerability, both Alice and Bob SHOULD change their values of x and y and re-exchange the encryption key as regularly as possible. They MUST also destroy all copies of keys as soon as they are no longer needed.</p>
+<p class="" style="">Note: Although most entities are capable of re-keying after each stanza, clients running in constrained runtime environments may require a few seconds to re-key. During Esession initiation these clients MAY negotiate the minimum number of stanzas to be exchanged between re-keys at the cost of a larger window of vulnerability. Entities MUST NOT initiate key re-exchanges more frequently than the agreed limit.</p>
+
+  <div class="indent">
+<h3>9.1 <a name="rekey-init">Re-Key Initiation</a>
+</h3>
+    <p class="" style="">Either Alice or Bob MAY initiate a key re-exchange. Here we describe the process initiated by Alice. First she MUST calculate new values for the encryption parameters:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1, where n is the number of bits per encryption block for the agreed encryption algorithm)</p></li>
+      <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      <li><p class="" style="">Generate an opaque unique key identifier (KID) for e</p></li>
+      <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the new shared secret)</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">To avoid extra stanzas, the new value of e SHOULD be sent to Bob along with an encrypted stanza. Note: Alice MUST NOT use the new K-E<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> to encrypt this stanza or to calculate the MAC. However, she MUST use them when sending subsequent stanzas.</p>
+    <p class="" style="">Note: There is no need for Alice to provide a signature because the calculation of the MAC includes the new value of e, see <a href="#exchange">Exchanging Stanzas</a>).</p>
+    <p class="caption">Example 24. Alice Sends Re-Key Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;key kid=' ** KID ** '&gt; ** Base64 encoded value of new e ** &lt;/key&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Bob may not receive the new key before he sends his next stanzas (they may cross in transit). So, before destroying her old values of K-E<span class="sub" style="">B</span> and K-M<span class="sub" style="">B</span>, Alice MUST wait until either she receives a stanza encrypted with the new key, or a reasonable time has passed (60 seconds should cover a network round-trip and calculations by a constrained client). Similarly she MUST wait before destroying her old value of x, in case Bob sends two stanzas before receiving Alice's new key (the first stanza might include a re-key).</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="rekey-accept">Re-Key Acceptance</a>
+</h3>
+    <p class="" style="">After Bob receives a stanza with a new value of e and he has decrypted the stanza with the old value of K-E<span class="sub" style="">A</span>, he MUST securely destroy all copies of K-E<span class="sub" style="">A</span> and K-E<span class="sub" style="">B</span> and perform the following calculations with the new value of e:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p</p></li>
+      <li><p class="" style="">Calculate K-E<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-E<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">He MUST use these new values to encrypt and decrypt all subsequent stanzas.  [<a href="#nt-id2260342">37</a>]</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="rekey-publish">Publishing Old MAC Values</a>
+</h3>
+    <p class="" style="">Once the expired MAC keys have been published, anyone could create valid arbitrary stanzas with them. This prevents anyone being able to prove the authenticity of a transcript of the Esession in the future.</p>
+    <p class="" style="">Either entity MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> within any encrypted stanza as long as it knows that all the stanzas that MAY use the old values have been received and validated. Note: A 'man-in-the-middle' could delay the delivery of stanzas indefinitely. So, before Alice publishes K-M<span class="sub" style="">A</span> (and K-M<span class="sub" style="">B</span>), she MUST wait until she has both sent a re-key to Bob and received a stanza from Bob encrypted with her new key. (She MAY also publish K-M<span class="sub" style="">B</span> after she has received a re-key from Bob.)</p>
+    <p class="caption">Example 25. Publishing Expired MAC Keys</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Entities SHOULD ignore any &lt;old/&gt; elements they receive.</p>
+  </div>
+  <h2>10.
+       <a name="terminate">Esession Termination</a>
+</h2>
+    <p class="" style="">Either entity MAY terminate an Esession at any time. To terminate a session Alice MUST send a stanza to Bob including a &lt;terminate/&gt; element with content "1"  [<a href="#nt-id2260471">38</a>]. Note: She MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> within her termination stanza as long as she is sure all the stanzas that MAY use the old values have been received and validated (see <a href="#rekey-publish">Publishing Old MAC Values</a>). She MUST then securely destroy all keys associated with the Esession.</p>
+    <p class="caption">Example 26. Alice Terminates an Esession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Bob receives a termination stanza he MUST verify the MAC (to be sure he received all the stanzas Alice sent him during the Esession) and, if the stanza was sent to him while he was online, immediately send a termination stanza back to Alice. Note: He MAY publish <span style="font-style: italic">any</span> old values of K-M<span class="sub" style="">A</span> or K-M<span class="sub" style="">B</span> within the termination stanza. He MUST then securely destroy all keys associated with the Esession.</p>
+    <p class="caption">Example 27. Bob Confirms Esession Termination</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;kid&gt; ** KID ** &lt;/kid&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Alice receives the stanza she MUST verify the MAC to be sure she received all the stanzas Bob sent her during the Esession. Once an entity has sent a termination stanza it MUST NOT send another stanza within the Esession.</p>
+  <h2>11.
+       <a name="sign">Signature Generation and Verification</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="sign-normal">XML Normalization</a>
+</h3>
+    <p class="" style="">Before the signature or MAC of a block of XML is generated or verified, all character data <span style="font-style: italic">between</span> all elements MUST be removed and the XML MUST be converted to canonical form (see <span class="ref" style="">Canonical XML</span>  [<a href="#nt-id2260635">39</a>]).</p>
+    <p class="" style="">All the XML this protocol requires to be signed or MACed is very simple, so in this case, canonicalization SHOULD only require the following changes:</p>
+    <ul>
+      <li>Set attribute value delimiters to quotation marks (i.e. simply replace all single quotes in the serialized XML with double quotes)</li>
+      <li>Impose lexicographic order on the attributes of "field" elements (i.e. ensure "type" is before "var")</li>
+    </ul>
+    <p class="" style="">Implementations MAY conceivably also need to make the following changes. Note: Empty elements and special characters SHOULD NOT appear in the signed or MACed XML specified in this protocol.</p>
+    <ul>
+      <li>Ensure there are no character references</li>
+      <li>Convert empty elements to start-end tag pairs</li>
+      <li>Ensure there is no whitespace except for single spaces before attributes</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="sign-hash">Hash</a>
+</h3>
+    <p class="" style="">Before the signature or MAC of a block of XML is generated or verified, the agreed hash algorithm MUST be used to generate the hash of the normalized XML.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>m_hash = HASH(m_content)</pre></div>
+  </div>
+  <div class="indent">
+<h3>11.3 <a name="sign-calc">Generation</a>
+</h3>
+    <p class="" style="">The signature generation depends on the type of private key being used.</p>
+    <div class="indent">
+<h3>11.3.1 <a name="sign-rsa-gen">RSA</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>signature_rsa = rsa_sign(rsa_private_key, m_hash, hashOID)</pre></div>
+      <p class="" style="">The multiprecision integer signature_rsa is the signature (see <span class="ref" style="">RFC 3447</span>  [<a href="#nt-id2260759">40</a>]).</p>
+    </div>
+    <div class="indent">
+<h3>11.3.2 <a name="sign-dsa-gen">DSA</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>sig_dsa_r, sig_dsa_s = dsa_sign(dsa_private_key, m_hash)</pre></div>
+      <p class="" style="">The multiprecision integers sig_dsa_r and sig_dsa_s are the signature (see <span class="ref" style="">Digital Signature Standard</span>  [<a href="#nt-id2260812">41</a>]).</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>11.4 <a name="sign-format">Signature Format</a>
+</h3>
+    <p class="" style="">The signature formats are the same for all public key formats. All integers are stored in big-endian byte order.</p>
+    <div class="indent">
+<h3>11.4.1 <a name="sign-rsa-format">RSA</a>
+</h3>
+      <p class="" style="">Base64 encoding of the signature_rsa multiprecision integer (without any header or length prefix).</p>
+    </div>
+    <div class="indent">
+<h3>11.4.2 <a name="sign-dsa-format">DSA</a>
+</h3>
+      <p class="" style="">Base64 encoding of the following structure:</p>
+      <ul>
+        <li>number of bytes in sig_dsa_r (2-byte integer)</li>
+        <li>sig_dsa_r</li>
+        <li>number of bytes in sig_dsa_s (2-byte integer)</li>
+        <li>sig_dsa_s</li>
+      </ul>
+    </div>
+  </div>
+  <div class="indent">
+<h3>11.5 <a name="sign-calc">Verification</a>
+</h3>
+    <p class="" style="">The signature verification depends on the type of public key being used.</p>
+    <div class="indent">
+<h3>11.5.1 <a name="sign-rsa-verify">RSA</a>
+</h3>
+      <p class="" style="">The rsa_modulus and rsa_public_exponent multiprecision integers are extracted from the other entity's authenticated public key. The signature_rsa multiprecision integer is the signature received from the other entity.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>boolean = rsa_verify(signature_rsa, m_hash, hashOID, rsa_modulus, rsa_public_exponent)</pre></div>
+    </div>
+    <div class="indent">
+<h3>11.5.2 <a name="sign-dsa-verify">DSA</a>
+</h3>
+      <p class="" style="">The dsa_p, dsa_q, dsa_g and dsa_y multiprecision integers are extracted from the other entity's authenticated public key. The sig_dsa_r and sig_dsa_s multiprecision integers are the signature received from the other entity.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>boolean = dsa_verify(sig_dsa_r, sig_dsa_s, m_hash, dsa_p, dsa_q, dsa_g, dsa_y)</pre></div>
+    </div>
+  </div>
+  <h2>12.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="sec-prng">Random Numbers</a>
+</h3>
+    <p class="" style="">Weak pseudo-random number generators (PRNG) enable successful attacks. Implementors MUST use a cryptographically strong PRNG to generate all random numbers (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2260992">42</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="sec-rekey">Re-Keying Limits</a>
+</h3>
+    <p class="" style="">After a key exchange an entity MUST NOT exchange a total of 2<span class="super" style="">32</span> encrypted blocks before it initiates a key re-exchange (see <span class="ref" style="">SSH Transport Layer Encryption Modes</span>  [<a href="#nt-id2261039">43</a>]). Note: This limitation also ensures the same key and counter values are never used to encrypt two different blocks using counter mode (thus preventing simple attacks).</p>
+    <p class="" style="">In order to reduce the Perfect Forward Secrecy window of vulnerability, after an extended period of activity, entities SHOULD either re-key or terminate the Esession.</p>
+  </div>
+  <div class="indent">
+<h3>12.3 <a name="sec-keys">Verifying Keys</a>
+</h3>
+    <p class="" style="">The trust system outlined in this document is based on Alice trusting that the public key presented by Bob is <span style="font-style: italic">actually</span> Bob's key (and vice versa). Determining this trust may be done in a variety of ways depending on the entities' support for different public key (certificate) formats, signing algorithms and signing authorities. For instance, if Bob publishes a PGP/GPG public key, Alice MAY verify that his key is signed by another key that she knows to be good. Or, if Bob provides an X.509 certificate, she MAY check that his key has been signed by a Certificate Authority that she trusts.</p>
+    <p class="" style="">When trust cannot be achieved automatically, methods that are not transparent to the users may be employed. For example, Bob could communicate the SHA-256 fingerprint of his public key to Alice via secure out-of-band communication (e.g. face-to-face). This would enable Alice to confirm that the public key she receives in-band is valid. Note however that very few people bother to verify fingerprints in this way. So this method is exceptionally vulnerable to 'man-in-the-middle' attacks. In order to reduce the window of vulnerability, an entity SHOULD remember the fingerprints of all user-validated public keys and alert the user in the future if ever the fingerprint(s) it stored for an entity do not match any of the received public keys.</p>
+    <p class="" style="">Alternatively Alice and Bob could agree a shared secret via secure out-of-band communication, Bob could then use it to create an HMAC of his public key that only Alice could verify.</p>
+    <p class="" style="">Note: If no keys are acceptable to Alice (because Alice has never verified any of the keys, and because either the keys are not signed, or Alice does not support the signature algorithms of the keys, or she cannot parse the certificate formats, or she does not recognise the authorities that signed the keys) then, although the Esession can still be encrypted, she cannot be sure she is communicating with Bob.</p>
+  </div>
+  <div class="indent">
+<h3>12.4 <a name="sec-replay">Replay Attacks</a>
+</h3>
+    <p class="" style="">The encryption block counters maintained implicitly by Alice and Bob (C<span class="sub" style="">A</span> and C<span class="sub" style="">B</span>) prevent stanzas being replayed within any Esession. They ensure that the MAC will be different for all stanzas, even if the HMAC key and the content of the stanza are identical.</p>
+    <p class="" style="">Alice and Bob MUST ensure that the value of e or d they provide when negotiating each online Esession is unique. This prevents complete online Esessions being replayed.</p>
+    <p class="" style="">Since Bob supplies the same value of d for all offline Esessions, to prevent complete offline Esessions being replayed to him, he MUST take care to securely store <span style="font-style: italic">new</span> values (or destroy existing values) of y and KID whenever he goes offline (see <a href="#init-publish">Publishing Esession Options</a>). Also, when Bob next comes online, he MUST remember all the values of e he receives in offline Esession initiation stanzas, and reject any offline Esessions that specify a value of e he has already received (see <a href="#init-accept">Accepting an Offline Esession</a>).</p>
+  </div>
+  <div class="indent">
+<h3>12.5 <a name="sec-unencrypted">Unencrypted Esessions</a>
+</h3>
+    <p class="" style="">Organisations with full disclosure policies may require entities to disable encryption to enable the logging of all messages on their server. Unencrypted Esessions meet all the <a href="#reqs-sec">Security Requirements</a> except for Confidentiality. This enables Alice to use the 'secure' Esession option to confirm securely with Bob that both client-server connections are secure.</p>
+  </div>
+  <div class="indent">
+<h3>12.6 <a name="sec-storage">Storage</a>
+</h3>
+    <p class="" style="">If either entity stores a (re-encrypted) transcript of an Esession for future consultation then the Perfect Forward Secrecy offered by this protocol is lost. If the negotiated value of the 'logging' <span style="font-weight: bold">Chat Session Negotiation</span> field is false the entities SHOULD NOT store any part of the Esession content (not even in encrypted form).</p>
+  </div>
+  <div class="indent">
+<h3>12.7 <a name="sec-offline">Offline Esessions</a>
+</h3>
+    <p class="" style="">Bob MAY decide not to support Offline Esessions since they are significantly less secure than online Esessions. The Perfect Forward Secrecy window of vulnerability is much longer. More seriously, Bob MUST store his private Diffie-Hellman key, y, to local disk or to a server (perhaps symmetrically encrypted with a password). It is <span style="font-style: italic">really</span> hard to securely erase something from a disk. Note: If Bob does not support Offline Esessions then, while he is offline, Alice will probably send him completely unprotected messages!</p>
+  </div>
+  <div class="indent">
+<h3>12.8 <a name="sec-general">Extra Responsabilities of Implementors</a>
+</h3>
+    <p class="" style="">Cryptography plays only a small part in an entity's security. Even if it implements this protocol perfectly it may still be vulnerable to other attacks. For examples, an implementation might store Esession keys on swap space or save private keys to a file in cleartext! Implementors MUST take very great care when developing applications with secure technologies.</p>
+  </div>
+  <div class="indent">
+<h3>12.9 <a name="sec-mandatory">Mandatory to Implement Technologies</a>
+</h3>
+    <p class="" style="">An implementation of ESession MUST support the Diffie-Hellman Key Agreement and HMAC algorithms. Note: The parameter names mentioned below are related to secure shell; see <span style="font-weight: bold">SSH Transport Layer Encryption Modes</span> for encryption algorithm details; see the <span class="ref" style="">IANA Secure Shell Protocol Parameters</span>  [<a href="#nt-id2261355">44</a>] for other names.</p>
+    <div class="indent">
+<h3>12.9.1 <a name="sec-mandatory-encryption">Encryption Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following encryption algorithm:</p>
+      <ul>
+        <li>aes128-ctr (see <span class="ref" style="">Advanced Encryption Standard</span>  [<a href="#nt-id2261402">45</a>])</li>
+      </ul>
+      <p class="" style="">The block length of an encryption algorithm's cipher SHOULD be at least 128 bits. An implementation of ESession MAY also support the following encryption algorithms:</p>
+      <ul>
+        <li>aes256-ctr</li>
+        <li>aes192-ctr</li>
+        <li>twofish256-ctr (see <span class="ref" style="">Twofish</span>  [<a href="#nt-id2261447">46</a>])</li>
+        <li>twofish192-ctr</li>
+        <li>twofish128-ctr</li>
+        <li>serpent256-ctr (see <span class="ref" style="">Serpent</span>  [<a href="#nt-id2261484">47</a>])</li>
+        <li>serpent192-ctr</li>
+        <li>serpent128-ctr</li>
+        <li>none (no encryption, only signing)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>12.9.2 <a name="sec-mandatory-sign">Key Signing Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following signing algorithm:</p>
+      <ul>
+        <li>rsa (see <span style="font-weight: bold">RFC 3447</span>)</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following signing algorithm:</p>
+      <ul>
+        <li>dsa (see <span style="font-weight: bold">Digital Signature Standard</span>)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>12.9.3 <a name="sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following public key formats:</p>
+      <ul>
+        <li>ssh-rsa</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following public key formats:</p>
+      <ul>
+        <li>ssh-dss</li>
+        <li>x509v3-sign-rsa (see <span class="ref" style="">X.509 Authentication in SSH2</span>  [<a href="#nt-id2261599">48</a>])</li>
+        <li>x509v3-sign-dss</li>
+        <li>pgp-sign-rsa</li>
+        <li>pgp-sign-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession MAY also support the following public key formats:</p>
+      <ul>
+        <li>spki-sign-rsa</li>
+        <li>spki-sign-dss</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>12.9.4 <a name="sec-mandatory-hash">Hash Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following hash algorithm:</p>
+      <ul>
+        <li>sha256 (see <span class="ref" style="">Secure Hash Standard</span>  [<a href="#nt-id2261676">49</a>])</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following hash algorithm (sha1 and md5 are NOT RECOMMENDED):</p>
+      <ul>
+        <li>whirlpool (see <span class="ref" style="">Whirlpool</span>  [<a href="#nt-id2261717">50</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>12.9.5 <a name="sec-mandatory-compress">Compression Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following compression algorithm:</p>
+      <ul>
+        <li>none (no compression, the output MUST be the same as the input)</li>
+      </ul>
+      <p class="" style="">Support for other algorithms is NOT RECOMMENDED since compression partially defeats the <a href="#reqs-repudiate">Repudiability</a> requirement of this JEP by making it more difficult for a third party (with some knowledge of the plaintext) to modify a transcript of an encrypted session in a meaningful way. However, encrypted content is pseudo-random and cannot be compressed, so, in those cases where bandwidth is severely constrained, an implementation of ESession MAY support the following algorithm to compress content before it is encrypted:</p>
+      <ul>
+        <li>zlib (see <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2261789">51</a>])</li>
+      </ul>
+    </div>
+  </div>
+<h2>13.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261829">52</a>]. </p>
+<h2>14.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="registrar-ns">Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261877">53</a>] shall register the following namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/esession</li>
+      <li>http://jabber.org/protocol/esession#init</li>
+      <li>http://jabber.org/protocol/esession#error</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>14.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2261937">54</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in <span style="font-style: italic">both</span> Encrypted Sessions and Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field
+      var='modp'
+      type='list-single'
+      label='MODP group number'/&gt;
+  &lt;field
+      var='crypt_algs'
+      type='list-single'
+      label='Symmetric block cipher options'/&gt;
+  &lt;field
+      var='hash_algs'
+      type='list-single'
+      label='Hash algorithm options'/&gt;
+  &lt;field
+      var='compress'
+      type='list-single'
+      label='Compression algorithm options'/&gt;
+  &lt;field
+      var='stanzas'
+      type='list-multi'
+      label='Stanzas types to encrypt'/&gt;
+  &lt;field
+      var='secure'
+      type='boolean'
+      label='Require encrypted client-server streams'/&gt;
+  &lt;field
+      var='rekey_freq'
+      type='text-single'
+      label='Minimum number of stanzas between key exchanges'/&gt;
+  &lt;field
+      var='accept_pkids'
+      type='list-multi'
+      label='Acceptable public key IDs'/&gt;
+  &lt;field
+      var='counter'
+      type='hidden'
+      label='Initial block counter'/&gt;
+  &lt;field
+      var='kid'
+      type='hidden'
+      label='Diffie-Hellman key ID'/&gt;
+  &lt;field
+      var='key'
+      type='hidden'
+      label='Diffie-Hellman key'/&gt;
+  &lt;field
+      var='pkey'
+      type='hidden'
+      label='Public key'/&gt;
+  &lt;field
+      var='pkids'
+      type='list-single'
+      label='Public key IDs'/&gt;
+  &lt;field
+      var='signs'
+      type='list-single'
+      label='Data form signatures'/&gt;
+  &lt;field
+      var='req_mac'
+      type='hidden'
+      label='MAC of initial request data form'/&gt;
+&lt;/form_type&gt;
+
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;jep&gt;JEP-0155&lt;/jep&gt;
+  ...
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>15.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>16.
+       <a name="keys">Public Key Publication and Retrieval</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is highly preliminary and will be specified in a separate proposal before this document reaches draft status.</span></p>
+  <p class="" style="">Entities SHOULD publish their long-term public signature-verification keys to all entities through their own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>).</p>
+
+  <p class="caption">Example 28. Entity Publishes Public Keys to Server</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='dp1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="" style="">Before initiating an ESession, if Bob does not already possess one of Alice's signature-verification keys, he SHOULD retrieve them from Alice's server.</p>
+  <p class="caption">Example 29. Bob Requests Public Keys from Alice's Server</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="caption">Example 30. Server Returns Public Keys</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='alice@example.org'
+    to='bob@example.com/laptop'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Bob should examine all the public keys and identify which ones are acceptable (see <a href="#sec-keys">Verifying Keys</a>).</p>
+<h2>17.
+       <a name="open">Open Issues</a>
+</h2>
+  <div class="indent">
+<h3>17.1 <a name="open-tothink">To Think About</a>
+</h3>
+    <ol start="" type="">
+      <li>Standardise on the X.509 public key and signature formats?</li>
+      <li>What challenges exist to make the OTR Gaim Plugin use this protocol natively when talking to Jabber entities? Can these be mitigated by 'non-critical' protocol changes?</li>
+      <li>Would anything in this protocol (e.g., its dependency on in-order stanza delivery) prevent an XMPP entity using it to exchange encrypted messages and presence with a user of a non-XMPP messaging system, assuming that the gateway both supports this protocol and is compatible with a purpose-built security plugin on the other user's client (e.g. a Gaim plugin connects to the gateway via a non-XMPP network)?</li>
+      <li>Could the protocol approximate SSH (or IPsec) more closely without losing the benefits of OTR?</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>17.2 <a name="open-todo">To Do</a>
+</h3>
+    <ol start="" type="">
+      <li>Separate public key publishing into another JEP. Should there be a disco item for each key?</li>
+      <li>Define names for X.509 SubjectPublicKeyInfo public key formats (different to X.509 certificates). This format must be used when keys are distributed within session initiation.</li>
+      <li>Add non-repudiable signing option</li>
+      <li>Move "secure" field to JEP-0155</li>
+      <li>Perhaps the JEP needs to specify more carefully how block counters are handled between messages, especially in the event of partial blocks?</li>
+      <li>Give examples of specific errors and discuss error scenarios throughout document (e.g., what should Bob do if he is not offline and he receives an offline key exchange stanza?).</li>
+      <li>Update Dependencies list</li>
+      <li>Define an <span style="font-style: italic">optional</span> protocol that would allow Bob to store y (and the PKIDs he trusts) 'securely' on his own server (before he goes offline). After going online Bob should retrieve the values of y that he stored before going offline (if any), and then use <span class="ref" style="">Flexible Offline Message Retrieval</span>  [<a href="#nt-id2262234">55</a>] (FOMR) to prevent any offline Esessions he can't decrypt being delivered to him (Each &lt;item/&gt; that corresponds to an Esession message MUST contain a &lt;kid/&gt; child. This allows Bob to discover which of his KIDs was used to encrypt the message. <span style="font-style: italic">N.B. This requires a new server feature, only Jive and XCP support FOMR!</span>). Bob SHOULD NOT request messages whose KID does not correspond to one of the values of y he retrieved. This is most likely to occur if he prefered not to store y on his server (because local storage is more secure), and he went offline using a different client and/or a different machine.</li>
+    </ol>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250608">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2250638">2</a>. RFC 3862: Common Presence and Instant Messaging (CPIM): Message Format &lt;<a href="http://www.ietf.org/rfc/rfc3862.txt">http://www.ietf.org/rfc/rfc3862.txt</a>&gt;.</p>
+<p><a name="nt-id2250659">3</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p><a name="nt-id2250680">4</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2250724">5</a>. Off-the-Record Communication, or, Why Not to Use PGP &lt;<a href="http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf">http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf</a>&gt;.</p>
+<p><a name="nt-id2250754">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2255716">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255767">8</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2255816">9</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2255837">10</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2255872">11</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255901">12</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256032">13</a>. SSH Protocol Architecture &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256004">14</a>. SSH Transport Layer Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256242">15</a>. The reliable association between an entity and its public keys is beyond the scope of this JEP.</p>
+<p><a name="nt-id2256270">16</a>. Naturally, it is possible that Alice or Bob may retain cleartext versions of the exchanged communications; however, that threat is out of scope for this JEP.</p>
+<p><a name="nt-id2256534">17</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256557">18</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2250251">19</a>. RFC 2631: Diffie-Hellman Key Agreement Method &lt;<a href="http://www.ietf.org/rfc/rfc2631.txt">http://www.ietf.org/rfc/rfc2631.txt</a>&gt;.</p>
+<p><a name="nt-id2257011">20</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2257085">21</a>. RFC 2409: The Internet Key Exchange (IKE) &lt;<a href="http://www.ietf.org/rfc/rfc2409.txt">http://www.ietf.org/rfc/rfc2409.txt</a>&gt;.</p>
+<p><a name="nt-id2257108">22</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p><a name="nt-id2257215">23</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2257355">24</a>. RFC 3766: Determining Strengths For Public Keys Used For Exchanging Symmetric Keys &lt;<a href="http://www.ietf.org/rfc/rfc3766.txt">http://www.ietf.org/rfc/rfc3766.txt</a>&gt;.</p>
+<p><a name="nt-id2257572">25</a>. The private signing keys may only be accessible to another of Bob's clients.</p>
+<p><a name="nt-id2257580">26</a>. Some servers may not support public key publishing.</p>
+<p><a name="nt-id2258090">27</a>. The more often Bob changes his published Esession options, the shorter the Perfect Forward Secrecy window of vulnerability. However, whenever he changes them he divulges his presence to all the entities that are monitoring them.</p>
+<p><a name="nt-id2258514">28</a>. Alice initializes Bob's block counter in case he comes online before she terminates the Esession.</p>
+<p><a name="nt-id2259069">29</a>. K-M<span class="sub" style="">A</span> is a hash of K-E<span class="sub" style="">A</span> (not K) to ensure that if an attacker recovers the decryption key she will not be able to cryptographically convince anyone that it was not her who created the stanza.</p>
+<p><a name="nt-id2259267">30</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2259343">31</a>. Although counter mode encryption requires no padding, implementations MAY still disguise the length of m by appending a random number of white-space characters.</p>
+<p><a name="nt-id2259362">32</a>. If Bob were to receive a stanza out-of-order, then he would fail to decrypt the stanza and be forced to terminate the Esession.</p>
+<p><a name="nt-id2259405">33</a>. Recommendation for Block Cipher Modes of Operation: Federal Information Processing Standards Publication 800-38a &lt;<a href="http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf">http://csrc.nist.gov/publications/ nistpubs/800-38a/sp800-38a.pdf</a>&gt;.</p>
+<p><a name="nt-id2259595">34</a>. RFC 2104: HMAC: Keyed-Hashing for Message Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2104.txt">http://www.ietf.org/rfc/rfc2104.txt</a>&gt;.</p>
+<p><a name="nt-id2259786">35</a>. If Bob were to receive a stanza out-of-order, then the MACs would not match because the values of C<span class="sub" style="">A</span> would not be synchronized.</p>
+<p><a name="nt-id2259916">36</a>. Bob MUST NOT send a stream error to his server since intermediate entities are not responsible for encoded content.</p>
+<p><a name="nt-id2260342">37</a>. If an entity fails to receive any stanza that includes a new key in the correct order, then it will fail to decrypt the next stanza it receives and be forced to terminate the Esession.</p>
+<p><a name="nt-id2260471">38</a>. Content is specified for the &lt;terminate/&gt; element to facilitate <a href="#sign-normal">XML Normalization</a>.</p>
+<p><a name="nt-id2260635">39</a>. Canonical XML 1.0 &lt;<a href="http://www.w3.org/TR/xml-c14n">http://www.w3.org/TR/xml-c14n</a>&gt;.</p>
+<p><a name="nt-id2260759">40</a>. RFC 3447: Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography Specifications Version 2.1 &lt;<a href="http://www.ietf.org/rfc/rfc3447.txt">http://www.ietf.org/rfc/rfc3447.txt</a>&gt;.</p>
+<p><a name="nt-id2260812">41</a>. Digital Signature Standard: Federal Information Processing Standards Publication 186  &lt;<a href="http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf">http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf</a>&gt;.</p>
+<p><a name="nt-id2260992">42</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2261039">43</a>. SSH Transport Layer Encryption Modes &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-04.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2261355">44</a>. IANA registry of parameters related to secure shell &lt;<a href="http://www.iana.org/assignments/ssh-parameters">http://www.iana.org/assignments/ssh-parameters</a>&gt;.</p>
+<p><a name="nt-id2261402">45</a>. Advanced Encryption Standard: Federal Information Processing Standards Publication 197 &lt;<a href="http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf">http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf</a>&gt;.</p>
+<p><a name="nt-id2261447">46</a>. The Twofish Block Cipher &lt;<a href="http://www.schneier.com/twofish.html">http://www.schneier.com/twofish.html</a>&gt;.</p>
+<p><a name="nt-id2261484">47</a>. The Serpent Block Cipher &lt;<a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">http://www.cl.cam.ac.uk/~rja14/serpent.html</a>&gt;.</p>
+<p><a name="nt-id2261599">48</a>. X.509 Authentication in SSH2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2261676">49</a>. Secure Hash Standard: Federal Information Processing Standards Publication 180-2  &lt;<a href="http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf">http://csrc.nist.gov/publications/fips/fips180-2/fips186-2withchangenotice.pdf</a>&gt;.</p>
+<p><a name="nt-id2261717">50</a>. The Whirlpool Hash Function &lt;<a href="http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html">http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html</a>&gt;.</p>
+<p><a name="nt-id2261789">51</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2261829">52</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261877">53</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2261937">54</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2262234">55</a>. JEP-0013: Flexible Offline Message Retrieval &lt;<a href="http://www.jabber.org/jeps/jep-0013.html">http://www.jabber.org/jeps/jep-0013.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2005-08-26)</h4>
+<div class="indent">Simplified XML normalization; added Synopsis and Efficiency requirement; defined signature formats (ip)
+    </div>
+<h4>Version 0.6 (2005-08-12)</h4>
+<div class="indent">Extended termination procedure; added object encryption/signing requirement and special case; clarified expired MAC publishing; added Flexible Offline Message Retrieval to Open Issues. (ip)
+    </div>
+<h4>Version 0.5 (2005-08-10)</h4>
+<div class="indent">Added flexibility requirement; added late signature of initial request; added termination MAC. (ip)
+    </div>
+<h4>Version 0.4 (2005-08-09)</h4>
+<div class="indent">Added (offline) replay protection; required offline Created header; compression is NOT RECOMMENDED; added second set of offline options for subscribers; added JIDs to session key generation; unencrypted sessions; added secure option; sign whole data form; HMAC whole &lt;encrypted/&gt; element; added Esession termination; option to distribute public keys within session initiation; added Integrity requirement; several clarifications (ip)
+    </div>
+<h4>Version 0.3 (2005-08-02)</h4>
+<div class="indent">Restored status to Experimental; complete rewrite; new Introduction, Background, Requirements and Security Considerations; new OTR-inspired protocol; JEP-0155-based negotiation; counter mode encryption; more secure hashes; offline sessions; re-keying; mac publishing; preliminary key and options publishing protocol. (ip/psa)
+    </div>
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.8.html
+++ b/content/xep-0116-0.8.html
@@ -1,0 +1,1861 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-09-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0116<br>
+            Version: 0.8<br>
+            Last Updated: 2005-09-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2104, RFC 2409, RFC 3526, RFC 3548, xml-c14n, JEP-0004, JEP-0020, JEP-0030, JEP-0068, JEP-0079, JEP-0155<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Encrypted%20Sessions%20(JEP-0116)">http://wiki.jabber.org/index.php/Encrypted Sessions (JEP-0116)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>3.1.  <a href="#terms-personae">Dramatis Personae</a>
+</dt></dl>
+<dt>4.  <a href="#reqs">Requirements</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#reqs-sec">Security Requirements</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#reqs-encrypt">Confidentiality</a>
+</dt>
+<dt>4.1.2.  <a href="#reqs-integrity">Integrity</a>
+</dt>
+<dt>4.1.3.  <a href="#reqs-replay">Replay Protection</a>
+</dt>
+<dt>4.1.4.  <a href="#reqs-forward">Perfect Forward Secrecy</a>
+</dt>
+<dt>4.1.5.  <a href="#reqs-auth">Authentication</a>
+</dt>
+<dt>4.1.6.  <a href="#reqs-repudiate">Repudiability</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#reqs-xmpp">Application Requirements</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#reqs-generality">Generality</a>
+</dt>
+<dt>4.2.2.  <a href="#reqs-implement">Implementability</a>
+</dt>
+<dt>4.2.3.  <a href="#reqs-usable">Usability</a>
+</dt>
+<dt>4.2.4.  <a href="#reqs-efficient">Efficiency</a>
+</dt>
+<dt>4.2.5.  <a href="#reqs-flexible">Flexibility</a>
+</dt>
+<dt>4.2.6.  <a href="#reqs-usable">Interoperability</a>
+</dt>
+<dt>4.2.7.  <a href="#reqs-offline">Offline Sessions</a>
+</dt>
+<dt>4.2.8.  <a href="#reqs-offline">Object Encryption</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#synopses">Synopses</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#synopses-params">Parameter Descriptions</a>
+</dt>
+<dt>5.2.  <a href="#synopses-online">Online Esession Negotiation</a>
+</dt>
+<dt>5.3.  <a href="#synopses-offline">Offline Esession Negotiation</a>
+</dt>
+</dl>
+<dt>6.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>7.  <a href="#init">ESession Initiation</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#init-online">Online Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#init-online-request">Esession Request</a>
+</dt>
+<dt>7.1.2.  <a href="#init-online-bobprep">Diffie-Hellman Preparation (Bob)</a>
+</dt>
+<dt>7.1.3.  <a href="#init-online-response">Esession Response</a>
+</dt>
+<dt>7.1.4.  <a href="#init-online-aliceprep">Diffie-Hellman Preparation (Alice)</a>
+</dt>
+<dt>7.1.5.  <a href="#init-online-complete">Diffie-Hellman Completion</a>
+</dt>
+</dl>
+<dt>7.2.  <a href="#init-offline">Offline Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>7.2.1.  <a href="#init-offline-publish">Publishing Esession Options</a>
+</dt>
+<dt>7.2.2.  <a href="#init-offline-request">Requesting Offline Esession Options</a>
+</dt>
+<dt>7.2.3.  <a href="#init-offline-prep">Diffie-Hellman Preparation (Offline)</a>
+</dt>
+<dt>7.2.4.  <a href="#init-offline-start">Starting an Offline Esession</a>
+</dt>
+<dt>7.2.5.  <a href="#init-offline-accept">Accepting Offline Esessions</a>
+</dt>
+</dl>
+<dt>7.3.  <a href="#init-keys">Generating Session Keys</a>
+</dt>
+</dl>
+<dt>8.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#exchange-separate">Encryptable Content</a>
+</dt>
+<dt>8.2.  <a href="#exchange-encrypt">Encryption</a>
+</dt>
+<dt>8.3.  <a href="#exchange-send">Sending an Encrypted Stanza</a>
+</dt>
+<dt>8.4.  <a href="#exchange-decrypt">Decryption</a>
+</dt>
+</dl>
+<dt>9.  <a href="#rekey">Re-Key Exchange</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#rekey-init">Re-Key Initiation</a>
+</dt>
+<dt>9.2.  <a href="#rekey-accept">Re-Key Acceptance</a>
+</dt>
+<dt>9.3.  <a href="#rekey-publish">Publishing Old MAC Values</a>
+</dt>
+</dl>
+<dt>10.  <a href="#terminate">Esession Termination</a>
+</dt>
+<dt>11.  <a href="#sign">Signature Generation and Verification</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#sign-normal">XML Normalization</a>
+</dt>
+<dt>11.2.  <a href="#sign-hash">Hash</a>
+</dt>
+<dt>11.3.  <a href="#sign-calc">Generation</a>
+</dt>
+<dl>
+<dt>11.3.1.  <a href="#sign-rsa-gen">RSA</a>
+</dt>
+<dt>11.3.2.  <a href="#sign-dsa-gen">DSA</a>
+</dt>
+</dl>
+<dt>11.4.  <a href="#sign-format">Signature Format</a>
+</dt>
+<dl>
+<dt>11.4.1.  <a href="#sign-rsa-format">RSA</a>
+</dt>
+<dt>11.4.2.  <a href="#sign-dsa-format">DSA</a>
+</dt>
+</dl>
+<dt>11.5.  <a href="#sign-calc">Verification</a>
+</dt>
+<dl>
+<dt>11.5.1.  <a href="#sign-rsa-verify">RSA</a>
+</dt>
+<dt>11.5.2.  <a href="#sign-dsa-verify">DSA</a>
+</dt>
+</dl>
+</dl>
+<dt>12.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#sec-prng">Random Numbers</a>
+</dt>
+<dt>12.2.  <a href="#sec-rekey">Re-Keying Limits</a>
+</dt>
+<dt>12.3.  <a href="#sec-keys">Verifying Keys</a>
+</dt>
+<dt>12.4.  <a href="#sec-replay">Replay Attacks</a>
+</dt>
+<dt>12.5.  <a href="#sec-unencrypted">Unencrypted Esessions</a>
+</dt>
+<dt>12.6.  <a href="#sec-storage">Storage</a>
+</dt>
+<dt>12.7.  <a href="#sec-offline">Offline Esessions</a>
+</dt>
+<dt>12.8.  <a href="#sec-general">Extra Responsabilities of Implementors</a>
+</dt>
+<dt>12.9.  <a href="#sec-mandatory">Mandatory to Implement Technologies</a>
+</dt>
+<dl>
+<dt>12.9.1.  <a href="#sec-mandatory-encryption">Block Cipher Algorithms</a>
+</dt>
+<dt>12.9.2.  <a href="#sec-mandatory-sign">Key Signing Algorithms</a>
+</dt>
+<dt>12.9.3.  <a href="#sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</dt>
+<dt>12.9.4.  <a href="#sec-mandatory-hash">Hash Algorithms</a>
+</dt>
+<dt>12.9.5.  <a href="#sec-mandatory-compress">Compression Algorithms</a>
+</dt>
+</dl>
+</dl>
+<dt>13.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#registrar-ns">Namespaces</a>
+</dt>
+<dt>14.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>15.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>16.  <a href="#keys">Public Key Publication and Retrieval</a>
+</dt>
+<dt>17.  <a href="#open">Open Issues</a>
+</dt>
+<dl>
+<dt>17.1.  <a href="#open-tothink">To Think About</a>
+</dt>
+<dt>17.2.  <a href="#open-todo">To Do</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">End-to-end encryption is a desirable feature for any communication technology. Ideally, such a technology would design encryption in from the beginning and would forbid unencrypted communications. Realistically, most communication technologies have not been designed in that manner, and Jabber/XMPP technologies are no exception. In particular, the original Jabber technologies developed in 1999 did not include end-to-end encryption by default. PGP-based encryption of message bodies and signing of presence information was added as an extension to the core protocols in the year 2000; this extension is documented in <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2250835">1</a>]. When the core protocols were formalized within the Internet Standards Process by the IETF's XMPP Working Group in 2003, a different extension was defined using S/MIME-based signing and encryption of CPIM-formatted messages (see <span class="ref" style="">RFC 3862</span>  [<a href="#nt-id2250790">2</a>]) and PIDF-formatted presence information (see <span class="ref" style="">RFC 3863</span>  [<a href="#nt-id2250818">3</a>]); this extension is specified in <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2250566">4</a>].</p>
+  <p class="" style="">For reasons described more fully below, the foregoing proposals (and others not mentioned) have not been widely implemented and deployed. This is unfortunate, since an open communication protocol needs to enable end-to-end encryption in order to be seriously considered for deployment by a broad range of users. This proposal describes a different approach to end-to-end encryption for use by entities that communicate using XMPP. The approach taken herein essentially translates the semantics of the secure shell protocol (SSH) into the syntax of XMPP, with some adjustments that reflect reports of security issues with SHA-1 and insights gleaned from implementation of "off-the-record" (OTR) communication in the Gaim encryption plugin as described in <span class="ref" style="">Off-the-Record Communication</span>  [<a href="#nt-id2250609">5</a>]. The result is a protocol for encrypted sessions or "ESessions".</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">As specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250676">6</a>], XMPP is an XML streaming protocol that enables the near-real-time exchange of XML fragments between any two (or more) network endpoints. To date, the main application built on top of the core XML streaming layer is instant messaging (IM) and presence, the base extensions for which are specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250646">7</a>]. There are three first-level elements of XML streams (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;); each of these "XML stanza" types has different semantics, which can complicate the task of defining a generalized approach to end-to-end encryption for XMPP. In addition, XML stanzas can be extended (via properly-namespaced child elements) for a wide variety of functionality. The chosen approach should enable encryption of several complete XML elements rather than only parts thereof (e.g., only the XML character data of the message &lt;body/&gt; element as in <span style="font-weight: bold">JEP-0027</span>).</p>
+  <p class="" style="">XMPP is a session-oriented communication technology: normally, a client authenticates with a server and maintains a long-lived connection that defines the client's XMPP session. Such stream-level sessions are secured via channel encryption using Transport Level Security (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2256421">8</a>]), as specified in Section 5 of <span style="font-weight: bold">RFC 3920</span>. However, there is no guarantee that all hops will implement or enforce channel encryption (or that intermediate routers are trustworthy), which makes end-to-end encryption desirable.</p>
+  <p class="" style="">The session metaphor also applies to communication between endpoints: for instance, in IM applications, most instant messaging exchanges occur in bursts within limited time periods (e.g., two people may send a fairly large number of messages during a five-minute chat and then not exchange messages again for hours or even days). The XML stanzas exchanged during such a session may not be limited to &lt;message/&gt; stanzas; for instance, the session may be triggered by a change in one of the parties' presence status (e.g., changing from away to available) and the session may involve the exchange of &lt;iq/&gt; stanzas (e.g., to transfer a file as specified in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256470">9</a>]). Endpoints may want to encrypt the stanzas they send to each other in such a way that the stanzas cannot be understood by untrusted mediating entities (such as servers) except to the extent required to understand the necessary routing information. (One complicating factor is that routing information may include not only the stanza's 'to', 'from', 'type, and 'id' attributes, but also <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256493">10</a>] extensions.)</p>
+  <p class="" style="">The foregoing XMPP communications exist in the context of a one-to-one communication session between two entities. However, several forms of XMPP communication exist outside the context of one-to-one communication sessions:</p>
+  <ul>
+    <li>Many-to-many sessions, such as a text conference in a chatroom as specified in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256529">11</a>].</li>
+    <li>One-to-many "broadcast", such as undirected presence stanzas sent from one user to many contacts (see <span style="font-weight: bold">RFC 3921</span>) and data syndication implemented using <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256558">12</a>].</li>
+    <li>One-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</li>
+  </ul>
+  <p class="" style="">Ideally, any technology for end-to-end encryption in XMPP could be extended to cover these scenarios as well as one-to-one communication sessions. However, both many-to-many sessions and one-to-many broadcast are deemed out of scope for this JEP. Offline communications are handled via a simple extension to the protocol for one-to-one sessions between two entities that are online simultaneously (see below).</p>
+  <p class="" style="">Because XMPP is a session-oriented communication technology, encryption schemes that are appropriate for less dynamic technologies may not be appropriate for XMPP. XMPP, with its in-order delivery of XML stanzas, is able to take advantage of encryption approaches that are not feasible for less dynamic technologies. In particular, existing approaches to encryption of Internet communications have generally assumed that the "thing" to be encrypted has a stable identity or is best understood as a standalone object (e.g., a file or email message); the term "object encryption" well captures this assumption. Both <span style="font-weight: bold">JEP-0027</span> and <span style="font-weight: bold">RFC 3923</span> assume that XMPP communications are more like the exchange of email messages than they are like an interactive session -- while <span style="font-weight: bold">JEP-0027</span> uses "old-style" PGP object encryption and <span style="font-weight: bold">RFC 3923</span> uses "new-style" S/MIME object encryption, both specify the use of object encryption. </p>
+  <p class="" style="">However, the session-oriented nature of XMPP may imply that the focus should be on "session encryption" rather than "object encryption". The paradigm for XMPP encryption may be something closer to the widely-deployed Secure Shell technology (see <span class="ref" style="">SSH Protocol Architecture</span>  [<a href="#nt-id2256688">13</a>] and <span class="ref" style="">SSH Transport Layer Protocol</span>  [<a href="#nt-id2256661">14</a>]) than to traditional encryption of files and standalone email messages. In many ways, Secure Shell (or, more specifically, OTR) is the conceptual model for the current proposal.</p>
+  <p class="" style="">Therefore, this JEP specifies a method for encrypted sessions ("ESessions") that takes advantage of the inherent possibilities and strengths of session encryption as opposed to object encryption. The basic concept is that of an encrypted session which acts as a secure tunnel between two endpoints. Once the tunnel is established, the content of all one-to-one XML stanzas exchanged between the endpoints will be encrypted and then transmitted within a "wrapper" protocol element.</p>
+<h2>3.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="terms-personae">Dramatis Personae</a>
+</h3>
+    <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+    <ol start="1" type="">
+      <li>"Alice" is the name of the initiator of the ESession. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+      <li>"Bob" is the name of the other participant in the ESession started by Alice. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    </ol>
+    <p class="" style="">While Alice and Bob are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an Esession.</p>
+  </div>
+<h2>4.
+       <a name="reqs">Requirements</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="reqs-sec">Security Requirements</a>
+</h3>
+    <p class="" style="">This JEP stipulates the following security requirements for end-to-end encryption of XMPP communications:</p>
+    <ul>
+      <li>Confidentiality</li>
+      <li>Integrity</li>
+      <li>Replay protection</li>
+      <li>Perfect forward secrecy</li>
+      <li>Authentication</li>
+      <li>Repudiability</li>
+    </ul>
+    <p class="" style="">Each of these requirements is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="reqs-encrypt">Confidentiality</a>
+</h3>
+      <p class="" style="">The one-to-one XML stanzas exchanged between two entities MUST NOT be understandable to any other entity that might intercept the communications.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="reqs-integrity">Integrity</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be sure that no other entity may change the content of the XML stanzas they exchange, or remove or insert stanzas into the Esession undetected.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.3 <a name="reqs-replay">Replay Protection</a>
+</h3>
+      <p class="" style="">Alice or Bob MUST be able to identify and reject any communications that are copies of their previous communications resent by another entity.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.4 <a name="reqs-forward">Perfect Forward Secrecy</a>
+</h3>
+      <p class="" style="">The encrypted communication MUST NOT be revealed even if long-lived keys are compromised in the future (e.g., Steve steals Bob's computer).</p>
+    </div>
+    <div class="indent">
+<h3>4.1.5 <a name="reqs-auth">Authentication</a>
+</h3>
+      <p class="" style="">Each party to a conversation MUST know that the other party is who he says he is (Alice must be able to know that Bob really is Bob, and vice versa).  [<a href="#nt-id2256898">15</a>]</p>
+    </div>
+    <div class="indent">
+<h3>4.1.6 <a name="reqs-repudiate">Repudiability</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be able to repudiate any stanza that occurs within an Esession. After an Esession has finished, it SHOULD NOT be possible to <span style="font-style: italic">prove cryptographically</span> that any transcript has not been modified by a third party.  [<a href="#nt-id2256925">16</a>]</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="reqs-xmpp">Application Requirements</a>
+</h3>
+    <p class="" style="">In addition to the foregoing security profile, this JEP also stipulates the following application-specific requirements for encrypted communication in the context of Jabber/XMPP technologies:</p>
+    <ul>
+      <li>Generality</li>
+      <li>Implementability</li>
+      <li>Usability</li>
+      <li>Efficiency</li>
+      <li>Flexibility</li>
+      <li>Interoperability</li>
+      <li>Offline "sessions"</li>
+      <li>Object encryption</li>
+    </ul>
+    <p class="" style="">Each of these is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.2.1 <a name="reqs-generality">Generality</a>
+</h3>
+      <p class="" style="">The solution should be generally applicable to any XML stanza type (&lt;message/&gt;, &lt;presence/&gt;, &lt;iq/&gt;) sent between two entities. It is deemed acceptable for now if the solution does not apply to many-to-many stanzas (e.g., groupchat messages sent within the context of multi-user chat) or one-to-many stanzas (e.g., presence "broadcasts" and pubsub notifications); end-to-end encryption of such stanzas may require separate solutions or extensions to the one-to-one session solution.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="reqs-implement">Implementability</a>
+</h3>
+      <p class="" style="">The only good security technology is an implemented security technology. The solution should be one that typical client developers can implement in a relatively straightforward and interoperable fashion.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="reqs-usable">Usability</a>
+</h3>
+      <p class="" style="">The requirement of usability takes implementability one step further by stipulating that the solution must be one that organizations may deploy and humans may use with 100% transparency (with the ease-of-use of https:). Experience has shown that: solutions requiring a full public key infrastructure do not get widely deployed, and solutions requiring any user action are not widely used. We can do better.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.4 <a name="reqs-efficient">Efficiency</a>
+</h3>
+      <p class="" style="">Cryptographic operations are highly CPU intensive, particularly public key and Diffie-Hellman operations. Cryptographic data structures can be relatively large especially public keys and certificates. The solution should perform efficiently even when CPU and network bandwidth are constrained.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.5 <a name="reqs-flexible">Flexibility</a>
+</h3>
+      <p class="" style="">The solution should be compatible with existing (and future) cryptographic algorithms and identity certification schemes (including X.509 and PGP).</p>
+    </div>
+    <div class="indent">
+<h3>4.2.6 <a name="reqs-usable">Interoperability</a>
+</h3>
+      <p class="" style="">Ideally, it would be possible for an XMPP user to exchange encrypted messages (and, potentially, presence information) with users of non-XMPP messaging systems.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.7 <a name="reqs-offline">Offline Sessions</a>
+</h3>
+      <p class="" style="">Ideally, it should be possible to encrypt one-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</p>
+    </div>
+    <div class="indent">
+<h3>4.2.8 <a name="reqs-offline">Object Encryption</a>
+</h3>
+      <p class="" style="">For cases where a session is not desired, it should be possible to encrypt, sign and send a single stanza in isolation, so-called "object encryption".</p>
+    </div>
+  </div>
+<h2>5.
+       <a name="synopses">Synopses</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">This section is informative, not normative.</span></p>
+  <div class="indent">
+<h3>5.1 <a name="synopses-params">Parameter Descriptions</a>
+</h3>
+    <p class="caption">Table 1: Online and Offline Negotiation</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Parameter</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">C<span class="sub" style="">A</span>, C<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">Block cipher initial counter value for blocks sent by Alice and Bob</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">pubKeys<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The IDs of all of Bob's public keys that either, Alice has validated (online), or Bob can sign for (offline)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">options</td>
+        <td align="" colspan="" rowspan="">Includes a set of possible values for each Esession parameter (see <a href="#init-online-request">Esession Request</a>)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">chosen</td>
+        <td align="" colspan="" rowspan="">Includes a chosen value for each Esession parameter</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">p, g</td>
+        <td align="" colspan="" rowspan="">Diffie-Hellman prime and generator</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HASH</td>
+        <td align="" colspan="" rowspan="">Selected hash algorithm</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">CIPHER</td>
+        <td align="" colspan="" rowspan="">Selected block cipher algorithm</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">n</td>
+        <td align="" colspan="" rowspan="">Block size of CIPHER in bits</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">x, y</td>
+        <td align="" colspan="" rowspan="">Alice and Bob's private Diffie-Hellman keys</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">e, d</td>
+        <td align="" colspan="" rowspan="">Alice and Bob's public Diffie-Hellman keys</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">pubKeys<span class="sub" style="">A</span>
+</td>
+        <td align="" colspan="" rowspan="">The IDs of all of Alice's public keys that either, Bob has validated (online), or Alice can sign for (offline)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">K</td>
+        <td align="" colspan="" rowspan="">Shared secret</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">JID<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">Alice and Bob's full Jabber IDs</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">K-C<span class="sub" style="">A</span>, K-C<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The cipher keys that Alice and Bob use to encrypt stanzas</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">K-M<span class="sub" style="">A</span>, K-M<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The MAC keys that Alice and Bob use to 'sign' encrypted stanzas</td>
+      </tr>
+    </table>
+
+    <p class="caption">Table 2: Online Negotiation Only</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <td align="" colspan="" rowspan="">signKey<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The private key that Bob uses to sign form<span class="sub" style="">B</span>
+</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">pubKey<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The public key that Alice should use to verify Bob's signature of form<span class="sub" style="">B</span>
+</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">signKey<span class="sub" style="">A</span>
+</td>
+        <td align="" colspan="" rowspan="">The private key that Alice uses to sign form<span class="sub" style="">C</span>
+</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">pubKey<span class="sub" style="">A</span>
+</td>
+        <td align="" colspan="" rowspan="">The public key that Bob should use to verify Alice's signature of form<span class="sub" style="">C</span>
+</td>
+      </tr>
+    </table>
+
+    <p class="caption">Table 3: Offline Negotiation Only</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Parameter</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">hashes<span class="sub" style="">A</span>
+</td>
+        <td align="" colspan="" rowspan="">The set of hashes of form<span class="sub" style="">A</span> (one for each of the hash algorithms that Bob supports)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">signKeys<span class="sub" style="">A</span>, signKeys<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">All the private keys that Alice or Bob is able to use to create signatures</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="indent">
+<h3>5.2 <a name="synopses-online">Online Esession Negotiation</a>
+</h3>
+    <p class="" style="">Alice uses this protocol when Bob is Online. She offers him a choice of algorithms and other parameters.</p>
+    
+    <pre>
+<span style="font-weight: bold">ALICE</span>                                 <span style="font-weight: bold">BOB</span> 
+
+C<span class="sub" style="">A</span> = random()
+form<span class="sub" style="">A</span> = {C<span class="sub" style="">A</span>, options, pubKeys<span class="sub" style="">B</span>}
+
+                             form<span class="sub" style="">A</span>
+                            ------&gt;
+                                      chosen ∈ options (p,g,HASH,CIPHER...)
+                                      C<span class="sub" style="">A</span> = C<span class="sub" style="">A</span> AND 2<span class="super" style="">n</span>-1 
+                                      C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span>
+                                      y = random()
+                                      d = g<span class="super" style="">y</span> mod p
+                                      hash<span class="sub" style="">A</span> = HASH(form<span class="sub" style="">A</span>)
+                                      pubKey<span class="sub" style="">B</span> ∈ pubKeys<span class="sub" style="">B</span> 
+                                      form<span class="sub" style="">B</span> = {chosen, d, hash<span class="sub" style="">A</span>, pubKey<span class="sub" style="">B</span>, pubKeys<span class="sub" style="">A</span>}
+                                      sign<span class="sub" style="">B</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>)
+                             form<span class="sub" style="">B</span>
+                            &lt;------
+                             sign<span class="sub" style="">B</span> 
+<span style="font-style: italic">assert</span> hash<span class="sub" style="">A</span> = HASH(form<span class="sub" style="">A</span>)
+<span style="font-style: italic">assert</span> chosen ∈ options
+<span style="font-style: italic">assert</span> d &gt; 1
+<span style="font-style: italic">verify</span>(sign<span class="sub" style="">B</span>, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>)
+C<span class="sub" style="">A</span> = C<span class="sub" style="">A</span> AND 2<span class="super" style="">n</span>-1 
+C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span>
+x = random()
+e = g<span class="super" style="">x</span> mod p
+K = d<span class="super" style="">x</span> mod p
+K-C<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)
+K-M<span class="sub" style="">A</span> = HASH(K-C<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)
+K-C<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)
+K-M<span class="sub" style="">B</span> = HASH(K-C<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)
+hash<span class="sub" style="">B</span> = HASH(form<span class="sub" style="">B</span>)
+pubKey<span class="sub" style="">A</span> ∈ pubKeys<span class="sub" style="">A</span> 
+form<span class="sub" style="">C</span> = {e, hash<span class="sub" style="">B</span>, pubKey<span class="sub" style="">A</span>}
+sign<span class="sub" style="">C</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">A</span>, form<span class="sub" style="">C</span>)
+                             form<span class="sub" style="">C</span>
+                            ------&gt;
+                             sign<span class="sub" style="">C</span> 
+                                      <span style="font-style: italic">assert</span> hash<span class="sub" style="">B</span> = HASH(form<span class="sub" style="">B</span>)
+                                      <span style="font-style: italic">verify</span>(sign<span class="sub" style="">C</span>, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">C</span>)
+                                      <span style="font-style: italic">assert</span> e &gt; 1
+                                      K = e<span class="super" style="">y</span> mod p
+                                      K-C<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)
+                                      K-M<span class="sub" style="">A</span> = HASH(K-C<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)
+                                      K-C<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)
+                                      K-M<span class="sub" style="">B</span> = HASH(K-C<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)
+    </pre>
+  </div>
+
+  <div class="indent">
+<h3>5.3 <a name="synopses-offline">Offline Esession Negotiation</a>
+</h3>
+    <p class="" style="">Alice uses this protocol when Bob is Offline. The diagram is split into three phases. First Bob publishes his Esession options before going offline, later Alice completes the key exchange (and sends him encrypted stanzas that are not shown below), finally when Bob comes online again he verifies and calculates the decryption key.</p>
+    <pre>
+<span style="font-weight: bold">BOB</span>                                  <span style="font-weight: bold">BOB'S SERVER</span>                     <span style="font-weight: bold">ALICE</span> 
+
+y = random()
+d = g<span class="super" style="">y</span> mod p
+form<span class="sub" style="">A</span> = {p, g, d, options, pubKeys<span class="sub" style="">B</span>}
+signs<span class="sub" style="">A</span> = <span style="font-style: italic">multi_sign</span>(signKeys<span class="sub" style="">B</span>, form<span class="sub" style="">A</span>)
+hashes<span class="sub" style="">A</span> = <span style="font-style: italic">multi_hash</span>(form<span class="sub" style="">A</span>)
+private = {y, hashes<span class="sub" style="">A</span>}
+<span style="font-style: italic">store</span>(private)
+                           form<span class="sub" style="">A</span>
+                          -------&gt;
+                           signs<span class="sub" style="">A</span> 
+                                     <span style="font-style: italic">store</span>(form<span class="sub" style="">A</span>, signs<span class="sub" style="">A</span>)
+-------------------------------------------------------------------------------------------------------------
+                                                            form<span class="sub" style="">A</span>
+                                                           -------&gt;
+                                                            signs<span class="sub" style="">A</span> 
+                                                                      <span style="font-style: italic">verify_one</span>(signs<span class="sub" style="">A</span>, pubKeys<span class="sub" style="">B</span>, form<span class="sub" style="">A</span>)
+                                                                      <span style="font-style: italic">assert</span> d &gt; 1
+                                                                      chosen ∈ options (HASH,CIPHER...)
+                                                                      C<span class="sub" style="">A</span> = random()
+                                                                      C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span>
+                                                                      x = random()
+                                                                      e = g<span class="super" style="">x</span> mod p
+                                                                      K = d<span class="super" style="">x</span> mod p
+                                                                      K-C<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)
+                                                                      K-M<span class="sub" style="">A</span> = HASH(K-C<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)
+                                                                      K-C<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)
+                                                                      K-M<span class="sub" style="">B</span> = HASH(K-C<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)
+                                                                      hash<span class="sub" style="">A</span> = HASH(form<span class="sub" style="">A</span>)
+                                                                      form<span class="sub" style="">B</span> = {chosen, C<span class="sub" style="">A</span>, e, hash<span class="sub" style="">A</span>, pubKeys<span class="sub" style="">A</span>}
+                                                                      signs<span class="sub" style="">B</span> = <span style="font-style: italic">multi_sign</span>(signKeys<span class="sub" style="">A</span>, form<span class="sub" style="">B</span>)
+                                                            form<span class="sub" style="">B</span>
+                                                           &lt;-------
+                                                            signs<span class="sub" style="">B</span> 
+                                     <span style="font-style: italic">store</span>(form<span class="sub" style="">B</span>, signs<span class="sub" style="">B</span>)
+-------------------------------------------------------------------------------------------------------------
+                           form<span class="sub" style="">B</span>
+                          &lt;-------
+                           signs<span class="sub" style="">B</span> 
+<span style="font-style: italic">retrieve</span>(private)
+<span style="font-style: italic">assert</span> hash<span class="sub" style="">A</span> ∈ hashes<span class="sub" style="">A</span> 
+<span style="font-style: italic">assert</span> chosen ∈ options
+<span style="font-style: italic">assert</span> e &gt; 1
+<span style="font-style: italic">verify_one</span>(signs<span class="sub" style="">B</span>, pubKeys<span class="sub" style="">A</span>, form<span class="sub" style="">B</span>)
+C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+K = e<span class="super" style="">y</span> mod p
+K-C<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)
+K-M<span class="sub" style="">A</span> = HASH(K-C<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)
+K-C<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)
+K-M<span class="sub" style="">B</span> = HASH(K-C<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)
+    </pre>
+  </div>
+<h2>6.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">Before attempting to engage in an ESession with Bob, Alice SHOULD discover whether he supports this protocol, using either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259458">17</a>] or the presence-based profile of <span style="font-weight: bold">JEP-0030</span> specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259484">18</a>].</p>
+  <p class="" style="">The normal course of events is for Alice to authenticate with her server, retrieve her roster (see <span style="font-weight: bold">RFC 3921</span>), send initial presence to her server, and then receive presence information from all the contacts in her roster. If the presence information she receives from some contacts does not include capabilities data (per <span style="font-weight: bold">JEP-0115</span>), Alice SHOULD then send a service discovery information ("disco#info") request to each of those contacts (in accordance with <span style="font-weight: bold">JEP-0030</span>). Such initial service discovery stanzas MUST NOT be considered part of encrypted communication sessions for the purposes of this JEP, since they perform a "bootstrapping" function that is a prerequisite to encrypted communications. The disco#info request sent from Alice to Bob might look as follows:</p>
+  <p class="caption">Example 1. Alice Queries Bob for Esession Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com/laptop'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Bob sends a disco#info reply and he supports the protocol defined herein, then he MUST include a service discovery feature variable of "http://jabber.org/protocol/esession".</p>
+  <p class="caption">Example 2. Bob Returns disco#info Data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='bob@example.com/laptop'
+    to='alice@example.org/pda'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='client' type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/esession'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>7.
+       <a name="init">ESession Initiation</a>
+</h2>
+  <p class="" style="">The process for establishing an ESession is essentially a translation into XMPP syntax of the SSH transport mechanism for establishing a secure session over an insecure transport (see <span style="font-weight: bold">SSH Transport Layer Protocol</span>). Specifically, as in SSH, ESession uses a Diffie-Hellman key exchange algorithm (see <span class="ref" style="">RFC 2631</span>  [<a href="#nt-id2259580">19</a>]) in the initial negotation (although, as we shall see, it does not use SHA-1 as the hashing algorithm).</p>
+  <p class="" style="">When Alice wishes to establish an ESession with Bob, Alice may choose between two different methods of performing the initial Diffie-Hellman key exchange, depending on whether Bob is online or not. Note: Alice MUST NOT initiate a new Esession with Bob if she already has one established with him.</p>
+
+  <div class="indent">
+<h3>7.1 <a name="init-online">Online Diffie-Hellman Key Exchange</a>
+</h3>
+    <p class="" style="">If Alice believes Bob may be online then she SHOULD retrieve Bob's long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) and then use the protocol specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2259646">20</a>] and Diffie-Hellman to negotiate the Esession options and the shared secret.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="init-online-request">Esession Request</a>
+</h3>
+      <p class="" style="">In addition to the "accept" and "logging" fields specified in <span style="font-weight: bold">Chat Session Negotiation</span>, Alice MUST specify each of the Esession options (algorithms etc.) she is willing to use, in her order of preference (see <a href="#sec-mandatory">Mandatory to Implement Technologies</a>). Note: Alice SHOULD NOT include a "reason" field since Aunt Tillie may not be aware the Esession request is not encrypted.</p>
+      <ol start="1" type="">
+        <li><p class="" style="">The list of Modular Exponential (MODP) group numbers (as specified in <span class="ref" style="">RFC 2409</span>  [<a href="#nt-id2259713">21</a>] or <span class="ref" style="">RFC 3526</span>  [<a href="#nt-id2259736">22</a>]) she is willing to use for Diffie-Hellman key exchange (valid group numbers include 1,2,3,4,5,14,15,16,17 and 18)</p></li>
+        <li><p class="" style="">Symmetric block cipher algorithm names</p></li>
+        <li><p class="" style="">Hash algorithm names</p></li>
+        <li><p class="" style="">Compression algorithm names</p></li>
+        <li><p class="" style="">The list of stanza types she is willing to encrypt and decrypt</p></li>
+        <li><p class="" style="">Whether or not both entities MUST be connected securely to their servers (see Section 5 of <span style="font-weight: bold">RFC 3920</span>)</p></li>
+        <li><p class="" style="">The minimum number of stanzas that MUST be exchanged before an entity MAY initiate a key re-exchange (1 - every stanza, 100 - every hundred stanzas). This value MUST be less than 2<span class="super" style="">32</span> (see <a href="#sec-rekey">Re-Keying Limits</a>)</p></li>
+        <li><p class="" style="">The Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2259813">23</a>]) SHA-256 fingerprint (PKID) of each of Bob's public signature-verification keys that she found acceptable (see <a href="#sec-keys">Verifying Keys</a>). Note: Alice SHOULD facilitate <a href="#sign-normal">XML Normalization</a> by <span style="font-style: italic">not</span> including an empty "accept_pkids" field.</p></li>
+      </ol>
+      <p class="" style="">Alice MUST also specify a randomly generated  [<a href="#nt-id2259838">24</a>] initial value of C<span class="sub" style="">A</span>, the block cipher counter for stanzas sent from Alice to Bob. The number of bits in C<span class="sub" style="">A</span> MUST be greater than or equal to the block sizes of all the block cipher options she proposes.</p>
+    <p class="caption">Example 3. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='form' xmlns='jabber:x:data'&gt;
+      &lt;field type="hidden" var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="accept"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="logging"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="modp"&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="crypt_algs"&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="hash_algs"&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="compress"&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-multi" var="stanzas"&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="secure"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded block counter ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="text-single" var="rekey_freq"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-multi" var="accept_pkids"&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='drop' condition='deliver' value='stored'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob does not support one or more of the options in each Esession field (except the 'accept_pkids' field), then he SHOULD return a &lt;feature-not-implemented/&gt; error (but he MAY return no error if, for example, he does not want to reveal his presence to Alice for whatever reason):</p>
+    <p class="caption">Example 4. Bob Informs Alice that Her Options Are Not Supported</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='bob@example.com/laptop'
+         to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    ...
+  &lt;/feature&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-options xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Either Bob or Alice MAY attempt to initiate a new ESession after any error during the initiation process. However, both MUST consider the previous negotiation to have failed and MUST discard any information learned through the previous negotiation.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="init-online-bobprep">Diffie-Hellman Preparation (Bob)</a>
+</h3>
+      <p class="" style="">If Bob is willing to start an ESession with Alice, he SHOULD retrieve Alice's long-term public signature-verification keys. He MUST select one of the options from each of the Esession fields he received from Alice including one hash algorithm ("HASH") and one of the MODP groups (see <span class="ref" style="">RFC 3766</span>  [<a href="#nt-id2250274">25</a>] or <span style="font-weight: bold">RFC 3526</span> for recommendations regarding balancing the sizes of symmetric cipher blocks and Diffie-Hellman moduli). Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). Bob MUST then perform the following computations (where n is the number of bits per cipher block for the selected block cipher algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Set C<span class="sub" style="">A</span> = C<span class="sub" style="">A</span> AND 2<span class="super" style="">n</span>-1 (i.e. truncate C<span class="sub" style="">A</span> to the block size)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the block counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.1.3 <a name="init-online-response">Esession Response</a>
+</h3>
+    <p class="" style="">Bob responds to Alice specifying the Esession options he selected.</p>
+    <p class="" style="">If Bob is willing to start an ESession with Alice, then instead of providing the PKID of his public key that he selected, Bob MUST specify the Base64 encoded SHA-256 fingerprint (PKID) of each of Alice's public signature-verification keys that he finds acceptable (see <a href="#sec-keys">Verifying Keys</a>). Note: The values Bob submits in the "accept_pkids" field are not selected from the options he received.</p>
+    <p class="" style="">Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Alice.</p>
+    <p class="" style="">In addition to the fields he received from Alice, Bob MUST include the Base64 encoded value of d. If Alice selected one or more of his public keys, and if Bob has access to a long-lived private signing key that corresponds to one of those keys  [<a href="#nt-id2260372">26</a>], then he MUST also include the PKID. Otherwise (for example, if Bob is unable to publish keys to his server or if Alice is unable to access keys published via his server  [<a href="#nt-id2260380">27</a>]), Bob MAY include one of his Base64 encoded public keys. In either case, Bob MUST include the signature (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field). He MUST also include the Base64 encoded HASH of the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the data form from Alice's Esession request.</p>
+    <p class="" style="">Note: Bob SHOULD facilitate <a href="#sign-normal">XML Normalization</a> by <span style="font-style: italic">not</span> including empty "accept_pkids", "pkids" or "signs" fields.</p>
+    <p class="" style="">However, if Bob is unwilling to start an ESession, but he is ready to initiate a one-to-one chat session with Alice (see <span style="font-weight: bold">Chat Session Negotiation</span>), then he SHOULD terminate the Esession negotiation by not specifying any of the five extra values in his response.</p>
+    <p class="caption">Example 5. Bob Responds to Alice (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="accept_pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="key"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="prev_hash"&gt;
+        &lt;value&gt; ** Base64 encoded HASH of Alice's previous form ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 6. Bob Responds to Alice (with Public Key)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+      &lt;field var="prev_hash"&gt;
+        &lt;value&gt; ** Base64 encoded HASH of Alice's previous form ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pkey"&gt;
+        &lt;value&gt; ** Base64 encoded public key ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If the value of d is less than two or if Bob provided an invalid signature (see <a href="#sign">Signature Verification</a>) then Alice MUST NOT proceed. If Alice provided a PKID but Bob did not provide a signature, or if Bob sent Alice a public key but she could not verify it belongs to him via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then she SHOULD send a &lt;not-acceptable/&gt; error to him.</p>
+    <p class="caption">Example 7. Alice Signals an Unacceptable or Missing Signature</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='alice@example.org/pda'
+         to='bob@example.com/laptop'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;invalid-signature xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.1.4 <a name="init-online-aliceprep">Diffie-Hellman Preparation (Alice)</a>
+</h3>
+      <p class="" style="">After verifying Bob's signature and his HASH of her request form, Alice can be certain that the value of d was actually generated by Bob in response to her Esession request. Alice MUST use the value of d and the Esession options specified in Bob's response to perform the following steps (where n is the number of bits per cipher block for the agreed block cipher algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Set C<span class="sub" style="">A</span> = C<span class="sub" style="">A</span> AND 2<span class="super" style="">n</span>-1</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span></p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (this is the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.1.5 <a name="init-online-complete">Diffie-Hellman Completion</a>
+</h3>
+    <p class="" style="">Alice then completes the Diffie-Hellman negotiation by sending Bob the Base64 encoded value of e. If Bob selected one or more of her public keys, and if Alice has access to a long-lived private signing key that corresponds to one of those keys, then she MUST also include the PKID. Otherwise, Alice MAY include one of her Base64 encoded public keys (see the <a href="#init-response">Esession Response</a> example).</p>
+    <p class="" style="">In either case, Alice MUST include the signature (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field). She MUST also include the Base64 encoded HASH of the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the data form from Bob's Esession response.</p>
+    <p class="" style="">Note: Alice SHOULD facilitate <a href="#sign-normal">XML Normalization</a> by <span style="font-style: italic">not</span> including empty "pkids" or "signs" fields.</p>
+    <p class="" style="">Alice MAY also send encrypted content (see <a href="#exchange">Exchanging Stanzas</a>) in the same stanza as the Diffie-Hellman completion. Note: If she also includes a &lt;terminate/&gt; element (see <a href="#terminate">Esession Termination</a>) within the &lt;encrypted/&gt; element then the Esession is terminated immediately. This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified).</p>
+    <p class="caption">Example 8. Alice Completes Diffie-Hellman Negotitation (with PKID)</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="key"&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="prev_hash"&gt;&lt;value&gt; ** Base64 encoded HASH of Bob's previous form ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pkids"&gt;&lt;value&gt; ** PKID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="signs"&gt;&lt;value&gt; ** signature of this form ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Bob provided a PKID but Alice did not provide a signature then he MAY send a failure notice to her. If Alice sent Bob a public key but he could not verify it belongs to her via secure out-of-band communication (see <a href="#sec-keys">Verifying Keys</a>) then he SHOULD send a failure notice to her. If Alice provided an invalid signature (see <a href="#sign">Signature Verification</a>), or an invalid HASH of his response form, or a value of e less than two, then he MUST send a failure notice to her. If Bob sends a failure notice then he SHOULD ignore any encrypted content in the stanza.</p>
+    <p class="" style="">If no error occurs, Bob MUST calculate K = e<span class="super" style="">y</span> mod p (the shared secret). Alice and Bob then have the same value for K and the key exchange is complete.</p>
+    </div>
+  </div>
+
+<div class="indent">
+<h3>7.2 <a name="init-offline">Offline Diffie-Hellman Key Exchange</a>
+</h3>
+  <p class="" style="">As described below, offline negotiation of an Esession is in essence a special case of online negotiation. Bob MAY publish a set of Esession options just before he goes offline (see <a href="#sec-offline">Offline Esessions</a> Security Considerations) to allow entities that subscribe to his presence to initiate Esessions and send encrypted stanzas to him while he is offline. He MAY also publish <span style="font-style: italic">another</span> similar set of relatively long-lived  [<a href="#nt-id2260890">28</a>] Esession options that any entity MAY use for the same purpose.</p>
+    <div class="indent">
+<h3>7.2.1 <a name="init-offline-publish">Publishing Esession Options</a>
+</h3>
+      <p class="" style="">In order to publish either set of his offline Esession options Bob MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Select a MODP group (that defines the constants p and g)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1, where n is the largest number of bits per cipher block for the block cipher algorithms he is willing to use)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Publish each of the Esession options he is willing to use (see <a href="#init-request">Esession Request</a>) including the value of d. He SHOULD do this through his own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>) or a similar protocol (out of scope for this JEP).</p></li>
+        <li><p class="" style="">Calculate one or more hashes ("HASHES") of the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the published data form (one for each of the hash algoritms he specified).</p></li>
+        <li><p class="" style="">Store the value of y and the HASHES in a secure way, so that he can retrieve them when he comes back online (idealy even if that is using a different client and/or a different machine)</p></li>
+      </ol>
+      <p class="" style="">If Bob will not be able to decrypt stanzas if he comes back online using a different client and/or a different machine then he SHOULD publish the resource of this client in the 'match_resource' field of his Esession options.</p>
+      <p class="" style="">Note: The single specified MODP group MUST be the one Bob used to generate d. The list of stanza types he is willing to decrypt MUST NOT include the value 'iq', and if he specifies a value in the 'match_resource' field then he MUST include only 'message'. Bob MUST also include the list of the PKIDs of all his public signature-verification keys that he can sign for, and the corresponding list of signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style=""><span style="font-style: italic">Note: This publishing protocol is highly preliminary and depends on a separate proposal.</span></p>
+      <p class="caption">Example 9. Bob Publishes His Esession Options for His Subscribers</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info-subscription'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="match_resource"&gt;
+        &lt;value&gt;laptop&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="logging"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="modp"&gt;
+        &lt;value&gt;2&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;
+        &lt;value&gt;aes256-ctr&lt;/value&gt;
+        &lt;value&gt;twofish256-ctr&lt;/value&gt;
+        &lt;value&gt;aes128-ctr&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="hash_algs"&gt;
+        &lt;value&gt;whirlpool&lt;/value&gt;
+        &lt;value&gt;sha256&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="compress"&gt;
+        &lt;value&gt;none&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="stanzas"&gt;
+        &lt;value&gt;message&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="secure"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="key"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">Bob MAY publish his Esession options for all entities using the same protocol except for the 'xmlns' and 'node' attributes of the &lt;query/&gt; element:</p>
+      <p class="caption">Example 10. Bob Publishes His Esession Options for All Entities</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.2.2 <a name="init-offline-request">Requesting Offline Esession Options</a>
+</h3>
+      <p class="" style="">If Alice believes Bob is offline she SHOULD request his Esession options and his long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) from his server.</p>
+      <p class="" style="">If Alice is subscribing to Bob's presence she MUST request his Esession Options exclusively for subscribers.</p>
+      <p class="caption">Example 11. Alice asks Bob's Server for his Esession Options (Subscribers)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If Alice is not subscribing to Bob's presence (or if Bob has no Esession Options exclusively for subscribers) she MUST use the following request instead.</p>
+      <p class="caption">Example 12. Alice asks Bob's Server for his Esession Options (All Entities)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com'
+    id='es3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If, after receiving Bob's public keys and Esession options, Alice is unable to verify any of Bob's signatures (see <a href="#sign">Signature Verification</a>) then she MAY decide to proceed no further, since she cannot be sure who will be able to decrypt her stanzas.</p>
+    </div>
+    <div class="indent">
+<h3>7.2.3 <a name="init-offline-prep">Diffie-Hellman Preparation (Offline)</a>
+</h3>
+      <p class="" style="">Alice MUST select one of the options from each of Bob's Esession fields including one hash algorithm ("HASH"). If she cannot support any of the options in a field (except the 'pkids' and 'signs' fields), or if the value of d is less than two, then she MUST NOT send encrypted stanzas to Bob while he is offline.</p>
+      <p class="" style="">Alice MUST use the value of d and the MODP group specified in Bob's Esession options to perform the following steps (where n is the number of bits per cipher block for the selected block cipher algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate the initial value of C<span class="sub" style="">A</span> with n random bits (C<span class="sub" style="">A</span> is the block cipher counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the block counter for stanzas sent from Bob to Alice  [<a href="#nt-id2261339">29</a>])</p></li>
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+        <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.2.4 <a name="init-offline-start">Starting an Offline Esession</a>
+</h3>
+      <p class="" style="">Alice then sends Bob the Base64 encoded values of e and C<span class="sub" style="">A</span>. She SHOULD also include the list of the PKIDs of all her public signature-verification keys that she can sign for, and the corresponding list of signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field). She MUST also include the Base64 encoded HASH of the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the data form from Bob's published Esession options.</p>
+      <p class="" style="">She also specifies which of Bob's Esession options she selected. Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Bob.</p>
+      <p class="" style="">Alice MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza. Note: If she also includes a &lt;terminate/&gt; element (see <a href="#terminate">Esession Termination</a>) within the &lt;encrypted/&gt; element then the Esession is terminated immediately. This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified).</p>
+      <p class="" style="">If Bob included a value in the 'match_resource' field of his Esession options, then Alice MUST address all the stanzas she sends within the offline Esession to the specified resource and use the <span style="font-weight: bold">Advanced Message Processing</span> protocol to ensure that they are not delivered to any other resource.</p>
+      <p class="caption">Example 13. Alice Establishes an ESession Without Negotiation</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop' type='chat'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/esession&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;2&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="counter"&gt;&lt;value&gt; ** Base64 encoded block counter ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="key"&gt;&lt;value&gt; ** Base64 encoded value of e ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="prev_hash"&gt;&lt;value&gt; ** Base64 encoded HASH of Bob's published form ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pkids"&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+        &lt;value&gt; ** PKID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="signs"&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+        &lt;value&gt; ** signature of form ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='??????' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+      <p class="" style="">Alice can assume that she and Bob have the same value for K and that the key exchange is complete.</p>
+    </div>
+    <div class="indent">
+<h3>7.2.5 <a name="init-offline-accept">Accepting Offline Esessions</a>
+</h3>
+      <p class="" style="">When Bob comes online he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li>
+<p class="" style="">Ensure he is no longer publishing offline Esession options exclusively for entities that are subscribing to his presence</p>
+            <p class="caption">Example 14. Bob Stops Publishing His Esession Options</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='bob@example.com/laptop' id='es4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/esession#subscription'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+        </li>
+        <li><p class="" style="">Retrieve any values of y and HASHES that he stored before going offline, and destroy in a secure way any persistently stored copies that correspond to Esession options exclusively for subscribers</p></li>
+      </ol>
+      <p class="" style="">When Bob receives a key exchange stanza from Alice then he MUST perform the following steps:</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Confirm that her HASH of his published options form matches one of the HASHES he retrieved and select the associated value of y.  [<a href="#nt-id2261648">30</a>]</p></li>
+        <li><p class="" style="">Confirm that he is prepared to support all the Esession options he received from Alice  [<a href="#nt-id2261664">31</a>]</p></li>
+        <li><p class="" style="">Confirm that the value of e is greater than one</p></li>
+        <li><p class="" style="">Confirm that he has not already received a key exchange stanza from Alice with the same value of e since he published his Esession options (see <a href="#sec-replay">Replay Attacks</a>). If the options were for subscribers, that means since he came online.</p></li>
+        <li><p class="" style="">Request Alice's public keys and, if possible, verify one of her signatures (see <a href="#sign">Signature Verification</a>; if he is unable to verify any of her signatures then he MAY decide to proceed no further, since he cannot be sure who started the Esession)</p></li>
+        <li><p class="" style="">Set the initial value of C<span class="sub" style="">A</span> to the counter value he received from Alice</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (to allow him to terminate the offline Esession)</p></li>
+        <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p (the shared secret)</p></li>
+      </ol>
+    </div>
+  </div>
+
+  <div class="indent">
+<h3>7.3 <a name="init-keys">Generating Session Keys</a>
+</h3>
+    <p class="" style="">Whichever method Alice used to perform the Diffie-Hellman key exchange (online or offline), once it is complete, then before Alice and Bob can start encrypting and decrypting stanzas they MUST both use the agreed hash algorithm ("HASH") and their full JIDs to generate two pairs of keys, one for each direction of the ESession. Note: JID<span class="sub" style="">B</span> MUST be Bob's bare JID throughout an offline Esession, even if he comes online in the middle of the Esession and the key is re-exchanged.</p>
+    <p class="" style="">For stanzas that Alice will send to Bob, the keys are calculated as:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Encryption key K-C<span class="sub" style="">A</span> = HASH(K, JID<span class="sub" style="">A</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">A</span> = HASH(K-C<span class="sub" style="">A</span>, JID<span class="sub" style="">B</span>)  [<a href="#nt-id2261908">32</a>]</p></li>
+    </ol>
+    <p class="" style="">For stanzas that Bob will send to Alice the keys are calculated as:</p>
+    <ol start="4" type="">
+      <li><p class="" style="">Encryption key K-C<span class="sub" style="">B</span> = HASH(K, JID<span class="sub" style="">B</span>)</p></li>
+      <li><p class="" style="">Integrity key K-M<span class="sub" style="">B</span> = HASH(K-C<span class="sub" style="">B</span>, JID<span class="sub" style="">A</span>)</p></li>
+    </ol>
+    <p class="" style="">Once the two pairs of keys have been calculated the value of K MUST be securely destroyed.</p>
+    <p class="" style="">As many bits of key data as are needed MUST be taken from the least significant bits of the hash output. When negotiating a hash, entities MUST ensure that the hash output is no shorter than the required key data. For algorithms with variable-length keys the maximum length (up to the hash output length) SHOULD be used.</p>
+
+    <p class="" style="">With these keys computed and the algorithms agreed upon, ESession initiation is now complete. From this point forward, Alice and Bob MUST exchange only encrypted forms of the one-to-one stanza types they agreed upon (e.g., &lt;message/&gt; and &lt;iq/&gt; stanzas).</p>
+  </div>
+<h2>8.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="exchange-separate">Encryptable Content</a>
+</h3>
+    <p class="" style="">Once an Esession has been established, whenever Alice wants to send Bob an encrypted stanza she MUST only encrypt the XML content that would normally be ignored by the intermediate servers. She MUST NOT encrypt stanza wrapper elements or <span style="font-weight: bold">Advanced Message Processing</span> elements.</p>
+    <p class="" style="">If this is an offline Esession then Alice SHOULD include a 'Created' SHIM header in the encrypted content. Bob SHOULD trust this header and ignore the unencrypted <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2262113">33</a>] element inserted by his server.</p>
+
+  <p class="caption">Example 15. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+
+  <p class="caption">Example 16. XML Content to be Encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+  &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+&lt;/headers&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+</pre></div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="exchange-encrypt">Encryption</a>
+</h3>
+
+    <p class="" style="">Alice MUST perform the following steps to encrypt the XML content. Note: if there is no XML content to be encrypted (e.g. if this is an empty <a href="#rekey">Re-Keying</a> or <a href="#terminate">Termination</a> stanza), then C<span class="sub" style="">A</span> MUST be incremented by 1 (see below), and only the last two steps (normalization and MAC calculation) should be performed.</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Serialize the XML content she wishes to send into an array of UTF-8 bytes, m.  [<a href="#nt-id2262192">34</a>]</p></li>
+      <li>
+        <p class="" style="">Compress m using the negotiated algorithm. If a compression algorithm other than 'none' was agreed, the compression context is typically initialized after key exchange and passed from one stanza to the next, with only a partial flush at the end of each stanza.  [<a href="#nt-id2262211">35</a>]</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = compress(m)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Encrypt the data with the agreed algorithm in counter mode (see <span class="ref" style=""> Recommendation for Block Cipher Modes of Operation</span>  [<a href="#nt-id2262253">36</a>]), using the encryption key K-C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented by 1 for each encrypted block or partial block (i.e. C<span class="sub" style="">A</span> = (C<span class="sub" style="">A</span> + 1) mod 2<span class="super" style="">n</span>, where n is the number of bits per cipher block for the agreed block cipher algorithm). Note: if the block cipher algorithm 'none' was agreed (see <a href="#sec-unencrypted">Unencrypted Esessions</a>) then encryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1 (for replay protection).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_final = encrypt(K-C<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Alice MUST now create the <a href="#sign-normal">Normalized</a> XML <span style="font-style: italic">content</span> of the &lt;encrypted/&gt; XML element. If there is encrypted XML content, the XML MUST include the Base64 encoded value of m_final wrapped in a &lt;data/&gt; element. Note: it MAY also contain one &lt;terminate/&gt; element (see <a href="#terminate">Termination</a>), one &lt;key/&gt; element and one or more &lt;old/&gt; elements (see <a href="#rekey">Re-Keying</a>).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_content = '&lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;'</pre></div>
+      </li>
+      <li>
+        <p class="" style="">The XML content and the value of Alice's block cipher counter C<span class="sub" style="">A</span> <span style="font-style: italic">before</span> the data was encrypted, are now processed through the HMAC algorithm (as defined in Section 2 of <span class="ref" style="">RFC 2104</span>  [<a href="#nt-id2262441">37</a>]), along with the agreed hash algorithm ("HASH") and the integrity key K-M<span class="sub" style="">A</span>.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>a_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+    </ol>
+
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="exchange-send">Sending an Encrypted Stanza</a>
+</h3>
+    <p class="" style="">Before sending the stanza to Bob, Alice MUST wrap m_content and the Base64 encoded value of a_mac (wrapped in a &lt;mac/&gt; element) inside an &lt;encrypted/&gt; element and insert it into the stanza in place of the original content. There MUST NOT be more than one &lt;encrypted/&gt; element per stanza.</p>
+    <p class="caption">Example 17. Message Stanza with Encrypted Content</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="exchange-decrypt">Decryption</a>
+</h3>
+
+    <p class="" style="">When Bob receives the stanza from Alice, he extracts and Base64 decodes the values of m_final and a_mac from the content and performs the following steps.</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Remove the &lt;mac/&gt; element from the &lt;encrypted/&gt; element and <a href="#sign-normal">Normalize</a> the remaining XML <span style="font-style: italic">content</span>. Calculate the Message Authentication Code (MAC) for the content.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>b_mac = HMAC(HASH, K-M<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Verify that b_mac and a_mac match. If they are not identical, the content has been tampered with and Bob MUST terminate the ESession, he MAY send a &lt;not-acceptable/&gt; error to Alice.  [<a href="#nt-id2260693">38</a>]</p>
+      </li>
+      <li>
+        <p class="" style="">Decrypt m_final using the agreed algorithm, K-C<span class="sub" style="">A</span> and C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented by 1 for each decrypted block (see <a href="#exchange-encrypt">Encryption</a>). Note: if the block cipher algorithm 'none' was agreed decryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = decrypt(K-C<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_final)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Decompress m_compressed using the negotiated algorithm (usually 'none').</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m = decompress(m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Replace the &lt;encrypted/&gt; element in the serialized XML stanza with m and feed the stanza into an XML parser. If the parser returns an XML format error then Bob MUST terminate the ESession, he MAY send a &lt;not-acceptable/&gt; error to Alice.  [<a href="#nt-id2262598">39</a>]</p>
+      </li>
+    </ol>
+  </div>
+  <h2>9.
+       <a name="rekey">Re-Key Exchange</a>
+</h2>
+<p class="" style="">Once an attacker has discovered an encryption key it could be used to decrypt all stanzas within a session, including stanzas that were intercepted <span style="font-style: italic">before</span> the key was discovered. To reduce the window of vulnerability, both Alice and Bob SHOULD change their values of x and y and re-exchange the encryption key as regularly as possible. They MUST also destroy all copies of keys as soon as they are no longer needed.</p>
+<p class="" style="">Note: Although most entities are capable of re-keying after each stanza, clients running in constrained runtime environments may require a few seconds to re-key. During Esession initiation these clients MAY negotiate the minimum number of stanzas to be exchanged between re-keys at the cost of a larger window of vulnerability. Entities MUST NOT initiate key re-exchanges more frequently than the agreed limit.</p>
+
+  <div class="indent">
+<h3>9.1 <a name="rekey-init">Re-Key Initiation</a>
+</h3>
+    <p class="" style="">Either Alice or Bob MAY initiate a key re-exchange. Here we describe the process initiated by Alice. First she MUST calculate new values for the encryption parameters:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1, where n is the number of bits per cipher block for the agreed block cipher algorithm)</p></li>
+      <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the new shared secret)</p></li>
+      <li><p class="" style="">Calculate K-C<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-C<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">To avoid extra stanzas, the new value of e SHOULD be sent to Bob along with an encrypted stanza. Note: Alice MUST NOT use the new K-C<span class="sub" style="">A</span> and K-M<span class="sub" style="">A</span> to encrypt this stanza or to calculate the MAC. However, she MUST use them when sending subsequent stanzas.</p>
+    <p class="" style="">Note: There is no need for Alice to provide a signature because the calculation of the MAC includes the new value of e, see <a href="#exchange">Exchanging Stanzas</a>).</p>
+    <p class="caption">Example 18. Alice Sends Re-Key Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;key&gt; ** Base64 encoded value of new e ** &lt;/key&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Bob may not receive the new key before he sends his next stanzas (they may cross in transit). So, before destroying her old values of K-C<span class="sub" style="">B</span> and K-M<span class="sub" style="">B</span>, Alice MUST wait until either she receives a stanza encrypted with the new key, or a reasonable time has passed (60 seconds should cover a network round-trip and calculations by a constrained client). Similarly she MUST wait before destroying her old value of x, in case Bob sends two stanzas before receiving Alice's new key (the first stanza might include a re-key).</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="rekey-accept">Re-Key Acceptance</a>
+</h3>
+    <p class="" style="">After Bob receives a stanza with a new value of e and confirmed it is greater than one, and he has decrypted the stanza with the old value of K-C<span class="sub" style="">A</span>, he MUST securely destroy all copies of K-C<span class="sub" style="">A</span> and K-C<span class="sub" style="">B</span> and perform the following calculations with the new value of e:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p</p></li>
+      <li><p class="" style="">Calculate K-C<span class="sub" style="">A</span>, K-M<span class="sub" style="">A</span>, K-C<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">He MUST use these new values to encrypt and decrypt all subsequent stanzas.  [<a href="#nt-id2263143">40</a>]</p>
+    <p class="" style="">The next time Bob sends Alice a stanza he MUST specify the number of rekeys he has received from her since he sent her his last stanza. He does that by setting the 'rekeys' attribute of the &lt;data/&gt; element. Note: The default value of the 'rekeys' attribute is zero.</p>
+    <p class="caption">Example 19. Bob's First Stanza After Receiving a Re-Key</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data rekeys='1'&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Alice receives the stanza from Bob she MUST use the 'rekeys' attribute to decide which of her values of K-C<span class="sub" style="">B</span> and K-M<span class="sub" style="">B</span> (or x) she should use to decrypt the stanza - otherwise she would not know if Bob received her rekey(s) before he sent the stanza. Once she is sure Bob has received her rekey(s) she MUST discard all her older values of K-C<span class="sub" style="">B</span>, K-M<span class="sub" style="">B</span> and x.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="rekey-publish">Publishing Old MAC Values</a>
+</h3>
+    <p class="" style="">Once the expired MAC keys have been published, anyone could create valid arbitrary stanzas with them. This prevents anyone being able to prove the authenticity of a transcript of the Esession in the future.</p>
+    <p class="" style="">Either entity MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> within any encrypted stanza as long as it knows that all the stanzas that MAY use the old values have been received and validated. Note: A 'man-in-the-middle' could delay the delivery of stanzas indefinitely. So, before Alice publishes K-M<span class="sub" style="">A</span> (and K-M<span class="sub" style="">B</span>), she MUST wait until she has both sent a re-key to Bob and received a stanza from Bob encrypted with her new key. (She MAY also publish K-M<span class="sub" style="">B</span> after she has received a re-key from Bob.)</p>
+    <p class="caption">Example 20. Publishing Expired MAC Keys</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Entities SHOULD ignore any &lt;old/&gt; elements they receive.</p>
+  </div>
+  <h2>10.
+       <a name="terminate">Esession Termination</a>
+</h2>
+    <p class="" style="">Either entity MAY terminate an Esession at any time. Entities MUST terminate all open Esessions before they go offline. To terminate an Esession Alice MUST send a stanza to Bob including a &lt;terminate/&gt; element with content "1"  [<a href="#nt-id2263350">41</a>]. Note: She MAY publish old values of K-M<span class="sub" style="">A</span> and/or K-M<span class="sub" style="">B</span> within her termination stanza as long as she is sure all the stanzas that MAY use the old values have been received and validated (see <a href="#rekey-publish">Publishing Old MAC Values</a>). She MUST then securely destroy all keys associated with the Esession.</p>
+    <p class="caption">Example 21. Alice Terminates an Esession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Bob receives a termination stanza he MUST verify the MAC (to be sure he received all the stanzas Alice sent him during the Esession) and, if the stanza was sent to him while he was online, immediately send a termination stanza back to Alice. Note: He MAY publish <span style="font-style: italic">any</span> old values of K-M<span class="sub" style="">A</span> or K-M<span class="sub" style="">B</span> within the termination stanza. He MUST then securely destroy all keys associated with the Esession.</p>
+    <p class="caption">Example 22. Bob Confirms Esession Termination</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Alice receives the stanza she MUST verify the MAC to be sure she received all the stanzas Bob sent her during the Esession. Once an entity has sent a termination stanza it MUST NOT send another stanza within the Esession.</p>
+    <p class="" style="">Note: If Alice notices that Bob comes online during her offline Esession with him then she MUST terminate the Esession immediately. If required she may then negotiate a new (more secure) online Esession.</p>
+    <p class="" style="">Note: Bob MUST NOT send encrypted content within an Esession started by Alice. If Alice is conducting an offline Esession with Bob when he is online (e.g., if she is not subscribing to his presence), then if Bob wants to send a stanza to Alice, he MUST terminate the offline Esession and start a new online Esession first.</p>
+  <h2>11.
+       <a name="sign">Signature Generation and Verification</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="sign-normal">XML Normalization</a>
+</h3>
+    <p class="" style="">Before the signature or MAC of a block of XML is generated or verified, all character data <span style="font-style: italic">between</span> all elements MUST be removed and the XML MUST be converted to canonical form (see <span class="ref" style="">Canonical XML</span>  [<a href="#nt-id2263537">42</a>]).</p>
+    <p class="" style="">All the XML this protocol requires to be signed or MACed is very simple, so in this case, canonicalization SHOULD only require the following changes:</p>
+    <ul>
+      <li>Set attribute value delimiters to quotation marks (i.e. simply replace all single quotes in the serialized XML with double quotes)</li>
+      <li>Impose lexicographic order on the attributes of "field" elements (i.e. ensure "type" is before "var")</li>
+    </ul>
+    <p class="" style="">Implementations MAY conceivably also need to make the following changes. Note: Empty elements and special characters SHOULD NOT appear in the signed or MACed XML specified in this protocol.</p>
+    <ul>
+      <li>Ensure there are no character references</li>
+      <li>Convert empty elements to start-end tag pairs</li>
+      <li>Ensure there is no whitespace except for single spaces before attributes</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="sign-hash">Hash</a>
+</h3>
+    <p class="" style="">Before the signature or MAC of a block of XML is generated or verified, the agreed hash algorithm MUST be used to generate the hash of the normalized XML.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>m_hash = HASH(m_content)</pre></div>
+  </div>
+  <div class="indent">
+<h3>11.3 <a name="sign-calc">Generation</a>
+</h3>
+    <p class="" style="">The signature generation depends on the type of private key being used.</p>
+    <div class="indent">
+<h3>11.3.1 <a name="sign-rsa-gen">RSA</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>signature_rsa = rsa_sign(rsa_private_key, m_hash, hashOID)</pre></div>
+      <p class="" style="">The multiprecision integer signature_rsa is the signature (see <span class="ref" style="">RFC 3447</span>  [<a href="#nt-id2263662">43</a>]).</p>
+    </div>
+    <div class="indent">
+<h3>11.3.2 <a name="sign-dsa-gen">DSA</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>sig_dsa_r, sig_dsa_s = dsa_sign(dsa_private_key, m_hash)</pre></div>
+      <p class="" style="">The multiprecision integers sig_dsa_r and sig_dsa_s are the signature (see <span class="ref" style="">Digital Signature Standard</span>  [<a href="#nt-id2263715">44</a>]).</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>11.4 <a name="sign-format">Signature Format</a>
+</h3>
+    <p class="" style="">The signature formats are the same for all public key formats. All integers are stored in big-endian byte order.</p>
+    <div class="indent">
+<h3>11.4.1 <a name="sign-rsa-format">RSA</a>
+</h3>
+      <p class="" style="">Base64 encoding of the signature_rsa multiprecision integer (without any header or length prefix).</p>
+    </div>
+    <div class="indent">
+<h3>11.4.2 <a name="sign-dsa-format">DSA</a>
+</h3>
+      <p class="" style="">Base64 encoding of the following structure:</p>
+      <ul>
+        <li>number of bytes in sig_dsa_r (2-byte integer)</li>
+        <li>sig_dsa_r</li>
+        <li>number of bytes in sig_dsa_s (2-byte integer)</li>
+        <li>sig_dsa_s</li>
+      </ul>
+    </div>
+  </div>
+  <div class="indent">
+<h3>11.5 <a name="sign-calc">Verification</a>
+</h3>
+    <p class="" style="">The signature verification depends on the type of public key being used.</p>
+    <div class="indent">
+<h3>11.5.1 <a name="sign-rsa-verify">RSA</a>
+</h3>
+      <p class="" style="">The rsa_modulus and rsa_public_exponent multiprecision integers are extracted from the other entity's authenticated public key. The signature_rsa multiprecision integer is the signature received from the other entity.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>boolean = rsa_verify(signature_rsa, m_hash, hashOID, rsa_modulus, rsa_public_exponent)</pre></div>
+    </div>
+    <div class="indent">
+<h3>11.5.2 <a name="sign-dsa-verify">DSA</a>
+</h3>
+      <p class="" style="">The dsa_p, dsa_q, dsa_g and dsa_y multiprecision integers are extracted from the other entity's authenticated public key. The sig_dsa_r and sig_dsa_s multiprecision integers are the signature received from the other entity.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>boolean = dsa_verify(sig_dsa_r, sig_dsa_s, m_hash, dsa_p, dsa_q, dsa_g, dsa_y)</pre></div>
+    </div>
+  </div>
+  <h2>12.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="sec-prng">Random Numbers</a>
+</h3>
+    <p class="" style="">Weak pseudo-random number generators (PRNG) enable successful attacks. Implementors MUST use a cryptographically strong PRNG to generate all random numbers (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2263895">45</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="sec-rekey">Re-Keying Limits</a>
+</h3>
+    <p class="" style="">After a key exchange an entity MUST NOT exchange a total of 2<span class="super" style="">32</span> encrypted blocks before it initiates a key re-exchange (see <span class="ref" style="">SSH Transport Layer Encryption Modes</span>  [<a href="#nt-id2263942">46</a>]). Note: This limitation also ensures the same key and counter values are never used to encrypt two different blocks using counter mode (thus preventing simple attacks).</p>
+    <p class="" style="">In order to reduce the Perfect Forward Secrecy window of vulnerability, after an extended period of activity, entities SHOULD either re-key or terminate the Esession.</p>
+  </div>
+  <div class="indent">
+<h3>12.3 <a name="sec-keys">Verifying Keys</a>
+</h3>
+    <p class="" style="">The trust system outlined in this document is based on Alice trusting that the public key presented by Bob is <span style="font-style: italic">actually</span> Bob's key (and vice versa). Determining this trust may be done in a variety of ways depending on the entities' support for different public key (certificate) formats, signing algorithms and signing authorities. For instance, if Bob publishes a PGP/GPG public key, Alice MAY verify that his key is signed by another key that she knows to be good. Or, if Bob provides an X.509 certificate, she MAY check that his key has been signed by a Certificate Authority that she trusts.</p>
+    <p class="" style="">When trust cannot be achieved automatically, methods that are not transparent to the users may be employed. For example, Bob could communicate the SHA-256 fingerprint of his public key to Alice via secure out-of-band communication (e.g. face-to-face). This would enable Alice to confirm that the public key she receives in-band is valid. Note however that very few people bother to verify fingerprints in this way. So this method is exceptionally vulnerable to 'man-in-the-middle' attacks. In order to reduce the window of vulnerability, an entity SHOULD remember the fingerprints of all user-validated public keys and alert the user in the future if ever the fingerprint(s) it stored for an entity do not match any of the received public keys.</p>
+    <p class="" style="">Alternatively Alice and Bob could agree a shared secret via secure out-of-band communication, Bob could then use it to create an HMAC of his public key that only Alice could verify.</p>
+    <p class="" style="">Note: If no keys are acceptable to Alice (because Alice has never verified any of the keys, and because either the keys are not signed, or Alice does not support the signature algorithms of the keys, or she cannot parse the certificate formats, or she does not recognise the authorities that signed the keys) then, although the Esession can still be encrypted, she cannot be sure she is communicating with Bob.</p>
+  </div>
+  <div class="indent">
+<h3>12.4 <a name="sec-replay">Replay Attacks</a>
+</h3>
+    <p class="" style="">The block cipher counters maintained implicitly by Alice and Bob (C<span class="sub" style="">A</span> and C<span class="sub" style="">B</span>) prevent stanzas being replayed within any Esession. They ensure that the MAC will be different for all stanzas, even if the HMAC key and the content of the stanza are identical.</p>
+    <p class="" style="">Alice and Bob MUST ensure that the value of e or d they provide when negotiating each online Esession is unique. This prevents complete online Esessions being replayed.</p>
+    <p class="" style="">Since Bob supplies the same value of d for all offline Esessions, to prevent complete offline Esessions being replayed to him, he MUST take care to securely store <span style="font-style: italic">new</span> values (or destroy existing values) of y and HASHES for subscribers whenever he goes offline (see <a href="#init-publish">Publishing Esession Options</a>). Also, when Bob comes online again, he MUST remember all the values of e he receives in offline Esession initiation stanzas, and reject any offline Esessions that specify a value of e he has already received (see <a href="#init-accept">Accepting an Offline Esession</a>).</p>
+    <p class="" style="">Note: If Bob publishes Esession options for non-subscribers, and if he does not update them whenever he comes online then, until he updates the options, he MUST save all the values of e he receives to secure persistent storage (along with the values of y and HASHES).</p>
+  </div>
+  <div class="indent">
+<h3>12.5 <a name="sec-unencrypted">Unencrypted Esessions</a>
+</h3>
+    <p class="" style="">Organisations with full disclosure policies may require entities to disable encryption to enable the logging of all messages on their server. Unencrypted Esessions meet all the <a href="#reqs-sec">Security Requirements</a> except for Confidentiality. This enables Alice to use the 'secure' Esession option to confirm securely with Bob that both client-server connections are secure.</p>
+  </div>
+  <div class="indent">
+<h3>12.6 <a name="sec-storage">Storage</a>
+</h3>
+    <p class="" style="">If either entity stores a (re-encrypted) transcript of an Esession for future consultation then the Perfect Forward Secrecy offered by this protocol is lost. If the negotiated value of the 'logging' <span style="font-weight: bold">Chat Session Negotiation</span> field is false the entities SHOULD NOT store any part of the Esession content (not even in encrypted form).</p>
+  </div>
+  <div class="indent">
+<h3>12.7 <a name="sec-offline">Offline Esessions</a>
+</h3>
+    <p class="" style="">Bob MAY decide not to support Offline Esessions since they are significantly less secure than online Esessions. The Perfect Forward Secrecy window of vulnerability is much longer. More seriously, Bob MUST store his private Diffie-Hellman key, y, to local disk or to a server (perhaps symmetrically encrypted with a password). It is <span style="font-style: italic">really</span> hard to securely erase something from a disk. Note: If Bob does not support Offline Esessions then, while he is offline, Alice will probably send him completely unprotected messages!</p>
+  </div>
+  <div class="indent">
+<h3>12.8 <a name="sec-general">Extra Responsabilities of Implementors</a>
+</h3>
+    <p class="" style="">Cryptography plays only a small part in an entity's security. Even if it implements this protocol perfectly it may still be vulnerable to other attacks. For examples, an implementation might store Esession keys on swap space or save private keys to a file in cleartext! Implementors MUST take very great care when developing applications with secure technologies.</p>
+  </div>
+  <div class="indent">
+<h3>12.9 <a name="sec-mandatory">Mandatory to Implement Technologies</a>
+</h3>
+    <p class="" style="">An implementation of ESession MUST support the Diffie-Hellman Key Agreement and HMAC algorithms. Note: The parameter names mentioned below are related to secure shell; see <span style="font-weight: bold">SSH Transport Layer Encryption Modes</span> for block cipher algorithm details; see the <span class="ref" style="">IANA Secure Shell Protocol Parameters Registry</span>  [<a href="#nt-id2264270">47</a>] for other names.</p>
+    <div class="indent">
+<h3>12.9.1 <a name="sec-mandatory-encryption">Block Cipher Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following block cipher algorithm:</p>
+      <ul>
+        <li>aes128-ctr (see <span class="ref" style="">Advanced Encryption Standard</span>  [<a href="#nt-id2264318">48</a>])</li>
+      </ul>
+      <p class="" style="">The block length of an block cipher algorithm's cipher SHOULD be at least 128 bits. An implementation of ESession MAY also support the following block cipher algorithms:</p>
+      <ul>
+        <li>aes256-ctr</li>
+        <li>aes192-ctr</li>
+        <li>twofish256-ctr (see <span class="ref" style="">Twofish</span>  [<a href="#nt-id2264362">49</a>])</li>
+        <li>twofish192-ctr</li>
+        <li>twofish128-ctr</li>
+        <li>serpent256-ctr (see <span class="ref" style="">Serpent</span>  [<a href="#nt-id2264399">50</a>])</li>
+        <li>serpent192-ctr</li>
+        <li>serpent128-ctr</li>
+        <li>none (no encryption, only signing)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>12.9.2 <a name="sec-mandatory-sign">Key Signing Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following signing algorithm:</p>
+      <ul>
+        <li>rsa (see <span style="font-weight: bold">RFC 3447</span>)</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following signing algorithm:</p>
+      <ul>
+        <li>dsa (see <span style="font-weight: bold">Digital Signature Standard</span>)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>12.9.3 <a name="sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following public key formats:</p>
+      <ul>
+        <li>ssh-rsa</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following public key formats:</p>
+      <ul>
+        <li>ssh-dss</li>
+        <li>x509v3-sign-rsa (see <span class="ref" style="">X.509 Authentication in SSH2</span>  [<a href="#nt-id2264514">51</a>])</li>
+        <li>x509v3-sign-dss</li>
+        <li>pgp-sign-rsa</li>
+        <li>pgp-sign-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession MAY also support the following public key formats:</p>
+      <ul>
+        <li>spki-sign-rsa</li>
+        <li>spki-sign-dss</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>12.9.4 <a name="sec-mandatory-hash">Hash Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following hash algorithm:</p>
+      <ul>
+        <li>sha256 (see <span class="ref" style="">Secure Hash Standard</span>  [<a href="#nt-id2264591">52</a>])</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following hash algorithm (sha1 and md5 are NOT RECOMMENDED):</p>
+      <ul>
+        <li>whirlpool (see <span class="ref" style="">Whirlpool</span>  [<a href="#nt-id2264634">53</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>12.9.5 <a name="sec-mandatory-compress">Compression Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following compression algorithm:</p>
+      <ul>
+        <li>none (no compression, the output MUST be the same as the input)</li>
+      </ul>
+      <p class="" style="">Support for other algorithms is NOT RECOMMENDED since compression partially defeats the <a href="#reqs-repudiate">Repudiability</a> requirement of this JEP by making it more difficult for a third party (with some knowledge of the plaintext) to modify a transcript of an encrypted session in a meaningful way. However, encrypted content is pseudo-random and cannot be compressed, so, in those cases where bandwidth is severely constrained, an implementation of ESession MAY support the following algorithm to compress content before it is encrypted:</p>
+      <ul>
+        <li>zlib (see <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2264704">54</a>])</li>
+      </ul>
+    </div>
+  </div>
+<h2>13.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2264745">55</a>]. </p>
+<h2>14.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="registrar-ns">Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2264792">56</a>] shall register the following namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/esession</li>
+      <li>http://jabber.org/protocol/esession#init</li>
+      <li>http://jabber.org/protocol/esession#error</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>14.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2264853">57</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in <span style="font-style: italic">both</span> Encrypted Sessions and Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field
+      var='match_resource'
+      type='text-single'
+      label='Target resource for offline Esessions'/&gt;
+  &lt;field
+      var='modp'
+      type='list-single'
+      label='MODP group number'/&gt;
+  &lt;field
+      var='crypt_algs'
+      type='list-single'
+      label='Symmetric block cipher options'/&gt;
+  &lt;field
+      var='hash_algs'
+      type='list-single'
+      label='Hash algorithm options'/&gt;
+  &lt;field
+      var='compress'
+      type='list-single'
+      label='Compression algorithm options'/&gt;
+  &lt;field
+      var='stanzas'
+      type='list-multi'
+      label='Stanzas types to encrypt'/&gt;
+  &lt;field
+      var='secure'
+      type='boolean'
+      label='Require encrypted client-server streams'/&gt;
+  &lt;field
+      var='rekey_freq'
+      type='text-single'
+      label='Minimum number of stanzas between key exchanges'/&gt;
+  &lt;field
+      var='accept_pkids'
+      type='list-multi'
+      label='Acceptable public key IDs'/&gt;
+  &lt;field
+      var='counter'
+      type='hidden'
+      label='Initial block counter'/&gt;
+  &lt;field
+      var='key'
+      type='hidden'
+      label='Diffie-Hellman key'/&gt;
+  &lt;field
+      var='pkey'
+      type='hidden'
+      label='Public key'/&gt;
+  &lt;field
+      var='pkids'
+      type='list-single'
+      label='Public key IDs'/&gt;
+  &lt;field
+      var='signs'
+      type='list-single'
+      label='Data form signatures'/&gt;
+  &lt;field
+      var='prev_hash'
+      type='hidden'
+      label='HASH of previous data form'/&gt;
+&lt;/form_type&gt;
+
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;jep&gt;JEP-0155&lt;/jep&gt;
+  ...
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>15.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>16.
+       <a name="keys">Public Key Publication and Retrieval</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is highly preliminary and will be specified in a separate proposal before this document reaches draft status.</span></p>
+  <p class="" style="">Entities SHOULD publish their long-term public signature-verification keys to all entities through their own server using the disco#publish-info feature (as <a href="http://mail.jabber.org/pipermail/standards-jig/2005-July/008131.html">NOT SPECIFIED</a> in <span style="font-weight: bold">JEP-0030</span>).</p>
+
+  <p class="caption">Example 23. Entity Publishes Public Keys to Server</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='dp1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="" style="">Before initiating an ESession, if Bob does not already possess one of Alice's signature-verification keys, he SHOULD retrieve them from Alice's server.</p>
+  <p class="caption">Example 24. Bob Requests Public Keys from Alice's Server</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="caption">Example 25. Server Returns Public Keys</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='alice@example.org'
+    to='bob@example.com/laptop'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Bob should examine all the public keys and identify which ones are acceptable (see <a href="#sec-keys">Verifying Keys</a>).</p>
+<h2>17.
+       <a name="open">Open Issues</a>
+</h2>
+  <div class="indent">
+<h3>17.1 <a name="open-tothink">To Think About</a>
+</h3>
+    <ol start="" type="">
+      <li>Split Offline Esessions into another JEP?</li>
+      <li>Standardise on the X.509 public key and signature formats?</li>
+      <li>What challenges exist to make the OTR Gaim Plugin use this protocol natively when talking to Jabber entities? Can these be mitigated by 'non-critical' protocol changes?</li>
+      <li>Would anything in this protocol (e.g., its dependency on in-order stanza delivery) prevent an XMPP entity using it to exchange encrypted messages and presence with a user of a non-XMPP messaging system, assuming that the gateway both supports this protocol and is compatible with a purpose-built security plugin on the other user's client (e.g. a Gaim plugin connects to the gateway via a non-XMPP network)?</li>
+      <li>Could the protocol approximate SSH (or IPsec) more closely without losing the benefits of OTR?</li>
+      <li>Could use <span class="ref" style="">Flexible Offline Message Retrieval</span>  [<a href="#nt-id2265097">58</a>] (FOMR) instead of AMP to prevent any offline Esessions Bob can't decrypt being delivered to him. (Each &lt;item/&gt; that corresponds to an Esession message would have to contain a &lt;prev_hash/&gt; child, to allow Bob to discover via his stored HASHES which of his stored values of y was used to encrypt the message.)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>17.2 <a name="open-todo">To Do</a>
+</h3>
+    <ol start="" type="">
+      <li>Ask the authors of AMP to explain how to achieve the match_resource functionality to be specified here.</li>
+      <li>Separate public key publishing into another JEP. Should there be a disco item for each key?</li>
+      <li>Define names for X.509 SubjectPublicKeyInfo public key formats (different to X.509 certificates). This format must be used when keys are distributed within session initiation.</li>
+      <li>Add non-repudiable signing option</li>
+      <li>Move "secure" field to JEP-0155</li>
+      <li>Perhaps the JEP needs to specify more carefully how block counters are handled between messages, especially in the event of partial blocks?</li>
+      <li>Give examples of specific errors and discuss error scenarios throughout document (e.g., what should Bob do if he is not offline and he receives an offline key exchange stanza?).</li>
+      <li>Update Dependencies list</li>
+      <li>Define an <span style="font-style: italic">optional</span> protocol that would allow Bob to store y and HASHES (and the PKIDs he trusts) 'securely' on his own server (before he goes offline).</li>
+    </ol>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250835">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2250790">2</a>. RFC 3862: Common Presence and Instant Messaging (CPIM): Message Format &lt;<a href="http://www.ietf.org/rfc/rfc3862.txt">http://www.ietf.org/rfc/rfc3862.txt</a>&gt;.</p>
+<p><a name="nt-id2250818">3</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p><a name="nt-id2250566">4</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2250609">5</a>. Off-the-Record Communication, or, Why Not to Use PGP &lt;<a href="http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf">http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf</a>&gt;.</p>
+<p><a name="nt-id2250676">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250646">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256421">8</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2256470">9</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256493">10</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256529">11</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256558">12</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256688">13</a>. SSH Protocol Architecture &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256661">14</a>. SSH Transport Layer Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256898">15</a>. The reliable association between an entity and its public keys is beyond the scope of this JEP.</p>
+<p><a name="nt-id2256925">16</a>. Naturally, it is possible that Alice or Bob may retain cleartext versions of the exchanged communications; however, that threat is out of scope for this JEP.</p>
+<p><a name="nt-id2259458">17</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259484">18</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2259580">19</a>. RFC 2631: Diffie-Hellman Key Agreement Method &lt;<a href="http://www.ietf.org/rfc/rfc2631.txt">http://www.ietf.org/rfc/rfc2631.txt</a>&gt;.</p>
+<p><a name="nt-id2259646">20</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2259713">21</a>. RFC 2409: The Internet Key Exchange (IKE) &lt;<a href="http://www.ietf.org/rfc/rfc2409.txt">http://www.ietf.org/rfc/rfc2409.txt</a>&gt;.</p>
+<p><a name="nt-id2259736">22</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p><a name="nt-id2259813">23</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2259838">24</a>. The inclusion of a random element in Alice's Esession request will enable Alice to verify that Bob's response is not a 'replay'.</p>
+<p><a name="nt-id2250274">25</a>. RFC 3766: Determining Strengths For Public Keys Used For Exchanging Symmetric Keys &lt;<a href="http://www.ietf.org/rfc/rfc3766.txt">http://www.ietf.org/rfc/rfc3766.txt</a>&gt;.</p>
+<p><a name="nt-id2260372">26</a>. The private signing keys may only be accessible to another of Bob's clients.</p>
+<p><a name="nt-id2260380">27</a>. Some servers may not support public key publishing.</p>
+<p><a name="nt-id2260890">28</a>. The more often Bob changes his published Esession options, the shorter the Perfect Forward Secrecy window of vulnerability. However, whenever he changes them he divulges his presence to all the entities that are monitoring them.</p>
+<p><a name="nt-id2261339">29</a>. Alice only initializes Bob's block counter in case he needs to terminate the Esession.</p>
+<p><a name="nt-id2261648">30</a>. The HASH may not match if, for example, Bob went offline using a different client and/or a different machine without publishing a 'match_resource' field. If it does not match then Bob cannot decrypt the offline Esession.</p>
+<p><a name="nt-id2261664">31</a>. If Bob has no copy of the options he published then he cannot be sure that Alice chose from those options.</p>
+<p><a name="nt-id2261908">32</a>. K-M<span class="sub" style="">A</span> is a hash of K-C<span class="sub" style="">A</span> (not K) to ensure that if an attacker recovers the decryption key she will not be able to cryptographically convince anyone that it was not her who created the stanza.</p>
+<p><a name="nt-id2262113">33</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2262192">34</a>. Although counter mode encryption requires no padding, implementations MAY still disguise the length of m by appending a random number of white-space characters.</p>
+<p><a name="nt-id2262211">35</a>. If Bob were to receive a stanza out-of-order, then he would fail to decrypt the stanza and be forced to terminate the Esession.</p>
+<p><a name="nt-id2262253">36</a>. Recommendation for Block Cipher Modes of Operation: Federal Information Processing Standards Publication 800-38a &lt;<a href="http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf">http://csrc.nist.gov/publications/ nistpubs/800-38a/sp800-38a.pdf</a>&gt;.</p>
+<p><a name="nt-id2262441">37</a>. RFC 2104: HMAC: Keyed-Hashing for Message Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2104.txt">http://www.ietf.org/rfc/rfc2104.txt</a>&gt;.</p>
+<p><a name="nt-id2260693">38</a>. If Bob were to receive a stanza out-of-order, then the MACs would not match because the values of C<span class="sub" style="">A</span> would not be synchronized.</p>
+<p><a name="nt-id2262598">39</a>. Bob MUST NOT send a stream error to his server since intermediate entities are not responsible for encoded content.</p>
+<p><a name="nt-id2263143">40</a>. If an entity fails to receive any stanza that includes a new key in the correct order, then it will fail to decrypt the next stanza it receives and be forced to terminate the Esession.</p>
+<p><a name="nt-id2263350">41</a>. Content is specified for the &lt;terminate/&gt; element to facilitate <a href="#sign-normal">XML Normalization</a>.</p>
+<p><a name="nt-id2263537">42</a>. Canonical XML 1.0 &lt;<a href="http://www.w3.org/TR/xml-c14n">http://www.w3.org/TR/xml-c14n</a>&gt;.</p>
+<p><a name="nt-id2263662">43</a>. RFC 3447: Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography Specifications Version 2.1 &lt;<a href="http://www.ietf.org/rfc/rfc3447.txt">http://www.ietf.org/rfc/rfc3447.txt</a>&gt;.</p>
+<p><a name="nt-id2263715">44</a>. Digital Signature Standard: Federal Information Processing Standards Publication 186  &lt;<a href="http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf">http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf</a>&gt;.</p>
+<p><a name="nt-id2263895">45</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2263942">46</a>. SSH Transport Layer Encryption Modes &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-05.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-05.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2264270">47</a>. IANA registry of parameters related to secure shell &lt;<a href="http://www.iana.org/assignments/ssh-parameters">http://www.iana.org/assignments/ssh-parameters</a>&gt;.</p>
+<p><a name="nt-id2264318">48</a>. Advanced Encryption Standard: Federal Information Processing Standards Publication 197 &lt;<a href="http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf">http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf</a>&gt;.</p>
+<p><a name="nt-id2264362">49</a>. The Twofish Block Cipher &lt;<a href="http://www.schneier.com/twofish.html">http://www.schneier.com/twofish.html</a>&gt;.</p>
+<p><a name="nt-id2264399">50</a>. The Serpent Block Cipher &lt;<a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">http://www.cl.cam.ac.uk/~rja14/serpent.html</a>&gt;.</p>
+<p><a name="nt-id2264514">51</a>. X.509 Authentication in SSH2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2264591">52</a>. Secure Hash Standard: Federal Information Processing Standards Publication 180-2  &lt;<a href="http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf">http://csrc.nist.gov/publications/fips/fips180-2/fips186-2withchangenotice.pdf</a>&gt;.</p>
+<p><a name="nt-id2264634">53</a>. The Whirlpool Hash Function &lt;<a href="http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html">http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html</a>&gt;.</p>
+<p><a name="nt-id2264704">54</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2264745">55</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2264792">56</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2264853">57</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2265097">58</a>. JEP-0013: Flexible Offline Message Retrieval &lt;<a href="http://www.jabber.org/jeps/jep-0013.html">http://www.jabber.org/jeps/jep-0013.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2005-09-27)</h4>
+<div class="indent">Added diagramatic synopses; Added match_resource field; replaced req_mac and kid fields with prev_hash; Alice specifies initial counter (doubles as nonce); many other improvements (ip)
+    </div>
+<h4>Version 0.7 (2005-08-26)</h4>
+<div class="indent">Simplified XML normalization; added Synopsis and Efficiency requirement; defined signature formats (ip)
+    </div>
+<h4>Version 0.6 (2005-08-12)</h4>
+<div class="indent">Extended termination procedure; added object encryption/signing requirement and special case; clarified expired MAC publishing; added Flexible Offline Message Retrieval to Open Issues. (ip)
+    </div>
+<h4>Version 0.5 (2005-08-10)</h4>
+<div class="indent">Added flexibility requirement; added late signature of initial request; added termination MAC. (ip)
+    </div>
+<h4>Version 0.4 (2005-08-09)</h4>
+<div class="indent">Added (offline) replay protection; required offline Created header; compression is NOT RECOMMENDED; added second set of offline options for subscribers; added JIDs to session key generation; unencrypted sessions; added secure option; sign whole data form; HMAC whole &lt;encrypted/&gt; element; added Esession termination; option to distribute public keys within session initiation; added Integrity requirement; several clarifications (ip)
+    </div>
+<h4>Version 0.3 (2005-08-02)</h4>
+<div class="indent">Restored status to Experimental; complete rewrite; new Introduction, Background, Requirements and Security Considerations; new OTR-inspired protocol; JEP-0155-based negotiation; counter mode encryption; more secure hashes; offline sessions; re-keying; mac publishing; preliminary key and options publishing protocol. (ip/psa)
+    </div>
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0116-0.9.html
+++ b/content/xep-0116-0.9.html
@@ -1,0 +1,2408 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0116: Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Description" content="This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0116">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0116: Encrypted Sessions</h1>
+<p>This JEP specifies a protocol for session-based, end-to-end encryption of XMPP communications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0116<br>
+            Version: 0.9<br>
+            Last Updated: 2005-11-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2104, RFC 2409, RFC 3526, RFC 3548, xml-c14n, JEP-0004, JEP-0020, JEP-0030, JEP-0068, JEP-0079, JEP-0155, JEP-0163<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: esession<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Encrypted%20Sessions%20(JEP-0116)">http://wiki.jabber.org/index.php/Encrypted Sessions (JEP-0116)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>3.1.  <a href="#terms-personae">Dramatis Personae</a>
+</dt></dl>
+<dt>4.  <a href="#reqs">Requirements</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#reqs-sec">Security Requirements</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#reqs-encrypt">Confidentiality</a>
+</dt>
+<dt>4.1.2.  <a href="#reqs-integrity">Integrity</a>
+</dt>
+<dt>4.1.3.  <a href="#reqs-replay">Replay Protection</a>
+</dt>
+<dt>4.1.4.  <a href="#reqs-forward">Perfect Forward Secrecy</a>
+</dt>
+<dt>4.1.5.  <a href="#reqs-auth">Authentication</a>
+</dt>
+<dt>4.1.6.  <a href="#reqs-id-protect">Identity Protection</a>
+</dt>
+<dt>4.1.7.  <a href="#reqs-repudiate">Repudiability</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#reqs-xmpp">Application Requirements</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#reqs-generality">Generality</a>
+</dt>
+<dt>4.2.2.  <a href="#reqs-implement">Implementability</a>
+</dt>
+<dt>4.2.3.  <a href="#reqs-usable">Usability</a>
+</dt>
+<dt>4.2.4.  <a href="#reqs-efficient">Efficiency</a>
+</dt>
+<dt>4.2.5.  <a href="#reqs-flexible">Flexibility</a>
+</dt>
+<dt>4.2.6.  <a href="#reqs-usable">Interoperability</a>
+</dt>
+<dt>4.2.7.  <a href="#reqs-offline">Offline Sessions</a>
+</dt>
+<dt>4.2.8.  <a href="#reqs-offline">Object Encryption</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#foundations">Cryptographic Origins - SIGMA</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#foundations-parameters">SIGMA Parameter Descriptions</a>
+</dt>
+<dt>5.2.  <a href="#foundations-skeleton-i">SIGMA-I Overview</a>
+</dt>
+<dt>5.3.  <a href="#foundations-skeleton-r">SIGMA-R Overview</a>
+</dt>
+<dt>5.4.  <a href="#foundations-core-i">SIGMA-I Key Exchange</a>
+</dt>
+<dt>5.5.  <a href="#foundations-core-r">SIGMA-R Key Exchange</a>
+</dt>
+</dl>
+<dt>6.  <a href="#design">Cryptographic Design</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#design-parameters">ESession Parameter Descriptions</a>
+</dt>
+<dt>6.2.  <a href="#design-online-i">Online ESession-I Negotiation</a>
+</dt>
+<dt>6.3.  <a href="#design-online-r">Online ESession-R Negotiation</a>
+</dt>
+<dt>6.4.  <a href="#design-offline">Offline ESession Negotiation</a>
+</dt>
+</dl>
+<dt>7.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>8.  <a href="#init">ESession Negotiation</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#init-online">Online Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>8.1.1.  <a href="#init-online-request">ESession Request</a>
+</dt>
+<dt>8.1.2.  <a href="#init-online-bobprep">Diffie-Hellman Preparation (Bob)</a>
+</dt>
+<dt>8.1.3.  <a href="#init-keys">Generating Session Keys</a>
+</dt>
+<dt>8.1.4.  <a href="#init-hide">Hiding Identity</a>
+</dt>
+<dt>8.1.5.  <a href="#init-online-response">ESession Response</a>
+</dt>
+<dt>8.1.6.  <a href="#init-online-aliceprep">Diffie-Hellman Preparation (Alice)</a>
+</dt>
+<dt>8.1.7.  <a href="#init-online-bobid">Verifying Bob's Identity</a>
+</dt>
+<dt>8.1.8.  <a href="#init-online-complete">ESession Completion</a>
+</dt>
+</dl>
+<dt>8.2.  <a href="#init-offline">Offline Diffie-Hellman Key Exchange</a>
+</dt>
+<dl>
+<dt>8.2.1.  <a href="#init-offline-publish">Publishing ESession Options</a>
+</dt>
+<dt>8.2.2.  <a href="#init-offline-request">Requesting Offline ESession Options</a>
+</dt>
+<dt>8.2.3.  <a href="#init-offline-start">Starting an Offline ESession</a>
+</dt>
+<dt>8.2.4.  <a href="#init-offline-accept">Accepting Offline ESessions</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#exchange-separate">Encryptable Content</a>
+</dt>
+<dt>9.2.  <a href="#exchange-encrypt">Encryption</a>
+</dt>
+<dt>9.3.  <a href="#exchange-send">Sending an Encrypted Stanza</a>
+</dt>
+<dt>9.4.  <a href="#exchange-decrypt">Decryption</a>
+</dt>
+</dl>
+<dt>10.  <a href="#rekey">Re-Key Exchange</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#rekey-init">Re-Key Initiation</a>
+</dt>
+<dt>10.2.  <a href="#rekey-accept">Re-Key Acceptance</a>
+</dt>
+<dt>10.3.  <a href="#rekey-publish">Publishing Old MAC Values</a>
+</dt>
+</dl>
+<dt>11.  <a href="#terminate">ESession Termination</a>
+</dt>
+<dt>12.  <a href="#sign">Signature Generation and Verification</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#sign-normal">XML Normalization</a>
+</dt>
+<dt>12.2.  <a href="#sign-hash">Hash</a>
+</dt>
+<dt>12.3.  <a href="#sign-calc">Generation</a>
+</dt>
+<dl>
+<dt>12.3.1.  <a href="#sign-rsa-gen">RSA</a>
+</dt>
+<dt>12.3.2.  <a href="#sign-dsa-gen">DSA</a>
+</dt>
+</dl>
+<dt>12.4.  <a href="#sign-format">Signature Format</a>
+</dt>
+<dl>
+<dt>12.4.1.  <a href="#sign-rsa-format">RSA</a>
+</dt>
+<dt>12.4.2.  <a href="#sign-dsa-format">DSA</a>
+</dt>
+</dl>
+<dt>12.5.  <a href="#sign-calc">Verification</a>
+</dt>
+<dl>
+<dt>12.5.1.  <a href="#sign-rsa-verify">RSA</a>
+</dt>
+<dt>12.5.2.  <a href="#sign-dsa-verify">DSA</a>
+</dt>
+</dl>
+</dl>
+<dt>13.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#sec-prng">Random Numbers</a>
+</dt>
+<dt>13.2.  <a href="#sec-rekey">Re-Keying Limits</a>
+</dt>
+<dt>13.3.  <a href="#sec-keys">Verifying Keys</a>
+</dt>
+<dt>13.4.  <a href="#sec-replay">Replay Attacks</a>
+</dt>
+<dt>13.5.  <a href="#sec-offline">Offline ESessions</a>
+</dt>
+<dt>13.6.  <a href="#sec-unencrypted">Unencrypted ESessions</a>
+</dt>
+<dt>13.7.  <a href="#sec-storage">Storage</a>
+</dt>
+<dt>13.8.  <a href="#sec-general">Extra Responsabilities of Implementors</a>
+</dt>
+<dt>13.9.  <a href="#sec-mandatory">Mandatory to Implement Technologies</a>
+</dt>
+<dl>
+<dt>13.9.1.  <a href="#sec-mandatory-encryption">Block Cipher Algorithms</a>
+</dt>
+<dt>13.9.2.  <a href="#sec-mandatory-sign">Key Signing Algorithms</a>
+</dt>
+<dt>13.9.3.  <a href="#sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</dt>
+<dt>13.9.4.  <a href="#sec-mandatory-hash">Hash Algorithms</a>
+</dt>
+<dt>13.9.5.  <a href="#sec-mandatory-compress">Compression Algorithms</a>
+</dt>
+</dl>
+</dl>
+<dt>14.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>15.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#registrar-ns">Namespaces</a>
+</dt>
+<dt>15.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>16.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>17.  <a href="#acknowledgments">Acknowledgments</a>
+</dt>
+<dt>18.  <a href="#keys">Public Key Publication and Retrieval</a>
+</dt>
+<dt>19.  <a href="#open">Open Issues</a>
+</dt>
+<dl>
+<dt>19.1.  <a href="#open-tothink">To Think About</a>
+</dt>
+<dt>19.2.  <a href="#open-todo">To Do</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">End-to-end encryption is a desirable feature for any communication technology. Ideally, such a technology would design encryption in from the beginning and would forbid unencrypted communications. Realistically, most communication technologies have not been designed in that manner, and Jabber/XMPP technologies are no exception. In particular, the original Jabber technologies developed in 1999 did not include end-to-end encryption by default. PGP-based encryption of message bodies and signing of presence information was added as an extension to the core protocols in the year 2000; this extension is documented in <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2250801">1</a>]. When the core protocols were formalized within the Internet Standards Process by the IETF's XMPP Working Group in 2003, a different extension was defined using S/MIME-based signing and encryption of CPIM-formatted messages (see <span class="ref" style="">RFC 3862</span>  [<a href="#nt-id2250832">2</a>]) and PIDF-formatted presence information (see <span class="ref" style="">RFC 3863</span>  [<a href="#nt-id2250855">3</a>]); this extension is specified in <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2250878">4</a>].</p>
+  <p class="" style="">For reasons described more fully below, the foregoing proposals (and others not mentioned) have not been widely implemented and deployed. This is unfortunate, since an open communication protocol needs to enable end-to-end encryption in order to be seriously considered for deployment by a broad range of users.</p>
+  <p class="" style="">This proposal describes a different approach to end-to-end encryption for use by entities that communicate using XMPP. The conceptual model for this encrypted sessions or "ESessions" approach was inspired by "off-the-record" (OTR) communication, as implemented in the Gaim encryption plugin and described in <span class="ref" style="">Off-the-Record Communication</span>  [<a href="#nt-id2250926">5</a>].</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">As specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250961">6</a>], XMPP is an XML streaming protocol that enables the near-real-time exchange of XML fragments between any two (or more) network endpoints. To date, the main application built on top of the core XML streaming layer is instant messaging (IM) and presence, the base extensions for which are specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2256505">7</a>]. There are three first-level elements of XML streams (&lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;); each of these "XML stanza" types has different semantics, which can complicate the task of defining a generalized approach to end-to-end encryption for XMPP. In addition, XML stanzas can be extended (via properly-namespaced child elements) for a wide variety of functionality. The chosen approach should enable encryption of several complete XML elements rather than only parts thereof (e.g., only the XML character data of the message &lt;body/&gt; element as in <span style="font-weight: bold">JEP-0027</span>).</p>
+  <p class="" style="">XMPP is a session-oriented communication technology: normally, a client authenticates with a server and maintains a long-lived connection that defines the client's XMPP session. Such stream-level sessions are secured via channel encryption using Transport Level Security (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2256558">8</a>]), as specified in Section 5 of <span style="font-weight: bold">RFC 3920</span>. However, there is no guarantee that all hops will implement or enforce channel encryption (or that intermediate routers are trustworthy), which makes end-to-end encryption desirable.</p>
+  <p class="" style="">The session metaphor also applies to communication between endpoints: for instance, in IM applications, most instant messaging exchanges occur in bursts within limited time periods (e.g., two people may send a fairly large number of messages during a five-minute chat and then not exchange messages again for hours or even days). The XML stanzas exchanged during such a session may not be limited to &lt;message/&gt; stanzas; for instance, the session may be triggered by a change in one of the parties' presence status (e.g., changing from away to available) and the session may involve the exchange of &lt;iq/&gt; stanzas (e.g., to transfer a file as specified in <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256605">9</a>]). Endpoints may want to encrypt the stanzas they send to each other in such a way that the stanzas cannot be understood by untrusted mediating entities (such as servers) except to the extent required to understand the necessary routing information. (One complicating factor is that routing information may include not only the stanza's 'to', 'from', 'type, and 'id' attributes, but also <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256626">10</a>] extensions.)</p>
+  <p class="" style="">The foregoing XMPP communications exist in the context of a one-to-one communication session between two entities. However, several forms of XMPP communication exist outside the context of one-to-one communication sessions:</p>
+  <ul>
+    <li>Many-to-many sessions, such as a text conference in a chatroom as specified in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256662">11</a>].</li>
+    <li>One-to-many "broadcast", such as undirected presence stanzas sent from one user to many contacts (see <span style="font-weight: bold">RFC 3921</span>) and data syndication implemented using <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256691">12</a>].</li>
+    <li>One-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</li>
+  </ul>
+  <p class="" style="">Ideally, any technology for end-to-end encryption in XMPP could be extended to cover these scenarios as well as one-to-one communication sessions. However, both many-to-many sessions and one-to-many broadcast are deemed out of scope for this JEP. Offline communications are handled via a simple extension to the protocol for one-to-one sessions between two entities that are online simultaneously (see below).</p>
+  <p class="" style="">Because XMPP is a session-oriented communication technology, encryption schemes that are appropriate for less dynamic technologies may not be appropriate for XMPP. XMPP, with its in-order delivery of XML stanzas, is able to take advantage of encryption approaches that are not feasible for less dynamic technologies. In particular, existing approaches to encryption of Internet communications have generally assumed that the "thing" to be encrypted has a stable identity or is best understood as a standalone object (e.g., a file or email message); the term "object encryption" well captures this assumption. Both <span style="font-weight: bold">JEP-0027</span> and <span style="font-weight: bold">RFC 3923</span> assume that XMPP communications are more like the exchange of email messages than they are like an interactive session -- while <span style="font-weight: bold">JEP-0027</span> uses "old-style" PGP object encryption and <span style="font-weight: bold">RFC 3923</span> uses "new-style" S/MIME object encryption, both specify the use of object encryption. </p>
+  <p class="" style="">However, the session-oriented nature of XMPP may imply that the focus should be on "session encryption" rather than "object encryption". The paradigm for XMPP encryption may be something closer to the widely-deployed Secure Shell technology (see <span class="ref" style="">SSH Protocol Architecture</span>  [<a href="#nt-id2256793">13</a>] and <span class="ref" style="">SSH Transport Layer Protocol</span>  [<a href="#nt-id2256814">14</a>]) than to traditional encryption of files and standalone email messages.</p>
+  <p class="" style="">Therefore, this JEP specifies a method for encrypted sessions ("ESessions") that takes advantage of the inherent possibilities and strengths of session encryption as opposed to object encryption. The basic concept is that of an encrypted session which acts as a secure tunnel between two endpoints. Once the tunnel is established, the content of all one-to-one XML stanzas exchanged between the endpoints will be encrypted and then transmitted within a "wrapper" protocol element.</p>
+<h2>3.
+       <a name="terms">Terminology</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="terms-personae">Dramatis Personae</a>
+</h3>
+    <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+    <ol start="1" type="">
+      <li>"Alice" is the name of the initiator of the ESession. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+      <li>"Bob" is the name of the other participant in the ESession started by Alice. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    </ol>
+    <p class="" style="">While Alice and Bob are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an ESession.</p>
+  </div>
+<h2>4.
+       <a name="reqs">Requirements</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="reqs-sec">Security Requirements</a>
+</h3>
+    <p class="" style="">This JEP stipulates the following security requirements for end-to-end encryption of XMPP communications:</p>
+    <ul>
+      <li>Confidentiality</li>
+      <li>Integrity</li>
+      <li>Replay protection</li>
+      <li>Perfect forward secrecy</li>
+      <li>Authentication</li>
+      <li>Identity Protection</li>
+      <li>Repudiability</li>
+    </ul>
+    <p class="" style="">Each of these requirements is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.1.1 <a name="reqs-encrypt">Confidentiality</a>
+</h3>
+      <p class="" style="">The one-to-one XML stanzas exchanged between two entities MUST NOT be understandable to any other entity that might intercept the communications.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="reqs-integrity">Integrity</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be sure that no other entity may change the content of the XML stanzas they exchange, or remove or insert stanzas into the ESession undetected.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.3 <a name="reqs-replay">Replay Protection</a>
+</h3>
+      <p class="" style="">Alice or Bob MUST be able to identify and reject any communications that are copies of their previous communications resent by another entity.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.4 <a name="reqs-forward">Perfect Forward Secrecy</a>
+</h3>
+      <p class="" style="">The encrypted communication MUST NOT be revealed even if long-lived keys are compromised in the future (e.g., Steve steals Bob's computer).</p>
+    </div>
+    <div class="indent">
+<h3>4.1.5 <a name="reqs-auth">Authentication</a>
+</h3>
+      <p class="" style="">Each party to a conversation MUST know that the other party is who he says he is (Alice must be able to know that Bob really is Bob, and vice versa).  [<a href="#nt-id2257044">15</a>]</p>
+    </div>
+    <div class="indent">
+<h3>4.1.6 <a name="reqs-id-protect">Identity Protection</a>
+</h3>
+      <p class="" style="">No other entity should be able to identify Alice or Bob. The JIDs they use to route their stanzas are unavoidably vulnerable to interception. However, the public keys they use SHOULD NOT be revealed to other entities using a passive attack. Bob SHOULD also be able to choose between protecting either his public key or Alice's public key from disclosure through active ("man-in-the-middle") attacks.</p>
+    </div>
+    <div class="indent">
+<h3>4.1.7 <a name="reqs-repudiate">Repudiability</a>
+</h3>
+      <p class="" style="">Alice and Bob MUST be able to repudiate any stanza that occurs within an ESession. After an ESession has finished, it SHOULD NOT be possible to <span style="font-style: italic">prove cryptographically</span> that any transcript has not been modified by a third party.  [<a href="#nt-id2257094">16</a>]</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="reqs-xmpp">Application Requirements</a>
+</h3>
+    <p class="" style="">In addition to the foregoing security profile, this JEP also stipulates the following application-specific requirements for encrypted communication in the context of Jabber/XMPP technologies:</p>
+    <ul>
+      <li>Generality</li>
+      <li>Implementability</li>
+      <li>Usability</li>
+      <li>Efficiency</li>
+      <li>Flexibility</li>
+      <li>Interoperability</li>
+      <li>Offline "sessions"</li>
+      <li>Object encryption</li>
+    </ul>
+    <p class="" style="">Each of these is explained in greater depth below.</p>
+    <div class="indent">
+<h3>4.2.1 <a name="reqs-generality">Generality</a>
+</h3>
+      <p class="" style="">The solution should be generally applicable to any XML stanza type (&lt;message/&gt;, &lt;presence/&gt;, &lt;iq/&gt;) sent between two entities. It is deemed acceptable for now if the solution does not apply to many-to-many stanzas (e.g., groupchat messages sent within the context of multi-user chat) or one-to-many stanzas (e.g., presence "broadcasts" and pubsub notifications); end-to-end encryption of such stanzas may require separate solutions or extensions to the one-to-one session solution.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="reqs-implement">Implementability</a>
+</h3>
+      <p class="" style="">The only good security technology is an implemented security technology. The solution should be one that typical client developers can implement in a relatively straightforward and interoperable fashion.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="reqs-usable">Usability</a>
+</h3>
+      <p class="" style="">The requirement of usability takes implementability one step further by stipulating that the solution must be one that organizations may deploy and humans may use with 100% transparency (with the ease-of-use of https:). Experience has shown that: solutions requiring a full public key infrastructure do not get widely deployed, and solutions requiring any user action are not widely used. We can do better.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.4 <a name="reqs-efficient">Efficiency</a>
+</h3>
+      <p class="" style="">Cryptographic operations are highly CPU intensive, particularly public key and Diffie-Hellman operations. Cryptographic data structures can be relatively large especially public keys and certificates. The solution should perform efficiently even when CPU and network bandwidth are constrained. The number of stanzas required for ESession negotiation should be minimized.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.5 <a name="reqs-flexible">Flexibility</a>
+</h3>
+      <p class="" style="">The solution should be compatible with existing (and future) cryptographic algorithms and identity certification schemes (including X.509 and PGP). The protocol should also be able to evolve to correct the weaknesses that are inevitably discovered once any cryptographic protocol is in widespread use.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.6 <a name="reqs-usable">Interoperability</a>
+</h3>
+      <p class="" style="">Ideally, it would be possible for an XMPP user to exchange encrypted messages (and, potentially, presence information) with users of non-XMPP messaging systems.</p>
+    </div>
+    <div class="indent">
+<h3>4.2.7 <a name="reqs-offline">Offline Sessions</a>
+</h3>
+      <p class="" style="">Ideally, it should be possible to encrypt one-to-one communications that are stored for later delivery rather than delivered immediately, such as so-called "offline messages".</p>
+    </div>
+    <div class="indent">
+<h3>4.2.8 <a name="reqs-offline">Object Encryption</a>
+</h3>
+      <p class="" style="">For cases where a session is not desired, it should be possible to encrypt, sign and send a single stanza in isolation, so-called "object encryption".</p>
+    </div>
+  </div>
+<h2>5.
+       <a name="foundations">Cryptographic Origins - SIGMA</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: Implementors of ESessions may ignore this section since it is purely informative.</span></p>
+  <p class="" style="">Authenticated key-exchange is the most challenging part of the design of any secure communication protocol. The ESessions key exchange essentially translates the <span class="ref" style="">SIGMA</span>  [<a href="#nt-id2250414">17</a>] [<a href="#nt-id2250401">18</a>] key-exchange protocol into the syntax of XMPP. This section provides an overview of SIGMA. The SIGMA approach underpins several standard key-exchange protocols including the Internet Key Exchange (IKE) protocol versions 1 and 2 (see <span class="ref" style="">RFC 2409</span>  [<a href="#nt-id2257553">19</a>] and <span class="ref" style="">IKEv2</span>  [<a href="#nt-id2257575">20</a>]).</p>
+  <p class="" style="">The 3-message SIGMA-I-based key exchange protects the identity of the <span style="font-style: italic">initiator</span> against active attacks. The 4-message SIGMA-R-based key exchange defends the <span style="font-style: italic">responder's</span> identity against active attacks. The differences between the two versions of the SIGMA protocol are highlighted in the diagrams.</p>
+  <div class="indent">
+<h3>5.1 <a name="foundations-parameters">SIGMA Parameter Descriptions</a>
+</h3>
+    <p class="caption">Table 1: SIGMA Overview Parameters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Parameter</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">g</td>
+        <td align="" colspan="" rowspan="">Diffie-Hellman generator</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">x, y</td>
+        <td align="" colspan="" rowspan="">Alice and Bob's private Diffie-Hellman keys</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">g<span class="super" style="">x</span>, g<span class="super" style="">y</span>
+</td>
+        <td align="" colspan="" rowspan="">Alice and Bob's public Diffie-Hellman keys</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">KS<span class="sub" style="">A</span>, KS<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The MAC keys that Alice and Bob use to calculate mac<span class="sub" style="">A</span> and mac<span class="sub" style="">B</span>
+</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">pubKey<span class="sub" style="">A</span>, pubKey<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The public keys that represent the identity of Alice and Bob, and are used to verify their signatures</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">mac<span class="sub" style="">A</span>, mac<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The MAC values that associate the shared secret with the identity of Alice or Bob</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">signKey<span class="sub" style="">A</span>, signKey<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The private keys that Alice and Bob use to sign</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">sign<span class="sub" style="">A</span>, sign<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">Alice's and Bob's signatures of the shared secret</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">KC<span class="sub" style="">A</span>, KC<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The cipher keys that Alice and Bob use to encrypt</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ID<span class="sub" style="">A</span>, ID<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The encrypted parameters that identify Alice and Bob to each other</td>
+      </tr>
+    </table>
+    <p class="caption">Table 2: Key Exchange Parameters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Parameter</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">p</td>
+        <td align="" colspan="" rowspan="">Diffie-Hellman prime</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">e, d</td>
+        <td align="" colspan="" rowspan="">Alice and Bob's public Diffie-Hellman keys (the same as g<span class="super" style="">x</span>, g<span class="super" style="">y</span>)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">K</td>
+        <td align="" colspan="" rowspan="">Shared secret</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">HASH</td>
+        <td align="" colspan="" rowspan="">Selected hash algorithm</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">Alice and Bob's session freshness nonces (ESession IDs)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">C<span class="sub" style="">A</span>, C<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">Block cipher initial counter value for blocks sent by Alice and Bob</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">n</td>
+        <td align="" colspan="" rowspan="">Block size of selected cipher algorithm in bits</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">KM<span class="sub" style="">A</span>, KM<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The MAC keys that Alice and Bob use to protect the integrity of encrypted data</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">M<span class="sub" style="">A</span>, M<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The MAC values that Alice and Bob use to confirm the integrity of encrypted data</td>
+      </tr>
+    </table>
+  </div>
+
+  <div class="indent">
+<h3>5.2 <a name="foundations-skeleton-i">SIGMA-I Overview</a>
+</h3>
+    <p class="" style="">The diagram below demonstrates the barest cryptographic skeleton of the SIGMA-I key exchange protocol. Here Bob allows Alice to protect her identity from active attacks, by allowing her to authenticate him before she communicates her identity. Note: The cipher keys (KC<span class="sub" style="">A</span> and KC<span class="sub" style="">B</span>) are different in each direction, making this exchange slightly more conservative than <span style="font-weight: bold">SIGMA</span>.</p>
+    <pre>
+<span style="font-weight: bold">ALICE</span>                                                <span style="font-weight: bold">BOB</span> 
+                                            g<span class="super" style="">x</span>
+                                      ------------&gt;
+
+                                                     mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(KS<span class="sub" style="">B</span>, {g<span class="super" style="">x</span>, g<span class="super" style="">y</span>, pubKey<span class="sub" style="">B</span>})
+                                                     sign<span class="sub" style="">B</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+                                                     ID<span class="sub" style="">B</span> = <span style="font-style: italic">cipher</span>(KC<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})
+                                         g<span class="super" style="">y</span>, ID<span class="sub" style="">B</span> 
+                                      &lt;------------
+
+<span style="font-style: italic">authenticate</span>(ID<span class="sub" style="">B</span>) 
+mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(KS<span class="sub" style="">A</span>, {g<span class="super" style="">y</span>, g<span class="super" style="">x</span>, pubKey<span class="sub" style="">A</span>})
+sign<span class="sub" style="">A</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+ID<span class="sub" style="">A</span> = <span style="font-style: italic">cipher</span>(KC<span class="sub" style="">A</span>, {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>})
+                                            ID<span class="sub" style="">A</span>
+                                      ------------&gt;
+
+                                                     <span style="font-style: italic">authenticate</span>(ID<span class="sub" style="">A</span>)
+    </pre>
+  </div>
+
+  <div class="indent">
+<h3>5.3 <a name="foundations-skeleton-r">SIGMA-R Overview</a>
+</h3>
+    <p class="" style="">The logic of the SIGMA-R protocol is similar to the SIGMA-I protocol. The diagram below demonstrates the skeleton of the key exchange. After receiving the first message from Alice, Bob chooses to protect his identity from active attacks by by delaying communicating his identity to Alice until he has authenticated her.</p>
+    <pre>
+<span style="font-weight: bold">ALICE</span>                                                <span style="font-weight: bold">BOB</span> 
+                                            g<span class="super" style="">x</span>
+                                      ------------&gt;
+
+                                                     mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(KS<span class="sub" style="">B</span>, {g<span class="super" style="">x</span>, g<span class="super" style="">y</span>, pubKey<span class="sub" style="">B</span>})
+                                                     sign<span class="sub" style="">B</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+                                                     ID<span class="sub" style="">B</span> = <span style="font-style: italic">cipher</span>(KC<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})
+                                            g<span class="super" style="">y</span>
+                                      &lt;------------
+
+mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(KS<span class="sub" style="">A</span>, {g<span class="super" style="">y</span>, g<span class="super" style="">x</span>, pubKey<span class="sub" style="">A</span>})
+sign<span class="sub" style="">A</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+ID<span class="sub" style="">A</span> = <span style="font-style: italic">cipher</span>(KC<span class="sub" style="">A</span>, {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>})
+                                           ID<span class="sub" style="">A</span>
+                                      ------------&gt;
+
+                                                     <span style="font-style: italic">authenticate</span>(ID<span class="sub" style="">A</span>)
+                                           ID<span class="sub" style="">B</span>
+                                      &lt;------------
+
+<span style="font-style: italic">authenticate</span>(ID<span class="sub" style="">B</span>)
+    </pre>
+    <p class="" style="">Note: In practice, Bob could delay calculating ID<span class="sub" style="">B</span> until after he has authenticated ID<span class="sub" style="">A</span>.</p>
+  </div>
+
+  <div class="indent">
+<h3>5.4 <a name="foundations-core-i">SIGMA-I Key Exchange</a>
+</h3>
+    <p class="" style="">The diagram below describes exactly the same SIGMA-I key exchange protocol as the <a href="#foundations-skeleton-i">SIGMA-I skeleton</a> above. It provides much more detail, without specifying any ESession-specific details. Note: The block cipher function, <span style="font-style: italic">cipher</span>, uses CTR mode.</p>
+    <pre>
+<span style="font-weight: bold">ALICE</span>                                        <span style="font-weight: bold">BOB</span> 
+
+x = <span style="font-style: italic">random</span>()
+e = g<span class="super" style="">x</span> mod p
+N<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+                                 e, N<span class="sub" style="">A</span>
+                             ------------&gt;
+                                             C<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+                                             y = <span style="font-style: italic">random</span>()
+                                             d = g<span class="super" style="">y</span> mod p
+                                             C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+                                             <span style="font-style: italic">assert</span> 1 &lt; e &lt; p-1
+                                             K = HASH(e<span class="super" style="">y</span> mod p)
+                                             KC<span class="sub" style="">A</span> = HASH(0, K)
+                                             KC<span class="sub" style="">B</span> = HASH(1, K)
+                                             KM<span class="sub" style="">A</span> = HASH(2, K)
+                                             KM<span class="sub" style="">B</span> = HASH(3, K)
+                                             KS<span class="sub" style="">A</span> = HASH(4, K)
+                                             KS<span class="sub" style="">B</span> = HASH(5, K)
+                                             N<span class="sub" style="">B</span> = <span style="font-style: italic">random</span>()
+                                             mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, C<span class="sub" style="">A</span>})
+                                             sign<span class="sub" style="">B</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+                                             ID<span class="sub" style="">B</span> = <span style="font-style: italic">cipher</span>(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})
+                                             M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+                               d, C<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>
+                             &lt;------------
+                                ID<span class="sub" style="">B</span>, M<span class="sub" style="">B</span> 
+C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+<span style="font-style: italic">assert</span> 1 &lt; d &lt; p-1
+K = HASH(d<span class="super" style="">x</span> mod p)
+KC<span class="sub" style="">A</span> = HASH(0, K)
+KC<span class="sub" style="">B</span> = HASH(1, K)
+KM<span class="sub" style="">A</span> = HASH(2, K)
+KM<span class="sub" style="">B</span> = HASH(3, K)
+KS<span class="sub" style="">A</span> = HASH(4, K)
+KS<span class="sub" style="">B</span> = HASH(5, K)
+<span style="font-style: italic">assert</span> M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+{pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>} = <span style="font-style: italic">decipher</span>(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, C<span class="sub" style="">A</span>})
+<span style="font-style: italic">verify</span>(sign<span class="sub" style="">B</span>, pubKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>) 
+mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>})
+sign<span class="sub" style="">A</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+ID<span class="sub" style="">A</span> = <span style="font-style: italic">cipher</span>(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>})
+M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                  ID<span class="sub" style="">A</span>
+                             ------------&gt;
+                                   M<span class="sub" style="">A</span> 
+                                             <span style="font-style: italic">assert</span> M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                             {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>} = <span style="font-style: italic">decipher</span>(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                             mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>})
+                                             <span style="font-style: italic">verify</span>(sign<span class="sub" style="">A</span>, pubKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+    </pre>
+  </div>
+
+  <div class="indent">
+<h3>5.5 <a name="foundations-core-r">SIGMA-R Key Exchange</a>
+</h3>
+    <p class="" style="">The diagram below describes exactly the same SIGMA-R key exchange protocol as the <a href="#foundations-skeleton-r">SIGMA-R skeleton</a> above. It provides much more detail, without specifying any ESession-specific details. Note: The block cipher function, <span style="font-style: italic">cipher</span>, uses CTR mode.</p>
+    <pre>
+<span style="font-weight: bold">ALICE</span>                                        <span style="font-weight: bold">BOB</span> 
+
+x = <span style="font-style: italic">random</span>()
+e = g<span class="super" style="">x</span> mod p
+N<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+                                 e, N<span class="sub" style="">A</span>
+                             ------------&gt;
+                                             C<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+                                             y = <span style="font-style: italic">random</span>()
+                                             d = g<span class="super" style="">y</span> mod p
+                                             C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+                                             <span style="font-style: italic">assert</span> 1 &lt; e &lt; p-1
+                                             K = HASH(e<span class="super" style="">y</span> mod p)
+                                             KC<span class="sub" style="">A</span> = HASH(0, K)
+                                             KC<span class="sub" style="">B</span> = HASH(1, K)
+                                             KM<span class="sub" style="">A</span> = HASH(2, K)
+                                             KM<span class="sub" style="">B</span> = HASH(3, K)
+                                             KS<span class="sub" style="">A</span> = HASH(4, K)
+                                             KS<span class="sub" style="">B</span> = HASH(5, K)
+                                             N<span class="sub" style="">B</span> = <span style="font-style: italic">random</span>()
+                                             mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, C<span class="sub" style="">A</span>})
+                                             sign<span class="sub" style="">B</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+                                             ID<span class="sub" style="">B</span> = <span style="font-style: italic">cipher</span>(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})
+                                             M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+                               d, C<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>
+                             &lt;------------
+C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+<span style="font-style: italic">assert</span> 1 &lt; d &lt; p-1
+K = HASH(d<span class="super" style="">x</span> mod p)
+KC<span class="sub" style="">A</span> = HASH(0, K)
+KC<span class="sub" style="">B</span> = HASH(1, K)
+KM<span class="sub" style="">A</span> = HASH(2, K)
+KM<span class="sub" style="">B</span> = HASH(3, K)
+KS<span class="sub" style="">A</span> = HASH(4, K)
+KS<span class="sub" style="">B</span> = HASH(5, K)
+mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>})
+sign<span class="sub" style="">A</span> = <span style="font-style: italic">sign</span>(signKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+ID<span class="sub" style="">A</span> = <span style="font-style: italic">cipher</span>(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>})
+M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                  ID<span class="sub" style="">A</span>
+                             ------------&gt;
+                                   M<span class="sub" style="">A</span> 
+                                             <span style="font-style: italic">assert</span> M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                             {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>} = <span style="font-style: italic">decipher</span>(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                             mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>})
+                                             <span style="font-style: italic">verify</span>(sign<span class="sub" style="">A</span>, pubKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+                                  ID<span class="sub" style="">B</span>
+                             &lt;------------
+                                   M<span class="sub" style="">B</span> 
+
+<span style="font-style: italic">assert</span> M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+{pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>} = <span style="font-style: italic">decipher</span>(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, C<span class="sub" style="">A</span>})
+<span style="font-style: italic">verify</span>(sign<span class="sub" style="">B</span>, pubKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+    </pre>
+  </div>
+<h2>6.
+       <a name="design">Cryptographic Design</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: Implementors of ESessions may ignore this section since it is purely informative.</span></p>
+  <p class="" style="">This section provides an overview of the full ESession key-exchange protocol from a cryptographic point of view. This protocol is based on the <span style="font-style: italic">full fledge</span> protocol, as described in Appendix B of the <span style="font-weight: bold">SIGMA</span> paper. It also uses <span style="font-style: italic">variant (ii)</span>, as described in Secion 5.4 of the same paper.</p>
+  <div class="indent">
+<h3>6.1 <a name="design-parameters">ESession Parameter Descriptions</a>
+</h3>
+    <p class="" style="">The table below describes the parameters that are not found in the <a href="#foundations-parameters">Parameter Descriptions</a> tables at the start of the previous section.</p>
+    <p class="caption">Table 3: ESession Negotiation Parameters</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Parameter</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">options</td>
+        <td align="" colspan="" rowspan="">Includes a set of possible values for each ESession parameter (see <a href="#init-online-request">ESession Request</a>)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">chosen</td>
+        <td align="" colspan="" rowspan="">Includes a chosen value for each ESession parameter</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">CIPHER</td>
+        <td align="" colspan="" rowspan="">Selected CTR-mode block cipher algorithm</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">DECIPHER</td>
+        <td align="" colspan="" rowspan="">Selected CTR-mode block decipher algorithm (corresponds to CIPHER)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">SIGN</td>
+        <td align="" colspan="" rowspan="">Selected signature algorithm</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">VERIFY</td>
+        <td align="" colspan="" rowspan="">The selected signature verification algorithm (corresponds to SIGN)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">x<span class="sub" style="">1</span>...x<span class="sub" style="">Z</span>
+</td>
+        <td align="" colspan="" rowspan="">Alice's private Diffie-Hellman keys - each value corresponds to one of Z different DH groups</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">e<span class="sub" style="">1</span>...e<span class="sub" style="">Z</span>
+</td>
+        <td align="" colspan="" rowspan="">The choice of public Diffie-Hellman keys that Alice offers Bob - each value corresponds to one of Z different DH groups (and a different value of x)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">*signKeys<span class="sub" style="">A</span>
+</td>
+        <td align="" colspan="" rowspan="">All the private keys that Alice is able to use to create signatures</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">*signs<span class="sub" style="">B</span>
+</td>
+        <td align="" colspan="" rowspan="">The set of signatures of form<span class="sub" style="">B</span> (one for each of Bob's private keys)</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">*pubKeys<span class="sub" style="">A</span>
+</td>
+        <td align="" colspan="" rowspan="">The IDs of all the public keys that Alice can sign for</td>
+      </tr>
+    </table>
+    <p class="" style="">* Offline negotiation only</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="design-online-i">Online ESession-I Negotiation</a>
+</h3>
+    <p class="" style="">Alice uses this protocol when Bob is Online. In addition to the key exchange described in the <a href="#foundations-core-i">SIGMA-I Key Exchange</a> protocol above, she offers Bob a choice of Diffie-Hellman groups with her corresponding values of e, various algorithms and other parameters.</p>
+    
+    <pre>
+<span style="font-weight: bold">ALICE</span>                                    <span style="font-weight: bold">BOB</span> 
+
+<span style="font-style: italic">for</span> g,p ∈ options
+    x = <span style="font-style: italic">random</span>()
+    e = g<span class="super" style="">x</span> mod p
+N<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+form<span class="sub" style="">A</span> = {e<span class="sub" style="">1</span>...e<span class="sub" style="">Z</span>, options, N<span class="sub" style="">A</span>}
+                                form<span class="sub" style="">A</span>
+                             ---------&gt;
+
+                                         chosen = {p,g,HASH,CIPHER,SIGN...} = <span style="font-style: italic">choose</span>(options)
+                                         e = <span style="font-style: italic">choose</span>(e<span class="sub" style="">1</span>...e<span class="sub" style="">Z</span>, p)
+                                         C<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+                                         y = <span style="font-style: italic">random</span>()
+                                         d = g<span class="super" style="">y</span> mod p
+                                         C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+                                         <span style="font-style: italic">assert</span> 1 &lt; e &lt; p-1
+                                         K = HASH(e<span class="super" style="">y</span> mod p)
+                                         KC<span class="sub" style="">A</span> = HASH(0, K)
+                                         KC<span class="sub" style="">B</span> = HASH(1, K)
+                                         KM<span class="sub" style="">A</span> = HASH(2, K)
+                                         KM<span class="sub" style="">B</span> = HASH(3, K)
+                                         KS<span class="sub" style="">A</span> = HASH(4, K)
+                                         KS<span class="sub" style="">B</span> = HASH(5, K)
+                                         N<span class="sub" style="">B</span> = <span style="font-style: italic">random</span>()
+                                         form<span class="sub" style="">B</span> = {C<span class="sub" style="">A</span>, chosen, d, N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>}
+                                         mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})
+                                         sign<span class="sub" style="">B</span> = SIGN(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+                                         ID<span class="sub" style="">B</span> = CIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})
+                                         M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+                                form<span class="sub" style="">B</span>
+                             &lt;---------
+                               ID<span class="sub" style="">B</span>, M<span class="sub" style="">B</span> 
+<span style="font-style: italic">assert</span> chosen ∈ options
+x = <span style="font-style: italic">choose</span>(x<span class="sub" style="">1</span>...x<span class="sub" style="">Z</span>, p)
+e = g<span class="super" style="">x</span> mod p
+C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+<span style="font-style: italic">assert</span> 1 &lt; d &lt; p-1
+K = HASH(d<span class="super" style="">x</span> mod p)
+KC<span class="sub" style="">A</span> = HASH(0, K)
+KC<span class="sub" style="">B</span> = HASH(1, K)
+KM<span class="sub" style="">A</span> = HASH(2, K)
+KM<span class="sub" style="">B</span> = HASH(3, K)
+KS<span class="sub" style="">A</span> = HASH(4, K)
+KS<span class="sub" style="">B</span> = HASH(5, K)
+<span style="font-style: italic">assert</span> M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+{pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>} = DECIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})
+VERIFY(sign<span class="sub" style="">B</span>, pubKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>) 
+mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>})
+sign<span class="sub" style="">A</span> = SIGN(signKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+ID<span class="sub" style="">A</span> = CIPHER(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>})
+M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                 ID<span class="sub" style="">A</span>
+                             ---------&gt;
+                               N<span class="sub" style="">B</span>, M<span class="sub" style="">A</span> 
+                                         <span style="font-style: italic">assert</span> M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                         {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>} = DECIPHER(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                         mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>})
+                                         VERIFY(sign<span class="sub" style="">A</span>, pubKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+    </pre>
+  </div>
+
+  <div class="indent">
+<h3>6.3 <a name="design-online-r">Online ESession-R Negotiation</a>
+</h3>
+    <p class="" style="">This protocol is similar to the <a href="#design-online-i">Online ESession-I Negotiation</a> above, except that after receiving the first message from Alice, Bob chooses to protect his identity from active attacks (by by delaying communicating his identity to Alice until he has authenticated her).</p>
+    <pre>
+<span style="font-weight: bold">ALICE</span>                                    <span style="font-weight: bold">BOB</span> 
+
+<span style="font-style: italic">for</span> g,p ∈ options
+    x = <span style="font-style: italic">random</span>()
+    e = g<span class="super" style="">x</span> mod p
+N<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+form<span class="sub" style="">A</span> = {e<span class="sub" style="">1</span>...e<span class="sub" style="">Z</span>, options, N<span class="sub" style="">A</span>}
+                                form<span class="sub" style="">A</span>
+                             ---------&gt;
+
+                                         chosen = {p,g,HASH,CIPHER,SIGN...} = <span style="font-style: italic">choose</span>(options)
+                                         e = <span style="font-style: italic">choose</span>(e<span class="sub" style="">1</span>...e<span class="sub" style="">Z</span>, p)
+                                         C<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+                                         y = <span style="font-style: italic">random</span>()
+                                         d = g<span class="super" style="">y</span> mod p
+                                         C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+                                         <span style="font-style: italic">assert</span> 1 &lt; e &lt; p-1
+                                         K = HASH(e<span class="super" style="">y</span> mod p)
+                                         KC<span class="sub" style="">A</span> = HASH(0, K)
+                                         KC<span class="sub" style="">B</span> = HASH(1, K)
+                                         KM<span class="sub" style="">A</span> = HASH(2, K)
+                                         KM<span class="sub" style="">B</span> = HASH(3, K)
+                                         KS<span class="sub" style="">A</span> = HASH(4, K)
+                                         KS<span class="sub" style="">B</span> = HASH(5, K)
+                                         N<span class="sub" style="">B</span> = <span style="font-style: italic">random</span>()
+                                         form<span class="sub" style="">B</span> = {C<span class="sub" style="">A</span>, chosen, d, N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>}
+                                         mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})
+                                         sign<span class="sub" style="">B</span> = SIGN(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+                                         ID<span class="sub" style="">B</span> = CIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})
+                                         M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+
+                                form<span class="sub" style="">B</span>
+                             &lt;---------
+<span style="font-style: italic">assert</span> chosen ∈ options
+x = <span style="font-style: italic">choose</span>(x<span class="sub" style="">1</span>...x<span class="sub" style="">Z</span>, p)
+e = g<span class="super" style="">x</span> mod p
+C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+<span style="font-style: italic">assert</span> 1 &lt; d &lt; p-1
+K = HASH(d<span class="super" style="">x</span> mod p)
+KC<span class="sub" style="">A</span> = HASH(0, K)
+KC<span class="sub" style="">B</span> = HASH(1, K)
+KM<span class="sub" style="">A</span> = HASH(2, K)
+KM<span class="sub" style="">B</span> = HASH(3, K)
+KS<span class="sub" style="">A</span> = HASH(4, K)
+KS<span class="sub" style="">B</span> = HASH(5, K)
+mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>})
+sign<span class="sub" style="">A</span> = SIGN(signKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+ID<span class="sub" style="">A</span> = CIPHER(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>})
+M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                 ID<span class="sub" style="">A</span>
+                             ---------&gt;
+                               N<span class="sub" style="">B</span>, M<span class="sub" style="">A</span> 
+                                        <span style="font-style: italic">assert</span> M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                        {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>} = DECIPHER(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)
+                                        mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>})
+                                        VERIFY(sign<span class="sub" style="">A</span>, pubKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)
+                                 ID<span class="sub" style="">B</span>
+                             &lt;---------
+                               N<span class="sub" style="">A</span>, M<span class="sub" style="">B</span> 
+
+<span style="font-style: italic">assert</span> M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+{pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>} = DECIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})
+VERIFY(sign<span class="sub" style="">B</span>, pubKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+    </pre>
+  </div>
+
+  <div class="indent">
+<h3>6.4 <a name="design-offline">Offline ESession Negotiation</a>
+</h3>
+    <p class="" style="">Bob uses this protocol to send stanzas to Alice when she is Offline. Note: Since the full <span style="font-weight: bold">SIGMA</span> protocol cannot be used if Alice is offline, her identity is not protected.</p>
+    <p class="" style="">The diagram is split into three phases. First Alice publishes her ESession options before going offline. Later Bob completes the key exchange (and sends her encrypted stanzas that are not shown below) these are all stored by Alice's server. Finally when Alice comes online again she verifies and calculates the decryption key.</p>
+    <p class="" style="">The differences between this offline protocol and the <a href="#design-online-i">Online ESession-I Negotiation</a> protocol above are highlighted in the diagram below.</p>
+    <pre>
+<span style="font-weight: bold">ALICE</span>                    <span style="font-weight: bold">ALICE'S SERVER</span>              <span style="font-weight: bold">BOB</span> 
+
+<span style="font-style: italic">for</span> g,p ∈ options
+    x = <span style="font-style: italic">random</span>()
+    e = g<span class="super" style="">x</span> mod p
+N<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+form<span class="sub" style="">A</span> = {e<span class="sub" style="">1</span>...e<span class="sub" style="">Z</span>, options, N<span class="sub" style="">A</span>, pubKeys<span class="sub" style="">A</span>}
+signs<span class="sub" style="">A</span> = <span style="font-style: italic">multi_sign</span>(signKeys<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>)
+<span style="font-style: italic">store</span>(N<span class="sub" style="">A</span>, x<span class="sub" style="">1</span>...x<span class="sub" style="">Z</span>)
+                   form<span class="sub" style="">A</span>
+                 --------&gt;
+                   signs<span class="sub" style="">A</span> 
+
+                         <span style="font-style: italic">store</span>(form<span class="sub" style="">A</span>, signs<span class="sub" style="">A</span>)
+---------------------------------------------------------------------------------------------------------
+                         <span style="font-style: italic">retrieve</span>(form<span class="sub" style="">A</span>, signs<span class="sub" style="">A</span>)
+
+                                             form<span class="sub" style="">A</span>
+                                           --------&gt;
+                                             signs<span class="sub" style="">A</span> 
+
+                                                     <span style="font-style: italic">verify_one</span>(signs<span class="sub" style="">A</span>, pubKeys<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>)
+                                                     chosen = {p,g,HASH,CIPHER,SIGN...} = <span style="font-style: italic">choose</span>(options)
+                                                     e = <span style="font-style: italic">choose</span>(e<span class="sub" style="">1</span>...e<span class="sub" style="">Z</span>, p)
+                                                     C<span class="sub" style="">A</span> = <span style="font-style: italic">random</span>()
+                                                     y = <span style="font-style: italic">random</span>()
+                                                     d = g<span class="super" style="">y</span> mod p
+                                                     C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+                                                     <span style="font-style: italic">assert</span> 1 &lt; e &lt; p-1
+                                                     K = HASH(e<span class="super" style="">y</span> mod p)
+                                                     KC<span class="sub" style="">A</span> = HASH(0, K)
+                                                     KC<span class="sub" style="">B</span> = HASH(1, K)
+                                                     KM<span class="sub" style="">A</span> = HASH(2, K)
+                                                     KM<span class="sub" style="">B</span> = HASH(3, K)
+                                                     KS<span class="sub" style="">A</span> = HASH(4, K)
+                                                     KS<span class="sub" style="">B</span> = HASH(5, K)
+                                                     N<span class="sub" style="">B</span> = <span style="font-style: italic">random</span>()
+                                                     form<span class="sub" style="">B</span> = {C<span class="sub" style="">A</span>, chosen, d, N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>}
+                                                     mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})
+                                                     sign<span class="sub" style="">B</span> = SIGN(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+                                                     ID<span class="sub" style="">B</span> = CIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})
+                                                     M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+
+                                             form<span class="sub" style="">B</span>
+                                           &lt;--------
+                                            ID<span class="sub" style="">B</span>, M<span class="sub" style="">B</span> 
+
+                         <span style="font-style: italic">store</span>(form<span class="sub" style="">B</span>,ID<span class="sub" style="">B</span>,M<span class="sub" style="">B</span>)
+---------------------------------------------------------------------------------------------------------
+                         <span style="font-style: italic">retrieve</span>(form<span class="sub" style="">B</span>,ID<span class="sub" style="">B</span>,M<span class="sub" style="">B</span>) 
+                   form<span class="sub" style="">B</span>
+                 &lt;--------
+                  ID<span class="sub" style="">B</span>, M<span class="sub" style="">B</span> 
+
+<span style="font-style: italic">retrieve</span>(N<span class="sub" style="">A</span>, x<span class="sub" style="">1</span>...x<span class="sub" style="">Z</span>) 
+<span style="font-style: italic">assert</span> chosen ∈ options
+x = <span style="font-style: italic">choose</span>(x<span class="sub" style="">1</span>...x<span class="sub" style="">Z</span>, p)
+e = g<span class="super" style="">x</span> mod p
+C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> 
+<span style="font-style: italic">assert</span> 1 &lt; d &lt; p-1
+K = HASH(d<span class="super" style="">x</span> mod p)
+KC<span class="sub" style="">A</span> = HASH(0, K)
+KC<span class="sub" style="">B</span> = HASH(1, K)
+KM<span class="sub" style="">A</span> = HASH(2, K)
+KM<span class="sub" style="">B</span> = HASH(3, K)
+KS<span class="sub" style="">A</span> = HASH(4, K)
+KS<span class="sub" style="">B</span> = HASH(5, K)
+<span style="font-style: italic">assert</span> M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+{pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>} = DECIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)
+mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})
+VERIFY(sign<span class="sub" style="">B</span>, pubKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)
+    </pre>
+    <p class="" style="">Note: KM<span class="sub" style="">B</span> is necessary only to allow Bob to terminate the ESession if he comes online before Alice terminates it. The calculation of KC<span class="sub" style="">B</span> and KS<span class="sub" style="">B</span> is not strictly necessary.</p>
+  </div>
+<h2>7.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">Before attempting to engage in an ESession with Bob, Alice SHOULD discover whether he supports this protocol, using either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2265567">21</a>] or the presence-based profile of <span style="font-weight: bold">JEP-0030</span> specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2265594">22</a>].</p>
+  <p class="" style="">The normal course of events is for Alice to authenticate with her server, retrieve her roster (see <span style="font-weight: bold">RFC 3921</span>), send initial presence to her server, and then receive presence information from all the contacts in her roster. If the presence information she receives from some contacts does not include capabilities data (per <span style="font-weight: bold">JEP-0115</span>), Alice SHOULD then send a service discovery information ("disco#info") request to each of those contacts (in accordance with <span style="font-weight: bold">JEP-0030</span>). Such initial service discovery stanzas MUST NOT be considered part of encrypted communication sessions for the purposes of this JEP, since they perform a "bootstrapping" function that is a prerequisite to encrypted communications. The disco#info request sent from Alice to Bob might look as follows:</p>
+  <p class="caption">Example 1. Alice Queries Bob for ESession Support via Disco</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='alice@example.org/pda'
+    to='bob@example.com/laptop'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Bob sends a disco#info reply and he supports the protocol defined herein, then he MUST include a service discovery feature variable of "http://jabber.org/protocol/esession".</p>
+  <p class="caption">Example 2. Bob Returns disco#info Data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='bob@example.com/laptop'
+    to='alice@example.org/pda'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='client' type='pc'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/esession'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>8.
+       <a name="init">ESession Negotiation</a>
+</h2>
+  <p class="" style="">The process for establishing a secure session over an insecure transport is essentially a negotiation of various ESession algorithms and other parameters, combined with a translation into XMPP syntax of the <span style="font-weight: bold">SIGMA</span> approach to Diffie-Hellman (see <span class="ref" style="">RFC 2631</span>  [<a href="#nt-id2265686">23</a>]) key agreement.</p>
+  <p class="" style="">When Alice wishes to establish an ESession with Bob, Alice may choose between two different methods of performing the initial Diffie-Hellman key exchange, depending on whether Bob is online or not. Note: Alice MUST NOT initiate a new ESession with Bob if she already has one established with him.</p>
+
+  <div class="indent">
+<h3>8.1 <a name="init-online">Online Diffie-Hellman Key Exchange</a>
+</h3>
+    <p class="" style="">If Alice believes Bob may be online then she SHOULD use the protocol specified in <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2265747">24</a>] to negotiate the ESession options and the keys.</p>
+    <div class="indent">
+<h3>8.1.1 <a name="init-online-request">ESession Request</a>
+</h3>
+      <p class="" style="">In addition to the "accept" and "logging" fields specified in <span style="font-weight: bold">Chat Session Negotiation</span>, Alice MUST specify each of the ESession options (see list below) that she is willing to use, in her order of preference (see <a href="#sec-mandatory">Mandatory to Implement Technologies</a>). Note: Alice SHOULD NOT include a "reason" field since Aunt Tillie may not be aware the ESession request is <span style="font-style: italic">not</span> encrypted.</p>
+      <ol start="" type="">
+        <li><p class="" style="">Whether or not both entities MUST be connected securely to their servers (see Section 5 of <span style="font-weight: bold">RFC 3920</span>)</p></li>
+        <li><p class="" style="">The list of Modular Exponential (MODP) group numbers (as specified in <span style="font-weight: bold">RFC 2409</span> or <span class="ref" style="">RFC 3526</span>  [<a href="#nt-id2265833">25</a>]) that MAY be used for Diffie-Hellman key exchange (valid group numbers include 1,2,3,4,5,14,15,16,17 and 18)</p></li>
+        <li><p class="" style="">Symmetric block cipher algorithm names</p></li>
+        <li><p class="" style="">Hash algorithm names</p></li>
+        <li><p class="" style="">Signature algorithm names</p></li>
+        <li><p class="" style="">Compression algorithm names</p></li>
+        <li><p class="" style="">The list of stanza types that MAY be encrypted and decrypted</p></li>
+        <li><p class="" style="">Whether or not the other entity MUST send the fingerprint (PKID) of its public signature-verification key instead of the full key</p></li>
+        <li><p class="" style="">The minimum and maximum versions of this document that are supported</p></li>
+        <li><p class="" style="">The minimum number of stanzas that MUST be exchanged before an entity MAY initiate a key re-exchange (1 - every stanza, 100 - every hundred stanzas). Note: This value MUST be less than 2<span class="super" style="">32</span> (see <a href="#sec-rekey">Re-Keying Limits</a>)</p></li>
+      </ol>
+      <p class="" style="">Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). For each MODP group that Alice specifies she MUST perform the following computations to calculate her Diffie-Hellman keys (where n is the number of bits per cipher block for the block cipher algorithm with the largest block size out of those she specified):</p>
+      <ol start="" type="">
+        <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      </ol>
+      <p class="" style="">Alice MUST send all her calculated values of e to Bob. She MUST also specify randomly generated Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2266024">26</a>]) value of N<span class="sub" style="">A</span> (her ESession ID).</p>
+      <p class="caption">Example 3. Alice Requests an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='form' xmlns='jabber:x:data'&gt;
+      &lt;field type="hidden" var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="accept"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="logging"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="secure"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="modp"&gt;
+        &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="crypt_algs"&gt;
+        &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="hash_algs"&gt;
+        &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="sign_algs"&gt;
+        &lt;option&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;dsa&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="compress"&gt;
+        &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="list-multi" var="stanzas"&gt;
+        &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;iq&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="boolean" var="pk_hash"&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type="list-single" var="ver"&gt;
+        &lt;option&gt;&lt;value&gt;1.0&lt;/value&gt;&lt;/option&gt;
+        &lt;option&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field type="text-single" var="rekey_freq"&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="my_nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="keys"&gt;
+        &lt;value&gt; ** Base64 encoded value of e5 ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded value of e14 ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded value of e2 ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='drop' condition='deliver' value='stored'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">If Bob does not support one or more of the options in each ESession field, then he SHOULD return a &lt;feature-not-implemented/&gt; error (but he MAY return no error if, for example, he does not want to reveal his presence to Alice for whatever reason):</p>
+      <p class="caption">Example 4. Bob Informs Alice that Her Options Are Not Supported</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='bob@example.com/laptop'
+         to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    ...
+  &lt;/feature&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-options xmlns='http://jabber.org/protocol/esession#error'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">Either Bob or Alice MAY attempt to initiate a new ESession after any error during the negotiation process. However, both MUST consider the previous negotiation to have failed and MUST discard any information learned through the previous negotiation.</p>
+      <p class="" style="">If Bob is unwilling to start an ESession, but he <span style="font-style: italic">is</span> ready to initiate a one-to-one chat session with Alice (see <span style="font-weight: bold">Chat Session Negotiation</span>), then he SHOULD accept the Chat Session and terminate the ESession negotiation by <span style="font-style: italic">not</span> including a 'nonce' field in his response.</p>
+      <p class="caption">Example 5. Bob Accepts Chat Session</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>8.1.2 <a name="init-online-bobprep">Diffie-Hellman Preparation (Bob)</a>
+</h3>
+      <p class="" style="">If Bob supports one or more of each of Alice's ESession options and is willing to start an ESession with Alice, then he MUST select one of the options from each of the ESession fields he received from Alice including one hash algorithm ("HASH"), and one of the MODP groups and Alice's corresponding value of e (see <span class="ref" style="">RFC 3766</span>  [<a href="#nt-id2266192">27</a>] or <span style="font-weight: bold">RFC 3526</span> for recommendations regarding balancing the sizes of symmetric cipher blocks and Diffie-Hellman moduli).</p>
+      <p class="" style="">Each MODP group has at least two well known constants: a large prime number p, and a generator g for a subgroup of GF(p). Bob SHOULD return a &lt;feature-not-implemented/&gt; error unless: 1 &lt; e &lt; p - 1</p>
+      <p class="" style="">Bob MUST then perform the following computations (where n is the number of bits per cipher block for the selected block cipher algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Generate a random number N<span class="sub" style="">B</span> (his ESession ID)</p></li>
+        <li><p class="" style="">Generate an n-bit random number C<span class="sub" style="">A</span> (the block cipher counter for stanzas sent from Alice to Bob)</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the block counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Generate a secret random number y (where 2<span class="super" style="">2n-1</span> &lt; y &lt; p - 1)</p></li>
+        <li><p class="" style="">Calculate d = g<span class="super" style="">y</span> mod p</p></li>
+        <li><p class="" style="">Calculate K = HASH(e<span class="super" style="">y</span> mod p) (the shared secret)</p></li>
+      </ol>
+    </div>
+
+    <div class="indent">
+<h3>8.1.3 <a name="init-keys">Generating Session Keys</a>
+</h3>
+      <p class="" style="">Bob MUST use the shared secret ("K") and the selected hash algorithm ("HASH") to generate two sets of three keys, one set for each direction of the ESession.</p>
+      <p class="" style="">For stanzas that Alice will send to Bob, the keys are calculated as:</p>
+      <ol start="" type="">
+        <li><p class="" style="">Encryption key KC<span class="sub" style="">A</span> = HASH(K, 0)</p></li>
+        <li><p class="" style="">Integrity key KM<span class="sub" style="">A</span> = HASH(K, 2)</p></li>
+        
+        <li><p class="" style="">SIGMA key KS<span class="sub" style="">A</span> = HASH(K, 4)</p></li>
+      </ol>
+      <p class="" style="">For stanzas that Bob will send to Alice the keys are calculated as:</p>
+      <ol start="4" type="">
+        <li><p class="" style="">Encryption key KC<span class="sub" style="">B</span> = HASH(K, 1)</p></li>
+        <li><p class="" style="">Integrity key KM<span class="sub" style="">B</span> = HASH(K, 3)</p></li>
+        <li><p class="" style="">SIGMA key KS<span class="sub" style="">B</span> = HASH(K, 5)</p></li>
+      </ol>
+      <p class="" style="">Once the sets of keys have been calculated the value of K MUST be securely destroyed.</p>
+      <p class="" style="">Note: As many bits of key data as are needed for each key MUST be taken from the least significant bits of the hash output. When negotiating a hash, entities MUST ensure that the hash output is no shorter than the required key data. For algorithms with variable-length keys the maximum length (up to the hash output length) SHOULD be used.</p>
+    </div>
+
+    <div class="indent">
+<h3>8.1.4 <a name="init-hide">Hiding Identity</a>
+</h3>
+      <p class="" style="">Bob MUST perform the following steps before he can prove his identity to Alice while protecting it from third parties.</p>
+      <ol start="" type="">
+        <li><p class="" style="">Select pubKey<span class="sub" style="">B</span>, the public key Alice should use to authenticate his signature with the signature algorithm he selected ("SIGN"). Note: If the value of the 'pk_hash' field that Alice sent Bob was true then Bob SHOULD set pubKey<span class="sub" style="">B</span> to HASH(pubKey<span class="sub" style="">B</span>).</p></li>
+        <li>
+<p class="" style="">Set form<span class="sub" style="">B</span> to the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the reponse data form he will send back to Alice (including his responses for all the fields he received from Alice).</p>
+            <p class="" style="">Bob MUST encapsulate the Base64 encoded values of C<span class="sub" style="">A</span> and Alice's N<span class="sub" style="">A</span> in two new 'counter' and 'nonce' fields and add them to form<span class="sub" style="">B</span>. Note: The 'pk_hash' field specifies whether or not Alice MUST send the fingerprint (PKID) of her public signature-verification key instead of her full key. Note: The value of the 'rekey_freq' field MUST be less than 2<span class="super" style="">32</span> and greater than or equal to the value specified by Alice. Note: Bob MUST place his Base64 encoded values of N<span class="sub" style="">B</span> and d in the 'my_nonce' and 'keys' fields. Bob MUST NOT return Alice's values of e.</p>
+</li>
+        <li>
+<p class="" style="">Concatenate Alice's ESession ID, Bob's ESession ID, d, pubKey<span class="sub" style="">B</span> and form<span class="sub" style="">B</span>, and calculate the HMAC (as defined in Section 2 of <span class="ref" style="">RFC 2104</span>  [<a href="#nt-id2266777">28</a>]) of the resulting byte string using the selected hash algorithm ("HASH") and the key KS<span class="sub" style="">B</span>.</p>
+            <p class="caption"></p>
+<div class="indent"><pre>mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})</pre></div>
+</li>
+        <li>
+<p class="" style="">Calculate sign<span class="sub" style="">B</span>, the signature of the HMAC result using his private signature key that corresponds to pubKey<span class="sub" style="">B</span></p>
+            <p class="caption"></p>
+<div class="indent"><pre>sign<span class="sub" style="">B</span> = SIGN(signKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)</pre></div>
+</li>
+        <li>
+<p class="" style="">Concatenate pubKey<span class="sub" style="">B</span> and sign<span class="sub" style="">B</span> and encrypt the resulting byte string with the agreed algorithm ("CIPHER") in counter mode (see <span class="ref" style=""> Recommendation for Block Cipher Modes of Operation</span>  [<a href="#nt-id2266963">29</a>]), using the encryption key KC<span class="sub" style="">B</span> and block counter C<span class="sub" style="">B</span>. Note: C<span class="sub" style="">B</span> MUST be incremented by 1 for each encrypted block or partial block (i.e. C<span class="sub" style="">B</span> = (C<span class="sub" style="">B</span> + 1) mod 2<span class="super" style="">n</span>, where n is the number of bits per cipher block for the agreed block cipher algorithm).</p>
+            <p class="caption"></p>
+<div class="indent"><pre>ID<span class="sub" style="">B</span> = CIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, {pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>})</pre></div>
+</li>
+        <li>
+<p class="" style="">Calculate the HMAC of the encrypted identity (ID<span class="sub" style="">B</span>) and the value of Bob's block cipher counter C<span class="sub" style="">B</span> <span style="font-style: italic">before</span> the encryption using the selected hash algorithm ("HASH") and the integrity key KM<span class="sub" style="">B</span>.</p>
+            <p class="caption"></p>
+<div class="indent"><pre>M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)</pre></div>
+</li>
+      </ol>
+    </div>
+
+    <div class="indent">
+<h3>8.1.5 <a name="init-online-response">ESession Response</a>
+</h3>
+    <p class="" style="">If Bob prefers the 3-message ESession negotiation, where Alice's identity is protected from active attacks instead of his own, then he should encapsulate the Base64 encoded values of ID<span class="sub" style="">B</span> and M<span class="sub" style="">B</span> in data form fields ('identity' and 'mac'), and append the new fields to form<span class="sub" style="">B</span>.</p>
+    <p class="" style="">Bob responds to Alice by sending her form<span class="sub" style="">B</span>.</p>
+
+    <p class="caption">Example 6. Bob Responds to Alice (3-Message Negotiation)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="sign_algs"&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pk_hash"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="ver"&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="my_nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="keys"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded block counter ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="identity"&gt;
+        &lt;value&gt; ** Encrypted identity ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="mac"&gt;
+        &lt;value&gt; ** Integrity of identity ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 7. Bob Responds to Alice (4-Message Negotiation)</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="accept"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="sign_algs"&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="pk_hash"&gt;&lt;value&gt;1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="ver"&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="my_nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="keys"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded block counter ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+
+    <div class="indent">
+<h3>8.1.6 <a name="init-online-aliceprep">Diffie-Hellman Preparation (Alice)</a>
+</h3>
+      <p class="" style="">After Alice receives Bob's response, she MUST use the value of d and the ESession options specified in Bob's response to perform the following steps (where p and g are the constants associated with the selected MODP group, HASH is the selected hash algorithm, and n is the number of bits per cipher block for the agreed block cipher algorithm):</p>
+      <ol start="1" type="">
+        <li><p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob if she is not prepared to support any of the ESession options specified by Bob (if any of the options were not included in her initial ESession request)</p></li>
+        <li><p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob unless: 1 &lt; d &lt; p - 1</p></li>
+        <li><p class="" style="">Set C<span class="sub" style="">B</span> = C<span class="sub" style="">A</span> XOR 2<span class="super" style="">n-1</span> (where C<span class="sub" style="">B</span> is the block counter for stanzas sent from Bob to Alice)</p></li>
+        <li><p class="" style="">Select her values of x and e that correspond to the selected MODP group (from all the values of x and e she calculated previously)</p></li>
+        <li><p class="" style="">Calculate K = HASH(d<span class="super" style="">x</span> mod p) (the shared secret)</p></li>
+        <li><p class="" style="">Generate the session keys (KC<span class="sub" style="">A</span>, KM<span class="sub" style="">A</span>, KS<span class="sub" style="">A</span>, KC<span class="sub" style="">B</span>, KM<span class="sub" style="">B</span> and KS<span class="sub" style="">B</span>) in the same way as Bob did (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>8.1.7 <a name="init-online-bobid">Verifying Bob's Identity</a>
+</h3>
+      <p class="" style="">If Bob included 'identity' and 'mac' fields in his response then Alice MUST also perform the following steps:</p>
+      <ol start="1" type="">
+        <li>
+<p class="" style="">Calculate the HMAC of the encrypted identity (ID<span class="sub" style="">B</span>) and the value of Bob's block cipher counter using HASH and the integrity key KM<span class="sub" style="">B</span>.</p>
+            <p class="caption"></p>
+<div class="indent"><pre>M<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)</pre></div>
+</li>
+        <li><p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob unless the value of M<span class="sub" style="">B</span> she calculated matches the one she received in the 'mac' field</p></li>
+        <li>
+<p class="" style="">Obtain pubKey<span class="sub" style="">B</span> and sign<span class="sub" style="">B</span> by decrypting ID<span class="sub" style="">B</span> with the agreed symmetric block cipher algorithm ("DECIPHER") in counter mode, using the encryption key KC<span class="sub" style="">B</span> and block counter C<span class="sub" style="">B</span>. Note: C<span class="sub" style="">B</span> MUST be incremented by 1 for each encrypted block or partial block (i.e. C<span class="sub" style="">B</span> = (C<span class="sub" style="">B</span> + 1) mod 2<span class="super" style="">n</span>, where n is the number of bits per cipher block for the agreed block cipher algorithm).</p>
+            <p class="caption"></p>
+<div class="indent"><pre>{pubKey<span class="sub" style="">B</span>, sign<span class="sub" style="">B</span>} = DECIPHER(KC<span class="sub" style="">B</span>, C<span class="sub" style="">B</span>, ID<span class="sub" style="">B</span>)</pre></div>
+</li>
+        <li><p class="" style="">If the value of the 'pk_hash' field she sent to Bob in her <a href="#init-online-request">ESession Request</a> was true, then Alice SHOULD change the value of pubKey<span class="sub" style="">B</span> to be her copy of the public key whose HASH matches the value of pubKey<span class="sub" style="">B</span> that she received from Bob. Note: If she cannot find a copy of the public key then Alice MUST terminate the ESession. She MAY then request a new ESession with the 'pk_hash' field set to false.</p></li>
+        <li><p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob unless she can confirm (or has previously confirmed) that pubKey<span class="sub" style="">B</span> really is Bob's public key, for examples, via secure out-of-band communication, or through a third-party authority (see <a href="#sec-keys">Verifying Keys</a>).</p></li>
+        <li><p class="" style="">Set the value of form<span class="sub" style="">B</span> to be the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the form she received from Bob without the 'identity' and 'mac' fields.</p></li>
+        <li>
+<p class="" style="">Concatenate Alice's ESession ID, Bob's ESession ID, d, pubKey<span class="sub" style="">B</span> and form<span class="sub" style="">B</span>, and calculate the HMAC of the resulting byte string using HASH and the key KS<span class="sub" style="">B</span>.</p>
+            <p class="caption"></p>
+<div class="indent"><pre>mac<span class="sub" style="">B</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">B</span>, {N<span class="sub" style="">A</span>, N<span class="sub" style="">B</span>, d, pubKey<span class="sub" style="">B</span>, form<span class="sub" style="">B</span>})</pre></div>
+</li>
+        <li>
+<p class="" style="">Return a &lt;feature-not-implemented/&gt; error to Bob unless she can use pubKey<span class="sub" style="">B</span> with the selected signature verification algorithm ("VERIFY") to confirm that sign<span class="sub" style="">B</span> is the signature of the HMAC result (see <a href="#sign">Signature Verification</a>).</p>
+            <p class="caption"></p>
+<div class="indent"><pre>VERIFY(sign<span class="sub" style="">B</span>, pubKey<span class="sub" style="">B</span>, mac<span class="sub" style="">B</span>)</pre></div>
+</li>
+      </ol>
+    </div>
+
+    <div class="indent">
+<h3>8.1.8 <a name="init-online-complete">ESession Completion</a>
+</h3>
+      <p class="" style="">Alice MUST then prove her identity to Bob while protecting it from third parties. She MUST perform the steps equivalent to those Bob performed above (see <a href="#init-hide">Hiding Identity</a> for a more detailed description). Alice's calculations are summarised below (pay attention to the order of N<span class="sub" style="">B</span> and N<span class="sub" style="">A</span> when calculating mac<span class="sub" style="">A</span>). Note: form<span class="sub" style="">A</span> is the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the <a href="#init-online-request">ESession Request</a> data form that she sent to Bob previously.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>})</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>sign<span class="sub" style="">A</span> = SIGN(signKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>ID<span class="sub" style="">A</span> = CIPHER(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, {pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>})</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)</pre></div>
+
+      <p class="" style="">Alice MUST send the Base64 encoded values of N<span class="sub" style="">B</span>, ID<span class="sub" style="">A</span> and M<span class="sub" style="">A</span> to Bob. If Alice has already confirmed Bob's identity (i.e. if Bob included 'identity' and 'mac' fields in his response), then she MAY also send encrypted content (see <a href="#exchange">Exchanging Stanzas</a>) in the same stanza as the proof of her identity.</p>
+      <p class="caption">Example 8. Alice Sends Bob Her Identity</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="nonce"&gt;&lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="identity"&gt;&lt;value&gt; ** Encrypted identity ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="mac"&gt;&lt;value&gt; ** Integrity of identity ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">If Alice also includes a &lt;terminate/&gt; element (see <a href="#terminate">ESession Termination</a>) within the &lt;encrypted/&gt; element then the ESession is terminated immediately. Note: This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified).</p>
+      <p class="" style="">After receiving Alice's identity Bob MUST verify it by performing steps equivalent to those described in the section <a href="#init-online-bobid">Verifying Bob's Identity</a> above. Bob's calculations are summarised below (pay attention to the order of N<span class="sub" style="">B</span> and N<span class="sub" style="">A</span> when calculating mac<span class="sub" style="">A</span>). Note: form<span class="sub" style="">A</span> is the <a href="#sign-normal">Normalized</a> <span style="font-style: italic">content</span> of the <a href="#init-online-request">ESession Request</a> data form (the <span style="font-style: italic">first</span> form) that Alice sent him. Note: If Bob sends an error to Alice then he SHOULD ignore any encrypted content he received in the stanza.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>M<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>{pubKey<span class="sub" style="">A</span>, sign<span class="sub" style="">A</span>} = DECIPHER(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, ID<span class="sub" style="">A</span>)</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>mac<span class="sub" style="">A</span> = <span style="font-style: italic">HMAC</span>(HASH, KS<span class="sub" style="">A</span>, {N<span class="sub" style="">B</span>, N<span class="sub" style="">A</span>, e, pubKey<span class="sub" style="">A</span>, form<span class="sub" style="">A</span>})</pre></div>
+      <p class="caption"></p>
+<div class="indent"><pre>VERIFY(sign<span class="sub" style="">A</span>, pubKey<span class="sub" style="">A</span>, mac<span class="sub" style="">A</span>)</pre></div>
+      <p class="" style="">If Alice has already confirmed Bob's identity (i.e. if Bob included 'identity' and 'mac' fields in his response above), then the ESession negotiation is complete.</p>
+      <p class="" style="">Otherwise, one more step is necessary. Bob MUST send Alice the Base64 encoded values of N<span class="sub" style="">A</span>, ID<span class="sub" style="">B</span> and M<span class="sub" style="">B</span> that he calculated previously (see <a href="#init-hide">Hiding Identity</a>). Note: He MAY also send encrypted content (see <a href="#exchange">Exchanging Stanzas</a>) in the same stanza.</p>
+      <p class="caption">Example 9. Bob Sends Alice His Identity</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;&lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="nonce"&gt;&lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="identity"&gt;&lt;value&gt; ** Encrypted identity ** &lt;/value&gt;&lt;/field&gt;
+      &lt;field var="mac"&gt;&lt;value&gt; ** Integrity of identity ** &lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">After receiving Bob's identity Alice MUST verify it by performing steps described in the section <a href="#init-online-bobid">Verifying Bob's Identity</a> above. Note: If Alice sends an error to Bob then she SHOULD ignore any encrypted content she received in the stanza.</p>
+    </div>
+  </div>
+
+<div class="indent">
+<h3>8.2 <a name="init-offline">Offline Diffie-Hellman Key Exchange</a>
+</h3>
+  <p class="" style="">As described below, offline negotiation of an ESession is in essence a special case of 3-message online ESession negotiation. Alice MAY publish a set of ESession options just before she goes offline (see <a href="#sec-offline">Offline ESessions</a> Security Considerations) to allow entities that subscribe to her presence to initiate ESessions and send encrypted stanzas to her while she is offline. She MAY also publish <span style="font-style: italic">another</span> similar set of relatively long-lived  [<a href="#nt-id2268780">30</a>] ESession options that any entity MAY use for the same purpose.</p>
+    <div class="indent">
+<h3>8.2.1 <a name="init-offline-publish">Publishing ESession Options</a>
+</h3>
+      <p class="" style="">In order to publish either set of her offline ESession options Alice MUST create an options data form in exactly the same way as she would create an <a href="#init-online-request">ESession Request</a> data form except she MUST omit The 'accept' and 'pk_hash' fields. Note: The list of stanza types she is willing to decrypt MUST NOT include the value 'iq'.</p>
+      <p class="" style="">Alice MUST store her value of N<span class="sub" style="">A</span> (her ESession ID) and all her values of x (one for each MODP group) in a secure way, so that she can retrieve them when she comes back online (idealy even if that is using a different client and/or a different machine)</p>
+      <p class="" style="">If Alice would not be able to decrypt stanzas if she came back online using a different client and/or a different machine then she SHOULD also encapsulate the resource of her client in a 'match_resource' field and append it to her options data form. In this case, the list of stanza types she is willing to decrypt MUST include only 'message'.</p>
+      <p class="" style="">Alice MUST also append to the content of the form the list of the fingerprints (PKIDs) of all her public signature-verification keys that she can sign for in a 'pkids' field, and the corresponding list of signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style="">Alice MUST publish the ESession options data form through her own server using <span class="ref" style="">Simplified Personal Publish-Subscribe</span>  [<a href="#nt-id2268910">31</a>].</p>
+      <p class="" style=""><span style="font-style: italic">Note: Version 0.1 of the SPPS protocol is Experimental, planned modifications will allow access to be limited to subscribers.</span></p>
+      <p class="caption">Example 10. Alice Publishes Her ESession Options for Her Subscribers</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='es2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/esession#subscription'&gt;
+      &lt;item&gt;
+        &lt;x type='form' xmlns='jabber:x:data'&gt;
+          &lt;field type="hidden" var="FORM_TYPE"&gt;
+            &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field type="boolean" var="logging"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field type="boolean" var="secure"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="modp"&gt;
+            &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="crypt_algs"&gt;
+            &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="hash_algs"&gt;
+            &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="sign_algs"&gt;
+            &lt;option&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;dsa&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="compress"&gt;
+            &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-multi" var="stanzas"&gt;
+            &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="ver"&gt;
+            &lt;option&gt;&lt;value&gt;1.0&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="text-single" var="rekey_freq"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="my_nonce"&gt;
+            &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="keys"&gt;
+            &lt;value&gt; ** Base64 encoded value of e5 ** &lt;/value&gt;
+            &lt;value&gt; ** Base64 encoded value of e14 ** &lt;/value&gt;
+            &lt;value&gt; ** Base64 encoded value of e2 ** &lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="match_resource"&gt;
+            &lt;value&gt;pda&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pkids"&gt;
+            &lt;value&gt; ** PKID ** &lt;/value&gt;
+            &lt;value&gt; ** PKID ** &lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="signs"&gt;
+            &lt;value&gt; ** signature of form ** &lt;/value&gt;
+            &lt;value&gt; ** signature of form ** &lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">Alice MAY publish her ESession options for all entities using the same protocol except for the 'node' attribute of the &lt;publish/&gt; element:</p>
+      <p class="caption">Example 11. Alice Publishes Her ESession Options for All Entities</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='es3'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/esession'&gt;
+      ...
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    </div>
+    <div class="indent">
+<h3>8.2.2 <a name="init-offline-request">Requesting Offline ESession Options</a>
+</h3>
+      <p class="" style="">If Bob believes Alice is offline he SHOULD request her ESession options and her long-term public signature-verification keys (see <a href="#keys">Public Key Publication and Retrieval</a>) from her server using <span style="font-weight: bold">Simplified Personal Publish-Subscribe</span>.</p>
+      <p class="" style=""><span style="font-style: italic">Note: Version 0.1 of the SPPS protocol is Experimental, planned modifications will allow the persistence and retrieval of the last published item.</span></p>
+      <p class="" style="">If Bob is subscribing to Alice's presence he MUST request her ESession Options exclusively for subscribers.</p>
+      <p class="caption">Example 12. Bob asks Alice's Server for her ESession Options (Subscribers)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='es4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;get node='http://jabber.org/protocol/esession#subscription'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If Bob is not subscribing to Alice's presence (or if Alice has no ESession options exclusively for subscribers) he MUST use the following request instead.</p>
+      <p class="caption">Example 13. Bob asks Alice's Server for her ESession Options (All Entities)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='es4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;get node='http://jabber.org/protocol/esession'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If, after receiving Alice's public keys and ESession options, Bob is unable to verify any of Alice's signatures of her offline options data form (see <a href="#sign">Signature Verification</a>) then he MAY decide to proceed no further, since he cannot be sure who will be able to decrypt his stanzas.</p>
+      <p class="" style="">If Bob does not support one or more of the options in each Alice's ESession fields, then he MUST NOT send encrypted stanzas to her while she is offline.</p>
+    </div>
+
+    <div class="indent">
+<h3>8.2.3 <a name="init-offline-start">Starting an Offline ESession</a>
+</h3>
+      <p class="" style="">Bob MUST now continue as if Alice had requested an online ESession, performing the steps described in three of the online negotiation sections:</p>
+      <ol start="1" type="">
+        <li><p class="" style=""><a href="#init-online-bobprep">Diffie-Hellman Preparation (Bob)</a> Note: If the value of e he selected is not valid, Bob SHOULD terminate the ESession <span style="font-style: italic">without</span> sending an error.</p></li>
+        <li><p class="" style=""><a href="#init-keys">Generating Session Keys</a></p></li>
+        <li><p class="" style=""><a href="#init-hide">Hiding Identity</a> Note: Since Bob did not receive a 'pk_hash' field, he MUST assume its value is false. Bob SHOULD NOT include a 'pk_hash' field in form<span class="sub" style="">B</span> since Alice has already proved her identity.</p></li>
+      </ol>
+      <p class="" style="">As with 3-message ESession negotiation, Bob should encapsulate the Base64 encoded values of ID<span class="sub" style="">B</span> and M<span class="sub" style="">B</span> in data form fields ('identity' and 'mac'), and append the new fields to form<span class="sub" style="">B</span>.</p>
+      <p class="" style="">Bob MAY also send encrypted content (see the <a href="#exchange">Exchanging Stanzas</a> section of this document) in the same stanza. Note: If he also includes a &lt;terminate/&gt; element (see <a href="#terminate">ESession Termination</a>) within the &lt;encrypted/&gt; element then the ESession is terminated immediately. This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified).</p>
+      <p class="" style="">If Alice included a 'match_resource' field in her ESession options, then Bob MUST address all the stanzas he sends within the offline ESession to the specified resource and use the <span style="font-weight: bold">Advanced Message Processing</span> protocol to ensure that they are not delivered to any other resource.</p>
+      <p class="" style="">After sending form<span class="sub" style="">B</span> to Alice, Bob can assume that the ESession negotiation is complete.</p>
+      <p class="caption">Example 14. Bob Establishes an ESession Without Negotiation</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda' type='chat'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="sign_algs"&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="ver"&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="my_nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="keys"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded block counter ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="identity"&gt;
+        &lt;value&gt; ** Encrypted identity ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="mac"&gt;
+        &lt;value&gt; ** Integrity of identity ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='??????' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+    <div class="indent">
+<h3>8.2.4 <a name="init-offline-accept">Accepting Offline ESessions</a>
+</h3>
+      <p class="" style="">When Alice comes online she MUST perform the following steps:</p>
+      <ol start="" type="">
+        <li>
+<p class="" style="">Ensure she is no longer publishing offline ESession options exclusively for entities that are subscribing to her presence.</p>
+            <p class="caption">Example 15. Alice Stops Publishing Her ESession Options</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='es5'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/esession#subscription'&gt;
+      &lt;item/&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+        </li>
+        <li><p class="" style="">Retrieve any values of N<span class="sub" style="">A</span> and x (one for each MODP group for each N<span class="sub" style="">A</span>) that she stored before going offline, and destroy in a secure way any persistently stored copies that correspond to ESession options exclusively for subscribers.</p></li>
+      </ol>
+      <p class="" style="">When Alice receives an offline ESession request stanza from Bob then she MUST perform the following steps:</p>
+      <ol start="" type="">
+        <li><p class="" style="">Select her value of x that corresponds to the 'nonce' and 'modp' fields she received from Bob.  [<a href="#nt-id2269432">32</a>]</p></li>
+        <li><p class="" style="">Confirm that she has not already received a key exchange stanza from Bob with the same value of d or N<span class="sub" style="">B</span> ('my_nonce' field) since she published her ESession options (see <a href="#sec-replay">Replay Attacks</a>). If the options were for subscribers, that means since she came online.</p></li>
+        <li>
+<p class="" style="">Alice MUST now continue as if Bob had responded to her online ESession request, performing the steps described in two of the online negotiation sections:</p>
+        <ul>
+          <li><p class="" style=""><a href="#init-online-aliceprep">Diffie-Hellman Preparation (Alice)</a> Note: If she is not prepared to support any of the ESession options specified by Bob, or if the value of d she selected is not valid, then Alice SHOULD terminate the ESession <span style="font-style: italic">without</span> sending an error.</p></li>
+          <li><p class="" style=""><a href="#init-online-bobid">Verifying Bob's Identity</a> Note: Since Alice did not send a 'pk_hash' field to Bob, she MUST assume its value is false. If the value of M<span class="sub" style="">B</span> she calculated does not match the one she received, or if she cannot confirm that pubKey<span class="sub" style="">B</span> really is Bob's public key, or if she cannot confirm that sign<span class="sub" style="">B</span> is the signature of the HMAC result, then Alice SHOULD terminate the ESession <span style="font-style: italic">without</span> sending an error.</p></li>
+        </ul>
+</li>
+      </ol>
+    </div>
+  </div>
+<h2>9.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="exchange-separate">Encryptable Content</a>
+</h3>
+    <p class="" style="">Once ESession negotiation is complete, Alice and Bob MUST exchange only encrypted forms of the one-to-one stanza types they agreed upon (e.g., &lt;message/&gt; and &lt;iq/&gt; stanzas).</p>
+    <p class="" style="">Whenever Alice wants to send Bob an encrypted stanza she MUST only encrypt the XML content that would normally be ignored by the intermediate servers. She MUST NOT encrypt stanza wrapper elements or <span style="font-weight: bold">Advanced Message Processing</span> elements.</p>
+    <p class="" style="">If this is an offline ESession then Alice SHOULD include a 'Created' SHIM header in the encrypted content. Bob SHOULD trust this header and ignore the unencrypted <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2269632">33</a>] element inserted by his server.</p>
+
+  <p class="caption">Example 16. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;body&gt;Hello, Bob!&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+
+  <p class="caption">Example 17. XML Content to be Encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Bob!&lt;/body&gt;
+&lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+  &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+&lt;/headers&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+</pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="exchange-encrypt">Encryption</a>
+</h3>
+
+    <p class="" style="">Alice MUST perform the following steps to encrypt the XML content. Note: if there is no XML content to be encrypted (e.g. if this is an empty <a href="#rekey">Re-Keying</a> or <a href="#terminate">Termination</a> stanza), then C<span class="sub" style="">A</span> MUST be incremented by 1 (see below), and only the last two steps (normalization and MAC calculation) should be performed.</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Serialize the XML content she wishes to send into an array of UTF-8 bytes, m.  [<a href="#nt-id2269709">34</a>]</p></li>
+      <li>
+        <p class="" style="">Compress m using the negotiated algorithm. If a compression algorithm other than 'none' was agreed, the compression context is typically initialized after key exchange and passed from one stanza to the next, with only a partial flush at the end of each stanza.  [<a href="#nt-id2269729">35</a>]</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = compress(m)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Encrypt the data with the agreed algorithm in counter mode, using the encryption key KC<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented by 1 for each encrypted block or partial block (i.e. C<span class="sub" style="">A</span> = (C<span class="sub" style="">A</span> + 1) mod 2<span class="super" style="">n</span>, where n is the number of bits per cipher block for the agreed block cipher algorithm). Note: if the block cipher algorithm 'none' was agreed (see <a href="#sec-unencrypted">Unencrypted ESessions</a>) then encryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1 (for replay protection).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_final = encrypt(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Alice MUST now create the <a href="#sign-normal">Normalized</a> XML <span style="font-style: italic">content</span> of the &lt;encrypted/&gt; XML element. If there is encrypted XML content, the XML MUST include the Base64 encoded value of m_final wrapped in a &lt;data/&gt; element. Note: the &lt;encrypted/&gt; element MAY also contain one &lt;terminate/&gt; element (see <a href="#terminate">Termination</a>), one &lt;key/&gt; element and one or more &lt;old/&gt; elements (see <a href="#rekey">Re-Keying</a>).</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_content = '&lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;'</pre></div>
+      </li>
+      <li>
+        <p class="" style="">The XML content and the value of Alice's block cipher counter C<span class="sub" style="">A</span> <span style="font-style: italic">before</span> the data was encrypted, are now processed through the HMAC algorithm, along with the agreed hash algorithm ("HASH") and the integrity key KM<span class="sub" style="">A</span>.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>a_mac = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+    </ol>
+
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="exchange-send">Sending an Encrypted Stanza</a>
+</h3>
+    <p class="" style="">Before sending the stanza to Bob, Alice MUST wrap m_content and the Base64 encoded value of a_mac (wrapped in a &lt;mac/&gt; element) inside an &lt;encrypted/&gt; element and insert it into the stanza in place of the original content. There MUST NOT be more than one &lt;encrypted/&gt; element per stanza.</p>
+    <p class="caption">Example 18. Message Stanza with Encrypted Content</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda'
+         to='bob@example.com/laptop'
+         type='chat'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' per-hop='true'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.4 <a name="exchange-decrypt">Decryption</a>
+</h3>
+
+    <p class="" style="">When Bob receives the stanza from Alice, he extracts and Base64 decodes the values of m_final and a_mac from the content and performs the following steps.</p>
+    <ol start="1" type="">
+      <li>
+        <p class="" style="">Remove the &lt;mac/&gt; element from the &lt;encrypted/&gt; element and <a href="#sign-normal">Normalize</a> the remaining XML <span style="font-style: italic">content</span>. Calculate the Message Authentication Code (MAC) for the content.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>b_mac = <span style="font-style: italic">HMAC</span>(HASH, KM<span class="sub" style="">A</span>, m_content, C<span class="sub" style="">A</span>)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Verify that b_mac and a_mac match. If they are not identical, the content has been tampered with and Bob MUST terminate the ESession, he MAY send a &lt;not-acceptable/&gt; error to Alice.  [<a href="#nt-id2270086">36</a>]</p>
+      </li>
+      <li>
+        <p class="" style="">Decrypt m_final using the agreed algorithm, KC<span class="sub" style="">A</span> and C<span class="sub" style="">A</span>. Note: C<span class="sub" style="">A</span> MUST be incremented by 1 for each decrypted block (see <a href="#exchange-encrypt">Encryption</a>). Note: if the block cipher algorithm 'none' was agreed decryption MUST NOT be performed and C<span class="sub" style="">A</span> MUST be incremented by 1.</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m_compressed = decrypt(KC<span class="sub" style="">A</span>, C<span class="sub" style="">A</span>, m_final)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Decompress m_compressed using the negotiated algorithm (usually 'none').</p>
+        <p class="caption"></p>
+<div class="indent"><pre>m = decompress(m_compressed)</pre></div>
+      </li>
+      <li>
+        <p class="" style="">Replace the &lt;encrypted/&gt; element in the serialized XML stanza with m and feed the stanza into an XML parser. If the parser returns an XML format error then Bob MUST terminate the ESession, he MAY send a &lt;not-acceptable/&gt; error to Alice.  [<a href="#nt-id2270262">37</a>]</p>
+      </li>
+    </ol>
+  </div>
+  <h2>10.
+       <a name="rekey">Re-Key Exchange</a>
+</h2>
+<p class="" style="">Once an attacker has discovered an encryption key it could be used to decrypt all stanzas within a session, including stanzas that were intercepted <span style="font-style: italic">before</span> the key was discovered. To reduce the window of vulnerability, both Alice and Bob SHOULD change their values of x and y and re-exchange the encryption key as regularly as possible. They MUST also destroy all copies of keys as soon as they are no longer needed.</p>
+<p class="" style="">Note: Although most entities are capable of re-keying after each stanza, clients running in constrained runtime environments may require a few seconds to re-key. During ESession negotiation these clients MAY negotiate the minimum number of stanzas to be exchanged between re-keys at the cost of a larger window of vulnerability. Entities MUST NOT initiate key re-exchanges more frequently than the agreed limit.</p>
+
+  <div class="indent">
+<h3>10.1 <a name="rekey-init">Re-Key Initiation</a>
+</h3>
+    <p class="" style="">Either Alice or Bob MAY initiate a key re-exchange. Here we describe the process initiated by Alice. First she MUST calculate new values for the encryption parameters:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Generate a secret random number x (where 2<span class="super" style="">2n-1</span> &lt; x &lt; p - 1, where n is the number of bits per cipher block for the agreed block cipher algorithm)</p></li>
+      <li><p class="" style="">Calculate e = g<span class="super" style="">x</span> mod p</p></li>
+      <li><p class="" style="">Calculate K = d<span class="super" style="">x</span> mod p (the new shared secret)</p></li>
+      <li><p class="" style="">Calculate KC<span class="sub" style="">A</span>, KM<span class="sub" style="">A</span>, KC<span class="sub" style="">B</span>, KM<span class="sub" style="">B</span> from K (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">To avoid extra stanzas, the new value of e SHOULD be sent to Bob along with an encrypted stanza. Note: Alice MUST NOT use the new KC<span class="sub" style="">A</span> and KM<span class="sub" style="">A</span> to encrypt this stanza or to calculate the MAC. However, she MUST use them when sending subsequent stanzas.</p>
+    <p class="" style="">Note: There is no need for Alice to provide a signature because the calculation of the MAC includes the new value of e, see <a href="#exchange">Exchanging Stanzas</a>).</p>
+    <p class="caption">Example 19. Alice Sends Re-Key Stanza</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;key&gt; ** Base64 encoded value of new e ** &lt;/key&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Note: Bob may not receive the new key before he sends his next stanzas (they may cross in transit). So, before destroying her old values of KC<span class="sub" style="">B</span> and KM<span class="sub" style="">B</span>, Alice MUST wait until either she receives a stanza encrypted with the new key, or a reasonable time has passed (60 seconds should cover a network round-trip and calculations by a constrained client). Similarly she MUST wait before destroying her old value of x, in case Bob sends two stanzas before receiving Alice's new key (the first stanza might include a re-key).</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="rekey-accept">Re-Key Acceptance</a>
+</h3>
+    <p class="" style="">After Bob receives a stanza with a new value of e and confirmed it is greater than one, and he has decrypted the stanza with the old value of KC<span class="sub" style="">A</span>, he MUST securely destroy all copies of KC<span class="sub" style="">A</span> and KC<span class="sub" style="">B</span> and perform the following calculations with the new value of e:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">Calculate K = e<span class="super" style="">y</span> mod p</p></li>
+      <li><p class="" style="">Calculate KC<span class="sub" style="">A</span>, KM<span class="sub" style="">A</span>, KC<span class="sub" style="">B</span>, KM<span class="sub" style="">B</span> from K (see <a href="#init-keys">Generating Session Keys</a>)</p></li>
+    </ol>
+    <p class="" style="">He MUST use these new values to encrypt and decrypt all subsequent stanzas.  [<a href="#nt-id2270626">38</a>]</p>
+    <p class="" style="">The next time Bob sends Alice a stanza he MUST specify the number of rekeys he has received from her since he sent her his last stanza. He does that by setting the 'rekeys' attribute of the &lt;data/&gt; element. Note: The default value of the 'rekeys' attribute is zero.</p>
+    <p class="caption">Example 20. Bob's First Stanza After Receiving a Re-Key</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data rekeys='1'&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Alice receives the stanza from Bob she MUST use the 'rekeys' attribute to decide which of her values of KC<span class="sub" style="">B</span> and KM<span class="sub" style="">B</span> (or x) she should use to decrypt the stanza - otherwise she would not know if Bob received her rekey(s) before he sent the stanza. Once she is sure Bob has received her rekey(s) she MUST discard all her older values of KC<span class="sub" style="">B</span>, KM<span class="sub" style="">B</span> and x.</p>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="rekey-publish">Publishing Old MAC Values</a>
+</h3>
+    <p class="" style="">Once the expired MAC keys have been published, anyone could create valid arbitrary stanzas with them. This prevents anyone being able to prove the authenticity of a transcript of the ESession in the future.</p>
+    <p class="" style="">Either entity MAY publish old values of KM<span class="sub" style="">A</span> and/or KM<span class="sub" style="">B</span> within any encrypted stanza as long as it knows that all the stanzas that MAY use the old values have been received and validated. Note: A 'man-in-the-middle' could delay the delivery of stanzas indefinitely. So, before Alice publishes KM<span class="sub" style="">A</span> (and KM<span class="sub" style="">B</span>), she MUST wait until she has both sent a re-key to Bob and received a stanza from Bob encrypted with her new key. (She MAY also publish KM<span class="sub" style="">B</span> after she has received a re-key from Bob.)</p>
+    <p class="caption">Example 21. Publishing Expired MAC Keys</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Entities SHOULD ignore any &lt;old/&gt; elements they receive.</p>
+  </div>
+  <h2>11.
+       <a name="terminate">ESession Termination</a>
+</h2>
+    <p class="" style="">Either entity MAY terminate an ESession at any time. Entities MUST terminate all open ESessions before they go offline. To terminate an ESession Alice MUST send a stanza to Bob including a &lt;terminate/&gt; element with content "1"  [<a href="#nt-id2270833">39</a>]. Note: She MAY publish old values of KM<span class="sub" style="">A</span> and/or KM<span class="sub" style="">B</span> within her termination stanza as long as she is sure all the stanzas that MAY use the old values have been received and validated (see <a href="#rekey-publish">Publishing Old MAC Values</a>). She MUST then securely destroy all keys associated with the ESession.</p>
+    <p class="caption">Example 22. Alice Terminates an ESession</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Bob receives a termination stanza he MUST verify the MAC (to be sure he received all the stanzas Alice sent him during the ESession) and, if the stanza was sent to him while he was online, immediately send a termination stanza back to Alice. Note: He MAY publish <span style="font-style: italic">any</span> old values of KM<span class="sub" style="">A</span> or KM<span class="sub" style="">B</span> within the termination stanza. He MUST then securely destroy all keys associated with the ESession.</p>
+    <p class="caption">Example 23. Bob Confirms ESession Termination</p>
+<div class="indent"><pre>
+&lt;message from='alice@example.org/pda' to='bob@example.com/laptop'&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;terminate&gt;1&lt;/terminate&gt;
+    &lt;old&gt; ** Base64 encoded old MAC key ** &lt;/old&gt;
+    &lt;mac&gt; ** Base64 encoded b_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">When Alice receives the stanza she MUST verify the MAC to be sure she received all the stanzas Bob sent her during the ESession. Once an entity has sent a termination stanza it MUST NOT send another stanza within the ESession.</p>
+    <p class="" style="">Note: If Alice notices that Bob comes online during her offline ESession with him then she MUST terminate the ESession immediately. If required she may then negotiate a new (more secure) online ESession.</p>
+    <p class="" style="">Note: Bob MUST NOT send encrypted content within an ESession started by Alice. If Alice is conducting an offline ESession with Bob when he is online (e.g., if she is not subscribing to his presence), then if Bob wants to send a stanza to Alice, he MUST terminate the offline ESession and start a new online ESession first.</p>
+  <h2>12.
+       <a name="sign">Signature Generation and Verification</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="sign-normal">XML Normalization</a>
+</h3>
+    <p class="" style="">Before the signature or MAC of a block of XML is generated or verified, all character data <span style="font-style: italic">between</span> all elements MUST be removed and the XML MUST be converted to canonical form (see <span class="ref" style="">Canonical XML</span>  [<a href="#nt-id2271020">40</a>]).</p>
+    <p class="" style="">All the XML this protocol requires to be signed or MACed is very simple, so in this case, canonicalization SHOULD only require the following changes:</p>
+    <ul>
+      <li>Set attribute value delimiters to quotation marks (i.e. simply replace all single quotes in the serialized XML with double quotes)</li>
+      <li>Impose lexicographic order on the attributes of "field" elements (i.e. ensure "type" is before "var")</li>
+    </ul>
+    <p class="" style="">Implementations MAY conceivably also need to make the following changes. Note: Empty elements and special characters SHOULD NOT appear in the signed or MACed XML specified in this protocol.</p>
+    <ul>
+      <li>Ensure there are no character references</li>
+      <li>Convert empty elements to start-end tag pairs</li>
+      <li>Ensure there is no whitespace except for single spaces before attributes</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="sign-hash">Hash</a>
+</h3>
+    <p class="" style="">Before the signature or MAC of a block of XML is generated or verified, the agreed hash algorithm MUST be used to generate the hash of the normalized XML.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>m_hash = HASH(m_content)</pre></div>
+  </div>
+  <div class="indent">
+<h3>12.3 <a name="sign-calc">Generation</a>
+</h3>
+    <p class="" style="">The signature generation depends on the type of private key being used.</p>
+    <div class="indent">
+<h3>12.3.1 <a name="sign-rsa-gen">RSA</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>signature_rsa = rsa_sign(rsa_private_key, m_hash, hashOID)</pre></div>
+      <p class="" style="">The multiprecision integer signature_rsa is the signature (see <span class="ref" style="">RFC 3447</span>  [<a href="#nt-id2271144">41</a>]).</p>
+    </div>
+    <div class="indent">
+<h3>12.3.2 <a name="sign-dsa-gen">DSA</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>sig_dsa_r, sig_dsa_s = dsa_sign(dsa_private_key, m_hash)</pre></div>
+      <p class="" style="">The multiprecision integers sig_dsa_r and sig_dsa_s are the signature (see <span class="ref" style="">Digital Signature Standard</span>  [<a href="#nt-id2271198">42</a>]).</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>12.4 <a name="sign-format">Signature Format</a>
+</h3>
+    <p class="" style="">The signature formats are the same for all public key formats. All integers are stored in big-endian byte order.</p>
+    <div class="indent">
+<h3>12.4.1 <a name="sign-rsa-format">RSA</a>
+</h3>
+      <p class="" style="">Base64 encoding of the signature_rsa multiprecision integer (without any header or length prefix).</p>
+    </div>
+    <div class="indent">
+<h3>12.4.2 <a name="sign-dsa-format">DSA</a>
+</h3>
+      <p class="" style="">Base64 encoding of the following structure:</p>
+      <ul>
+        <li>number of bytes in sig_dsa_r (2-byte integer)</li>
+        <li>sig_dsa_r</li>
+        <li>number of bytes in sig_dsa_s (2-byte integer)</li>
+        <li>sig_dsa_s</li>
+      </ul>
+    </div>
+  </div>
+  <div class="indent">
+<h3>12.5 <a name="sign-calc">Verification</a>
+</h3>
+    <p class="" style="">The signature verification depends on the type of public key being used.</p>
+    <div class="indent">
+<h3>12.5.1 <a name="sign-rsa-verify">RSA</a>
+</h3>
+      <p class="" style="">The rsa_modulus and rsa_public_exponent multiprecision integers are extracted from the other entity's authenticated public key. The signature_rsa multiprecision integer is the signature received from the other entity.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>boolean = rsa_verify(signature_rsa, m_hash, hashOID, rsa_modulus, rsa_public_exponent)</pre></div>
+    </div>
+    <div class="indent">
+<h3>12.5.2 <a name="sign-dsa-verify">DSA</a>
+</h3>
+      <p class="" style="">The dsa_p, dsa_q, dsa_g and dsa_y multiprecision integers are extracted from the other entity's authenticated public key. The sig_dsa_r and sig_dsa_s multiprecision integers are the signature received from the other entity.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>boolean = dsa_verify(sig_dsa_r, sig_dsa_s, m_hash, dsa_p, dsa_q, dsa_g, dsa_y)</pre></div>
+    </div>
+  </div>
+  <h2>13.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="sec-prng">Random Numbers</a>
+</h3>
+    <p class="" style="">Weak pseudo-random number generators (PRNG) enable successful attacks. Implementors MUST use a cryptographically strong PRNG to generate all random numbers (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2271377">43</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="sec-rekey">Re-Keying Limits</a>
+</h3>
+    <p class="" style="">After a key exchange an entity MUST NOT exchange a total of 2<span class="super" style="">32</span> encrypted blocks before it initiates a key re-exchange (see <span class="ref" style="">SSH Transport Layer Encryption Modes</span>  [<a href="#nt-id2271425">44</a>]). Note: This limitation also ensures the same key and counter values are never used to encrypt two different blocks using counter mode (thus preventing simple attacks).</p>
+    <p class="" style="">In order to reduce the Perfect Forward Secrecy window of vulnerability, after an extended period of activity, entities SHOULD either re-key or terminate the ESession.</p>
+  </div>
+  <div class="indent">
+<h3>13.3 <a name="sec-keys">Verifying Keys</a>
+</h3>
+    <p class="" style="">The trust system outlined in this document is based on Alice trusting that the public key presented by Bob is <span style="font-style: italic">actually</span> Bob's key (and vice versa). Determining this trust may be done in a variety of ways depending on the entities' support for different public key (certificate) formats, signing algorithms and signing authorities. For instance, if Bob publishes a PGP/GPG public key, Alice MAY verify that his key is signed by another key that she knows to be good. Or, if Bob provides an X.509 certificate, she MAY check that his key has been signed by a Certificate Authority that she trusts.</p>
+    <p class="" style="">When trust cannot be achieved automatically, methods that are not transparent to the users may be employed. For example, Bob could communicate the SHA-256 fingerprint of his public key to Alice via secure out-of-band communication (e.g. face-to-face). This would enable Alice to confirm that the public key she receives in-band is valid. Note however that very few people bother to verify fingerprints in this way. So this method is exceptionally vulnerable to 'man-in-the-middle' attacks. In order to reduce the window of vulnerability, an entity SHOULD remember the fingerprints of all user-validated public keys and alert the user in the future if ever the fingerprint(s) it stored for an entity do not match any of the received public keys.</p>
+    <p class="" style="">Alternatively Alice and Bob could agree a shared secret via secure out-of-band communication, Bob could then use it to create an HMAC of his public key that only Alice could verify.</p>
+    <p class="" style="">Note: If no keys are acceptable to Alice (because Alice has never verified any of the keys, and because either the keys are not signed, or Alice does not support the signature algorithms of the keys, or she cannot parse the certificate formats, or she does not recognise the authorities that signed the keys) then, although the ESession can still be encrypted, she cannot be sure she is communicating with Bob.</p>
+  </div>
+  <div class="indent">
+<h3>13.4 <a name="sec-replay">Replay Attacks</a>
+</h3>
+    <p class="" style="">The block cipher counters maintained implicitly by Alice and Bob (C<span class="sub" style="">A</span> and C<span class="sub" style="">B</span>) prevent stanzas being replayed within any ESession. They ensure that the MAC will be different for all stanzas, even if the HMAC key and the content of the stanza are identical.</p>
+    <p class="" style="">Alice and Bob MUST ensure that the value of e or d they provide when negotiating each online ESession is unique. This prevents complete online ESessions being replayed.</p>
+    <p class="" style="">Since Alice supplies the same set of values of e for all offline ESessions, to prevent complete offline ESessions being replayed to her, she MUST take care to securely store <span style="font-style: italic">new</span> values (or destroy existing values) of N<span class="sub" style="">A</span> and x for subscribers whenever she goes offline (see <a href="#init-publish">Publishing ESession Options</a>). Also, when Alice comes online again, she MUST remember all the values of d he receives in offline ESession negotiation stanzas, and reject any offline ESessions that specify a value of d she has already received (see <a href="#init-accept">Accepting an Offline ESession</a>).</p>
+    <p class="" style="">Note: If Alice publishes ESession options for non-subscribers, and if she does not update them whenever she comes online then, until she updates the options, she MUST save all the values of d she receives to secure persistent storage (along with the values of N<span class="sub" style="">A</span> and x).</p>
+  </div>
+  <div class="indent">
+<h3>13.5 <a name="sec-offline">Offline ESessions</a>
+</h3>
+    <p class="" style="">Alice MAY decide not to support Offline ESessions since they are significantly less secure than online ESessions. The Perfect Forward Secrecy window of vulnerability is much longer. More seriously, Alice MUST store her private Diffie-Hellman keys, x<span class="sub" style="">1</span>...x<span class="sub" style="">Z</span>, to local disk or to a server (perhaps symmetrically encrypted with a password). It is <span style="font-style: italic">really</span> hard to securely erase something from a disk.</p>
+    <p class="" style="">Note: If Alice does not support Offline ESessions then, while she is offline, Bob, or Aunt Tillie, will probably send her completely unprotected messages!</p>
+  </div>
+  <div class="indent">
+<h3>13.6 <a name="sec-unencrypted">Unencrypted ESessions</a>
+</h3>
+    <p class="" style="">Organisations with full disclosure policies may require entities to disable encryption to enable the logging of all messages on their server. Unencrypted ESessions meet all the <a href="#reqs-sec">Security Requirements</a> except for Confidentiality. This enables Alice to use the 'secure' ESession option to confirm securely with Bob that both client-server connections are secure.</p>
+  </div>
+  <div class="indent">
+<h3>13.7 <a name="sec-storage">Storage</a>
+</h3>
+    <p class="" style="">If either entity stores a (re-encrypted) transcript of an ESession for future consultation then the Perfect Forward Secrecy offered by this protocol is lost. If the negotiated value of the 'logging' <span style="font-weight: bold">Chat Session Negotiation</span> field is false the entities SHOULD NOT store any part of the ESession content (not even in encrypted form).</p>
+  </div>
+  <div class="indent">
+<h3>13.8 <a name="sec-general">Extra Responsabilities of Implementors</a>
+</h3>
+    <p class="" style="">Cryptography plays only a small part in an entity's security. Even if it implements this protocol perfectly it may still be vulnerable to other attacks. For examples, an implementation might store ESession keys on swap space or save private keys to a file in cleartext! Implementors MUST take very great care when developing applications with secure technologies.</p>
+  </div>
+  <div class="indent">
+<h3>13.9 <a name="sec-mandatory">Mandatory to Implement Technologies</a>
+</h3>
+    <p class="" style="">An implementation of ESession MUST support the Diffie-Hellman Key Agreement and HMAC algorithms. Note: The parameter names mentioned below are related to secure shell; see <span style="font-weight: bold">SSH Transport Layer Encryption Modes</span> for block cipher algorithm details; see the <span class="ref" style="">IANA Secure Shell Protocol Parameters Registry</span>  [<a href="#nt-id2271798">45</a>] for other names.</p>
+    <div class="indent">
+<h3>13.9.1 <a name="sec-mandatory-encryption">Block Cipher Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following block cipher algorithm:</p>
+      <ul>
+        <li>aes128-ctr (see <span class="ref" style="">Advanced Encryption Standard</span>  [<a href="#nt-id2271845">46</a>])</li>
+      </ul>
+      <p class="" style="">The block length of an block cipher algorithm's cipher SHOULD be at least 128 bits. An implementation of ESession MAY also support the following block cipher algorithms:</p>
+      <ul>
+        <li>aes256-ctr</li>
+        <li>aes192-ctr</li>
+        <li>twofish256-ctr (see <span class="ref" style="">Twofish</span>  [<a href="#nt-id2271890">47</a>])</li>
+        <li>twofish192-ctr</li>
+        <li>twofish128-ctr</li>
+        <li>serpent256-ctr (see <span class="ref" style="">Serpent</span>  [<a href="#nt-id2271924">48</a>])</li>
+        <li>serpent192-ctr</li>
+        <li>serpent128-ctr</li>
+        <li>none (no encryption, only signing)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>13.9.2 <a name="sec-mandatory-sign">Key Signing Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support at least the following signing algorithm:</p>
+      <ul>
+        <li>rsa (see <span style="font-weight: bold">RFC 3447</span>)</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following signing algorithm:</p>
+      <ul>
+        <li>dsa (see <span style="font-weight: bold">Digital Signature Standard</span>)</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>13.9.3 <a name="sec-mandatory-public">Public Signature-Verification-Key Formats</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following public key formats:</p>
+      <ul>
+        <li>ssh-rsa</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following public key formats:</p>
+      <ul>
+        <li>ssh-dss</li>
+        <li>x509v3-sign-rsa (see <span class="ref" style="">X.509 Authentication in SSH2</span>  [<a href="#nt-id2272042">49</a>])</li>
+        <li>x509v3-sign-dss</li>
+        <li>pgp-sign-rsa</li>
+        <li>pgp-sign-dss</li>
+      </ul>
+      <p class="" style="">An implementation of ESession MAY also support the following public key formats:</p>
+      <ul>
+        <li>spki-sign-rsa</li>
+        <li>spki-sign-dss</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>13.9.4 <a name="sec-mandatory-hash">Hash Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following hash algorithm:</p>
+      <ul>
+        <li>sha256 (see <span class="ref" style="">Secure Hash Standard</span>  [<a href="#nt-id2272119">50</a>])</li>
+      </ul>
+      <p class="" style="">An implementation of ESession SHOULD also support at least the following hash algorithm (sha1 and md5 are NOT RECOMMENDED):</p>
+      <ul>
+        <li>whirlpool (see <span class="ref" style="">Whirlpool</span>  [<a href="#nt-id2272162">51</a>])</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>13.9.5 <a name="sec-mandatory-compress">Compression Algorithms</a>
+</h3>
+      <p class="" style="">An implementation of ESession MUST support the following compression algorithm:</p>
+      <ul>
+        <li>none (no compression, the output MUST be the same as the input)</li>
+      </ul>
+      <p class="" style="">Support for other algorithms is NOT RECOMMENDED since compression partially defeats the <a href="#reqs-repudiate">Repudiability</a> requirement of this JEP by making it more difficult for a third party (with some knowledge of the plaintext) to modify a transcript of an encrypted session in a meaningful way. However, encrypted content is pseudo-random and cannot be compressed, so, in those cases where bandwidth is severely constrained, an implementation of ESession MAY support the following algorithms to compress content before it is encrypted:</p>
+      <ul>
+        <li>lzw (see <span class="ref" style="">Standard ECMA-151</span>  [<a href="#nt-id2272232">52</a>])</li>
+        <li>zlib (see <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2272258">53</a>])</li>
+      </ul>
+    </div>
+  </div>
+<h2>14.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2272299">54</a>]. </p>
+<h2>15.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>15.1 <a name="registrar-ns">Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2272385">55</a>] shall register the following namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/esession</li>
+      <li>http://jabber.org/protocol/esession#init</li>
+      <li>http://jabber.org/protocol/esession#error</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>15.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2272407">56</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in <span style="font-style: italic">both</span> Encrypted Sessions and Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/esession&lt;/name&gt;
+  &lt;jep&gt;JEP-0116&lt;/jep&gt;
+  &lt;desc&gt;ESession negotiation forms&lt;/desc&gt;
+  &lt;field
+      var='match_resource'
+      type='text-single'
+      label='Target resource for offline ESessions'/&gt;
+  &lt;field
+      var='secure'
+      type='boolean'
+      label='Require encrypted client-server streams'/&gt;
+  &lt;field
+      var='modp'
+      type='list-single'
+      label='MODP group number'/&gt;
+  &lt;field
+      var='crypt_algs'
+      type='list-single'
+      label='Symmetric block cipher options'/&gt;
+  &lt;field
+      var='hash_algs'
+      type='list-single'
+      label='Hash algorithm options'/&gt;
+  &lt;field
+      var='sign_algs'
+      type='list-single'
+      label='Signature algorithm options'/&gt;
+  &lt;field
+      var='compress'
+      type='list-single'
+      label='Compression algorithm options'/&gt;
+  &lt;field
+      var='stanzas'
+      type='list-multi'
+      label='Stanzas types to encrypt'/&gt;
+  &lt;field
+      var='pk_hash'
+      type='boolean'
+      label='Respond with public key fingerprint'/&gt;
+  &lt;field
+      var='ver'
+      type='list-single'
+      label='Supported versions of JEP-0116'/&gt;
+  &lt;field
+      var='rekey_freq'
+      type='text-single'
+      label='Minimum number of stanzas between key exchanges'/&gt;
+  &lt;field
+      var='keys'
+      type='hidden'
+      label='Diffie-Hellman keys'/&gt;
+  &lt;field
+      var='my_nonce'
+      type='hidden'
+      label='ESession ID of Sender'/&gt;
+  &lt;field
+      var='nonce'
+      type='hidden'
+      label='ESession ID of Receiver'/&gt;
+  &lt;field
+      var='counter'
+      type='hidden'
+      label='Initial block counter'/&gt;
+  &lt;field
+      var='pkids'
+      type='list-single'
+      label='Public key IDs'/&gt;
+  &lt;field
+      var='signs'
+      type='list-single'
+      label='Data form signatures'/&gt;
+&lt;/form_type&gt;
+
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;jep&gt;JEP-0155&lt;/jep&gt;
+  ...
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>16.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>17.
+       <a name="acknowledgments">Acknowledgments</a>
+</h2>
+  <p class="" style="">The authors would like to thank Ian Goldberg for the time he spent reviewing this protocol and for his invaluable suggestions and comments.</p>
+<h2>18.
+       <a name="keys">Public Key Publication and Retrieval</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is depricated and will be specified in a separate proposal before this document reaches draft status.</span></p>
+  <p class="" style="">Entities SHOULD publish their long-term public signature-verification keys to all entities through their own server using SPPS.</p>
+  <p class="caption">Example 24. Entity Publishes Public Keys to Server</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='dp1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="" style="">Before initiating an ESession, if Bob does not already possess one of Alice's signature-verification keys, he SHOULD retrieve them from Alice's server.</p>
+  <p class="caption">Example 25. Bob Requests Public Keys from Alice's Server</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="caption">Example 26. Server Returns Public Keys</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='alice@example.org'
+    to='bob@example.com/laptop'
+    id='dp2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/publickeys'&gt;
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/publickeys&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='types'&gt;
+        &lt;value&gt;x509v3-sign-rsa&lt;/value&gt;
+        &lt;value&gt;pgp-sign-dss&lt;/value&gt;
+        &lt;value&gt;ssh-rsa&lt;/value&gt;
+        &lt;value&gt;ssh-dss&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='keys'&gt;
+        &lt;value&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned RSA public key ** &lt;/value&gt;
+        &lt;value&gt; ** Base64 encoded unsigned DSS public key ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Bob should examine all the public keys and identify which ones are acceptable (see <a href="#sec-keys">Verifying Keys</a>).</p>
+<h2>19.
+       <a name="open">Open Issues</a>
+</h2>
+  <div class="indent">
+<h3>19.1 <a name="open-tothink">To Think About</a>
+</h3>
+    <ol start="" type="">
+      <li>Split Offline ESessions into another JEP?</li>
+      <li>Standardise on the X.509 public key and signature formats?</li>
+      <li>What challenges exist to make the OTR Gaim Plugin use this protocol natively when talking to Jabber entities? Can these be mitigated by 'non-critical' protocol changes?</li>
+      <li>Would anything in this protocol (e.g., its dependency on in-order stanza delivery) prevent an XMPP entity using it to exchange encrypted messages and presence with a user of a non-XMPP messaging system, assuming that the gateway both supports this protocol and is compatible with a purpose-built security plugin on the other user's client (e.g. a Gaim plugin connects to the gateway via a non-XMPP network)?</li>
+      <li>Could use <span class="ref" style="">Flexible Offline Message Retrieval</span>  [<a href="#nt-id2272656">57</a>] (FOMR) instead of AMP to prevent any offline ESessions Bob can't decrypt being delivered to him. (Each &lt;item/&gt; that corresponds to an ESession message would have to contain a &lt;ESessionID/&gt; child, to allow Bob to discover which of his stored values of y was used to encrypt the message.)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>19.2 <a name="open-todo">To Do</a>
+</h3>
+    <ol start="" type="">
+      <li>Ask the authors of AMP to explain how to achieve the match_resource functionality to be specified here.</li>
+      <li>Separate public key publishing into another JEP. Should there be a separate SPPS node for each key?</li>
+      <li>Define names for X.509 SubjectPublicKeyInfo public key formats (different to X.509 certificates). This format must be used when keys are distributed within session negotiation.</li>
+      <li>Add non-repudiable signing option</li>
+      <li>Move "secure" field to JEP-0155</li>
+      <li>Perhaps the JEP needs to specify more carefully how block counters are handled between messages, especially in the event of partial blocks?</li>
+      <li>Give examples of specific errors and discuss error scenarios throughout document (e.g., what should Bob do if he is not offline and he receives an offline key exchange stanza?).</li>
+      <li>Update Dependencies list</li>
+      <li>Define an <span style="font-style: italic">optional</span> protocol that would allow Alice to store values of N<span class="sub" style="">A</span> and x (and the PKIDs she trusts) 'securely' on her own server (before she goes offline).</li>
+    </ol>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250801">1</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2250832">2</a>. RFC 3862: Common Presence and Instant Messaging (CPIM): Message Format &lt;<a href="http://www.ietf.org/rfc/rfc3862.txt">http://www.ietf.org/rfc/rfc3862.txt</a>&gt;.</p>
+<p><a name="nt-id2250855">3</a>. RFC 3863: Presence Information Data Format (PIDF) &lt;<a href="http://www.ietf.org/rfc/rfc3863.txt">http://www.ietf.org/rfc/rfc3863.txt</a>&gt;.</p>
+<p><a name="nt-id2250878">4</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2250926">5</a>. Off-the-Record Communication, or, Why Not to Use PGP &lt;<a href="http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf">http://www.isaac.cs.berkeley.edu/~iang/pubs/otr-wpes.pdf</a>&gt;.</p>
+<p><a name="nt-id2250961">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256505">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256558">8</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2256605">9</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256626">10</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256662">11</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256691">12</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256793">13</a>. SSH Protocol Architecture &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-architecture-22.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256814">14</a>. SSH Transport Layer Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-transport-24.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2257044">15</a>. The reliable association between an entity and its public keys is beyond the scope of this JEP.</p>
+<p><a name="nt-id2257094">16</a>. Naturally, it is possible that Alice or Bob may retain cleartext versions of the exchanged communications; however, that threat is out of scope for this JEP.</p>
+<p><a name="nt-id2250414">17</a>. SIGMA: the 'SIGn-and-MAc' Approach to Authenticated Diffie-Hellman and its Use in the IKE Protocols (Hugo Krawczyk, June 12 2003) &lt;<a href="http://web.archive.org/web/20040409013835/http://www.ee.technion.ac.il/~hugo/sigma.ps">http://www.ee.technion.ac.il/~hugo/sigma.ps</a>&gt;.</p>
+<p><a name="nt-id2250401">18</a>. Like <span style="font-weight: bold">RFC 2409</span>, this protocol uses <span style="font-style: italic">variant (ii)</span>, as described in Secion 5.4 of the <span style="font-weight: bold">SIGMA</span> paper.</p>
+<p><a name="nt-id2257553">19</a>. RFC 2409: The Internet Key Exchange (IKE) &lt;<a href="http://www.ietf.org/rfc/rfc2409.txt">http://www.ietf.org/rfc/rfc2409.txt</a>&gt;.</p>
+<p><a name="nt-id2257575">20</a>. Internet Key Exchange (IKEv2) Protocol &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-ipsec-ikev2-17.txt">http://www.ietf.org/internet-drafts/draft-ietf-ipsec-ikev2-17.txt</a>&gt;.</p>
+<p><a name="nt-id2265567">21</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2265594">22</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2265686">23</a>. RFC 2631: Diffie-Hellman Key Agreement Method &lt;<a href="http://www.ietf.org/rfc/rfc2631.txt">http://www.ietf.org/rfc/rfc2631.txt</a>&gt;.</p>
+<p><a name="nt-id2265747">24</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2265833">25</a>. RFC 3526: More Modular Exponential (MODP) Diffie-Hellman Groups &lt;<a href="http://www.ietf.org/rfc/rfc3526.txt">http://www.ietf.org/rfc/rfc3526.txt</a>&gt;.</p>
+<p><a name="nt-id2266024">26</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2266192">27</a>. RFC 3766: Determining Strengths For Public Keys Used For Exchanging Symmetric Keys &lt;<a href="http://www.ietf.org/rfc/rfc3766.txt">http://www.ietf.org/rfc/rfc3766.txt</a>&gt;.</p>
+<p><a name="nt-id2266777">28</a>. RFC 2104: HMAC: Keyed-Hashing for Message Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2104.txt">http://www.ietf.org/rfc/rfc2104.txt</a>&gt;.</p>
+<p><a name="nt-id2266963">29</a>. Recommendation for Block Cipher Modes of Operation: Federal Information Processing Standards Publication 800-38a &lt;<a href="http://csrc.nist.gov/publications/nistpubs/800-38a/sp800-38a.pdf">http://csrc.nist.gov/publications/ nistpubs/800-38a/sp800-38a.pdf</a>&gt;.</p>
+<p><a name="nt-id2268780">30</a>. The more often Alice changes her published ESession options, the shorter the Perfect Forward Secrecy window of vulnerability. However, whenever she changes them she divulges her presence to all the entities that are monitoring them.</p>
+<p><a name="nt-id2268910">31</a>. JEP-0163: Simplified Personal Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2269432">32</a>. Alice may not be able to find the specified value of x if, for example, she went offline using a different client and/or a different machine without publishing a 'match_resource' field. In this case Alice cannot decrypt the offline ESession!</p>
+<p><a name="nt-id2269632">33</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2269709">34</a>. Although counter mode encryption requires no padding, implementations MAY still disguise the length of m by appending a random number of white-space characters.</p>
+<p><a name="nt-id2269729">35</a>. If Bob were to receive a stanza out-of-order, then he would fail to decrypt the stanza and be forced to terminate the ESession.</p>
+<p><a name="nt-id2270086">36</a>. If Bob were to receive a stanza out-of-order, then the MACs would not match because the values of C<span class="sub" style="">A</span> would not be synchronized.</p>
+<p><a name="nt-id2270262">37</a>. Bob MUST NOT send a stream error to his server since intermediate entities are not responsible for encoded content.</p>
+<p><a name="nt-id2270626">38</a>. If an entity fails to receive any stanza that includes a new key in the correct order, then it will fail to decrypt the next stanza it receives and be forced to terminate the ESession.</p>
+<p><a name="nt-id2270833">39</a>. Content is specified for the &lt;terminate/&gt; element to facilitate <a href="#sign-normal">XML Normalization</a>.</p>
+<p><a name="nt-id2271020">40</a>. Canonical XML 1.0 &lt;<a href="http://www.w3.org/TR/xml-c14n">http://www.w3.org/TR/xml-c14n</a>&gt;.</p>
+<p><a name="nt-id2271144">41</a>. RFC 3447: Public-Key Cryptography Standards (PKCS) #1: RSA Cryptography Specifications Version 2.1 &lt;<a href="http://www.ietf.org/rfc/rfc3447.txt">http://www.ietf.org/rfc/rfc3447.txt</a>&gt;.</p>
+<p><a name="nt-id2271198">42</a>. Digital Signature Standard: Federal Information Processing Standards Publication 186  &lt;<a href="http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf">http://csrc.nist.gov/publications/fips/fips186-2/fips186-2-change1.pdf</a>&gt;.</p>
+<p><a name="nt-id2271377">43</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2271425">44</a>. SSH Transport Layer Encryption Modes &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-05.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-newmodes-05.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2271798">45</a>. IANA registry of parameters related to secure shell &lt;<a href="http://www.iana.org/assignments/ssh-parameters">http://www.iana.org/assignments/ssh-parameters</a>&gt;.</p>
+<p><a name="nt-id2271845">46</a>. Advanced Encryption Standard: Federal Information Processing Standards Publication 197 &lt;<a href="http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf">http://csrc.nist.gov/publications/fips/fips197/fips-197.pdf</a>&gt;.</p>
+<p><a name="nt-id2271890">47</a>. The Twofish Block Cipher &lt;<a href="http://www.schneier.com/twofish.html">http://www.schneier.com/twofish.html</a>&gt;.</p>
+<p><a name="nt-id2271924">48</a>. The Serpent Block Cipher &lt;<a href="http://www.cl.cam.ac.uk/~rja14/serpent.html">http://www.cl.cam.ac.uk/~rja14/serpent.html</a>&gt;.</p>
+<p><a name="nt-id2272042">49</a>. X.509 Authentication in SSH2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt">http://www.ietf.org/internet-drafts/draft-ietf-secsh-x509-02.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2272119">50</a>. Secure Hash Standard: Federal Information Processing Standards Publication 180-2  &lt;<a href="http://csrc.nist.gov/publications/fips/fips180-2/fips180-2withchangenotice.pdf">http://csrc.nist.gov/publications/fips/fips180-2/fips186-2withchangenotice.pdf</a>&gt;.</p>
+<p><a name="nt-id2272162">51</a>. The Whirlpool Hash Function &lt;<a href="http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html">http://paginas.terra.com.br/informatica/paulobarreto/WhirlpoolPage.html</a>&gt;.</p>
+<p><a name="nt-id2272232">52</a>. Standard ECMA-151: Data Compression for Information Interchange - Adaptive Coding with Embedded Dictionary - DLCZ Algorithm &lt;<a href="http://www.ecma-international.org/publications/standards/Ecma-151.htm">http://www.ecma-international.org/publications/standards/Ecma-151.htm</a>&gt;.</p>
+<p><a name="nt-id2272258">53</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2272299">54</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2272385">55</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2272407">56</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2272656">57</a>. JEP-0013: Flexible Offline Message Retrieval &lt;<a href="http://www.jabber.org/jeps/jep-0013.html">http://www.jabber.org/jeps/jep-0013.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2005-11-29)</h4>
+<div class="indent">Modified protocol in line with SIGMA: added Identity Protection requirement, no pre-indication of acceptable keys, send multiple values of e with ESession request, offline options published via SPPS, added LZW compression (ip)
+    </div>
+<h4>Version 0.8 (2005-09-27)</h4>
+<div class="indent">Added diagramatic synopses; Added match_resource field; replaced req_mac and kid fields with prev_hash; Alice specifies initial counter (doubles as nonce); many other improvements (ip)
+    </div>
+<h4>Version 0.7 (2005-08-26)</h4>
+<div class="indent">Simplified XML normalization; added Synopsis and Efficiency requirement; defined signature formats (ip)
+    </div>
+<h4>Version 0.6 (2005-08-12)</h4>
+<div class="indent">Extended termination procedure; added object encryption/signing requirement and special case; clarified expired MAC publishing; added Flexible Offline Message Retrieval to Open Issues. (ip)
+    </div>
+<h4>Version 0.5 (2005-08-10)</h4>
+<div class="indent">Added flexibility requirement; added late signature of initial request; added termination MAC. (ip)
+    </div>
+<h4>Version 0.4 (2005-08-09)</h4>
+<div class="indent">Added (offline) replay protection; required offline Created header; compression is NOT RECOMMENDED; added second set of offline options for subscribers; added JIDs to session key generation; unencrypted sessions; added secure option; sign whole data form; HMAC whole &lt;encrypted/&gt; element; added ESession termination; option to distribute public keys within session negotiation; added Integrity requirement; several clarifications (ip)
+    </div>
+<h4>Version 0.3 (2005-08-02)</h4>
+<div class="indent">Restored status to Experimental; complete rewrite; new Introduction, Background, Requirements and Security Considerations; new OTR-inspired protocol; JEP-0155-based negotiation; counter mode encryption; more secure hashes; offline sessions; re-keying; mac publishing; preliminary key and options publishing protocol. (ip/psa)
+    </div>
+<h4>Version 0.2 (2004-07-26)</h4>
+<div class="indent">At the request of the JEP author, changed status to Retracted. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-09)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0117-0.4.html
+++ b/content/xep-0117-0.4.html
@@ -1,0 +1,188 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0117: Intermediate IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Intermediate IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0117">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0117: Intermediate IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0117<br>
+            Version: 0.4<br>
+            Last Updated: 2004-08-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0045, JEP-0071, JEP-0073, JEP-0096, JEP-0115<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#intro">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">Basic IM Protocol Suite</span>  [<a href="#nt-id2596122">1</a>] introduced the concept of a &quot;protocol suite&quot;. This document extends the basic support specified in JEP-0073 by defining an Intermediate IM Protocol Suite.</p>
+<h2>2.
+       <a name="intro">Requirements and Approach</a>
+</h2>
+  <p class="" style="">This document follows the same approach as JEP-0073. By design, the Basic IM Protocol Suite does not include more advanced instant messaging functionality; the present document fills the need for a protocol suite that addresses such functionality.</p>
+  <p class="" style="">A protocol is deemed worthy of inclusion in this protocol suite if:</p>
+  <ul>
+    <li>It addresses common needs of instant messaging users that are addressed by virtually all other popular IM services or systems.</li>
+    <li>It is more advanced than basic IM and presence.</li>
+    <li>It has achieved a status of at least Draft within the Jabber Software Foundation's standards process (as defined in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596094">2</a>]).</li>
+  </ul>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">We define the Intermediate IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0073: Basic IM Protocol Suite</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596304">3</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref">XHTML-IM</span>  [<a href="#nt-id2596240">4</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref">File Transfer</span>  [<a href="#nt-id2596280">5</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref">Entity Capabilities</span>  [<a href="#nt-id2601878">6</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+  </table>
+  <p class="" style="">Note well that the foregoing protocols apply to clients only (i.e., they do not introduce new requirements for servers). In addition, these protocols have their own dependencies, which include:</p>
+  <ul>
+    <li>
+<span class="ref">Data Forms</span>  [<a href="#nt-id2601830">7</a>]</li>
+    <li>
+<span class="ref">Feature Negotiation</span>  [<a href="#nt-id2601847">8</a>]</li>
+    <li>
+<span class="ref">In-Band Bytestreams</span>  [<a href="#nt-id2601971">9</a>]</li>
+    <li>
+<span class="ref">SOCKS5 Bytestreams</span>  [<a href="#nt-id2601992">10</a>]</li>
+  </ul>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no additional security considerations above and beyond those defined in the documents on which it depends.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2601941">11</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602103">12</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596122">1</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596094">2</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596304">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596240">4</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596280">5</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601878">6</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601830">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601847">8</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601971">9</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601992">10</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601941">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602103">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2004-08-18)</h4>
+<div class="indent">Clarified several matters in the text; changed name from &quot;advanced&quot; to &quot;intermediate&quot;. (psa)
+    </div>
+<h4>Version 0.3 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.2 (2003-11-24)</h4>
+<div class="indent">Changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0117-0.5.html
+++ b/content/xep-0117-0.5.html
@@ -1,0 +1,177 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0117: Intermediate IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Intermediate IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0117">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0117: Intermediate IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0117<br>
+            Version: 0.5<br>
+            Last Updated: 2005-04-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0045, JEP-0071, JEP-0073, JEP-0096, JEP-0115<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br></p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#intro">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Basic IM Protocol Suite</span>  [<a href="#nt-id2251363">1</a>] introduced the concept of a "protocol suite". This document extends the basic support specified in JEP-0073 by defining an Intermediate IM Protocol Suite.</p>
+<h2>2.
+       <a name="intro">Requirements and Approach</a>
+</h2>
+  <p class="" style="">This document follows the same approach as JEP-0073. By design, the Basic IM Protocol Suite does not include more advanced instant messaging functionality; the present document fills the need for a protocol suite that addresses such functionality.</p>
+  <p class="" style="">A protocol is deemed worthy of inclusion in this protocol suite if:</p>
+  <ul>
+    <li>It addresses common needs of instant messaging users that are addressed by virtually all other popular IM services or systems.</li>
+    <li>It is more advanced than basic IM and presence.</li>
+    <li>It has achieved a status of at least Draft within the Jabber Software Foundation's standards process (as defined in <span class="ref" style="">Jabber Enhancement Proposals</span>  [<a href="#nt-id2250422">2</a>]).</li>
+  </ul>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">We define the Intermediate IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0073: Basic IM Protocol Suite</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2251114">3</a>]</td>
+      <td align="" colspan="" rowspan="">Support is REQUIRED for all <a href="http://www.jabber.org/jeps/jep-0045.html#user">Occupant Use Cases</a> and for the <a href="http://www.jabber.org/jeps/jep-0045.html#createroom-instant">Creating an Instant Room</a> use case</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2251158">4</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">File Transfer</span>  [<a href="#nt-id2251234">5</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2251213">6</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+  </table>
+  <p class="" style="">Note well that the foregoing protocols apply to clients only (i.e., they do not introduce new requirements for servers). In addition, these protocols have their own dependencies, which include:</p>
+  <ul>
+    <li>
+<span class="ref" style="">Data Forms</span>  [<a href="#nt-id2255161">7</a>]</li>
+    <li>
+<span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2255183">8</a>]</li>
+    <li>
+<span class="ref" style="">In-Band Bytestreams</span>  [<a href="#nt-id2255206">9</a>]</li>
+    <li>
+<span class="ref" style="">SOCKS5 Bytestreams</span>  [<a href="#nt-id2255226">10</a>]</li>
+  </ul>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no additional security considerations above and beyond those defined in the documents on which it depends.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255276">11</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255317">12</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251363">1</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p><a name="nt-id2250422">2</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p><a name="nt-id2251114">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2251158">4</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2251234">5</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2251213">6</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2255161">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2255183">8</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2255206">9</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p><a name="nt-id2255226">10</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p><a name="nt-id2255276">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255317">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2005-04-21)</h4>
+<div class="indent">Modified the JEP-0045 profile to require occupant use cases and instant room creation only. (psa)
+    </div>
+<h4>Version 0.4 (2004-08-18)</h4>
+<div class="indent">Clarified several matters in the text; changed name from "advanced" to "intermediate". (psa)
+    </div>
+<h4>Version 0.3 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.2 (2003-11-24)</h4>
+<div class="indent">Changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0117-0.6.html
+++ b/content/xep-0117-0.6.html
@@ -1,0 +1,184 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0117: Intermediate IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Intermediate IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0117">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0117: Intermediate IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0117<br>
+            Version: 0.6<br>
+            Last Updated: 2005-06-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0045, JEP-0071, JEP-0073, JEP-0096, JEP-0115<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#intro">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Basic IM Protocol Suite</span>  [<a href="#nt-id2251179">1</a>] introduced the concept of a "protocol suite". This document extends the basic support specified in JEP-0073 by defining an Intermediate IM Protocol Suite.</p>
+<h2>2.
+       <a name="intro">Requirements and Approach</a>
+</h2>
+  <p class="" style="">This document follows the same approach as JEP-0073. By design, the Basic IM Protocol Suite does not include more advanced instant messaging functionality; the present document fills the need for a protocol suite that addresses such functionality.</p>
+  <p class="" style="">A protocol is deemed worthy of inclusion in this protocol suite if:</p>
+  <ul>
+    <li>It addresses common needs of instant messaging users that are addressed by virtually all other popular IM services or systems.</li>
+    <li>It is more advanced than basic IM and presence.</li>
+    <li>It has achieved a status of at least Draft within the Jabber Software Foundation's standards process (as defined in <span class="ref" style="">Jabber Enhancement Proposals</span>  [<a href="#nt-id2251246">2</a>]).</li>
+  </ul>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">We define the Intermediate IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0073: Basic IM Protocol Suite</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250462">3</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2250503">4</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">File Transfer</span>  [<a href="#nt-id2250573">5</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2250558">6</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+  </table>
+  <p class="" style="">Note well that the foregoing protocols apply to clients only (i.e., they do not introduce new requirements for servers). In addition, these protocols have their own dependencies, which include:</p>
+  <ul>
+    <li>
+<span class="ref" style="">Data Forms</span>  [<a href="#nt-id2255227">7</a>]</li>
+    <li>
+<span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2255250">8</a>]</li>
+    <li>
+<span class="ref" style="">In-Band Bytestreams</span>  [<a href="#nt-id2255272">9</a>]</li>
+    <li>
+<span class="ref" style="">SOCKS5 Bytestreams</span>  [<a href="#nt-id2255293">10</a>]</li>
+  </ul>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no additional security considerations above and beyond those defined in the documents on which it depends.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255381">11</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255365">12</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251179">1</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p><a name="nt-id2251246">2</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p><a name="nt-id2250462">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2250503">4</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2250573">5</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2250558">6</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2255227">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2255250">8</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2255272">9</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p><a name="nt-id2255293">10</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p><a name="nt-id2255381">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255365">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-06-02)</h4>
+<div class="indent">Per Council discussion, modified the JEP-0045 profile to require all MUC use cases. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-21)</h4>
+<div class="indent">Modified the JEP-0045 profile to require occupant use cases and instant room creation only. (psa)
+    </div>
+<h4>Version 0.4 (2004-08-18)</h4>
+<div class="indent">Clarified several matters in the text; changed name from "advanced" to "intermediate". (psa)
+    </div>
+<h4>Version 0.3 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.2 (2003-11-24)</h4>
+<div class="indent">Changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0117-0.7.html
+++ b/content/xep-0117-0.7.html
@@ -1,0 +1,197 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0117: Intermediate IM Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Intermediate IM Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-08">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0117">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0117: Intermediate IM Protocol Suite</h1>
+<p>This JEP defines a recommended suite of Jabber/XMPP protocols to be supported by intermediate instant messaging and presence applications.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0117<br>
+            Version: 0.7<br>
+            Last Updated: 2005-06-08<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0045, JEP-0071, JEP-0073, JEP-0096, JEP-0115<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#intro">Requirements and Approach</a>
+</dt>
+<dt>3.  <a href="#def">Definition</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Basic IM Protocol Suite</span>  [<a href="#nt-id2251197">1</a>] introduced the concept of a "protocol suite". This document extends the basic support specified in <span style="font-weight: bold">JEP-0073</span> by specifying an Intermediate IM Protocol Suite.</p>
+<h2>2.
+       <a name="intro">Requirements and Approach</a>
+</h2>
+  <p class="" style="">This document follows the same approach as <span style="font-weight: bold">JEP-0073</span>. By design, the Basic IM Protocol Suite does not include more advanced instant messaging functionality; the present document fills the need for a protocol suite that addresses such functionality.</p>
+  <p class="" style="">A protocol is deemed worthy of inclusion in this protocol suite if:</p>
+  <ul>
+    <li>It addresses common needs of instant messaging users that are addressed by virtually all other popular IM services or systems.</li>
+    <li>It is more advanced than basic IM and presence.</li>
+    <li>It has achieved a status of at least Draft within the Jabber Software Foundation's standards process (as defined in <span class="ref" style="">Jabber Enhancement Proposals</span>  [<a href="#nt-id2251309">2</a>]).</li>
+  </ul>
+<h2>3.
+       <a name="def">Definition</a>
+</h2>
+  <p class="" style="">We define the Intermediate IM Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0073: Basic IM Protocol Suite</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250489">3</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2250565">4</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">File Transfer</span>  [<a href="#nt-id2250538">5</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2255235">6</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+  </table>
+  <p class="" style="">Note well that the foregoing protocols apply to clients only (i.e., they do not introduce new requirements for servers). In addition, these protocols have their own dependencies, which include the following JEPs (as well as various IETF RFCs and W3C specifications):</p>
+  <ul>
+    <li>
+<span class="ref" style="">Data Forms</span>  [<a href="#nt-id2255278">7</a>]</li>
+    <li>
+<span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2255300">8</a>]</li>
+    <li>
+<span class="ref" style="">In-Band Bytestreams</span>  [<a href="#nt-id2255322">9</a>]</li>
+    <li>
+<span class="ref" style="">SOCKS5 Bytestreams</span>  [<a href="#nt-id2255342">10</a>]</li>
+    <li>
+<span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2255364">11</a>]</li>
+    <li>
+<span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2255386">12</a>]</li>
+    <li>
+<span class="ref" style="">Stream Initiation</span>  [<a href="#nt-id2255406">13</a>]</li>
+  </ul>
+  <p class="" style="">In addition, because the intermediate suite builds on the basic suite, by definition all protocols required by <span style="font-weight: bold">JEP-0073</span> are also required by the intermediate suite (refer to <span style="font-weight: bold">JEP-0073</span> for details).</p>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no additional security considerations above and beyond those defined in the documents on which it depends.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255476">14</a>].</p> 
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255517">15</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251197">1</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p><a name="nt-id2251309">2</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p><a name="nt-id2250489">3</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2250565">4</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2250538">5</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2255235">6</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2255278">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2255300">8</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2255322">9</a>. JEP-0047: In-Band Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0047.html">http://www.jabber.org/jeps/jep-0047.html</a>&gt;.</p>
+<p><a name="nt-id2255342">10</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p><a name="nt-id2255364">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2255386">12</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2255406">13</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p><a name="nt-id2255476">14</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255517">15</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2005-06-08)</h4>
+<div class="indent">Further clarified dependencies. (psa)
+    </div>
+<h4>Version 0.6 (2005-06-02)</h4>
+<div class="indent">Per Council discussion, modified the JEP-0045 profile to require all MUC use cases. (psa)
+    </div>
+<h4>Version 0.5 (2005-04-21)</h4>
+<div class="indent">Modified the JEP-0045 profile to require occupant use cases and instant room creation only. (psa)
+    </div>
+<h4>Version 0.4 (2004-08-18)</h4>
+<div class="indent">Clarified several matters in the text; changed name from "advanced" to "intermediate". (psa)
+    </div>
+<h4>Version 0.3 (2004-03-24)</h4>
+<div class="indent">Updated to reflect approval of XMPP Core and XMPP IM. (psa)
+    </div>
+<h4>Version 0.2 (2003-11-24)</h4>
+<div class="indent">Changed status to Deferred. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0118-0.10.html
+++ b/content/xep-0118-0.10.html
@@ -1,0 +1,368 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0118: User Tune</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Tune">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the music to which a user is listening.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0118">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0118: User Tune</h1>
+<p>This JEP defines a protocol for communicating information about the music to which a user is listening.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0118<br>
+            Version: 0.10<br>
+            Last Updated: 2004-10-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: tune<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#protocol-elements">Container Element and Child Elements</a>
+</dt>
+<dt>2.2.  <a href="#protocol-transport">Transport Mechanism</a>
+</dt>
+<dt>2.3.  <a href="#protocol-stop">Stop Command</a>
+</dt>
+</dl>
+<dt>3.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>6.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a protocol for communicating information about the music to which a user is listening. Such information may be seen as a kind of &quot;extended presence&quot;, and users may want to communicate such information to their contacts on the network as a fun add-on to traditional IM applications or to provide integration with common music-player applications.</p>
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="protocol-elements">Container Element and Child Elements</a>
+</h3>
+    <p class="" style="">Information about tunes is provided by the user and propagated on the network by the user's client. The information container for tune data is a &lt;tune/&gt; element that is qualified by the 'http://jabber.org/protocol/tune' namespace. The tune information itself is provided as the XML character data of the following children of the &lt;tune/&gt; element:</p>
+    <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Description</th>
+        <th colspan="" rowspan="">Example</th>
+        <th colspan="" rowspan="">Datatype</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">artist</td>
+        <td align="" colspan="" rowspan="">The artist or performer of the song or piece</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">title</td>
+        <td align="" colspan="" rowspan="">The title of the song or piece</td>
+        <td align="" colspan="" rowspan="">Heart of the Sunrise</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">source</td>
+        <td align="" colspan="" rowspan="">The collection (e.g., album) or other source (e.g., a band website that hosts streams or audio files)</td>
+        <td align="" colspan="" rowspan="">Yessongs</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">track</td>
+        <td align="" colspan="" rowspan="">A unique identifier for the tune; e.g., the track number within a collection or the specific URI for the object (e.g., a stream or audio file)</td>
+        <td align="" colspan="" rowspan="">3</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">length</td>
+        <td align="" colspan="" rowspan="">The duration of the song or piece in seconds</td>
+        <td align="" colspan="" rowspan="">686</td>
+        <td align="" colspan="" rowspan="">xs:unsignedShort</td>
+      </tr>
+    </table>
+    <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602129">1</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="protocol-transport">Transport Mechanism</a>
+</h3>
+    <p class="" style="">Tune information SHOULD be communicated and transported by means of the <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602070">2</a>] protocol. Because tune information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+    <p class="caption">Example 1. User Publishes Tune Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='pubsub.jabber.org'
+    id='tunes123'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The tune information is then delivered to all subscribers:</p>
+    <p class="caption">Example 2. Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602253">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Naturally, further extensions could be included, e.g., using <span class="ref">Out-of-Band Data</span>  [<a href="#nt-id2602209">4</a>] to specify a URL where one could buy the recording.</p>
+    <p class="caption">Example 4. Tune info with URL</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+	  &lt;x xmlns='jabber:x:oob'&gt;
+	    &lt;url&gt;http://www.amazon.com/exec/obidos/ASIN/B000002J1Y&lt;/url&gt;
+	  &lt;/x&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="protocol-stop">Stop Command</a>
+</h3>
+    <p class="" style="">In order to indicate that the user is no longer listening to any tunes, the user's client SHOULD send an empty &lt;tune/&gt; element, which can be considered a &quot;stop command&quot; for user tunes:</p>
+    <p class="caption">Example 5. User Publishes &quot;Stop Playing&quot; Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='pubsub.jabber.org'
+    id='tunes345'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'/&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Empty Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'/&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">To prevent a large number of updates when a user is skipping through tracks, an implementation may wait several seconds before publishing new tune information.</p>
+  <p class="" style="">If the length is unknown (e.g., the user is listening to a stream), the &lt;length/&gt; element SHOULD NOT be included.</p>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This protocol introduces no security considerations above and beyond those defined in <span style="font-weight: bold">Publish-Subscribe</span> (JEP-0060).</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602476">5</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602423">6</a>] shall include 'http://jabber.org/protocol/tune' in its registry of protocol namespaces.</p>
+  </div>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/tune'
+    xmlns='http://jabber.org/protocol/tune'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='tune'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='artist' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='title' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='source' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='track' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='length' type='xs:unsignedShort' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602129">1</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602070">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602253">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602209">4</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602476">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602423">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2004-10-29)</h4>
+<div class="indent">Added example with URL. (psa)
+    </div>
+<h4>Version 0.9 (2004-10-27)</h4>
+<div class="indent">Changed recommendation to not include the &lt;length/&gt; element if the track time is unknown. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Added implementation notes; clarified nature of &lt;source/&gt; and &lt;track/&gt; elements; if length is unknown, set to zero. (psa)
+    </div>
+<h4>Version 0.7 (2004-05-20)</h4>
+<div class="indent">Changed &lt;length/&gt; datatype from xs:duration to xs:unsignedShort. (psa)
+    </div>
+<h4>Version 0.6 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.5 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to tune elements. (psa)
+    </div>
+<h4>Version 0.4 (2003-12-14)</h4>
+<div class="indent">Slight modifications to track changes to infobits JEPs. (psa)
+    </div>
+<h4>Version 0.3 (2003-10-23)</h4>
+<div class="indent">Replaced tune elements with infobits. (psa)
+    </div>
+<h4>Version 0.2 (2003-09-10)</h4>
+<div class="indent">Added &quot;stop&quot; function via empty &lt;tune/&gt; element. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0118-0.7.html
+++ b/content/xep-0118-0.7.html
@@ -1,0 +1,326 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0118: User Tune</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Tune">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the music to which a user is listening.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-05-20">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0118">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0118: User Tune</h1>
+<p>This JEP defines a protocol for communicating information about the music to which a user is listening.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0118<br>
+            Version: 0.7<br>
+            Last Updated: 2004-05-20<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: tune<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#protocol-elements">Container Element and Child Elements</a>
+</dt>
+<dt>2.2.  <a href="#protocol-transport">Transport Mechanism</a>
+</dt>
+<dt>2.3.  <a href="#protocol-stop">Stop Command</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>5.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>6.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a protocol for communicating information about the music to which a user is listening. Such information may be seen as a kind of &quot;extended presence&quot;, and users may want to communicate such information to their contacts on the network as a fun add-on to traditional IM applications or to provide integration with common music-player applications.</p>
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="protocol-elements">Container Element and Child Elements</a>
+</h3>
+    <p class="" style="">Information about tunes is provided by the user and propagated on the network by the user's client. The information container for tune data is a &lt;tune/&gt; element that is qualified by the 'http://jabber.org/protocol/tune' namespace. The tune information itself is provided as the XML character data of the following children of the &lt;tune/&gt; element:</p>
+    <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Description</th>
+        <th colspan="" rowspan="">Example</th>
+        <th colspan="" rowspan="">Datatype</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">artist</td>
+        <td align="" colspan="" rowspan="">The artist or performer of the song or piece</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">title</td>
+        <td align="" colspan="" rowspan="">The title of the song or piece</td>
+        <td align="" colspan="" rowspan="">Heart of the Sunrise</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">source</td>
+        <td align="" colspan="" rowspan="">The collection (e.g., album) or other source (e.g., a live music feed)</td>
+        <td align="" colspan="" rowspan="">Yessongs</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">track</td>
+        <td align="" colspan="" rowspan="">A unique identifier for the tune; e.g., the track number within a collection or a URI for the object</td>
+        <td align="" colspan="" rowspan="">3</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">length</td>
+        <td align="" colspan="" rowspan="">The duration of the song or piece in seconds</td>
+        <td align="" colspan="" rowspan="">686</td>
+        <td align="" colspan="" rowspan="">xs:unsignedShort</td>
+      </tr>
+    </table>
+    <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602039">1</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="protocol-transport">Transport Mechanism</a>
+</h3>
+    <p class="" style="">Tune information SHOULD be communicated and transported by means of the <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2601980">2</a>] protocol. Because tune information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+    <p class="caption">Example 1. User Publishes Tune Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='pubsub.jabber.org'
+    id='tunes123'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The tune information is then delivered to all subscribers:</p>
+    <p class="caption">Example 2. Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602162">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="protocol-stop">Stop Command</a>
+</h3>
+    <p class="" style="">In order to indicate that the user is no longer listening to any tunes, the user's client SHOULD send an empty &lt;tune/&gt; element, which can be considered a &quot;stop command&quot; for user tunes:</p>
+    <p class="caption">Example 4. User Publishes &quot;Stop Playing&quot; Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='pubsub.jabber.org'
+    id='tunes345'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'/&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Empty Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'/&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This protocol introduces no security considerations above and beyond those defined in <span style="font-weight: bold">Publish-Subscribe</span> (JEP-0060).</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602302">4</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602249">5</a>] shall include 'http://jabber.org/protocol/tune' in its registry of protocol namespaces.</p>
+  </div>
+<h2>6.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/tune'
+    xmlns='http://jabber.org/protocol/tune'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='tune'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='artist' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='title' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='source' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='track' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='length' type='xs:unsignedShort' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602039">1</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2601980">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602162">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602302">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602249">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2004-05-20)</h4>
+<div class="indent">Changed &lt;length/&gt; datatype from xs:duration to xs:unsignedShort. (psa)
+    </div>
+<h4>Version 0.6 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.5 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to tune elements. (psa)
+    </div>
+<h4>Version 0.4 (2003-12-14)</h4>
+<div class="indent">Slight modifications to track changes to infobits JEPs. (psa)
+    </div>
+<h4>Version 0.3 (2003-10-23)</h4>
+<div class="indent">Replaced tune elements with infobits. (psa)
+    </div>
+<h4>Version 0.2 (2003-09-10)</h4>
+<div class="indent">Added &quot;stop&quot; function via empty &lt;tune/&gt; element. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0118-0.8.html
+++ b/content/xep-0118-0.8.html
@@ -1,0 +1,336 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0118: User Tune</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Tune">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the music to which a user is listening.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0118">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0118: User Tune</h1>
+<p>This JEP defines a protocol for communicating information about the music to which a user is listening.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0118<br>
+            Version: 0.8<br>
+            Last Updated: 2004-10-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: tune<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#protocol-elements">Container Element and Child Elements</a>
+</dt>
+<dt>2.2.  <a href="#protocol-transport">Transport Mechanism</a>
+</dt>
+<dt>2.3.  <a href="#protocol-stop">Stop Command</a>
+</dt>
+</dl>
+<dt>3.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>6.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a protocol for communicating information about the music to which a user is listening. Such information may be seen as a kind of &quot;extended presence&quot;, and users may want to communicate such information to their contacts on the network as a fun add-on to traditional IM applications or to provide integration with common music-player applications.</p>
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="protocol-elements">Container Element and Child Elements</a>
+</h3>
+    <p class="" style="">Information about tunes is provided by the user and propagated on the network by the user's client. The information container for tune data is a &lt;tune/&gt; element that is qualified by the 'http://jabber.org/protocol/tune' namespace. The tune information itself is provided as the XML character data of the following children of the &lt;tune/&gt; element:</p>
+    <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Description</th>
+        <th colspan="" rowspan="">Example</th>
+        <th colspan="" rowspan="">Datatype</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">artist</td>
+        <td align="" colspan="" rowspan="">The artist or performer of the song or piece</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">title</td>
+        <td align="" colspan="" rowspan="">The title of the song or piece</td>
+        <td align="" colspan="" rowspan="">Heart of the Sunrise</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">source</td>
+        <td align="" colspan="" rowspan="">The collection (e.g., album) or other source (e.g., a band website that hosts streams or audio files)</td>
+        <td align="" colspan="" rowspan="">Yessongs</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">track</td>
+        <td align="" colspan="" rowspan="">A unique identifier for the tune; e.g., the track number within a collection or the specific URI for the object (e.g., a stream or audio file)</td>
+        <td align="" colspan="" rowspan="">3</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">length</td>
+        <td align="" colspan="" rowspan="">The duration of the song or piece in seconds</td>
+        <td align="" colspan="" rowspan="">686</td>
+        <td align="" colspan="" rowspan="">xs:unsignedShort</td>
+      </tr>
+    </table>
+    <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602083">1</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="protocol-transport">Transport Mechanism</a>
+</h3>
+    <p class="" style="">Tune information SHOULD be communicated and transported by means of the <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602024">2</a>] protocol. Because tune information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+    <p class="caption">Example 1. User Publishes Tune Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='pubsub.jabber.org'
+    id='tunes123'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The tune information is then delivered to all subscribers:</p>
+    <p class="caption">Example 2. Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602206">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="protocol-stop">Stop Command</a>
+</h3>
+    <p class="" style="">In order to indicate that the user is no longer listening to any tunes, the user's client SHOULD send an empty &lt;tune/&gt; element, which can be considered a &quot;stop command&quot; for user tunes:</p>
+    <p class="caption">Example 4. User Publishes &quot;Stop Playing&quot; Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='pubsub.jabber.org'
+    id='tunes345'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'/&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Empty Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'/&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">To prevent a large number of updates when a user is skipping through tracks, an implementation may wait several seconds before publishing new tune information.</p>
+  <p class="" style="">If the length is unknown (e.g., the user is listening to a stream), the &lt;length/&gt; element SHOULD be set to zero.</p>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This protocol introduces no security considerations above and beyond those defined in <span style="font-weight: bold">Publish-Subscribe</span> (JEP-0060).</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602380">4</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602327">5</a>] shall include 'http://jabber.org/protocol/tune' in its registry of protocol namespaces.</p>
+  </div>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/tune'
+    xmlns='http://jabber.org/protocol/tune'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='tune'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='artist' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='title' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='source' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='track' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='length' type='xs:unsignedShort' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602083">1</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602024">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602206">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602380">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602327">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Added implementation notes; clarified nature of &lt;source/&gt; and &lt;track/&gt; elements; if length is unknown, set to zero. (psa)
+    </div>
+<h4>Version 0.7 (2004-05-20)</h4>
+<div class="indent">Changed &lt;length/&gt; datatype from xs:duration to xs:unsignedShort. (psa)
+    </div>
+<h4>Version 0.6 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.5 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to tune elements. (psa)
+    </div>
+<h4>Version 0.4 (2003-12-14)</h4>
+<div class="indent">Slight modifications to track changes to infobits JEPs. (psa)
+    </div>
+<h4>Version 0.3 (2003-10-23)</h4>
+<div class="indent">Replaced tune elements with infobits. (psa)
+    </div>
+<h4>Version 0.2 (2003-09-10)</h4>
+<div class="indent">Added &quot;stop&quot; function via empty &lt;tune/&gt; element. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0118-0.9.html
+++ b/content/xep-0118-0.9.html
@@ -1,0 +1,339 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0118: User Tune</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Tune">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for communicating information about the music to which a user is listening.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0118">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0118: User Tune</h1>
+<p>This JEP defines a protocol for communicating information about the music to which a user is listening.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0118<br>
+            Version: 0.9<br>
+            Last Updated: 2004-10-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: tune<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#protocol-elements">Container Element and Child Elements</a>
+</dt>
+<dt>2.2.  <a href="#protocol-transport">Transport Mechanism</a>
+</dt>
+<dt>2.3.  <a href="#protocol-stop">Stop Command</a>
+</dt>
+</dl>
+<dt>3.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>6.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines a protocol for communicating information about the music to which a user is listening. Such information may be seen as a kind of &quot;extended presence&quot;, and users may want to communicate such information to their contacts on the network as a fun add-on to traditional IM applications or to provide integration with common music-player applications.</p>
+<h2>2.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="protocol-elements">Container Element and Child Elements</a>
+</h3>
+    <p class="" style="">Information about tunes is provided by the user and propagated on the network by the user's client. The information container for tune data is a &lt;tune/&gt; element that is qualified by the 'http://jabber.org/protocol/tune' namespace. The tune information itself is provided as the XML character data of the following children of the &lt;tune/&gt; element:</p>
+    <p class="caption">Table 1: Child Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Description</th>
+        <th colspan="" rowspan="">Example</th>
+        <th colspan="" rowspan="">Datatype</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">artist</td>
+        <td align="" colspan="" rowspan="">The artist or performer of the song or piece</td>
+        <td align="" colspan="" rowspan="">Yes</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">title</td>
+        <td align="" colspan="" rowspan="">The title of the song or piece</td>
+        <td align="" colspan="" rowspan="">Heart of the Sunrise</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">source</td>
+        <td align="" colspan="" rowspan="">The collection (e.g., album) or other source (e.g., a band website that hosts streams or audio files)</td>
+        <td align="" colspan="" rowspan="">Yessongs</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">track</td>
+        <td align="" colspan="" rowspan="">A unique identifier for the tune; e.g., the track number within a collection or the specific URI for the object (e.g., a stream or audio file)</td>
+        <td align="" colspan="" rowspan="">3</td>
+        <td align="" colspan="" rowspan="">xs:string</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">length</td>
+        <td align="" colspan="" rowspan="">The duration of the song or piece in seconds</td>
+        <td align="" colspan="" rowspan="">686</td>
+        <td align="" colspan="" rowspan="">xs:unsignedShort</td>
+      </tr>
+    </table>
+    <p class="" style="">NOTE: The datatypes specified above are defined in <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602108">1</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="protocol-transport">Transport Mechanism</a>
+</h3>
+    <p class="" style="">Tune information SHOULD be communicated and transported by means of the <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2602050">2</a>] protocol. Because tune information is not pure presence information and can change independently of the user's availability, it SHOULD NOT be provided as an extension to &lt;presence/&gt;.</p>
+    <p class="caption">Example 1. User Publishes Tune Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='pubsub.jabber.org'
+    id='tunes123'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The tune information is then delivered to all subscribers:</p>
+    <p class="caption">Example 2. Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">As mentioned in JEP-0060, the stanza containing the event notification or payload MAY also include 'replyto' data (as specified by the <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602232">3</a>] protocol) to provide an explicit association between the published data and the user:</p>
+    <p class="caption">Example 3. Event notification with extended stanza addressing</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Yes&lt;/artist&gt;
+          &lt;title&gt;Heart of the Sunrise&lt;/title&gt;
+          &lt;source&gt;Yessongs&lt;/source&gt;
+          &lt;track&gt;3&lt;/track&gt;
+          &lt;length&gt;686&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="protocol-stop">Stop Command</a>
+</h3>
+    <p class="" style="">In order to indicate that the user is no longer listening to any tunes, the user's client SHOULD send an empty &lt;tune/&gt; element, which can be considered a &quot;stop command&quot; for user tunes:</p>
+    <p class="caption">Example 4. User Publishes &quot;Stop Playing&quot; Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/work'
+    to='pubsub.jabber.org'
+    id='tunes345'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'/&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Empty Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.jabber.org'
+    to='maineboy@jabber.org'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='generic/tunes/stpeter@jabber.org'&gt;
+      &lt;item id='current'&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'/&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">To prevent a large number of updates when a user is skipping through tracks, an implementation may wait several seconds before publishing new tune information.</p>
+  <p class="" style="">If the length is unknown (e.g., the user is listening to a stream), the &lt;length/&gt; element SHOULD NOT be included.</p>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This protocol introduces no security considerations above and beyond those defined in <span style="font-weight: bold">Publish-Subscribe</span> (JEP-0060).</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602405">4</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602353">5</a>] shall include 'http://jabber.org/protocol/tune' in its registry of protocol namespaces.</p>
+  </div>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/tune'
+    xmlns='http://jabber.org/protocol/tune'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='tune'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='artist' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='title' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='source' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='track' type='xs:string' minOccurs='0'/&gt;
+        &lt;xs:element name='length' type='xs:unsignedShort' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602108">1</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602050">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602232">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602405">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602353">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2004-10-27)</h4>
+<div class="indent">Changed recommendation to not include the &lt;length/&gt; element if the track time is unknown. (psa)
+    </div>
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Added implementation notes; clarified nature of &lt;source/&gt; and &lt;track/&gt; elements; if length is unknown, set to zero. (psa)
+    </div>
+<h4>Version 0.7 (2004-05-20)</h4>
+<div class="indent">Changed &lt;length/&gt; datatype from xs:duration to xs:unsignedShort. (psa)
+    </div>
+<h4>Version 0.6 (2004-04-25)</h4>
+<div class="indent">Corrected several errors; added reference to JEP-0033. (psa)
+    </div>
+<h4>Version 0.5 (2004-02-19)</h4>
+<div class="indent">Reverted from infobits to tune elements. (psa)
+    </div>
+<h4>Version 0.4 (2003-12-14)</h4>
+<div class="indent">Slight modifications to track changes to infobits JEPs. (psa)
+    </div>
+<h4>Version 0.3 (2003-10-23)</h4>
+<div class="indent">Replaced tune elements with infobits. (psa)
+    </div>
+<h4>Version 0.2 (2003-09-10)</h4>
+<div class="indent">Added &quot;stop&quot; function via empty &lt;tune/&gt; element. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0119-0.5.html
+++ b/content/xep-0119-0.5.html
@@ -1,0 +1,393 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0119: Extended Presence Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Extended Presence Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a set of XMPP extensions that provide support for &quot;extended presence&quot; information.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-07-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0119">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0119: Extended Presence Protocol Suite</h1>
+<p>This JEP specifies a set of XMPP extensions that provide support for &quot;extended presence&quot; information.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0119<br>
+            Version: 0.5<br>
+            Last Updated: 2004-07-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060, JEP-0073<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#suite">Extended Presence Protocol Suite</a>
+</dt>
+<dt>5.  <a href="#discovery">Extended Presence Pubsub and Discovery</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A number of network services enable the exchange of information about an entity's availability for communications over the network. This information is usually called &quot;presence&quot;. Examples include a person's availability to talk over a traditional or mobile telephony network, chat over an instant messaging (IM) network, or participate in a video conference. In this core sense, presence is a boolean, &quot;on/off&quot; indicator of network availability.</p>
+  <p class="" style="">Over time, this core notion of presence has been extended to include other information about the entity that either (1) changes quickly or (2) affects the entity's interest in or ability to engage in communications. Examples of such &quot;extended presence&quot; include a person's proximity to or interaction with a user agent (e.g., &quot;away&quot; or &quot;do not disturb&quot;), activity (e.g., &quot;driving&quot;), ambient environment (e.g., &quot;noisy&quot;), and mood (e.g., &quot;grumpy&quot;). Related information includes data about the person's available devices (e.g., &quot;phone&quot; or &quot;IM&quot;), current contact modes or address, and date/time ranges for availability. Because extended presence information can change throughout the day, it is distinct from more stable information about the individual (such as is captured in a vCard or other long-lived metadata).</p>
+  <p class="" style="">This document describes a unified approach to the provision and communication of extended presence information using the Extensible Messaging and Presence Protocol (XMPP), in the form of a &quot;protocol suite&quot; that incorporates by reference a number of existing XMPP extensions.</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">XMPP began life as a dedicated instant messaging and presence protocol within the Jabber community. The needs of this community were not advanced (simple IM and presence), and the presence model designed by that community mainly takes account of basic presence only (i.e., on/off availability on an IM network). Within this model (and using the terminology of <span class="ref">RFC 2778</span>  [<a href="#nt-id2596197">1</a>]), the only watchers are those in the principal's contact list (in XMPP called a &quot;roster&quot;). In addition, authorization to receive basic presence broadcasts is handled by the principal through a combination of roster management and basic presence subscriptions as defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2596298">2</a>]. The presence service is tied to the principal's session with a server, and the server's internal session manager handles both presence and instant messaging functionality (although IM and presence can be separated in system configuration or &quot;on the fly&quot; via negative presence priorities).</p>
+  <p class="" style="">This basic presence model was not designed for the more advanced world of extended presence, wherein there are many granular extended presence nodes, each with its own set of publishers and subscribers. However, there is a more advanced protocol that is specially designed to fully implement the publish-subscribe design pattern on top of XMPP, specified in <span style="font-weight: bold">JEP-0060:</span> <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596149">3</a>]. The publish-subscribe protocol can be used to create a presence service that provides full control over each type of extended presence data.</p>
+  <p class="" style="">In particular, the provision and communication of extended presence information follows the classic publish-subscribe design pattern: an individual publishes information such as geographical location data, and the data is broadcasted to all subscribers who are authorized to receive that data. (Alternatively, the data can be published on behalf of the individual, such as by a mobile telephony service that has knowledge of the individual's geographical location and authorization to act as a publisher of that data.) In general, the relationship between the publisher and subscriber is mediated by a service that receives publication requests, broadcasts data to subscribers, and enables the individual to manage lists of entities that are authorized to publish or subscribe to the data.</p>
+  <p class="" style="">The following diagram provides a schematic representation of such a system.</p>
+<p class="caption"></p>
+<div class="indent"><pre>
+
+Mobile                                  XMPP
+Telephony          Principal           Session
+Service                |               Manager
+   |__________ ________|_________  _______|
+             | |   | |   |   |   | |
+             |1| |2| |3| |4| |5| |6|
+           +-------------------------+
+           |                         |
+           |    Presence Service     |
+           |                         |
+           +-------------------------+
+             |1| |2| |3| |4| |5| |6|
+             |___| |_|   | _______|_
+               |    |    ||   |    |
+              Sub  Sub  Sub  Sub  Sub
+</pre></div>
+  <p class="" style="">In this example, there are six different extended presence nodes (these might be, for example, geographical location, placetype, activity, mood, IM network availability, etc.). The principal is authorized to publish to all six, a Mobile Telephony Service is also authorized to publish to Node 1 (e.g., geolocation), and an XMPP Session Manager is also authorized to publish to Node 6 (e.g., IM network availability). There are five subscribers: Subscriber 1 is authorized to receive data from Node 1 and Node 2, Subscriber 2 is authorized to Node 2 and Node 3, Subscriber 3 is authorized to receive data from Node 4 and Node 6, and Subscribers 4 and 5 are authorized to receive data from Node 6 only.</p>
+  <p class="" style="">It is clear that this model enables a highly flexible presence service with regard to the granularity of extended presence information that an individual can publish, the management of authorized publishers, and the management of authorized subscribers. The generic publish-subscribe pattern is the future of extended presence services in XMPP.</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This document follows the same approach as <span class="ref">Basic IM Protocol Suite</span>  [<a href="#nt-id2601861">4</a>]. By design, the basic suite does not include more advanced functionality related to &quot;extended presence&quot;; the present document fills the need for a protocol suite that addresses such functionality.</p>
+  <p class="" style="">A protocol is deemed worthy of inclusion in this protocol suite if:</p>
+  <ul>
+    <li>It addresses &quot;extended presence&quot; data that is defined in other presence services or protocols (e.g., Wireless Village and SIMPLE), or that is felt to be needed within the Jabber/XMPP community.</li>
+    <li>It has achieved a status of at least Draft within the Jabber Software Foundation's standards process (as defined in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2601816">5</a>]).</li>
+  </ul>
+<h2>4.
+       <a name="suite">Extended Presence Protocol Suite</a>
+</h2>
+  <p class="" style="">We define the Extended Presence Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0073: Basic IM Protocol Suite</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED (prerequisite)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0060: Publish-Subscribe</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED (prerequisite)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref">User Geolocation</span>  [<a href="#nt-id2602046">6</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref">User Physical Location</span>  [<a href="#nt-id2601987">7</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref">User Activity</span>  [<a href="#nt-id2602023">8</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref">User Mood</span>  [<a href="#nt-id2602087">9</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+  </table>
+<h2>5.
+       <a name="discovery">Extended Presence Pubsub and Discovery</a>
+</h2>
+  <p class="" style="">In order to expedite the discovery of all the extended presence pubsub nodes offered by a user, it is RECOMMENDED to use a combination of publish-subscribe nodes and well-known <span class="ref">Service Discovery</span>  [<a href="#nt-id2602220">10</a>] nodes as described below (the latter using the service discovery publishing functionality described in the <a href="http://www.jabber.org/jeps/jep-0030.html#publish">Publishing Available Items</a> section of JEP-0030). The suggested protocol flow to be followed by the user in publishing these items, and by the contact in retrieving these items, is shown below.</p>
+  <p class="" style="">First, the user creates a pubsub node for his extended presence.</p>
+  <p class="caption">Example 1. User creates extended presence pubsub node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net'
+    to='pubsub.shakespeare.lit'
+    id='create1'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+        &lt;create node='romeo-extended-presence-node'/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 2. Pubsub service acknowledges node creation</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    to='romeo@montague.net'
+    from='pubsub.shakespeare.lit'
+    id='create1'/&gt;
+  </pre></div>
+  <p class="" style="">Having created a pubsub node for his extended presence information, the user now publishes this pubsub node to the service discovery node &quot;http://jabber.org/protocol/extended-presence&quot; at his bare JID (using the service discovery publishing protocol) so that other entities can determine the location of his extended presence information when he is offline.</p>
+  <p class="caption">Example 3. User publishes pubsub node location as a disco item</p>
+<div class="indent"><pre>
+&lt;iq id='disco-set-1'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/extended-presence'&gt;
+    &lt;item action='update'
+          jid='pubsub.shakespeare.lit'
+          node='romeo-extended-presence-node'
+          name='Extended Presence'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 4. User's server acknowledges disco node publication</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/home' 
+    id='disco-set-1'
+    to='romeo@montague.net/home' 
+    type='result'/&gt;
+  </pre></div>
+  <p class="" style="">Now the user creates a specific extended presence node, such as a geolocation node.</p>
+  <p class="caption">Example 5. User creates pubsub node for geolocation information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='pubsub.shakespeare.lit'
+    id='create2'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+        &lt;create node='romeo-geolocation-information'/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 6. Pubsub service acknowledges node creation</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    to='romeo@montague.net'
+    from='pubsub.shakespeare.lit'
+    id='create2'/&gt;
+  </pre></div>
+  <p class="" style="">Next, the user publishes his geolocation information pubsub node to the node &quot;http://jabber.org/protocol/geoloc&quot; at his bare JID (using the service discovery publishing protocol) so that it may be discovered even when he is offline.</p>
+  <p class="caption">Example 7. User publishes this node as a disco item</p>
+<div class="indent"><pre>
+&lt;iq id='disco-set-2'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/geoloc'&gt;
+    &lt;item action='update'
+          jid='pubsub.shakespeare.lit'
+          name='Geographic Location'
+          node='romeo-geolocation-information'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 8. User's server acknowledges disco node publication</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/home' 
+    id='disco-set-2'
+    to='romeo@montague.net/home' 
+    type='result'/&gt;
+  </pre></div>
+  <p class="" style="">The user also publishes the geolocation pubsub node as an item under the extended presence pubsub node. The pubsub ItemID MUST be the namespace of the relevant presence extension protocol (in this case, 'http://jabber.org/protocol/geoloc').</p>
+  <p class="caption">Example 9. User publishes geoloc node as extended presence item</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='pubsub.shakespeare.lit'
+    id='publish1'&gt;
+   &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;publish node='romeo-extended-presence-node'&gt;
+        &lt;item id='http://jabber.org/protocol/geoloc'&gt;
+          &lt;item xmlns='http://jabber.org/protocol/disco#items'
+                action='update'
+                jid='pubsub.shakespeare.lit'
+                name='Geographic Location'
+                node='romeo-geolocation-information'/&gt;
+        &lt;/item&gt;
+      &lt;/publish&gt;
+    &lt;/pubsub&gt;
+ &lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 10. Pubsub service acknowledges item publication</p>
+<div class="indent"><pre>
+&lt;iq from='pubsub.shakespeare.lit' 
+    id='publish1' 
+    to='romeo@montague.net/home' type='result'/&gt;
+  </pre></div>
+  <p class="" style="">At this point, a contact who is interested only in the user's geolocation information can send a disco#items request to the node &quot;http://jabber.org/protocol/geoloc&quot; at the user's bare JID:</p>
+  <p class="caption">Example 11. Contact requests geoloc node as disco item</p>
+<div class="indent"><pre>
+&lt;iq from='nurse@capulet.com/pda'
+    id='disco-get-1'
+    to='romeo@montague.net'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/geoloc'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 12. Server informs contact of published geoloc node</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net'
+    id='disco-get-1'
+    to='nurse@capulet.com/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/geoloc'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Geographic Location'
+          node='romeo-geolocation-information'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The contact can then subscribe to that pubsub node.</p>
+  <p class="" style="">On the other hand, a contact who is interested in all of the user's extended presence information can send a disco#items request to the node &quot;http://jabber.org/protocol/extended-presence&quot; at the user's bare jid:</p>
+  <p class="caption">Example 13. Contact requests extended presence node as disco item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='disco-get-2'
+    to='romeo@montague.net'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/extended-presence'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 14. Server informs contact of published extended presence node</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net'
+    id='disco-get-2'
+    to='juliet@capulet.com/balcony'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/extended-presence'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Geolographic Location'
+          node='romeo-geolocation-information'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Mood Information'
+          node='romeo-mood-information'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Activity Information'
+          node='romeo-activity'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This document introduces no new security considerations above and beyond those defined in the documents on which this proposal depends.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602570">11</a>].</p> 
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602517">12</a>] shall add 'http://jabber.org/protocol/extended-presence' to its registry of well-known Service Discovery nodes.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">There is no schema associated with the 'http://jabber.org/protocol/extended-presence' namespace, since it is used only for service discovery.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596197">1</a>. RFC 2778: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2778.txt">http://www.ietf.org/rfc/rfc2778.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596298">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596149">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601861">4</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601816">5</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602046">6</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601987">7</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602023">8</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602087">9</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602220">10</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602570">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602517">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2004-07-22)</h4>
+<div class="indent">Further defined the pubsub/disco interaction. (psa)
+    </div>
+<h4>Version 0.4 (2004-05-12)</h4>
+<div class="indent">Removed text on auto-subscribe functionality. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-11)</h4>
+<div class="indent">Added introduction and background; defined well-known service discovery node for extended presence information; described auto-subscribe functionality. (psa)
+    </div>
+<h4>Version 0.2 (2003-11-24)</h4>
+<div class="indent">Status changed to Deferred. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0119-0.6.html
+++ b/content/xep-0119-0.6.html
@@ -1,0 +1,399 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0119: Extended Presence Protocol Suite</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Extended Presence Protocol Suite">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content='This JEP specifies a set of XMPP extensions that provide support for "extended presence" information.'>
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0119">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0119: Extended Presence Protocol Suite</h1>
+<p>This JEP specifies a set of XMPP extensions that provide support for "extended presence" information.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0119<br>
+            Version: 0.6<br>
+            Last Updated: 2005-03-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060, JEP-0073, JEP-0080, JEP-0084, JEP-0107, JEP-0108, JEP-0112<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Extended%20Presence%20Protocol%20Suite%20(JEP-0119)">http://wiki.jabber.org/index.php/Extended Presence Protocol Suite (JEP-0119)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#background">Background</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#suite">Extended Presence Protocol Suite</a>
+</dt>
+<dt>5.  <a href="#discovery">Extended Presence Pubsub and Discovery</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A number of network services enable the exchange of information about an entity's availability for communications over the network. This information is usually called "presence". Examples include a person's availability to talk over a traditional or mobile telephony network, chat over an instant messaging (IM) network, or participate in a video conference. In this core sense, presence is a boolean, "on/off" indicator of network availability.</p>
+  <p class="" style="">Over time, this core notion of presence has been extended to include other information about the entity that either (1) changes quickly or (2) affects the entity's interest in or ability to engage in communications. Examples of such "extended presence" include a person's proximity to or interaction with a user agent (e.g., "away" or "do not disturb"), activity (e.g., "driving"), ambient environment (e.g., "noisy"), and mood (e.g., "grumpy"). Related information includes data about the person's available devices (e.g., "phone" or "IM"), current contact modes or address, and date/time ranges for availability. Because extended presence information can change throughout the day, it is distinct from more stable information about the individual (such as is captured in a vCard or other long-lived metadata).</p>
+  <p class="" style="">This document describes a unified approach to the provision and communication of extended presence information using the Extensible Messaging and Presence Protocol (XMPP), in the form of a "protocol suite" that incorporates by reference a number of existing XMPP extensions.</p>
+<h2>2.
+       <a name="background">Background</a>
+</h2>
+  <p class="" style="">XMPP began life as a dedicated instant messaging and presence protocol within the Jabber community. The needs of this community were not advanced (simple IM and presence), and the presence model designed by that community mainly takes account of basic presence only (i.e., on/off availability on an IM network). Within this model (and using the terminology of <span class="ref" style="">RFC 2778</span>  [<a href="#nt-id2250571">1</a>]), the only watchers are those in the principal's contact list (in XMPP called a "roster"). In addition, authorization to receive basic presence broadcasts is handled by the principal through a combination of roster management and basic presence subscriptions as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250739">2</a>]. The presence service is tied to the principal's session with a server, and the server's internal session manager handles both presence and instant messaging functionality (although IM and presence can be separated in system configuration or "on the fly" via negative presence priorities).</p>
+  <p class="" style="">This basic presence model was not designed for the more advanced world of extended presence, wherein there are many granular extended presence nodes, each with its own set of publishers and subscribers. However, there is a more advanced protocol that is specially designed to fully implement the publish-subscribe design pattern on top of XMPP, specified in <span style="font-weight: bold">JEP-0060:</span> <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250794">3</a>]. The publish-subscribe protocol can be used to create a presence service that provides full control over each type of extended presence data.</p>
+  <p class="" style="">In particular, the provision and communication of extended presence information follows the classic publish-subscribe design pattern: an individual publishes information such as geographical location data, and the data is broadcasted to all subscribers who are authorized to receive that data. (Alternatively, the data can be published on behalf of the individual, such as by a mobile telephony service that has knowledge of the individual's geographical location and authorization to act as a publisher of that data.) In general, the relationship between the publisher and subscriber is mediated by a service that receives publication requests, broadcasts data to subscribers, and enables the individual to manage lists of entities that are authorized to publish or subscribe to the data.</p>
+  <p class="" style="">The following diagram provides a schematic representation of such a system.</p>
+<p class="caption"></p>
+<div class="indent"><pre>
+
+Mobile                                  XMPP
+Telephony          Principal           Session
+Service                |               Manager
+   |__________ ________|_________  _______|
+             | |   | |   |   |   | |
+             |1| |2| |3| |4| |5| |6|
+           +-------------------------+
+           |                         |
+           |    Extended Presence    |
+	   |         Service         |
+           |                         |
+           +-------------------------+
+             |1| |2| |3| |4| |5| |6|
+             |___| |_|   | _______|_
+               |    |    ||   |    |
+              Sub  Sub  Sub  Sub  Sub
+</pre></div>
+  <p class="" style="">In this example, there are six different extended presence nodes (these might be, for example, geographical location, icon/avatar, activity, mood, network availability, etc.). The principal is authorized to publish to all six, a Mobile Telephony Service is also authorized to publish to Node 1 (e.g., geolocation), and an XMPP Session Manager is also authorized to publish to Node 6 (e.g., network availability). There are five subscribers: Subscriber 1 is authorized to receive data from Node 1 and Node 2, Subscriber 2 is authorized to Node 2 and Node 3, Subscriber 3 is authorized to receive data from Node 4 and Node 6, and Subscribers 4 and 5 are authorized to receive data from Node 6 only.</p>
+  <p class="" style="">It is clear that this model enables a highly flexible presence service with regard to the granularity of extended presence information that an individual can publish, the management of authorized publishers, and the management of authorized subscribers. The generic publish-subscribe pattern is the future of extended presence services in XMPP.</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This document follows the same approach as <span class="ref" style="">Basic IM Protocol Suite</span>  [<a href="#nt-id2250712">4</a>]. By design, the Basic IM Protocol Ssuite does not include more advanced functionality related to "extended presence"; the present document fills the need for a protocol suite that addresses such functionality.</p>
+  <p class="" style="">A protocol is deemed worthy of inclusion in this protocol suite if:</p>
+  <ul>
+    <li>It addresses "extended presence" data that is defined in other presence services or protocols (e.g., Wireless Village or SIMPLE), or that is felt to be needed within the Jabber/XMPP community.</li>
+    <li>It has achieved a status of at least Draft within the Jabber Software Foundation's standards process (as defined in <span class="ref" style="">Jabber Enhancement Proposals</span>  [<a href="#nt-id2250692">5</a>]).</li>
+  </ul>
+<h2>4.
+       <a name="suite">Extended Presence Protocol Suite</a>
+</h2>
+  <p class="" style="">We define the Extended Presence Protocol Suite as follows:</p>
+  <p class="caption">Table 1: Required and Recommended Specifications</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Specification</th>
+      <th colspan="" rowspan="">Requirement Level</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0073: Basic IM Protocol Suite</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED (prerequisite)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan=""><span style="font-weight: bold">JEP-0060: Publish-Subscribe</span></td>
+      <td align="" colspan="" rowspan="">REQUIRED (prerequisite)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2256327">6</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2256371">7</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">User Activity</span>  [<a href="#nt-id2256402">8</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">User Mood</span>  [<a href="#nt-id2256474">9</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">
+<span class="ref" style="">User Avatar</span>  [<a href="#nt-id2256450">10</a>]</td>
+      <td align="" colspan="" rowspan="">REQUIRED</td>
+    </tr>
+  </table>
+<h2>5.
+       <a name="discovery">Extended Presence Pubsub and Discovery</a>
+</h2>
+  <p class="" style="">In order to expedite the discovery of all the extended presence pubsub nodes offered by a user, it is RECOMMENDED to use a combination of publish-subscribe nodes and well-known <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256520">11</a>] nodes as described below (the latter using the service discovery publishing functionality described in the <a href="http://www.jabber.org/jeps/jep-0030.html#publish">Publishing Available Items</a> section of JEP-0030). The suggested protocol flow to be followed by the user in publishing these items, and by the contact in retrieving these items, is shown below.</p>
+  <p class="" style="">First, the user creates a pubsub node for his extended presence.</p>
+  <p class="caption">Example 1. User creates extended presence pubsub node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net'
+    to='pubsub.shakespeare.lit'
+    id='create1'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+        &lt;create node='romeo-extended-presence-node'/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 2. Pubsub service acknowledges node creation</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    to='romeo@montague.net'
+    from='pubsub.shakespeare.lit'
+    id='create1'/&gt;
+  </pre></div>
+  <p class="" style="">Having created a pubsub node for his extended presence information, the user now publishes this pubsub node to the service discovery node "http://jabber.org/protocol/extended-presence" at his bare JID (using the service discovery publishing protocol) so that other entities can determine the location of his extended presence information when he is offline.</p>
+  <p class="caption">Example 3. User publishes pubsub node location as a disco item</p>
+<div class="indent"><pre>
+&lt;iq id='disco-set-1'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/extended-presence'&gt;
+    &lt;item action='update'
+          jid='pubsub.shakespeare.lit'
+          node='romeo-extended-presence-node'
+          name='Extended Presence'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 4. User's server acknowledges disco node publication</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/home' 
+    id='disco-set-1'
+    to='romeo@montague.net/home' 
+    type='result'/&gt;
+  </pre></div>
+  <p class="" style="">Now the user creates a specific extended presence node, such as a geolocation node.</p>
+  <p class="caption">Example 5. User creates pubsub node for geolocation information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='pubsub.shakespeare.lit'
+    id='create2'&gt;
+    &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+        &lt;create node='romeo-geolocation-information'/&gt;
+    &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 6. Pubsub service acknowledges node creation</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    to='romeo@montague.net'
+    from='pubsub.shakespeare.lit'
+    id='create2'/&gt;
+  </pre></div>
+  <p class="" style="">Next, the user publishes his geolocation information pubsub node to the node "http://jabber.org/protocol/geoloc" at his bare JID (using the service discovery publishing protocol) so that it may be discovered even when he is offline.</p>
+  <p class="caption">Example 7. User publishes this node as a disco item</p>
+<div class="indent"><pre>
+&lt;iq id='disco-set-2'
+    type='set'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/geoloc'&gt;
+    &lt;item action='update'
+          jid='pubsub.shakespeare.lit'
+          name='Geographic Location'
+          node='romeo-geolocation-information'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 8. User's server acknowledges disco node publication</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/home' 
+    id='disco-set-2'
+    to='romeo@montague.net/home' 
+    type='result'/&gt;
+  </pre></div>
+  <p class="" style="">The user also publishes the geolocation pubsub node as an item under the extended presence pubsub node. The pubsub ItemID MUST be the namespace of the relevant presence extension protocol (in this case, 'http://jabber.org/protocol/geoloc').</p>
+  <p class="caption">Example 9. User publishes geoloc node as extended presence item</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='pubsub.shakespeare.lit'
+    id='publish1'&gt;
+   &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+      &lt;publish node='romeo-extended-presence-node'&gt;
+        &lt;item id='http://jabber.org/protocol/geoloc'&gt;
+          &lt;item xmlns='http://jabber.org/protocol/disco#items'
+                action='update'
+                jid='pubsub.shakespeare.lit'
+                name='Geographic Location'
+                node='romeo-geolocation-information'/&gt;
+        &lt;/item&gt;
+      &lt;/publish&gt;
+    &lt;/pubsub&gt;
+ &lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 10. Pubsub service acknowledges item publication</p>
+<div class="indent"><pre>
+&lt;iq from='pubsub.shakespeare.lit' 
+    id='publish1' 
+    to='romeo@montague.net/home' type='result'/&gt;
+  </pre></div>
+  <p class="" style="">At this point, a contact who is interested only in the user's geolocation information can send a disco#items request to the node "http://jabber.org/protocol/geoloc" at the user's bare JID:</p>
+  <p class="caption">Example 11. Contact requests geoloc node as disco item</p>
+<div class="indent"><pre>
+&lt;iq from='nurse@capulet.com/pda'
+    id='disco-get-1'
+    to='romeo@montague.net'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/geoloc'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 12. Server informs contact of published geoloc node</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net'
+    id='disco-get-1'
+    to='nurse@capulet.com/pda'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/geoloc'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Geographic Location'
+          node='romeo-geolocation-information'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The contact can then subscribe to that pubsub node.</p>
+  <p class="" style="">On the other hand, a contact who is interested in all of the user's extended presence information can send a disco#items request to the node "http://jabber.org/protocol/extended-presence" at the user's bare jid:</p>
+  <p class="caption">Example 13. Contact requests extended presence nodes as disco items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='disco-get-2'
+    to='romeo@montague.net'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/extended-presence'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 14. Server informs contact of published extended presence nodes</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net'
+    id='disco-get-2'
+    to='juliet@capulet.com/balcony'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/extended-presence'&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Geolographic Location'
+          node='romeo-geolocation-information'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Mood Information'
+          node='romeo-mood-information'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Activity Information'
+          node='romeo-activity'/&gt;
+    &lt;item jid='pubsub.shakespeare.lit'
+          name='Avatar Information'
+          node='romeo-avatar'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This document introduces no new security considerations above and beyond those defined in the documents on which it depends.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256821">12</a>].</p> 
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256872">13</a>] shall include 'http://jabber.org/protocol/extended-presence' in its registry of well-known Service Discovery nodes.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">There is no schema associated with the 'http://jabber.org/protocol/extended-presence' namespace, since it is used only for service discovery.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250571">1</a>. RFC 2778: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2778.txt">http://www.ietf.org/rfc/rfc2778.txt</a>&gt;.</p>
+<p><a name="nt-id2250739">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250794">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250712">4</a>. JEP-0073: Basic IM Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0073.html">http://www.jabber.org/jeps/jep-0073.html</a>&gt;.</p>
+<p><a name="nt-id2250692">5</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p><a name="nt-id2256327">6</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2256371">7</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2256402">8</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p><a name="nt-id2256474">9</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2256450">10</a>. JEP-0084: User Avatar &lt;<a href="http://www.jabber.org/jeps/jep-0084.html">http://www.jabber.org/jeps/jep-0084.html</a>&gt;.</p>
+<p><a name="nt-id2256520">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256821">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256872">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-03-28)</h4>
+<div class="indent">Added avatar support to required protocols. (psa)
+    </div>
+<h4>Version 0.5 (2004-07-22)</h4>
+<div class="indent">Further defined the pubsub/disco interaction. (psa)
+    </div>
+<h4>Version 0.4 (2004-05-12)</h4>
+<div class="indent">Removed text on auto-subscribe functionality. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-11)</h4>
+<div class="indent">Added introduction and background; defined well-known service discovery node for extended presence information; described auto-subscribe functionality. (psa)
+    </div>
+<h4>Version 0.2 (2003-11-24)</h4>
+<div class="indent">Status changed to Deferred. (psa)
+    </div>
+<h4>Version 0.1 (2003-09-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0124-0.8.html
+++ b/content/xep-0124-0.8.html
@@ -1,0 +1,1103 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0124: HTTP Binding</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="HTTP Binding">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0124">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0124: HTTP Binding</h1>
+<p>This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0124<br>
+            Version: 0.8<br>
+            Last Updated: 2004-10-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 1945, RFC 2068, RFC 3174<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: httpbind<br>
+</p>
+<h2>Author Information</h2>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>5.  <a href="#http">HTTP Version and HTTP Headers</a>
+</dt>
+<dt>6.  <a href="#wrapper">&lt;body/&gt; Wrapper Element</a>
+</dt>
+<dt>7.  <a href="#session">Initiating an HTTP Session</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#session-request">Requesting a Session</a>
+</dt>
+<dt>7.2.  <a href="#session-create">Session Creation</a>
+</dt>
+<dt>7.3.  <a href="#session-features">Communication of Stream Features</a>
+</dt>
+</dl>
+<dt>8.  <a href="#preconditions">Additional Preconditions</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#preconditions-xmpp">XMPP Methods</a>
+</dt>
+<dt>8.2.  <a href="#preconditions-iqauth">jabber:iq:auth</a>
+</dt>
+</dl>
+<dt>9.  <a href="#stanzas">Sending and Receiving XML Stanzas</a>
+</dt>
+<dt>10.  <a href="#terminate">Terminating the HTTP Session</a>
+</dt>
+<dt>11.  <a href="#rids">Request IDs</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#rids-order">In-Order Message Forwarding</a>
+</dt>
+<dt>11.2.  <a href="#rids-broken">Broken Connections</a>
+</dt>
+</dl>
+<dt>12.  <a href="#keys">Protecting Insecure Sessions</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#keys-applic">Applicability</a>
+</dt>
+<dt>12.2.  <a href="#keys-intro">Introduction</a>
+</dt>
+<dt>12.3.  <a href="#keys-generate">Generating the Key Sequence</a>
+</dt>
+<dt>12.4.  <a href="#keys-use">Use of Keys</a>
+</dt>
+<dt>12.5.  <a href="#keys-switch">Switching to Another Key Sequence</a>
+</dt>
+</dl>
+<dt>13.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#errorstatus-http">HTTP Conditions</a>
+</dt>
+<dt>13.2.  <a href="#errorstatus-terminal">Terminal Binding Conditions</a>
+</dt>
+<dt>13.3.  <a href="#errorstatus-recover">Recoverable Binding Conditions</a>
+</dt>
+<dt>13.4.  <a href="#errorstatus-stanza">XMPP Stanza Conditions</a>
+</dt>
+</dl>
+<dt>14.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>15.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>16.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>16.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>17.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">
+<span class="ref">XMPP Core</span>  [<a href="#nt-id2596359">1</a>] defines XML streams bound to TCP (see <span class="ref">RFC 793</span>  [<a href="#nt-id2596381">2</a>]) as the standard transport layer for Jabber/XMPP communications. However, the binding of XMPP to TCP is not always feasible because of client runtime environment and/or network constraints. This JEP describes the usage of the Hypertext Transfer Protocol (HTTP, see <span class="ref">RFC 2068</span>  [<a href="#nt-id2596396">3</a>] and <span class="ref">RFC 1945</span>  [<a href="#nt-id2596296">4</a>]) as an alternative transport binding that supports such constrained environments, normally via deployment of a specialized server-side connection manager that communicates with clients via HTTP rather than TCP.</p>
+    <p class="" style="">Before the authors pursued publication of this JEP, other approaches were explored. One possible approach might have been to apply state to a series of HTTP transactions via HTTP &quot;cookies&quot; as specified in <span class="ref">RFC 2965</span>  [<a href="#nt-id2596329">5</a>]. However, there are several significant computing platforms which provide only limited access to underlying HTTP requests/responses; worse, some platforms hide or remove cookie-related headers. Therefore the cookie approach was rejected.</p>
+    <p class="" style="">Another approach might have been to modify or extend <span class="ref">Jabber HTTP Polling</span>  [<a href="#nt-id2601972">6</a>]. This informational protocol has been used by Jabber clients without runtime constraints to access XMPP servers from behind firewalls. Unfortunately, the method defined in JEP-0025 also depends on cookies, does not meet most of the requirements described below, and cannot be extended without breaking all existing implementations.</p>
+    <p class="" style="">Therefore, this JEP specifies a new way of transporting XMPP via HTTP. All information is encoded in the body of standard HTTP POST requests and responses. Each HTTP body contains a single &lt;body/&gt; XML wrapper element (not to be confused with the &lt;body/&gt; child of the &lt;message/&gt; stanza as defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2601912">7</a>]), which encapsulates zero or more XML stanzas.</p>
+    <p class="" style="">Although this JEP documents some XMPP-specific features, the binding is not part of XMPP. In fact, the protocol is extensible and could be used to implement any bidirectional stream of XML stanzas.</p>
+  <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+    <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+      <p class="" style="">This document inherits terminology regarding the Hypertext Transport Protocol from RFCs 1945 and 2068.</p>
+    </div>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">Platform limitiations, security restrictions, and other constraints imply that many clients can connect to Internet resources (e.g., Jabber servers) only via HTTP. The following design requirements reflect the need to offer performance as close as possible to a standard TCP connection.</p>
+    <ol start="" type="">
+      <li>Compatible with constrained runtime environments (e.g., mobile and browser-based clients).</li>
+      <li>Compatible with restricted network connections (e.g., firewalls, proxies, and gateways).</li>
+      <li>Fault tolerant (e.g., session recovers after an underlying TCP connection breaks during an HTTP request).</li>
+      <li>Extensible (based on XML).</li>
+      <li>Consume significantly less bandwidth than polling-based solutions.</li>
+      <li>Significantly more responsive than polling-based solutions.</li>
+      <li>Support for polling (for clients that are limited to one HTTP connection at a time).</li>
+      <li>XML stanzas should arrive at the server in the order they were sent by the client.</li>
+      <li>Protect against unauthorized users interjecting HTTP requests into a session.</li>
+    </ol>
+    <p class="" style="">Compatibility with constrained runtime environments implies the following restrictions:</p>
+    <ul>
+      <li>Clients should not be required to have programmatic access to the headers of each HTTP request and response (e.g., cookies or status codes).</li>
+      <li>The body of each HTTP request and response should be parsable XML with a single root element.</li>
+      <li>Clients should be able to specify the Content-Type of the HTTP responses they receive.</li>
+    </ul>
+  <h2>4.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+    <p class="" style="">The binding of XMPP to HTTP assumes a different architecture from that described for the binding of XMPP to TCP as defined in <span style="font-weight: bold">XMPP Core</span>. In particular, because HTTP is not the native binding for XMPP, we assume that most XMPP implementations will utilize a specialized &quot;connection manager&quot; to handle HTTP connections rather than the usual TCP connections. Effectively, such a connection manager will be a specialized HTTP server that translates between the HTTP requests and responses defined herein and the XML streams (or a server API) implemented by the XMPP server or servers with which it communicates, thus enabling an HTTP client to connect to an XMPP server. We can illustrate this graphically as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+  XMPP Server
+      |
+      |  [XML streams or server API]
+      |
+Connection Manager
+      |
+      |  [HTTP + &lt;body/&gt; wrapper]
+      |
+  HTTP Client
+    </pre></div>
+    <p class="" style="">This JEP addresses communications between an HTTP client and the connection manager only. It does not address communications between the connection manager and the XMPP server, since such communications are implementation-specific (e.g., the connection manager and the XMPP server may use <span class="ref">Jabber Component Protocol</span>  [<a href="#nt-id2602267">8</a>] or an API defined by the XMPP server implementation in order to communicate; alternatively, the XMPP server may natively support the HTTP binding, in which case the connection manager will be a logical entity rather than a physical entity).</p>
+    <p class="" style="">Furthermore, no aspect of the HTTP binding limits its use to client-to-server communications; i.e., it could be used for server-to-server or component-to-server communications as well (probably through a slight change to the XML schema). However, this document focuses exclusively on use of the HTTP binding by clients that cannot maintain persistent TCP connections to a server and that therefore cannot use the TCP binding defined in <span style="font-weight: bold">XMPP Core</span>. We assume that servers and components are under no such restrictions and thus would use the TCP binding.</p>
+  <h2>5.
+       <a name="http">HTTP Version and HTTP Headers</a>
+</h2>
+    <p class="" style="">Clients SHOULD send HTTP requests over persistent HTTP/1.1 connections. However, a constrained client MAY open a new HTTP/1.0 connection (as defined in RFC 1945) to send each request.</p>
+    <p class="" style="">Requests and responses MAY include HTTP headers not specified herein. The receiver SHOULD ignore any such headers.</p>
+  <h2>6.
+       <a name="wrapper">&lt;body/&gt; Wrapper Element</a>
+</h2>
+    <p class="" style="">The body of each HTTP request and response contains a single &lt;body/&gt; wrapper element. The &lt;body/&gt; element MUST contain zero or more complete XML elements. It MUST NOT contain partial XML elements.</p>
+    <p class="" style="">If the &lt;body/&gt; wrapper element is not empty, then it MUST contain one of the following:</p>
+    <ul>
+      <li>One or more complete XMPP stanzas (&lt;message/&gt;, &lt;presence/&gt;, and/or &lt;iq/&gt;).</li>
+      <li>A complete &lt;stream:features/&gt; element qualified by the 'http://etherx.jabber.org/streams' namespace.</li>
+      <li>A complete element used for SASL negotiation and qualified by the 'urn:ietf:params:xml:ns:xmpp-sasl' namespace.</li>
+      <li>XML elements associated with a binding error condition. For details, refer to the <a href="#errorstatus-binding">Binding Conditions</a> section below.</li>
+    </ul>
+    <p class="" style="">Note: Inclusion of TLS negotiation elements is allowed but is NOT RECOMMENDED (see below).</p>
+    <p class="" style="">The &lt;body/&gt; wrapper element SHOULD be qualified by the 'http://jabber.org/protocol/httpbind' namespace, and child elements SHOULD be qualified by their respective namespaces (e.g., 'http://etherx.jabber.org/streams' for stream features, 'urn:ietf:params:xml:ns:xmpp-sasl' for SASL negotiation, and 'jabber:client' for XML stanzas). However, even if the client does not specify the namespaces, the connection manager MUST ensure that the XMPP it provides to the XMPP server or other entities on the network meets the namespacing requirements of <span style="font-weight: bold">XMPP Core</span>.</p>
+    <p class="" style="">The &lt;body/&gt; element of every client request MUST possess a sequential request ID encapsulated via the 'rid' attribute. The client MUST generate a large positive non-zero random integer for the first 'rid' and then increment that value by one for each subsequent request. For details, refer to the <a href="#rids">Request IDs</a> section below.</p>
+  <h2>7.
+       <a name="session">Initiating an HTTP Session</a>
+</h2>
+    <div class="indent">
+<h3>7.1 <a name="session-request">Requesting a Session</a>
+</h3>
+      <p class="" style="">The first request from the client to the connection manager creates a new session.</p>
+      <p class="" style="">The &lt;body/&gt; element of the first request SHOULD possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-weight: bold">'to'</span> -- This attribute specifies the target domain (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'xml:lang'</span> -- This attribute (as defined in Section 2.12 of <span class="ref">XML 1.0</span>  [<a href="#nt-id2602565">9</a>]) specifies the default language of any human-readable XML character data sent or received during the session (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'wait'</span> -- This attribute specifies the longest time (in seconds) that the connection manager is allowed to wait before responding to any request during the session. This enables the client to prevent its TCP connection from expiring due to inactivity, as well as to limit the delay before it discovers any network failure.</li>
+        <li>
+<span style="font-weight: bold">'hold'</span> -- This attribute specifies the maximum number of requests the connection manager is allowed to keep waiting at any one time during the session. (For example, if a constrained client is unable to keep open more than two HTTP connections to the same HTTP server simultaneously, then it SHOULD specify a value of &quot;1&quot;.)</li>
+      </ul>
+      <p class="" style="">Note: Clients that only support polling behavior MAY prevent the connection manager from waiting by setting 'wait' or 'hold' to &quot;0&quot;. However, polling is NOT RECOMMENDED since the associated increase in bandwidth consumption and the decrease in responsiveness are typically one or two orders of magnitude!</p>
+      <p class="" style="">Some clients are constrained to only accept HTTP responses with specific Content-Types (e.g., &quot;text/html&quot;). The &lt;body/&gt; element of the first request MAY possess a 'content' attribute. This specifies the value of the HTTP Content-Type header that MUST appear in all the connection manager's responses during the session. If the client request does not possess a 'content' attribute, then the HTTP Content-Type of responses MUST be &quot;text/xml; charset=utf-8&quot;.</p>
+      <p class="" style="">Note: The HTTP Content-Type of client requests SHOULD also be &quot;text/xml; charset=utf-8&quot;. Clients MAY specify another value if they are constrained to do so (e.g., &quot;application/x-www-form-urlencoded&quot; or &quot;text/plain&quot;). The client and connection manager SHOULD ignore all HTTP Content-Type headers they receive. The connection manager is not required to convert between UTF-8 and other character encodings. For both requests and responses, the &lt;body/&gt; element and its content SHOULD be UTF-8 encoded, even if the HTTP Content-Type header specifies a different charset.</p>
+      <p class="caption">Example 1. Requesting an HTTP session</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">Note: Unlike the protocol defined in JEP-0025, an opening &lt;stream:stream&gt; tag is not sent. The protocol defined herein abstracts from XML streams between the connection manager and the client. Any XML streams between the connection manager and an XMPP server are the responsibility of the connection manager.</p>
+      <p class="" style="">Note: All requests after the first one MUST include a valid 'sid' attribue (provided by the connection manager in the session creation response below). The initialization request is unique in that the &lt;body/&gt; element MUST NOT possess a 'sid' attribute.</p>
+    </div>
+    <div class="indent">
+<h3>7.2 <a name="session-create">Session Creation</a>
+</h3>
+      <p class="" style="">After receiving a new session request, the connection manager MUST generate an opaque, unpredictable session identifier (or SID). The SID MUST be unique within the context of the connection manager application. The connection manager then returns that SID to the client in a response &lt;body/&gt; element.</p>
+      <p class="" style="">The connection manager MUST specify a 'wait' attribute. This is the longest time (in seconds) that it will wait before responding to any request during the session. The time MUST be less than or equal to the value specified in the session request.</p>
+      <p class="" style="">The connection manager MAY limit the number of simultaneous requests the client makes with the 'requests' attribute. The RECOMMENDED value is &quot;2&quot;. Servers that only support polling behavior MUST prevent clients from making simultaneous requests by setting the 'requests' attribute to a value of &quot;1&quot; (however, polling is NOT RECOMMENDED). In any case, clients MUST NOT make more simultaneous requests than specified by the connection manager.</p>
+      <p class="" style="">The connection manager SHOULD include two additional attributes in the session creation response element, specifying the shortest allowable polling interval and the longest allowable inactivity period (both in seconds). Communication of these parameters enables the client to engage in appropriate behavior (e.g., not sending empty request elements more often than desired, and ensuring that the periods with no requests pending are never too long).</p>
+      <p class="caption">Example 2. Session creation response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 128
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">Note: The 'authid' attribute contains the value of the XMPP stream ID generated by the XMPP server. The connection manager MUST retrieve the stream ID and pass it unmodified to the client. This value is needed by the client to successfully complete digest authentication using <span class="ref">Non-SASL Authentication</span>  [<a href="#nt-id2602849">10</a>] (see the <a href="#preconditions-iqauth">jabber:iq:auth</a> section below).</p>
+    <p class="" style="">Note: If the 'authid' attribute is not included in the connection manager's response to the session creation request (e.g., because the connection manager has not yet received a stream ID from the XMPP server), then the client SHOULD send empty request elements (see the &quot;Requesting XML Stanzas&quot; example below) until it receives a response with an 'authid' attribute. In any case, the connection manager MUST return the 'authid' in a response to the client as soon as possible after it receives the stream ID from the XMPP server.</p>
+    <p class="" style="">Separate 'sid' and 'authid' attributes are required because the connection manager is not necessarily part of a single XMPP server (e.g., it may handle HTTP connections on behalf of multiple XMPP servers).</p>
+    </div>
+    <div class="indent">
+<h3>7.3 <a name="session-features">Communication of Stream Features</a>
+</h3>
+      <p class="" style="">As an immediate child of the session creation response, the connection manager MAY include a stream features element, as defined by <span style="font-weight: bold">XMPP Core</span>.</p>
+      <p class="caption">Example 3. Session creation response with stream features</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 417
+
+&lt;body wait='60'
+      inactivity='60'
+      polling='5'
+      requests='2'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;stream:features xmlns='http://etherx.jabber.org/streams'&gt;
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'&gt;
+  &lt;/stream:features&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The stream features SHOULD NOT include a feature for Transport Layer Security (TLS), since channel encryption SHOULD be negotiated at the HTTP layer (see the <a href="#security">Security Considerations</a> section below).</p>
+    </div>
+  <h2>8.
+       <a name="preconditions">Additional Preconditions</a>
+</h2>
+    <p class="" style="">Initializing an HTTP session is the first precondition to sending XML message, presence, and IQ stanzas. However, before processing XML stanzas from the client, the connection manager MUST require completion of additional preconditions using either of the following methods:</p>
+    <ul>
+      <li>
+        <p class="" style="">XMPP authentication, resource binding, and IM session creation, in the following order:</p>
+        <ol start="" type="">
+          <li>Optionally, TLS negotiation as defined in Section 5 of <span style="font-weight: bold">XMPP Core</span> (this is NOT RECOMMENDED since channel encryption SHOULD be negotiated at the HTTP layer; see the <a href="#security">Security Considerations</a> section below)</li>
+          <li>SASL authentication as defined in Section 6 of <span style="font-weight: bold">XMPP Core</span>
+</li>
+          <li>Resource Binding as defined in Section 7 of <span style="font-weight: bold">XMPP Core</span>
+</li>
+          <li>IM Session Establishment as defined in Section 3 of <span style="font-weight: bold">XMPP IM</span>, if appropriate</li>
+        </ol>
+      </li>
+      <li>
+        <p class="" style="">Simultaneous authentication and resource binding as defined in <span style="font-weight: bold">Non-SASL Authentication</span>, upon which a Jabber server will also establish an IM session on behalf of the connected resource.</p>
+      </li>
+    </ul>
+    <p class="" style="">It is RECOMMENDED to use the XMPP methods as defined in <span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span>, rather than using older non-SASL authentication.</p>
+
+    <div class="indent">
+<h3>8.1 <a name="preconditions-xmpp">XMPP Methods</a>
+</h3>
+      <p class="" style="">A success case for authentication, resource binding, and IM session establishment using the XMPP protocols is shown below. For detailed specification of these protocols (including error cases) and for specification of TLS negotiation, refer to <span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span>.</p>
+      <p class="caption">Example 4. SASL authentication step 1</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 172
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='DIGEST-MD5'/&gt;
+&lt;/body&gt;</pre></div>
+
+
+
+      <p class="caption">Example 5. SASL authentication step 2</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 250
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cmVhbG09InNvbWVyZWFsbSIsbm9uY2U9Ik9BNk1HOXRFUUdtMmhoIixxb3A9
+    ImF1dGgiLGNoYXJzZXQ9dXRmLTgsYWxnb3JpdGhtPW1kNS1zZXNzCg==
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 6. SASL authentication step 3</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 418
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    dXNlcm5hbWU9InNvbWVub2RlIixyZWFsbT0ic29tZXJlYWxtIixub25jZT0i
+    T0E2TUc5dEVRR20yaGgiLGNub25jZT0iT0E2TUhYaDZWcVRyUmsiLG5jPTAw
+    MDAwMDAxLHFvcD1hdXRoLGRpZ2VzdC11cmk9InhtcHAvZXhhbXBsZS5jb20i
+    LHJlc3BvbnNlPWQzODhkYWQ5MGQ0YmJkNzYwYTE1MjMyMWYyMTQzYWY3LGNo
+    YXJzZXQ9dXRmLTgK
+&lt;/response&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 7. SASL authentication step 4</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 190
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cnNwYXV0aD1lYTQwZjYwMzM1YzQyN2I1NTI3Yjg0ZGJhYmNkZmZmZAo=
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 8. SASL authentication step 5</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 152
+
+&lt;body rid='3197423133'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 9. SASL authentication step 6</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 121
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="" style="">Note: Because the context for a client's communication with a connection manager in the HTTP transport binding is HTTP rather than XML streams (as in the TCP binding), there is no need to re-start communications (e.g., by generating a new SID) at this point.</p>
+
+      <p class="caption">Example 10. Resource binding request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 240
+
+&lt;body rid='3197423134'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 11. Resource binding result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 221
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='result'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;jid&gt;stpeter@jabber.org/httpclient&lt;/jid&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 12. IM session request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 261
+
+&lt;body rid='3197423135'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='stpeter@jabber.org/httpclient'
+      id='sess_1'
+      to='jabber.org'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'/&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 13. IM session result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 175
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='jabber.org'
+      id='sess_1'
+      to='stpeter@jabber.org/httpclient'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+
+    </div>
+
+    <div class="indent">
+<h3>8.2 <a name="preconditions-iqauth">jabber:iq:auth</a>
+</h3>
+      <p class="" style="">A success case for simultaneous authentication, resource binding, and IM session creation using the original &quot;jabber:iq:auth&quot; protocol is shown below. For further details regarding use of this protocol, refer to JEP-0078. If digest authentication is used, then the stream ID value used to compute the hashed password MUST be the value of the 'authid' attribute provided by the connection manager in the response to the initialization element or in a subsequent response (see the <a href="#session-create">Session Creation</a> section above).</p>
+      <p class="caption">Example 14. Non-SASL authentication request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 281
+
+&lt;body rid='2842791421'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;query xmlns='jabber:iq:auth'&gt;
+      &lt;username&gt;stpeter&lt;/username&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+      &lt;password&gt;jabber-rocks&lt;/password&gt;
+    &lt;/query&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 15. Authentication result (success)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 144
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 16. Authentication result (failure)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 226
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='error'
+      xmlns='jabber:client'&gt;
+    &lt;error code='401' type='auth'&gt;
+      &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>9.
+       <a name="stanzas">Sending and Receiving XML Stanzas</a>
+</h2>
+    <p class="" style="">After the client has successfully completed all required preconditions, it can send and receive XML stanzas via the HTTP binding.</p>
+    <p class="caption">Example 17. Transmitting stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='2842791422'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message to='friend@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">Upon receipt of a request, the connection manager MUST forward the content of the &lt;body/&gt; element to the XMPP server as soon as possible. However, it must forward the content from different requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">The connection manager MUST also return an HTTP 200 OK response with a &lt;body/&gt; element to the client. Note: This does not indicate that the stanzas have been successfully delivered to the destination Jabber endpoint.</p>
+    <p class="" style="">It is RECOMMENDED that the connection manager not return an HTTP result until a stanza has arrived from the XMPP server for delivery to the client. However, the connection manager SHOULD NOT wait longer than the time specified by the client in the 'wait' attribute of its session creation request, and it SHOULD NOT keep more HTTP requests waiting at a time than the number specified in the 'hold' attribute of the session creation request. In any case it MUST respond to requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">If there are no stanzas waiting or ready to be delivered within the waiting period, then the connection manager SHOULD include an empty &lt;body/&gt; element in the HTTP result:</p>
+    <p class="caption">Example 18. Empty response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 64
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">If the connection manager has received one or more stanzas from the XMPP server for delivery to the client, then it SHOULD return the stanzas in the body of its response as soon as possible after receiving them from the XMPP server.</p>
+    <p class="caption">Example 19. Response with queued stanza</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 185
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message from='contact@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message from='friend@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The client MAY poll the connection manager for incoming stanzas by sending an empty &lt;body/&gt; element.</p>
+    <p class="caption">Example 20. Requesting XML Stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='2842791423'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The connection manager MUST wait and respond in the same way as it does after receiving stanzas from the client.</p>
+    <p class="" style="">If the client sends two consecutive empty requests within a period shorter than that specified by the 'polling' attribute in the session creation response, then the connection manager SHOULD terminate the HTTP session and return an HTTP 403 (Forbidden) error to the client.</p>
+    <p class="caption">Example 21. Too frequent polling response</p>
+<div class="indent"><pre>
+HTTP/1.1 403 Forbidden
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    <p class="" style="">If the connection manager did not specify a shortest allowable polling interval in the session creation response, then it MUST allow the client to poll as frequently as it chooses.</p>
+    <p class="" style="">After receiving a response from the connection manager, if no other requests are pending and the client did not specify polling behavior in the session creation request (by setting 'wait' or 'hold' to &quot;0&quot;), it SHOULD make a new request as soon as possible. In any case, if no requests are pending, the client MUST make a new request before the maximum inactivity period has expired. This period is specified by the 'inactivity' attribute in the session creation response.</p>
+    <p class="" style="">If the connection manager has responded to all the requests it has received and the time since its last response is longer than the maximum inactivity period, then it SHOULD terminate the session without informing the client (if the client makes another request, the connection manager SHOULD respond as if the session does not exist).</p>
+    <p class="" style="">If the connection manager did not specify a maximum inactivity period in the session creation response, then it MUST allow the client to be inactive for as long as it chooses.</p>
+  <h2>10.
+       <a name="terminate">Terminating the HTTP Session</a>
+</h2>
+    <p class="" style="">At any time, the client MAY gracefully terminate the session by sending a &lt;body/&gt; element with a 'type' attribute set to &quot;terminate&quot;. The termination request SHOULD include an XMPP presence stanza of type &quot;unavailable&quot; to ensure graceful logoff with the XMPP server.</p>
+    <p class="caption">Example 22. Session termination by client</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 153
+
+&lt;body rid='2842791424'
+      sid='SomeSID'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;presence type='unavailable'
+            xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The connection manager SHOULD return an HTTP 200 OK response with an empty &lt;body/&gt; element. Upon receiving the response, the client MUST consider the HTTP session to have been terminated.</p>
+  <h2>11.
+       <a name="rids">Request IDs</a>
+</h2>
+    <div class="indent">
+<h3>11.1 <a name="rids-order">In-Order Message Forwarding</a>
+</h3>
+      <p class="" style="">When a client makes simultaneous requests, the connection manager may receive them out of order. The connection manager MUST forward the stanzas to the XMPP server and respond to the client requests in the order specified by the 'rid' attributes. The client MUST process responses received from the connection manager in the order the requests were made.</p>
+      <p class="" style="">The connection manager SHOULD expect the 'rid' attribute to be within a window of values greater than the 'rid' of the previous request. The size of the window is equal to the maximum number of simultaneous requests allowed by the connection manager. If it receives a request with a 'rid' greater than the values in the window, then the connection manager MUST terminate the session with an error:</p>
+      <p class="caption">Example 23. Unexpected rid error</p>
+<div class="indent"><pre>
+HTTP/1.1 401 Unauthorized
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>11.2 <a name="rids-broken">Broken Connections</a>
+</h3>
+      <p class="" style="">Unreliable network communications or client constraints can result in broken connections. The connection manager SHOULD remember the 'rid' and the associated HTTP response body of the client's most recent requests which did not result in an HTTP or binding error. The number of responses kept in the buffer should be the same as the maximum number of simultaneous requests allowed by the connection manager.</p>
+      <p class="" style="">If the network connection is broken or closed before the client receives a response to a request from the connection manager, then the client MAY resend an exact copy of the original request. Whenever the connection manager receives a request with a 'rid' that it has already received, it SHOULD return an HTTP 200 (OK) response that includes the buffered copy of the original XML response to the client (i.e., a &lt;body/&gt; wrapper element possessing appropriate attributes and optionally containing one or more XML stanzas or other allowable XML elements). If the original response is not available (e.g., it is no longer in the buffer), then the connection manager MUST return an HTTP 401 (Unauthorized) error:</p>
+      <p class="caption">Example 24. Response not in buffer error</p>
+<div class="indent"><pre>
+HTTP/1.1 401 Unauthorized
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+      <p class="" style="">Note: The error is the same whether the 'rid' is too large or too small. This makes it more difficult for an attacker to discover an acceptable value.</p>
+    </div>
+  <h2>12.
+       <a name="keys">Protecting Insecure Sessions</a>
+</h2>
+    <div class="indent">
+<h3>12.1 <a name="keys-applic">Applicability</a>
+</h3>
+      <p class="" style="">The OPTIONAL key sequencing mechanism described here MAY be used if the client's session with the connection manager is not secure. The session should be considered secure only if all client requests are made via TLS/SSL HTTP connections and the connection manager generates an unpredictable session ID. If the session is secure, it is not necessary to use this key sequencing mechanism.</p>
+      <p class="" style="">Even if the session is not secure, the unpredictable session and request IDs specified in the preceding sections of this document already provide a level of protection similar to that provided by a standard XMPP connection bound to a single pair of persistent TCP/IP connections, and thus provide sufficient protection against a 'blind' attacker. However, in some circumstances, the key sequencing mechanism defined below helps to protect against a more determined and knowledgeable attacker.</p>
+      <p class="" style="">It is important to recognize that the key sequencing mechanism defined below helps to protect only against an attacker who is able to view the contents of all requests or responses in an insecure session but who is not able to alter the contents of those requests (in this case, the mechanism prevents the attacker from interjecting HTTP requests into the session, e.g., termination requests or responses). However, the key sequencing mechanism does not provide any protection when the attacker is able to alter the contents of insecure requests or responses.</p>
+    </div>
+    <div class="indent">
+<h3>12.2 <a name="keys-intro">Introduction</a>
+</h3>
+      <p class="" style="">The HTTP requests of each session MAY be spread across a series of different socket connections. This would enable an unauthorized user that obtains the session ID and request ID of a session and then use their own socket connection to interject &lt;body/&gt; request elements into the session and receive the corresponding responses.</p>
+      <p class="" style="">The key sequencing mechanism below protects against such attacks by enabling a connection manager to detect &lt;body/&gt; request elements interjected by a third party.</p>
+    </div>
+    <div class="indent">
+<h3>12.3 <a name="keys-generate">Generating the Key Sequence</a>
+</h3>
+      <p class="" style="">Prior to requesting a new session, the client MUST select an unpredictable counter (&quot;n&quot;) and an unpredictable value (&quot;seed&quot;). The client then processes the &quot;seed&quot; through a cryptographic hash and converts the resulting 160 bits to a hexadecimal string K(1). It does this &quot;n&quot; times to arrive at the initial key K(n). The hashing algorithm MUST be SHA-1 as defined in <span class="ref">RFC 3174</span>  [<a href="#nt-id2604470">11</a>].</p>
+      <p class="caption">Example 25. Creating the key sequence</p>
+<div class="indent"><pre>
+        K(1) = hex(SHA-1(seed))
+        K(2) = hex(SHA-1(K(1)))
+        ...
+        K(n) = hex(SHA-1(K(n-1)))
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>12.4 <a name="keys-use">Use of Keys</a>
+</h3>
+      <p class="" style="">The client MUST set the 'newkey' attribute of the first request in the session to the value K(n).</p>
+      <p class="caption">Example 26. Session Request with Initial Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      newkey='ca393b51b682f61f98e7877d61146407f3d0a770'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The client MUST set the 'key' attribute of all subsequent requests to the value of the next key in the generated sequence (decrementing from K(n-1) towards K(1) with each request sent).</p>
+    <p class="caption">Example 27. Request with Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      key='bfb06a6f113cd6fd3838ab9d300fdb4fe3da2f7d'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The connection manager MAY verify the key by calculating the SHA-1 hash of the key and comparing it to the 'newkey' attribute of the previous request (or the 'key' attribute if the 'newkey' attribute was not set). If the values do not match (or if it receives a request without a 'key' attribute and the 'newkey' or 'key' attribute of the previous request was set), then the connection manager MUST NOT process the element, MUST terminate the session, and MUST return an HTTP 401 (Unauthorized) error.</p>
+      <p class="caption">Example 28. Invalid Key Sequence Error</p>
+<div class="indent"><pre>
+HTTP/1.1 401 Unauthorized
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>12.5 <a name="keys-switch">Switching to Another Key Sequence</a>
+</h3>
+      <p class="" style="">A client SHOULD choose a high value for &quot;n&quot; when generating the key sequence. However, if the session lasts long enough that the client arrives at the last key in the sequence K(1) then the client MUST switch to a new key sequence.</p>
+      <p class="" style="">The client MUST:</p>
+      <ol start="" type="">
+        <li>Choose new values for &quot;seed&quot; and &quot;n&quot;.</li>
+        <li>Generate a new key sequence using the algorithm defined above.</li>
+        <li>Set the 'key' attribute of the request to the next value in the old sequence (i.e. K(1), the last value).</li>
+        <li>Set the 'newkey' attribute of the request to the value K(n) from the new sequence.</li>
+      </ol>
+      <p class="caption">Example 29. New Key Sequence</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      key='6f825e81f4532b2c5fa2d12457d8a1f22e8f838e'
+      newkey='113f58a37245ec9637266cf2fb6e48bfeaf7964e'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>13.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+    <p class="" style="">There are four types of error and status reporting in HTTP responses:</p>
+    <p class="caption">Table 1: Error Condition Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition Type</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">HTTP Conditions</span></td>
+<td align="" colspan="" rowspan="">The connection manager responds to an invalid client request with a standard HTTP error. These are used for binding syntax errors, possible attacks, etc. Note that constrained clients are unable to differentiate between HTTP errors.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Terminal Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These error conditions may be read by constrained clients. They are used for connection manager problems, abstracting stream errors, and communication problems between the connection manager and the XMPP server.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Recoverable Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These report communication problems between the connection manager and the client. They do not terminate the session. Clients recover from these errors by resending the last two &lt;body/&gt; wrapper elements.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP Stanza Conditions</span></td>
+<td align="" colspan="" rowspan="">XMPP errors relating to XML stanzas within &lt;body/&gt; wrapper elements are, in general, defined in the appropriate RFC or JEP. They do not terminate the session. An example of such usage is shown above in relation to <span style="font-weight: bold">Non-SASL Authentication</span>.</td>
+</tr>
+    </table>
+    <p class="" style="">Full descriptions are provided below.</p>
+    <div class="indent">
+<h3>13.1 <a name="errorstatus-http">HTTP Conditions</a>
+</h3>
+      <p class="" style="">The following HTTP error and status codes are used in particular ways by this protocol (other HTTP error and status codes may be used as appropriate). Upon receiving an HTTP error (200, 400, 401, 403), the HTTP client MUST consider the HTTP session to be null and void.</p>
+      <p class="" style="">Note: These are pure HTTP codes as defined in the HTTP specification, and are not to be confused with the HTTP-style error codes traditionally used in Jabber protocols and documented in <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2604874">12</a>].</p>
+      <p class="caption">Table 2: HTTP Error and Status Codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Code</th>
+          <th colspan="" rowspan="">Name</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">200</td>
+          <td align="" colspan="" rowspan="">OK</td>
+          <td align="" colspan="" rowspan="">Response to valid client request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">400</td>
+          <td align="" colspan="" rowspan="">Bad Request</td>
+          <td align="" colspan="" rowspan="">Inform client that the format of an HTTP header or binding element is unacceptable (e.g., syntax error).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">401</td>
+          <td align="" colspan="" rowspan="">Unauthorized</td>
+          <td align="" colspan="" rowspan="">Inform client that (1) 'sid' is not valid, (2) 'rid' is larger than the upper limit of the expected window, (3) connection manager is unable to resend response, (4) 'key' sequence is invalid.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">403</td>
+          <td align="" colspan="" rowspan="">Forbidden</td>
+          <td align="" colspan="" rowspan="">Inform client that it has broken the session rules (polling too-frequently, too many simultaneous connections).</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>13.2 <a name="errorstatus-terminal">Terminal Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a fatal error by setting a 'type' attribute of the &lt;body/&gt; element to &quot;terminate&quot;. These binding errors imply that the HTTP session is terminated. (Note: Many of these conditions correspond to the relevant XMPP stream error conditions specified in <span style="font-weight: bold">XMPP Core</span>, but actual XMPP stream error conditions experienced between the connection manager and the server are contained only in the &quot;remote-stream-error&quot; condition as described below.)</p>
+      <p class="caption">Example 30. Remote connection failed error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='terminate'
+      condition='remote-connection-failed'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The following values of the 'condition' attribute are defined:</p>
+      <p class="caption">Table 3: Binding Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Condition</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-gone</td>
+          <td align="" colspan="" rowspan="">The target hostname specified in the 'to' attribute is no longer serviced by the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-unknown</td>
+          <td align="" colspan="" rowspan="">The target hostname specified in the 'to' attribute is unknown to the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">improper-addressing</td>
+          <td align="" colspan="" rowspan="">The initialization element lacks a 'to' attribute (or the attribute has no value) but the connection manager requires one.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">internal-server-error</td>
+          <td align="" colspan="" rowspan="">The connection manager has experienced an internal error that prevents it from servicing the request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">other-request</td>
+          <td align="" colspan="" rowspan="">Another request being processed at the same time as this request caused the session to terminate.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-connection-failed</td>
+          <td align="" colspan="" rowspan="">The connection manager was unable to connect to, or has lost its connection to, the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-stream-error</td>
+          <td align="" colspan="" rowspan="">Encapsulates an XMPP stream error. The content of the binding is a copy of the content of the &lt;stream:error/&gt; element received from the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">see-other-uri</td>
+          <td align="" colspan="" rowspan="">The connection manager does not operate at this URI (e.g., the connection manager accepts only SSL/TLS connections at some https: URI rather than the http: URI requested by the client). The client may try POSTing to the URI in the content of the &lt;uri/&gt; child element.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">system-shutdown</td>
+          <td align="" colspan="" rowspan="">The connection manager is being shut down. All active HTTP sessions are being terminated. No new sessions can be created.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">undefined-condition</td>
+          <td align="" colspan="" rowspan="">The error is not one of those defined herein; the connection manager SHOULD include application-specific information in the content of the &lt;body/&gt; wrapper element.</td>
+        </tr>
+      </table>
+      <p class="" style="">The following is an example of a &quot;see-other-uri&quot; condition:</p>
+      <p class="caption">Example 31. See other URI error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='see-other-uri'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;uri&gt;https://secure.jabber.org/xmppcm&lt;/uri&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The following is an example of a &quot;remote-stream-error&quot; condition:</p>
+      <p class="caption">Example 32. Remote error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='remote-stream-error'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;xml-not-well-formed xmlns='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+  &lt;text xmlns='urn:ietf:params:xml:ns:xmpp-streams'
+        xml:lang='en'&gt;
+    Some special application diagnostic information!
+  &lt;/text&gt;
+  &lt;escape-your-data xmlns='application-ns'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">Naturally, the client MAY report binding errors to the connection manager as well, although this is unlikely.</p>
+    </div>
+    <div class="indent">
+<h3>13.3 <a name="errorstatus-recover">Recoverable Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a recoverable error by setting a 'type' attribute of the &lt;body/&gt; element to &quot;error&quot;. These errors do not imply that the HTTP session is terminated.</p>
+      <p class="" style="">If it decides to recover from the error, then the client MUST repeat the HTTP request and the previous HTTP request. The content of both requests MUST be identical to the &lt;body/&gt; elements of the original requests. This allows the server to recover a session after the previous request was lost due to a communication failure.</p>
+      <p class="caption">Example 33. Recoverable error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='error'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    </div>
+    <div class="indent">
+<h3>13.4 <a name="errorstatus-stanza">XMPP Stanza Conditions</a>
+</h3>
+      <p class="" style="">Application-level error conditions will normally be generated by a third entity (e.g., an IM contact) and routed to the client through the connection manager; therefore they are out of scope for the transport binding defined herein and are described in the appropriate RFC or JEP.</p>
+      <p class="" style="">However, it is possible that a connection manager will receive a stanza for delivery to a client even though the client connection is no longer active (e.g., before the connection manager is able to inform a server that the connection has died). In this case, the connection manager would return an error to the server; it is RECOMMENDED that the connection manager proceed as follows, since the situation is similar to that addressed by point #2 of Section 11.1 of <span style="font-weight: bold">XMPP IM</span>:</p>
+      <ol start="" type="">
+        <li>If the delivered stanza was &lt;presence/&gt;, silently drop the stanza and do not return an error to the sender.</li>
+        <li>If the delivered stanza was &lt;iq/&gt;, return a &lt;service-unavailable/&gt; error to the sender.</li>
+        <li>If the delivered stanza was &lt;message/&gt;, return a &lt;recipient-unavailable/&gt; error to the sender.</li>
+      </ol>
+      <p class="" style="">When a server receives a &lt;message/&gt; stanza of type &quot;error&quot; containing a &lt;recipient-unavailable/&gt; condition from a connection manager, it SHOULD store the message for later delivery if offline storage is enabled, otherwise route the error stanza to the sender.</p>
+    </div>
+  <h2>14.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Communications SHOULD occur over an encrypted channel. Negotiation of channel encryption SHOULD occur at the HTTP layer, not the application layer; such negotiation SHOULD follow the protocol defined in <span class="ref">RFC 2817</span>  [<a href="#nt-id2605576">13</a>].</p>
+    <p class="" style="">The session identifier (SID) and initial request identifier (RID) are security-critical and therefore MUST be both unpredictable and nonrepeating (see <span class="ref">RFC 1750</span>  [<a href="#nt-id2605612">14</a>] for recommendations regarding randomness of SIDs and initial RIDs for security purposes).</p>
+  <h2>15.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2605661">15</a>].</p>
+  <h2>16.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>16.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">Upon advancement of this proposal to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605714">16</a>] shall add 'http://jabber.org/protocol/httpbind' to its registry of protocol namespaces.</p>
+    </div>
+  <h2>17.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    targetNamespace='http://jabber.org/protocol/httpbind'
+    xmlns='http://jabber.org/protocol/httpbind'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='http://etherx.jabber.org/streams'
+             schemaLocation='http://etherx.jabber.org/streams.xsd'/&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:stream='http://etherx.jabber.org/streams'&gt;
+        &lt;xs:element ref='stream:features'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-tls'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-streams'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='jabber:client'
+                minOccurs='0'
+                maxOccurs='unbounded'/&gt;
+        &lt;xs:element name='uri'
+                minOccurs='0'
+                maxOccurs='1'
+                type='xs:string'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='authid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='condition' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='host-gone'/&gt;
+            &lt;xs:enumeration value='host-unknown'/&gt;
+            &lt;xs:enumeration value='improper-addressing'/&gt;
+            &lt;xs:enumeration value='internal-server-error'/&gt;
+            &lt;xs:enumeration value='remote-connection-failed'/&gt;
+            &lt;xs:enumeration value='remote-stream-error'/&gt;
+            &lt;xs:enumeration value='see-other-uri'/&gt;
+            &lt;xs:enumeration value='system-shutdown'/&gt;
+            &lt;xs:enumeration value='undefined-condition'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='content' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='hold' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='inactivity' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='key' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='newkey' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='polling' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='requests' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='rid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+            &lt;xs:enumeration value='terminate'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='wait' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='xml:lang' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596359">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596381">2</a>. RFC 793: Transmission Control Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0793.txt">http://www.ietf.org/rfc/rfc0793.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596396">3</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596296">4</a>. RFC 1945: Hypertext Transfer Protocol -- HTTP/1.0 &lt;<a href="http://www.ietf.org/rfc/rfc1945.txt">http://www.ietf.org/rfc/rfc1945.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596329">5</a>. RFC 2965: HTTP State Management Mechanism &lt;<a href="http://www.ietf.org/rfc/rfc2965.txt">http://www.ietf.org/rfc/rfc2965.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601972">6</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601912">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602267">8</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602565">9</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p>
+<a name="nt-id2602849">10</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604470">11</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2604874">12</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605576">13</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2605612">14</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2605661">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605714">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Specified that wait attribute must be included in the session creation response. (ip)
+    </div>
+<h4>Version 0.7 (2004-08-12)</h4>
+<div class="indent">Defined appropriate XMPP stanza error conditions. (psa/ip)
+    </div>
+<h4>Version 0.6 (2004-07-19)</h4>
+<div class="indent">Added xml:lang attribute to the session request; added recoverable binding error conditions. (ip)
+    </div>
+<h4>Version 0.5 (2004-05-07)</h4>
+<div class="indent">Protocol refactored to enable simultaneous requests (request identifier attribute, wait attribute, hold attribute, requests attribute) and recovery of broken connections; added content attribute; removed all wrapper types except 'terminate'; updated error handling; made key mechanism optional (should use SSL/TLS instead). (ip/psa)
+    </div>
+<h4>Version 0.4 (2004-02-23)</h4>
+<div class="indent">Fixed typos; removed &quot;resource-constraint&quot; binding error; added HTTP 403 error to table. (psa/ip)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Added 'authid' attribute to enable communication of XMPP stream ID (used in digest authentication); specified that Content-Types other than &quot;text/xml&quot; are allowed to support older HTTP clients; specified business rule for connection manager queueing of client requests; changed &lt;packet/&gt; to &lt;body/&gt; to support older HTTP clients; changed 'to' attribute on initialization element from MAY to SHOULD; recommended inclusion of unavailable presence in termination element sent from client; described architectural assumptions; specified binding-specific error handling. (psa/ip)
+    </div>
+<h4>Version 0.2 (2004-01-13)</h4>
+<div class="indent">Added 'to' attribute on the initialization element; specified that 'text/html' is allowable for backwards-compatibility. (dss/psa)
+    </div>
+<h4>Version 0.1 (2003-11-06)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0124-1.0.html
+++ b/content/xep-0124-1.0.html
@@ -1,0 +1,1109 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0124: HTTP Binding</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="HTTP Binding">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-03">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0124">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0124: HTTP Binding</h1>
+<p>This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0124<br>
+            Version: 1.0<br>
+            Last Updated: 2005-03-03<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 1945, RFC 2068, RFC 3174<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: httpbind<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/httpbind/httpbind.xsd">http://jabber.org/protocol/httpbind/httpbind.xsd</a>&gt;<br></p>
+<h2>Author Information</h2>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>5.  <a href="#http">HTTP Version and HTTP Headers</a>
+</dt>
+<dt>6.  <a href="#wrapper">&lt;body/&gt; Wrapper Element</a>
+</dt>
+<dt>7.  <a href="#session">Initiating an HTTP Session</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#session-request">Requesting a Session</a>
+</dt>
+<dt>7.2.  <a href="#session-create">Session Creation</a>
+</dt>
+<dt>7.3.  <a href="#session-features">Communication of Stream Features</a>
+</dt>
+</dl>
+<dt>8.  <a href="#preconditions">Additional Preconditions</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#preconditions-xmpp">XMPP Methods</a>
+</dt>
+<dt>8.2.  <a href="#preconditions-iqauth">jabber:iq:auth</a>
+</dt>
+</dl>
+<dt>9.  <a href="#stanzas">Sending and Receiving XML Stanzas</a>
+</dt>
+<dt>10.  <a href="#terminate">Terminating the HTTP Session</a>
+</dt>
+<dt>11.  <a href="#rids">Request IDs</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#rids-order">In-Order Message Forwarding</a>
+</dt>
+<dt>11.2.  <a href="#rids-broken">Broken Connections</a>
+</dt>
+</dl>
+<dt>12.  <a href="#keys">Protecting Insecure Sessions</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#keys-applic">Applicability</a>
+</dt>
+<dt>12.2.  <a href="#keys-intro">Introduction</a>
+</dt>
+<dt>12.3.  <a href="#keys-generate">Generating the Key Sequence</a>
+</dt>
+<dt>12.4.  <a href="#keys-use">Use of Keys</a>
+</dt>
+<dt>12.5.  <a href="#keys-switch">Switching to Another Key Sequence</a>
+</dt>
+</dl>
+<dt>13.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#errorstatus-http">HTTP Conditions</a>
+</dt>
+<dt>13.2.  <a href="#errorstatus-terminal">Terminal Binding Conditions</a>
+</dt>
+<dt>13.3.  <a href="#errorstatus-recover">Recoverable Binding Conditions</a>
+</dt>
+<dt>13.4.  <a href="#errorstatus-stanza">XMPP Stanza Conditions</a>
+</dt>
+</dl>
+<dt>14.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>15.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>16.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>16.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>17.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250389">1</a>] defines XML streams bound to TCP (see <span class="ref" style="">RFC 793</span>  [<a href="#nt-id2250413">2</a>]) as the standard transport layer for Jabber/XMPP communications. However, the binding of XMPP to TCP is not always feasible because of client runtime environment and/or network constraints. This JEP describes the usage of the Hypertext Transfer Protocol (HTTP, see <span class="ref" style="">RFC 2068</span>  [<a href="#nt-id2250436">3</a>] and <span class="ref" style="">RFC 1945</span>  [<a href="#nt-id2250458">4</a>]) as an alternative transport binding that supports such constrained environments, normally via deployment of a specialized server-side connection manager that communicates with clients via HTTP rather than TCP.</p>
+    <p class="" style="">Before the authors pursued publication of this JEP, other approaches were explored. One possible approach might have been to apply state to a series of HTTP transactions via HTTP "cookies" as specified in <span class="ref" style="">RFC 2965</span>  [<a href="#nt-id2250493">5</a>]. However, there are several significant computing platforms which provide only limited access to underlying HTTP requests/responses; worse, some platforms hide or remove cookie-related headers. Therefore the cookie approach was rejected.</p>
+    <p class="" style="">Another approach might have been to modify or extend <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2254992">6</a>]. This informational protocol has been used by Jabber clients without runtime constraints to access XMPP servers from behind firewalls. Unfortunately, the method defined in JEP-0025 also depends on cookies, does not meet most of the requirements described below, and cannot be extended without breaking all existing implementations.</p>
+    <p class="" style="">Therefore, this JEP specifies a new way of transporting XMPP via HTTP. All information is encoded in the body of standard HTTP POST requests and responses. Each HTTP body contains a single &lt;body/&gt; XML wrapper element (not to be confused with the &lt;body/&gt; child of the &lt;message/&gt; stanza as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2255026">7</a>]), which encapsulates zero or more XML stanzas.</p>
+    <p class="" style="">Although this JEP documents some XMPP-specific features, the binding is not part of XMPP. In fact, the protocol is extensible and could be used to implement any bidirectional stream of XML stanzas.</p>
+  <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+    <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+      <p class="" style="">This document inherits terminology regarding the Hypertext Transport Protocol from RFCs 1945 and 2068.</p>
+    </div>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">Platform limitiations, security restrictions, and other constraints imply that many clients can connect to Internet resources (e.g., Jabber servers) only via HTTP. The following design requirements reflect the need to offer performance as close as possible to a standard TCP connection.</p>
+    <ol start="" type="">
+      <li>Compatible with constrained runtime environments (e.g., mobile and browser-based clients).</li>
+      <li>Compatible with restricted network connections (e.g., firewalls, proxies, and gateways).</li>
+      <li>Fault tolerant (e.g., session recovers after an underlying TCP connection breaks during an HTTP request).</li>
+      <li>Extensible (based on XML).</li>
+      <li>Consume significantly less bandwidth than polling-based solutions.</li>
+      <li>Significantly more responsive than polling-based solutions.</li>
+      <li>Support for polling (for clients that are limited to one HTTP connection at a time).</li>
+      <li>XML stanzas should arrive at the server in the order they were sent by the client.</li>
+      <li>Protect against unauthorized users interjecting HTTP requests into a session.</li>
+    </ol>
+    <p class="" style="">Compatibility with constrained runtime environments implies the following restrictions:</p>
+    <ul>
+      <li>Clients should not be required to have programmatic access to the headers of each HTTP request and response (e.g., cookies or status codes).</li>
+      <li>The body of each HTTP request and response should be parsable XML with a single root element.</li>
+      <li>Clients should be able to specify the Content-Type of the HTTP responses they receive.</li>
+    </ul>
+  <h2>4.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+    <p class="" style="">The binding of XMPP to HTTP assumes a different architecture from that described for the binding of XMPP to TCP as defined in <span style="font-weight: bold">XMPP Core</span>. In particular, because HTTP is not the native binding for XMPP, we assume that most XMPP implementations will utilize a specialized "connection manager" to handle HTTP connections rather than the usual TCP connections. Effectively, such a connection manager will be a specialized HTTP server that translates between the HTTP requests and responses defined herein and the XML streams (or a server API) implemented by the XMPP server or servers with which it communicates, thus enabling an HTTP client to connect to an XMPP server. We can illustrate this graphically as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+  XMPP Server
+      |
+      |  [XML streams or server API]
+      |
+Connection Manager
+      |
+      |  [HTTP + &lt;body/&gt; wrapper]
+      |
+  HTTP Client
+    </pre></div>
+    <p class="" style="">This JEP addresses communications between an HTTP client and the connection manager only. It does not address communications between the connection manager and the XMPP server, since such communications are implementation-specific (e.g., the connection manager and the XMPP server may use <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2255228">8</a>] or an API defined by the XMPP server implementation in order to communicate; alternatively, the XMPP server may natively support the HTTP binding, in which case the connection manager will be a logical entity rather than a physical entity).</p>
+    <p class="" style="">Furthermore, no aspect of the HTTP binding limits its use to client-to-server communications; i.e., it could be used for server-to-server or component-to-server communications as well (probably through a slight change to the XML schema). However, this document focuses exclusively on use of the HTTP binding by clients that cannot maintain persistent TCP connections to a server and that therefore cannot use the TCP binding defined in <span style="font-weight: bold">XMPP Core</span>. We assume that servers and components are under no such restrictions and thus would use the TCP binding.</p>
+  <h2>5.
+       <a name="http">HTTP Version and HTTP Headers</a>
+</h2>
+    <p class="" style="">Clients SHOULD send HTTP requests over persistent HTTP/1.1 connections. However, a constrained client MAY open a new HTTP/1.0 connection (as defined in RFC 1945) to send each request.</p>
+    <p class="" style="">Requests and responses MAY include HTTP headers not specified herein. The receiver SHOULD ignore any such headers.</p>
+  <h2>6.
+       <a name="wrapper">&lt;body/&gt; Wrapper Element</a>
+</h2>
+    <p class="" style="">The body of each HTTP request and response contains a single &lt;body/&gt; wrapper element. The &lt;body/&gt; element MUST contain zero or more complete XML elements. It MUST NOT contain partial XML elements.</p>
+    <p class="" style="">If the &lt;body/&gt; wrapper element is not empty, then it MUST contain one of the following:</p>
+    <ul>
+      <li>One or more complete XMPP stanzas (&lt;message/&gt;, &lt;presence/&gt;, and/or &lt;iq/&gt;).</li>
+      <li>A complete &lt;stream:features/&gt; element qualified by the 'http://etherx.jabber.org/streams' namespace.</li>
+      <li>A complete element used for SASL negotiation and qualified by the 'urn:ietf:params:xml:ns:xmpp-sasl' namespace.</li>
+      <li>XML elements associated with a binding error condition. For details, refer to the <a href="#errorstatus-binding">Binding Conditions</a> section below.</li>
+    </ul>
+    <p class="" style="">Note: Inclusion of TLS negotiation elements is allowed but is NOT RECOMMENDED (see below).</p>
+    <p class="" style="">The &lt;body/&gt; wrapper element SHOULD be qualified by the 'http://jabber.org/protocol/httpbind' namespace, and child elements SHOULD be qualified by their respective namespaces (e.g., 'http://etherx.jabber.org/streams' for stream features, 'urn:ietf:params:xml:ns:xmpp-sasl' for SASL negotiation, and 'jabber:client' for XML stanzas). However, even if the client does not specify the namespaces, the connection manager MUST ensure that the XMPP it provides to the XMPP server or other entities on the network meets the namespacing requirements of <span style="font-weight: bold">XMPP Core</span>.</p>
+    <p class="" style="">The &lt;body/&gt; element of every client request MUST possess a sequential request ID encapsulated via the 'rid' attribute. The client MUST generate a large positive non-zero random integer for the first 'rid' and then increment that value by one for each subsequent request. For details, refer to the <a href="#rids">Request IDs</a> section below.</p>
+  <h2>7.
+       <a name="session">Initiating an HTTP Session</a>
+</h2>
+    <div class="indent">
+<h3>7.1 <a name="session-request">Requesting a Session</a>
+</h3>
+      <p class="" style="">The first request from the client to the connection manager creates a new session.</p>
+      <p class="" style="">The &lt;body/&gt; element of the first request SHOULD possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-weight: bold">'to'</span> -- This attribute specifies the target domain (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'xml:lang'</span> -- This attribute (as defined in Section 2.12 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2255473">9</a>]) specifies the default language of any human-readable XML character data sent or received during the session (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'wait'</span> -- This attribute specifies the longest time (in seconds) that the connection manager is allowed to wait before responding to any request during the session. This enables the client to prevent its TCP connection from expiring due to inactivity, as well as to limit the delay before it discovers any network failure.</li>
+        <li>
+<span style="font-weight: bold">'hold'</span> -- This attribute specifies the maximum number of requests the connection manager is allowed to keep waiting at any one time during the session. (For example, if a constrained client is unable to keep open more than two HTTP connections to the same HTTP server simultaneously, then it SHOULD specify a value of "1".)</li>
+      </ul>
+      <p class="" style="">Note: Clients that only support polling behavior MAY prevent the connection manager from waiting by setting 'wait' or 'hold' to "0". However, polling is NOT RECOMMENDED since the associated increase in bandwidth consumption and the decrease in responsiveness are typically one or two orders of magnitude!</p>
+      <p class="" style="">Some clients are constrained to only accept HTTP responses with specific Content-Types (e.g., "text/html"). The &lt;body/&gt; element of the first request MAY possess a 'content' attribute. This specifies the value of the HTTP Content-Type header that MUST appear in all the connection manager's responses during the session. If the client request does not possess a 'content' attribute, then the HTTP Content-Type of responses MUST be "text/xml; charset=utf-8".</p>
+      <p class="" style="">Note: The HTTP Content-Type of client requests SHOULD also be "text/xml; charset=utf-8". Clients MAY specify another value if they are constrained to do so (e.g., "application/x-www-form-urlencoded" or "text/plain"). The client and connection manager SHOULD ignore all HTTP Content-Type headers they receive.</p>
+      <p class="caption">Example 1. Requesting an HTTP session</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">Note: Unlike the protocol defined in JEP-0025, an opening &lt;stream:stream&gt; tag is not sent. The protocol defined herein abstracts from XML streams between the connection manager and the client. Any XML streams between the connection manager and an XMPP server are the responsibility of the connection manager.</p>
+      <p class="" style="">Note: All requests after the first one MUST include a valid 'sid' attribue (provided by the connection manager in the session creation response below). The initialization request is unique in that the &lt;body/&gt; element MUST NOT possess a 'sid' attribute.</p>
+    </div>
+    <div class="indent">
+<h3>7.2 <a name="session-create">Session Creation</a>
+</h3>
+      <p class="" style="">After receiving a new session request, the connection manager MUST generate an opaque, unpredictable session identifier (or SID). The SID MUST be unique within the context of the connection manager application. The connection manager then returns that SID to the client in a response &lt;body/&gt; element.</p>
+      <p class="" style="">The connection manager MUST specify a 'wait' attribute. This is the longest time (in seconds) that it will wait before responding to any request during the session. The time MUST be less than or equal to the value specified in the session request.</p>
+      <p class="" style="">The connection manager MAY limit the number of simultaneous requests the client makes with the 'requests' attribute. The RECOMMENDED value is "2". Servers that only support polling behavior MUST prevent clients from making simultaneous requests by setting the 'requests' attribute to a value of "1" (however, polling is NOT RECOMMENDED). In any case, clients MUST NOT make more simultaneous requests than specified by the connection manager.</p>
+      <p class="" style="">The connection manager SHOULD include two additional attributes in the session creation response element, specifying the shortest allowable polling interval and the longest allowable inactivity period (both in seconds). Communication of these parameters enables the client to engage in appropriate behavior (e.g., not sending empty request elements more often than desired, and ensuring that the periods with no requests pending are never too long).</p>
+      <p class="" style="">For both requests and responses, the &lt;body/&gt; element and its content SHOULD be UTF-8 encoded. If the HTTP Content-Type header of a request/response specifies a character encoding other than UTF-8, then the connection manager MAY convert between UTF-8 and the other character encoding. However, even in this case, it is OPTIONAL for the connection manager to convert between encodings. The connection manager MAY inform the client which encodings it can convert by setting the optional 'charsets' attribute in the session creation response element to a space-separated list of encodings.
+         [<a href="#nt-id2255698">10</a>]
+        </p>
+      <p class="caption">Example 2. Session creation response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 128
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      sid='SomeSID'
+      charsets='ISO_8859-1 ISO-2022-JP'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">Note: The 'authid' attribute contains the value of the XMPP stream ID generated by the XMPP server. The connection manager MUST retrieve the stream ID and pass it unmodified to the client. This value is needed by the client to successfully complete digest authentication using <span class="ref" style="">Non-SASL Authentication</span>  [<a href="#nt-id2255794">12</a>] (see the <a href="#preconditions-iqauth">jabber:iq:auth</a> section below).</p>
+    <p class="" style="">Note: If the 'authid' attribute is not included in the connection manager's response to the session creation request (e.g., because the connection manager has not yet received a stream ID from the XMPP server), then the client SHOULD send empty request elements (see the "Requesting XML Stanzas" example below) until it receives a response with an 'authid' attribute. In any case, the connection manager MUST return the 'authid' in a response to the client as soon as possible after it receives the stream ID from the XMPP server.</p>
+    <p class="" style="">Separate 'sid' and 'authid' attributes are required because the connection manager is not necessarily part of a single XMPP server (e.g., it may handle HTTP connections on behalf of multiple XMPP servers).</p>
+    </div>
+    <div class="indent">
+<h3>7.3 <a name="session-features">Communication of Stream Features</a>
+</h3>
+      <p class="" style="">As an immediate child of the session creation response, the connection manager MAY include a stream features element, as defined by <span style="font-weight: bold">XMPP Core</span>.</p>
+      <p class="caption">Example 3. Session creation response with stream features</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 417
+
+&lt;body wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;stream:features xmlns='http://etherx.jabber.org/streams'&gt;
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'&gt;
+  &lt;/stream:features&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The stream features SHOULD NOT include a feature for Transport Layer Security (TLS), since channel encryption SHOULD be negotiated at the HTTP layer (see the <a href="#security">Security Considerations</a> section below).</p>
+    </div>
+  <h2>8.
+       <a name="preconditions">Additional Preconditions</a>
+</h2>
+    <p class="" style="">Initializing an HTTP session is the first precondition to sending XML message, presence, and IQ stanzas. However, before processing XML stanzas from the client, the connection manager MUST require completion of additional preconditions using either of the following methods:</p>
+    <ul>
+      <li>
+        <p class="" style="">XMPP authentication, resource binding, and IM session creation, in the following order:</p>
+        <ol start="" type="">
+          <li>Optionally, TLS negotiation as defined in Section 5 of <span style="font-weight: bold">XMPP Core</span> (this is NOT RECOMMENDED since channel encryption SHOULD be negotiated at the HTTP layer; see the <a href="#security">Security Considerations</a> section below)</li>
+          <li>SASL authentication as defined in Section 6 of <span style="font-weight: bold">XMPP Core</span>
+</li>
+          <li>Resource Binding as defined in Section 7 of <span style="font-weight: bold">XMPP Core</span>
+</li>
+          <li>IM Session Establishment as defined in Section 3 of <span style="font-weight: bold">XMPP IM</span>, if appropriate</li>
+        </ol>
+      </li>
+      <li>
+        <p class="" style="">Simultaneous authentication and resource binding as defined in <span style="font-weight: bold">Non-SASL Authentication</span>, upon which a Jabber server will also establish an IM session on behalf of the connected resource.</p>
+      </li>
+    </ul>
+    <p class="" style="">It is RECOMMENDED to use the XMPP methods as defined in <span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span>, rather than using older non-SASL authentication.</p>
+
+    <div class="indent">
+<h3>8.1 <a name="preconditions-xmpp">XMPP Methods</a>
+</h3>
+      <p class="" style="">A success case for authentication, resource binding, and IM session establishment using the XMPP protocols is shown below. For detailed specification of these protocols (including error cases) and for specification of TLS negotiation, refer to <span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span>.</p>
+      <p class="caption">Example 4. SASL authentication step 1</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 172
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='DIGEST-MD5'/&gt;
+&lt;/body&gt;</pre></div>
+
+
+
+      <p class="caption">Example 5. SASL authentication step 2</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 250
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cmVhbG09InNvbWVyZWFsbSIsbm9uY2U9Ik9BNk1HOXRFUUdtMmhoIixxb3A9
+    ImF1dGgiLGNoYXJzZXQ9dXRmLTgsYWxnb3JpdGhtPW1kNS1zZXNzCg==
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 6. SASL authentication step 3</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 418
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    dXNlcm5hbWU9InNvbWVub2RlIixyZWFsbT0ic29tZXJlYWxtIixub25jZT0i
+    T0E2TUc5dEVRR20yaGgiLGNub25jZT0iT0E2TUhYaDZWcVRyUmsiLG5jPTAw
+    MDAwMDAxLHFvcD1hdXRoLGRpZ2VzdC11cmk9InhtcHAvZXhhbXBsZS5jb20i
+    LHJlc3BvbnNlPWQzODhkYWQ5MGQ0YmJkNzYwYTE1MjMyMWYyMTQzYWY3LGNo
+    YXJzZXQ9dXRmLTgK
+&lt;/response&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 7. SASL authentication step 4</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 190
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cnNwYXV0aD1lYTQwZjYwMzM1YzQyN2I1NTI3Yjg0ZGJhYmNkZmZmZAo=
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 8. SASL authentication step 5</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 152
+
+&lt;body rid='3197423133'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 9. SASL authentication step 6</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 121
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="" style="">Note: Because the context for a client's communication with a connection manager in the HTTP transport binding is HTTP rather than XML streams (as in the TCP binding), there is no need to re-start communications (e.g., by generating a new SID) at this point.</p>
+
+      <p class="caption">Example 10. Resource binding request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 240
+
+&lt;body rid='3197423134'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 11. Resource binding result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 221
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='result'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;jid&gt;stpeter@jabber.org/httpclient&lt;/jid&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 12. IM session request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 261
+
+&lt;body rid='3197423135'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='stpeter@jabber.org/httpclient'
+      id='sess_1'
+      to='jabber.org'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'/&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 13. IM session result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 175
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='jabber.org'
+      id='sess_1'
+      to='stpeter@jabber.org/httpclient'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+
+    </div>
+
+    <div class="indent">
+<h3>8.2 <a name="preconditions-iqauth">jabber:iq:auth</a>
+</h3>
+      <p class="" style="">A success case for simultaneous authentication, resource binding, and IM session creation using the original "jabber:iq:auth" protocol is shown below. For further details regarding use of this protocol, refer to JEP-0078. If digest authentication is used, then the stream ID value used to compute the hashed password MUST be the value of the 'authid' attribute provided by the connection manager in the response to the initialization element or in a subsequent response (see the <a href="#session-create">Session Creation</a> section above).</p>
+      <p class="caption">Example 14. Non-SASL authentication request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 281
+
+&lt;body rid='2842791421'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;query xmlns='jabber:iq:auth'&gt;
+      &lt;username&gt;stpeter&lt;/username&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+      &lt;password&gt;jabber-rocks&lt;/password&gt;
+    &lt;/query&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 15. Authentication result (success)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 144
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 16. Authentication result (failure)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 226
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='error'
+      xmlns='jabber:client'&gt;
+    &lt;error code='401' type='auth'&gt;
+      &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>9.
+       <a name="stanzas">Sending and Receiving XML Stanzas</a>
+</h2>
+    <p class="" style="">After the client has successfully completed all required preconditions, it can send and receive XML stanzas via the HTTP binding.</p>
+    <p class="caption">Example 17. Transmitting stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='2842791422'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message to='friend@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">Upon receipt of a request, the connection manager MUST forward the content of the &lt;body/&gt; element to the XMPP server as soon as possible. However, it must forward the content from different requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">The connection manager MUST also return an HTTP 200 OK response with a &lt;body/&gt; element to the client. Note: This does not indicate that the stanzas have been successfully delivered to the destination Jabber endpoint.</p>
+    <p class="" style="">It is RECOMMENDED that the connection manager not return an HTTP result until a stanza has arrived from the XMPP server for delivery to the client. However, the connection manager SHOULD NOT wait longer than the time specified by the client in the 'wait' attribute of its session creation request, and it SHOULD NOT keep more HTTP requests waiting at a time than the number specified in the 'hold' attribute of the session creation request. In any case it MUST respond to requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">If there are no stanzas waiting or ready to be delivered within the waiting period, then the connection manager SHOULD include an empty &lt;body/&gt; element in the HTTP result:</p>
+    <p class="caption">Example 18. Empty response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 64
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">If the connection manager has received one or more stanzas from the XMPP server for delivery to the client, then it SHOULD return the stanzas in the body of its response as soon as possible after receiving them from the XMPP server.</p>
+    <p class="caption">Example 19. Response with queued stanza</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 185
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message from='contact@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message from='friend@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The client MAY poll the connection manager for incoming stanzas by sending an empty &lt;body/&gt; element.</p>
+    <p class="caption">Example 20. Requesting XML Stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='2842791423'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The connection manager MUST wait and respond in the same way as it does after receiving stanzas from the client.</p>
+    <p class="" style="">If the client sends two consecutive empty requests within a period shorter than that specified by the 'polling' attribute in the session creation response, then the connection manager SHOULD terminate the HTTP session and return an HTTP 403 (Forbidden) error to the client.</p>
+    <p class="caption">Example 21. Too frequent polling response</p>
+<div class="indent"><pre>
+HTTP/1.1 403 Forbidden
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    <p class="" style="">If the connection manager did not specify a shortest allowable polling interval in the session creation response, then it MUST allow the client to poll as frequently as it chooses.</p>
+    <p class="" style="">After receiving a response from the connection manager, if no other requests are pending and the client did not specify polling behavior in the session creation request (by setting 'wait' or 'hold' to "0"), it SHOULD make a new request as soon as possible. In any case, if no requests are pending, the client MUST make a new request before the maximum inactivity period has expired. This period is specified by the 'inactivity' attribute in the session creation response.</p>
+    <p class="" style="">If the connection manager has responded to all the requests it has received and the time since its last response is longer than the maximum inactivity period, then it SHOULD terminate the session without informing the client (if the client makes another request, the connection manager SHOULD respond as if the session does not exist).</p>
+    <p class="" style="">If the connection manager did not specify a maximum inactivity period in the session creation response, then it MUST allow the client to be inactive for as long as it chooses.</p>
+  <h2>10.
+       <a name="terminate">Terminating the HTTP Session</a>
+</h2>
+    <p class="" style="">At any time, the client MAY gracefully terminate the session by sending a &lt;body/&gt; element with a 'type' attribute set to "terminate". The termination request SHOULD include an XMPP presence stanza of type "unavailable" to ensure graceful logoff with the XMPP server.</p>
+    <p class="caption">Example 22. Session termination by client</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 153
+
+&lt;body rid='2842791424'
+      sid='SomeSID'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;presence type='unavailable'
+            xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The connection manager SHOULD return an HTTP 200 OK response with an empty &lt;body/&gt; element. Upon receiving the response, the client MUST consider the HTTP session to have been terminated.</p>
+  <h2>11.
+       <a name="rids">Request IDs</a>
+</h2>
+    <div class="indent">
+<h3>11.1 <a name="rids-order">In-Order Message Forwarding</a>
+</h3>
+      <p class="" style="">When a client makes simultaneous requests, the connection manager may receive them out of order. The connection manager MUST forward the stanzas to the XMPP server and respond to the client requests in the order specified by the 'rid' attributes. The client MUST process responses received from the connection manager in the order the requests were made.</p>
+      <p class="" style="">The connection manager SHOULD expect the 'rid' attribute to be within a window of values greater than the 'rid' of the previous request. The size of the window is equal to the maximum number of simultaneous requests allowed by the connection manager. If it receives a request with a 'rid' greater than the values in the window, then the connection manager MUST terminate the session with an error:</p>
+      <p class="caption">Example 23. Unexpected rid error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>11.2 <a name="rids-broken">Broken Connections</a>
+</h3>
+      <p class="" style="">Unreliable network communications or client constraints can result in broken connections. The connection manager SHOULD remember the 'rid' and the associated HTTP response body of the client's most recent requests which did not result in an HTTP or binding error. The number of responses kept in the buffer should be the same as the maximum number of simultaneous requests allowed by the connection manager.</p>
+      <p class="" style="">If the network connection is broken or closed before the client receives a response to a request from the connection manager, then the client MAY resend an exact copy of the original request. Whenever the connection manager receives a request with a 'rid' that it has already received, it SHOULD return an HTTP 200 (OK) response that includes the buffered copy of the original XML response to the client (i.e., a &lt;body/&gt; wrapper element possessing appropriate attributes and optionally containing one or more XML stanzas or other allowable XML elements). If the original response is not available (e.g., it is no longer in the buffer), then the connection manager MUST return an HTTP 404 (Not Found) error:</p>
+      <p class="caption">Example 24. Response not in buffer error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+      <p class="" style="">Note: The error is the same whether the 'rid' is too large or too small. This makes it more difficult for an attacker to discover an acceptable value.</p>
+    </div>
+  <h2>12.
+       <a name="keys">Protecting Insecure Sessions</a>
+</h2>
+    <div class="indent">
+<h3>12.1 <a name="keys-applic">Applicability</a>
+</h3>
+      <p class="" style="">The OPTIONAL key sequencing mechanism described here MAY be used if the client's session with the connection manager is not secure. The session should be considered secure only if all client requests are made via TLS/SSL HTTP connections and the connection manager generates an unpredictable session ID. If the session is secure, it is not necessary to use this key sequencing mechanism.</p>
+      <p class="" style="">Even if the session is not secure, the unpredictable session and request IDs specified in the preceding sections of this document already provide a level of protection similar to that provided by a standard XMPP connection bound to a single pair of persistent TCP/IP connections, and thus provide sufficient protection against a 'blind' attacker. However, in some circumstances, the key sequencing mechanism defined below helps to protect against a more determined and knowledgeable attacker.</p>
+      <p class="" style="">It is important to recognize that the key sequencing mechanism defined below helps to protect only against an attacker who is able to view the contents of all requests or responses in an insecure session but who is not able to alter the contents of those requests (in this case, the mechanism prevents the attacker from interjecting HTTP requests into the session, e.g., termination requests or responses). However, the key sequencing mechanism does not provide any protection when the attacker is able to alter the contents of insecure requests or responses.</p>
+    </div>
+    <div class="indent">
+<h3>12.2 <a name="keys-intro">Introduction</a>
+</h3>
+      <p class="" style="">The HTTP requests of each session MAY be spread across a series of different socket connections. This would enable an unauthorized user that obtains the session ID and request ID of a session and then use their own socket connection to interject &lt;body/&gt; request elements into the session and receive the corresponding responses.</p>
+      <p class="" style="">The key sequencing mechanism below protects against such attacks by enabling a connection manager to detect &lt;body/&gt; request elements interjected by a third party.</p>
+    </div>
+    <div class="indent">
+<h3>12.3 <a name="keys-generate">Generating the Key Sequence</a>
+</h3>
+      <p class="" style="">Prior to requesting a new session, the client MUST select an unpredictable counter ("n") and an unpredictable value ("seed"). The client then processes the "seed" through a cryptographic hash and converts the resulting 160 bits to a hexadecimal string K(1). It does this "n" times to arrive at the initial key K(n). The hashing algorithm MUST be SHA-1 as defined in <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2256871">13</a>].</p>
+      <p class="caption">Example 25. Creating the key sequence</p>
+<div class="indent"><pre>
+        K(1) = hex(SHA-1(seed))
+        K(2) = hex(SHA-1(K(1)))
+        ...
+        K(n) = hex(SHA-1(K(n-1)))
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>12.4 <a name="keys-use">Use of Keys</a>
+</h3>
+      <p class="" style="">The client MUST set the 'newkey' attribute of the first request in the session to the value K(n).</p>
+      <p class="caption">Example 26. Session Request with Initial Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      newkey='ca393b51b682f61f98e7877d61146407f3d0a770'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The client MUST set the 'key' attribute of all subsequent requests to the value of the next key in the generated sequence (decrementing from K(n-1) towards K(1) with each request sent).</p>
+    <p class="caption">Example 27. Request with Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      key='bfb06a6f113cd6fd3838ab9d300fdb4fe3da2f7d'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The connection manager MAY verify the key by calculating the SHA-1 hash of the key and comparing it to the 'newkey' attribute of the previous request (or the 'key' attribute if the 'newkey' attribute was not set). If the values do not match (or if it receives a request without a 'key' attribute and the 'newkey' or 'key' attribute of the previous request was set), then the connection manager MUST NOT process the element, MUST terminate the session, and MUST return an HTTP 404 (Not Found) error.</p>
+      <p class="caption">Example 28. Invalid Key Sequence Error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>12.5 <a name="keys-switch">Switching to Another Key Sequence</a>
+</h3>
+      <p class="" style="">A client SHOULD choose a high value for "n" when generating the key sequence. However, if the session lasts long enough that the client arrives at the last key in the sequence K(1) then the client MUST switch to a new key sequence.</p>
+      <p class="" style="">The client MUST:</p>
+      <ol start="" type="">
+        <li>Choose new values for "seed" and "n".</li>
+        <li>Generate a new key sequence using the algorithm defined above.</li>
+        <li>Set the 'key' attribute of the request to the next value in the old sequence (i.e. K(1), the last value).</li>
+        <li>Set the 'newkey' attribute of the request to the value K(n) from the new sequence.</li>
+      </ol>
+      <p class="caption">Example 29. New Key Sequence</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      key='6f825e81f4532b2c5fa2d12457d8a1f22e8f838e'
+      newkey='113f58a37245ec9637266cf2fb6e48bfeaf7964e'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>13.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+    <p class="" style="">There are four types of error and status reporting in HTTP responses:</p>
+    <p class="caption">Table 1: Error Condition Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition Type</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">HTTP Conditions</span></td>
+<td align="" colspan="" rowspan="">The connection manager responds to an invalid client request with a standard HTTP error. These are used for binding syntax errors, possible attacks, etc. Note that constrained clients are unable to differentiate between HTTP errors.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Terminal Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These error conditions may be read by constrained clients. They are used for connection manager problems, abstracting stream errors, and communication problems between the connection manager and the XMPP server.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Recoverable Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These report communication problems between the connection manager and the client. They do not terminate the session. Clients recover from these errors by resending the last two &lt;body/&gt; wrapper elements.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP Stanza Conditions</span></td>
+<td align="" colspan="" rowspan="">XMPP errors relating to XML stanzas within &lt;body/&gt; wrapper elements are, in general, defined in the appropriate RFC or JEP. They do not terminate the session. An example of such usage is shown above in relation to <span style="font-weight: bold">Non-SASL Authentication</span>.</td>
+</tr>
+    </table>
+    <p class="" style="">Full descriptions are provided below.</p>
+    <div class="indent">
+<h3>13.1 <a name="errorstatus-http">HTTP Conditions</a>
+</h3>
+      <p class="" style="">The following HTTP error and status codes are used in particular ways by this protocol (other HTTP error and status codes may be used as appropriate). Upon receiving an HTTP error (400, 403, 404), the HTTP client MUST consider the HTTP session to be null and void.</p>
+      <p class="" style="">Note: These are pure HTTP codes as defined in the HTTP specification, and are not to be confused with the HTTP-style error codes traditionally used in Jabber protocols and documented in <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257230">14</a>].</p>
+      <p class="caption">Table 2: HTTP Error and Status Codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Code</th>
+          <th colspan="" rowspan="">Name</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">200</td>
+          <td align="" colspan="" rowspan="">OK</td>
+          <td align="" colspan="" rowspan="">Response to valid client request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">400</td>
+          <td align="" colspan="" rowspan="">Bad Request</td>
+          <td align="" colspan="" rowspan="">Inform client that the format of an HTTP header or binding element is unacceptable (e.g., syntax error).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">403</td>
+          <td align="" colspan="" rowspan="">Forbidden</td>
+          <td align="" colspan="" rowspan="">Inform client that it has broken the session rules (polling too-frequently, too many simultaneous connections).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">404</td>
+          <td align="" colspan="" rowspan="">Not Found</td>
+          <td align="" colspan="" rowspan="">Inform client that (1) 'sid' is not valid, (2) 'rid' is larger than the upper limit of the expected window, (3) connection manager is unable to resend response, (4) 'key' sequence is invalid.</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>13.2 <a name="errorstatus-terminal">Terminal Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a fatal error by setting a 'type' attribute of the &lt;body/&gt; element to "terminate". These binding errors imply that the HTTP session is terminated. (Note: Many of these conditions correspond to the relevant XMPP stream error conditions specified in <span style="font-weight: bold">XMPP Core</span>, but actual XMPP stream error conditions experienced between the connection manager and the server are contained only in the "remote-stream-error" condition as described below.)</p>
+      <p class="caption">Example 30. Remote connection failed error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='terminate'
+      condition='remote-connection-failed'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The following values of the 'condition' attribute are defined:</p>
+      <p class="caption">Table 3: Binding Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Condition</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-gone</td>
+          <td align="" colspan="" rowspan="">The target hostname specified in the 'to' attribute is no longer serviced by the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-unknown</td>
+          <td align="" colspan="" rowspan="">The target hostname specified in the 'to' attribute is unknown to the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">improper-addressing</td>
+          <td align="" colspan="" rowspan="">The initialization element lacks a 'to' attribute (or the attribute has no value) but the connection manager requires one.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">internal-server-error</td>
+          <td align="" colspan="" rowspan="">The connection manager has experienced an internal error that prevents it from servicing the request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">other-request</td>
+          <td align="" colspan="" rowspan="">Another request being processed at the same time as this request caused the session to terminate.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-connection-failed</td>
+          <td align="" colspan="" rowspan="">The connection manager was unable to connect to, or has lost its connection to, the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-stream-error</td>
+          <td align="" colspan="" rowspan="">Encapsulates an XMPP stream error. The content of the binding is a copy of the content of the &lt;stream:error/&gt; element received from the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">see-other-uri</td>
+          <td align="" colspan="" rowspan="">The connection manager does not operate at this URI (e.g., the connection manager accepts only SSL/TLS connections at some https: URI rather than the http: URI requested by the client). The client may try POSTing to the URI in the content of the &lt;uri/&gt; child element.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">system-shutdown</td>
+          <td align="" colspan="" rowspan="">The connection manager is being shut down. All active HTTP sessions are being terminated. No new sessions can be created.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">undefined-condition</td>
+          <td align="" colspan="" rowspan="">The error is not one of those defined herein; the connection manager SHOULD include application-specific information in the content of the &lt;body/&gt; wrapper element.</td>
+        </tr>
+      </table>
+      <p class="" style="">The following is an example of a "see-other-uri" condition:</p>
+      <p class="caption">Example 31. See other URI error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='see-other-uri'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;uri&gt;https://secure.jabber.org/xmppcm&lt;/uri&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The following is an example of a "remote-stream-error" condition:</p>
+      <p class="caption">Example 32. Remote error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='remote-stream-error'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;xml-not-well-formed xmlns='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+  &lt;text xmlns='urn:ietf:params:xml:ns:xmpp-streams'
+        xml:lang='en'&gt;
+    Some special application diagnostic information!
+  &lt;/text&gt;
+  &lt;escape-your-data xmlns='application-ns'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">Naturally, the client MAY report binding errors to the connection manager as well, although this is unlikely.</p>
+    </div>
+    <div class="indent">
+<h3>13.3 <a name="errorstatus-recover">Recoverable Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a recoverable error by setting a 'type' attribute of the &lt;body/&gt; element to "error". These errors do not imply that the HTTP session is terminated.</p>
+      <p class="" style="">If it decides to recover from the error, then the client MUST repeat the HTTP request and the previous HTTP request. The content of both requests MUST be identical to the &lt;body/&gt; elements of the original requests. This allows the server to recover a session after the previous request was lost due to a communication failure.</p>
+      <p class="caption">Example 33. Recoverable error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='error'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    </div>
+    <div class="indent">
+<h3>13.4 <a name="errorstatus-stanza">XMPP Stanza Conditions</a>
+</h3>
+      <p class="" style="">Application-level error conditions will normally be generated by a third entity (e.g., an IM contact) and routed to the client through the connection manager; therefore they are out of scope for the transport binding defined herein and are described in the appropriate RFC or JEP.</p>
+      <p class="" style="">However, it is possible that a connection manager will receive a stanza for delivery to a client even though the client connection is no longer active (e.g., before the connection manager is able to inform a server that the connection has died). In this case, the connection manager would return an error to the server; it is RECOMMENDED that the connection manager proceed as follows, since the situation is similar to that addressed by point #2 of Section 11.1 of <span style="font-weight: bold">XMPP IM</span>:</p>
+      <ol start="" type="">
+        <li>If the delivered stanza was &lt;presence/&gt;, silently drop the stanza and do not return an error to the sender.</li>
+        <li>If the delivered stanza was &lt;iq/&gt;, return a &lt;service-unavailable/&gt; error to the sender.</li>
+        <li>If the delivered stanza was &lt;message/&gt;, return a &lt;recipient-unavailable/&gt; error to the sender.</li>
+      </ol>
+      <p class="" style="">When a server receives a &lt;message/&gt; stanza of type "error" containing a &lt;recipient-unavailable/&gt; condition from a connection manager, it SHOULD store the message for later delivery if offline storage is enabled, otherwise route the error stanza to the sender.</p>
+    </div>
+  <h2>14.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Communications SHOULD occur over an encrypted channel. Negotiation of channel encryption SHOULD occur at the HTTP layer, not the application layer; such negotiation SHOULD follow the protocol defined in <span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2258051">15</a>].</p>
+    <p class="" style="">The session identifier (SID) and initial request identifier (RID) are security-critical and therefore MUST be both unpredictable and nonrepeating (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2258082">16</a>] for recommendations regarding randomness of SIDs and initial RIDs for security purposes).</p>
+  <h2>15.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258120">17</a>].</p>
+  <h2>16.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>16.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258205">18</a>] includes 'http://jabber.org/protocol/httpbind' in its registry of protocol namespaces.</p>
+    </div>
+  <h2>17.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    targetNamespace='http://jabber.org/protocol/httpbind'
+    xmlns='http://jabber.org/protocol/httpbind'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0124: http://www.jabber.org/jeps/jep-0124.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import namespace='http://etherx.jabber.org/streams'
+             schemaLocation='http://etherx.jabber.org/streams.xsd'/&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:stream='http://etherx.jabber.org/streams'&gt;
+        &lt;xs:element ref='stream:features'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-tls'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-streams'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='jabber:client'
+                minOccurs='0'
+                maxOccurs='unbounded'/&gt;
+        &lt;xs:element name='uri'
+                minOccurs='0'
+                maxOccurs='1'
+                type='xs:string'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='authid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='charsets' type='xs:NMTOKENS' use='optional'/&gt;
+      &lt;xs:attribute name='condition' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='host-gone'/&gt;
+            &lt;xs:enumeration value='host-unknown'/&gt;
+            &lt;xs:enumeration value='improper-addressing'/&gt;
+            &lt;xs:enumeration value='internal-server-error'/&gt;
+            &lt;xs:enumeration value='remote-connection-failed'/&gt;
+            &lt;xs:enumeration value='remote-stream-error'/&gt;
+            &lt;xs:enumeration value='see-other-uri'/&gt;
+            &lt;xs:enumeration value='system-shutdown'/&gt;
+            &lt;xs:enumeration value='undefined-condition'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='content' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='hold' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='inactivity' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='key' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='newkey' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='polling' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='requests' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='rid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+            &lt;xs:enumeration value='terminate'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='wait' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='xml:lang' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2250389">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250413">2</a>. RFC 793: Transmission Control Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0793.txt">http://www.ietf.org/rfc/rfc0793.txt</a>&gt;.</p>
+<p><a name="nt-id2250436">3</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+<p><a name="nt-id2250458">4</a>. RFC 1945: Hypertext Transfer Protocol -- HTTP/1.0 &lt;<a href="http://www.ietf.org/rfc/rfc1945.txt">http://www.ietf.org/rfc/rfc1945.txt</a>&gt;.</p>
+<p><a name="nt-id2250493">5</a>. RFC 2965: HTTP State Management Mechanism &lt;<a href="http://www.ietf.org/rfc/rfc2965.txt">http://www.ietf.org/rfc/rfc2965.txt</a>&gt;.</p>
+<p><a name="nt-id2254992">6</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2255026">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255228">8</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2255473">9</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2255698">10</a>. Each character set name (or character encoding name -- we use the terms interchangeably) SHOULD be of type NMTOKEN, where the names are separated by the white space character #x20, resulting in a tokenized attribute type of NMTOKENS (see Section 3.3.1 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2255712">11</a>]). Strictly speaking, the Character Sets registry maintained by the Internet Assigned Numbers Authority (see &lt;<a href="http://www.iana.org/assignments/character-sets">http://www.iana.org/assignments/character-sets</a>&gt;) allows a character set name to contain any printable US-ASCII character, which might include characters not allowed by the NMTOKEN construction of XML 1.0; however, the only existing character set name which includes such a character is "NF_Z_62-010_(1973)".</p>
+<p><a name="nt-id2255712">11</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2255794">12</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p><a name="nt-id2256871">13</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2257230">14</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2258051">15</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2258082">16</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2258120">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258205">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2005-03-03)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.10 (2004-11-08)</h4>
+<div class="indent">Changed HTTP 401 errors to HTTP 404. (ip)
+    </div>
+<h4>Version 0.9 (2004-10-26)</h4>
+<div class="indent">Added charset attribute. (ip/psa)
+    </div>
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Specified that wait attribute must be included in the session creation response. (ip)
+    </div>
+<h4>Version 0.7 (2004-08-12)</h4>
+<div class="indent">Defined appropriate XMPP stanza error conditions. (psa/ip)
+    </div>
+<h4>Version 0.6 (2004-07-19)</h4>
+<div class="indent">Added xml:lang attribute to the session request; added recoverable binding error conditions. (ip)
+    </div>
+<h4>Version 0.5 (2004-05-07)</h4>
+<div class="indent">Protocol refactored to enable simultaneous requests (request identifier attribute, wait attribute, hold attribute, requests attribute) and recovery of broken connections; added content attribute; removed all wrapper types except 'terminate'; updated error handling; made key mechanism optional (should use SSL/TLS instead). (ip/psa)
+    </div>
+<h4>Version 0.4 (2004-02-23)</h4>
+<div class="indent">Fixed typos; removed "resource-constraint" binding error; added HTTP 403 error to table. (psa/ip)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Added 'authid' attribute to enable communication of XMPP stream ID (used in digest authentication); specified that Content-Types other than "text/xml" are allowed to support older HTTP clients; specified business rule for connection manager queueing of client requests; changed &lt;packet/&gt; to &lt;body/&gt; to support older HTTP clients; changed 'to' attribute on initialization element from MAY to SHOULD; recommended inclusion of unavailable presence in termination element sent from client; described architectural assumptions; specified binding-specific error handling. (psa/ip)
+    </div>
+<h4>Version 0.2 (2004-01-13)</h4>
+<div class="indent">Added 'to' attribute on the initialization element; specified that 'text/html' is allowable for backwards-compatibility. (dss/psa)
+    </div>
+<h4>Version 0.1 (2003-11-06)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0124-1.1.html
+++ b/content/xep-0124-1.1.html
@@ -1,0 +1,1139 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0124: HTTP Binding</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="HTTP Binding">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0124">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0124: HTTP Binding</h1>
+<p>This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0124<br>
+            Version: 1.1<br>
+            Last Updated: 2005-06-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 1945, RFC 2068, RFC 3174<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: httpbind<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/httpbind/httpbind.xsd">http://jabber.org/protocol/httpbind/httpbind.xsd</a>&gt;<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>5.  <a href="#http">HTTP Version and HTTP Headers</a>
+</dt>
+<dt>6.  <a href="#compression">Compression</a>
+</dt>
+<dt>7.  <a href="#wrapper">&lt;body/&gt; Wrapper Element</a>
+</dt>
+<dt>8.  <a href="#session">Initiating an HTTP Session</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#session-request">Requesting a Session</a>
+</dt>
+<dt>8.2.  <a href="#session-create">Session Creation</a>
+</dt>
+<dt>8.3.  <a href="#session-features">Communication of Stream Features</a>
+</dt>
+</dl>
+<dt>9.  <a href="#preconditions">Additional Preconditions</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#preconditions-xmpp">XMPP Methods</a>
+</dt>
+<dt>9.2.  <a href="#preconditions-iqauth">jabber:iq:auth</a>
+</dt>
+</dl>
+<dt>10.  <a href="#stanzas">Sending and Receiving XML Stanzas</a>
+</dt>
+<dt>11.  <a href="#terminate">Terminating the HTTP Session</a>
+</dt>
+<dt>12.  <a href="#rids">Request IDs</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#rids-order">In-Order Message Forwarding</a>
+</dt>
+<dt>12.2.  <a href="#rids-broken">Broken Connections</a>
+</dt>
+</dl>
+<dt>13.  <a href="#keys">Protecting Insecure Sessions</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#keys-applic">Applicability</a>
+</dt>
+<dt>13.2.  <a href="#keys-intro">Introduction</a>
+</dt>
+<dt>13.3.  <a href="#keys-generate">Generating the Key Sequence</a>
+</dt>
+<dt>13.4.  <a href="#keys-use">Use of Keys</a>
+</dt>
+<dt>13.5.  <a href="#keys-switch">Switching to Another Key Sequence</a>
+</dt>
+</dl>
+<dt>14.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#errorstatus-http">HTTP Conditions</a>
+</dt>
+<dt>14.2.  <a href="#errorstatus-terminal">Terminal Binding Conditions</a>
+</dt>
+<dt>14.3.  <a href="#errorstatus-recover">Recoverable Binding Conditions</a>
+</dt>
+<dt>14.4.  <a href="#errorstatus-stanza">XMPP Stanza Conditions</a>
+</dt>
+</dl>
+<dt>15.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>16.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>17.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>17.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>18.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250476">1</a>] defines XML streams bound to TCP (see <span class="ref" style="">RFC 793</span>  [<a href="#nt-id2250502">2</a>]) as the standard transport layer for Jabber/XMPP communications. However, the binding of XMPP to TCP is not always feasible because of client runtime environment and/or network constraints. This JEP describes the usage of the Hypertext Transfer Protocol (HTTP, see <span class="ref" style="">RFC 2068</span>  [<a href="#nt-id2250526">3</a>] and <span class="ref" style="">RFC 1945</span>  [<a href="#nt-id2250540">4</a>]) as an alternative transport binding that supports such constrained environments, normally via deployment of a specialized server-side connection manager that communicates with clients via HTTP rather than TCP.</p>
+    <p class="" style="">Before the authors pursued publication of this JEP, other approaches were explored. One possible approach might have been to apply state to a series of HTTP transactions via HTTP "cookies" as specified in <span class="ref" style="">RFC 2965</span>  [<a href="#nt-id2255193">5</a>]. However, there are several significant computing platforms which provide only limited access to underlying HTTP requests/responses; worse, some platforms hide or remove cookie-related headers. Therefore the cookie approach was rejected.</p>
+    <p class="" style="">Another approach might have been to modify or extend <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2255224">6</a>]. This informational protocol has been used by Jabber clients without runtime constraints to access XMPP servers from behind firewalls. Unfortunately, the method defined in JEP-0025 also depends on cookies, does not meet most of the requirements described below, and cannot be extended without breaking all existing implementations.</p>
+    <p class="" style="">Therefore, this JEP specifies a new way of transporting XMPP via HTTP. All information is encoded in the body of standard HTTP POST requests and responses. Each HTTP body contains a single &lt;body/&gt; XML wrapper element (not to be confused with the &lt;body/&gt; child of the &lt;message/&gt; stanza as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2255264">7</a>]), which encapsulates zero or more XML stanzas.</p>
+    <p class="" style="">Although this JEP documents some XMPP-specific features, the binding is not part of XMPP. In fact, the protocol is extensible and could be used to implement any bidirectional stream of XML stanzas.</p>
+  <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+    <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+      <p class="" style="">This document inherits terminology regarding the Hypertext Transport Protocol from RFCs 1945 and 2068.</p>
+    </div>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">Platform limitiations, security restrictions, and other constraints imply that many clients can connect to Internet resources (e.g., Jabber servers) only via HTTP. The following design requirements reflect the need to offer performance as close as possible to a standard TCP connection.</p>
+    <ol start="" type="">
+      <li>Compatible with constrained runtime environments (e.g., mobile and browser-based clients).</li>
+      <li>Compatible with restricted network connections (e.g., firewalls, proxies, and gateways).</li>
+      <li>Fault tolerant (e.g., session recovers after an underlying TCP connection breaks during an HTTP request).</li>
+      <li>Extensible (based on XML).</li>
+      <li>Consume significantly less bandwidth than polling-based solutions.</li>
+      <li>Significantly more responsive than polling-based solutions.</li>
+      <li>Support for polling (for clients that are limited to one HTTP connection at a time).</li>
+      <li>XML stanzas should arrive at the server in the order they were sent by the client.</li>
+      <li>Protect against unauthorized users interjecting HTTP requests into a session.</li>
+    </ol>
+    <p class="" style="">Compatibility with constrained runtime environments implies the following restrictions:</p>
+    <ul>
+      <li>Clients should not be required to have programmatic access to the headers of each HTTP request and response (e.g., cookies or status codes).</li>
+      <li>The body of each HTTP request and response should be parsable XML with a single root element.</li>
+      <li>Clients should be able to specify the Content-Type of the HTTP responses they receive.</li>
+    </ul>
+  <h2>4.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+    <p class="" style="">The binding of XMPP to HTTP assumes a different architecture from that described for the binding of XMPP to TCP as defined in <span style="font-weight: bold">RFC 3920</span>. In particular, because HTTP is not the native binding for XMPP, we assume that most XMPP implementations will utilize a specialized "connection manager" to handle HTTP connections rather than the usual TCP connections. Effectively, such a connection manager will be a specialized HTTP server that translates between the HTTP requests and responses defined herein and the XML streams (or a server API) implemented by the XMPP server or servers with which it communicates, thus enabling an HTTP client to connect to an XMPP server. We can illustrate this graphically as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+  XMPP Server
+      |
+      |  [XML streams or server API]
+      |
+Connection Manager
+      |
+      |  [HTTP + &lt;body/&gt; wrapper]
+      |
+  HTTP Client
+    </pre></div>
+    <p class="" style="">This JEP addresses communications between an HTTP client and the connection manager only. It does not address communications between the connection manager and the XMPP server, since such communications are implementation-specific (e.g., the connection manager and the XMPP server may use <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2255466">8</a>] or an API defined by the XMPP server implementation in order to communicate; alternatively, the XMPP server may natively support the HTTP binding, in which case the connection manager will be a logical entity rather than a physical entity).</p>
+    <p class="" style="">Furthermore, no aspect of the HTTP binding limits its use to client-to-server communications; i.e., it could be used for server-to-server or component-to-server communications as well (probably through a slight change to the XML schema). However, this document focuses exclusively on use of the HTTP binding by clients that cannot maintain persistent TCP connections to a server and that therefore cannot use the TCP binding defined in <span style="font-weight: bold">RFC 3920</span>. We assume that servers and components are under no such restrictions and thus would use the TCP binding.</p>
+  <h2>5.
+       <a name="http">HTTP Version and HTTP Headers</a>
+</h2>
+    <p class="" style="">Clients SHOULD send HTTP requests over persistent HTTP/1.1 connections. However, a constrained client MAY open a new HTTP/1.0 connection (as defined in RFC 1945) to send each request.</p>
+    <p class="" style="">Requests and responses MAY include HTTP headers not specified herein. The receiver SHOULD ignore any such headers.</p>
+  <h2>6.
+       <a name="compression">Compression</a>
+</h2>
+    <p class="" style="">Clients MAY include an HTTP Accept-Encoding header in any request. If the connection manager receives a request with an Accept-Encoding header, it MAY include an HTTP Content-Encoding header in the response (indicating one of the encodings specified in the request) and compress the response body accordingly.</p>
+    <p class="" style="">TLS compression (as defined in <span style="font-weight: bold">RFC 3920</span>) and Stream Compression (as defined in <span class="ref" style="">Stream Compression</span>  [<a href="#nt-id2255611">9</a>]) are NOT RECOMMENDED since compression SHOULD be negotiated at the HTTP layer and with the 'accept' attribute (see the <a href="#session-create">Session Creation</a> section below). TLS compression and Stream Compression SHOULD NOT be used simultaneously with HTTP content encoding.</p>
+  <h2>7.
+       <a name="wrapper">&lt;body/&gt; Wrapper Element</a>
+</h2>
+    <p class="" style="">The body of each HTTP request and response contains a single &lt;body/&gt; wrapper element. The &lt;body/&gt; element MUST contain zero or more complete XML elements. It MUST NOT contain partial XML elements.</p>
+    <p class="" style="">If the &lt;body/&gt; wrapper element is not empty, then it MUST contain one of the following:</p>
+    <ul>
+      <li>One or more complete XMPP stanzas (&lt;message/&gt;, &lt;presence/&gt;, and/or &lt;iq/&gt;).</li>
+      <li>A complete &lt;stream:features/&gt; element qualified by the 'http://etherx.jabber.org/streams' namespace.</li>
+      <li>A complete element used for SASL negotiation and qualified by the 'urn:ietf:params:xml:ns:xmpp-sasl' namespace.</li>
+      <li>XML elements associated with a binding error condition. For details, refer to the <a href="#errorstatus-binding">Binding Conditions</a> section below.</li>
+    </ul>
+    <p class="" style="">Note: Inclusion of TLS negotiation elements is allowed but is NOT RECOMMENDED (see <a href="#preconditions">Additional Preconditions</a> below).</p>
+    <p class="" style="">The &lt;body/&gt; wrapper element SHOULD be qualified by the 'http://jabber.org/protocol/httpbind' namespace, and child elements SHOULD be qualified by their respective namespaces (e.g., 'http://etherx.jabber.org/streams' for stream features, 'urn:ietf:params:xml:ns:xmpp-sasl' for SASL negotiation, and 'jabber:client' for XML stanzas). However, even if the client does not specify the namespaces, the connection manager MUST ensure that the XMPP it provides to the XMPP server or other entities on the network meets the namespacing requirements of <span style="font-weight: bold">RFC 3920</span>.</p>
+    <p class="" style="">The &lt;body/&gt; element of every client request MUST possess a sequential request ID encapsulated via the 'rid' attribute. The client MUST generate a large positive non-zero random integer for the first 'rid' and then increment that value by one for each subsequent request. For details, refer to the <a href="#rids">Request IDs</a> section below.</p>
+  <h2>8.
+       <a name="session">Initiating an HTTP Session</a>
+</h2>
+    <div class="indent">
+<h3>8.1 <a name="session-request">Requesting a Session</a>
+</h3>
+      <p class="" style="">The first request from the client to the connection manager creates a new session.</p>
+      <p class="" style="">The &lt;body/&gt; element of the first request SHOULD possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-weight: bold">'to'</span> -- This attribute specifies the target domain (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'xml:lang'</span> -- This attribute (as defined in Section 2.12 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2255792">10</a>]) specifies the default language of any human-readable XML character data sent or received during the session (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'wait'</span> -- This attribute specifies the longest time (in seconds) that the connection manager is allowed to wait before responding to any request during the session. This enables the client to prevent its TCP connection from expiring due to inactivity, as well as to limit the delay before it discovers any network failure.</li>
+        <li>
+<span style="font-weight: bold">'hold'</span> -- This attribute specifies the maximum number of requests the connection manager is allowed to keep waiting at any one time during the session. (For example, if a constrained client is unable to keep open more than two HTTP connections to the same HTTP server simultaneously, then it SHOULD specify a value of "1".)</li>
+      </ul>
+      <p class="" style="">Note: Clients that only support polling behavior MAY prevent the connection manager from waiting by setting 'wait' or 'hold' to "0". However, polling is NOT RECOMMENDED since the associated increase in bandwidth consumption and the decrease in responsiveness are typically one or two orders of magnitude!</p>
+      <p class="" style="">Some clients are constrained to only accept HTTP responses with specific Content-Types (e.g., "text/html"). The &lt;body/&gt; element of the first request MAY possess a 'content' attribute. This specifies the value of the HTTP Content-Type header that MUST appear in all the connection manager's responses during the session. If the client request does not possess a 'content' attribute, then the HTTP Content-Type of responses MUST be "text/xml; charset=utf-8".</p>
+      <p class="" style="">Note: The HTTP Content-Type of client requests SHOULD also be "text/xml; charset=utf-8". Clients MAY specify another value if they are constrained to do so (e.g., "application/x-www-form-urlencoded" or "text/plain"). The client and connection manager SHOULD ignore all HTTP Content-Type headers they receive.</p>
+      <p class="caption">Example 1. Requesting an HTTP session</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">Note: Unlike the protocol defined in JEP-0025, an opening &lt;stream:stream&gt; tag is not sent. The protocol defined herein abstracts from XML streams between the connection manager and the client. Any XML streams between the connection manager and an XMPP server are the responsibility of the connection manager.</p>
+      <p class="" style="">Note: All requests after the first one MUST include a valid 'sid' attribue (provided by the connection manager in the session creation response below). The initialization request is unique in that the &lt;body/&gt; element MUST NOT possess a 'sid' attribute.</p>
+    </div>
+    <div class="indent">
+<h3>8.2 <a name="session-create">Session Creation</a>
+</h3>
+      <p class="" style="">After receiving a new session request, the connection manager MUST generate an opaque, unpredictable session identifier (or SID). The SID MUST be unique within the context of the connection manager application. The connection manager then returns that SID to the client in a response &lt;body/&gt; element.</p>
+      <p class="" style="">The connection manager MUST specify a 'wait' attribute. This is the longest time (in seconds) that it will wait before responding to any request during the session. The time MUST be less than or equal to the value specified in the session request.</p>
+      <p class="" style="">The connection manager MAY limit the number of simultaneous requests the client makes with the 'requests' attribute. The RECOMMENDED value is "2". Servers that only support polling behavior MUST prevent clients from making simultaneous requests by setting the 'requests' attribute to a value of "1" (however, polling is NOT RECOMMENDED). In any case, clients MUST NOT make more simultaneous requests than specified by the connection manager.</p>
+      <p class="" style="">The connection manager SHOULD include two additional attributes in the session creation response element, specifying the shortest allowable polling interval and the longest allowable inactivity period (both in seconds). Communication of these parameters enables the client to engage in appropriate behavior (e.g., not sending empty request elements more often than desired, and ensuring that the periods with no requests pending are never too long).</p>
+      <p class="" style="">The connection manager MAY include an 'accept' attribute in the session creation response element, to specify the content encodings it can decompress. After receiving a session creation response with an 'accept' attribute, clients MAY include an HTTP Content-Encoding header in subsequent requests (indicating one of the encodings specified in the 'accept' attribute) and compress the bodies of the requests accordingly.</p>
+      <p class="" style="">For both requests and responses, the &lt;body/&gt; element and its content SHOULD be UTF-8 encoded. If the HTTP Content-Type header of a request/response specifies a character encoding other than UTF-8, then the connection manager MAY convert between UTF-8 and the other character encoding. However, even in this case, it is OPTIONAL for the connection manager to convert between encodings. The connection manager MAY inform the client which encodings it can convert by setting the optional 'charsets' attribute in the session creation response element to a space-separated list of encodings.
+         [<a href="#nt-id2250127">11</a>]
+        </p>
+      <p class="caption">Example 2. Session creation response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 128
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      accept='deflate,gzip'
+      sid='SomeSID'
+      charsets='ISO_8859-1 ISO-2022-JP'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">Note: The 'authid' attribute contains the value of the XMPP stream ID generated by the XMPP server. The connection manager MUST retrieve the stream ID and pass it unmodified to the client. This value is needed by the client to successfully complete digest authentication using <span class="ref" style="">Non-SASL Authentication</span>  [<a href="#nt-id2250210">13</a>] (see the <a href="#preconditions-iqauth">jabber:iq:auth</a> section below).</p>
+    <p class="" style="">Note: If the 'authid' attribute is not included in the connection manager's response to the session creation request (e.g., because the connection manager has not yet received a stream ID from the XMPP server), then the client SHOULD send empty request elements (see the "Requesting XML Stanzas" example below) until it receives a response with an 'authid' attribute. In any case, the connection manager MUST return the 'authid' in a response to the client as soon as possible after it receives the stream ID from the XMPP server.</p>
+    <p class="" style="">Separate 'sid' and 'authid' attributes are required because the connection manager is not necessarily part of a single XMPP server (e.g., it may handle HTTP connections on behalf of multiple XMPP servers).</p>
+    </div>
+    <div class="indent">
+<h3>8.3 <a name="session-features">Communication of Stream Features</a>
+</h3>
+      <p class="" style="">As an immediate child of the session creation response, the connection manager MAY include a stream features element, as defined by <span style="font-weight: bold">RFC 3920</span>.</p>
+      <p class="caption">Example 3. Session creation response with stream features</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 417
+
+&lt;body wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      accept='deflate,gzip'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;stream:features xmlns='http://etherx.jabber.org/streams'&gt;
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'&gt;
+  &lt;/stream:features&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The stream features SHOULD NOT include a feature for Transport Layer Security (TLS), since channel encryption SHOULD be negotiated at the HTTP layer (see the <a href="#security">Security Considerations</a> section below).</p>
+    </div>
+  <h2>9.
+       <a name="preconditions">Additional Preconditions</a>
+</h2>
+    <p class="" style="">Initializing an HTTP session is the first precondition to sending XML message, presence, and IQ stanzas. However, before processing XML stanzas from the client, the connection manager MUST require completion of additional preconditions using either of the following methods:</p>
+    <ul>
+      <li>
+        <p class="" style="">XMPP authentication, resource binding, and IM session creation, in the following order:</p>
+        <ol start="" type="">
+          <li>Optionally, TLS negotiation as defined in Section 5 of <span style="font-weight: bold">RFC 3920</span> (this is NOT RECOMMENDED since channel encryption and compression SHOULD be negotiated at the HTTP layer; see the <a href="#security">Security Considerations</a> section below)</li>
+          <li>SASL authentication as defined in Section 6 of <span style="font-weight: bold">RFC 3920</span>
+</li>
+          <li>Resource Binding as defined in Section 7 of <span style="font-weight: bold">RFC 3920</span>
+</li>
+          <li>IM Session Establishment as defined in Section 3 of <span style="font-weight: bold">XMPP IM</span>, if appropriate</li>
+        </ol>
+      </li>
+      <li>
+        <p class="" style="">Simultaneous authentication and resource binding as defined in <span style="font-weight: bold">Non-SASL Authentication</span>, upon which a Jabber server will also establish an IM session on behalf of the connected resource.</p>
+      </li>
+    </ul>
+    <p class="" style="">It is RECOMMENDED to use the XMPP methods as defined in <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">XMPP IM</span>, rather than using older non-SASL authentication.</p>
+
+    <div class="indent">
+<h3>9.1 <a name="preconditions-xmpp">XMPP Methods</a>
+</h3>
+      <p class="" style="">A success case for authentication, resource binding, and IM session establishment using the XMPP protocols is shown below. For detailed specification of these protocols (including error cases) and for specification of TLS negotiation, refer to <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">XMPP IM</span>.</p>
+      <p class="caption">Example 4. SASL authentication step 1</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 172
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='DIGEST-MD5'/&gt;
+&lt;/body&gt;</pre></div>
+
+
+
+      <p class="caption">Example 5. SASL authentication step 2</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 250
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cmVhbG09InNvbWVyZWFsbSIsbm9uY2U9Ik9BNk1HOXRFUUdtMmhoIixxb3A9
+    ImF1dGgiLGNoYXJzZXQ9dXRmLTgsYWxnb3JpdGhtPW1kNS1zZXNzCg==
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 6. SASL authentication step 3</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 418
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    dXNlcm5hbWU9InNvbWVub2RlIixyZWFsbT0ic29tZXJlYWxtIixub25jZT0i
+    T0E2TUc5dEVRR20yaGgiLGNub25jZT0iT0E2TUhYaDZWcVRyUmsiLG5jPTAw
+    MDAwMDAxLHFvcD1hdXRoLGRpZ2VzdC11cmk9InhtcHAvZXhhbXBsZS5jb20i
+    LHJlc3BvbnNlPWQzODhkYWQ5MGQ0YmJkNzYwYTE1MjMyMWYyMTQzYWY3LGNo
+    YXJzZXQ9dXRmLTgK
+&lt;/response&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 7. SASL authentication step 4</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 190
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cnNwYXV0aD1lYTQwZjYwMzM1YzQyN2I1NTI3Yjg0ZGJhYmNkZmZmZAo=
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 8. SASL authentication step 5</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 152
+
+&lt;body rid='3197423133'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 9. SASL authentication step 6</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 121
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="" style="">Note: Because the context for a client's communication with a connection manager in the HTTP transport binding is HTTP rather than XML streams (as in the TCP binding), there is no need to re-start communications (e.g., by generating a new SID) at this point.</p>
+
+      <p class="caption">Example 10. Resource binding request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 240
+
+&lt;body rid='3197423134'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 11. Resource binding result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 221
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='result'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;jid&gt;stpeter@jabber.org/httpclient&lt;/jid&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 12. IM session request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 261
+
+&lt;body rid='3197423135'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='stpeter@jabber.org/httpclient'
+      id='sess_1'
+      to='jabber.org'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'/&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 13. IM session result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 175
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='jabber.org'
+      id='sess_1'
+      to='stpeter@jabber.org/httpclient'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+
+    </div>
+
+    <div class="indent">
+<h3>9.2 <a name="preconditions-iqauth">jabber:iq:auth</a>
+</h3>
+      <p class="" style="">A success case for simultaneous authentication, resource binding, and IM session creation using the original "jabber:iq:auth" protocol is shown below. For further details regarding use of this protocol, refer to JEP-0078. If digest authentication is used, then the stream ID value used to compute the hashed password MUST be the value of the 'authid' attribute provided by the connection manager in the response to the initialization element or in a subsequent response (see the <a href="#session-create">Session Creation</a> section above).</p>
+      <p class="caption">Example 14. Non-SASL authentication request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 281
+
+&lt;body rid='2842791421'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;query xmlns='jabber:iq:auth'&gt;
+      &lt;username&gt;stpeter&lt;/username&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+      &lt;password&gt;jabber-rocks&lt;/password&gt;
+    &lt;/query&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 15. Authentication result (success)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 144
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 16. Authentication result (failure)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 226
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='error'
+      xmlns='jabber:client'&gt;
+    &lt;error code='401' type='auth'&gt;
+      &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>10.
+       <a name="stanzas">Sending and Receiving XML Stanzas</a>
+</h2>
+    <p class="" style="">After the client has successfully completed all required preconditions, it can send and receive XML stanzas via the HTTP binding.</p>
+    <p class="caption">Example 17. Transmitting stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='2842791422'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message to='friend@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">Upon receipt of a request, the connection manager MUST forward the content of the &lt;body/&gt; element to the XMPP server as soon as possible. However, it must forward the content from different requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">The connection manager MUST also return an HTTP 200 OK response with a &lt;body/&gt; element to the client. Note: This does not indicate that the stanzas have been successfully delivered to the destination Jabber endpoint.</p>
+    <p class="" style="">It is RECOMMENDED that the connection manager not return an HTTP result until a stanza has arrived from the XMPP server for delivery to the client. However, the connection manager SHOULD NOT wait longer than the time specified by the client in the 'wait' attribute of its session creation request, and it SHOULD NOT keep more HTTP requests waiting at a time than the number specified in the 'hold' attribute of the session creation request. In any case it MUST respond to requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">If there are no stanzas waiting or ready to be delivered within the waiting period, then the connection manager SHOULD include an empty &lt;body/&gt; element in the HTTP result:</p>
+    <p class="caption">Example 18. Empty response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 64
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">If the connection manager has received one or more stanzas from the XMPP server for delivery to the client, then it SHOULD return the stanzas in the body of its response as soon as possible after receiving them from the XMPP server.</p>
+    <p class="caption">Example 19. Response with queued stanza</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 185
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message from='contact@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message from='friend@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The client MAY poll the connection manager for incoming stanzas by sending an empty &lt;body/&gt; element.</p>
+    <p class="caption">Example 20. Requesting XML Stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='2842791423'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The connection manager MUST wait and respond in the same way as it does after receiving stanzas from the client.</p>
+    <p class="" style="">If the client sends two consecutive empty requests within a period shorter than that specified by the 'polling' attribute in the session creation response, then the connection manager SHOULD terminate the HTTP session and return an HTTP 403 (Forbidden) error to the client.</p>
+    <p class="caption">Example 21. Too frequent polling response</p>
+<div class="indent"><pre>
+HTTP/1.1 403 Forbidden
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    <p class="" style="">If the connection manager did not specify a shortest allowable polling interval in the session creation response, then it MUST allow the client to poll as frequently as it chooses.</p>
+    <p class="" style="">After receiving a response from the connection manager, if no other requests are pending and the client did not specify polling behavior in the session creation request (by setting 'wait' or 'hold' to "0"), it SHOULD make a new request as soon as possible. In any case, if no requests are pending, the client MUST make a new request before the maximum inactivity period has expired. This period is specified by the 'inactivity' attribute in the session creation response.</p>
+    <p class="" style="">If the connection manager has responded to all the requests it has received and the time since its last response is longer than the maximum inactivity period, then it SHOULD terminate the session without informing the client (if the client makes another request, the connection manager SHOULD respond as if the session does not exist).</p>
+    <p class="" style="">If the connection manager did not specify a maximum inactivity period in the session creation response, then it MUST allow the client to be inactive for as long as it chooses.</p>
+  <h2>11.
+       <a name="terminate">Terminating the HTTP Session</a>
+</h2>
+    <p class="" style="">At any time, the client MAY gracefully terminate the session by sending a &lt;body/&gt; element with a 'type' attribute set to "terminate". The termination request SHOULD include an XMPP presence stanza of type "unavailable" to ensure graceful logoff with the XMPP server.</p>
+    <p class="caption">Example 22. Session termination by client</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 153
+
+&lt;body rid='2842791424'
+      sid='SomeSID'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;presence type='unavailable'
+            xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The connection manager SHOULD return an HTTP 200 OK response with an empty &lt;body/&gt; element. Upon receiving the response, the client MUST consider the HTTP session to have been terminated.</p>
+  <h2>12.
+       <a name="rids">Request IDs</a>
+</h2>
+    <div class="indent">
+<h3>12.1 <a name="rids-order">In-Order Message Forwarding</a>
+</h3>
+      <p class="" style="">When a client makes simultaneous requests, the connection manager may receive them out of order. The connection manager MUST forward the stanzas to the XMPP server and respond to the client requests in the order specified by the 'rid' attributes. The client MUST process responses received from the connection manager in the order the requests were made.</p>
+      <p class="" style="">The connection manager SHOULD expect the 'rid' attribute to be within a window of values greater than the 'rid' of the previous request. The size of the window is equal to the maximum number of simultaneous requests allowed by the connection manager. If it receives a request with a 'rid' greater than the values in the window, then the connection manager MUST terminate the session with an error:</p>
+      <p class="caption">Example 23. Unexpected rid error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>12.2 <a name="rids-broken">Broken Connections</a>
+</h3>
+      <p class="" style="">Unreliable network communications or client constraints can result in broken connections. The connection manager SHOULD remember the 'rid' and the associated HTTP response body of the client's most recent requests which did not result in an HTTP or binding error. The number of responses kept in the buffer should be the same as the maximum number of simultaneous requests allowed by the connection manager.</p>
+      <p class="" style="">If the network connection is broken or closed before the client receives a response to a request from the connection manager, then the client MAY resend an exact copy of the original request. Whenever the connection manager receives a request with a 'rid' that it has already received, it SHOULD return an HTTP 200 (OK) response that includes the buffered copy of the original XML response to the client (i.e., a &lt;body/&gt; wrapper element possessing appropriate attributes and optionally containing one or more XML stanzas or other allowable XML elements). If the original response is not available (e.g., it is no longer in the buffer), then the connection manager MUST return an HTTP 404 (Not Found) error:</p>
+      <p class="caption">Example 24. Response not in buffer error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+      <p class="" style="">Note: The error is the same whether the 'rid' is too large or too small. This makes it more difficult for an attacker to discover an acceptable value.</p>
+    </div>
+  <h2>13.
+       <a name="keys">Protecting Insecure Sessions</a>
+</h2>
+    <div class="indent">
+<h3>13.1 <a name="keys-applic">Applicability</a>
+</h3>
+      <p class="" style="">The OPTIONAL key sequencing mechanism described here MAY be used if the client's session with the connection manager is not secure. The session should be considered secure only if all client requests are made via TLS/SSL HTTP connections and the connection manager generates an unpredictable session ID. If the session is secure, it is not necessary to use this key sequencing mechanism.</p>
+      <p class="" style="">Even if the session is not secure, the unpredictable session and request IDs specified in the preceding sections of this document already provide a level of protection similar to that provided by a standard XMPP connection bound to a single pair of persistent TCP/IP connections, and thus provide sufficient protection against a 'blind' attacker. However, in some circumstances, the key sequencing mechanism defined below helps to protect against a more determined and knowledgeable attacker.</p>
+      <p class="" style="">It is important to recognize that the key sequencing mechanism defined below helps to protect only against an attacker who is able to view the contents of all requests or responses in an insecure session but who is not able to alter the contents of those requests (in this case, the mechanism prevents the attacker from interjecting HTTP requests into the session, e.g., termination requests or responses). However, the key sequencing mechanism does not provide any protection when the attacker is able to alter the contents of insecure requests or responses.</p>
+    </div>
+    <div class="indent">
+<h3>13.2 <a name="keys-intro">Introduction</a>
+</h3>
+      <p class="" style="">The HTTP requests of each session MAY be spread across a series of different socket connections. This would enable an unauthorized user that obtains the session ID and request ID of a session and then use their own socket connection to interject &lt;body/&gt; request elements into the session and receive the corresponding responses.</p>
+      <p class="" style="">The key sequencing mechanism below protects against such attacks by enabling a connection manager to detect &lt;body/&gt; request elements interjected by a third party.</p>
+    </div>
+    <div class="indent">
+<h3>13.3 <a name="keys-generate">Generating the Key Sequence</a>
+</h3>
+      <p class="" style="">Prior to requesting a new session, the client MUST select an unpredictable counter ("n") and an unpredictable value ("seed"). The client then processes the "seed" through a cryptographic hash and converts the resulting 160 bits to a hexadecimal string K(1). It does this "n" times to arrive at the initial key K(n). The hashing algorithm MUST be SHA-1 as defined in <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2257347">14</a>].</p>
+      <p class="caption">Example 25. Creating the key sequence</p>
+<div class="indent"><pre>
+        K(1) = hex(SHA-1(seed))
+        K(2) = hex(SHA-1(K(1)))
+        ...
+        K(n) = hex(SHA-1(K(n-1)))
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.4 <a name="keys-use">Use of Keys</a>
+</h3>
+      <p class="" style="">The client MUST set the 'newkey' attribute of the first request in the session to the value K(n).</p>
+      <p class="caption">Example 26. Session Request with Initial Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      newkey='ca393b51b682f61f98e7877d61146407f3d0a770'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The client MUST set the 'key' attribute of all subsequent requests to the value of the next key in the generated sequence (decrementing from K(n-1) towards K(1) with each request sent).</p>
+    <p class="caption">Example 27. Request with Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      key='bfb06a6f113cd6fd3838ab9d300fdb4fe3da2f7d'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The connection manager MAY verify the key by calculating the SHA-1 hash of the key and comparing it to the 'newkey' attribute of the previous request (or the 'key' attribute if the 'newkey' attribute was not set). If the values do not match (or if it receives a request without a 'key' attribute and the 'newkey' or 'key' attribute of the previous request was set), then the connection manager MUST NOT process the element, MUST terminate the session, and MUST return an HTTP 404 (Not Found) error.</p>
+      <p class="caption">Example 28. Invalid Key Sequence Error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>13.5 <a name="keys-switch">Switching to Another Key Sequence</a>
+</h3>
+      <p class="" style="">A client SHOULD choose a high value for "n" when generating the key sequence. However, if the session lasts long enough that the client arrives at the last key in the sequence K(1) then the client MUST switch to a new key sequence.</p>
+      <p class="" style="">The client MUST:</p>
+      <ol start="" type="">
+        <li>Choose new values for "seed" and "n".</li>
+        <li>Generate a new key sequence using the algorithm defined above.</li>
+        <li>Set the 'key' attribute of the request to the next value in the old sequence (i.e. K(1), the last value).</li>
+        <li>Set the 'newkey' attribute of the request to the value K(n) from the new sequence.</li>
+      </ol>
+      <p class="caption">Example 29. New Key Sequence</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      key='6f825e81f4532b2c5fa2d12457d8a1f22e8f838e'
+      newkey='113f58a37245ec9637266cf2fb6e48bfeaf7964e'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>14.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+    <p class="" style="">There are four types of error and status reporting in HTTP responses:</p>
+    <p class="caption">Table 1: Error Condition Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition Type</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">HTTP Conditions</span></td>
+<td align="" colspan="" rowspan="">The connection manager responds to an invalid client request with a standard HTTP error. These are used for binding syntax errors, possible attacks, etc. Note that constrained clients are unable to differentiate between HTTP errors.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Terminal Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These error conditions may be read by constrained clients. They are used for connection manager problems, abstracting stream errors, and communication problems between the connection manager and the XMPP server.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Recoverable Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These report communication problems between the connection manager and the client. They do not terminate the session. Clients recover from these errors by resending the last two &lt;body/&gt; wrapper elements.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP Stanza Conditions</span></td>
+<td align="" colspan="" rowspan="">XMPP errors relating to XML stanzas within &lt;body/&gt; wrapper elements are, in general, defined in the appropriate RFC or JEP. They do not terminate the session. An example of such usage is shown above in relation to <span style="font-weight: bold">Non-SASL Authentication</span>.</td>
+</tr>
+    </table>
+    <p class="" style="">Full descriptions are provided below.</p>
+    <div class="indent">
+<h3>14.1 <a name="errorstatus-http">HTTP Conditions</a>
+</h3>
+      <p class="" style="">The following HTTP error and status codes are used in particular ways by this protocol (other HTTP error and status codes may be used as appropriate). Upon receiving an HTTP error (400, 403, 404), the HTTP client MUST consider the HTTP session to be null and void.</p>
+      <p class="" style="">Note: These are pure HTTP codes as defined in the HTTP specification, and are not to be confused with the HTTP-style error codes traditionally used in Jabber protocols and documented in <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257710">15</a>].</p>
+      <p class="caption">Table 2: HTTP Error and Status Codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Code</th>
+          <th colspan="" rowspan="">Name</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">200</td>
+          <td align="" colspan="" rowspan="">OK</td>
+          <td align="" colspan="" rowspan="">Response to valid client request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">400</td>
+          <td align="" colspan="" rowspan="">Bad Request</td>
+          <td align="" colspan="" rowspan="">Inform client that the format of an HTTP header or binding element is unacceptable (e.g., syntax error).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">403</td>
+          <td align="" colspan="" rowspan="">Forbidden</td>
+          <td align="" colspan="" rowspan="">Inform client that it has broken the session rules (polling too-frequently, too many simultaneous connections).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">404</td>
+          <td align="" colspan="" rowspan="">Not Found</td>
+          <td align="" colspan="" rowspan="">Inform client that (1) 'sid' is not valid, (2) 'rid' is larger than the upper limit of the expected window, (3) connection manager is unable to resend response, (4) 'key' sequence is invalid.</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>14.2 <a name="errorstatus-terminal">Terminal Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a fatal error by setting a 'type' attribute of the &lt;body/&gt; element to "terminate". These binding errors imply that the HTTP session is terminated. (Note: Many of these conditions correspond to the relevant XMPP stream error conditions specified in <span style="font-weight: bold">RFC 3920</span>, but actual XMPP stream error conditions experienced between the connection manager and the server are contained only in the "remote-stream-error" condition as described below.)</p>
+      <p class="caption">Example 30. Remote connection failed error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='terminate'
+      condition='remote-connection-failed'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The following values of the 'condition' attribute are defined:</p>
+      <p class="caption">Table 3: Binding Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Condition</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-gone</td>
+          <td align="" colspan="" rowspan="">The target hostname specified in the 'to' attribute is no longer serviced by the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-unknown</td>
+          <td align="" colspan="" rowspan="">The target hostname specified in the 'to' attribute is unknown to the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">improper-addressing</td>
+          <td align="" colspan="" rowspan="">The initialization element lacks a 'to' attribute (or the attribute has no value) but the connection manager requires one.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">internal-server-error</td>
+          <td align="" colspan="" rowspan="">The connection manager has experienced an internal error that prevents it from servicing the request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">other-request</td>
+          <td align="" colspan="" rowspan="">Another request being processed at the same time as this request caused the session to terminate.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-connection-failed</td>
+          <td align="" colspan="" rowspan="">The connection manager was unable to connect to, or has lost its connection to, the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-stream-error</td>
+          <td align="" colspan="" rowspan="">Encapsulates an XMPP stream error. The content of the binding is a copy of the content of the &lt;stream:error/&gt; element received from the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">see-other-uri</td>
+          <td align="" colspan="" rowspan="">The connection manager does not operate at this URI (e.g., the connection manager accepts only SSL/TLS connections at some https: URI rather than the http: URI requested by the client). The client may try POSTing to the URI in the content of the &lt;uri/&gt; child element.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">system-shutdown</td>
+          <td align="" colspan="" rowspan="">The connection manager is being shut down. All active HTTP sessions are being terminated. No new sessions can be created.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">undefined-condition</td>
+          <td align="" colspan="" rowspan="">The error is not one of those defined herein; the connection manager SHOULD include application-specific information in the content of the &lt;body/&gt; wrapper element.</td>
+        </tr>
+      </table>
+      <p class="" style="">The following is an example of a "see-other-uri" condition:</p>
+      <p class="caption">Example 31. See other URI error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='see-other-uri'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;uri&gt;https://secure.jabber.org/xmppcm&lt;/uri&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The following is an example of a "remote-stream-error" condition:</p>
+      <p class="caption">Example 32. Remote error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='remote-stream-error'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;xml-not-well-formed xmlns='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+  &lt;text xmlns='urn:ietf:params:xml:ns:xmpp-streams'
+        xml:lang='en'&gt;
+    Some special application diagnostic information!
+  &lt;/text&gt;
+  &lt;escape-your-data xmlns='application-ns'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">Naturally, the client MAY report binding errors to the connection manager as well, although this is unlikely.</p>
+    </div>
+    <div class="indent">
+<h3>14.3 <a name="errorstatus-recover">Recoverable Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a recoverable error by setting a 'type' attribute of the &lt;body/&gt; element to "error". These errors do not imply that the HTTP session is terminated.</p>
+      <p class="" style="">If it decides to recover from the error, then the client MUST repeat the HTTP request and the previous HTTP request. The content of both requests MUST be identical to the &lt;body/&gt; elements of the original requests. This allows the server to recover a session after the previous request was lost due to a communication failure.</p>
+      <p class="caption">Example 33. Recoverable error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='error'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    </div>
+    <div class="indent">
+<h3>14.4 <a name="errorstatus-stanza">XMPP Stanza Conditions</a>
+</h3>
+      <p class="" style="">Application-level error conditions will normally be generated by a third entity (e.g., an IM contact) and routed to the client through the connection manager; therefore they are out of scope for the transport binding defined herein and are described in the appropriate RFC or JEP.</p>
+      <p class="" style="">However, it is possible that a connection manager will receive a stanza for delivery to a client even though the client connection is no longer active (e.g., before the connection manager is able to inform a server that the connection has died). In this case, the connection manager would return an error to the server; it is RECOMMENDED that the connection manager proceed as follows, since the situation is similar to that addressed by point #2 of Section 11.1 of <span style="font-weight: bold">XMPP IM</span>:</p>
+      <ol start="" type="">
+        <li>If the delivered stanza was &lt;presence/&gt;, silently drop the stanza and do not return an error to the sender.</li>
+        <li>If the delivered stanza was &lt;iq/&gt;, return a &lt;service-unavailable/&gt; error to the sender.</li>
+        <li>If the delivered stanza was &lt;message/&gt;, return a &lt;recipient-unavailable/&gt; error to the sender.</li>
+      </ol>
+      <p class="" style="">When a server receives a &lt;message/&gt; stanza of type "error" containing a &lt;recipient-unavailable/&gt; condition from a connection manager, it SHOULD store the message for later delivery if offline storage is enabled, otherwise route the error stanza to the sender.</p>
+    </div>
+  <h2>15.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Communications SHOULD occur over an encrypted channel. Negotiation of channel encryption SHOULD occur at the HTTP layer, not the application layer; such negotiation SHOULD follow the protocol defined in <span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2258396">16</a>].</p>
+    <p class="" style="">The session identifier (SID) and initial request identifier (RID) are security-critical and therefore MUST be both unpredictable and nonrepeating (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2258428">17</a>] for recommendations regarding randomness of SIDs and initial RIDs for security purposes).</p>
+  <h2>16.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258500">18</a>].</p>
+  <h2>17.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>17.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258515">19</a>] includes 'http://jabber.org/protocol/httpbind' in its registry of protocol namespaces.</p>
+    </div>
+  <h2>18.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    targetNamespace='http://jabber.org/protocol/httpbind'
+    xmlns='http://jabber.org/protocol/httpbind'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0124: http://www.jabber.org/jeps/jep-0124.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import namespace='http://etherx.jabber.org/streams'
+             schemaLocation='http://etherx.jabber.org/streams.xsd'/&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:stream='http://etherx.jabber.org/streams'&gt;
+        &lt;xs:element ref='stream:features'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-tls'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-streams'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='jabber:client'
+                minOccurs='0'
+                maxOccurs='unbounded'/&gt;
+        &lt;xs:element name='uri'
+                minOccurs='0'
+                maxOccurs='1'
+                type='xs:string'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='authid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='charsets' type='xs:NMTOKENS' use='optional'/&gt;
+      &lt;xs:attribute name='condition' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='host-gone'/&gt;
+            &lt;xs:enumeration value='host-unknown'/&gt;
+            &lt;xs:enumeration value='improper-addressing'/&gt;
+            &lt;xs:enumeration value='internal-server-error'/&gt;
+            &lt;xs:enumeration value='remote-connection-failed'/&gt;
+            &lt;xs:enumeration value='remote-stream-error'/&gt;
+            &lt;xs:enumeration value='see-other-uri'/&gt;
+            &lt;xs:enumeration value='system-shutdown'/&gt;
+            &lt;xs:enumeration value='undefined-condition'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='accept' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='content' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='hold' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='inactivity' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='key' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='newkey' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='polling' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='requests' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='rid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+            &lt;xs:enumeration value='terminate'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='wait' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='xml:lang' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250476">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250502">2</a>. RFC 793: Transmission Control Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0793.txt">http://www.ietf.org/rfc/rfc0793.txt</a>&gt;.</p>
+<p><a name="nt-id2250526">3</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+<p><a name="nt-id2250540">4</a>. RFC 1945: Hypertext Transfer Protocol -- HTTP/1.0 &lt;<a href="http://www.ietf.org/rfc/rfc1945.txt">http://www.ietf.org/rfc/rfc1945.txt</a>&gt;.</p>
+<p><a name="nt-id2255193">5</a>. RFC 2965: HTTP State Management Mechanism &lt;<a href="http://www.ietf.org/rfc/rfc2965.txt">http://www.ietf.org/rfc/rfc2965.txt</a>&gt;.</p>
+<p><a name="nt-id2255224">6</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2255264">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255466">8</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2255611">9</a>. JEP-0138: Stream Compression &lt;<a href="http://www.jabber.org/jeps/jep-0138.html">http://www.jabber.org/jeps/jep-0138.html</a>&gt;.</p>
+<p><a name="nt-id2255792">10</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2250127">11</a>. Each character set name (or character encoding name -- we use the terms interchangeably) SHOULD be of type NMTOKEN, where the names are separated by the white space character #x20, resulting in a tokenized attribute type of NMTOKENS (see Section 3.3.1 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2250142">12</a>]). Strictly speaking, the Character Sets registry maintained by the Internet Assigned Numbers Authority (see &lt;<a href="http://www.iana.org/assignments/character-sets">http://www.iana.org/assignments/character-sets</a>&gt;) allows a character set name to contain any printable US-ASCII character, which might include characters not allowed by the NMTOKEN construction of XML 1.0; however, the only existing character set name which includes such a character is "NF_Z_62-010_(1973)".</p>
+<p><a name="nt-id2250142">12</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2250210">13</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p><a name="nt-id2257347">14</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2257710">15</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2258396">16</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2258428">17</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2258500">18</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258515">19</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2005-06-02)</h4>
+<div class="indent">Specified optional use of HTTP Accept-Encoding and Content-Encoding headers for compression at HTTP binding level. (ip)
+    </div>
+<h4>Version 1.0 (2005-03-03)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.10 (2004-11-08)</h4>
+<div class="indent">Changed HTTP 401 errors to HTTP 404. (ip)
+    </div>
+<h4>Version 0.9 (2004-10-26)</h4>
+<div class="indent">Added charset attribute. (ip/psa)
+    </div>
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Specified that wait attribute must be included in the session creation response. (ip)
+    </div>
+<h4>Version 0.7 (2004-08-12)</h4>
+<div class="indent">Defined appropriate XMPP stanza error conditions. (psa/ip)
+    </div>
+<h4>Version 0.6 (2004-07-19)</h4>
+<div class="indent">Added xml:lang attribute to the session request; added recoverable binding error conditions. (ip)
+    </div>
+<h4>Version 0.5 (2004-05-07)</h4>
+<div class="indent">Protocol refactored to enable simultaneous requests (request identifier attribute, wait attribute, hold attribute, requests attribute) and recovery of broken connections; added content attribute; removed all wrapper types except 'terminate'; updated error handling; made key mechanism optional (should use SSL/TLS instead). (ip/psa)
+    </div>
+<h4>Version 0.4 (2004-02-23)</h4>
+<div class="indent">Fixed typos; removed "resource-constraint" binding error; added HTTP 403 error to table. (psa/ip)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Added 'authid' attribute to enable communication of XMPP stream ID (used in digest authentication); specified that Content-Types other than "text/xml" are allowed to support older HTTP clients; specified business rule for connection manager queueing of client requests; changed &lt;packet/&gt; to &lt;body/&gt; to support older HTTP clients; changed 'to' attribute on initialization element from MAY to SHOULD; recommended inclusion of unavailable presence in termination element sent from client; described architectural assumptions; specified binding-specific error handling. (psa/ip)
+    </div>
+<h4>Version 0.2 (2004-01-13)</h4>
+<div class="indent">Added 'to' attribute on the initialization element; specified that 'text/html' is allowable for backwards-compatibility. (dss/psa)
+    </div>
+<h4>Version 0.1 (2003-11-06)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0124-1.2.html
+++ b/content/xep-0124-1.2.html
@@ -1,0 +1,1156 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0124: HTTP Binding</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="HTTP Binding">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0124">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0124: HTTP Binding</h1>
+<p>This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0124<br>
+            Version: 1.2<br>
+            Last Updated: 2005-06-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 1945, RFC 2068, RFC 3174<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: httpbind<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/httpbind/httpbind.xsd">http://jabber.org/protocol/httpbind/httpbind.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/HTTP%20Binding%20(JEP-0124)">http://wiki.jabber.org/index.php/HTTP Binding (JEP-0124)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>5.  <a href="#http">HTTP Version and HTTP Headers</a>
+</dt>
+<dt>6.  <a href="#compression">Compression</a>
+</dt>
+<dt>7.  <a href="#wrapper">&lt;body/&gt; Wrapper Element</a>
+</dt>
+<dt>8.  <a href="#session">Initiating an HTTP Session</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#session-request">Requesting a Session</a>
+</dt>
+<dt>8.2.  <a href="#session-create">Session Creation</a>
+</dt>
+<dt>8.3.  <a href="#session-features">Communication of Stream Features</a>
+</dt>
+</dl>
+<dt>9.  <a href="#preconditions">Additional Preconditions</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#preconditions-xmpp">XMPP Methods</a>
+</dt>
+<dt>9.2.  <a href="#preconditions-iqauth">jabber:iq:auth</a>
+</dt>
+</dl>
+<dt>10.  <a href="#stanzas">Sending and Receiving XML Stanzas</a>
+</dt>
+<dt>11.  <a href="#terminate">Terminating the HTTP Session</a>
+</dt>
+<dt>12.  <a href="#rids">Request IDs</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#rids-order">In-Order Message Forwarding</a>
+</dt>
+<dt>12.2.  <a href="#rids-broken">Broken Connections</a>
+</dt>
+</dl>
+<dt>13.  <a href="#keys">Protecting Insecure Sessions</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#keys-applic">Applicability</a>
+</dt>
+<dt>13.2.  <a href="#keys-intro">Introduction</a>
+</dt>
+<dt>13.3.  <a href="#keys-generate">Generating the Key Sequence</a>
+</dt>
+<dt>13.4.  <a href="#keys-use">Use of Keys</a>
+</dt>
+<dt>13.5.  <a href="#keys-switch">Switching to Another Key Sequence</a>
+</dt>
+</dl>
+<dt>14.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#errorstatus-http">HTTP Conditions</a>
+</dt>
+<dt>14.2.  <a href="#errorstatus-terminal">Terminal Binding Conditions</a>
+</dt>
+<dt>14.3.  <a href="#errorstatus-recover">Recoverable Binding Conditions</a>
+</dt>
+<dt>14.4.  <a href="#errorstatus-stanza">XMPP Stanza Conditions</a>
+</dt>
+</dl>
+<dt>15.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>16.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>17.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>17.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>18.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250713">1</a>] defines XML streams bound to TCP (see <span class="ref" style="">RFC 793</span>  [<a href="#nt-id2250739">2</a>]) as the standard transport layer for Jabber/XMPP communications. However, the binding of XMPP to TCP is not always feasible because of client runtime environment and/or network constraints. This JEP describes the usage of the Hypertext Transfer Protocol (HTTP, see <span class="ref" style="">RFC 2068</span>  [<a href="#nt-id2250764">3</a>] and <span class="ref" style="">RFC 1945</span>  [<a href="#nt-id2250785">4</a>]) as an alternative transport binding that supports such constrained environments, normally via deployment of a specialized server-side connection manager that communicates with clients via HTTP rather than TCP.</p>
+    <p class="" style="">Before the authors pursued publication of this JEP, other approaches were explored. One possible approach might have been to apply state to a series of HTTP transactions via HTTP "cookies" as specified in <span class="ref" style="">RFC 2965</span>  [<a href="#nt-id2250817">5</a>]. However, there are several significant computing platforms which provide only limited access to underlying HTTP requests/responses; worse, some platforms hide or remove cookie-related headers. Therefore the cookie approach was rejected.</p>
+    <p class="" style="">Another approach might have been to modify or extend <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2256260">6</a>]. This informational protocol has been used by Jabber clients without runtime constraints to access XMPP servers from behind firewalls. Unfortunately, the method defined in JEP-0025 also depends on cookies, does not meet most of the requirements described below, and cannot be extended without breaking all existing implementations.</p>
+    <p class="" style="">Therefore, this JEP specifies a new way of transporting XMPP via HTTP. All information is encoded in the body of standard HTTP POST requests and responses. Each HTTP body contains a single &lt;body/&gt; XML wrapper element (not to be confused with the &lt;body/&gt; child of the &lt;message/&gt; stanza as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256294">7</a>]), which encapsulates zero or more XML stanzas.</p>
+    <p class="" style="">Although this JEP documents some XMPP-specific features, the binding is not part of XMPP. In fact, the protocol is extensible and could be used to implement any bidirectional stream of XML stanzas.</p>
+  <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+    <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+      <p class="" style="">This document inherits terminology regarding the Hypertext Transport Protocol from RFCs 1945 and 2068.</p>
+    </div>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">Platform limitiations, security restrictions, and other constraints imply that many clients can connect to Internet resources (e.g., Jabber servers) only via HTTP. The following design requirements reflect the need to offer performance as close as possible to a standard TCP connection.</p>
+    <ol start="" type="">
+      <li>Compatible with constrained runtime environments (e.g., mobile and browser-based clients).</li>
+      <li>Compatible with restricted network connections (e.g., firewalls, proxies, and gateways).</li>
+      <li>Fault tolerant (e.g., session recovers after an underlying TCP connection breaks during an HTTP request).</li>
+      <li>Extensible (based on XML).</li>
+      <li>Consume significantly less bandwidth than polling-based solutions.</li>
+      <li>Significantly more responsive than polling-based solutions.</li>
+      <li>Support for polling (for clients that are limited to one HTTP connection at a time).</li>
+      <li>XML stanzas should arrive at the server in the order they were sent by the client.</li>
+      <li>Protect against unauthorized users interjecting HTTP requests into a session.</li>
+    </ol>
+    <p class="" style="">Compatibility with constrained runtime environments implies the following restrictions:</p>
+    <ul>
+      <li>Clients should not be required to have programmatic access to the headers of each HTTP request and response (e.g., cookies or status codes).</li>
+      <li>The body of each HTTP request and response should be parsable XML with a single root element.</li>
+      <li>Clients should be able to specify the Content-Type of the HTTP responses they receive.</li>
+    </ul>
+  <h2>4.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+    <p class="" style="">The binding of XMPP to HTTP assumes a different architecture from that described for the binding of XMPP to TCP as defined in <span style="font-weight: bold">RFC 3920</span>. In particular, because HTTP is not the native binding for XMPP, we assume that most XMPP implementations will utilize a specialized "connection manager" to handle HTTP connections rather than the usual TCP connections. Effectively, such a connection manager will be a specialized HTTP server that translates between the HTTP requests and responses defined herein and the XML streams (or a server API) implemented by the XMPP server or servers with which it communicates, thus enabling an HTTP client to connect to an XMPP server. We can illustrate this graphically as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+  XMPP Server
+      |
+      |  [XML streams or server API]
+      |
+Connection Manager
+      |
+      |  [HTTP + &lt;body/&gt; wrapper]
+      |
+  HTTP Client
+    </pre></div>
+    <p class="" style="">This JEP addresses communications between an HTTP client and the connection manager only. It does not address communications between the connection manager and the XMPP server, since such communications are implementation-specific (e.g., the connection manager and the XMPP server may use <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2256494">8</a>] or an API defined by the XMPP server implementation in order to communicate; alternatively, the XMPP server may natively support the HTTP binding, in which case the connection manager will be a logical entity rather than a physical entity).</p>
+    <p class="" style="">Furthermore, no aspect of the HTTP binding limits its use to client-to-server communications; i.e., it could be used for server-to-server or component-to-server communications as well (probably through a slight change to the XML schema). However, this document focuses exclusively on use of the HTTP binding by clients that cannot maintain persistent TCP connections to a server and that therefore cannot use the TCP binding defined in <span style="font-weight: bold">RFC 3920</span>. We assume that servers and components are under no such restrictions and thus would use the TCP binding.</p>
+  <h2>5.
+       <a name="http">HTTP Version and HTTP Headers</a>
+</h2>
+    <p class="" style="">Clients SHOULD send HTTP requests over persistent HTTP/1.1 connections. However, a constrained client MAY open a new HTTP/1.0 connection (as defined in RFC 1945) to send each request.</p>
+    <p class="" style="">Requests and responses MAY include HTTP headers not specified herein. The receiver SHOULD ignore any such headers.</p>
+  <h2>6.
+       <a name="compression">Compression</a>
+</h2>
+    <p class="" style="">Clients MAY include an HTTP Accept-Encoding header in any request. If the connection manager receives a request with an Accept-Encoding header, it MAY include an HTTP Content-Encoding header in the response (indicating one of the encodings specified in the request) and compress the response body accordingly.</p>
+    <p class="" style="">TLS compression (as defined in <span style="font-weight: bold">RFC 3920</span>) and Stream Compression (as defined in <span class="ref" style="">Stream Compression</span>  [<a href="#nt-id2256642">9</a>]) are NOT RECOMMENDED since compression SHOULD be negotiated at the HTTP layer and with the 'accept' attribute (see the <a href="#session-create">Session Creation</a> section below). TLS compression and Stream Compression SHOULD NOT be used simultaneously with HTTP content encoding.</p>
+  <h2>7.
+       <a name="wrapper">&lt;body/&gt; Wrapper Element</a>
+</h2>
+    <p class="" style="">The body of each HTTP request and response contains a single &lt;body/&gt; wrapper element. The &lt;body/&gt; element MUST contain zero or more complete XML elements. It MUST NOT contain partial XML elements.</p>
+    <p class="" style="">If the &lt;body/&gt; wrapper element is not empty, then it MUST contain one of the following:</p>
+    <ul>
+      <li>One or more complete XMPP stanzas (&lt;message/&gt;, &lt;presence/&gt;, and/or &lt;iq/&gt;).</li>
+      <li>A complete &lt;stream:features/&gt; element qualified by the 'http://etherx.jabber.org/streams' namespace.</li>
+      <li>A complete element used for SASL negotiation and qualified by the 'urn:ietf:params:xml:ns:xmpp-sasl' namespace.</li>
+      <li>XML elements associated with a binding error condition. For details, refer to the <a href="#errorstatus-binding">Binding Conditions</a> section below.</li>
+    </ul>
+    <p class="" style="">Note: Inclusion of TLS negotiation elements is allowed but is NOT RECOMMENDED (see <a href="#preconditions">Additional Preconditions</a> below).</p>
+    <p class="" style="">The &lt;body/&gt; wrapper element SHOULD be qualified by the 'http://jabber.org/protocol/httpbind' namespace, and child elements SHOULD be qualified by their respective namespaces (e.g., 'http://etherx.jabber.org/streams' for stream features, 'urn:ietf:params:xml:ns:xmpp-sasl' for SASL negotiation, and 'jabber:client' for XML stanzas). However, even if the client does not specify the namespaces, the connection manager MUST ensure that the XMPP it provides to the XMPP server or other entities on the network meets the namespacing requirements of <span style="font-weight: bold">RFC 3920</span>.</p>
+    <p class="" style="">The &lt;body/&gt; element of every client request MUST possess a sequential request ID encapsulated via the 'rid' attribute. The client MUST generate a large positive non-zero random integer for the first 'rid' and then increment that value by one for each subsequent request. For details, refer to the <a href="#rids">Request IDs</a> section below.</p>
+  <h2>8.
+       <a name="session">Initiating an HTTP Session</a>
+</h2>
+    <div class="indent">
+<h3>8.1 <a name="session-request">Requesting a Session</a>
+</h3>
+      <p class="" style="">The first request from the client to the connection manager creates a new session.</p>
+      <p class="" style="">The &lt;body/&gt; element of the first request SHOULD possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-weight: bold">'to'</span> -- This attribute specifies the target domain (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'xml:lang'</span> -- This attribute (as defined in Section 2.12 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2256824">10</a>]) specifies the default language of any human-readable XML character data sent or received during the session (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'wait'</span> -- This attribute specifies the longest time (in seconds) that the connection manager is allowed to wait before responding to any request during the session. This enables the client to prevent its TCP connection from expiring due to inactivity, as well as to limit the delay before it discovers any network failure.</li>
+        <li>
+<span style="font-weight: bold">'hold'</span> -- This attribute specifies the maximum number of requests the connection manager is allowed to keep waiting at any one time during the session. (For example, if a constrained client is unable to keep open more than two HTTP connections to the same HTTP server simultaneously, then it SHOULD specify a value of "1".)</li>
+      </ul>
+      <p class="" style="">Note: Clients that only support polling behavior MAY prevent the connection manager from waiting by setting 'wait' or 'hold' to "0". However, polling is NOT RECOMMENDED since the associated increase in bandwidth consumption and the decrease in responsiveness are typically one or two orders of magnitude!</p>
+      <p class="" style="">A connection manager MAY be configured to enable sessions with more than one XMPP server in different domains. When requesting a session with such a 'proxy' connection manager, a client SHOULD specify a 'route' attribute with an XMPP IRI (see <span class="ref" style="">XMPP IRI/URI</span>  [<a href="#nt-id2256898">11</a>]) to indicate which protocol, host, and port  [<a href="#nt-id2256845">12</a>] it wants to communicate with. A connection manager that is configured to work only with a single XMPP server (or only with a defined list of XMPP domains and their respective hosts and ports) MAY ignore the 'route' attribute. (Note that the 'to' attribute specifies the XMPP domain, not the host machine.)</p>
+      <p class="" style="">A client MAY include a 'secure' attribute to specify that communications between the connection manager and the XMPP server must be "secure". (Note: The 'secure' attribute is of type xs:boolean (see <span class="ref" style="">XML Schema Part 2</span>  [<a href="#nt-id2256980">13</a>]) and the default value is "false".  [<a href="#nt-id2256937">14</a>]) If a connection manager receives a session request with the 'secure' attribute set to 'true' or '1', then it MUST respond to the client with a  <a href="#errorstatus-terminal">remote-connection-failed</a> error as soon as it determines that it cannot communicate in a secure way with the XMPP server. A connection manager SHOULD consider communications with the XMPP server to be "secure" if they are encrypted using TLS or SSL with verified certificates, or if it is running on the same physical machine as the XMPP server. A connection manager MAY consider communications over a "private" network to be secure, even without TLS or SSL; however, a network SHOULD be considered "private" only if the administrator of the connection manager is sure that unknown individuals or processes do not have access to the network (i.e., individuals or processes who do not have access to either the connection manager or the XMPP server).</p>
+      <p class="" style="">Some clients are constrained to only accept HTTP responses with specific Content-Types (e.g., "text/html"). The &lt;body/&gt; element of the first request MAY possess a 'content' attribute. This specifies the value of the HTTP Content-Type header that MUST appear in all the connection manager's responses during the session. If the client request does not possess a 'content' attribute, then the HTTP Content-Type of responses MUST be "text/xml; charset=utf-8".</p>
+      <p class="" style="">Note: The HTTP Content-Type of client requests SHOULD also be "text/xml; charset=utf-8". Clients MAY specify another value if they are constrained to do so (e.g., "application/x-www-form-urlencoded" or "text/plain"). The client and connection manager SHOULD ignore all HTTP Content-Type headers they receive.</p>
+      <p class="caption">Example 1. Requesting an HTTP session</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      route='xmpp:jabber.org:80'
+      secure='true'
+      wait='60'
+      xml:lang='en'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">Note: Unlike the protocol defined in JEP-0025, an opening &lt;stream:stream&gt; tag is not sent. The protocol defined herein abstracts from XML streams between the connection manager and the client. Any XML streams between the connection manager and an XMPP server are the responsibility of the connection manager.</p>
+      <p class="" style="">Note: All requests after the first one MUST include a valid 'sid' attribue (provided by the connection manager in the session creation response below). The initialization request is unique in that the &lt;body/&gt; element MUST NOT possess a 'sid' attribute.</p>
+    </div>
+    <div class="indent">
+<h3>8.2 <a name="session-create">Session Creation</a>
+</h3>
+      <p class="" style="">After receiving a new session request, the connection manager MUST generate an opaque, unpredictable session identifier (or SID). The SID MUST be unique within the context of the connection manager application. The connection manager then returns that SID to the client in a response &lt;body/&gt; element.</p>
+      <p class="" style="">The connection manager MUST specify a 'wait' attribute. This is the longest time (in seconds) that it will wait before responding to any request during the session. The time MUST be less than or equal to the value specified in the session request.</p>
+      <p class="" style="">The connection manager MAY limit the number of simultaneous requests the client makes with the 'requests' attribute. The RECOMMENDED value is "2". Servers that only support polling behavior MUST prevent clients from making simultaneous requests by setting the 'requests' attribute to a value of "1" (however, polling is NOT RECOMMENDED). In any case, clients MUST NOT make more simultaneous requests than specified by the connection manager.</p>
+      <p class="" style="">The connection manager SHOULD include two additional attributes in the session creation response element, specifying the shortest allowable polling interval and the longest allowable inactivity period (both in seconds). Communication of these parameters enables the client to engage in appropriate behavior (e.g., not sending empty request elements more often than desired, and ensuring that the periods with no requests pending are never too long).</p>
+      <p class="" style="">The connection manager MAY include an 'accept' attribute in the session creation response element, to specify the content encodings it can decompress. After receiving a session creation response with an 'accept' attribute, clients MAY include an HTTP Content-Encoding header in subsequent requests (indicating one of the encodings specified in the 'accept' attribute) and compress the bodies of the requests accordingly.</p>
+      <p class="" style="">For both requests and responses, the &lt;body/&gt; element and its content SHOULD be UTF-8 encoded. If the HTTP Content-Type header of a request/response specifies a character encoding other than UTF-8, then the connection manager MAY convert between UTF-8 and the other character encoding. However, even in this case, it is OPTIONAL for the connection manager to convert between encodings. The connection manager MAY inform the client which encodings it can convert by setting the optional 'charsets' attribute in the session creation response element to a space-separated list of encodings.
+         [<a href="#nt-id2257180">15</a>]
+        </p>
+      <p class="caption">Example 2. Session creation response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 128
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      accept='deflate,gzip'
+      sid='SomeSID'
+      charsets='ISO_8859-1 ISO-2022-JP'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">Note: The 'authid' attribute contains the value of the XMPP stream ID generated by the XMPP server. The connection manager MUST retrieve the stream ID and pass it unmodified to the client. This value is needed by the client to successfully complete digest authentication using <span class="ref" style="">Non-SASL Authentication</span>  [<a href="#nt-id2250303">17</a>] (see the <a href="#preconditions-iqauth">jabber:iq:auth</a> section below).</p>
+    <p class="" style="">Note: If the 'authid' attribute is not included in the connection manager's response to the session creation request (e.g., because the connection manager has not yet received a stream ID from the XMPP server), then the client SHOULD send empty request elements (see the "Requesting XML Stanzas" example below) until it receives a response with an 'authid' attribute. In any case, the connection manager MUST return the 'authid' in a response to the client as soon as possible after it receives the stream ID from the XMPP server.</p>
+    <p class="" style="">Separate 'sid' and 'authid' attributes are required because the connection manager is not necessarily part of a single XMPP server (e.g., it may handle HTTP connections on behalf of multiple XMPP servers).</p>
+    </div>
+    <div class="indent">
+<h3>8.3 <a name="session-features">Communication of Stream Features</a>
+</h3>
+      <p class="" style="">As an immediate child of the response that contains the 'authid' attribute, the connection manager SHOULD include a stream features element, as defined by <span style="font-weight: bold">RFC 3920</span>.</p>
+      <p class="caption">Example 3. Session creation response with stream features</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 417
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      accept='deflate,gzip'
+      sid='SomeSID'
+      charsets='ISO_8859-1 ISO-2022-JP'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;stream:features xmlns='http://etherx.jabber.org/streams'&gt;
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'&gt;
+  &lt;/stream:features&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The stream features SHOULD NOT include a feature for Transport Layer Security (TLS), since channel encryption SHOULD be negotiated at the HTTP layer (see the <a href="#security">Security Considerations</a> section below).</p>
+    </div>
+  <h2>9.
+       <a name="preconditions">Additional Preconditions</a>
+</h2>
+    <p class="" style="">Initializing an HTTP session is the first precondition to sending XML message, presence, and IQ stanzas. However, before processing XML stanzas from the client, the connection manager MUST require completion of additional preconditions using either of the following methods:</p>
+    <ul>
+      <li>
+        <p class="" style="">XMPP authentication, resource binding, and IM session creation, in the following order:</p>
+        <ol start="" type="">
+          <li>Optionally, TLS negotiation as defined in Section 5 of <span style="font-weight: bold">RFC 3920</span> (this is NOT RECOMMENDED since channel encryption and compression SHOULD be negotiated at the HTTP layer; see the <a href="#security">Security Considerations</a> section below)</li>
+          <li>SASL authentication as defined in Section 6 of <span style="font-weight: bold">RFC 3920</span>
+</li>
+          <li>Resource Binding as defined in Section 7 of <span style="font-weight: bold">RFC 3920</span>
+</li>
+          <li>IM Session Establishment as defined in Section 3 of <span style="font-weight: bold">RFC 3921</span>, if appropriate</li>
+        </ol>
+      </li>
+      <li>
+        <p class="" style="">Simultaneous authentication and resource binding as defined in <span style="font-weight: bold">Non-SASL Authentication</span>, upon which a Jabber server will also establish an IM session on behalf of the connected resource.</p>
+      </li>
+    </ul>
+    <p class="" style="">It is RECOMMENDED to use the XMPP methods as defined in <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>, rather than using older non-SASL authentication.</p>
+
+    <div class="indent">
+<h3>9.1 <a name="preconditions-xmpp">XMPP Methods</a>
+</h3>
+      <p class="" style="">A success case for authentication, resource binding, and IM session establishment using the XMPP protocols is shown below. For detailed specification of these protocols (including error cases) and for specification of TLS negotiation, refer to <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>.</p>
+      <p class="caption">Example 4. SASL authentication step 1</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 172
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='DIGEST-MD5'/&gt;
+&lt;/body&gt;</pre></div>
+
+
+
+      <p class="caption">Example 5. SASL authentication step 2</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 250
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cmVhbG09InNvbWVyZWFsbSIsbm9uY2U9Ik9BNk1HOXRFUUdtMmhoIixxb3A9
+    ImF1dGgiLGNoYXJzZXQ9dXRmLTgsYWxnb3JpdGhtPW1kNS1zZXNzCg==
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 6. SASL authentication step 3</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 418
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    dXNlcm5hbWU9InNvbWVub2RlIixyZWFsbT0ic29tZXJlYWxtIixub25jZT0i
+    T0E2TUc5dEVRR20yaGgiLGNub25jZT0iT0E2TUhYaDZWcVRyUmsiLG5jPTAw
+    MDAwMDAxLHFvcD1hdXRoLGRpZ2VzdC11cmk9InhtcHAvZXhhbXBsZS5jb20i
+    LHJlc3BvbnNlPWQzODhkYWQ5MGQ0YmJkNzYwYTE1MjMyMWYyMTQzYWY3LGNo
+    YXJzZXQ9dXRmLTgK
+&lt;/response&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 7. SASL authentication step 4</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 190
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cnNwYXV0aD1lYTQwZjYwMzM1YzQyN2I1NTI3Yjg0ZGJhYmNkZmZmZAo=
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 8. SASL authentication step 5</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 152
+
+&lt;body rid='3197423133'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 9. SASL authentication step 6</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 121
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="" style="">Note: Because the context for a client's communication with a connection manager in the HTTP transport binding is HTTP rather than XML streams (as in the TCP binding), there is no need to re-start communications (e.g., by generating a new SID) at this point.</p>
+
+      <p class="caption">Example 10. Resource binding request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 240
+
+&lt;body rid='3197423134'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 11. Resource binding result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 221
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='result'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;jid&gt;stpeter@jabber.org/httpclient&lt;/jid&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 12. IM session request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 261
+
+&lt;body rid='3197423135'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='stpeter@jabber.org/httpclient'
+      id='sess_1'
+      to='jabber.org'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'/&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 13. IM session result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 175
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='jabber.org'
+      id='sess_1'
+      to='stpeter@jabber.org/httpclient'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+
+    </div>
+
+    <div class="indent">
+<h3>9.2 <a name="preconditions-iqauth">jabber:iq:auth</a>
+</h3>
+      <p class="" style="">A success case for simultaneous authentication, resource binding, and IM session creation using the original "jabber:iq:auth" protocol is shown below. For further details regarding use of this protocol, refer to JEP-0078. If digest authentication is used, then the stream ID value used to compute the hashed password MUST be the value of the 'authid' attribute provided by the connection manager in the response to the initialization element or in a subsequent response (see the <a href="#session-create">Session Creation</a> section above).</p>
+      <p class="caption">Example 14. Non-SASL authentication request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 281
+
+&lt;body rid='2842791421'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;query xmlns='jabber:iq:auth'&gt;
+      &lt;username&gt;stpeter&lt;/username&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+      &lt;password&gt;jabber-rocks&lt;/password&gt;
+    &lt;/query&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 15. Authentication result (success)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 144
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 16. Authentication result (failure)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 226
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='error'
+      xmlns='jabber:client'&gt;
+    &lt;error code='401' type='auth'&gt;
+      &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>10.
+       <a name="stanzas">Sending and Receiving XML Stanzas</a>
+</h2>
+    <p class="" style="">After the client has successfully completed all required preconditions, it can send and receive XML stanzas via the HTTP binding.</p>
+    <p class="caption">Example 17. Transmitting stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='2842791422'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message to='friend@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">Upon receipt of a request, the connection manager MUST forward the content of the &lt;body/&gt; element to the XMPP server as soon as possible. However, it must forward the content from different requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">The connection manager MUST also return an HTTP 200 OK response with a &lt;body/&gt; element to the client. Note: This does not indicate that the stanzas have been successfully delivered to the destination Jabber endpoint.</p>
+    <p class="" style="">It is RECOMMENDED that the connection manager not return an HTTP result until a stanza has arrived from the XMPP server for delivery to the client. However, the connection manager SHOULD NOT wait longer than the time specified by the client in the 'wait' attribute of its session creation request, and it SHOULD NOT keep more HTTP requests waiting at a time than the number specified in the 'hold' attribute of the session creation request. In any case it MUST respond to requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">If there are no stanzas waiting or ready to be delivered within the waiting period, then the connection manager SHOULD include an empty &lt;body/&gt; element in the HTTP result:</p>
+    <p class="caption">Example 18. Empty response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 64
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">If the connection manager has received one or more stanzas from the XMPP server for delivery to the client, then it SHOULD return the stanzas in the body of its response as soon as possible after receiving them from the XMPP server.</p>
+    <p class="caption">Example 19. Response with queued stanza</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 185
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message from='contact@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message from='friend@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The client MAY poll the connection manager for incoming stanzas by sending an empty &lt;body/&gt; element.</p>
+    <p class="caption">Example 20. Requesting XML Stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='2842791423'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The connection manager MUST wait and respond in the same way as it does after receiving stanzas from the client.</p>
+    <p class="" style="">If the client sends two consecutive empty requests within a period shorter than that specified by the 'polling' attribute in the session creation response, then the connection manager SHOULD terminate the HTTP session and return an HTTP 403 (Forbidden) error to the client.</p>
+    <p class="caption">Example 21. Too frequent polling response</p>
+<div class="indent"><pre>
+HTTP/1.1 403 Forbidden
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    <p class="" style="">If the connection manager did not specify a shortest allowable polling interval in the session creation response, then it MUST allow the client to poll as frequently as it chooses.</p>
+    <p class="" style="">After receiving a response from the connection manager, if no other requests are pending and the client did not specify polling behavior in the session creation request (by setting 'wait' or 'hold' to "0"), it SHOULD make a new request as soon as possible. In any case, if no requests are pending, the client MUST make a new request before the maximum inactivity period has expired. This period is specified by the 'inactivity' attribute in the session creation response.</p>
+    <p class="" style="">If the connection manager has responded to all the requests it has received and the time since its last response is longer than the maximum inactivity period, then it SHOULD terminate the session without informing the client (if the client makes another request, the connection manager SHOULD respond as if the session does not exist).</p>
+    <p class="" style="">If the connection manager did not specify a maximum inactivity period in the session creation response, then it MUST allow the client to be inactive for as long as it chooses.</p>
+  <h2>11.
+       <a name="terminate">Terminating the HTTP Session</a>
+</h2>
+    <p class="" style="">At any time, the client MAY gracefully terminate the session by sending a &lt;body/&gt; element with a 'type' attribute set to "terminate". The termination request SHOULD include an XMPP presence stanza of type "unavailable" to ensure graceful logoff with the XMPP server.</p>
+    <p class="caption">Example 22. Session termination by client</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 153
+
+&lt;body rid='2842791424'
+      sid='SomeSID'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;presence type='unavailable'
+            xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The connection manager SHOULD return an HTTP 200 OK response with an empty &lt;body/&gt; element. Upon receiving the response, the client MUST consider the HTTP session to have been terminated.</p>
+  <h2>12.
+       <a name="rids">Request IDs</a>
+</h2>
+    <div class="indent">
+<h3>12.1 <a name="rids-order">In-Order Message Forwarding</a>
+</h3>
+      <p class="" style="">When a client makes simultaneous requests, the connection manager may receive them out of order. The connection manager MUST forward the stanzas to the XMPP server and respond to the client requests in the order specified by the 'rid' attributes. The client MUST process responses received from the connection manager in the order the requests were made.</p>
+      <p class="" style="">The connection manager SHOULD expect the 'rid' attribute to be within a window of values greater than the 'rid' of the previous request. The size of the window is equal to the maximum number of simultaneous requests allowed by the connection manager. If it receives a request with a 'rid' greater than the values in the window, then the connection manager MUST terminate the session with an error:</p>
+      <p class="caption">Example 23. Unexpected rid error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>12.2 <a name="rids-broken">Broken Connections</a>
+</h3>
+      <p class="" style="">Unreliable network communications or client constraints can result in broken connections. The connection manager SHOULD remember the 'rid' and the associated HTTP response body of the client's most recent requests which did not result in an HTTP or binding error. The number of responses kept in the buffer should be the same as the maximum number of simultaneous requests allowed by the connection manager.</p>
+      <p class="" style="">If the network connection is broken or closed before the client receives a response to a request from the connection manager, then the client MAY resend an exact copy of the original request. Whenever the connection manager receives a request with a 'rid' that it has already received, it SHOULD return an HTTP 200 (OK) response that includes the buffered copy of the original XML response to the client (i.e., a &lt;body/&gt; wrapper element possessing appropriate attributes and optionally containing one or more XML stanzas or other allowable XML elements). If the original response is not available (e.g., it is no longer in the buffer), then the connection manager MUST return an HTTP 404 (Not Found) error:</p>
+      <p class="caption">Example 24. Response not in buffer error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+      <p class="" style="">Note: The error is the same whether the 'rid' is too large or too small. This makes it more difficult for an attacker to discover an acceptable value.</p>
+    </div>
+  <h2>13.
+       <a name="keys">Protecting Insecure Sessions</a>
+</h2>
+    <div class="indent">
+<h3>13.1 <a name="keys-applic">Applicability</a>
+</h3>
+      <p class="" style="">The OPTIONAL key sequencing mechanism described here MAY be used if the client's session with the connection manager is not secure. The session should be considered secure only if all client requests are made via TLS/SSL HTTP connections and the connection manager generates an unpredictable session ID. If the session is secure, it is not necessary to use this key sequencing mechanism.</p>
+      <p class="" style="">Even if the session is not secure, the unpredictable session and request IDs specified in the preceding sections of this document already provide a level of protection similar to that provided by a standard XMPP connection bound to a single pair of persistent TCP/IP connections, and thus provide sufficient protection against a 'blind' attacker. However, in some circumstances, the key sequencing mechanism defined below helps to protect against a more determined and knowledgeable attacker.</p>
+      <p class="" style="">It is important to recognize that the key sequencing mechanism defined below helps to protect only against an attacker who is able to view the contents of all requests or responses in an insecure session but who is not able to alter the contents of those requests (in this case, the mechanism prevents the attacker from interjecting HTTP requests into the session, e.g., termination requests or responses). However, the key sequencing mechanism does not provide any protection when the attacker is able to alter the contents of insecure requests or responses.</p>
+    </div>
+    <div class="indent">
+<h3>13.2 <a name="keys-intro">Introduction</a>
+</h3>
+      <p class="" style="">The HTTP requests of each session MAY be spread across a series of different socket connections. This would enable an unauthorized user that obtains the session ID and request ID of a session and then use their own socket connection to interject &lt;body/&gt; request elements into the session and receive the corresponding responses.</p>
+      <p class="" style="">The key sequencing mechanism below protects against such attacks by enabling a connection manager to detect &lt;body/&gt; request elements interjected by a third party.</p>
+    </div>
+    <div class="indent">
+<h3>13.3 <a name="keys-generate">Generating the Key Sequence</a>
+</h3>
+      <p class="" style="">Prior to requesting a new session, the client MUST select an unpredictable counter ("n") and an unpredictable value ("seed"). The client then processes the "seed" through a cryptographic hash and converts the resulting 160 bits to a hexadecimal string K(1). It does this "n" times to arrive at the initial key K(n). The hashing algorithm MUST be SHA-1 as defined in <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2258493">18</a>].</p>
+      <p class="caption">Example 25. Creating the key sequence</p>
+<div class="indent"><pre>
+        K(1) = hex(SHA-1(seed))
+        K(2) = hex(SHA-1(K(1)))
+        ...
+        K(n) = hex(SHA-1(K(n-1)))
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.4 <a name="keys-use">Use of Keys</a>
+</h3>
+      <p class="" style="">The client MUST set the 'newkey' attribute of the first request in the session to the value K(n).</p>
+      <p class="caption">Example 26. Session Request with Initial Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      newkey='ca393b51b682f61f98e7877d61146407f3d0a770'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The client MUST set the 'key' attribute of all subsequent requests to the value of the next key in the generated sequence (decrementing from K(n-1) towards K(1) with each request sent).</p>
+    <p class="caption">Example 27. Request with Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      key='bfb06a6f113cd6fd3838ab9d300fdb4fe3da2f7d'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The connection manager MAY verify the key by calculating the SHA-1 hash of the key and comparing it to the 'newkey' attribute of the previous request (or the 'key' attribute if the 'newkey' attribute was not set). If the values do not match (or if it receives a request without a 'key' attribute and the 'newkey' or 'key' attribute of the previous request was set), then the connection manager MUST NOT process the element, MUST terminate the session, and MUST return an HTTP 404 (Not Found) error.</p>
+      <p class="caption">Example 28. Invalid Key Sequence Error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>13.5 <a name="keys-switch">Switching to Another Key Sequence</a>
+</h3>
+      <p class="" style="">A client SHOULD choose a high value for "n" when generating the key sequence. However, if the session lasts long enough that the client arrives at the last key in the sequence K(1) then the client MUST switch to a new key sequence.</p>
+      <p class="" style="">The client MUST:</p>
+      <ol start="" type="">
+        <li>Choose new values for "seed" and "n".</li>
+        <li>Generate a new key sequence using the algorithm defined above.</li>
+        <li>Set the 'key' attribute of the request to the next value in the old sequence (i.e. K(1), the last value).</li>
+        <li>Set the 'newkey' attribute of the request to the value K(n) from the new sequence.</li>
+      </ol>
+      <p class="caption">Example 29. New Key Sequence</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      key='6f825e81f4532b2c5fa2d12457d8a1f22e8f838e'
+      newkey='113f58a37245ec9637266cf2fb6e48bfeaf7964e'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>14.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+    <p class="" style="">There are four types of error and status reporting in HTTP responses:</p>
+    <p class="caption">Table 1: Error Condition Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition Type</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">HTTP Conditions</span></td>
+<td align="" colspan="" rowspan="">The connection manager responds to an invalid client request with a standard HTTP error. These are used for binding syntax errors, possible attacks, etc. Note that constrained clients are unable to differentiate between HTTP errors.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Terminal Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These error conditions may be read by constrained clients. They are used for connection manager problems, abstracting stream errors, and communication problems between the connection manager and the XMPP server.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Recoverable Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These report communication problems between the connection manager and the client. They do not terminate the session. Clients recover from these errors by resending the last two &lt;body/&gt; wrapper elements.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP Stanza Conditions</span></td>
+<td align="" colspan="" rowspan="">XMPP errors relating to XML stanzas within &lt;body/&gt; wrapper elements are, in general, defined in the appropriate RFC or JEP. They do not terminate the session. An example of such usage is shown above in relation to <span style="font-weight: bold">Non-SASL Authentication</span>.</td>
+</tr>
+    </table>
+    <p class="" style="">Full descriptions are provided below.</p>
+    <div class="indent">
+<h3>14.1 <a name="errorstatus-http">HTTP Conditions</a>
+</h3>
+      <p class="" style="">The following HTTP error and status codes are used in particular ways by this protocol (other HTTP error and status codes may be used as appropriate). Upon receiving an HTTP error (400, 403, 404), the HTTP client MUST consider the HTTP session to be null and void.</p>
+      <p class="" style="">Note: These are pure HTTP codes as defined in the HTTP specification, and are not to be confused with the HTTP-style error codes traditionally used in Jabber protocols and documented in <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2258855">19</a>].</p>
+      <p class="caption">Table 2: HTTP Error and Status Codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Code</th>
+          <th colspan="" rowspan="">Name</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">200</td>
+          <td align="" colspan="" rowspan="">OK</td>
+          <td align="" colspan="" rowspan="">Response to valid client request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">400</td>
+          <td align="" colspan="" rowspan="">Bad Request</td>
+          <td align="" colspan="" rowspan="">Inform client that the format of an HTTP header or binding element is unacceptable (e.g., syntax error).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">403</td>
+          <td align="" colspan="" rowspan="">Forbidden</td>
+          <td align="" colspan="" rowspan="">Inform client that it has broken the session rules (polling too-frequently, too many simultaneous connections).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">404</td>
+          <td align="" colspan="" rowspan="">Not Found</td>
+          <td align="" colspan="" rowspan="">Inform client that (1) 'sid' is not valid, (2) 'rid' is larger than the upper limit of the expected window, (3) connection manager is unable to resend response, (4) 'key' sequence is invalid.</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>14.2 <a name="errorstatus-terminal">Terminal Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a fatal error by setting a 'type' attribute of the &lt;body/&gt; element to "terminate". These binding errors imply that the HTTP session is terminated. (Note: Many of these conditions correspond to the relevant XMPP stream error conditions specified in <span style="font-weight: bold">RFC 3920</span>, but actual XMPP stream error conditions experienced between the connection manager and the server are contained only in the "remote-stream-error" condition as described below.)</p>
+      <p class="caption">Example 30. Remote connection failed error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='terminate'
+      condition='remote-connection-failed'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The following values of the 'condition' attribute are defined:</p>
+      <p class="caption">Table 3: Binding Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Condition</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-gone</td>
+          <td align="" colspan="" rowspan="">The target domain specified in the 'to' attribute or the target host or port specified in the 'route' attribute is no longer serviced by the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-unknown</td>
+          <td align="" colspan="" rowspan="">The target domain specified in the 'to' attribute or the target host or port specified in the 'route' attribute is unknown to the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">improper-addressing</td>
+          <td align="" colspan="" rowspan="">The initialization element lacks a 'to' or 'route' attribute (or the attribute has no value) but the connection manager requires one.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">internal-server-error</td>
+          <td align="" colspan="" rowspan="">The connection manager has experienced an internal error that prevents it from servicing the request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">other-request</td>
+          <td align="" colspan="" rowspan="">Another request being processed at the same time as this request caused the session to terminate.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-connection-failed</td>
+          <td align="" colspan="" rowspan="">The connection manager was unable to connect to, or unable to connect securely to, or has lost its connection to, the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-stream-error</td>
+          <td align="" colspan="" rowspan="">Encapsulates an XMPP stream error. The content of the binding is a copy of the content of the &lt;stream:error/&gt; element received from the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">see-other-uri</td>
+          <td align="" colspan="" rowspan="">The connection manager does not operate at this URI (e.g., the connection manager accepts only SSL/TLS connections at some https: URI rather than the http: URI requested by the client). The client may try POSTing to the URI in the content of the &lt;uri/&gt; child element.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">system-shutdown</td>
+          <td align="" colspan="" rowspan="">The connection manager is being shut down. All active HTTP sessions are being terminated. No new sessions can be created.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">undefined-condition</td>
+          <td align="" colspan="" rowspan="">The error is not one of those defined herein; the connection manager SHOULD include application-specific information in the content of the &lt;body/&gt; wrapper element.</td>
+        </tr>
+      </table>
+      <p class="" style="">The following is an example of a "see-other-uri" condition:</p>
+      <p class="caption">Example 31. See other URI error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='see-other-uri'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;uri&gt;https://secure.jabber.org/xmppcm&lt;/uri&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The following is an example of a "remote-stream-error" condition:</p>
+      <p class="caption">Example 32. Remote error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='remote-stream-error'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;xml-not-well-formed xmlns='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+  &lt;text xmlns='urn:ietf:params:xml:ns:xmpp-streams'
+        xml:lang='en'&gt;
+    Some special application diagnostic information!
+  &lt;/text&gt;
+  &lt;escape-your-data xmlns='application-ns'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">Naturally, the client MAY report binding errors to the connection manager as well, although this is unlikely.</p>
+    </div>
+    <div class="indent">
+<h3>14.3 <a name="errorstatus-recover">Recoverable Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a recoverable error by setting a 'type' attribute of the &lt;body/&gt; element to "error". These errors do not imply that the HTTP session is terminated.</p>
+      <p class="" style="">If it decides to recover from the error, then the client MUST repeat the HTTP request and the previous HTTP request. The content of both requests MUST be identical to the &lt;body/&gt; elements of the original requests. This allows the server to recover a session after the previous request was lost due to a communication failure.</p>
+      <p class="caption">Example 33. Recoverable error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='error'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    </div>
+    <div class="indent">
+<h3>14.4 <a name="errorstatus-stanza">XMPP Stanza Conditions</a>
+</h3>
+      <p class="" style="">Application-level error conditions will normally be generated by a third entity (e.g., an IM contact) and routed to the client through the connection manager; therefore they are out of scope for the transport binding defined herein and are described in the appropriate RFC or JEP.</p>
+      <p class="" style="">However, it is possible that a connection manager will receive a stanza for delivery to a client even though the client connection is no longer active (e.g., before the connection manager is able to inform a server that the connection has died). In this case, the connection manager would return an error to the server; it is RECOMMENDED that the connection manager proceed as follows, since the situation is similar to that addressed by point #2 of Section 11.1 of <span style="font-weight: bold">RFC 3921</span>:</p>
+      <ol start="" type="">
+        <li>If the delivered stanza was &lt;presence/&gt;, silently drop the stanza and do not return an error to the sender.</li>
+        <li>If the delivered stanza was &lt;iq/&gt;, return a &lt;service-unavailable/&gt; error to the sender.</li>
+        <li>If the delivered stanza was &lt;message/&gt;, return a &lt;recipient-unavailable/&gt; error to the sender.</li>
+      </ol>
+      <p class="" style="">When a server receives a &lt;message/&gt; stanza of type "error" containing a &lt;recipient-unavailable/&gt; condition from a connection manager, it SHOULD store the message for later delivery if offline storage is enabled, otherwise route the error stanza to the sender.</p>
+    </div>
+  <h2>15.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">All communications SHOULD occur over an encrypted channel. Negotiation of channel encryption between the client and the connection manager SHOULD occur at the HTTP layer, not the application layer; such negotiation SHOULD follow the protocol defined in <span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2259544">20</a>].</p>
+    <p class="" style="">The session identifier (SID) and initial request identifier (RID) are security-critical and therefore MUST be both unpredictable and nonrepeating (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2259578">21</a>] for recommendations regarding randomness of SIDs and initial RIDs for security purposes).</p>
+  <h2>16.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259597">22</a>].</p>
+  <h2>17.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>17.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259664">23</a>] includes 'http://jabber.org/protocol/httpbind' in its registry of protocol namespaces.</p>
+    </div>
+  <h2>18.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    targetNamespace='http://jabber.org/protocol/httpbind'
+    xmlns='http://jabber.org/protocol/httpbind'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0124: http://www.jabber.org/jeps/jep-0124.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import namespace='http://etherx.jabber.org/streams'
+             schemaLocation='http://etherx.jabber.org/streams.xsd'/&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:stream='http://etherx.jabber.org/streams'&gt;
+        &lt;xs:element ref='stream:features'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-tls'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-streams'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='jabber:client'
+                minOccurs='0'
+                maxOccurs='unbounded'/&gt;
+        &lt;xs:element name='uri'
+                minOccurs='0'
+                maxOccurs='1'
+                type='xs:string'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='accept' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='authid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='charsets' type='xs:NMTOKENS' use='optional'/&gt;
+      &lt;xs:attribute name='condition' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='host-gone'/&gt;
+            &lt;xs:enumeration value='host-unknown'/&gt;
+            &lt;xs:enumeration value='improper-addressing'/&gt;
+            &lt;xs:enumeration value='internal-server-error'/&gt;
+            &lt;xs:enumeration value='remote-connection-failed'/&gt;
+            &lt;xs:enumeration value='remote-stream-error'/&gt;
+            &lt;xs:enumeration value='see-other-uri'/&gt;
+            &lt;xs:enumeration value='system-shutdown'/&gt;
+            &lt;xs:enumeration value='undefined-condition'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='content' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='hold' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='inactivity' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='key' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='newkey' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='polling' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='requests' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='rid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='route' type='xs:anyURI' use='optional'/&gt;
+      &lt;xs:attribute name='secure' type='xs:boolean' use='optional' default='false'/&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+            &lt;xs:enumeration value='terminate'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='wait' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='xml:lang' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250713">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250739">2</a>. RFC 793: Transmission Control Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0793.txt">http://www.ietf.org/rfc/rfc0793.txt</a>&gt;.</p>
+<p><a name="nt-id2250764">3</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+<p><a name="nt-id2250785">4</a>. RFC 1945: Hypertext Transfer Protocol -- HTTP/1.0 &lt;<a href="http://www.ietf.org/rfc/rfc1945.txt">http://www.ietf.org/rfc/rfc1945.txt</a>&gt;.</p>
+<p><a name="nt-id2250817">5</a>. RFC 2965: HTTP State Management Mechanism &lt;<a href="http://www.ietf.org/rfc/rfc2965.txt">http://www.ietf.org/rfc/rfc2965.txt</a>&gt;.</p>
+<p><a name="nt-id2256260">6</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2256294">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256494">8</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2256642">9</a>. JEP-0138: Stream Compression &lt;<a href="http://www.jabber.org/jeps/jep-0138.html">http://www.jabber.org/jeps/jep-0138.html</a>&gt;.</p>
+<p><a name="nt-id2256824">10</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2256898">11</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-02.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256845">12</a>. The XMPP IRI specifcation does not currently allow a port in an XMPP IRI; the authors will pursue the matter within the Internet Standards Process.</p>
+<p><a name="nt-id2256980">13</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p><a name="nt-id2256937">14</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2257180">15</a>. Each character set name (or character encoding name -- we use the terms interchangeably) SHOULD be of type NMTOKEN, where the names are separated by the white space character #x20, resulting in a tokenized attribute type of NMTOKENS (see Section 3.3.1 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2257195">16</a>]). Strictly speaking, the Character Sets registry maintained by the Internet Assigned Numbers Authority (see &lt;<a href="http://www.iana.org/assignments/character-sets">http://www.iana.org/assignments/character-sets</a>&gt;) allows a character set name to contain any printable US-ASCII character, which might include characters not allowed by the NMTOKEN construction of XML 1.0; however, the only existing character set name which includes such a character is "NF_Z_62-010_(1973)".</p>
+<p><a name="nt-id2257195">16</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2250303">17</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p><a name="nt-id2258493">18</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2258855">19</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2259544">20</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2259578">21</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2259597">22</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259664">23</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.2 (2005-06-16)</h4>
+<div class="indent">Specified optional use of route and secure attributes in session request. Minor correction: the stream features element should be included in the response that contains the authid attribute (this is not necessarily the session creation response). (ip)
+    </div>
+<h4>Version 1.1 (2005-06-02)</h4>
+<div class="indent">Specified optional use of HTTP Accept-Encoding and Content-Encoding headers for compression at HTTP binding level. (ip)
+    </div>
+<h4>Version 1.0 (2005-03-03)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.10 (2004-11-08)</h4>
+<div class="indent">Changed HTTP 401 errors to HTTP 404. (ip)
+    </div>
+<h4>Version 0.9 (2004-10-26)</h4>
+<div class="indent">Added charset attribute. (ip/psa)
+    </div>
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Specified that wait attribute must be included in the session creation response. (ip)
+    </div>
+<h4>Version 0.7 (2004-08-12)</h4>
+<div class="indent">Defined appropriate XMPP stanza error conditions. (psa/ip)
+    </div>
+<h4>Version 0.6 (2004-07-19)</h4>
+<div class="indent">Added xml:lang attribute to the session request; added recoverable binding error conditions. (ip)
+    </div>
+<h4>Version 0.5 (2004-05-07)</h4>
+<div class="indent">Protocol refactored to enable simultaneous requests (request identifier attribute, wait attribute, hold attribute, requests attribute) and recovery of broken connections; added content attribute; removed all wrapper types except 'terminate'; updated error handling; made key mechanism optional (should use SSL/TLS instead). (ip/psa)
+    </div>
+<h4>Version 0.4 (2004-02-23)</h4>
+<div class="indent">Fixed typos; removed "resource-constraint" binding error; added HTTP 403 error to table. (psa/ip)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Added 'authid' attribute to enable communication of XMPP stream ID (used in digest authentication); specified that Content-Types other than "text/xml" are allowed to support older HTTP clients; specified business rule for connection manager queueing of client requests; changed &lt;packet/&gt; to &lt;body/&gt; to support older HTTP clients; changed 'to' attribute on initialization element from MAY to SHOULD; recommended inclusion of unavailable presence in termination element sent from client; described architectural assumptions; specified binding-specific error handling. (psa/ip)
+    </div>
+<h4>Version 0.2 (2004-01-13)</h4>
+<div class="indent">Added 'to' attribute on the initialization element; specified that 'text/html' is allowable for backwards-compatibility. (dss/psa)
+    </div>
+<h4>Version 0.1 (2003-11-06)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0124-1.3.html
+++ b/content/xep-0124-1.3.html
@@ -1,0 +1,1159 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0124: HTTP Binding</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="HTTP Binding">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0124">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0124: HTTP Binding</h1>
+<p>This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0124<br>
+            Version: 1.3<br>
+            Last Updated: 2005-11-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 1945, RFC 2068, RFC 3174<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: httpbind<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/httpbind/httpbind.xsd">http://jabber.org/protocol/httpbind/httpbind.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/HTTP%20Binding%20(JEP-0124)">http://wiki.jabber.org/index.php/HTTP Binding (JEP-0124)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>5.  <a href="#http">HTTP Version and HTTP Headers</a>
+</dt>
+<dt>6.  <a href="#compression">Compression</a>
+</dt>
+<dt>7.  <a href="#wrapper">&lt;body/&gt; Wrapper Element</a>
+</dt>
+<dt>8.  <a href="#session">Initiating an HTTP Session</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#session-request">Requesting a Session</a>
+</dt>
+<dt>8.2.  <a href="#session-create">Session Creation</a>
+</dt>
+<dt>8.3.  <a href="#session-features">Communication of Stream Features</a>
+</dt>
+</dl>
+<dt>9.  <a href="#preconditions">Additional Preconditions</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#preconditions-xmpp">XMPP Methods</a>
+</dt>
+<dt>9.2.  <a href="#preconditions-iqauth">jabber:iq:auth</a>
+</dt>
+</dl>
+<dt>10.  <a href="#stanzas">Sending and Receiving XML Stanzas</a>
+</dt>
+<dt>11.  <a href="#terminate">Terminating the HTTP Session</a>
+</dt>
+<dt>12.  <a href="#rids">Request IDs</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#rids-order">In-Order Message Forwarding</a>
+</dt>
+<dt>12.2.  <a href="#rids-broken">Broken Connections</a>
+</dt>
+</dl>
+<dt>13.  <a href="#keys">Protecting Insecure Sessions</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#keys-applic">Applicability</a>
+</dt>
+<dt>13.2.  <a href="#keys-intro">Introduction</a>
+</dt>
+<dt>13.3.  <a href="#keys-generate">Generating the Key Sequence</a>
+</dt>
+<dt>13.4.  <a href="#keys-use">Use of Keys</a>
+</dt>
+<dt>13.5.  <a href="#keys-switch">Switching to Another Key Sequence</a>
+</dt>
+</dl>
+<dt>14.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#errorstatus-http">HTTP Conditions</a>
+</dt>
+<dt>14.2.  <a href="#errorstatus-terminal">Terminal Binding Conditions</a>
+</dt>
+<dt>14.3.  <a href="#errorstatus-recover">Recoverable Binding Conditions</a>
+</dt>
+<dt>14.4.  <a href="#errorstatus-stanza">XMPP Stanza Conditions</a>
+</dt>
+</dl>
+<dt>15.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>16.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>17.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>17.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>18.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250876">1</a>] defines XML streams bound to TCP (see <span class="ref" style="">RFC 793</span>  [<a href="#nt-id2250900">2</a>]) as the standard transport layer for Jabber/XMPP communications. However, the binding of XMPP to TCP is not always feasible because of client runtime environment and/or network constraints. This JEP describes the usage of the Hypertext Transfer Protocol (HTTP, see <span class="ref" style="">RFC 2068</span>  [<a href="#nt-id2250958">3</a>] and <span class="ref" style="">RFC 1945</span>  [<a href="#nt-id2250915">4</a>]) as an alternative transport binding that supports such constrained environments, normally via deployment of a specialized server-side connection manager that communicates with clients via HTTP rather than TCP.</p>
+    <p class="" style="">Before the authors pursued publication of this JEP, other approaches were explored. One possible approach might have been to apply state to a series of HTTP transactions via HTTP "cookies" as specified in <span class="ref" style="">RFC 2965</span>  [<a href="#nt-id2256305">5</a>]. However, there are several significant computing platforms which provide only limited access to underlying HTTP requests/responses; worse, some platforms hide or remove cookie-related headers. Therefore the cookie approach was rejected.</p>
+    <p class="" style="">Another approach might have been to modify or extend <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2256336">6</a>]. This informational protocol has been used by Jabber clients without runtime constraints to access XMPP servers from behind firewalls. Unfortunately, the method defined in JEP-0025 also depends on cookies, does not meet most of the requirements described below, and cannot be extended without breaking all existing implementations.</p>
+    <p class="" style="">Therefore, this JEP specifies a new way of transporting XMPP via HTTP. All information is encoded in the body of standard HTTP POST requests and responses. Each HTTP body contains a single &lt;body/&gt; XML wrapper element (not to be confused with the &lt;body/&gt; child of the &lt;message/&gt; stanza as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256373">7</a>]), which encapsulates zero or more XML stanzas.</p>
+    <p class="" style="">Although this JEP documents some XMPP-specific features, the binding is not part of XMPP. In fact, the protocol is extensible and could be used to implement any bidirectional stream of XML stanzas.</p>
+  <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+    <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+      <p class="" style="">This document inherits terminology regarding the Hypertext Transport Protocol from RFCs 1945 and 2068.</p>
+    </div>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">Platform limitiations, security restrictions, and other constraints imply that many clients can connect to Internet resources (e.g., Jabber servers) only via HTTP. The following design requirements reflect the need to offer performance as close as possible to a standard TCP connection.</p>
+    <ol start="" type="">
+      <li>Compatible with constrained runtime environments (e.g., mobile and browser-based clients).</li>
+      <li>Compatible with restricted network connections (e.g., firewalls, proxies, and gateways).</li>
+      <li>Fault tolerant (e.g., session recovers after an underlying TCP connection breaks during an HTTP request).</li>
+      <li>Extensible (based on XML).</li>
+      <li>Consume significantly less bandwidth than polling-based solutions.</li>
+      <li>Significantly more responsive than polling-based solutions.</li>
+      <li>Support for polling (for clients that are limited to one HTTP connection at a time).</li>
+      <li>XML stanzas should arrive at the server in the order they were sent by the client.</li>
+      <li>Protect against unauthorized users interjecting HTTP requests into a session.</li>
+    </ol>
+    <p class="" style="">Compatibility with constrained runtime environments implies the following restrictions:</p>
+    <ul>
+      <li>Clients should not be required to have programmatic access to the headers of each HTTP request and response (e.g., cookies or status codes).</li>
+      <li>The body of each HTTP request and response should be parsable XML with a single root element.</li>
+      <li>Clients should be able to specify the Content-Type of the HTTP responses they receive.</li>
+    </ul>
+  <h2>4.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+    <p class="" style="">The binding of XMPP to HTTP assumes a different architecture from that described for the binding of XMPP to TCP as defined in <span style="font-weight: bold">RFC 3920</span>. In particular, because HTTP is not the native binding for XMPP, we assume that most XMPP implementations will utilize a specialized "connection manager" to handle HTTP connections rather than the usual TCP connections. Effectively, such a connection manager will be a specialized HTTP server that translates between the HTTP requests and responses defined herein and the XML streams (or a server API) implemented by the XMPP server or servers with which it communicates, thus enabling an HTTP client to connect to an XMPP server. We can illustrate this graphically as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+  XMPP Server
+      |
+      |  [XML streams or server API]
+      |
+Connection Manager
+      |
+      |  [HTTP + &lt;body/&gt; wrapper]
+      |
+  HTTP Client
+    </pre></div>
+    <p class="" style="">This JEP addresses communications between an HTTP client and the connection manager only. It does not address communications between the connection manager and the XMPP server, since such communications are implementation-specific (e.g., the connection manager and the XMPP server may use <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2256579">8</a>] or an API defined by the XMPP server implementation in order to communicate; alternatively, the XMPP server may natively support the HTTP binding, in which case the connection manager will be a logical entity rather than a physical entity).</p>
+    <p class="" style="">Furthermore, no aspect of the HTTP binding limits its use to client-to-server communications; i.e., it could be used for server-to-server or component-to-server communications as well (probably through a slight change to the XML schema). However, this document focuses exclusively on use of the HTTP binding by clients that cannot maintain persistent TCP connections to a server and that therefore cannot use the TCP binding defined in <span style="font-weight: bold">RFC 3920</span>. We assume that servers and components are under no such restrictions and thus would use the TCP binding.</p>
+  <h2>5.
+       <a name="http">HTTP Version and HTTP Headers</a>
+</h2>
+    <p class="" style="">Clients SHOULD send HTTP requests over persistent HTTP/1.1 connections. However, a constrained client MAY open a new HTTP/1.0 connection (as defined in RFC 1945) to send each request.</p>
+    <p class="" style="">Requests and responses MAY include HTTP headers not specified herein. The receiver SHOULD ignore any such headers.</p>
+  <h2>6.
+       <a name="compression">Compression</a>
+</h2>
+    <p class="" style="">Clients MAY include an HTTP Accept-Encoding header in any request. If the connection manager receives a request with an Accept-Encoding header, it MAY include an HTTP Content-Encoding header in the response (indicating one of the encodings specified in the request) and compress the response body accordingly.</p>
+    <p class="" style="">TLS compression (as defined in <span style="font-weight: bold">RFC 3920</span>) and Stream Compression (as defined in <span class="ref" style="">Stream Compression</span>  [<a href="#nt-id2256722">9</a>]) are NOT RECOMMENDED since compression SHOULD be negotiated at the HTTP layer and with the 'accept' attribute (see the <a href="#session-create">Session Creation</a> section below). TLS compression and Stream Compression SHOULD NOT be used simultaneously with HTTP content encoding.</p>
+  <h2>7.
+       <a name="wrapper">&lt;body/&gt; Wrapper Element</a>
+</h2>
+    <p class="" style="">The body of each HTTP request and response contains a single &lt;body/&gt; wrapper element. The &lt;body/&gt; element MUST contain zero or more complete XML elements. It MUST NOT contain partial XML elements.</p>
+    <p class="" style="">If the &lt;body/&gt; wrapper element is not empty, then it MUST contain one of the following:</p>
+    <ul>
+      <li>One or more complete XMPP stanzas (&lt;message/&gt;, &lt;presence/&gt;, and/or &lt;iq/&gt;).</li>
+      <li>A complete &lt;stream:features/&gt; element qualified by the 'http://etherx.jabber.org/streams' namespace.</li>
+      <li>A complete element used for SASL negotiation and qualified by the 'urn:ietf:params:xml:ns:xmpp-sasl' namespace.</li>
+      <li>XML elements associated with a binding error condition. For details, refer to the <a href="#errorstatus-binding">Binding Conditions</a> section below.</li>
+    </ul>
+    <p class="" style="">Note: Inclusion of TLS negotiation elements is allowed but is NOT RECOMMENDED (see <a href="#preconditions">Additional Preconditions</a> below).</p>
+    <p class="" style="">The &lt;body/&gt; wrapper element SHOULD be qualified by the 'http://jabber.org/protocol/httpbind' namespace, and child elements SHOULD be qualified by their respective namespaces (e.g., 'http://etherx.jabber.org/streams' for stream features, 'urn:ietf:params:xml:ns:xmpp-sasl' for SASL negotiation, and 'jabber:client' for XML stanzas). However, even if the client does not specify the namespaces, the connection manager MUST ensure that the XMPP it provides to the XMPP server or other entities on the network meets the namespacing requirements of <span style="font-weight: bold">RFC 3920</span>.</p>
+    <p class="" style="">The &lt;body/&gt; element of every client request MUST possess a sequential request ID encapsulated via the 'rid' attribute. The client MUST generate a large positive non-zero random integer for the first 'rid' and then increment that value by one for each subsequent request. For details, refer to the <a href="#rids">Request IDs</a> section below.</p>
+  <h2>8.
+       <a name="session">Initiating an HTTP Session</a>
+</h2>
+    <div class="indent">
+<h3>8.1 <a name="session-request">Requesting a Session</a>
+</h3>
+      <p class="" style="">The first request from the client to the connection manager creates a new session.</p>
+      <p class="" style="">The &lt;body/&gt; element of the first request SHOULD possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-weight: bold">'to'</span> -- This attribute specifies the target domain (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'xml:lang'</span> -- This attribute (as defined in Section 2.12 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2256903">10</a>]) specifies the default language of any human-readable XML character data sent or received during the session (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'wait'</span> -- This attribute specifies the longest time (in seconds) that the connection manager is allowed to wait before responding to any request during the session. This enables the client to prevent its TCP connection from expiring due to inactivity, as well as to limit the delay before it discovers any network failure.</li>
+        <li>
+<span style="font-weight: bold">'hold'</span> -- This attribute specifies the maximum number of requests the connection manager is allowed to keep waiting at any one time during the session. (For example, if a constrained client is unable to keep open more than two HTTP connections to the same HTTP server simultaneously, then it SHOULD specify a value of "1".)</li>
+      </ul>
+      <p class="" style="">Note: Clients that only support polling behavior MAY prevent the connection manager from waiting by setting 'wait' or 'hold' to "0". However, polling is NOT RECOMMENDED since the associated increase in bandwidth consumption and the decrease in responsiveness are typically one or two orders of magnitude!</p>
+      <p class="" style="">A connection manager MAY be configured to enable sessions with more than one XMPP server in different domains. When requesting a session with such a 'proxy' connection manager, a client SHOULD specify a 'route' attribute with an XMPP IRI (see <span class="ref" style="">XMPP URI Scheme</span>  [<a href="#nt-id2256976">11</a>]) to indicate which protocol, host, and port  [<a href="#nt-id2256925">12</a>] it wants to communicate with. A connection manager that is configured to work only with a single XMPP server (or only with a defined list of XMPP domains and their respective hosts and ports) MAY ignore the 'route' attribute. (Note that the 'to' attribute specifies the XMPP domain, not the host machine.)</p>
+      <p class="" style="">A client MAY include a 'secure' attribute to specify that communications between the connection manager and the XMPP server must be "secure". (Note: The 'secure' attribute is of type xs:boolean (see <span class="ref" style="">XML Schema Part 2</span>  [<a href="#nt-id2257058">13</a>]) and the default value is "false".  [<a href="#nt-id2257014">14</a>]) If a connection manager receives a session request with the 'secure' attribute set to 'true' or '1', then it MUST respond to the client with a  <a href="#errorstatus-terminal">remote-connection-failed</a> error as soon as it determines that it cannot communicate in a secure way with the XMPP server. A connection manager SHOULD consider communications with the XMPP server to be "secure" if they are encrypted using TLS or SSL with verified certificates, or if it is running on the same physical machine as the XMPP server. A connection manager MAY consider communications over a "private" network to be secure, even without TLS or SSL; however, a network SHOULD be considered "private" only if the administrator of the connection manager is sure that unknown individuals or processes do not have access to the network (i.e., individuals or processes who do not have access to either the connection manager or the XMPP server).</p>
+      <p class="" style="">Some clients are constrained to only accept HTTP responses with specific Content-Types (e.g., "text/html"). The &lt;body/&gt; element of the first request MAY possess a 'content' attribute. This specifies the value of the HTTP Content-Type header that MUST appear in all the connection manager's responses during the session. If the client request does not possess a 'content' attribute, then the HTTP Content-Type of responses MUST be "text/xml; charset=utf-8".</p>
+      <p class="" style="">Note: The HTTP Content-Type of client requests SHOULD also be "text/xml; charset=utf-8". Clients MAY specify another value if they are constrained to do so (e.g., "application/x-www-form-urlencoded" or "text/plain"). The client and connection manager SHOULD ignore all HTTP Content-Type headers they receive.</p>
+      <p class="caption">Example 1. Requesting an HTTP session</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      route='xmpp:jabber.org:80'
+      secure='true'
+      wait='60'
+      xml:lang='en'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">Note: Unlike the protocol defined in JEP-0025, an opening &lt;stream:stream&gt; tag is not sent. The protocol defined herein abstracts from XML streams between the connection manager and the client. Any XML streams between the connection manager and an XMPP server are the responsibility of the connection manager.</p>
+      <p class="" style="">Note: All requests after the first one MUST include a valid 'sid' attribue (provided by the connection manager in the session creation response below). The initialization request is unique in that the &lt;body/&gt; element MUST NOT possess a 'sid' attribute.</p>
+    </div>
+    <div class="indent">
+<h3>8.2 <a name="session-create">Session Creation</a>
+</h3>
+      <p class="" style="">After receiving a new session request, the connection manager MUST generate an opaque, unpredictable session identifier (or SID). The SID MUST be unique within the context of the connection manager application. The connection manager then returns that SID to the client in a response &lt;body/&gt; element.</p>
+      <p class="" style="">The connection manager MUST specify a 'wait' attribute. This is the longest time (in seconds) that it will wait before responding to any request during the session. The time MUST be less than or equal to the value specified in the session request.</p>
+      <p class="" style="">The connection manager MAY limit the number of simultaneous requests the client makes with the 'requests' attribute. The RECOMMENDED value is "2". Servers that only support polling behavior MUST prevent clients from making simultaneous requests by setting the 'requests' attribute to a value of "1" (however, polling is NOT RECOMMENDED). In any case, clients MUST NOT make more simultaneous requests than specified by the connection manager.</p>
+      <p class="" style="">The connection manager SHOULD include two additional attributes in the session creation response element, specifying the shortest allowable polling interval and the longest allowable inactivity period (both in seconds). Communication of these parameters enables the client to engage in appropriate behavior (e.g., not sending empty request elements more often than desired, and ensuring that the periods with no requests pending are never too long).</p>
+      <p class="" style="">The connection manager MAY include an 'accept' attribute in the session creation response element, to specify the content encodings it can decompress. After receiving a session creation response with an 'accept' attribute, clients MAY include an HTTP Content-Encoding header in subsequent requests (indicating one of the encodings specified in the 'accept' attribute) and compress the bodies of the requests accordingly.</p>
+      <p class="" style="">For both requests and responses, the &lt;body/&gt; element and its content SHOULD be UTF-8 encoded. If the HTTP Content-Type header of a request/response specifies a character encoding other than UTF-8, then the connection manager MAY convert between UTF-8 and the other character encoding. However, even in this case, it is OPTIONAL for the connection manager to convert between encodings. The connection manager MAY inform the client which encodings it can convert by setting the optional 'charsets' attribute in the session creation response element to a space-separated list of encodings.
+         [<a href="#nt-id2257259">15</a>]
+        </p>
+      <p class="caption">Example 2. Session creation response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 128
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      accept='deflate,gzip'
+      sid='SomeSID'
+      charsets='ISO_8859-1 ISO-2022-JP'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">Note: The 'authid' attribute contains the value of the XMPP stream ID generated by the XMPP server. The connection manager MUST retrieve the stream ID and pass it unmodified to the client. This value is needed by the client to successfully complete digest authentication using <span class="ref" style="">Non-SASL Authentication</span>  [<a href="#nt-id2257356">17</a>] (see the <a href="#preconditions-iqauth">jabber:iq:auth</a> section below).</p>
+    <p class="" style="">Note: If the 'authid' attribute is not included in the connection manager's response to the session creation request (e.g., because the connection manager has not yet received a stream ID from the XMPP server), then the client SHOULD send empty request elements (see the "Requesting XML Stanzas" example below) until it receives a response with an 'authid' attribute. In any case, the connection manager MUST return the 'authid' in a response to the client as soon as possible after it receives the stream ID from the XMPP server.</p>
+    <p class="" style="">Separate 'sid' and 'authid' attributes are required because the connection manager is not necessarily part of a single XMPP server (e.g., it may handle HTTP connections on behalf of multiple XMPP servers).</p>
+    </div>
+    <div class="indent">
+<h3>8.3 <a name="session-features">Communication of Stream Features</a>
+</h3>
+      <p class="" style="">As an immediate child of the response that contains the 'authid' attribute, the connection manager SHOULD include a stream features element, as defined by <span style="font-weight: bold">RFC 3920</span>.</p>
+      <p class="caption">Example 3. Session creation response with stream features</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 417
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      accept='deflate,gzip'
+      sid='SomeSID'
+      charsets='ISO_8859-1 ISO-2022-JP'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;stream:features xmlns='http://etherx.jabber.org/streams'&gt;
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'&gt;
+  &lt;/stream:features&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The stream features SHOULD NOT include a feature for Transport Layer Security (TLS), since channel encryption SHOULD be negotiated at the HTTP layer (see the <a href="#security">Security Considerations</a> section below).</p>
+    </div>
+  <h2>9.
+       <a name="preconditions">Additional Preconditions</a>
+</h2>
+    <p class="" style="">Initializing an HTTP session is the first precondition to sending XML message, presence, and IQ stanzas. However, before processing XML stanzas from the client, the connection manager MUST require completion of additional preconditions using either of the following methods:</p>
+    <ul>
+      <li>
+        <p class="" style="">XMPP authentication, resource binding, and IM session creation, in the following order:</p>
+        <ol start="" type="">
+          <li>Optionally, TLS negotiation as defined in Section 5 of <span style="font-weight: bold">RFC 3920</span> (this is NOT RECOMMENDED since channel encryption and compression SHOULD be negotiated at the HTTP layer; see the <a href="#security">Security Considerations</a> section below)</li>
+          <li>SASL authentication as defined in Section 6 of <span style="font-weight: bold">RFC 3920</span>
+</li>
+          <li>Resource Binding as defined in Section 7 of <span style="font-weight: bold">RFC 3920</span>
+</li>
+          <li>IM Session Establishment as defined in Section 3 of <span style="font-weight: bold">RFC 3921</span>, if appropriate</li>
+        </ol>
+      </li>
+      <li>
+        <p class="" style="">Simultaneous authentication and resource binding as defined in <span style="font-weight: bold">Non-SASL Authentication</span>, upon which a Jabber server will also establish an IM session on behalf of the connected resource.</p>
+      </li>
+    </ul>
+    <p class="" style="">It is RECOMMENDED to use the XMPP methods as defined in <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>, rather than using older non-SASL authentication.</p>
+
+    <div class="indent">
+<h3>9.1 <a name="preconditions-xmpp">XMPP Methods</a>
+</h3>
+      <p class="" style="">A success case for authentication, resource binding, and IM session establishment using the XMPP protocols is shown below. For detailed specification of these protocols (including error cases) and for specification of TLS negotiation, refer to <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>.</p>
+      <p class="caption">Example 4. SASL authentication step 1</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 172
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='DIGEST-MD5'/&gt;
+&lt;/body&gt;</pre></div>
+
+
+
+      <p class="caption">Example 5. SASL authentication step 2</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 250
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cmVhbG09InNvbWVyZWFsbSIsbm9uY2U9Ik9BNk1HOXRFUUdtMmhoIixxb3A9
+    ImF1dGgiLGNoYXJzZXQ9dXRmLTgsYWxnb3JpdGhtPW1kNS1zZXNzCg==
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 6. SASL authentication step 3</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 418
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    dXNlcm5hbWU9InNvbWVub2RlIixyZWFsbT0ic29tZXJlYWxtIixub25jZT0i
+    T0E2TUc5dEVRR20yaGgiLGNub25jZT0iT0E2TUhYaDZWcVRyUmsiLG5jPTAw
+    MDAwMDAxLHFvcD1hdXRoLGRpZ2VzdC11cmk9InhtcHAvZXhhbXBsZS5jb20i
+    LHJlc3BvbnNlPWQzODhkYWQ5MGQ0YmJkNzYwYTE1MjMyMWYyMTQzYWY3LGNo
+    YXJzZXQ9dXRmLTgK
+&lt;/response&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 7. SASL authentication step 4</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 190
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cnNwYXV0aD1lYTQwZjYwMzM1YzQyN2I1NTI3Yjg0ZGJhYmNkZmZmZAo=
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 8. SASL authentication step 5</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 152
+
+&lt;body rid='3197423133'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 9. SASL authentication step 6</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 121
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="" style="">Note: Because the context for a client's communication with a connection manager in the HTTP transport binding is HTTP rather than XML streams (as in the TCP binding), there is no need to re-start communications (e.g., by generating a new SID) at this point.</p>
+
+      <p class="caption">Example 10. Resource binding request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 240
+
+&lt;body rid='3197423134'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 11. Resource binding result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 221
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='result'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;jid&gt;stpeter@jabber.org/httpclient&lt;/jid&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 12. IM session request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 261
+
+&lt;body rid='3197423135'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='stpeter@jabber.org/httpclient'
+      id='sess_1'
+      to='jabber.org'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'/&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 13. IM session result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 175
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='jabber.org'
+      id='sess_1'
+      to='stpeter@jabber.org/httpclient'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+
+    </div>
+
+    <div class="indent">
+<h3>9.2 <a name="preconditions-iqauth">jabber:iq:auth</a>
+</h3>
+      <p class="" style="">A success case for simultaneous authentication, resource binding, and IM session creation using the original "jabber:iq:auth" protocol is shown below. For further details regarding use of this protocol, refer to JEP-0078. If digest authentication is used, then the stream ID value used to compute the hashed password MUST be the value of the 'authid' attribute provided by the connection manager in the response to the initialization element or in a subsequent response (see the <a href="#session-create">Session Creation</a> section above).</p>
+      <p class="caption">Example 14. Non-SASL authentication request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 281
+
+&lt;body rid='2842791421'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;query xmlns='jabber:iq:auth'&gt;
+      &lt;username&gt;stpeter&lt;/username&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+      &lt;password&gt;jabber-rocks&lt;/password&gt;
+    &lt;/query&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 15. Authentication result (success)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 144
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 16. Authentication result (failure)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 226
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='error'
+      xmlns='jabber:client'&gt;
+    &lt;error code='401' type='auth'&gt;
+      &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>10.
+       <a name="stanzas">Sending and Receiving XML Stanzas</a>
+</h2>
+    <p class="" style="">After the client has successfully completed all required preconditions, it can send and receive XML stanzas via the HTTP binding.</p>
+    <p class="caption">Example 17. Transmitting stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='2842791422'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message to='friend@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">Upon receipt of a request, the connection manager MUST forward the content of the &lt;body/&gt; element to the XMPP server as soon as possible. However, it must forward the content from different requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">The connection manager MUST also return an HTTP 200 OK response with a &lt;body/&gt; element to the client. Note: This does not indicate that the stanzas have been successfully delivered to the destination Jabber endpoint.</p>
+    <p class="" style="">It is RECOMMENDED that the connection manager not return an HTTP result until a stanza has arrived from the XMPP server for delivery to the client. However, the connection manager SHOULD NOT wait longer than the time specified by the client in the 'wait' attribute of its session creation request, and it SHOULD NOT keep more HTTP requests waiting at a time than the number specified in the 'hold' attribute of the session creation request. In any case it MUST respond to requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">If there are no stanzas waiting or ready to be delivered within the waiting period, then the connection manager SHOULD include an empty &lt;body/&gt; element in the HTTP result:</p>
+    <p class="caption">Example 18. Empty response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 64
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">If the connection manager has received one or more stanzas from the XMPP server for delivery to the client, then it SHOULD return the stanzas in the body of its response as soon as possible after receiving them from the XMPP server.</p>
+    <p class="caption">Example 19. Response with queued stanza</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 185
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message from='contact@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message from='friend@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The client MAY poll the connection manager for incoming stanzas by sending an empty &lt;body/&gt; element.</p>
+    <p class="caption">Example 20. Requesting XML Stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='2842791423'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The connection manager MUST wait and respond in the same way as it does after receiving stanzas from the client.</p>
+    <p class="" style="">If the client sends two consecutive empty requests within a period shorter than that specified by the 'polling' attribute in the session creation response, then the connection manager SHOULD terminate the HTTP session and return an HTTP 403 (Forbidden) error to the client.</p>
+    <p class="caption">Example 21. Too frequent polling response</p>
+<div class="indent"><pre>
+HTTP/1.1 403 Forbidden
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    <p class="" style="">If the connection manager did not specify a shortest allowable polling interval in the session creation response, then it MUST allow the client to poll as frequently as it chooses.</p>
+    <p class="" style="">After receiving a response from the connection manager, if no other requests are pending and the client did not specify polling behavior in the session creation request (by setting 'wait' or 'hold' to "0"), it SHOULD make a new request as soon as possible. In any case, if no requests are pending, the client MUST make a new request before the maximum inactivity period has expired. This period is specified by the 'inactivity' attribute in the session creation response.</p>
+    <p class="" style="">If the connection manager has responded to all the requests it has received and the time since its last response is longer than the maximum inactivity period, then it SHOULD terminate the session without informing the client (if the client makes another request, the connection manager SHOULD respond as if the session does not exist).</p>
+    <p class="" style="">If the connection manager did not specify a maximum inactivity period in the session creation response, then it MUST allow the client to be inactive for as long as it chooses.</p>
+  <h2>11.
+       <a name="terminate">Terminating the HTTP Session</a>
+</h2>
+    <p class="" style="">At any time, the client MAY gracefully terminate the session by sending a &lt;body/&gt; element with a 'type' attribute set to "terminate". The termination request SHOULD include an XMPP presence stanza of type "unavailable" to ensure graceful logoff with the XMPP server.</p>
+    <p class="caption">Example 22. Session termination by client</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 153
+
+&lt;body rid='2842791424'
+      sid='SomeSID'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;presence type='unavailable'
+            xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The connection manager SHOULD return an HTTP 200 OK response with an empty &lt;body/&gt; element. Upon receiving the response, the client MUST consider the HTTP session to have been terminated.</p>
+  <h2>12.
+       <a name="rids">Request IDs</a>
+</h2>
+    <div class="indent">
+<h3>12.1 <a name="rids-order">In-Order Message Forwarding</a>
+</h3>
+      <p class="" style="">When a client makes simultaneous requests, the connection manager may receive them out of order. The connection manager MUST forward the stanzas to the XMPP server and respond to the client requests in the order specified by the 'rid' attributes. The client MUST process responses received from the connection manager in the order the requests were made.</p>
+      <p class="" style="">The connection manager SHOULD expect the 'rid' attribute to be within a window of values greater than the 'rid' of the previous request. The size of the window is equal to the maximum number of simultaneous requests allowed by the connection manager. If it receives a request with a 'rid' greater than the values in the window, then the connection manager MUST terminate the session with an error:</p>
+      <p class="caption">Example 23. Unexpected rid error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>12.2 <a name="rids-broken">Broken Connections</a>
+</h3>
+      <p class="" style="">Unreliable network communications or client constraints can result in broken connections. The connection manager SHOULD remember the 'rid' and the associated HTTP response body of the client's most recent requests which did not result in an HTTP or binding error. The number of responses kept in the buffer should be the same as the maximum number of simultaneous requests allowed by the connection manager.</p>
+      <p class="" style="">If the network connection is broken or closed before the client receives a response to a request from the connection manager, then the client MAY resend an exact copy of the original request. Whenever the connection manager receives a request with a 'rid' that it has already received, it SHOULD return an HTTP 200 (OK) response that includes the buffered copy of the original XML response to the client (i.e., a &lt;body/&gt; wrapper element possessing appropriate attributes and optionally containing one or more XML stanzas or other allowable XML elements). If the original response is not available (e.g., it is no longer in the buffer), then the connection manager MUST return an HTTP 404 (Not Found) error:</p>
+      <p class="caption">Example 24. Response not in buffer error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+      <p class="" style="">Note: The error is the same whether the 'rid' is too large or too small. This makes it more difficult for an attacker to discover an acceptable value.</p>
+    </div>
+  <h2>13.
+       <a name="keys">Protecting Insecure Sessions</a>
+</h2>
+    <div class="indent">
+<h3>13.1 <a name="keys-applic">Applicability</a>
+</h3>
+      <p class="" style="">The OPTIONAL key sequencing mechanism described here MAY be used if the client's session with the connection manager is not secure. The session should be considered secure only if all client requests are made via TLS/SSL HTTP connections and the connection manager generates an unpredictable session ID. If the session is secure, it is not necessary to use this key sequencing mechanism.</p>
+      <p class="" style="">Even if the session is not secure, the unpredictable session and request IDs specified in the preceding sections of this document already provide a level of protection similar to that provided by a standard XMPP connection bound to a single pair of persistent TCP/IP connections, and thus provide sufficient protection against a 'blind' attacker. However, in some circumstances, the key sequencing mechanism defined below helps to protect against a more determined and knowledgeable attacker.</p>
+      <p class="" style="">It is important to recognize that the key sequencing mechanism defined below helps to protect only against an attacker who is able to view the contents of all requests or responses in an insecure session but who is not able to alter the contents of those requests (in this case, the mechanism prevents the attacker from interjecting HTTP requests into the session, e.g., termination requests or responses). However, the key sequencing mechanism does not provide any protection when the attacker is able to alter the contents of insecure requests or responses.</p>
+    </div>
+    <div class="indent">
+<h3>13.2 <a name="keys-intro">Introduction</a>
+</h3>
+      <p class="" style="">The HTTP requests of each session MAY be spread across a series of different socket connections. This would enable an unauthorized user that obtains the session ID and request ID of a session and then use their own socket connection to interject &lt;body/&gt; request elements into the session and receive the corresponding responses.</p>
+      <p class="" style="">The key sequencing mechanism below protects against such attacks by enabling a connection manager to detect &lt;body/&gt; request elements interjected by a third party.</p>
+    </div>
+    <div class="indent">
+<h3>13.3 <a name="keys-generate">Generating the Key Sequence</a>
+</h3>
+      <p class="" style="">Prior to requesting a new session, the client MUST select an unpredictable counter ("n") and an unpredictable value ("seed"). The client then processes the "seed" through a cryptographic hash and converts the resulting 160 bits to a hexadecimal string K(1). It does this "n" times to arrive at the initial key K(n). The hashing algorithm MUST be SHA-1 as defined in <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2258453">18</a>].</p>
+      <p class="caption">Example 25. Creating the key sequence</p>
+<div class="indent"><pre>
+        K(1) = hex(SHA-1(seed))
+        K(2) = hex(SHA-1(K(1)))
+        ...
+        K(n) = hex(SHA-1(K(n-1)))
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.4 <a name="keys-use">Use of Keys</a>
+</h3>
+      <p class="" style="">The client MUST set the 'newkey' attribute of the first request in the session to the value K(n).</p>
+      <p class="caption">Example 26. Session Request with Initial Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      newkey='ca393b51b682f61f98e7877d61146407f3d0a770'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The client MUST set the 'key' attribute of all subsequent requests to the value of the next key in the generated sequence (decrementing from K(n-1) towards K(1) with each request sent).</p>
+    <p class="caption">Example 27. Request with Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      key='bfb06a6f113cd6fd3838ab9d300fdb4fe3da2f7d'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The connection manager MAY verify the key by calculating the SHA-1 hash of the key and comparing it to the 'newkey' attribute of the previous request (or the 'key' attribute if the 'newkey' attribute was not set). If the values do not match (or if it receives a request without a 'key' attribute and the 'newkey' or 'key' attribute of the previous request was set), then the connection manager MUST NOT process the element, MUST terminate the session, and MUST return an HTTP 404 (Not Found) error.</p>
+      <p class="caption">Example 28. Invalid Key Sequence Error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>13.5 <a name="keys-switch">Switching to Another Key Sequence</a>
+</h3>
+      <p class="" style="">A client SHOULD choose a high value for "n" when generating the key sequence. However, if the session lasts long enough that the client arrives at the last key in the sequence K(1) then the client MUST switch to a new key sequence.</p>
+      <p class="" style="">The client MUST:</p>
+      <ol start="" type="">
+        <li>Choose new values for "seed" and "n".</li>
+        <li>Generate a new key sequence using the algorithm defined above.</li>
+        <li>Set the 'key' attribute of the request to the next value in the old sequence (i.e. K(1), the last value).</li>
+        <li>Set the 'newkey' attribute of the request to the value K(n) from the new sequence.</li>
+      </ol>
+      <p class="caption">Example 29. New Key Sequence</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      key='6f825e81f4532b2c5fa2d12457d8a1f22e8f838e'
+      newkey='113f58a37245ec9637266cf2fb6e48bfeaf7964e'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>14.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+    <p class="" style="">There are four types of error and status reporting in HTTP responses:</p>
+    <p class="caption">Table 1: Error Condition Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition Type</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">HTTP Conditions</span></td>
+<td align="" colspan="" rowspan="">The connection manager responds to an invalid client request with a standard HTTP error. These are used for binding syntax errors, possible attacks, etc. Note that constrained clients are unable to differentiate between HTTP errors.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Terminal Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These error conditions may be read by constrained clients. They are used for connection manager problems, abstracting stream errors, and communication problems between the connection manager and the XMPP server.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Recoverable Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These report communication problems between the connection manager and the client. They do not terminate the session. Clients recover from these errors by resending the last two &lt;body/&gt; wrapper elements.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP Stanza Conditions</span></td>
+<td align="" colspan="" rowspan="">XMPP errors relating to XML stanzas within &lt;body/&gt; wrapper elements are, in general, defined in the appropriate RFC or JEP. They do not terminate the session. An example of such usage is shown above in relation to <span style="font-weight: bold">Non-SASL Authentication</span>.</td>
+</tr>
+    </table>
+    <p class="" style="">Full descriptions are provided below.</p>
+    <div class="indent">
+<h3>14.1 <a name="errorstatus-http">HTTP Conditions</a>
+</h3>
+      <p class="" style="">The following HTTP error and status codes are used in particular ways by this protocol (other HTTP error and status codes may be used as appropriate). Upon receiving an HTTP error (400, 403, 404), the HTTP client MUST consider the HTTP session to be null and void.</p>
+      <p class="" style="">Note: These are pure HTTP codes as defined in the HTTP specification, and are not to be confused with the HTTP-style error codes traditionally used in Jabber protocols and documented in <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2258815">19</a>].</p>
+      <p class="caption">Table 2: HTTP Error and Status Codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Code</th>
+          <th colspan="" rowspan="">Name</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">200</td>
+          <td align="" colspan="" rowspan="">OK</td>
+          <td align="" colspan="" rowspan="">Response to valid client request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">400</td>
+          <td align="" colspan="" rowspan="">Bad Request</td>
+          <td align="" colspan="" rowspan="">Inform client that the format of an HTTP header or binding element is unacceptable (e.g., syntax error).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">403</td>
+          <td align="" colspan="" rowspan="">Forbidden</td>
+          <td align="" colspan="" rowspan="">Inform client that it has broken the session rules (polling too-frequently, too many simultaneous connections).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">404</td>
+          <td align="" colspan="" rowspan="">Not Found</td>
+          <td align="" colspan="" rowspan="">Inform client that (1) 'sid' is not valid, (2) 'rid' is larger than the upper limit of the expected window, (3) connection manager is unable to resend response, (4) 'key' sequence is invalid.</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>14.2 <a name="errorstatus-terminal">Terminal Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a fatal error by setting a 'type' attribute of the &lt;body/&gt; element to "terminate". These binding errors imply that the HTTP session is terminated. (Note: Many of these conditions correspond to the relevant XMPP stream error conditions specified in <span style="font-weight: bold">RFC 3920</span>, but actual XMPP stream error conditions experienced between the connection manager and the server are contained only in the "remote-stream-error" condition as described below.)</p>
+      <p class="caption">Example 30. Remote connection failed error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='terminate'
+      condition='remote-connection-failed'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The following values of the 'condition' attribute are defined:</p>
+      <p class="caption">Table 3: Binding Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Condition</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-gone</td>
+          <td align="" colspan="" rowspan="">The target domain specified in the 'to' attribute or the target host or port specified in the 'route' attribute is no longer serviced by the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-unknown</td>
+          <td align="" colspan="" rowspan="">The target domain specified in the 'to' attribute or the target host or port specified in the 'route' attribute is unknown to the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">improper-addressing</td>
+          <td align="" colspan="" rowspan="">The initialization element lacks a 'to' or 'route' attribute (or the attribute has no value) but the connection manager requires one.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">internal-server-error</td>
+          <td align="" colspan="" rowspan="">The connection manager has experienced an internal error that prevents it from servicing the request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">other-request</td>
+          <td align="" colspan="" rowspan="">Another request being processed at the same time as this request caused the session to terminate.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-connection-failed</td>
+          <td align="" colspan="" rowspan="">The connection manager was unable to connect to, or unable to connect securely to, or has lost its connection to, the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-stream-error</td>
+          <td align="" colspan="" rowspan="">Encapsulates an XMPP stream error. The content of the binding is a copy of the content of the &lt;stream:error/&gt; element received from the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">see-other-uri</td>
+          <td align="" colspan="" rowspan="">The connection manager does not operate at this URI (e.g., the connection manager accepts only SSL/TLS connections at some https: URI rather than the http: URI requested by the client). The client may try POSTing to the URI in the content of the &lt;uri/&gt; child element.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">system-shutdown</td>
+          <td align="" colspan="" rowspan="">The connection manager is being shut down. All active HTTP sessions are being terminated. No new sessions can be created.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">undefined-condition</td>
+          <td align="" colspan="" rowspan="">The error is not one of those defined herein; the connection manager SHOULD include application-specific information in the content of the &lt;body/&gt; wrapper element.</td>
+        </tr>
+      </table>
+      <p class="" style="">The following is an example of a "see-other-uri" condition:</p>
+      <p class="caption">Example 31. See other URI error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='see-other-uri'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;uri&gt;https://secure.jabber.org/xmppcm&lt;/uri&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The following is an example of a "remote-stream-error" condition:</p>
+      <p class="caption">Example 32. Remote error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='remote-stream-error'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;xml-not-well-formed xmlns='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+  &lt;text xmlns='urn:ietf:params:xml:ns:xmpp-streams'
+        xml:lang='en'&gt;
+    Some special application diagnostic information!
+  &lt;/text&gt;
+  &lt;escape-your-data xmlns='application-ns'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">Naturally, the client MAY report binding errors to the connection manager as well, although this is unlikely.</p>
+    </div>
+    <div class="indent">
+<h3>14.3 <a name="errorstatus-recover">Recoverable Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a recoverable error by setting a 'type' attribute of the &lt;body/&gt; element to "error". These errors do not imply that the HTTP session is terminated.</p>
+      <p class="" style="">If it decides to recover from the error, then the client MUST repeat the HTTP request and the previous HTTP request. The content of both requests MUST be identical to the &lt;body/&gt; elements of the original requests. This allows the server to recover a session after the previous request was lost due to a communication failure.</p>
+      <p class="caption">Example 33. Recoverable error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='error'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    </div>
+    <div class="indent">
+<h3>14.4 <a name="errorstatus-stanza">XMPP Stanza Conditions</a>
+</h3>
+      <p class="" style="">Application-level error conditions will normally be generated by a third entity (e.g., an IM contact) and routed to the client through the connection manager; therefore they are out of scope for the transport binding defined herein and are described in the appropriate RFC or JEP.</p>
+      <p class="" style="">However, it is possible that a connection manager will receive a stanza for delivery to a client even though the client connection is no longer active (e.g., before the connection manager is able to inform a server that the connection has died). In this case, the connection manager would return an error to the server; it is RECOMMENDED that the connection manager proceed as follows, since the situation is similar to that addressed by point #2 of Section 11.1 of <span style="font-weight: bold">RFC 3921</span>:</p>
+      <ol start="" type="">
+        <li>If the delivered stanza was &lt;presence/&gt;, silently drop the stanza and do not return an error to the sender.</li>
+        <li>If the delivered stanza was &lt;iq/&gt;, return a &lt;service-unavailable/&gt; error to the sender.</li>
+        <li>If the delivered stanza was &lt;message/&gt;, return a &lt;recipient-unavailable/&gt; error to the sender.</li>
+      </ol>
+      <p class="" style="">When a server receives a &lt;message/&gt; stanza of type "error" containing a &lt;recipient-unavailable/&gt; condition from a connection manager, it SHOULD store the message for later delivery if offline storage is enabled, otherwise route the error stanza to the sender.</p>
+    </div>
+  <h2>15.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">All communications SHOULD occur over an encrypted channel. Negotiation of channel encryption between the client and the connection manager SHOULD occur at the HTTP layer, not the application layer; such negotiation SHOULD follow the protocol defined in <span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2259504">20</a>].</p>
+    <p class="" style="">The session identifier (SID) and initial request identifier (RID) are security-critical and therefore MUST be both unpredictable and nonrepeating (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2259538">21</a>] for recommendations regarding randomness of SIDs and initial RIDs for security purposes).</p>
+  <h2>16.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259557">22</a>].</p>
+  <h2>17.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>17.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259624">23</a>] includes 'http://jabber.org/protocol/httpbind' in its registry of protocol namespaces.</p>
+    </div>
+  <h2>18.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    targetNamespace='http://jabber.org/protocol/httpbind'
+    xmlns='http://jabber.org/protocol/httpbind'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0124: http://www.jabber.org/jeps/jep-0124.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import namespace='http://etherx.jabber.org/streams'
+             schemaLocation='http://etherx.jabber.org/streams.xsd'/&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:stream='http://etherx.jabber.org/streams'&gt;
+        &lt;xs:element ref='stream:features'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-tls'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-streams'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='jabber:client'
+                minOccurs='0'
+                maxOccurs='unbounded'/&gt;
+        &lt;xs:element name='uri'
+                minOccurs='0'
+                maxOccurs='1'
+                type='xs:string'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='accept' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='authid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='charsets' type='xs:NMTOKENS' use='optional'/&gt;
+      &lt;xs:attribute name='condition' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='host-gone'/&gt;
+            &lt;xs:enumeration value='host-unknown'/&gt;
+            &lt;xs:enumeration value='improper-addressing'/&gt;
+            &lt;xs:enumeration value='internal-server-error'/&gt;
+            &lt;xs:enumeration value='remote-connection-failed'/&gt;
+            &lt;xs:enumeration value='remote-stream-error'/&gt;
+            &lt;xs:enumeration value='see-other-uri'/&gt;
+            &lt;xs:enumeration value='system-shutdown'/&gt;
+            &lt;xs:enumeration value='undefined-condition'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='content' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='hold' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='inactivity' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='key' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='newkey' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='polling' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='requests' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='rid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='route' type='xs:anyURI' use='optional'/&gt;
+      &lt;xs:attribute name='secure' type='xs:boolean' use='optional' default='false'/&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+            &lt;xs:enumeration value='terminate'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='wait' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='xml:lang' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250876">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250900">2</a>. RFC 793: Transmission Control Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0793.txt">http://www.ietf.org/rfc/rfc0793.txt</a>&gt;.</p>
+<p><a name="nt-id2250958">3</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+<p><a name="nt-id2250915">4</a>. RFC 1945: Hypertext Transfer Protocol -- HTTP/1.0 &lt;<a href="http://www.ietf.org/rfc/rfc1945.txt">http://www.ietf.org/rfc/rfc1945.txt</a>&gt;.</p>
+<p><a name="nt-id2256305">5</a>. RFC 2965: HTTP State Management Mechanism &lt;<a href="http://www.ietf.org/rfc/rfc2965.txt">http://www.ietf.org/rfc/rfc2965.txt</a>&gt;.</p>
+<p><a name="nt-id2256336">6</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2256373">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256579">8</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2256722">9</a>. JEP-0138: Stream Compression &lt;<a href="http://www.jabber.org/jeps/jep-0138.html">http://www.jabber.org/jeps/jep-0138.html</a>&gt;.</p>
+<p><a name="nt-id2256903">10</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2256976">11</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-03.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-03.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256925">12</a>. The XMPP IRI specifcation does not currently allow a port in an XMPP IRI; the authors will pursue the matter within the Internet Standards Process.</p>
+<p><a name="nt-id2257058">13</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p><a name="nt-id2257014">14</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2257259">15</a>. Each character set name (or character encoding name -- we use the terms interchangeably) SHOULD be of type NMTOKEN, where the names are separated by the white space character #x20, resulting in a tokenized attribute type of NMTOKENS (see Section 3.3.1 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2257274">16</a>]). Strictly speaking, the Character Sets registry maintained by the Internet Assigned Numbers Authority (see &lt;<a href="http://www.iana.org/assignments/character-sets">http://www.iana.org/assignments/character-sets</a>&gt;) allows a character set name to contain any printable US-ASCII character, which might include characters not allowed by the NMTOKEN construction of XML 1.0; however, the only existing character set name which includes such a character is "NF_Z_62-010_(1973)".</p>
+<p><a name="nt-id2257274">16</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2257356">17</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p><a name="nt-id2258453">18</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2258815">19</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2259504">20</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2259538">21</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2259557">22</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259624">23</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.3 (2005-11-02)</h4>
+<div class="indent">Corrected stream:features namespace and the Recoverable Binding Conditions section; recommended that connection manager shall return secure attribute to client; recommended end-to-end encryption through proxy connection managers. (ip)
+    </div>
+<h4>Version 1.2 (2005-06-16)</h4>
+<div class="indent">Specified optional use of route and secure attributes in session request. Minor correction: the stream features element should be included in the response that contains the authid attribute (this is not necessarily the session creation response). (ip)
+    </div>
+<h4>Version 1.1 (2005-06-02)</h4>
+<div class="indent">Specified optional use of HTTP Accept-Encoding and Content-Encoding headers for compression at HTTP binding level. (ip)
+    </div>
+<h4>Version 1.0 (2005-03-03)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.10 (2004-11-08)</h4>
+<div class="indent">Changed HTTP 401 errors to HTTP 404. (ip)
+    </div>
+<h4>Version 0.9 (2004-10-26)</h4>
+<div class="indent">Added charset attribute. (ip/psa)
+    </div>
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Specified that wait attribute must be included in the session creation response. (ip)
+    </div>
+<h4>Version 0.7 (2004-08-12)</h4>
+<div class="indent">Defined appropriate XMPP stanza error conditions. (psa/ip)
+    </div>
+<h4>Version 0.6 (2004-07-19)</h4>
+<div class="indent">Added xml:lang attribute to the session request; added recoverable binding error conditions. (ip)
+    </div>
+<h4>Version 0.5 (2004-05-07)</h4>
+<div class="indent">Protocol refactored to enable simultaneous requests (request identifier attribute, wait attribute, hold attribute, requests attribute) and recovery of broken connections; added content attribute; removed all wrapper types except 'terminate'; updated error handling; made key mechanism optional (should use SSL/TLS instead). (ip/psa)
+    </div>
+<h4>Version 0.4 (2004-02-23)</h4>
+<div class="indent">Fixed typos; removed "resource-constraint" binding error; added HTTP 403 error to table. (psa/ip)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Added 'authid' attribute to enable communication of XMPP stream ID (used in digest authentication); specified that Content-Types other than "text/xml" are allowed to support older HTTP clients; specified business rule for connection manager queueing of client requests; changed &lt;packet/&gt; to &lt;body/&gt; to support older HTTP clients; changed 'to' attribute on initialization element from MAY to SHOULD; recommended inclusion of unavailable presence in termination element sent from client; described architectural assumptions; specified binding-specific error handling. (psa/ip)
+    </div>
+<h4>Version 0.2 (2004-01-13)</h4>
+<div class="indent">Added 'to' attribute on the initialization element; specified that 'text/html' is allowable for backwards-compatibility. (dss/psa)
+    </div>
+<h4>Version 0.1 (2003-11-06)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0124-1.4.html
+++ b/content/xep-0124-1.4.html
@@ -1,0 +1,1166 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0124: HTTP Binding</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="HTTP Binding">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Dave Smith">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-14">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0124">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0124: HTTP Binding</h1>
+<p>This JEP defines a binding of Jabber/XMPP communications to a transport layer of HTTP rather than TCP.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0124<br>
+            Version: 1.4<br>
+            Last Updated: 2005-12-14<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 1945, RFC 2068, RFC 3174<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: httpbind<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/httpbind/httpbind.xsd">http://jabber.org/protocol/httpbind/httpbind.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/HTTP%20Binding%20(JEP-0124)">http://wiki.jabber.org/index.php/HTTP Binding (JEP-0124)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+<h3>Dave Smith</h3>
+<p class="indent">
+        Email: dizzyd@jabber.org<br>
+        JID: dizzyd@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dl><dt>2.1.  <a href="#terms-http">HTTP Terms</a>
+</dt></dl>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#arch">Architectural Assumptions</a>
+</dt>
+<dt>5.  <a href="#http">HTTP Version and HTTP Headers</a>
+</dt>
+<dt>6.  <a href="#compression">Compression</a>
+</dt>
+<dt>7.  <a href="#wrapper">&lt;body/&gt; Wrapper Element</a>
+</dt>
+<dt>8.  <a href="#session">Initiating an HTTP Session</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#session-request">Requesting a Session</a>
+</dt>
+<dt>8.2.  <a href="#session-create">Session Creation</a>
+</dt>
+<dt>8.3.  <a href="#session-features">Communication of Stream Features</a>
+</dt>
+</dl>
+<dt>9.  <a href="#preconditions">Additional Preconditions</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#preconditions-xmpp">XMPP Methods</a>
+</dt>
+<dt>9.2.  <a href="#preconditions-iqauth">jabber:iq:auth</a>
+</dt>
+</dl>
+<dt>10.  <a href="#stanzas">Sending and Receiving XML Stanzas</a>
+</dt>
+<dt>11.  <a href="#terminate">Terminating the HTTP Session</a>
+</dt>
+<dt>12.  <a href="#rids">Request IDs</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#rids-order">In-Order Message Forwarding</a>
+</dt>
+<dt>12.2.  <a href="#rids-broken">Broken Connections</a>
+</dt>
+</dl>
+<dt>13.  <a href="#keys">Protecting Insecure Sessions</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#keys-applic">Applicability</a>
+</dt>
+<dt>13.2.  <a href="#keys-intro">Introduction</a>
+</dt>
+<dt>13.3.  <a href="#keys-generate">Generating the Key Sequence</a>
+</dt>
+<dt>13.4.  <a href="#keys-use">Use of Keys</a>
+</dt>
+<dt>13.5.  <a href="#keys-switch">Switching to Another Key Sequence</a>
+</dt>
+</dl>
+<dt>14.  <a href="#errorstatus">Error and Status Codes</a>
+</dt>
+<dl>
+<dt>14.1.  <a href="#errorstatus-http">HTTP Conditions</a>
+</dt>
+<dt>14.2.  <a href="#errorstatus-terminal">Terminal Binding Conditions</a>
+</dt>
+<dt>14.3.  <a href="#errorstatus-recover">Recoverable Binding Conditions</a>
+</dt>
+<dt>14.4.  <a href="#errorstatus-stanza">XMPP Stanza Conditions</a>
+</dt>
+</dl>
+<dt>15.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>16.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>17.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>17.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>18.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250893">1</a>] defines XML streams bound to TCP (see <span class="ref" style="">RFC 793</span>  [<a href="#nt-id2250919">2</a>]) as the standard transport layer for Jabber/XMPP communications. However, the binding of XMPP to TCP is not always feasible because of client runtime environment and/or network constraints. This JEP describes the usage of the Hypertext Transfer Protocol (HTTP, see <span class="ref" style="">RFC 2068</span>  [<a href="#nt-id2250942">3</a>] and <span class="ref" style="">RFC 1945</span>  [<a href="#nt-id2250965">4</a>]) as an alternative transport binding that supports such constrained environments, normally via deployment of a specialized server-side connection manager that communicates with clients via HTTP rather than TCP.</p>
+    <p class="" style="">Before the authors pursued publication of this JEP, other approaches were explored. One possible approach might have been to apply state to a series of HTTP transactions via HTTP "cookies" as specified in <span class="ref" style="">RFC 2965</span>  [<a href="#nt-id2256322">5</a>]. However, there are several significant computing platforms which provide only limited access to underlying HTTP requests/responses; worse, some platforms hide or remove cookie-related headers. Therefore the cookie approach was rejected.</p>
+    <p class="" style="">Another approach might have been to modify or extend <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2256353">6</a>]. This informational protocol has been used by Jabber clients without runtime constraints to access XMPP servers from behind firewalls. Unfortunately, the method defined in JEP-0025 also depends on cookies, does not meet most of the requirements described below, and cannot be extended without breaking all existing implementations.</p>
+    <p class="" style="">Therefore, this JEP specifies a new way of transporting XMPP via HTTP. All information is encoded in the body of standard HTTP POST requests and responses. Each HTTP body contains a single &lt;body/&gt; XML wrapper element (not to be confused with the &lt;body/&gt; child of the &lt;message/&gt; stanza as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256391">7</a>]), which encapsulates zero or more XML stanzas.</p>
+    <p class="" style="">Although this JEP documents some XMPP-specific features, the binding is not part of XMPP. In fact, the protocol is extensible and could be used to implement any bidirectional stream of XML stanzas.</p>
+  <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+    <div class="indent">
+<h3>2.1 <a name="terms-http">HTTP Terms</a>
+</h3>
+      <p class="" style="">This document inherits terminology regarding the Hypertext Transport Protocol from RFCs 1945 and 2068.</p>
+    </div>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">Platform limitiations, security restrictions, and other constraints imply that many clients can connect to Internet resources (e.g., Jabber servers) only via HTTP. The following design requirements reflect the need to offer performance as close as possible to a standard TCP connection.</p>
+    <ol start="" type="">
+      <li>Compatible with constrained runtime environments (e.g., mobile and browser-based clients).</li>
+      <li>Compatible with restricted network connections (e.g., firewalls, proxies, and gateways).</li>
+      <li>Fault tolerant (e.g., session recovers after an underlying TCP connection breaks during an HTTP request).</li>
+      <li>Extensible (based on XML).</li>
+      <li>Consume significantly less bandwidth than polling-based solutions.</li>
+      <li>Significantly more responsive than polling-based solutions.</li>
+      <li>Support for polling (for clients that are limited to one HTTP connection at a time).</li>
+      <li>XML stanzas should arrive at the server in the order they were sent by the client.</li>
+      <li>Protect against unauthorized users interjecting HTTP requests into a session.</li>
+    </ol>
+    <p class="" style="">Compatibility with constrained runtime environments implies the following restrictions:</p>
+    <ul>
+      <li>Clients should not be required to have programmatic access to the headers of each HTTP request and response (e.g., cookies or status codes).</li>
+      <li>The body of each HTTP request and response should be parsable XML with a single root element.</li>
+      <li>Clients should be able to specify the Content-Type of the HTTP responses they receive.</li>
+    </ul>
+  <h2>4.
+       <a name="arch">Architectural Assumptions</a>
+</h2>
+    <p class="" style="">The binding of XMPP to HTTP assumes a different architecture from that described for the binding of XMPP to TCP as defined in <span style="font-weight: bold">RFC 3920</span>. In particular, because HTTP is not the native binding for XMPP, we assume that most XMPP implementations will utilize a specialized "connection manager" to handle HTTP connections rather than the usual TCP connections. Effectively, such a connection manager will be a specialized HTTP server that translates between the HTTP requests and responses defined herein and the XML streams (or a server API) implemented by the XMPP server or servers with which it communicates, thus enabling an HTTP client to connect to an XMPP server. We can illustrate this graphically as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+  XMPP Server
+      |
+      |  [XML streams or server API]
+      |
+Connection Manager
+      |
+      |  [HTTP + &lt;body/&gt; wrapper]
+      |
+  HTTP Client
+    </pre></div>
+    <p class="" style="">This JEP addresses communications between an HTTP client and the connection manager only. It does not address communications between the connection manager and the XMPP server, since such communications are implementation-specific (e.g., the connection manager and the XMPP server may use <span class="ref" style="">Jabber Component Protocol</span>  [<a href="#nt-id2256596">8</a>] or an API defined by the XMPP server implementation in order to communicate; alternatively, the XMPP server may natively support the HTTP binding, in which case the connection manager will be a logical entity rather than a physical entity).</p>
+    <p class="" style="">Furthermore, no aspect of the HTTP binding limits its use to client-to-server communications; i.e., it could be used for server-to-server or component-to-server communications as well (probably through a slight change to the XML schema). However, this document focuses exclusively on use of the HTTP binding by clients that cannot maintain persistent TCP connections to a server and that therefore cannot use the TCP binding defined in <span style="font-weight: bold">RFC 3920</span>. We assume that servers and components are under no such restrictions and thus would use the TCP binding.</p>
+  <h2>5.
+       <a name="http">HTTP Version and HTTP Headers</a>
+</h2>
+    <p class="" style="">Clients SHOULD send HTTP requests over persistent HTTP/1.1 connections. However, a constrained client MAY open a new HTTP/1.0 connection (as defined in RFC 1945) to send each request.</p>
+    <p class="" style="">Requests and responses MAY include HTTP headers not specified herein. The receiver SHOULD ignore any such headers.</p>
+  <h2>6.
+       <a name="compression">Compression</a>
+</h2>
+    <p class="" style="">Clients MAY include an HTTP Accept-Encoding header in any request. If the connection manager receives a request with an Accept-Encoding header, it MAY include an HTTP Content-Encoding header in the response (indicating one of the encodings specified in the request) and compress the response body accordingly.</p>
+    <p class="" style="">TLS compression (as defined in <span style="font-weight: bold">RFC 3920</span>) and Stream Compression (as defined in <span class="ref" style="">Stream Compression</span>  [<a href="#nt-id2256740">9</a>]) are NOT RECOMMENDED since compression SHOULD be negotiated at the HTTP layer and with the 'accept' attribute (see the <a href="#session-create">Session Creation</a> section below). TLS compression and Stream Compression SHOULD NOT be used simultaneously with HTTP content encoding.</p>
+  <h2>7.
+       <a name="wrapper">&lt;body/&gt; Wrapper Element</a>
+</h2>
+    <p class="" style="">The body of each HTTP request and response contains a single &lt;body/&gt; wrapper element. The &lt;body/&gt; element MUST contain zero or more complete XML elements. It MUST NOT contain partial XML elements.</p>
+    <p class="" style="">If the &lt;body/&gt; wrapper element is not empty, then it MUST contain one of the following:</p>
+    <ul>
+      <li>One or more complete XMPP stanzas (&lt;message/&gt;, &lt;presence/&gt;, and/or &lt;iq/&gt;).</li>
+      <li>A complete &lt;stream:features/&gt; element (in which case the body element MUST include namespace xmlns:stream='http://etherx.jabber.org/streams').</li>
+      <li>A complete element used for SASL negotiation and qualified by the 'urn:ietf:params:xml:ns:xmpp-sasl' namespace.</li>
+      <li>XML elements associated with a binding error condition. For details, refer to the <a href="#errorstatus-binding">Binding Conditions</a> section below.</li>
+    </ul>
+    <p class="" style="">Note: Inclusion of TLS negotiation elements is allowed but is NOT RECOMMENDED (see <a href="#preconditions">Additional Preconditions</a> below).</p>
+    <p class="" style="">The &lt;body/&gt; wrapper element SHOULD be qualified by the 'http://jabber.org/protocol/httpbind' namespace, and child elements SHOULD be qualified by their respective namespaces (e.g., 'http://etherx.jabber.org/streams' for stream features, 'urn:ietf:params:xml:ns:xmpp-sasl' for SASL negotiation, and 'jabber:client' for XML stanzas). However, even if the client does not specify the namespaces, the connection manager MUST ensure that the XMPP it provides to the XMPP server or other entities on the network meets the namespacing requirements of <span style="font-weight: bold">RFC 3920</span>.</p>
+    <p class="" style="">The &lt;body/&gt; element of every client request MUST possess a sequential request ID encapsulated via the 'rid' attribute. The client MUST generate a large positive non-zero random integer for the first 'rid' and then increment that value by one for each subsequent request. For details, refer to the <a href="#rids">Request IDs</a> section below.</p>
+  <h2>8.
+       <a name="session">Initiating an HTTP Session</a>
+</h2>
+    <div class="indent">
+<h3>8.1 <a name="session-request">Requesting a Session</a>
+</h3>
+      <p class="" style="">The first request from the client to the connection manager creates a new session.</p>
+      <p class="" style="">The &lt;body/&gt; element of the first request SHOULD possess the following attributes:</p>
+      <ul>
+        <li>
+<span style="font-weight: bold">'to'</span> -- This attribute specifies the target domain (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'xml:lang'</span> -- This attribute (as defined in Section 2.12 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2256922">10</a>]) specifies the default language of any human-readable XML character data sent or received during the session (this attribute SHOULD NOT be included on any request but the first request).</li>
+        <li>
+<span style="font-weight: bold">'wait'</span> -- This attribute specifies the longest time (in seconds) that the connection manager is allowed to wait before responding to any request during the session. This enables the client to prevent its TCP connection from expiring due to inactivity, as well as to limit the delay before it discovers any network failure.</li>
+        <li>
+<span style="font-weight: bold">'hold'</span> -- This attribute specifies the maximum number of requests the connection manager is allowed to keep waiting at any one time during the session. (For example, if a constrained client is unable to keep open more than two HTTP connections to the same HTTP server simultaneously, then it SHOULD specify a value of "1".)</li>
+      </ul>
+      <p class="" style="">Note: Clients that only support polling behavior MAY prevent the connection manager from waiting by setting 'wait' or 'hold' to "0". However, polling is NOT RECOMMENDED since the associated increase in bandwidth consumption and the decrease in responsiveness are typically one or two orders of magnitude!</p>
+      <p class="" style="">A connection manager MAY be configured to enable sessions with more than one XMPP server in different domains. When requesting a session with such a 'proxy' connection manager, a client SHOULD include a 'route' attribute that specifies the protocol, hostname, and port of the server with which it wants to communicate, formatted as "proto:host:port" (e.g., "xmpp:jabber.org:9999").  [<a href="#nt-id2250317">11</a>] A connection manager that is configured to work only with a single XMPP server (or only with a defined list of XMPP domains and their respective hosts and ports) MAY ignore the 'route' attribute. (Note that the 'to' attribute specifies the XMPP domain, not the host machine.)</p>
+      <p class="" style="">A client MAY include a 'secure' attribute to specify that communications between the connection manager and the XMPP server must be "secure". (Note: The 'secure' attribute is of type xs:boolean (see <span class="ref" style="">XML Schema Part 2</span>  [<a href="#nt-id2250402">12</a>]) and the default value is "false".  [<a href="#nt-id2257078">13</a>]) If a connection manager receives a session request with the 'secure' attribute set to 'true' or '1', then it MUST respond to the client with a  <a href="#errorstatus-terminal">remote-connection-failed</a> error as soon as it determines that it cannot communicate in a secure way with the XMPP server. A connection manager SHOULD consider communications with the XMPP server to be "secure" if they are encrypted using TLS or SSL with verified certificates, or if it is running on the same physical machine as the XMPP server. A connection manager MAY consider communications over a "private" network to be secure, even without TLS or SSL; however, a network SHOULD be considered "private" only if the administrator of the connection manager is sure that unknown individuals or processes do not have access to the network (i.e., individuals or processes who do not have access to either the connection manager or the XMPP server). The connection manager SHOULD try to establish a secure connection with the XMPP server even if the client does not specifically require it.</p>
+      <p class="" style="">Some clients are constrained to only accept HTTP responses with specific Content-Types (e.g., "text/html"). The &lt;body/&gt; element of the first request MAY possess a 'content' attribute. This specifies the value of the HTTP Content-Type header that MUST appear in all the connection manager's responses during the session. If the client request does not possess a 'content' attribute, then the HTTP Content-Type of responses MUST be "text/xml; charset=utf-8".</p>
+      <p class="" style="">Note: The HTTP Content-Type of client requests SHOULD also be "text/xml; charset=utf-8". Clients MAY specify another value if they are constrained to do so (e.g., "application/x-www-form-urlencoded" or "text/plain"). The client and connection manager SHOULD ignore all HTTP Content-Type headers they receive.</p>
+      <p class="caption">Example 1. Requesting an HTTP session</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      route='xmpp:jabber.org:9999'
+      secure='true'
+      wait='60'
+      xml:lang='en'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">Note: Unlike the protocol defined in JEP-0025, an opening &lt;stream:stream&gt; tag is not sent. The protocol defined herein abstracts from XML streams between the connection manager and the client. Any XML streams between the connection manager and an XMPP server are the responsibility of the connection manager.</p>
+      <p class="" style="">Note: All requests after the first one MUST include a valid 'sid' attribue (provided by the connection manager in the session creation response below). The initialization request is unique in that the &lt;body/&gt; element MUST NOT possess a 'sid' attribute.</p>
+    </div>
+    <div class="indent">
+<h3>8.2 <a name="session-create">Session Creation</a>
+</h3>
+      <p class="" style="">After receiving a new session request, the connection manager MUST generate an opaque, unpredictable session identifier (or SID). The SID MUST be unique within the context of the connection manager application. The connection manager then returns that SID to the client in a response &lt;body/&gt; element.</p>
+      <p class="" style="">The connection manager MUST specify a 'wait' attribute. This is the longest time (in seconds) that it will wait before responding to any request during the session. The time MUST be less than or equal to the value specified in the session request.</p>
+      <p class="" style="">The connection manager MAY limit the number of simultaneous requests the client makes with the 'requests' attribute. The RECOMMENDED value is "2". Servers that only support polling behavior MUST prevent clients from making simultaneous requests by setting the 'requests' attribute to a value of "1" (however, polling is NOT RECOMMENDED). In any case, clients MUST NOT make more simultaneous requests than specified by the connection manager.</p>
+      <p class="" style="">The connection manager SHOULD include two additional attributes in the session creation response element, specifying the shortest allowable polling interval and the longest allowable inactivity period (both in seconds). Communication of these parameters enables the client to engage in appropriate behavior (e.g., not sending empty request elements more often than desired, and ensuring that the periods with no requests pending are never too long).</p>
+      <p class="" style="">The connection manager MAY include an 'accept' attribute in the session creation response element, to specify the content encodings it can decompress. After receiving a session creation response with an 'accept' attribute, clients MAY include an HTTP Content-Encoding header in subsequent requests (indicating one of the encodings specified in the 'accept' attribute) and compress the bodies of the requests accordingly.</p>
+      <p class="" style="">For both requests and responses, the &lt;body/&gt; element and its content SHOULD be UTF-8 encoded. If the HTTP Content-Type header of a request/response specifies a character encoding other than UTF-8, then the connection manager MAY convert between UTF-8 and the other character encoding. However, even in this case, it is OPTIONAL for the connection manager to convert between encodings. The connection manager MAY inform the client which encodings it can convert by setting the optional 'charsets' attribute in the session creation response element to a space-separated list of encodings.
+         [<a href="#nt-id2257408">14</a>]
+        </p>
+      <p class="caption">Example 2. Session creation response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 128
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      accept='deflate,gzip'
+      sid='SomeSID'
+      secure='true'
+      charsets='ISO_8859-1 ISO-2022-JP'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">Note: The 'authid' attribute contains the value of the XMPP stream ID generated by the XMPP server. The connection manager MUST retrieve the stream ID and pass it unmodified to the client. This value is needed by the client to successfully complete digest authentication using <span class="ref" style="">Non-SASL Authentication</span>  [<a href="#nt-id2257503">16</a>] (see the <a href="#preconditions-iqauth">jabber:iq:auth</a> section below).</p>
+    <p class="" style="">Note: If the 'authid' attribute is not included in the connection manager's response to the session creation request (e.g., because the connection manager has not yet received a stream ID from the XMPP server), then the client SHOULD send empty request elements (see the "Requesting XML Stanzas" example below) until it receives a response with an 'authid' attribute. In any case, the connection manager MUST return the 'authid' in a response to the client as soon as possible after it receives the stream ID from the XMPP server.</p>
+    <p class="" style="">Separate 'sid' and 'authid' attributes are required because the connection manager is not necessarily part of a single XMPP server (e.g., it may handle HTTP connections on behalf of multiple XMPP servers).</p>
+    <p class="" style="">If it established a secure connection to the XMPP server (as defined in <a href="#session">Initiating an HTTP Session</a>), then the connection manager SHOULD include the 'secure' attribute set to 'true' or '1' in the response to the client that contains the 'authid' attribute.</p>
+    </div>
+    <div class="indent">
+<h3>8.3 <a name="session-features">Communication of Stream Features</a>
+</h3>
+      <p class="" style="">As an immediate child of the response that contains the 'authid' attribute, the connection manager SHOULD include a stream features element, as defined by <span style="font-weight: bold">RFC 3920</span>.</p>
+      <p class="caption">Example 3. Session creation response with stream features</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 417
+
+&lt;body authid='ServerStreamID'
+      wait='60'
+      inactivity='30'
+      polling='5'
+      requests='2'
+      accept='deflate,gzip'
+      sid='SomeSID'
+      charsets='ISO_8859-1 ISO-2022-JP'
+      xmlns='http://jabber.org/protocol/httpbind'
+      xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  &lt;stream:features&gt;
+    &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+      &lt;mechanism&gt;DIGEST-MD5&lt;/mechanism&gt;
+      &lt;mechanism&gt;PLAIN&lt;/mechanism&gt;
+    &lt;/mechanisms&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'&gt;
+  &lt;/stream:features&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The stream features SHOULD NOT include a feature for Transport Layer Security (TLS), since channel encryption SHOULD be negotiated at the HTTP layer (see the <a href="#security">Security Considerations</a> section below).</p>
+    </div>
+  <h2>9.
+       <a name="preconditions">Additional Preconditions</a>
+</h2>
+    <p class="" style="">Initializing an HTTP session is the first precondition to sending XML message, presence, and IQ stanzas. However, before processing XML stanzas from the client, the connection manager MUST require completion of additional preconditions using either of the following methods:</p>
+    <ul>
+      <li>
+        <p class="" style="">XMPP authentication, resource binding, and IM session creation, in the following order:</p>
+        <ol start="" type="">
+          <li>Optionally, TLS negotiation as defined in Section 5 of <span style="font-weight: bold">RFC 3920</span> (this is NOT RECOMMENDED since channel encryption and compression SHOULD be negotiated at the HTTP layer; see the <a href="#security">Security Considerations</a> section below)</li>
+          <li>SASL authentication as defined in Section 6 of <span style="font-weight: bold">RFC 3920</span>
+</li>
+          <li>Resource Binding as defined in Section 7 of <span style="font-weight: bold">RFC 3920</span>
+</li>
+          <li>IM Session Establishment as defined in Section 3 of <span style="font-weight: bold">RFC 3921</span>, if appropriate</li>
+        </ol>
+      </li>
+      <li>
+        <p class="" style="">Simultaneous authentication and resource binding as defined in <span style="font-weight: bold">Non-SASL Authentication</span>, upon which a Jabber server will also establish an IM session on behalf of the connected resource.</p>
+      </li>
+    </ul>
+    <p class="" style="">It is RECOMMENDED to use the XMPP methods as defined in <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>, rather than using older non-SASL authentication.</p>
+
+    <div class="indent">
+<h3>9.1 <a name="preconditions-xmpp">XMPP Methods</a>
+</h3>
+      <p class="" style="">A success case for authentication, resource binding, and IM session establishment using the XMPP protocols is shown below. For detailed specification of these protocols (including error cases) and for specification of TLS negotiation, refer to <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>.</p>
+      <p class="caption">Example 4. SASL authentication step 1</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 172
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='DIGEST-MD5'/&gt;
+&lt;/body&gt;</pre></div>
+
+
+
+      <p class="caption">Example 5. SASL authentication step 2</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 250
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cmVhbG09InNvbWVyZWFsbSIsbm9uY2U9Ik9BNk1HOXRFUUdtMmhoIixxb3A9
+    ImF1dGgiLGNoYXJzZXQ9dXRmLTgsYWxnb3JpdGhtPW1kNS1zZXNzCg==
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 6. SASL authentication step 3</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 418
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    dXNlcm5hbWU9InNvbWVub2RlIixyZWFsbT0ic29tZXJlYWxtIixub25jZT0i
+    T0E2TUc5dEVRR20yaGgiLGNub25jZT0iT0E2TUhYaDZWcVRyUmsiLG5jPTAw
+    MDAwMDAxLHFvcD1hdXRoLGRpZ2VzdC11cmk9InhtcHAvZXhhbXBsZS5jb20i
+    LHJlc3BvbnNlPWQzODhkYWQ5MGQ0YmJkNzYwYTE1MjMyMWYyMTQzYWY3LGNo
+    YXJzZXQ9dXRmLTgK
+  &lt;/response&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 7. SASL authentication step 4</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 190
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;challenge xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    cnNwYXV0aD1lYTQwZjYwMzM1YzQyN2I1NTI3Yjg0ZGJhYmNkZmZmZAo=
+  &lt;/challenge&gt;
+&lt;/body&gt;</pre></div>
+
+
+      <p class="caption">Example 8. SASL authentication step 5</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 152
+
+&lt;body rid='3197423133'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;response xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 9. SASL authentication step 6</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 121
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="" style="">Note: Because the context for a client's communication with a connection manager in the HTTP transport binding is HTTP rather than XML streams (as in the TCP binding), there is no need to re-start communications (e.g., by generating a new SID) at this point.</p>
+
+      <p class="caption">Example 10. Resource binding request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 240
+
+&lt;body rid='3197423134'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 11. Resource binding result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 221
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='bind_1'
+      type='result'
+      xmlns='jabber:client'&gt;
+    &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+      &lt;jid&gt;stpeter@jabber.org/httpclient&lt;/jid&gt;
+    &lt;/bind&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 12. IM session request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Content-Type: text/xml; charset=utf-8
+Content-Length: 261
+
+&lt;body rid='3197423135'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='stpeter@jabber.org/httpclient'
+      id='sess_1'
+      to='jabber.org'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;session xmlns='urn:ietf:params:xml:ns:xmpp-session'/&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+
+      <p class="caption">Example 13. IM session result</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 175
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq from='jabber.org'
+      id='sess_1'
+      to='stpeter@jabber.org/httpclient'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+
+    </div>
+
+    <div class="indent">
+<h3>9.2 <a name="preconditions-iqauth">jabber:iq:auth</a>
+</h3>
+      <p class="" style="">A success case for simultaneous authentication, resource binding, and IM session creation using the original "jabber:iq:auth" protocol is shown below. For further details regarding use of this protocol, refer to JEP-0078. If digest authentication is used, then the stream ID value used to compute the hashed password MUST be the value of the 'authid' attribute provided by the connection manager in the response to the initialization element or in a subsequent response (see the <a href="#session-create">Session Creation</a> section above).</p>
+      <p class="caption">Example 14. Non-SASL authentication request</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 281
+
+&lt;body rid='2842791421'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='set'
+      xmlns='jabber:client'&gt;
+    &lt;query xmlns='jabber:iq:auth'&gt;
+      &lt;username&gt;stpeter&lt;/username&gt;
+      &lt;resource&gt;httpclient&lt;/resource&gt;
+      &lt;password&gt;jabber-rocks&lt;/password&gt;
+    &lt;/query&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 15. Authentication result (success)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 144
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='result'
+      xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="caption">Example 16. Authentication result (failure)</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 226
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;iq id='A01'
+      type='error'
+      xmlns='jabber:client'&gt;
+    &lt;error code='401' type='auth'&gt;
+      &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>10.
+       <a name="stanzas">Sending and Receiving XML Stanzas</a>
+</h2>
+    <p class="" style="">After the client has successfully completed all required preconditions, it can send and receive XML stanzas via the HTTP binding.</p>
+    <p class="caption">Example 17. Transmitting stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='2842791422'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message to='friend@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">Upon receipt of a request, the connection manager MUST forward the content of the &lt;body/&gt; element to the XMPP server as soon as possible. However, it must forward the content from different requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">The connection manager MUST also return an HTTP 200 OK response with a &lt;body/&gt; element to the client. Note: This does not indicate that the stanzas have been successfully delivered to the destination Jabber endpoint.</p>
+    <p class="" style="">It is RECOMMENDED that the connection manager not return an HTTP result until a stanza has arrived from the XMPP server for delivery to the client. However, the connection manager SHOULD NOT wait longer than the time specified by the client in the 'wait' attribute of its session creation request, and it SHOULD NOT keep more HTTP requests waiting at a time than the number specified in the 'hold' attribute of the session creation request. In any case it MUST respond to requests in the order specified by their 'rid' attributes.</p>
+    <p class="" style="">If there are no stanzas waiting or ready to be delivered within the waiting period, then the connection manager SHOULD include an empty &lt;body/&gt; element in the HTTP result:</p>
+    <p class="caption">Example 18. Empty response</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 64
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">If the connection manager has received one or more stanzas from the XMPP server for delivery to the client, then it SHOULD return the stanzas in the body of its response as soon as possible after receiving them from the XMPP server.</p>
+    <p class="caption">Example 19. Response with queued stanza</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 185
+
+&lt;body xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message from='contact@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+  &lt;message from='friend@example.com'
+           to='user@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi yourself!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The client MAY poll the connection manager for incoming stanzas by sending an empty &lt;body/&gt; element.</p>
+    <p class="caption">Example 20. Requesting XML Stanzas</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='2842791423'
+      sid='SomeSID'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The connection manager MUST wait and respond in the same way as it does after receiving stanzas from the client.</p>
+    <p class="" style="">If the client sends two consecutive empty requests within a period shorter than that specified by the 'polling' attribute in the session creation response, then the connection manager SHOULD terminate the HTTP session and return an HTTP 403 (Forbidden) error to the client.</p>
+    <p class="caption">Example 21. Too frequent polling response</p>
+<div class="indent"><pre>
+HTTP/1.1 403 Forbidden
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    <p class="" style="">If the connection manager did not specify a shortest allowable polling interval in the session creation response, then it MUST allow the client to poll as frequently as it chooses.</p>
+    <p class="" style="">After receiving a response from the connection manager, if no other requests are pending and the client did not specify polling behavior in the session creation request (by setting 'wait' or 'hold' to "0"), it SHOULD make a new request as soon as possible. In any case, if no requests are pending, the client MUST make a new request before the maximum inactivity period has expired. This period is specified by the 'inactivity' attribute in the session creation response.</p>
+    <p class="" style="">If the connection manager has responded to all the requests it has received and the time since its last response is longer than the maximum inactivity period, then it SHOULD terminate the session without informing the client (if the client makes another request, the connection manager SHOULD respond as if the session does not exist).</p>
+    <p class="" style="">If the connection manager did not specify a maximum inactivity period in the session creation response, then it MUST allow the client to be inactive for as long as it chooses.</p>
+  <h2>11.
+       <a name="terminate">Terminating the HTTP Session</a>
+</h2>
+    <p class="" style="">At any time, the client MAY gracefully terminate the session by sending a &lt;body/&gt; element with a 'type' attribute set to "terminate". The termination request SHOULD include an XMPP presence stanza of type "unavailable" to ensure graceful logoff with the XMPP server.</p>
+    <p class="caption">Example 22. Session termination by client</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 153
+
+&lt;body rid='2842791424'
+      sid='SomeSID'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;presence type='unavailable'
+            xmlns='jabber:client'/&gt;
+&lt;/body&gt;</pre></div>
+    <p class="" style="">The connection manager SHOULD return an HTTP 200 OK response with an empty &lt;body/&gt; element. Upon receiving the response, the client MUST consider the HTTP session to have been terminated.</p>
+  <h2>12.
+       <a name="rids">Request IDs</a>
+</h2>
+    <div class="indent">
+<h3>12.1 <a name="rids-order">In-Order Message Forwarding</a>
+</h3>
+      <p class="" style="">When a client makes simultaneous requests, the connection manager may receive them out of order. The connection manager MUST forward the stanzas to the XMPP server and respond to the client requests in the order specified by the 'rid' attributes. The client MUST process responses received from the connection manager in the order the requests were made.</p>
+      <p class="" style="">The connection manager SHOULD expect the 'rid' attribute to be within a window of values greater than the 'rid' of the previous request. The size of the window is equal to the maximum number of simultaneous requests allowed by the connection manager. If it receives a request with a 'rid' greater than the values in the window, then the connection manager MUST terminate the session with an error:</p>
+      <p class="caption">Example 23. Unexpected rid error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>12.2 <a name="rids-broken">Broken Connections</a>
+</h3>
+      <p class="" style="">Unreliable network communications or client constraints can result in broken connections. The connection manager SHOULD remember the 'rid' and the associated HTTP response body of the client's most recent requests which did not result in an HTTP or binding error. The number of responses kept in the buffer should be the same as the maximum number of simultaneous requests allowed by the connection manager.</p>
+      <p class="" style="">If the network connection is broken or closed before the client receives a response to a request from the connection manager, then the client MAY resend an exact copy of the original request. Whenever the connection manager receives a request with a 'rid' that it has already received, it SHOULD return an HTTP 200 (OK) response that includes the buffered copy of the original XML response to the client (i.e., a &lt;body/&gt; wrapper element possessing appropriate attributes and optionally containing one or more XML stanzas or other allowable XML elements). If the original response is not available (e.g., it is no longer in the buffer), then the connection manager MUST return an HTTP 404 (Not Found) error:</p>
+      <p class="caption">Example 24. Response not in buffer error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+      <p class="" style="">Note: The error is the same whether the 'rid' is too large or too small. This makes it more difficult for an attacker to discover an acceptable value.</p>
+    </div>
+  <h2>13.
+       <a name="keys">Protecting Insecure Sessions</a>
+</h2>
+    <div class="indent">
+<h3>13.1 <a name="keys-applic">Applicability</a>
+</h3>
+      <p class="" style="">The OPTIONAL key sequencing mechanism described here MAY be used if the client's session with the connection manager is not secure. The session should be considered secure only if all client requests are made via TLS/SSL HTTP connections and the connection manager generates an unpredictable session ID. If the session is secure, it is not necessary to use this key sequencing mechanism.</p>
+      <p class="" style="">Even if the session is not secure, the unpredictable session and request IDs specified in the preceding sections of this document already provide a level of protection similar to that provided by a standard XMPP connection bound to a single pair of persistent TCP/IP connections, and thus provide sufficient protection against a 'blind' attacker. However, in some circumstances, the key sequencing mechanism defined below helps to protect against a more determined and knowledgeable attacker.</p>
+      <p class="" style="">It is important to recognize that the key sequencing mechanism defined below helps to protect only against an attacker who is able to view the contents of all requests or responses in an insecure session but who is not able to alter the contents of those requests (in this case, the mechanism prevents the attacker from interjecting HTTP requests into the session, e.g., termination requests or responses). However, the key sequencing mechanism does not provide any protection when the attacker is able to alter the contents of insecure requests or responses.</p>
+    </div>
+    <div class="indent">
+<h3>13.2 <a name="keys-intro">Introduction</a>
+</h3>
+      <p class="" style="">The HTTP requests of each session MAY be spread across a series of different socket connections. This would enable an unauthorized user that obtains the session ID and request ID of a session and then use their own socket connection to interject &lt;body/&gt; request elements into the session and receive the corresponding responses.</p>
+      <p class="" style="">The key sequencing mechanism below protects against such attacks by enabling a connection manager to detect &lt;body/&gt; request elements interjected by a third party.</p>
+    </div>
+    <div class="indent">
+<h3>13.3 <a name="keys-generate">Generating the Key Sequence</a>
+</h3>
+      <p class="" style="">Prior to requesting a new session, the client MUST select an unpredictable counter ("n") and an unpredictable value ("seed"). The client then processes the "seed" through a cryptographic hash and converts the resulting 160 bits to a hexadecimal string K(1). It does this "n" times to arrive at the initial key K(n). The hashing algorithm MUST be SHA-1 as defined in <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2258601">17</a>].</p>
+      <p class="caption">Example 25. Creating the key sequence</p>
+<div class="indent"><pre>
+        K(1) = hex(SHA-1(seed))
+        K(2) = hex(SHA-1(K(1)))
+        ...
+        K(n) = hex(SHA-1(K(n-1)))
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>13.4 <a name="keys-use">Use of Keys</a>
+</h3>
+      <p class="" style="">The client MUST set the 'newkey' attribute of the first request in the session to the value K(n).</p>
+      <p class="caption">Example 26. Session Request with Initial Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 104
+
+&lt;body content='text/xml; charset=utf-8'
+      hold='1'
+      rid='3197423130'
+      to='jabber.org'
+      wait='60'
+      xml:lang='en'
+      newkey='ca393b51b682f61f98e7877d61146407f3d0a770'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    <p class="" style="">The client MUST set the 'key' attribute of all subsequent requests to the value of the next key in the generated sequence (decrementing from K(n-1) towards K(1) with each request sent).</p>
+    <p class="caption">Example 27. Request with Key</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 88
+
+&lt;body rid='3197423131'
+      sid='SomeSID'
+      key='bfb06a6f113cd6fd3838ab9d300fdb4fe3da2f7d'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The connection manager MAY verify the key by calculating the SHA-1 hash of the key and comparing it to the 'newkey' attribute of the previous request (or the 'key' attribute if the 'newkey' attribute was not set). If the values do not match (or if it receives a request without a 'key' attribute and the 'newkey' or 'key' attribute of the previous request was set), then the connection manager MUST NOT process the element, MUST terminate the session, and MUST return an HTTP 404 (Not Found) error.</p>
+      <p class="caption">Example 28. Invalid Key Sequence Error</p>
+<div class="indent"><pre>
+HTTP/1.1 404 Not Found
+Content-Type: text/xml; charset=utf-8
+Content-Length: 0</pre></div>
+    </div>
+    <div class="indent">
+<h3>13.5 <a name="keys-switch">Switching to Another Key Sequence</a>
+</h3>
+      <p class="" style="">A client SHOULD choose a high value for "n" when generating the key sequence. However, if the session lasts long enough that the client arrives at the last key in the sequence K(1) then the client MUST switch to a new key sequence.</p>
+      <p class="" style="">The client MUST:</p>
+      <ol start="" type="">
+        <li>Choose new values for "seed" and "n".</li>
+        <li>Generate a new key sequence using the algorithm defined above.</li>
+        <li>Set the 'key' attribute of the request to the next value in the old sequence (i.e. K(1), the last value).</li>
+        <li>Set the 'newkey' attribute of the request to the value K(n) from the new sequence.</li>
+      </ol>
+      <p class="caption">Example 29. New Key Sequence</p>
+<div class="indent"><pre>
+POST /webclient HTTP/1.1
+Host: httpcm.jabber.org
+Accept-Encoding: gzip, deflate
+Content-Type: text/xml; charset=utf-8
+Content-Length: 188
+
+&lt;body rid='3197423132'
+      sid='SomeSID'
+      key='6f825e81f4532b2c5fa2d12457d8a1f22e8f838e'
+      newkey='113f58a37245ec9637266cf2fb6e48bfeaf7964e'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;message to='contact@example.com'
+           xmlns='jabber:client'&gt;
+    &lt;body&gt;Hi there!&lt;/body&gt;
+  &lt;/message&gt;
+&lt;/body&gt;</pre></div>
+    </div>
+  <h2>14.
+       <a name="errorstatus">Error and Status Codes</a>
+</h2>
+    <p class="" style="">There are four types of error and status reporting in HTTP responses:</p>
+    <p class="caption">Table 1: Error Condition Types</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+<th colspan="" rowspan="">Condition Type</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">HTTP Conditions</span></td>
+<td align="" colspan="" rowspan="">The connection manager responds to an invalid client request with a standard HTTP error. These are used for binding syntax errors, possible attacks, etc. Note that constrained clients are unable to differentiate between HTTP errors.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Terminal Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These error conditions may be read by constrained clients. They are used for connection manager problems, abstracting stream errors, and communication problems between the connection manager and the XMPP server.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">Recoverable Binding Conditions</span></td>
+<td align="" colspan="" rowspan="">These report communication problems between the connection manager and the client. They do not terminate the session. Clients recover from these errors by resending the last two &lt;body/&gt; wrapper elements.</td>
+</tr>
+      <tr class="body">
+<td align="" colspan="" rowspan=""><span style="font-weight: bold">XMPP Stanza Conditions</span></td>
+<td align="" colspan="" rowspan="">XMPP errors relating to XML stanzas within &lt;body/&gt; wrapper elements are, in general, defined in the appropriate RFC or JEP. They do not terminate the session. An example of such usage is shown above in relation to <span style="font-weight: bold">Non-SASL Authentication</span>.</td>
+</tr>
+    </table>
+    <p class="" style="">Full descriptions are provided below.</p>
+    <div class="indent">
+<h3>14.1 <a name="errorstatus-http">HTTP Conditions</a>
+</h3>
+      <p class="" style="">The following HTTP error and status codes are used in particular ways by this protocol (other HTTP error and status codes may be used as appropriate). Upon receiving an HTTP error (400, 403, 404), the HTTP client MUST consider the HTTP session to be null and void.</p>
+      <p class="" style="">Note: These are pure HTTP codes as defined in the HTTP specification, and are not to be confused with the HTTP-style error codes traditionally used in Jabber protocols and documented in <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2258963">18</a>].</p>
+      <p class="caption">Table 2: HTTP Error and Status Codes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Code</th>
+          <th colspan="" rowspan="">Name</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">200</td>
+          <td align="" colspan="" rowspan="">OK</td>
+          <td align="" colspan="" rowspan="">Response to valid client request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">400</td>
+          <td align="" colspan="" rowspan="">Bad Request</td>
+          <td align="" colspan="" rowspan="">Inform client that the format of an HTTP header or binding element is unacceptable (e.g., syntax error).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">403</td>
+          <td align="" colspan="" rowspan="">Forbidden</td>
+          <td align="" colspan="" rowspan="">Inform client that it has broken the session rules (polling too-frequently, too many simultaneous connections).</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">404</td>
+          <td align="" colspan="" rowspan="">Not Found</td>
+          <td align="" colspan="" rowspan="">Inform client that (1) 'sid' is not valid, (2) 'rid' is larger than the upper limit of the expected window, (3) connection manager is unable to resend response, (4) 'key' sequence is invalid.</td>
+        </tr>
+      </table>
+    </div>
+    <div class="indent">
+<h3>14.2 <a name="errorstatus-terminal">Terminal Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a fatal error by setting a 'type' attribute of the &lt;body/&gt; element to "terminate". These binding errors imply that the HTTP session is terminated. (Note: Many of these conditions correspond to the relevant XMPP stream error conditions specified in <span style="font-weight: bold">RFC 3920</span>, but actual XMPP stream error conditions experienced between the connection manager and the server are contained only in the "remote-stream-error" condition as described below.)</p>
+      <p class="caption">Example 30. Remote connection failed error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='terminate'
+      condition='remote-connection-failed'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+      <p class="" style="">The following values of the 'condition' attribute are defined:</p>
+      <p class="caption">Table 3: Binding Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+          <th colspan="" rowspan="">Condition</th>
+          <th colspan="" rowspan="">Purpose</th>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-gone</td>
+          <td align="" colspan="" rowspan="">The target domain specified in the 'to' attribute or the target host or port specified in the 'route' attribute is no longer serviced by the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">host-unknown</td>
+          <td align="" colspan="" rowspan="">The target domain specified in the 'to' attribute or the target host or port specified in the 'route' attribute is unknown to the connection manager.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">improper-addressing</td>
+          <td align="" colspan="" rowspan="">The initialization element lacks a 'to' or 'route' attribute (or the attribute has no value) but the connection manager requires one.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">internal-server-error</td>
+          <td align="" colspan="" rowspan="">The connection manager has experienced an internal error that prevents it from servicing the request.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">other-request</td>
+          <td align="" colspan="" rowspan="">Another request being processed at the same time as this request caused the session to terminate.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-connection-failed</td>
+          <td align="" colspan="" rowspan="">The connection manager was unable to connect to, or unable to connect securely to, or has lost its connection to, the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">remote-stream-error</td>
+          <td align="" colspan="" rowspan="">Encapsulates an XMPP stream error. The content of the binding is a copy of the content of the &lt;stream:error/&gt; element received from the XMPP server.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">see-other-uri</td>
+          <td align="" colspan="" rowspan="">The connection manager does not operate at this URI (e.g., the connection manager accepts only SSL/TLS connections at some https: URI rather than the http: URI requested by the client). The client may try POSTing to the URI in the content of the &lt;uri/&gt; child element.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">system-shutdown</td>
+          <td align="" colspan="" rowspan="">The connection manager is being shut down. All active HTTP sessions are being terminated. No new sessions can be created.</td>
+        </tr>
+        <tr class="body">
+          <td align="" colspan="" rowspan="">undefined-condition</td>
+          <td align="" colspan="" rowspan="">The error is not one of those defined herein; the connection manager SHOULD include application-specific information in the content of the &lt;body/&gt; wrapper element.</td>
+        </tr>
+      </table>
+      <p class="" style="">The following is an example of a "see-other-uri" condition:</p>
+      <p class="caption">Example 31. See other URI error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='see-other-uri'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;uri&gt;https://secure.jabber.org/xmppcm&lt;/uri&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">The following is an example of a "remote-stream-error" condition:</p>
+      <p class="caption">Example 32. Remote error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body condition='remote-stream-error'
+      type='terminate'
+      xmlns='http://jabber.org/protocol/httpbind'&gt;
+  &lt;xml-not-well-formed xmlns='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+  &lt;text xmlns='urn:ietf:params:xml:ns:xmpp-streams'
+        xml:lang='en'&gt;
+    Some special application diagnostic information!
+  &lt;/text&gt;
+  &lt;escape-your-data xmlns='application-ns'/&gt;
+&lt;/body&gt;</pre></div>
+      <p class="" style="">Naturally, the client MAY report binding errors to the connection manager as well, although this is unlikely.</p>
+    </div>
+    <div class="indent">
+<h3>14.3 <a name="errorstatus-recover">Recoverable Binding Conditions</a>
+</h3>
+      <p class="" style="">In any response it sends to the client, the connection manager MAY return a recoverable error by setting a 'type' attribute of the &lt;body/&gt; element to "error". These errors do not imply that the HTTP session is terminated.</p>
+      <p class="" style="">If it decides to recover from the error, then the client MUST repeat the HTTP request and all the preceding HTTP requests that have not received responses. The content of these requests MUST be identical to the &lt;body/&gt; elements of the original requests. This allows the connection manager to recover a session after the previous request was lost due to a communication failure.</p>
+      <p class="caption">Example 33. Recoverable error</p>
+<div class="indent"><pre>
+HTTP/1.1 200 OK
+Content-Type: text/xml; charset=utf-8
+Content-Length: 68
+
+&lt;body type='error'
+      xmlns='http://jabber.org/protocol/httpbind'/&gt;</pre></div>
+    </div>
+    <div class="indent">
+<h3>14.4 <a name="errorstatus-stanza">XMPP Stanza Conditions</a>
+</h3>
+      <p class="" style="">Application-level error conditions will normally be generated by a third entity (e.g., an IM contact) and routed to the client through the connection manager; therefore they are out of scope for the transport binding defined herein and are described in the appropriate RFC or JEP.</p>
+      <p class="" style="">However, it is possible that a connection manager will receive a stanza for delivery to a client even though the client connection is no longer active (e.g., before the connection manager is able to inform a server that the connection has died). In this case, the connection manager would return an error to the server; it is RECOMMENDED that the connection manager proceed as follows, since the situation is similar to that addressed by point #2 of Section 11.1 of <span style="font-weight: bold">RFC 3921</span>:</p>
+      <ol start="" type="">
+        <li>If the delivered stanza was &lt;presence/&gt;, silently drop the stanza and do not return an error to the sender.</li>
+        <li>If the delivered stanza was &lt;iq/&gt;, return a &lt;service-unavailable/&gt; error to the sender.</li>
+        <li>If the delivered stanza was &lt;message/&gt;, return a &lt;recipient-unavailable/&gt; error to the sender.</li>
+      </ol>
+      <p class="" style="">When a server receives a &lt;message/&gt; stanza of type "error" containing a &lt;recipient-unavailable/&gt; condition from a connection manager, it SHOULD store the message for later delivery if offline storage is enabled, otherwise route the error stanza to the sender.</p>
+    </div>
+  <h2>15.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">All communications SHOULD occur over an encrypted channel. Negotiation of channel encryption between the client and the connection manager SHOULD occur at the HTTP layer, not the application layer; such negotiation SHOULD follow the protocol defined in <span class="ref" style="">RFC 2817</span>  [<a href="#nt-id2259690">19</a>].</p>
+    <p class="" style="">The session identifier (SID) and initial request identifier (RID) are security-critical and therefore MUST be both unpredictable and nonrepeating (see <span class="ref" style="">RFC 1750</span>  [<a href="#nt-id2259669">20</a>] for recommendations regarding randomness of SIDs and initial RIDs for security purposes).</p>
+    <p class="" style="">In cases where the connection manager acts as a 'proxy' independent of the XMPP server, it creates another security vulnerability in addition to those on the XMPP servers. It is RECOMMENDED that clients ensure the security of stanzas sent through the connection manager (and XMPP servers) in both directions by encrypting them end-to-end (e.g., by establishing <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2259724">21</a>]).</p>
+  <h2>16.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259757">22</a>].</p>
+  <h2>17.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>17.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259804">23</a>] includes 'http://jabber.org/protocol/httpbind' in its registry of protocol namespaces.</p>
+    </div>
+  <h2>18.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    targetNamespace='http://jabber.org/protocol/httpbind'
+    xmlns='http://jabber.org/protocol/httpbind'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0124: http://www.jabber.org/jeps/jep-0124.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import namespace='http://etherx.jabber.org/streams'
+             schemaLocation='http://etherx.jabber.org/streams.xsd'/&gt;
+
+  &lt;xs:element name='body'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice xmlns:stream='http://etherx.jabber.org/streams'&gt;
+        &lt;xs:element ref='stream:features'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-tls'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-sasl'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='urn:ietf:params:xml:ns:xmpp-streams'
+                minOccurs='0'
+                maxOccurs='1'/&gt;
+        &lt;xs:any namespace='jabber:client'
+                minOccurs='0'
+                maxOccurs='unbounded'/&gt;
+        &lt;xs:element name='uri'
+                minOccurs='0'
+                maxOccurs='1'
+                type='xs:string'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='accept' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='authid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='charsets' type='xs:NMTOKENS' use='optional'/&gt;
+      &lt;xs:attribute name='condition' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='host-gone'/&gt;
+            &lt;xs:enumeration value='host-unknown'/&gt;
+            &lt;xs:enumeration value='improper-addressing'/&gt;
+            &lt;xs:enumeration value='internal-server-error'/&gt;
+            &lt;xs:enumeration value='remote-connection-failed'/&gt;
+            &lt;xs:enumeration value='remote-stream-error'/&gt;
+            &lt;xs:enumeration value='see-other-uri'/&gt;
+            &lt;xs:enumeration value='system-shutdown'/&gt;
+            &lt;xs:enumeration value='undefined-condition'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='content' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='hold' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='inactivity' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='key' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='newkey' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='polling' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='requests' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='rid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='route' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='secure' type='xs:boolean' use='optional' default='false'/&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='to' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+            &lt;xs:enumeration value='terminate'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='wait' type='xs:byte' use='optional'/&gt;
+      &lt;xs:attribute name='xml:lang' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250893">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250919">2</a>. RFC 793: Transmission Control Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0793.txt">http://www.ietf.org/rfc/rfc0793.txt</a>&gt;.</p>
+<p><a name="nt-id2250942">3</a>. RFC 2068: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2068.txt">http://www.ietf.org/rfc/rfc2068.txt</a>&gt;.</p>
+<p><a name="nt-id2250965">4</a>. RFC 1945: Hypertext Transfer Protocol -- HTTP/1.0 &lt;<a href="http://www.ietf.org/rfc/rfc1945.txt">http://www.ietf.org/rfc/rfc1945.txt</a>&gt;.</p>
+<p><a name="nt-id2256322">5</a>. RFC 2965: HTTP State Management Mechanism &lt;<a href="http://www.ietf.org/rfc/rfc2965.txt">http://www.ietf.org/rfc/rfc2965.txt</a>&gt;.</p>
+<p><a name="nt-id2256353">6</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2256391">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256596">8</a>. JEP-0114: Jabber Component Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0114.html">http://www.jabber.org/jeps/jep-0114.html</a>&gt;.</p>
+<p><a name="nt-id2256740">9</a>. JEP-0138: Stream Compression &lt;<a href="http://www.jabber.org/jeps/jep-0138.html">http://www.jabber.org/jeps/jep-0138.html</a>&gt;.</p>
+<p><a name="nt-id2256922">10</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2250317">11</a>. Although the syntax of the 'route' attribute bears a superficial resemblance to a URI or IRI, it is not a URI/IRI and MUST NOT be processed in accordance with the rules specified in <span style="font-weight: bold">RFC 3986</span>, <span style="font-weight: bold">RFC 3987</span>, or <span style="font-weight: bold">draft-saintandre-xmpp-iri</span>.</p>
+<p><a name="nt-id2250402">12</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p><a name="nt-id2257078">13</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2257408">14</a>. Each character set name (or character encoding name -- we use the terms interchangeably) SHOULD be of type NMTOKEN, where the names are separated by the white space character #x20, resulting in a tokenized attribute type of NMTOKENS (see Section 3.3.1 of <span class="ref" style="">XML 1.0</span>  [<a href="#nt-id2257422">15</a>]). Strictly speaking, the Character Sets registry maintained by the Internet Assigned Numbers Authority (see &lt;<a href="http://www.iana.org/assignments/character-sets">http://www.iana.org/assignments/character-sets</a>&gt;) allows a character set name to contain any printable US-ASCII character, which might include characters not allowed by the NMTOKEN construction of XML 1.0; however, the only existing character set name which includes such a character is "NF_Z_62-010_(1973)".</p>
+<p><a name="nt-id2257422">15</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p><a name="nt-id2257503">16</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p><a name="nt-id2258601">17</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2258963">18</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2259690">19</a>. RFC 2817: Upgrading to TLS Within HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2817.txt">http://www.ietf.org/rfc/rfc2817.txt</a>&gt;.</p>
+<p><a name="nt-id2259669">20</a>. RFC 1750: Randomness Recommendations for Security &lt;<a href="http://www.ietf.org/rfc/rfc1750.txt">http://www.ietf.org/rfc/rfc1750.txt</a>&gt;.</p>
+<p><a name="nt-id2259724">21</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2259757">22</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259804">23</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.4 (2005-12-14)</h4>
+<div class="indent">Modified syntax of route attribute to be proto:host:port rather than XMPP URI/IRI. (psa)
+    </div>
+<h4>Version 1.3 (2005-11-02)</h4>
+<div class="indent">Corrected stream:features namespace and the Recoverable Binding Conditions section; recommended that connection manager shall return secure attribute to client; recommended end-to-end encryption through proxy connection managers. (ip)
+    </div>
+<h4>Version 1.2 (2005-06-16)</h4>
+<div class="indent">Specified optional use of route and secure attributes in session request. Minor correction: the stream features element should be included in the response that contains the authid attribute (this is not necessarily the session creation response). (ip)
+    </div>
+<h4>Version 1.1 (2005-06-02)</h4>
+<div class="indent">Specified optional use of HTTP Accept-Encoding and Content-Encoding headers for compression at HTTP binding level. (ip)
+    </div>
+<h4>Version 1.0 (2005-03-03)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.10 (2004-11-08)</h4>
+<div class="indent">Changed HTTP 401 errors to HTTP 404. (ip)
+    </div>
+<h4>Version 0.9 (2004-10-26)</h4>
+<div class="indent">Added charset attribute. (ip/psa)
+    </div>
+<h4>Version 0.8 (2004-10-26)</h4>
+<div class="indent">Specified that wait attribute must be included in the session creation response. (ip)
+    </div>
+<h4>Version 0.7 (2004-08-12)</h4>
+<div class="indent">Defined appropriate XMPP stanza error conditions. (psa/ip)
+    </div>
+<h4>Version 0.6 (2004-07-19)</h4>
+<div class="indent">Added xml:lang attribute to the session request; added recoverable binding error conditions. (ip)
+    </div>
+<h4>Version 0.5 (2004-05-07)</h4>
+<div class="indent">Protocol refactored to enable simultaneous requests (request identifier attribute, wait attribute, hold attribute, requests attribute) and recovery of broken connections; added content attribute; removed all wrapper types except 'terminate'; updated error handling; made key mechanism optional (should use SSL/TLS instead). (ip/psa)
+    </div>
+<h4>Version 0.4 (2004-02-23)</h4>
+<div class="indent">Fixed typos; removed "resource-constraint" binding error; added HTTP 403 error to table. (psa/ip)
+    </div>
+<h4>Version 0.3 (2004-02-19)</h4>
+<div class="indent">Added 'authid' attribute to enable communication of XMPP stream ID (used in digest authentication); specified that Content-Types other than "text/xml" are allowed to support older HTTP clients; specified business rule for connection manager queueing of client requests; changed &lt;packet/&gt; to &lt;body/&gt; to support older HTTP clients; changed 'to' attribute on initialization element from MAY to SHOULD; recommended inclusion of unavailable presence in termination element sent from client; described architectural assumptions; specified binding-specific error handling. (psa/ip)
+    </div>
+<h4>Version 0.2 (2004-01-13)</h4>
+<div class="indent">Added 'to' attribute on the initialization element; specified that 'text/html' is allowable for backwards-compatibility. (dss/psa)
+    </div>
+<h4>Version 0.1 (2003-11-06)</h4>
+<div class="indent">Initial version. (dss/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0126-1.0.html
+++ b/content/xep-0126-1.0.html
@@ -1,0 +1,501 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0126: Invisibility</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Invisibility">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP describes best practices regarding implementation of invisible presence by means of XMPP privacy lists.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-03-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0126">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0126: Invisibility</h1>
+<p>This JEP describes best practices regarding implementation of invisible presence by means of XMPP privacy lists.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Informational JEP defines a best practice or protocol profile that has been approved by the Jabber Council and/or the JSF Board of Directors. Implementations are encouraged and the best practice or protocol profile is appropriate for deployment in production systems.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Informational<br>
+            Number: 0126<br>
+            Version: 1.0<br>
+            Last Updated: 2004-03-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br></p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2250435">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2250495">Requirements</a>
+</dt>
+<dt>3.  <a href="#sect-id2251147">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2251201">Log In as Globally Invisible</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2251275">Become Selectively Visible</a>
+</dt>
+<dl>
+<dt>3.2.1.  <a href="#sect-id2251316">Becoming Visible by JID</a>
+</dt>
+<dt>3.2.2.  <a href="#sect-id2251356">Becoming Visible by Roster Group</a>
+</dt>
+<dt>3.2.3.  <a href="#sect-id2255150">Becoming Visible by Subscription Type</a>
+</dt>
+</dl>
+<dt>3.3.  <a href="#sect-id2255205">Become Globally Visible</a>
+</dt>
+<dt>3.4.  <a href="#sect-id2255255">Become Selectively Invisible</a>
+</dt>
+<dl>
+<dt>3.4.1.  <a href="#sect-id2255301">Becoming Invisible by JID</a>
+</dt>
+<dt>3.4.2.  <a href="#sect-id2250080">Becoming Invisible by Roster Group</a>
+</dt>
+<dt>3.4.3.  <a href="#sect-id2250124">Becoming Invisible by Subscription Type</a>
+</dt>
+</dl>
+<dt>3.5.  <a href="#sect-id2250178">Become Globally Invisible</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2255606">Implementation Notes</a>
+</dt>
+<dt>5.  <a href="#sect-id2255699">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2255791">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2255910">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2255922">Formal Definition</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2250435">Introduction</a>
+</h2>
+  <p class="" style="">Several popular instant messaging services implement a feature known as invisibility: the ability to remain online yet appear offline to some or all of one's contacts. A number of Jabber servers and clients have also implemented such a feature, using special values of the &lt;presence/&gt; element's 'type' attribute (e.g., &lt;presence type='invisible'/&gt;). Unfortunately, such implementations are not compliant with <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250479">1</a>] and <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250470">2</a>], which specify that only the 'type' attribute values defined in the XML schema for the 'jabber:client' and 'jabber:server' namespaces are allowed in XMPP (and those values do not include "invisible"). However, <span style="font-weight: bold">XMPP IM</span> also defines a privacy lists protocol (i.e., the 'jabber:iq:privacy' namespace) that can be used to implement invisibility in an XMPP-compliant manner. This JEP documents how to do just that.</p>
+<h2>2.
+       <a name="sect-id2250495">Requirements</a>
+</h2>
+  <p class="" style="">This document addresses the following requirements:</p>
+  <ul>
+    <li>Enable users to appear visible or invisible to some or all contacts at any time.</li>
+    <li>Enable users to selectively change visibility based on roster group, subscription state, or individual JID.</li>
+    <li>Do so in an XMPP-compliant manner.</li>
+  </ul>
+<h2>3.
+       <a name="sect-id2251147">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP addresses the following use cases:</p>
+  <ol start="" type="">
+    <li>Log In as Globally Invisible</li>
+    <li>Become Selectively Visible</li>
+    <li>Become Globally Visible</li>
+    <li>Become Selectively Invisible</li>
+    <li>Become Globally Invisible</li>
+  </ol>
+  <p class="" style="">These use cases are defined below in "chronological" order by following a scenario in which a user (1) logs in as invisible, (2) becomes selectively visible to certain contacts, (3) becomes visible to all contacts, (4) becomes selectively invisible to certain contacts, and finally (5) becomes invisible to all contacts.</p>
+  <div class="indent">
+<h3>3.1 <a name="sect-id2251201">Log In as Globally Invisible</a>
+</h3>
+    <p class="" style="">If a user wants to log in as invisible, a certain order of events MUST be followed. Specifically, after authenticating but before sending initial presence, the user MUST define (if necessary) and set as active a privacy list that blocks all outbound presence notifications.</p>
+    <p class="caption">Example 1. User Defines and Sets Global Invisibility Privacy Rule</p>
+<div class="indent"><pre>
+... authentication / session establishment ...
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='inv1'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='invisible'&gt;
+      &lt;item action='deny' order='1'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+    &lt;/list&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active1'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='invisible'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the user could have defined this list during a previous session and could simply set the relevant list as active when logging in, rather than defining the list on login. Both steps are shown here for completeness.</p>
+    <p class="" style="">The user may now send initial presence to the server.</p>
+    <p class="caption">Example 2. User Sends Initial Presence</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;status&gt;I'm not really here, you understand!&lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Even though the user has sent initial presence, that presence information will not be broadcasted to any of the user's contacts, since the active privacy list blocks all outbound presence notifications.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sect-id2251275">Become Selectively Visible</a>
+</h3>
+    <p class="" style="">Let us now suppose that the user tires of being globally invisible, and decides to become visible to some -- but not all -- contacts (not even famous magic rings possess this feature). The 'jabber:iq:privacy' namespace gives the user three options:</p>
+    <ul>
+      <li>become visible only to specific JIDs</li>
+      <li>become visible only to specific roster groups</li>
+      <li>become visible based on subscription state</li>
+    </ul>
+    <p class="" style="">Examples of these options are shown below.</p>
+    <div class="indent">
+<h3>3.2.1 <a name="sect-id2251316">Becoming Visible by JID</a>
+</h3>
+      <p class="caption">Example 3. User Defines and Sets Selective Visibility Privacy Rule (by JID)</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='inv2'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='visible-to-Frodo'&gt;
+      &lt;item type='jid'
+            value='frodo@tolkien.lit'
+            action='allow'
+            order='1'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+      &lt;item action='deny' order='2'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+    &lt;/list&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active2'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='visible-to-Frodo'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The foregoing privacy list blocks outbound presence notifications to every JID except one. In order to ensure synchronization of presence notifications, the client SHOULD now send the user's last available presence to any active resources associated with the selected JID:</p>
+      <p class="caption">Example 4. Client Sends Last Available Presence</p>
+<div class="indent"><pre>
+&lt;presence from='bilbo@tolkien.net/shire'
+          to='frodo@tolkien.lit/garden'&gt;
+  &lt;status&gt;I'm not really here, you understand!&lt;/status&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.2.2 <a name="sect-id2251356">Becoming Visible by Roster Group</a>
+</h3>
+      <p class="caption">Example 5. User Defines and Sets Selective Visibility Privacy Rule (by Roster Group)</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='inv3'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='visible-to-Bagginses'&gt;
+      &lt;item type='group'
+            value='Bagginses'
+            action='allow'
+            order='1'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+      &lt;item action='deny' order='2'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+    &lt;/list&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active3'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='visible-to-Bagginses'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The foregoing privacy list blocks outbound presence notifications to every JID except those in a certain roster group. In order to ensure synchronization of presence notifications, the client SHOULD now send the user's last available presence to any active resources associated with JIDs in that group:</p>
+      <p class="caption">Example 6. Client Sends Last Available Presence</p>
+<div class="indent"><pre>
+&lt;presence from='bilbo@tolkien.net/shire'
+          to='frodo@tolkien.lit/garden'&gt;
+  &lt;status&gt;I'm not really here, you understand!&lt;/status&gt;
+&lt;/presence&gt;
+
+&lt;presence from='bilbo@tolkien.net/shire'
+          to='bungo@tolkien.lit/pub'&gt;
+  &lt;status&gt;I'm not really here, you understand!&lt;/status&gt;
+&lt;/presence&gt;
+
+&lt;presence from='bilbo@tolkien.net/shire'
+          to='rosa.baggins@tolkien.lit/home'&gt;
+  &lt;status&gt;I'm not really here, you understand!&lt;/status&gt;
+&lt;/presence&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.2.3 <a name="sect-id2255150">Becoming Visible by Subscription Type</a>
+</h3>
+      <p class="" style="">Becoming visible or invisible by subscription type is probably much less likely than becoming visible by JID or roster group; however, it is described here for the sake of completeness.</p>
+      <p class="caption">Example 7. User Defines and Sets Selective Visibility Privacy Rule (by Subscription State)</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='inv4'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='visible-to-both'&gt;
+      &lt;item type='subscription'
+            value='both'
+            action='allow'
+            order='1'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+      &lt;item action='deny' order='2'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+    &lt;/list&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active4'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='visible-to-both'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The foregoing privacy list blocks outbound presence notifications to every JID except those that are in the user's roster with a subscription type of "both". Outbound presence notifications are sent accordingly.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="sect-id2255205">Become Globally Visible</a>
+</h3>
+    <p class="" style="">Let us now suppose that the user wants to become visible to all those who are subscribed to his presence. This easy to do by defining and setting as active a new privacy list (here again, the privacy list may have been defined previously).</p>
+    <p class="caption">Example 8. User Defines and Sets Global Visibility Privacy Rule</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='inv5'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='visible'&gt;
+      &lt;item action='allow' order='1'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+    &lt;/list&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active5'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='visible'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Because globally allowing outbound presence notifications is most likely the default behavior of any server, a more straightforward way to become globally visible is to decline the use of any active rule (the equivalent, as it were, of taking off a magic invisibility ring):</p>
+    <p class="caption">Example 9. User Declines the Use of Any Active Rule</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active6'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="sect-id2255255">Become Selectively Invisible</a>
+</h3>
+    <p class="" style="">Let us now suppose that the user no longer wants to be globally visible, but desires to be invisible only to some -- but not all -- contacts. As with visibility, here again the 'jabber:iq:privacy' namespace gives the user three options:</p>
+    <ul>
+      <li>Become invisible only to specific JIDs</li>
+      <li>Become invisible only to specific roster groups</li>
+      <li>Become invisible based on subscription state</li>
+    </ul>
+    <p class="" style="">Examples of these options are shown below.</p>
+    <div class="indent">
+<h3>3.4.1 <a name="sect-id2255301">Becoming Invisible by JID</a>
+</h3>
+      <p class="caption">Example 10. User Defines and Sets Selective Invisibility Privacy Rule (by JID)</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='inv6'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='invisible-to-Gandalf'&gt;
+      &lt;item type='jid'
+            value='gandalf@tolkien.lit'
+            action='deny'
+            order='1'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+      &lt;item action='allow' order='2'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+    &lt;/list&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active7'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='invisible-to-Gandalf'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The foregoing privacy list allows outbound presence notifications to every JID except one. In order to ensure synchronization of presence notifications, the client SHOULD now send unavailable presence from the user to any active resources associated with the selected JID:</p>
+      <p class="caption">Example 11. Client Sends Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence from='bilbo@tolkien.net/shire'
+          to='gandalf@tolkien.lit/forest'
+          type='unavailable'/&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.4.2 <a name="sect-id2250080">Becoming Invisible by Roster Group</a>
+</h3>
+      <p class="caption">Example 12. User Defines and Sets Selective Invisibility Privacy Rule (by Roster Group)</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='inv7'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='invisible-to-Wizards'&gt;
+      &lt;item type='group'
+            value='Wizards'
+            action='deny'
+            order='1'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+      &lt;item action='allow' order='2'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+    &lt;/list&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active8'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='invisible-to-Wizards'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The foregoing privacy list allows outbound presence notifications to every JID except those in a certain roster group. In order to ensure synchronization of presence notifications, the client SHOULD now send unavailable presence from the user to any active resources associated with JIDs in that group:</p>
+      <p class="caption">Example 13. Client Sends Unavailable Presence</p>
+<div class="indent"><pre>
+&lt;presence from='bilbo@tolkien.net/shire'
+          to='gandalf@tolkien.lit/forest'
+          type='unavailable'/&gt;
+
+&lt;presence from='bilbo@tolkien.net/shire'
+          to='sauramon@tolkien.lit/chamber'
+          type='unavailable'/&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.4.3 <a name="sect-id2250124">Becoming Invisible by Subscription Type</a>
+</h3>
+      <p class="" style="">Becoming visible or invisible by subscription type is probably much less likely than becoming visible by JID or roster group; however, it is described here for the sake of completeness.</p>
+      <p class="caption">Example 14. User Defines and Sets Selective Invisibility Privacy Rule (by Subscription State)</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='inv8'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='invisible-to-from'&gt;
+      &lt;item type='subscription'
+            value='from'
+            action='deny'
+            order='1'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+      &lt;item action='allow' order='2'&gt;
+        &lt;presence-out/&gt;
+      &lt;/item&gt;
+    &lt;/list&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active9'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='invisible-to-from'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The foregoing privacy list allows outbound presence notifications to every JID except those that are in the user's roster with a subscription type of "to". Outbound presence stanzas of type "unavailable" are sent accordingly.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="sect-id2250178">Become Globally Invisible</a>
+</h3>
+    <p class="" style="">In order to become globally invisible again, the user simply sets as active the global invisibility list previously defined:</p>
+    <p class="caption">Example 15. User Becomes Globally Invisible</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' type='set' id='active10'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;active name='invisible'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="sect-id2255606">Implementation Notes</a>
+</h2>
+  <p class="" style="">The foregoing text explains the protocol used to implement invisibility. Naturally, client developers will most likely want to hide these protocol details from the end user. For example, rather than forcing the end user to navigate the details of privacy list management, a client could simply provide a "Go Invisible" button that sets as active the appropriate privacy list.</p>
+  <p class="" style="">Note well that the privacy lists used to implement invisibility SHOULD be active lists and <span style="font-style: italic">not</span> the default list.</p>
+  <p class="" style="">To help ensure cross-client compatibility, it is RECOMMENDED to use the privacy list names "visible" and "invisible" for simple global visibility and invisibility respectively. It is also RECOMMENDED to use list names of the form "visible-to-GroupName" and "invisible-to-JID" for simple lists that implement visibility or invisibility with regard to roster groups and JIDs. Obviously list names could become rather complex, such as "visible-to-Group1 Group2 Group3". Implementations MUST NOT attempt to derive semantic meaning from privacy list names; these recommendations are provided for ease of use only with regard to basic privacy lists related to visibility/invisibility.</p>
+  <p class="" style="">In general it is probably easiest for users to become visible/invisible either globally or based on roster group, since these models are conceptually simple. Although, naturally, a client developer cannot tell users what to do, it probably best to encourage the use of conceptually simple models for privacy lists.</p>
+  <p class="" style="">Privacy lists can become complex and must be carefully managed by clients. For example, let us imagine that the user is currently applying another active list unrelated to visibility (e.g., a list that blocks communications with a stalker); if the user then clicks "Go Invisible" and the client is not smart, it could overwrite the stalker blocking. Therefore, if the user has an active list that incorporates rules other than those related to visibility/invisibility, the client SHOULD either assume that visibility/invisibility is an overlay on the list currently in use (generating an appropriate privacy list that takes both into account) or prompt the user regarding their intentions. In the absence of privacy lists unrelated to visibility/invisibility, the client may proceed in a less cautious fashion.</p>
+<h2>5.
+       <a name="sect-id2255699">Security Considerations</a>
+</h2>
+  <p class="" style="">For security concerns related to privacy lists, refer to <span style="font-weight: bold">XMPP IM</span>. Care must be taken regarding privacy lists, especially so that visibility/invisibility rules do not overwrite existing rules the user has set for the sake of security and privacy; see the "Implementation Notes" for details.</p>
+  <p class="" style="">It is important to recognize that invisibility can be defeated without more advanced privacy lists than those defined above and an awareness of context on the part of a client. For example, a contact can send an IQ request to a user's usual full JID using <span class="ref" style="">Last Activity</span>  [<a href="#nt-id2255755">3</a>], <span class="ref" style="">Entity Time</span>  [<a href="#nt-id2255778">4</a>], or <span class="ref" style="">Software Version</span>  [<a href="#nt-id2255801">5</a>] and receive a reply, thus providing information that reveals the user's availability. In addition, <span style="font-weight: bold">Last Activity</span> requests to the user's bare JID will normally reveal the user's availability as well. To help ensure that the user's invisibility cannot be defeated in this way, the user's client SHOULD add IQ blocking to the relevant privacy list. Finally, the user's client SHOULD NOT return "is-composing" events as defined in <span class="ref" style="">Message Events</span>  [<a href="#nt-id2255830">6</a>] or <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2255852">7</a>].</p>
+<h2>6.
+       <a name="sect-id2255791">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255872">8</a>].</p>
+<h2>7.
+       <a name="sect-id2255910">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255931">9</a>] as a result of this JEP.</p>
+<h2>8.
+       <a name="sect-id2255922">Formal Definition</a>
+</h2>
+  <p class="" style="">The XML schema for the 'jabber:iq:privacy' namespace is contained in <span style="font-weight: bold">XMPP IM</span>.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2250479">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250470">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255755">3</a>. JEP-0012: Last Activity &lt;<a href="http://www.jabber.org/jeps/jep-0012.html">http://www.jabber.org/jeps/jep-0012.html</a>&gt;.</p>
+<p><a name="nt-id2255778">4</a>. JEP-0090: Entity Time &lt;<a href="http://www.jabber.org/jeps/jep-0090.html">http://www.jabber.org/jeps/jep-0090.html</a>&gt;.</p>
+<p><a name="nt-id2255801">5</a>. JEP-0092: Software Version &lt;<a href="http://www.jabber.org/jeps/jep-0092.html">http://www.jabber.org/jeps/jep-0092.html</a>&gt;.</p>
+<p><a name="nt-id2255830">6</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2255852">7</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2255872">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255931">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2004-03-05)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Active. (psa)
+    </div>
+<h4>Version 0.4 (2004-02-10)</h4>
+<div class="indent">Minor editorial clarifications. (psa)
+    </div>
+<h4>Version 0.3 (2004-01-22)</h4>
+<div class="indent">Added client responsibility for sending last available or unavailable presence. (psa)
+    </div>
+<h4>Version 0.2 (2004-01-21)</h4>
+<div class="indent">Added more detail to the Security Considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-01-08)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0127-0.1.html
+++ b/content/xep-0127-0.1.html
@@ -1,0 +1,312 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0127: Common Alerting Protocol (CAP) Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Common Alerting Protocol (CAP) Over XMPP">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Boyd Fletcher">
+<meta name="DC.Description" content="This JEP specifies a method for sending Common Alerting Protocol (CAP) data over Jabber/XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-02-23">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0127">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0127: Common Alerting Protocol (CAP) Over XMPP</h1>
+<p>This JEP specifies a method for sending Common Alerting Protocol (CAP) data over Jabber/XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0127<br>
+            Version: 0.1<br>
+            Last Updated: 2004-02-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, Common Alerting Protocol<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: None<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Boyd Fletcher</h3>
+<p class="indent">
+        Email: Boyd.Fletcher@je.jfcom.mil<br>
+        JID: bfletcher@jabber.com</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2596003">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596171">Terminology</a>
+</dt>
+<dt>3.  <a href="#sect-id2596088">Protocol</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2596399">Direct Messages</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2596252">PubSub</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2595916">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2595944">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2595821">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2602175">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2596003">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Common Alerting Protocol</span>  [<a href="#nt-id2596030">1</a>] (CAP) is an open format for alerts and notifications, defined by <span class="ref">OASIS</span>  [<a href="#nt-id2596162">2</a>]. CAP was developed to address the call, published in a (U.S.) National Science and Technology Council report, for &quot;a standard method ... to collect and relay instantaneously and automatically all types of hazard warnings and reports&quot;. Given that the Extensible Messaging and Presence Protocol (XMPP) provides a near-real-time transport mechanism for structured information, and that CAP is defined as an XML data format, it makes sense to define a way to transport CAP information over XMPP. Such a method is defined herein.</p>
+<h2>2.
+       <a name="sect-id2596171">Terminology</a>
+</h2>
+  <p class="" style="">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in <span class="ref">RFC 2119</span>  [<a href="#nt-id2596106">3</a>].</p>
+<h2>3.
+       <a name="sect-id2596088">Protocol</a>
+</h2>
+  <p class="" style="">Because the alerts and notifications structured via CAP require a &quot;push&quot; medium, they SHOULD be sent via the XML &lt;message/&gt; stanza defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2596263">4</a>]. The message could be (1) sent directly from the sender to a recipient or list of recipients (which might include a <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596356">5</a>] room) via standard XMPP messaging or (2) published to a list of subscribers via <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596384">6</a>]. Both methods are described below.</p>
+  <div class="indent">
+<h3>3.1 <a name="sect-id2596399">Direct Messages</a>
+</h3>
+    <p class="" style="">In the case of direct messages, the message stanza SHOULD have no 'type' attribute, but MAY have any defined type that is appropriate to the communications context (e.g., &quot;groupchat&quot; in a text conference). The &lt;alert/&gt; element SHOULD be the only child element of the message stanza, but other elements MAY be included as necessary (e.g., a &lt;body/&gt; child in the 'jabber:client' namespace providing a natural-language description of the alert). The 'id' attribute of the &lt;message/&gt; stanza MAY be set to the value of the CAP &lt;identifier/&gt; element.</p>
+    <p class="" style="">The following example shows Example A.2 from the CAP specification sent as a direct message.</p>
+    <p class="caption">Example 1. An Alert Sent as a Message</p>
+<div class="indent"><pre>
+&lt;message from='KSTO@NWS.NOAA.GOV' 
+         to='weatherbot@jabber.org'
+         id='KSTO1055887203'&gt;
+  &lt;alert xmlns='http://www.incident.com/cap/1.0'
+    &lt;identifier&gt;KSTO1055887203&lt;/identifier&gt;
+    &lt;sender&gt;KSTO@NWS.NOAA.GOV&lt;/sender&gt;
+    &lt;sent&gt;2003-06-17T14:57:00-07:00&lt;/sent&gt;
+    &lt;status&gt;Actual&lt;/status&gt;
+    &lt;msgType&gt;Alert&lt;/msgType&gt;
+    &lt;scope&gt;Public&lt;/scope&gt;
+    &lt;info&gt;
+      &lt;category&gt;Met&lt;/category&gt;
+      &lt;event&gt;SEVERE THUNDERSTORM&lt;/event&gt;
+      &lt;urgency&gt;Severe&lt;/urgency&gt;
+      &lt;certainty&gt;Likely&lt;/certainty&gt;
+      &lt;eventCode&gt;same=SVR&lt;/eventCode&gt;
+      &lt;senderName&gt;NATIONAL WEATHER SERVICE SACRAMENTO&lt;/senderName&gt;
+      &lt;headline&gt;SEVERE THUNDERSTORM WARNING&lt;/headline&gt;
+      &lt;description&gt;
+        AT 254 PM PDT... NATIONAL WEATHER SERVICE DOPPLER RADAR 
+        INDICATED A SEVERE THUNDERSTORM OVER SOUTH CENTRAL ALPINE 
+        COUNTY... OR ABOUT 18 MILES SOUTHEAST OF KIRKWOOD... 
+        MOVING SOUTHWEST AT 5 MPH. HAIL... INTENSE RAIN AND STRONG 
+        DAMAGING WINDS ARE LIKELY WITH THIS STORM
+      &lt;/description&gt;
+      &lt;instruction&gt;
+        TAKE COVER IN A SUBSTANTIAL SHELTER UNTIL THE STORM PASSES
+      &lt;/instruction&gt;
+      &lt;contact&gt;BARUFFALDI/JUSKIE&lt;/contact&gt;
+      &lt;area&gt;
+        &lt;areaDesc&gt;
+          EXTREME NORTH CENTRAL TUOLUMNE COUNTY IN CALIFORNIA, 
+          EXTREME NORTHEASTERN CALAVERAS COUNTY IN CALIFORNIA,
+          SOUTHWESTERN ALPINE COUNTY IN CALIFORNIA
+        &lt;/areaDesc&gt;
+        &lt;polygon&gt;
+          38.47,-120.14 38.34,-119.95 38.52,-119.74 
+          38.62,-119.89 38.47,-120.14
+        &lt;/polygon&gt;
+        &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+        &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+        &lt;geocode&gt;fips6=006103&lt;/geocode&gt;
+      &lt;/area&gt;
+    &lt;/info&gt;
+  &lt;/alert&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sect-id2596252">PubSub</a>
+</h3>
+    <p class="" style="">The publish-subscribe protocol defined in JEP-0060 provides a way to send information to a number of subscribers, and to control the list of subscribers.</p>
+    <p class="" style="">The following example shows Example A.2 from the CAP specification published to a pubsub node.</p>
+    <p class="caption">Example 2. An Alert Published to a PubSub Node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='KSTO@NWS.NOAA.GOV'
+    to='pubsub.jabber.org'
+    id='someID'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='NOAA-ALERTS'&gt;
+      &lt;item id='KSTO1055887203'&gt;
+        &lt;alert xmlns='http://www.incident.com/cap/1.0'
+          &lt;identifier&gt;KSTO1055887203&lt;/identifier&gt;
+          &lt;sender&gt;KSTO@NWS.NOAA.GOV&lt;/sender&gt;
+          &lt;sent&gt;2003-06-17T14:57:00-07:00&lt;/sent&gt;
+          &lt;status&gt;Actual&lt;/status&gt;
+          &lt;msgType&gt;Alert&lt;/msgType&gt;
+          &lt;scope&gt;Public&lt;/scope&gt;
+          &lt;info&gt;
+            &lt;category&gt;Met&lt;/category&gt;
+            &lt;event&gt;SEVERE THUNDERSTORM&lt;/event&gt;
+            &lt;urgency&gt;Severe&lt;/urgency&gt;
+            &lt;certainty&gt;Likely&lt;/certainty&gt;
+            &lt;eventCode&gt;same=SVR&lt;/eventCode&gt;
+            &lt;senderName&gt;NATIONAL WEATHER SERVICE SACRAMENTO&lt;/senderName&gt;
+            &lt;headline&gt;SEVERE THUNDERSTORM WARNING&lt;/headline&gt;
+            &lt;description&gt;
+              AT 254 PM PDT... NATIONAL WEATHER SERVICE DOPPLER RADAR 
+              INDICATED A SEVERE THUNDERSTORM OVER SOUTH CENTRAL ALPINE 
+              COUNTY... OR ABOUT 18 MILES SOUTHEAST OF KIRKWOOD... 
+              MOVING SOUTHWEST AT 5 MPH. HAIL... INTENSE RAIN AND STRONG 
+              DAMAGING WINDS ARE LIKELY WITH THIS STORM
+            &lt;/description&gt;
+            &lt;instruction&gt;
+              TAKE COVER IN A SUBSTANTIAL SHELTER UNTIL THE STORM PASSES
+            &lt;/instruction&gt;
+            &lt;contact&gt;BARUFFALDI/JUSKIE&lt;/contact&gt;
+            &lt;area&gt;
+              &lt;areaDesc&gt;
+                EXTREME NORTH CENTRAL TUOLUMNE COUNTY IN CALIFORNIA, 
+                EXTREME NORTHEASTERN CALAVERAS COUNTY IN CALIFORNIA,
+                SOUTHWESTERN ALPINE COUNTY IN CALIFORNIA
+              &lt;/areaDesc&gt;
+              &lt;polygon&gt;
+                38.47,-120.14 38.34,-119.95 38.52,-119.74 
+                38.62,-119.89 38.47,-120.14
+              &lt;/polygon&gt;
+              &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+              &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+              &lt;geocode&gt;fips6=006103&lt;/geocode&gt;
+            &lt;/area&gt;
+          &lt;/info&gt;
+        &lt;/alert&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the pubsub node is configured to deliver payloads to all subscribers, the information is then sent to all subscribers.</p>
+    <p class="caption">Example 3. An Alert Sent as a PubSub Payload</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.jabber.org'
+         to='weatherbot@jabber.org'&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;NOAA-ALERTS&quot;&gt;
+      &lt;alert xmlns='http://www.incident.com/cap/1.0'
+        &lt;identifier&gt;KSTO1055887203&lt;/identifier&gt;
+        &lt;sender&gt;KSTO@NWS.NOAA.GOV&lt;/sender&gt;
+        &lt;sent&gt;2003-06-17T14:57:00-07:00&lt;/sent&gt;
+        &lt;status&gt;Actual&lt;/status&gt;
+        &lt;msgType&gt;Alert&lt;/msgType&gt;
+        &lt;scope&gt;Public&lt;/scope&gt;
+        &lt;info&gt;
+          &lt;category&gt;Met&lt;/category&gt;
+          &lt;event&gt;SEVERE THUNDERSTORM&lt;/event&gt;
+          &lt;urgency&gt;Severe&lt;/urgency&gt;
+          &lt;certainty&gt;Likely&lt;/certainty&gt;
+          &lt;eventCode&gt;same=SVR&lt;/eventCode&gt;
+          &lt;senderName&gt;NATIONAL WEATHER SERVICE SACRAMENTO&lt;/senderName&gt;
+          &lt;headline&gt;SEVERE THUNDERSTORM WARNING&lt;/headline&gt;
+          &lt;description&gt;
+            AT 254 PM PDT... NATIONAL WEATHER SERVICE DOPPLER RADAR 
+            INDICATED A SEVERE THUNDERSTORM OVER SOUTH CENTRAL ALPINE 
+            COUNTY... OR ABOUT 18 MILES SOUTHEAST OF KIRKWOOD... 
+            MOVING SOUTHWEST AT 5 MPH. HAIL... INTENSE RAIN AND STRONG 
+            DAMAGING WINDS ARE LIKELY WITH THIS STORM
+          &lt;/description&gt;
+          &lt;instruction&gt;
+            TAKE COVER IN A SUBSTANTIAL SHELTER UNTIL THE STORM PASSES
+          &lt;/instruction&gt;
+          &lt;contact&gt;BARUFFALDI/JUSKIE&lt;/contact&gt;
+          &lt;area&gt;
+            &lt;areaDesc&gt;
+              EXTREME NORTH CENTRAL TUOLUMNE COUNTY IN CALIFORNIA, 
+              EXTREME NORTHEASTERN CALAVERAS COUNTY IN CALIFORNIA,
+              SOUTHWESTERN ALPINE COUNTY IN CALIFORNIA
+            &lt;/areaDesc&gt;
+            &lt;polygon&gt;
+              38.47,-120.14 38.34,-119.95 38.52,-119.74 
+              38.62,-119.89 38.47,-120.14
+            &lt;/polygon&gt;
+            &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+            &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+            &lt;geocode&gt;fips6=006103&lt;/geocode&gt;
+          &lt;/area&gt;
+        &lt;/info&gt;
+      &lt;/alert&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="sect-id2595916">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP are defined in <span style="font-weight: bold">XMPP Core</span>; security considerations for CAP are defined in <span style="font-weight: bold">Common Alerting Protocol, v. 1.0</span>.</p>
+<h2>5.
+       <a name="sect-id2595944">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2595843">7</a>].</p>
+<h2>6.
+       <a name="sect-id2595821">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602269">8</a>] as a result of this JEP.</p>
+<h2>7.
+       <a name="sect-id2602175">XML Schema</a>
+</h2>
+  <p class="" style="">The CAP information format is defined by an XML schema. The reader is referred to the CAP specification for the relevant schema definition.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596030">1</a>. Common Alerting Protocol, v. 1.0 &lt;<a href="http://www.oasis-open.org/committees/documents.php?wg_abbrev=emergency">http://www.oasis-open.org/committees/documents.php?wg_abbrev=emergency</a>&gt;.</p>
+<p>
+<a name="nt-id2596162">2</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596106">3</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596263">4</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596356">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596384">6</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595843">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602269">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-02-23)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0127-0.2.html
+++ b/content/xep-0127-0.2.html
@@ -1,0 +1,325 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0127: Common Alerting Protocol (CAP) Over XMPP</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Common Alerting Protocol (CAP) Over XMPP">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Boyd Fletcher">
+<meta name="DC.Description" content="This JEP specifies a method for sending Common Alerting Protocol (CAP) data over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0127">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0127: Common Alerting Protocol (CAP) Over XMPP</h1>
+<p>This JEP specifies a method for sending Common Alerting Protocol (CAP) data over XMPP.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0127<br>
+            Version: 0.2<br>
+            Last Updated: 2004-11-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, Common Alerting Protocol<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: None<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Boyd Fletcher</h3>
+<p class="indent">
+        Email: Boyd.Fletcher@je.jfcom.mil<br>
+        JID: bfletcher@jabber.com</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2596035">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596108">Terminology</a>
+</dt>
+<dt>3.  <a href="#sect-id2596157">Protocol</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2596290">Direct Messages</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2596380">PubSub</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2595923">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2595824">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2595868">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2602304">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2596035">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Common Alerting Protocol</span>  [<a href="#nt-id2596174">1</a>] (CAP) is an open format for alerts and notifications, defined by <span class="ref">OASIS</span>  [<a href="#nt-id2596194">2</a>]. CAP was developed to address the call, published in a (U.S.) National Science and Technology Council report, for &quot;a standard method ... to collect and relay instantaneously and automatically all types of hazard warnings and reports&quot;. Given that the Extensible Messaging and Presence Protocol (see <span class="ref">XMPP Core</span>  [<a href="#nt-id2596093">3</a>]) provides a near-real-time transport mechanism for structured information, and that CAP is defined as an XML data format, it makes sense to define a way to transport CAP information over XMPP. Such a method is defined herein.</p>
+<h2>2.
+       <a name="sect-id2596108">Terminology</a>
+</h2>
+  <p class="" style="">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in <span class="ref">RFC 2119</span>  [<a href="#nt-id2596141">4</a>].</p>
+<h2>3.
+       <a name="sect-id2596157">Protocol</a>
+</h2>
+  <p class="" style="">Because the alerts and notifications structured via CAP require a &quot;push&quot; medium, they SHOULD be sent via the XML &lt;message/&gt; stanza defined in <span style="font-weight: bold">XMPP Core</span>. The message could be sent using either of the following methods:</p>
+  <ol start="" type="">
+    <li>Directly from the sender to a single recipient, a list of recipients (using <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2596390">5</a>]), or a <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596409">6</a>] room</li>
+    <li>Published to a list of subscribers via <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596274">7</a>]</li>
+  </ol>
+  <p class="" style="">Both methods are described below.</p>
+  <div class="indent">
+<h3>3.1 <a name="sect-id2596290">Direct Messages</a>
+</h3>
+    <p class="" style="">In the case of direct messages, the message stanza SHOULD have no 'type' attribute, but MAY have any defined type that is appropriate to the communications context (e.g., &quot;groupchat&quot; in a text conference). The &lt;alert/&gt; element SHOULD be the only child element of the message stanza, but other elements MAY be included as necessary (e.g., a &lt;body/&gt; child in the 'jabber:client' namespace providing a natural-language description of the alert). The 'id' attribute of the &lt;message/&gt; stanza MAY be set to the value of the CAP &lt;identifier/&gt; element.</p>
+    <p class="" style="">The following example shows Example A.2 from the CAP specification sent as a direct message.</p>
+    <p class="caption">Example 1. An Alert Sent as a Message</p>
+<div class="indent"><pre>
+&lt;message from='KSTO@NWS.NOAA.GOV' 
+         to='weatherbot@jabber.org'
+         id='KSTO1055887203'&gt;
+  &lt;alert xmlns='http://www.incident.com/cap/1.0'&gt;
+    &lt;identifier&gt;KSTO1055887203&lt;/identifier&gt;
+    &lt;sender&gt;KSTO@NWS.NOAA.GOV&lt;/sender&gt;
+    &lt;sent&gt;2003-06-17T14:57:00-07:00&lt;/sent&gt;
+    &lt;status&gt;Actual&lt;/status&gt;
+    &lt;msgType&gt;Alert&lt;/msgType&gt;
+    &lt;scope&gt;Public&lt;/scope&gt;
+    &lt;info&gt;
+      &lt;category&gt;Met&lt;/category&gt;
+      &lt;event&gt;SEVERE THUNDERSTORM&lt;/event&gt;
+      &lt;urgency&gt;Severe&lt;/urgency&gt;
+      &lt;certainty&gt;Likely&lt;/certainty&gt;
+      &lt;eventCode&gt;same=SVR&lt;/eventCode&gt;
+      &lt;senderName&gt;NATIONAL WEATHER SERVICE SACRAMENTO&lt;/senderName&gt;
+      &lt;headline&gt;SEVERE THUNDERSTORM WARNING&lt;/headline&gt;
+      &lt;description&gt;
+        AT 254 PM PDT... NATIONAL WEATHER SERVICE DOPPLER RADAR 
+        INDICATED A SEVERE THUNDERSTORM OVER SOUTH CENTRAL ALPINE 
+        COUNTY... OR ABOUT 18 MILES SOUTHEAST OF KIRKWOOD... 
+        MOVING SOUTHWEST AT 5 MPH. HAIL... INTENSE RAIN AND STRONG 
+        DAMAGING WINDS ARE LIKELY WITH THIS STORM
+      &lt;/description&gt;
+      &lt;instruction&gt;
+        TAKE COVER IN A SUBSTANTIAL SHELTER UNTIL THE STORM PASSES
+      &lt;/instruction&gt;
+      &lt;contact&gt;BARUFFALDI/JUSKIE&lt;/contact&gt;
+      &lt;area&gt;
+        &lt;areaDesc&gt;
+          EXTREME NORTH CENTRAL TUOLUMNE COUNTY IN CALIFORNIA, 
+          EXTREME NORTHEASTERN CALAVERAS COUNTY IN CALIFORNIA,
+          SOUTHWESTERN ALPINE COUNTY IN CALIFORNIA
+        &lt;/areaDesc&gt;
+        &lt;polygon&gt;
+          38.47,-120.14 38.34,-119.95 38.52,-119.74 
+          38.62,-119.89 38.47,-120.14
+        &lt;/polygon&gt;
+        &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+        &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+        &lt;geocode&gt;fips6=006103&lt;/geocode&gt;
+      &lt;/area&gt;
+    &lt;/info&gt;
+  &lt;/alert&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sect-id2596380">PubSub</a>
+</h3>
+    <p class="" style="">The publish-subscribe protocol defined in JEP-0060 provides a way to send information to a number of subscribers, and to control the list of subscribers.</p>
+    <p class="" style="">The following example shows Example A.2 from the CAP specification published to a pubsub node.</p>
+    <p class="caption">Example 2. An Alert Published to a PubSub Node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='KSTO@NWS.NOAA.GOV'
+    to='pubsub.jabber.org'
+    id='someID'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='NOAA-ALERTS'&gt;
+      &lt;item id='KSTO1055887203'&gt;
+        &lt;alert xmlns='http://www.incident.com/cap/1.0'&gt;
+          &lt;identifier&gt;KSTO1055887203&lt;/identifier&gt;
+          &lt;sender&gt;KSTO@NWS.NOAA.GOV&lt;/sender&gt;
+          &lt;sent&gt;2003-06-17T14:57:00-07:00&lt;/sent&gt;
+          &lt;status&gt;Actual&lt;/status&gt;
+          &lt;msgType&gt;Alert&lt;/msgType&gt;
+          &lt;scope&gt;Public&lt;/scope&gt;
+          &lt;info&gt;
+            &lt;category&gt;Met&lt;/category&gt;
+            &lt;event&gt;SEVERE THUNDERSTORM&lt;/event&gt;
+            &lt;urgency&gt;Severe&lt;/urgency&gt;
+            &lt;certainty&gt;Likely&lt;/certainty&gt;
+            &lt;eventCode&gt;same=SVR&lt;/eventCode&gt;
+            &lt;senderName&gt;NATIONAL WEATHER SERVICE SACRAMENTO&lt;/senderName&gt;
+            &lt;headline&gt;SEVERE THUNDERSTORM WARNING&lt;/headline&gt;
+            &lt;description&gt;
+              AT 254 PM PDT... NATIONAL WEATHER SERVICE DOPPLER RADAR 
+              INDICATED A SEVERE THUNDERSTORM OVER SOUTH CENTRAL ALPINE 
+              COUNTY... OR ABOUT 18 MILES SOUTHEAST OF KIRKWOOD... 
+              MOVING SOUTHWEST AT 5 MPH. HAIL... INTENSE RAIN AND STRONG 
+              DAMAGING WINDS ARE LIKELY WITH THIS STORM
+            &lt;/description&gt;
+            &lt;instruction&gt;
+              TAKE COVER IN A SUBSTANTIAL SHELTER UNTIL THE STORM PASSES
+            &lt;/instruction&gt;
+            &lt;contact&gt;BARUFFALDI/JUSKIE&lt;/contact&gt;
+            &lt;area&gt;
+              &lt;areaDesc&gt;
+                EXTREME NORTH CENTRAL TUOLUMNE COUNTY IN CALIFORNIA, 
+                EXTREME NORTHEASTERN CALAVERAS COUNTY IN CALIFORNIA,
+                SOUTHWESTERN ALPINE COUNTY IN CALIFORNIA
+              &lt;/areaDesc&gt;
+              &lt;polygon&gt;
+                38.47,-120.14 38.34,-119.95 38.52,-119.74 
+                38.62,-119.89 38.47,-120.14
+              &lt;/polygon&gt;
+              &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+              &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+              &lt;geocode&gt;fips6=006103&lt;/geocode&gt;
+            &lt;/area&gt;
+          &lt;/info&gt;
+        &lt;/alert&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the pubsub node is configured to deliver payloads, the information is then sent to all subscribers.</p>
+    <p class="caption">Example 3. An Alert Sent as a PubSub Payload</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.jabber.org'
+         to='weatherbot@jabber.org'&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;NOAA-ALERTS&quot;&gt;
+      &lt;alert xmlns='http://www.incident.com/cap/1.0'&gt;
+        &lt;identifier&gt;KSTO1055887203&lt;/identifier&gt;
+        &lt;sender&gt;KSTO@NWS.NOAA.GOV&lt;/sender&gt;
+        &lt;sent&gt;2003-06-17T14:57:00-07:00&lt;/sent&gt;
+        &lt;status&gt;Actual&lt;/status&gt;
+        &lt;msgType&gt;Alert&lt;/msgType&gt;
+        &lt;scope&gt;Public&lt;/scope&gt;
+        &lt;info&gt;
+          &lt;category&gt;Met&lt;/category&gt;
+          &lt;event&gt;SEVERE THUNDERSTORM&lt;/event&gt;
+          &lt;urgency&gt;Severe&lt;/urgency&gt;
+          &lt;certainty&gt;Likely&lt;/certainty&gt;
+          &lt;eventCode&gt;same=SVR&lt;/eventCode&gt;
+          &lt;senderName&gt;NATIONAL WEATHER SERVICE SACRAMENTO&lt;/senderName&gt;
+          &lt;headline&gt;SEVERE THUNDERSTORM WARNING&lt;/headline&gt;
+          &lt;description&gt;
+            AT 254 PM PDT... NATIONAL WEATHER SERVICE DOPPLER RADAR 
+            INDICATED A SEVERE THUNDERSTORM OVER SOUTH CENTRAL ALPINE 
+            COUNTY... OR ABOUT 18 MILES SOUTHEAST OF KIRKWOOD... 
+            MOVING SOUTHWEST AT 5 MPH. HAIL... INTENSE RAIN AND STRONG 
+            DAMAGING WINDS ARE LIKELY WITH THIS STORM
+          &lt;/description&gt;
+          &lt;instruction&gt;
+            TAKE COVER IN A SUBSTANTIAL SHELTER UNTIL THE STORM PASSES
+          &lt;/instruction&gt;
+          &lt;contact&gt;BARUFFALDI/JUSKIE&lt;/contact&gt;
+          &lt;area&gt;
+            &lt;areaDesc&gt;
+              EXTREME NORTH CENTRAL TUOLUMNE COUNTY IN CALIFORNIA, 
+              EXTREME NORTHEASTERN CALAVERAS COUNTY IN CALIFORNIA,
+              SOUTHWESTERN ALPINE COUNTY IN CALIFORNIA
+            &lt;/areaDesc&gt;
+            &lt;polygon&gt;
+              38.47,-120.14 38.34,-119.95 38.52,-119.74 
+              38.62,-119.89 38.47,-120.14
+            &lt;/polygon&gt;
+            &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+            &lt;geocode&gt;fips6=006109&lt;/geocode&gt;
+            &lt;geocode&gt;fips6=006103&lt;/geocode&gt;
+          &lt;/area&gt;
+        &lt;/info&gt;
+      &lt;/alert&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="sect-id2595923">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for CAP are defined in <span style="font-weight: bold">Common Alerting Protocol, v. 1.0</span>; security considerations for XMPP are defined in <span style="font-weight: bold">RFC 3920: XMPP Core</span>; security considerations for the XMPP publish-subscribe extension are defined in <span style="font-weight: bold">JEP-0060: Publish Subscribe</span>.</p>
+  <p class="" style="">Furthermore, it may be appropriate to include the &quot;Classification&quot;, &quot;Distribute&quot;, and/or &quot;Store&quot; headers specified in <span class="ref">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2595844">8</a>] in order to safeguard CAP data.</p>
+<h2>5.
+       <a name="sect-id2595824">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602377">9</a>].</p>
+<h2>6.
+       <a name="sect-id2595868">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602322">10</a>] as a result of this JEP.</p>
+<h2>7.
+       <a name="sect-id2602304">XML Schema</a>
+</h2>
+  <p class="" style="">The CAP information format is defined by an XML schema. The reader is referred to the CAP specification for the relevant schema definition.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596174">1</a>. Common Alerting Protocol, v. 1.0 &lt;<a href="http://www.oasis-open.org/committees/documents.php?wg_abbrev=emergency">http://www.oasis-open.org/committees/documents.php?wg_abbrev=emergency</a>&gt;.</p>
+<p>
+<a name="nt-id2596194">2</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596093">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596141">4</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596390">5</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596409">6</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596274">7</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595844">8</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602377">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602322">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-11-09)</h4>
+<div class="indent">Added references to JEP-0033 and JEP-0131. (psa)
+    </div>
+<h4>Version 0.1 (2004-02-23)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0128-0.2.html
+++ b/content/xep-0128-0.2.html
@@ -1,0 +1,240 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0128: Service Discovery Extensions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Discovery Extensions">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies best practices for including extended information in Service Discovery results.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-03-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0128">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0128: Service Discovery Extensions</h1>
+<p>This JEP specifies best practices for including extended information in Service Discovery results.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0128<br>
+            Version: 0.2<br>
+            Last Updated: 2004-03-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004, JEP-0030, JEP-0068<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#recommendations">Recommendations</a>
+</dt>
+<dt>3.  <a href="#examples">Examples</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#examples-server">IM Server</a>
+</dt>
+<dt>3.2.  <a href="#examples-muc">Multi-User Chat Room</a>
+</dt>
+</dl>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Developers periodically wonder why <span class="ref">Service Discovery</span>  [<a href="#nt-id2595976">1</a>] does not include more bits of information. For example, why does the &lt;identity/&gt; element not include a 'description' attribute, and can we add one now? The answer is: well, it just doesn't, and at this point it's too late to make further changes (since JEP-0030 is Final). So the best approach is to specify a well-defined extension mechanism.</p>
+  <p class="" style="">Let us consider an example. A <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596042">2</a>] room might want to include additional information in its service discovery results, such as the full room description, the current discussion topic (room subject), the number of occupants in the room, and the JID of the room owner.</p>
+  <p class="" style="">Adding one new attribute to the service discovery schema (even if that were an option) would not solve the problem, since a MUC service might want to provide certain bits of information, whereas a <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596080">3</a>] service might want to provide other bits.</p>
+  <p class="" style="">A better solution would be to include extended information qualified by a namespace that provides a way to flexibly define structured data formats. Thankfully, we already possess such a protocol: <span class="ref">Data Forms</span>  [<a href="#nt-id2596113">4</a>]. In addition, we possess a way to define common fields used in data forms: <span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2596133">5</a>]. Using these building blocks, we can define some best practices for extending service discovery results.</p>
+<h2>2.
+       <a name="recommendations">Recommendations</a>
+</h2>
+  <p class="" style="">If an entity desires to provide extended information about itself in an IQ results stanza within the context of the <span style="font-weight: bold">Service Discovery</span> protocol, it SHOULD do so by including each bit of information as the XML character data of the &lt;value/&gt; child of a distinct &lt;field/&gt; element, with the entire set of fields contained within an &lt;x/&gt; element of type &quot;result&quot; qualified by the 'jabber:x:data' namespace; this &lt;x/&gt; element SHOULD be a child of the &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/disco#info' namespace. Thus the IQ result SHOULD be of the following form:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;x type='result' xmlns='jabber:x:data'&gt;
+      &lt;field var='[var-name]' label='[optional]'&gt;
+        &lt;value&gt;[var-value]&lt;/value&gt;
+      &lt;/field&gt;
+      ...
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;</pre></div>
+  <p class="" style="">Note: A &lt;field/&gt; element MAY contain more than one &lt;value/&gt; child if appropriate.</p>
+  <p class="" style="">If the data fields are to be used in the context of a protocol approved by the Jabber Software Foundation, they SHOULD be described in the relevant Jabber Enhancement Proposal and registered in accordance with the rules defined in JEP-0068, resulting in the inclusion of a &lt;field/&gt; element whose 'var' attribute has a value of &quot;FORM_TYPE&quot; and whose 'type' attribute has a value of &quot;hidden&quot;.</p>
+  <p class="" style="">An entity MUST NOT supply extended information about associated children communicated via the 'http://jabber.org/protocol/disco#items' namespace, since a core principle of <span style="font-weight: bold">Service Discovery</span> is that an entity must define its own identity only and must not define the identity of any children associated with the entity.</p>
+<h2>3.
+       <a name="examples">Examples</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="examples-server">IM Server</a>
+</h3>
+    <p class="" style="">The following is an example of including a disco extension in the IQ result sent by a standard instant messaging server.</p>
+    <p class="caption">Example 1. Entity Queries Server for Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='capulet.com'
+    to='shakespeare.lit'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='shakespeare.lit'
+    to='capulet.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='server'
+        type='im'
+        name='shakespeare.lit jabber server'/&gt;
+    &lt;feature var='jabber:iq:register'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/network/serverinfo&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='c2s_port'&gt;
+        &lt;value&gt;5222&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='c2s_port_ssl'&gt;
+        &lt;value&gt;5223&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http_access'&gt;
+        &lt;value&gt;http://shakespeare.lit/jabber&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='ip_version'&gt;
+        &lt;value&gt;ipv4&lt;/value&gt;
+        &lt;value&gt;ipv6&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='info_url'&gt;
+        &lt;value&gt;http://shakespeare.lit/support.php&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="examples-muc">Multi-User Chat Room</a>
+</h3>
+    <p class="" style="">The following is an example of including a disco extension in the IQ result sent by a Multi-User Chat room.</p>
+    <p class="caption">Example 2. User Queries Room for Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='hag66@shakespeare.lit/pda'
+    to='darkcave@macbeth.shakespeare.lit'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='darkcave@macbeth.shakespeare.lit'
+    to='hag66@shakespeare.lit/pda'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity
+        category='conference'
+        type='text'
+        name='A Dark Cave'/&gt;
+    &lt;feature var='http://jabber.org/protocol/muc'/&gt;
+    &lt;feature var='jabber:iq:register'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#roominfo&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_description' label='Description'&gt;
+        &lt;value&gt;The place for all good witches!&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_subject' label='Subject'&gt;
+        &lt;value&gt;Spells&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_occupants' label='Number of occupants'&gt;
+        &lt;value&gt;3&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='muc#roominfo_lang' label='Language of discussion'&gt;
+        &lt;value&gt;en&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Applications SHOULD ensure that information disclosed in a disco extension is appropriate for discovery by any entity on the network.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2601966">6</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2601905">7</a>]; however, JEPs following the best practices defined herein may register FORM_TYPEs and field values with the Jabber Registrar.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595976">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596042">2</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596080">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596113">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596133">5</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601966">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601905">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-03-15)</h4>
+<div class="indent">Clarified syntax and corrected several errors; added IM server example. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-05)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0130-0.3.html
+++ b/content/xep-0130-0.3.html
@@ -1,0 +1,1016 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0130: Waiting Lists</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Waiting Lists">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Yehezkel Dallal">
+<meta name="DC.Creator" content="Alexandre Nolle">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Mark Troyer">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a &quot;waiting list&quot; and be informed when the contact creates an IM account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0130">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0130: Waiting Lists</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a &quot;waiting list&quot; and be informed when the contact creates an IM account.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0130<br>
+            Version: 0.3<br>
+            Last Updated: 2004-09-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: waitlist<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Yehezkel Dallal</h3>
+<p class="indent">
+        Email: yehezkeld@followap.com<br>
+</p>
+<h3>Alexandre Nolle</h3>
+<p class="indent">
+        Email: anolle@francetelecom.com<br>
+</p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jean-louis.seguineau@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+<h3>Mark Troyer</h3>
+<p class="indent">
+        Email: mtroyer@jabber.com<br>
+        JID: mtroyer@corp.jabber.com</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#imuser-retrieve">IM User Retrieves Current Waiting List</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#imuser-retrieve-primary">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#imuser-retrieve-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#imuser-add">IM User Adds Contact to Waiting List</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#imuser-add-primary">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#imuser-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#imuser-remove">IM User Removes Contact from Waiting List</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#imuser-remove-primary">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#imuser-remove-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-imuser">IM User Interaction With WaitingListService</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#protocol-imuser-retrieve">IM User Retrieves Current Waiting List</a>
+</dt>
+<dt>5.1.2.  <a href="#protocol-imuser-add">IM User Adds Contact to Waiting List</a>
+</dt>
+<dt>5.1.3.  <a href="#protocol-imuser-remove">IM User Removes Contact from Waiting List</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#protocol-service">WaitingListService Interaction With InteropPartners</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current Waiting List</a>
+</dt>
+<dt>5.2.2.  <a href="#protocol-service-add">ServiceProvider's WaitingListService Adds Contact to Waiting List</a>
+</dt>
+<dt>5.2.3.  <a href="#protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from Waiting List</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">An IM user may want to be informed when a contact creates an IM account. If the user knows some information about the contact (e.g., a phone number or email address), the user's service can use that information to place the contact on a &quot;waiting list&quot;, then inform the user when the contact creates an IM account. This document defines an extension to <span class="ref">XMPP Core</span>  [<a href="#nt-id2595921">1</a>] and <span class="ref">XMPP IM</span>  [<a href="#nt-id2595943">2</a>] that enables such &quot;waiting list&quot; functionality, including the ability to add contacts on other domains if service providers agree to interoperate (e.g., to add a contact who uses a different mobile telephony service provider).</p>
+    <p class="" style=""><span style="font-style: italic">Note: The protocol defined herein is currently in use at several large service providers in Europe. Others are welcome to use the protocol.</span></p>
+  <h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+    <p class="caption">Table 1: Terms Used</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Contact</td>
+        <td align="" colspan="" rowspan="">A person with whom an IM User seeks to communicate, identified by a URI such as tel:phone-number (see <span class="ref">RFC 3966</span>  [<a href="#nt-id2596301">3</a>]) or mailto:email-address (see <span class="ref">RFC 2368</span>  [<a href="#nt-id2596330">4</a>]).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">IM User</td>
+        <td align="" colspan="" rowspan="">Any Customer who has registered for instant messaging services.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">InteropPartner</td>
+        <td align="" colspan="" rowspan="">Any company that agrees to interoperate using the protocol defined herein.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">JID</td>
+        <td align="" colspan="" rowspan="">The unique identifier of an IM User in the XMPP protocol. Outside the context of an IM session, a JID is of the form &lt;user@domain&gt; (&quot;bare JID&quot;); within the context of an IM session, a JID is of the form &lt;user@domain/resource&gt; (&quot;full JID&quot;).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ServiceProvider</td>
+        <td align="" colspan="" rowspan="">A company that provides telephony or email services to a Customer.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">URI</td>
+        <td align="" colspan="" rowspan="">A Uniform Resource Identifier as defined in <span class="ref">RFC 3986</span>  [<a href="#nt-id2596393">5</a>]. Specific URI schemes that may be useful in this specification incldue 'tel:', 'mailto:', and 'sip:', but any URI scheme may be used.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Waiting List</td>
+        <td align="" colspan="" rowspan="">A list of contacts whom an entity (IM User or ServiceProvider) is waiting to hear about regarding their status as instant messaging users.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">WaitingListService</td>
+        <td align="" colspan="" rowspan="">An XMPP service that maintains waiting lists for IM Users and/or InteropPartners.</td>
+      </tr>
+    </table>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This protocol MUST enable an IM user to:</p>
+    <ol start="1" type="1">
+      <li>Request the user's current waiting list</li>
+      <li>Add a contact to a local waiting list (based on some URI associated with the contact)</li>
+      <li>Receive notification from a local waiting list service if the contact has (or subsequently creates) an IM account</li>
+      <li>Remove a contact from the waiting list</li>
+    </ol>
+    <p class="" style="">In addition, this protocol MUST enable a service provider to:</p>
+    <ol start="1" type="1">
+      <li>Request the service's current waiting list</li>
+      <li>Add a contact to a waiting list at an interoperability partner (based on some URI associated with the contact)</li>
+      <li>Receive notification from the interoperability partner if the contact has (or subsequently creates) an IM account</li>
+      <li>Remove a contact from the waiting list</li>
+    </ol>
+  <h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="imuser-retrieve">IM User Retrieves Current Waiting List</a>
+</h3>
+      <p class="" style="">Before adding or removing contacts from its waiting list, an IM User SHOULD retrieve its current waiting list. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.1.1 <a name="imuser-retrieve-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User discovers WaitingListService hosted by ServiceProvider [A1]; it is RECOMMENDED to do this immediately after logging in.</li>
+          <li>IM User requests current Waiting List from WaitingListService.</li>
+          <li>WaitingListService returns Waiting List to IM User, including any items for which JIDs have been discovered [A2].</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.1.2 <a name="imuser-retrieve-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>ServiceProvider does not host a WaitingListService:
+          <ol start="1" type="1">
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>IM User does not have a Waiting List:
+          <ol start="1" type="1">
+              <li>WaitingListService returns &quot;Not Found&quot; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="imuser-add">IM User Adds Contact to Waiting List</a>
+</h3>
+      <p class="" style="">An IM User may know a Contact's URI but not the Contact's JID. In order to subscribe to the Contact's presence or otherwise communicate with the Contact over an instant messaging system, the IM user first needs to discover the Contact's JID based on the Contact's URI phone number or email address. However, the Contact may not yet have an IM account. Because the IM User may therefore need to wait until the Contact creates an account, the IM User needs to add the Contact to a &quot;waiting list&quot;. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.2.1 <a name="imuser-add-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User SHOULD first complete use case for &quot;IM User Retrieves Current Waiting List&quot;.</li>
+          <li>IM User requests addition of Contact to Waiting List based on Contact's URI.</li>
+          <li>WaitingListService determines that the URI scheme is supported [A1].</li>
+          <li>WaitingListService determines that the information provided is a valid URI for that URI scheme [A2].</li>
+          <li>WaitingListService acknowledges addition of Contact to IM User's Waiting List.</li>
+          <li>WaitingListService determines that Contact's URI does not belong to a person served by ServiceProvider [A3].</li>
+          <li>WaitingListService discovers WaitingListServices hosted by one or more InteropPartners.</li>
+          <li>WaitingListService queries one or more InteropPartner's WaitingListServices for JID associated with URI.</li>
+          <li>InteropPartner's WaitingListService determines that Contact's URI belongs to a person served by that partner [A4].</li>
+          <li>InteropPartner's WaitingListService determines that Contact is an IM User [A5].</li>
+          <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of JID associated with Contact's URI. [A6]</li>
+          <li>ServiceProvider's WaitingListService informs IM User of Contact's JID. [A8]</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.2.2 <a name="imuser-add-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>The URI scheme is not supported:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &quot;Bad Request&quot; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>The information provided is not a valid URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &quot;Bad Request&quot; or &quot;Remote Server Error&quot; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>URI belongs to person served by ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService determines that Contact is an IM User registered with ServiceProvider [A7].</li>
+              <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+              <li>WaitingListService informs IM User of Contact's JID.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>URI does not belong to a person served by InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner sends &quot;Not Found&quot; error to WaitingListService.</li>
+              <li>If all InteropPartners queried return &quot;Not Found&quot; error, WaitingListService sends &quot;Not Found&quot; error (or local equivalent) to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner records WaitingListService's request for JID associated with URI.</li>
+              <li>OPTIONALLY, InteropPartner invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>InteropPartner informs Service Provider's WaitingListService of JID associated with Contact's URI.</li>
+              <li>ServiceProvider's WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact denies request:
+            <ol start="1" type="1">
+              <li>InteropPartner's WaitingListService sends &quot;Not Authorized&quot; error to ServiceProvider's WaitingListService.</li>
+              <li>ServiceProvider's WaitingListService sends &quot;Not Authorized&quot; error (or local equivalent) to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService records IM User's request for JID associated with URI.</li>
+              <li>OPTIONALLY, WaitingListService invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact's URI is not handled by any ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI that no InteropPartner services Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3 <a name="imuser-remove">IM User Removes Contact from Waiting List</a>
+</h3>
+      <p class="" style="">An IM User may want to remove an item from its waiting list.</p>
+      <div class="indent">
+<h3>4.3.1 <a name="imuser-remove-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User sends removal request to WaitingListService.</li>
+          <li>WaitingListService removes IM User's request for JID associated with URI.</li>
+          <li>WaitingListService informs IM User of successful removal [A1].</li>
+          <li>WaitingListService sends removal request to appropriate InteropPartner's WaitingListService [A2].</li>
+          <li>InteropPartner's WaitingListService determines that URI belongs to a person served by that partner.</li>
+          <li>InteropPartner's WaitingListService removes ServiceProvider's WaitingListService's request for JID.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of successful removal.</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.3.2 <a name="imuser-remove-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User never requested JID associated with URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &quot;Not Found&quot; error to IM User.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact URI is served by WaitingListService or IM User was not the only person who requested the JID:
+            <ol start="1" type="1">
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+  <h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="protocol-imuser">IM User Interaction With WaitingListService</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document is provided for the sake of domains that implement XMPP as their local protocol; domains that implement another protocol will use their service-specific protocol to complete the user-to-domain interaction. Support for the protocol defined in this section is NOT REQUIRED for services that do not implement XMPP as their local protocol.</span>
+      </p>
+      <div class="indent">
+<h3>5.1.1 <a name="protocol-imuser-retrieve">IM User Retrieves Current Waiting List</a>
+</h3>
+        <p class="" style="">It is RECOMMENDED for an IM User's client to retrieve the waiting list immediately after logging in. However, first it must discover its local WaitingListService.</p>
+        <p class="caption">Example 1. IM User Discovers WaitingListService by Sending Agents Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 2. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.service-provider.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. IM User Discovers WaitingListService by Sending Service Discovery Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 4. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 5. IM User Queries WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The WaitingListService SHOULD return detailed information about the service it provides, including URI schemes supported.</p>
+        <p class="caption">Example 6. WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory'
+              type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/mailto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/tel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Once an IM User has discovered the WaitingListService, the user's client SHOULD request its current waiting list:</p>
+        <p class="caption">Example 7. IM User Requests its Current Waiting List</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Upon request, the WaitingListService MUST return the current waiting list to the IM User:</p>
+        <p class="caption">Example 8. WaitingListService Returns Waiting List to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Each ItemID MUST be unique within the scope of the client's waiting list items. The value of the ItemID is an opaque string; an implementation MAY assign semantic meaning to the ItemID (e.g., id=&quot;John Smith (mobile)&quot; rather than id=&quot;12345&quot;), but such meaning is implementation-specific and outside the scope of the waiting list protocol itself. The user MAY include a &lt;name/&gt; element containing a natural-language name for the contact.</p>
+        <p class="" style="">The Waiting List MAY contain an item for which a JID has been discovered.</p>
+        <p class="caption">Example 9. IM User Asks for its Waiting List including Newly Discovered JID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='jidask1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345' jid='stpeter@jabber.org'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.2 <a name="protocol-imuser-add">IM User Adds Contact to Waiting List</a>
+</h3>
+        <p class="" style="">Once an IM User's client has discovered the WaitingListService and requested the user's waiting list, the user can add Contacts to the waiting list based on the Contact's URI. (Note: This JEP uses the example of phone numbers via the 'tel' URI scheme, but the same rules apply to waiting list items based on email addresses or other URI schemes.)</p>
+        <p class="caption">Example 10. IM User Requests Addition of Contact to Waiting List</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='waitlist.service-provider.com'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided an invalid Phone Number (e.g., too many digits) or Email Address (e.g., no '@' character), WaitingListService sends &quot;Not Acceptable&quot; error to IM User.</p>
+        <p class="caption">Example 11. WaitingListService Returns &quot;Not Acceptable&quot; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">(For information about error syntax, refer to <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2603504">6</a>].)</p>
+        <p class="" style="">If the IM User included a JID in the request, WaitingListService sends &quot;Bad Request&quot; error to IM User. (Note: A WaitingListService MUST NOT return a non-XMPP URI to an IM User based on the Contact's JID; see Security Considerations.)</p>
+        <p class="caption">Example 12. WaitingListService Returns &quot;Bad Request&quot; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item jid='some-jid'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If neither of the previous two errors was generated, WaitingListService informs IM User that request was successfully received, including unique ID number for the new waiting list item.</p>
+        <p class="caption">Example 13. WaitingListService Informs IM User that Request was Received</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided a URI that is not served by an InteropPartner (e.g., a phone number associated with a telephony provider that is not in the WaitingListService's whitelist of InteropPartners), WaitingListService MAY send a &quot;Remote Server Error&quot; error to IM User.</p>
+        <p class="caption">Example 14. WaitingListService Returns &quot;Remote Server Error&quot; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='502' type='wait'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID when the IQ result is returned to the user, it MAY include the waiting list item in the IQ result:</p>
+        <p class="caption">Example 15. WaitingListService Returns IQ Result to IM User (With Contact JID)</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID (or learns Contact JID from InteropPartner), it MUST inform IM User via &quot;JID push&quot; message:</p>
+        <p class="caption">Example 16. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;This message contains a waiting list item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">Note: The JID push uses &lt;message/&gt; because the WaitingListService has no knowledge of the user's presence and therefore cannot assume that an IQ will be received by the user at a specific resource.</p>
+        <p class="" style="">If WaitingListService learns that Contact's URI is not handled by any InteropPartner, it SHOULD inform IM User via &quot;JID push&quot; message:</p>
+        <p class="caption">Example 17. WaitingListService Informs IM User that No InteropPartner Handles Contact's URI</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;Sorry, we cannot find this contact.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' 
+          jid='contact@service-provider.com'
+          type='error'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+      &lt;error code='404' 
+             type='cancel'
+             xmlns='jabber:client'&gt;
+        &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;/error&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">In order to remove the item from the waiting list, the IM User MUST complete the &quot;Remove Contact from Waiting List&quot; use case.</p>
+      </div>
+      <div class="indent">
+<h3>5.1.3 <a name="protocol-imuser-remove">IM User Removes Contact from Waiting List</a>
+</h3>
+        <p class="caption">Example 18. IM User Sends Removal Request to WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='remove1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService previously recorded request, WaitingListService removes request from list and returns result to IM User.</p>
+        <p class="caption">Example 19. WaitingListService Returns Result to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='remove1'/&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService did not previously record this request, WaitingListService sends &quot;Not Found&quot; error to IM User.</p>
+        <p class="caption">Example 20. WaitingListService Returns &quot;Not Found&quot; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>5.2 <a name="protocol-service">WaitingListService Interaction With InteropPartners</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document describes the inter-domain protocol for communication between WaitingListServices. The protocol defined in this section MUST be implemented by service providers.</span>
+      </p>
+      <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a &quot;whitelist&quot; of InteropPartner's WaitingListServices with which it communicates. Therefore service discovery SHOULD NOT be necessary. However, if necessary it MAY use either the Agents Information protocol or the Service Discovery protocol as described in the following examples.</p>
+      <p class="" style="">Note: The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</p>
+      <div class="indent">
+<h3>5.2.1 <a name="protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current Waiting List</a>
+</h3>
+        <p class="caption">Example 21. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Agents Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 22. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.interop-partner.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 23. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Service Discovery Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 24. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 25. Service Provider Queries InteropPartner's WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 26. InteropPartner's WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory'
+              type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.2.2 <a name="protocol-service-add">ServiceProvider's WaitingListService Adds Contact to Waiting List</a>
+</h3>
+        <p class="" style="">Once a ServiceProvider's WaitingListService has discovered the InteropPartner's WaitingListService and requested its waiting list, the ServiceProvider's WaitingListService can add items to its waiting list based on URI.</p>
+        <p class="caption">Example 27. ServiceProvider's WaitingListService Adds New Item to Waiting List</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is not associated with a person served by this InteropPartner, InteropPartner sends &quot;Not Found&quot; error to ServiceProvider.</p>
+        <p class="caption">Example 28. InteropPartner Returns &quot;Not Found&quot; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is associated with a person served by this InteropPartner, InteropPartner sends acknowledgement of waiting list addition to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 29. InteropPartner's WaitingListService Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact is an IM User served by InteropPartner, InteropPartner's WaitingListService pushes Contact's JID to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 30. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 31. ServiceProvider's WaitingListService Acknowledges Receipt of JID Push</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='jidpush4'/&gt;
+        </pre></div>
+        <p class="" style="">After receiving acknowledgement (but not before), InteropPartner's WaitingListService MUST remove that item from the waiting list for the ServiceProvider's WaitingListService.</p>
+      </div>
+      <div class="indent">
+<h3>5.2.3 <a name="protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from Waiting List</a>
+</h3>
+        <p class="caption">Example 32. ServiceProvider Requests Removal of Item from Waiting List</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='remove2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If item exists on waiting list, InteropPartner's WaitingListService removes item from list and returns result to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 33. InteropPartner Returns Result to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'/&gt;
+        </pre></div>
+        <p class="" style="">If item does not exist on waiting list, InteropPartner's WaitingListService sends &quot;Not Found&quot; error to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 34. InteropPartner Returns &quot;Not Found&quot; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <ol start="1" type="1">
+      <li>Protocols and mechanisms for inviting a Contact to register as an IM User are out of scope for this proposal and shall be determined by each InteropPartner individually.</li>
+      <li>A ServiceProvider's WaitingListService MUST record which of its IM Users have requested the JID associated with Contact's URI, and an InteropPartner's WaitingListService MUST record that Service Provider's WaitingListService (not User) has requested JID associated with Contact's URI. Therefore when Contact registers, InteropPartner's WaitingListService informs its local users as well as ServiceProvider's WaitingListService, and ServiceProvider's WaitingListService informs its local users.</li>
+      <li>The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</li>
+      <li>Once an IM User learns a Contact's JID, the IM User MAY send a normal subscription request to the Contact, setting the &quot;to&quot; address to Contact's JID. This interaction is defined in the base XMPP specifications and is out of scope for this document.</li>
+      <li>Implementations MUST support the older <span class="ref">Agent Information</span>  [<a href="#nt-id2604207">7</a>] protocol and SHOULD support <span class="ref">Service Discovery</span>  [<a href="#nt-id2604228">8</a>]. Note well that the Agent Information protocol will eventually be deprecated in favor of Service Discovery.</li>
+      <li>An IM User's client receives waiting list information either via a &quot;JID push&quot; message (received from WaitingListService at any time) or in the IQ result received after requesting the waiting list (since one or more of the waiting list items may contain a JID). (The same rule applies to a ServiceProvider's WaitingListService that receives an IQ set from an InteropPartner's WaitingListService.)</li>
+      <li>When an IM User logs in, the user's client SHOULD request the current waiting list.</li>
+      <li>Although the examples in this JEP show the hostname of the WaitingListService as 'waitlist.third-party.com' (etc.), this is for convenience only; the hostname MAY be any valid DNS hostname.</li>
+      <li>When sending JID pushes, an implementation MAY specify a message type of 'headline', which in some deployments will prevent such messages from being stored offline for later delivery.</li>
+    </ol>
+  <h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a &quot;whitelist&quot; of InteropPartners with which it communicates. The WaitingListService SHOULD NOT communicate with any InteropPartners that are not on the whitelist.</p>
+    <p class="" style="">Requesting JIDs via waiting lists is not bidirectional; i.e., a service MUST NOT allow an IM User to discover a Contact's non-XMPP URI based on the Contact's JID.</p>
+    <p class="" style="">A service MAY require a Contact to approve the disclosure of the contact's JID, either as a global preference or for each request; however, this is a local policy matter.</p>
+  <h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2604353">9</a>].</p>
+  <h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2604292">10</a>] shall register the 'http://jabber.org/protocol/waitinglist' namespace as a result of this JEP.</p>
+    <p class="" style="">For use in Service Discovery, supported URI schemes SHOULD be registered using namespace names of the form 'http://jabber.org/protocol/waitlist/schemes/SCHEME-NAME'. This JEP registers the following two namespace names for URI schemes, but others MAY be registered in the future using standard registration procedures:</p>
+    <ul>
+      <li>http://jabber.org/protocol/waitlist/schemes/mailto</li>
+      <li>http://jabber.org/protocol/waitlist/schemes/tel</li>
+    </ul>
+  <h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="" style="">The following schema is descriptive, not normative.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/waitinglist'
+    xmlns='http://jabber.org/protocol/waitinglist'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='1'&gt;&gt;
+        &lt;xs:sequence xmlns:xmpp='jabber:client'&gt;
+          &lt;xs:element ref='uri' minOccurs='1' maxOccurs='1'/&gt;
+          &lt;xs:element ref='name' minOccurs='0' maxOccurs='1'/&gt;
+          &lt;xs:element ref='xmpp:error' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element ref='remove'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='jid'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='type'
+                    use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='uri' type='xs:string'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='scheme'
+                    type='xs:NCNAME'
+                    use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='name' type='string1023'/&gt;
+
+  &lt;xs:element name='remove' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='string1023'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:maxLength value='1023'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595921">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595943">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596301">3</a>. RFC 3966: The tel URI for Telephone Numbers &lt;<a href="http://www.ietf.org/rfc/rfc3966.txt">http://www.ietf.org/rfc/rfc3966.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596330">4</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596393">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603504">6</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604207">7</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604228">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2604353">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2604292">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2004-09-27)</h4>
+<div class="indent">Corrected error syntax used when Contact URI is not handled by any InteropPartner. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-03)</h4>
+<div class="indent">Added alternate flow for situation in which Contact URI is not handled by any InteropPartner; changed headline message type for JID pushes from SHOULD to MAY; clarified semantics of item ID; added name child of item; corrected and updated the XML schema; updated examples to use XMPP error conditions. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-18)</h4>
+<div class="indent">Initial version (see XML source for earlier revisions). (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0130-0.4.html
+++ b/content/xep-0130-0.4.html
@@ -1,0 +1,1032 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0130: Waiting Lists</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Waiting Lists">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Yehezkel Dallal">
+<meta name="DC.Creator" content="Alexandre Nolle">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Mark Troyer">
+<meta name="DC.Description" content='This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a "waiting list" and be informed when the contact creates an IM account.'>
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0130">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0130: Waiting Lists</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a "waiting list" and be informed when the contact creates an IM account.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0130<br>
+            Version: 0.4<br>
+            Last Updated: 2005-04-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0094, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: waitlist<br></p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Yehezkel Dallal</h3>
+<p class="indent">
+        Email: yehezkeld@followap.com<br></p>
+<h3>Alexandre Nolle</h3>
+<p class="indent">
+        Email: anolle@francetelecom.com<br></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jean-louis.seguineau@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+<h3>Mark Troyer</h3>
+<p class="indent">
+        Email: mtroyer@jabber.com<br>
+        JID: mtroyer@corp.jabber.com</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#imuser-retrieve-primary">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#imuser-retrieve-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#imuser-add-primary">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#imuser-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#imuser-remove-primary">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#imuser-remove-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-imuser">IM User Interaction With WaitingListService</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dt>5.1.2.  <a href="#protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dt>5.1.3.  <a href="#protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#protocol-service">WaitingListService Interaction With InteropPartners</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</dt>
+<dt>5.2.2.  <a href="#protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</dt>
+<dt>5.2.3.  <a href="#protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-identities">Service Discovery Identities</a>
+</dt>
+<dt>9.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">An IM user may want to be informed when a contact creates an IM account. If the user knows some information about the contact (e.g., a phone number or email address), the user's service can use that information to place the contact on a "waiting list", then inform the user when the contact creates an IM account. This document defines an extension to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251140">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2251201">2</a>] that enables such "waiting list" functionality, including the ability to add contacts on other domains if service providers agree to interoperate (e.g., to add a contact who uses a different mobile telephony service provider).</p>
+    <p class="" style=""><span style="font-style: italic">Note: The protocol defined herein is currently in use at several large service providers in Europe. Others are welcome to use the protocol.</span></p>
+  <h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+    <p class="caption">Table 1: Terms Used</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Contact</td>
+        <td align="" colspan="" rowspan="">A person with whom an IM User seeks to communicate, identified by a URI such as &lt;tel:PhoneNumber&gt; (see <span class="ref" style="">RFC 3966</span>  [<a href="#nt-id2251287">3</a>]) or &lt;mailto:EmailAddress&gt; (see <span class="ref" style="">RFC 2368</span>  [<a href="#nt-id2251310">4</a>]).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Customer</td>
+        <td align="" colspan="" rowspan="">A person who is contracted for services with a ServiceProvider.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">IM User</td>
+        <td align="" colspan="" rowspan="">Any Customer who has registered for instant messaging services.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">InteropPartner</td>
+        <td align="" colspan="" rowspan="">Any company that agrees to interoperate using the protocol defined herein.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">JID</td>
+        <td align="" colspan="" rowspan="">The unique identifier of an IM User in the XMPP protocol. Outside the context of an IM session, a JID is of the form &lt;user@domain&gt; ("bare JID"); within the context of an IM session, a JID is of the form &lt;user@domain/resource&gt; ("full JID").</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ServiceProvider</td>
+        <td align="" colspan="" rowspan="">A company that provides telephony or email services to a Customer.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">URI</td>
+        <td align="" colspan="" rowspan="">A Uniform Resource Identifier as defined in <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2255105">5</a>]. Specific URI schemes that may be useful in this specification include 'tel:', 'mailto:', and 'sip:', but any URI scheme may be used.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Waiting List</td>
+        <td align="" colspan="" rowspan="">A list of Contacts whom an entity (IM User or InteropPartner) is waiting to hear about regarding their status as instant messaging users.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">WaitingListService</td>
+        <td align="" colspan="" rowspan="">An XMPP service that maintains Waiting lists for IM Users and/or InteropPartners.</td>
+      </tr>
+    </table>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This protocol MUST enable an IM User to:</p>
+    <ol start="1" type="1">
+      <li>Request the user's current Waiting List</li>
+      <li>Add a Contact to a local WaitingList (based on some URI associated with the Contact)</li>
+      <li>Receive notification from a local WaitingListService if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+    <p class="" style="">In addition, this protocol MUST enable a ServiceProvider to:</p>
+    <ol start="1" type="1">
+      <li>Request the service's current WaitingList</li>
+      <li>Add a Contact to a WaitingList at an InteroPartner (based on some URI associated with the Contact)</li>
+      <li>Receive notification from the InteropPartner if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+  <h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+      <p class="" style="">Before adding or removing Contacts from its WaitingList, an IM User SHOULD retrieve its current WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.1.1 <a name="imuser-retrieve-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User discovers WaitingListService hosted by ServiceProvider [A1]; it is RECOMMENDED to do this immediately after logging in.</li>
+          <li>IM User requests current WaitingList from WaitingListService.</li>
+          <li>WaitingListService returns WaitingList to IM User, including any items for which JIDs have been discovered [A2].</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.1.2 <a name="imuser-retrieve-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>ServiceProvider does not host a WaitingListService:
+          <ol start="1" type="1">
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>IM User does not have a Waiting List:
+          <ol start="1" type="1">
+              <li>WaitingListService returns &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may know a URI for a Contact (e.g., a phone number or email address) but not the Contact's JID. In order to subscribe to the Contact's presence or otherwise communicate with the Contact over an instant messaging system, the IM User first needs to discover the Contact's JID based on a URI for the Contact. However, the Contact may not yet have an IM account. Because the IM User may therefore need to wait until the Contact creates an account, the IM User needs to add the Contact to a WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.2.1 <a name="imuser-add-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User SHOULD first complete use case for "IM User Retrieves Current WaitingList".</li>
+          <li>IM User requests addition of Contact to WaitingList based on Contact's URI.</li>
+          <li>WaitingListService determines that the URI scheme is supported [A1].</li>
+          <li>WaitingListService determines that the information provided is a valid URI for that URI scheme [A2].</li>
+          <li>WaitingListService acknowledges addition of Contact to IM User's WaitingList.</li>
+          <li>WaitingListService determines that Contact's URI does not belong to a person served by ServiceProvider [A3].</li>
+          <li>WaitingListService discovers WaitingListServices hosted by one or more InteropPartners.</li>
+          <li>WaitingListService queries one or more InteropPartner's WaitingListServices for JID associated with URI.</li>
+          <li>InteropPartner's WaitingListService determines that Contact's URI belongs to a person served by that partner [A4].</li>
+          <li>InteropPartner's WaitingListService determines that Contact is an IM User [A5].</li>
+          <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of JID associated with Contact's URI. [A6]</li>
+          <li>ServiceProvider's WaitingListService informs IM User of Contact's JID. [A8]</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.2.2 <a name="imuser-add-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>The URI scheme is not supported:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;bad-request/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>The information provided is not a valid URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;bad-request/&gt; or &lt;remote-server-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>URI belongs to person served by ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService determines that Contact is an IM User registered with ServiceProvider [A7].</li>
+              <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+              <li>WaitingListService informs IM User of Contact's JID.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>URI does not belong to a person served by InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner sends &lt;item-not-found/&gt; error to WaitingListService.</li>
+              <li>If all InteropPartners queried return &lt;item-not-found/&gt; error, WaitingListService sends &lt;item-not-found/&gt; error (or local equivalent) to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner records WaitingListService's request for JID associated with URI.</li>
+              <li>OPTIONALLY, InteropPartner invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>InteropPartner informs Service Provider's WaitingListService of JID associated with Contact's URI.</li>
+              <li>ServiceProvider's WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact denies request:
+            <ol start="1" type="1">
+              <li>InteropPartner's WaitingListService sends &lt;not-authorized/&gt; error to ServiceProvider's WaitingListService.</li>
+              <li>ServiceProvider's WaitingListService sends &lt;not-authorized/&gt; error (or local equivalent) to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService records IM User's request for JID associated with URI.</li>
+              <li>OPTIONALLY, WaitingListService invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact's URI is not handled by any ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI that no InteropPartner services Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3 <a name="imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may want to remove an item from its WaitingList.</p>
+      <div class="indent">
+<h3>4.3.1 <a name="imuser-remove-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User sends removal request to WaitingListService.</li>
+          <li>WaitingListService removes IM User's request for JID associated with URI.</li>
+          <li>WaitingListService informs IM User of successful removal [A1].</li>
+          <li>WaitingListService sends removal request to appropriate InteropPartner's WaitingListService [A2].</li>
+          <li>InteropPartner's WaitingListService determines that URI belongs to a person served by that partner.</li>
+          <li>InteropPartner's WaitingListService removes ServiceProvider's WaitingListService's request for JID.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of successful removal.</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.3.2 <a name="imuser-remove-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User never requested JID associated with URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact URI is served by WaitingListService or IM User was not the only person who requested the JID:
+            <ol start="1" type="1">
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+  <h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="protocol-imuser">IM User Interaction With WaitingListService</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document is provided for the sake of domains that implement XMPP as their local protocol; domains that implement another protocol will use their service-specific protocol to complete the user-to-domain interaction. Support for the protocol defined in this section is NOT REQUIRED for services that do not implement XMPP as their local protocol.</span>
+      </p>
+      <div class="indent">
+<h3>5.1.1 <a name="protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+        <p class="" style="">It is RECOMMENDED for an IM User's client to retrieve the WaitingList immediately after logging in. However, first it must discover its local WaitingListService. An IM User MAY use either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255861">6</a>] or the deprecated <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2255885">7</a>] protocol.</p>
+        <p class="caption">Example 1. IM User Discovers WaitingListService by Sending Agent Information Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 2. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.service-provider.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. IM User Discovers WaitingListService by Sending Service Discovery Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 4. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 5. IM User Queries WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The WaitingListService SHOULD return detailed information about the service it provides, including the URI schemes it supports (see also the <a href="#registrar-features">Service Discovery Features</a> section of this document).</p>
+        <p class="caption">Example 6. WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory' type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/mailto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/tel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Once an IM User has discovered the WaitingListService, the user's client SHOULD request its current Waiting List:</p>
+        <p class="caption">Example 7. IM User Requests its Current WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Upon request, the WaitingListService MUST return the current WaitingList to the IM User:</p>
+        <p class="caption">Example 8. WaitingListService Returns WaitingList to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Each ItemID MUST be unique within the scope of the client's WaitingList items. The value of the ItemID is an opaque string; an implementation MAY assign semantic meaning to the ItemID (e.g., id="John Smith (mobile)" rather than id="12345"), but such meaning is implementation-specific and outside the scope of the protocol defined herein. The user MAY include a &lt;name/&gt; element containing a natural-language name for the Contact.</p>
+        <p class="" style="">The WaitingList MAY contain an item for which a JID has been discovered.</p>
+        <p class="caption">Example 9. IM User Asks for its WaitingList including Newly Discovered JID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='jidask1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345' jid='stpeter@jabber.org'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.2 <a name="protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once an IM User's client has discovered the WaitingListService and requested the user's WaitingList, the user can add Contacts to the WaitingList based on the Contact's URI. (Note: This JEP uses the example of phone numbers via the 'tel' URI scheme, but the same rules apply to WaitingList items based on email addresses or other URI schemes.)</p>
+        <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='waitlist.service-provider.com'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided an invalid URI (e.g., a phone number with too many digits or an email address with no '@' character), WaitingListService MUST return a &lt;not-acceptable/&gt; error to the IM User.</p>
+        <p class="caption">Example 11. WaitingListService Returns &lt;not-acceptable/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">(For information about error syntax, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256141">8</a>].)</p>
+        <p class="" style="">If the IM User included a JID in the request, WaitingListService sends &lt;bad-request/&gt; error to IM User. (Note: A WaitingListService MUST NOT return a non-XMPP URI to an IM User based on the Contact's JID; see the <a href="#security">Security Considerations</a> section of this document.)</p>
+        <p class="caption">Example 12. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item jid='some-jid'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided a URI that is not served by an InteropPartner (e.g., a phone number associated with a telephony provider that is not in the WaitingListService's whitelist of InteropPartners), WaitingListService MAY send a &lt;remote-server-not-found/&gt; error to IM User.</p>
+        <p class="caption">Example 13. WaitingListService Returns &lt;remote-server-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;remote-server-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If none of the foregoing errors was generated but the WaitingListService does not immediately know the Contact JID, WaitingListService MUST inform the IM User that the request was successfully received, including a unique ID number for the new WaitingList item.</p>
+        <p class="caption">Example 14. WaitingListService Informs IM User that Request was Received</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID when the IQ result is returned to the user, it MAY include the WaitingList item in the IQ result:</p>
+        <p class="caption">Example 15. WaitingListService Returns IQ Result to IM User (With Contact JID)</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID (or learns Contact JID from InteropPartner), it MUST inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 16. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">Note: The JID push uses &lt;message/&gt; because the WaitingListService has no knowledge of the user's presence and therefore cannot assume that an IQ will be received by the user at a specific resource.</p>
+        <p class="" style="">If WaitingListService learns that Contact's URI is not handled by any InteropPartner, it SHOULD inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 17. WaitingListService Informs IM User that No InteropPartner Handles Contact's URI</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;Sorry, we cannot find this contact.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' 
+          jid='contact@service-provider.com'
+          type='error'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+      &lt;error code='404' 
+             type='cancel'
+             xmlns='jabber:client'&gt;
+        &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;/error&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.3 <a name="protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+        <p class="" style="">In order to remove the item from the WaitingList, the IM User MUST complete the "Remove Contact from WaitingList" use case.</p>
+        <p class="caption">Example 18. IM User Sends Removal Request to WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='remove1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService previously recorded request, WaitingListService removes request from list and returns result to IM User.</p>
+        <p class="caption">Example 19. WaitingListService Returns Result to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='remove1'/&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService did not previously record this request, WaitingListService MUST return an &lt;item-not-found/&gt; error to the IM User.</p>
+        <p class="caption">Example 20. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>5.2 <a name="protocol-service">WaitingListService Interaction With InteropPartners</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document describes the inter-domain protocol for communication between WaitingListServices. The protocol defined in this section MUST be implemented by ServiceProviders.</span>
+      </p>
+      <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartner's WaitingListServices with which it communicates. Therefore service discovery SHOULD NOT be necessary. However, if necessary it MAY use either the <span style="font-weight: bold">Agent Information</span> protocol or the <span style="font-weight: bold">Service Discovery</span> protocol as described in the following examples.</p>
+      <p class="" style="">Note: The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</p>
+      <div class="indent">
+<h3>5.2.1 <a name="protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</h3>
+        <p class="caption">Example 21. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Agent Information Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 22. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.interop-partner.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 23. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Service Discovery Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 24. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 25. Service Provider Queries InteropPartner's WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 26. InteropPartner's WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory'
+              type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.2.2 <a name="protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once a ServiceProvider's WaitingListService has discovered the InteropPartner's WaitingListService and requested its WaitingList, the ServiceProvider's WaitingListService can add items to its WaitingList based on URI.</p>
+        <p class="caption">Example 27. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is not associated with a person served by this InteropPartner, the InteropPartner MUST return an &lt;item-not-found/&gt; error to the ServiceProvider.</p>
+        <p class="caption">Example 28. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is associated with a person served by this InteropPartner, InteropPartner MUST return acknowledgement of the WaitingList addition to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 29. InteropPartner's WaitingListService Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact is an IM User served by InteropPartner, InteropPartner's WaitingListService pushes Contact's JID to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 30. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 31. ServiceProvider's WaitingListService Acknowledges Receipt of JID Push</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='jidpush4'/&gt;
+        </pre></div>
+        <p class="" style="">After receiving acknowledgement (but not before), InteropPartner's WaitingListService MUST remove that item from the WaitingList for the ServiceProvider's WaitingListService.</p>
+      </div>
+      <div class="indent">
+<h3>5.2.3 <a name="protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</h3>
+        <p class="caption">Example 32. ServiceProvider Requests Removal of Item from WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='remove2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If item exists on WaitingList, InteropPartner's WaitingListService removes item from list and returns result to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 33. InteropPartner Returns Result to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'/&gt;
+        </pre></div>
+        <p class="" style="">If item does not exist on WaitingList, InteropPartner's WaitingListService MUST return an &lt;item-not-found/&gt; error to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 34. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <ol start="1" type="1">
+      <li>Protocols and mechanisms for inviting a Contact to register as an IM User are out of scope for this proposal and shall be determined by each InteropPartner individually.</li>
+      <li>A ServiceProvider's WaitingListService MUST record which of its IM Users have requested the JID associated with Contact's URI, and an InteropPartner's WaitingListService MUST record that Service Provider's WaitingListService (not User) has requested JID associated with Contact's URI. Therefore when Contact registers, InteropPartner's WaitingListService informs its local users as well as ServiceProvider's WaitingListService, and ServiceProvider's WaitingListService informs its local users.</li>
+      <li>The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</li>
+      <li>Once an IM User learns a Contact's JID, the IM User MAY send a normal subscription request to the Contact, setting the "to" address to Contact's JID. This interaction is defined in the base XMPP specifications and is out of scope for this document.</li>
+      <li>For historical reasons, implementations MUST support the older <span style="font-weight: bold">Agent Information</span> protocol (JEP-0094) and SHOULD support <span style="font-weight: bold">Service Discovery</span> (JEP-0030). Note well that the <span style="font-weight: bold">Agent Information</span> protocol will eventually be deprecated in favor of <span style="font-weight: bold">Service Discovery</span>.</li>
+      <li>An IM User's client receives WaitingList information either through a "JID push" message (received from WaitingListService at any time) or in the IQ result received after requesting the WaitingList (since one or more of the WaitingList items may contain a JID). (The same rule applies to a ServiceProvider's WaitingListService that receives an IQ set from an InteropPartner's WaitingListService.)</li>
+      <li>When an IM User logs in, the user's client SHOULD request the current WaitingList.</li>
+      <li>Although the examples in this JEP show the hostname of the WaitingListService as 'waitlist.third-party.com' (etc.), this is for convenience only; the hostname MAY be any valid DNS hostname.</li>
+      <li>When sending JID pushes, an implementation MAY specify a message type of 'headline', which in some deployments will prevent such messages from being stored offline for later delivery.</li>
+    </ol>
+  <h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartners with which it communicates. The WaitingListService SHOULD NOT communicate with any InteropPartners that are not on the whitelist.</p>
+    <p class="" style="">Requesting JIDs via WaitingLists is not bidirectional; i.e., a service MUST NOT allow an IM User to discover a Contact's non-XMPP URI based on the Contact's JID.</p>
+    <p class="" style="">A service MAY require a Contact to approve the disclosure of the Contact's JID, either as a global preference or for each request; however, this is a local policy matter.</p>
+  <h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257001">9</a>].</p>
+  <h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257044">10</a>] shall include 'http://jabber.org/protocol/waitinglist' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>9.2 <a name="registrar-identities">Service Discovery Identities</a>
+</h3>
+      <p class="" style="">The Jabber Registar shall include a type of "waitinglist" in the "directory" category in its registry of service discovery identities.</p>
+    </div>
+    <div class="indent">
+<h3>9.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall include supported URI schemes in its registry of service discovery features. These features shall be of the form 'http://jabber.org/protocol/waitlist/schemes/SCHEME-NAME'.</p>
+      <p class="" style="">This JEP registers the following two namespace names for URI schemes, but others MAY be registered in the future using standard registration procedures:</p>
+      <ul>
+        <li>http://jabber.org/protocol/waitlist/schemes/mailto</li>
+        <li>http://jabber.org/protocol/waitlist/schemes/tel</li>
+      </ul>
+    </div>
+  <h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/waitinglist'
+    xmlns='http://jabber.org/protocol/waitinglist'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='jabber:client'/&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='1'&gt;&gt;
+        &lt;xs:sequence xmlns:xmpp='jabber:client'&gt;
+          &lt;xs:element ref='uri' minOccurs='1' maxOccurs='1'/&gt;
+          &lt;xs:element ref='name' minOccurs='0' maxOccurs='1'/&gt;
+          &lt;xs:element ref='xmpp:error' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element ref='remove'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='jid'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='type'
+                    use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='uri' type='xs:string'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='scheme'
+                    type='xs:NCNAME'
+                    use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='name' type='string1023'/&gt;
+
+  &lt;xs:element name='remove' type='empty'/&gt;
+
+  &lt;xs:simpleType name='string1023'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:maxLength value='1023'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251140">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251201">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251287">3</a>. RFC 3966: The tel URI for Telephone Numbers &lt;<a href="http://www.ietf.org/rfc/rfc3966.txt">http://www.ietf.org/rfc/rfc3966.txt</a>&gt;.</p>
+<p><a name="nt-id2251310">4</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p><a name="nt-id2255105">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2255861">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255885">7</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2256141">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257001">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257044">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2005-04-01)</h4>
+<div class="indent">Changed JEP type to Informational; corrected Remote Server Error example to use &lt;remote-server-not-found/&gt; rather than &lt;service-unavailable/&gt;; added service discovery identity to Jabber Registrar Considerations; corrected text regarding registration of service discovery features; corrected some small errors in the text, examples, and schema. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-27)</h4>
+<div class="indent">Corrected error syntax used when Contact URI is not handled by any InteropPartner. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-03)</h4>
+<div class="indent">Added alternate flow for situation in which Contact URI is not handled by any InteropPartner; changed headline message type for JID pushes from SHOULD to MAY; clarified semantics of item ID; added name child of item; corrected and updated the XML schema; updated examples to use XMPP error conditions. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-18)</h4>
+<div class="indent">Initial version (see XML source for earlier revisions). (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0130-0.5.html
+++ b/content/xep-0130-0.5.html
@@ -1,0 +1,1039 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0130: Waiting Lists</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Waiting Lists">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Yehezkel Dallal">
+<meta name="DC.Creator" content="Alexandre Nolle">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Mark Troyer">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0130">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0130: Waiting Lists</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Historical<br>
+            Number: 0130<br>
+            Version: 0.5<br>
+            Last Updated: 2005-05-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0094, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: waitlist<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Yehezkel Dallal</h3>
+<p class="indent">
+        Email: yehezkeld@followap.com<br></p>
+<h3>Alexandre Nolle</h3>
+<p class="indent">
+        Email: anolle@francetelecom.com<br></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jean-louis.seguineau@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+<h3>Mark Troyer</h3>
+<p class="indent">
+        Email: mtroyer@jabber.com<br>
+        JID: mtroyer@corp.jabber.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#imuser-retrieve-primary">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#imuser-retrieve-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#imuser-add-primary">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#imuser-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#imuser-remove-primary">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#imuser-remove-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-imuser">IM User Interaction With WaitingListService</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dt>5.1.2.  <a href="#protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dt>5.1.3.  <a href="#protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#protocol-service">WaitingListService Interaction With InteropPartners</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</dt>
+<dt>5.2.2.  <a href="#protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</dt>
+<dt>5.2.3.  <a href="#protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-identities">Service Discovery Identities</a>
+</dt>
+<dt>9.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">An IM user may want to be informed when a contact creates an IM account. If the user knows some information about the contact (e.g., a phone number or email address), the user's service can use that information to place the contact on a "waiting list", then inform the user when the contact creates an IM account. This document defines an extension to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251241">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2251305">2</a>] that enables such "waiting list" functionality, including the ability to add contacts on other domains if service providers agree to interoperate (e.g., to add a contact who uses a different mobile telephony service provider).</p>
+    <p class="" style=""><span style="font-style: italic">Note: The protocol defined herein is currently in use at several large service providers in Europe. Others are welcome to use the protocol.</span></p>
+  <h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+    <p class="caption">Table 1: Terms Used</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Contact</td>
+        <td align="" colspan="" rowspan="">A person with whom an IM User seeks to communicate, identified by a URI such as &lt;tel:PhoneNumber&gt; (see <span class="ref" style="">RFC 3966</span>  [<a href="#nt-id2251387">3</a>]) or &lt;mailto:EmailAddress&gt; (see <span class="ref" style="">RFC 2368</span>  [<a href="#nt-id2251411">4</a>]).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Customer</td>
+        <td align="" colspan="" rowspan="">A person who is contracted for services with a ServiceProvider.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">IM User</td>
+        <td align="" colspan="" rowspan="">Any Customer who has registered for instant messaging services.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">InteropPartner</td>
+        <td align="" colspan="" rowspan="">Any company that agrees to interoperate using the protocol defined herein.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">JID</td>
+        <td align="" colspan="" rowspan="">The unique identifier of an IM User in the XMPP protocol. Outside the context of an IM session, a JID is of the form &lt;user@domain&gt; ("bare JID"); within the context of an IM session, a JID is of the form &lt;user@domain/resource&gt; ("full JID").</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ServiceProvider</td>
+        <td align="" colspan="" rowspan="">A company that provides telephony or email services to a Customer.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">URI</td>
+        <td align="" colspan="" rowspan="">A Uniform Resource Identifier as defined in <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2255626">5</a>]. Specific URI schemes that may be useful in this specification include 'tel:', 'mailto:', and 'sip:', but any URI scheme may be used.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Waiting List</td>
+        <td align="" colspan="" rowspan="">A list of Contacts whom an entity (IM User or InteropPartner) is waiting to hear about regarding their status as instant messaging users.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">WaitingListService</td>
+        <td align="" colspan="" rowspan="">An XMPP service that maintains Waiting lists for IM Users and/or InteropPartners.</td>
+      </tr>
+    </table>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This protocol is designed so that an IM User can:</p>
+    <ol start="1" type="1">
+      <li>Request the user's current Waiting List</li>
+      <li>Add a Contact to a local WaitingList (based on some URI associated with the Contact)</li>
+      <li>Receive notification from a local WaitingListService if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+    <p class="" style="">In addition, this protocol is designed so that a ServiceProvider can:</p>
+    <ol start="1" type="1">
+      <li>Request the service's current WaitingList</li>
+      <li>Add a Contact to a WaitingList at an InteroPartner (based on some URI associated with the Contact)</li>
+      <li>Receive notification from the InteropPartner if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+  <h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+      <p class="" style="">Before adding or removing Contacts from its WaitingList, an IM User SHOULD retrieve its current WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.1.1 <a name="imuser-retrieve-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User discovers WaitingListService hosted by ServiceProvider [A1]; it is RECOMMENDED to do this immediately after logging in.</li>
+          <li>IM User requests current WaitingList from WaitingListService.</li>
+          <li>WaitingListService returns WaitingList to IM User, including any items for which JIDs have been discovered [A2].</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.1.2 <a name="imuser-retrieve-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>ServiceProvider does not host a WaitingListService:
+          <ol start="1" type="1">
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>IM User does not have a Waiting List:
+          <ol start="1" type="1">
+              <li>WaitingListService returns &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may know a URI for a Contact (e.g., a phone number or email address) but not the Contact's JID. In order to subscribe to the Contact's presence or otherwise communicate with the Contact over an instant messaging system, the IM User first needs to discover the Contact's JID based on a URI for the Contact. However, the Contact may not yet have an IM account. Because the IM User may therefore need to wait until the Contact creates an account, the IM User needs to add the Contact to a WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.2.1 <a name="imuser-add-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User SHOULD first complete use case for "IM User Retrieves Current WaitingList".</li>
+          <li>IM User requests addition of Contact to WaitingList based on Contact's URI.</li>
+          <li>WaitingListService determines that the URI scheme is supported [A1].</li>
+          <li>WaitingListService determines that the information provided is a valid URI for that URI scheme [A2].</li>
+          <li>WaitingListService acknowledges addition of Contact to IM User's WaitingList.</li>
+          <li>WaitingListService determines that Contact's URI does not belong to a person served by ServiceProvider [A3].</li>
+          <li>WaitingListService discovers WaitingListServices hosted by one or more InteropPartners.</li>
+          <li>WaitingListService queries one or more InteropPartner's WaitingListServices for JID associated with URI.</li>
+          <li>InteropPartner's WaitingListService determines that Contact's URI belongs to a person served by that partner [A4].</li>
+          <li>InteropPartner's WaitingListService determines that Contact is an IM User [A5].</li>
+          <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of JID associated with Contact's URI. [A6]</li>
+          <li>ServiceProvider's WaitingListService informs IM User of Contact's JID. [A8]</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.2.2 <a name="imuser-add-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>The URI scheme is not supported:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;bad-request/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>The information provided is not a valid URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;bad-request/&gt; or &lt;remote-server-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>URI belongs to person served by ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService determines that Contact is an IM User registered with ServiceProvider [A7].</li>
+              <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+              <li>WaitingListService informs IM User of Contact's JID.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>URI does not belong to a person served by InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner sends &lt;item-not-found/&gt; error to WaitingListService.</li>
+              <li>If all InteropPartners queried return &lt;item-not-found/&gt; error, WaitingListService sends &lt;item-not-found/&gt; error (or local equivalent) to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner records WaitingListService's request for JID associated with URI.</li>
+              <li>OPTIONALLY, InteropPartner invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>InteropPartner informs Service Provider's WaitingListService of JID associated with Contact's URI.</li>
+              <li>ServiceProvider's WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact denies request:
+            <ol start="1" type="1">
+              <li>InteropPartner's WaitingListService sends &lt;not-authorized/&gt; error to ServiceProvider's WaitingListService.</li>
+              <li>ServiceProvider's WaitingListService sends &lt;not-authorized/&gt; error (or local equivalent) to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService records IM User's request for JID associated with URI.</li>
+              <li>OPTIONALLY, WaitingListService invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact's URI is not handled by any ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI that no InteropPartner services Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3 <a name="imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may want to remove an item from its WaitingList.</p>
+      <div class="indent">
+<h3>4.3.1 <a name="imuser-remove-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User sends removal request to WaitingListService.</li>
+          <li>WaitingListService removes IM User's request for JID associated with URI.</li>
+          <li>WaitingListService informs IM User of successful removal [A1].</li>
+          <li>WaitingListService sends removal request to appropriate InteropPartner's WaitingListService [A2].</li>
+          <li>InteropPartner's WaitingListService determines that URI belongs to a person served by that partner.</li>
+          <li>InteropPartner's WaitingListService removes ServiceProvider's WaitingListService's request for JID.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of successful removal.</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.3.2 <a name="imuser-remove-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User never requested JID associated with URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact URI is served by WaitingListService or IM User was not the only person who requested the JID:
+            <ol start="1" type="1">
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+  <h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="protocol-imuser">IM User Interaction With WaitingListService</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document is provided for the sake of domains that implement XMPP as their local protocol; domains that implement another protocol will use their service-specific protocol to complete the user-to-domain interaction. Support for the protocol defined in this section is NOT REQUIRED for services that do not implement XMPP as their local protocol.</span>
+      </p>
+      <div class="indent">
+<h3>5.1.1 <a name="protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+        <p class="" style="">It is RECOMMENDED for an IM User's client to retrieve the WaitingList immediately after logging in. However, first it must discover its local WaitingListService. An IM User MAY use either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256383">6</a>] or the deprecated <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2256406">7</a>] protocol.</p>
+        <p class="caption">Example 1. IM User Discovers WaitingListService by Sending Agent Information Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 2. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.service-provider.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. IM User Discovers WaitingListService by Sending Service Discovery Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 4. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 5. IM User Queries WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The WaitingListService SHOULD return detailed information about the service it provides, including the URI schemes it supports (see also the <a href="#registrar-features">Service Discovery Features</a> section of this document).</p>
+        <p class="caption">Example 6. WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory' type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/mailto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/tel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Once an IM User has discovered the WaitingListService, the user's client SHOULD request its current Waiting List:</p>
+        <p class="caption">Example 7. IM User Requests its Current WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Upon request, the WaitingListService MUST return the current WaitingList to the IM User:</p>
+        <p class="caption">Example 8. WaitingListService Returns WaitingList to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='request1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Each ItemID MUST be unique within the scope of the client's WaitingList items. The value of the ItemID is an opaque string; an implementation MAY assign semantic meaning to the ItemID (e.g., id="John Smith (mobile)" rather than id="12345"), but such meaning is implementation-specific and outside the scope of the protocol defined herein. The user MAY include a &lt;name/&gt; element containing a natural-language name for the Contact.</p>
+        <p class="" style="">The WaitingList MAY contain an item for which a JID has been discovered.</p>
+        <p class="caption">Example 9. IM User Asks for its WaitingList including Newly Discovered JID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='jidask1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='jidask1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345' jid='stpeter@jabber.org'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.2 <a name="protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once an IM User's client has discovered the WaitingListService and requested the user's WaitingList, the user can add Contacts to the WaitingList based on the Contact's URI. (Note: This JEP uses the example of phone numbers via the 'tel' URI scheme, but the same rules apply to WaitingList items based on email addresses or other URI schemes.)</p>
+        <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='waitlist.service-provider.com'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided an invalid URI (e.g., a phone number with too many digits or an email address with no '@' character), WaitingListService MUST return a &lt;not-acceptable/&gt; error to the IM User.</p>
+        <p class="caption">Example 11. WaitingListService Returns &lt;not-acceptable/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">(For information about error syntax, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256663">8</a>].)</p>
+        <p class="" style="">If the IM User included a JID in the request, WaitingListService sends &lt;bad-request/&gt; error to IM User. (Note: A WaitingListService MUST NOT return a non-XMPP URI to an IM User based on the Contact's JID; see the <a href="#security">Security Considerations</a> section of this document.)</p>
+        <p class="caption">Example 12. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item jid='some-jid'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided a URI that is not served by an InteropPartner (e.g., a phone number associated with a telephony provider that is not in the WaitingListService's whitelist of InteropPartners), WaitingListService MAY send a &lt;remote-server-not-found/&gt; error to IM User.</p>
+        <p class="caption">Example 13. WaitingListService Returns &lt;remote-server-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;remote-server-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If no error was generated but the WaitingListService does not immediately know the Contact JID, WaitingListService MUST inform the IM User that the request was successfully received, including a unique ID number for the new WaitingList item.</p>
+        <p class="caption">Example 14. WaitingListService Informs IM User that Request was Received</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID when the IQ result is returned to the user, it MAY include the WaitingList item in the IQ result:</p>
+        <p class="caption">Example 15. WaitingListService Returns IQ Result to IM User (With Contact JID)</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID (or learns Contact JID from InteropPartner), it MUST inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 16. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">Note: The JID push uses &lt;message/&gt; because the WaitingListService has no knowledge of the user's presence and therefore cannot assume that an &lt;iq/&gt; stanza will be received by the user at a specific resource.</p>
+        <p class="" style="">If WaitingListService learns that Contact's URI is not handled by any InteropPartner, it SHOULD inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 17. WaitingListService Informs IM User that No InteropPartner Handles Contact's URI</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;Sorry, we cannot find this contact.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' 
+          jid='contact@service-provider.com'
+          type='error'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+      &lt;error code='404' 
+             type='cancel'
+             xmlns='jabber:client'&gt;
+        &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;/error&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.3 <a name="protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+        <p class="" style="">In order to remove the item from the WaitingList, the IM User MUST complete the "Remove Contact from WaitingList" use case.</p>
+        <p class="caption">Example 18. IM User Sends Removal Request to WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='remove1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService previously recorded request, WaitingListService removes request from list and returns result to IM User.</p>
+        <p class="caption">Example 19. WaitingListService Returns Result to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='remove1'/&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService did not previously record this request, WaitingListService MUST return an &lt;item-not-found/&gt; error to the IM User.</p>
+        <p class="caption">Example 20. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='remove1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>5.2 <a name="protocol-service">WaitingListService Interaction With InteropPartners</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document describes the inter-domain protocol for communication between WaitingListServices. The protocol defined in this section MUST be implemented by ServiceProviders.</span>
+      </p>
+      <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartner's WaitingListServices with which it communicates. Therefore service discovery SHOULD NOT be necessary. However, if necessary it MAY use either the <span style="font-weight: bold">Agent Information</span> protocol or the <span style="font-weight: bold">Service Discovery</span> protocol as described in the following examples.</p>
+      <p class="" style="">Note: The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</p>
+      <div class="indent">
+<h3>5.2.1 <a name="protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</h3>
+        <p class="caption">Example 21. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Agent Information Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 22. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.interop-partner.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 23. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Service Discovery Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 24. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 25. Service Provider Queries InteropPartner's WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 26. InteropPartner's WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory'
+              type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.2.2 <a name="protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once a ServiceProvider's WaitingListService has discovered the InteropPartner's WaitingListService and requested its WaitingList, the ServiceProvider's WaitingListService can add items to its WaitingList based on URI.</p>
+        <p class="caption">Example 27. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is not associated with a person served by this InteropPartner, the InteropPartner MUST return an &lt;item-not-found/&gt; error to the ServiceProvider.</p>
+        <p class="caption">Example 28. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is associated with a person served by this InteropPartner, InteropPartner MUST return acknowledgement of the WaitingList addition to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 29. InteropPartner's WaitingListService Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact is an IM User served by InteropPartner, InteropPartner's WaitingListService pushes Contact's JID to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 30. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 31. ServiceProvider's WaitingListService Acknowledges Receipt of JID Push</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='jidpush1'/&gt;
+        </pre></div>
+        <p class="" style="">After receiving acknowledgement (but not before), InteropPartner's WaitingListService MUST remove that item from the WaitingList for the ServiceProvider's WaitingListService.</p>
+      </div>
+      <div class="indent">
+<h3>5.2.3 <a name="protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</h3>
+        <p class="caption">Example 32. ServiceProvider Requests Removal of Item from WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='remove2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If item exists on WaitingList, InteropPartner's WaitingListService removes item from list and returns result to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 33. InteropPartner Returns Result to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'/&gt;
+        </pre></div>
+        <p class="" style="">If item does not exist on WaitingList, InteropPartner's WaitingListService MUST return an &lt;item-not-found/&gt; error to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 34. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <ol start="1" type="1">
+      <li>Protocols and mechanisms for inviting a Contact to register as an IM User are out of scope for this proposal and shall be determined by each InteropPartner individually.</li>
+      <li>A ServiceProvider's WaitingListService MUST record which of its IM Users have requested the JID associated with Contact's URI, and an InteropPartner's WaitingListService MUST record that Service Provider's WaitingListService (not User) has requested JID associated with Contact's URI. Therefore when Contact registers, InteropPartner's WaitingListService informs its local users as well as ServiceProvider's WaitingListService, and ServiceProvider's WaitingListService informs its local users.</li>
+      <li>The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</li>
+      <li>Once an IM User learns a Contact's JID, the IM User MAY send a normal subscription request to the Contact, setting the "to" address to Contact's JID. This interaction is defined in the base XMPP specifications and is out of scope for this document.</li>
+      <li>For historical reasons, implementations MUST support the older <span style="font-weight: bold">Agent Information</span> protocol (JEP-0094) and SHOULD support <span style="font-weight: bold">Service Discovery</span> (JEP-0030). Note well that the <span style="font-weight: bold">Agent Information</span> protocol will eventually be deprecated in favor of <span style="font-weight: bold">Service Discovery</span>.</li>
+      <li>An IM User's client receives WaitingList information either through a "JID push" message (received from WaitingListService at any time) or in the IQ result received after requesting the WaitingList (since one or more of the WaitingList items may contain a JID). (The same rule applies to a ServiceProvider's WaitingListService that receives an IQ set from an InteropPartner's WaitingListService.)</li>
+      <li>When an IM User logs in, the user's client SHOULD request the current WaitingList.</li>
+      <li>Although the examples in this JEP show the hostname of the WaitingListService as 'waitlist.third-party.com' (etc.), this is for convenience only; the hostname MAY be any valid DNS hostname.</li>
+      <li>When sending JID pushes, an implementation MAY specify a message type of 'headline', which in some deployments will prevent such messages from being stored offline for later delivery.</li>
+    </ol>
+  <h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartners with which it communicates. The WaitingListService SHOULD NOT communicate with any InteropPartners that are not on the whitelist.</p>
+    <p class="" style="">Requesting JIDs via WaitingLists is not bidirectional; i.e., a service MUST NOT allow an IM User to discover a Contact's non-XMPP URI based on the Contact's JID.</p>
+    <p class="" style="">A service MAY require a Contact to approve the disclosure of the Contact's JID, either as a global preference or for each request; however, this is a local policy matter.</p>
+  <h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257516">9</a>].</p>
+  <h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257563">10</a>] shall include 'http://jabber.org/protocol/waitinglist' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>9.2 <a name="registrar-identities">Service Discovery Identities</a>
+</h3>
+      <p class="" style="">The Jabber Registar shall include a type of "waitinglist" in the "directory" category in its registry of service discovery identities.</p>
+    </div>
+    <div class="indent">
+<h3>9.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall include supported URI schemes in its registry of service discovery features. These features shall be of the form 'http://jabber.org/protocol/waitlist/schemes/SCHEME-NAME'.</p>
+      <p class="" style="">This JEP registers the following two namespace names for URI schemes, but others MAY be registered in the future using standard registration procedures:</p>
+      <ul>
+        <li>http://jabber.org/protocol/waitlist/schemes/mailto</li>
+        <li>http://jabber.org/protocol/waitlist/schemes/tel</li>
+      </ul>
+    </div>
+  <h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/waitinglist'
+    xmlns='http://jabber.org/protocol/waitinglist'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='jabber:client'/&gt;
+
+  &lt;xs:element name='waitlist'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='1'&gt;&gt;
+        &lt;xs:sequence xmlns:xmpp='jabber:client'&gt;
+          &lt;xs:element ref='uri' minOccurs='1' maxOccurs='1'/&gt;
+          &lt;xs:element ref='name' minOccurs='0' maxOccurs='1'/&gt;
+          &lt;xs:element ref='xmpp:error' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element ref='remove'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='jid'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='type'
+                    use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='uri' type='xs:string'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='scheme'
+                    type='xs:NCNAME'
+                    use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='name' type='string1023'/&gt;
+
+  &lt;xs:element name='remove' type='empty'/&gt;
+
+  &lt;xs:simpleType name='string1023'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:maxLength value='1023'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251241">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251305">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251387">3</a>. RFC 3966: The tel URI for Telephone Numbers &lt;<a href="http://www.ietf.org/rfc/rfc3966.txt">http://www.ietf.org/rfc/rfc3966.txt</a>&gt;.</p>
+<p><a name="nt-id2251411">4</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p><a name="nt-id2255626">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2256383">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256406">7</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2256663">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257516">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257563">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2005-05-16)</h4>
+<div class="indent">Corrected schema and IQ examples by changing root element for namespace from &lt;query/&gt; to &lt;waitlist/&gt; (this had been used for message examples but not IQ examples). (psa)
+    </div>
+<h4>Version 0.4 (2005-04-01)</h4>
+<div class="indent">Changed JEP type to Informational; corrected Remote Server Error example to use &lt;remote-server-not-found/&gt; rather than &lt;service-unavailable/&gt;; added service discovery identity to Jabber Registrar Considerations; corrected text regarding registration of service discovery features; corrected some small errors in the text, examples, and schema. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-27)</h4>
+<div class="indent">Corrected error syntax used when Contact URI is not handled by any InteropPartner. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-03)</h4>
+<div class="indent">Added alternate flow for situation in which Contact URI is not handled by any InteropPartner; changed headline message type for JID pushes from SHOULD to MAY; clarified semantics of item ID; added name child of item; corrected and updated the XML schema; updated examples to use XMPP error conditions. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-18)</h4>
+<div class="indent">Initial version (see XML source for earlier revisions). (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0130-0.6.html
+++ b/content/xep-0130-0.6.html
@@ -1,0 +1,1120 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0130: Waiting Lists</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Waiting Lists">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Yehezkel Dallal">
+<meta name="DC.Creator" content="Alexandre Nolle">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Mark Troyer">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-08-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0130">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0130: Waiting Lists</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Historical<br>
+            Number: 0130<br>
+            Version: 0.6<br>
+            Last Updated: 2005-08-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0094, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: waitlist<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Yehezkel Dallal</h3>
+<p class="indent">
+        Email: yehezkeld@followap.com<br></p>
+<h3>Alexandre Nolle</h3>
+<p class="indent">
+        Email: anolle@francetelecom.com<br></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jean-louis.seguineau@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+<h3>Mark Troyer</h3>
+<p class="indent">
+        Email: mtroyer@jabber.com<br>
+        JID: mtroyer@corp.jabber.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#imuser-retrieve-primary">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#imuser-retrieve-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#imuser-add-primary">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#imuser-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#imuser-remove-primary">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#imuser-remove-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-imuser">IM User Interaction With WaitingListService</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dt>5.1.2.  <a href="#protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dt>5.1.3.  <a href="#protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#protocol-service">WaitingListService Interaction With InteropPartners</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</dt>
+<dt>5.2.2.  <a href="#protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</dt>
+<dt>5.2.3.  <a href="#protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-identities">Service Discovery Identities</a>
+</dt>
+<dt>9.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">An IM user may want to be informed when a contact creates an IM account. If the user knows some information about the contact (e.g., a phone number or email address), the user's service can use that information to place the contact on a "waiting list", then inform the user when the contact creates an IM account. This document defines an extension to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251260">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2251324">2</a>] that enables such "waiting list" functionality, including the ability to add contacts on other domains if service providers agree to interoperate (e.g., to add a contact who uses a different mobile telephony service provider).</p>
+    <p class="" style=""><span style="font-style: italic">Note: The protocol defined herein is currently in use at several large service providers in Europe. Others are welcome to use the protocol.</span></p>
+  <h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+    <p class="caption">Table 1: Terms Used</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Contact</td>
+        <td align="" colspan="" rowspan="">A person with whom an IM User seeks to communicate, identified by a URI such as &lt;tel:PhoneNumber&gt; (see <span class="ref" style="">RFC 3966</span>  [<a href="#nt-id2251444">3</a>]) or &lt;mailto:EmailAddress&gt; (see <span class="ref" style="">RFC 2368</span>  [<a href="#nt-id2251414">4</a>]).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Customer</td>
+        <td align="" colspan="" rowspan="">A person who is contracted for services with a ServiceProvider.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">IM User</td>
+        <td align="" colspan="" rowspan="">Any Customer who has registered for instant messaging services.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">InteropPartner</td>
+        <td align="" colspan="" rowspan="">Any company that agrees to interoperate using the protocol defined herein.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">JID</td>
+        <td align="" colspan="" rowspan="">The unique identifier of an IM User in the XMPP protocol. Outside the context of an IM session, a JID is of the form &lt;user@domain&gt; ("bare JID"); within the context of an IM session, a JID is of the form &lt;user@domain/resource&gt; ("full JID").</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ServiceProvider</td>
+        <td align="" colspan="" rowspan="">A company that provides telephony or email services to a Customer.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">URI</td>
+        <td align="" colspan="" rowspan="">A Uniform Resource Identifier as defined in <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2255709">5</a>]. Specific URI schemes that may be useful in this specification include 'tel:', 'mailto:', and 'sip:', but any URI scheme may be used.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Waiting List</td>
+        <td align="" colspan="" rowspan="">A list of Contacts whom an entity (IM User or InteropPartner) is waiting to hear about regarding their status as instant messaging users.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">WaitingListService</td>
+        <td align="" colspan="" rowspan="">An XMPP service that maintains Waiting lists for IM Users and/or InteropPartners.</td>
+      </tr>
+    </table>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This protocol is designed so that an IM User can:</p>
+    <ol start="1" type="1">
+      <li>Request the user's current Waiting List</li>
+      <li>Add a Contact to a local WaitingList (based on some URI associated with the Contact)</li>
+      <li>Receive notification from a local WaitingListService if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+    <p class="" style="">In addition, this protocol is designed so that a ServiceProvider can:</p>
+    <ol start="1" type="1">
+      <li>Request the service's current WaitingList</li>
+      <li>Add a Contact to a WaitingList at an InteroPartner (based on some URI associated with the Contact)</li>
+      <li>Receive notification from the InteropPartner if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+  <h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+      <p class="" style="">Before adding or removing Contacts from its WaitingList, an IM User SHOULD retrieve its current WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.1.1 <a name="imuser-retrieve-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User discovers WaitingListService hosted by ServiceProvider [A1]; it is RECOMMENDED to do this immediately after logging in.</li>
+          <li>IM User requests current WaitingList from WaitingListService.</li>
+          <li>WaitingListService returns WaitingList to IM User, including any items for which JIDs have been discovered [A2].</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.1.2 <a name="imuser-retrieve-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>ServiceProvider does not host a WaitingListService:
+          <ol start="1" type="1">
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>IM User does not have a Waiting List:
+          <ol start="1" type="1">
+              <li>WaitingListService returns &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may know a URI for a Contact (e.g., a phone number or email address) but not the Contact's JID. In order to subscribe to the Contact's presence or otherwise communicate with the Contact over an instant messaging system, the IM User first needs to discover the Contact's JID based on a URI for the Contact. However, the Contact may not yet have an IM account. Because the IM User may therefore need to wait until the Contact creates an account, the IM User needs to add the Contact to a WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.2.1 <a name="imuser-add-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User SHOULD first complete use case for "IM User Retrieves Current WaitingList".</li>
+          <li>IM User requests addition of Contact to WaitingList based on Contact's URI.</li>
+          <li>WaitingListService determines that the URI scheme is supported [A1].</li>
+          <li>WaitingListService determines that the information provided is a valid URI for that URI scheme [A2].</li>
+          <li>WaitingListService acknowledges addition of Contact to IM User's WaitingList.</li>
+          <li>WaitingListService determines that Contact's URI does not belong to a person served by ServiceProvider [A3].</li>
+          <li>WaitingListService discovers WaitingListServices hosted by one or more InteropPartners.</li>
+          <li>WaitingListService queries one or more InteropPartner's WaitingListServices for JID associated with URI.</li>
+          <li>InteropPartner's WaitingListService determines that Contact's URI belongs to a person served by that partner [A4].</li>
+          <li>InteropPartner's WaitingListService determines that Contact is an IM User [A5].</li>
+          <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of JID associated with Contact's URI. [A6]</li>
+          <li>ServiceProvider's WaitingListService informs IM User of Contact's JID. [A8]</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.2.2 <a name="imuser-add-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>The URI scheme is not supported:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;bad-request/&gt; error to IM User and does not add contact to WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>The information provided is not a valid URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;not-acceptable/&gt; error to IM User and does not add contact to WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>URI belongs to person served by ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService determines that Contact is an IM User registered with ServiceProvider [A7].</li>
+              <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+              <li>WaitingListService informs IM User of Contact's JID.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>URI does not belong to a person served by InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner sends &lt;item-not-found/&gt; error to WaitingListService.</li>
+              <li>If all InteropPartners queried return &lt;item-not-found/&gt; error, WaitingListService sends &lt;item-not-found/&gt; error (or local equivalent) to IM User and IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner records WaitingListService's request for JID associated with URI.</li>
+              <li>OPTIONALLY, InteropPartner invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>InteropPartner informs Service Provider's WaitingListService of JID associated with Contact's URI.</li>
+              <li>ServiceProvider's WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact denies request:
+            <ol start="1" type="1">
+              <li>InteropPartner's WaitingListService sends &lt;not-authorized/&gt; error to ServiceProvider's WaitingListService.</li>
+              <li>ServiceProvider's WaitingListService sends &lt;not-authorized/&gt; error (or local equivalent) to IM User.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService records IM User's request for JID associated with URI.</li>
+              <li>OPTIONALLY, WaitingListService invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact's URI is not handled by any ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI that no InteropPartner services Contact's URI.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Connection to ServiceProvider times out:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;remote-server-timeout/&gt; error (or local equivalent) to IM User.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3 <a name="imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may want to remove an item from its WaitingList (or removing the item may be recommended as part of an unsuccessful flow in the previous use case).</p>
+      <div class="indent">
+<h3>4.3.1 <a name="imuser-remove-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User sends removal request to WaitingListService.</li>
+          <li>WaitingListService removes IM User's request for JID associated with URI.</li>
+          <li>WaitingListService informs IM User of successful removal [A1].</li>
+          <li>WaitingListService sends removal request to appropriate InteropPartner's WaitingListService [A2].</li>
+          <li>InteropPartner's WaitingListService determines that URI belongs to a person served by that partner.</li>
+          <li>InteropPartner's WaitingListService removes ServiceProvider's WaitingListService's request for JID.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of successful removal.</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.3.2 <a name="imuser-remove-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User never requested JID associated with URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact URI is served by WaitingListService or IM User was not the only person who requested the JID:
+            <ol start="1" type="1">
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+  <h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="protocol-imuser">IM User Interaction With WaitingListService</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document is provided for the sake of domains that implement XMPP as their local protocol; domains that implement another protocol will use their service-specific protocol to complete the user-to-domain interaction. Support for the protocol defined in this section is NOT REQUIRED for services that do not implement XMPP as their local protocol.</span>
+      </p>
+      <div class="indent">
+<h3>5.1.1 <a name="protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+        <p class="" style="">It is RECOMMENDED for an IM User's client to retrieve the WaitingList immediately after logging in. However, first it must discover its local WaitingListService. An IM User MAY use either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256504">6</a>] or the deprecated <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2256530">7</a>] protocol.</p>
+        <p class="caption">Example 1. IM User Discovers WaitingListService by Sending Agent Information Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 2. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.service-provider.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. IM User Discovers WaitingListService by Sending Service Discovery Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 4. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 5. IM User Queries WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The WaitingListService SHOULD return detailed information about the service it provides, including the URI schemes it supports (see also the <a href="#registrar-features">Service Discovery Features</a> section of this document).</p>
+        <p class="caption">Example 6. WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory' type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/mailto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/tel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Once an IM User has discovered the WaitingListService, the user's client SHOULD request its current Waiting List:</p>
+        <p class="caption">Example 7. IM User Requests its Current WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Upon request, the WaitingListService MUST return the current WaitingList to the IM User:</p>
+        <p class="caption">Example 8. WaitingListService Returns WaitingList to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='request1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Each ItemID MUST be unique within the scope of the client's WaitingList items. The value of the ItemID is an opaque string; an implementation MAY assign semantic meaning to the ItemID (e.g., id="John Smith (mobile)" rather than id="12345"), but such meaning is implementation-specific and outside the scope of the protocol defined herein. The user MAY include a &lt;name/&gt; element containing a natural-language name for the Contact.</p>
+        <p class="" style="">The WaitingList MAY contain an item for which a JID has been discovered.</p>
+        <p class="caption">Example 9. IM User Asks for its WaitingList including Newly Discovered JID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='jidask1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='jidask1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345' jid='stpeter@jabber.org'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.2 <a name="protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once an IM User's client has discovered the WaitingListService and requested the user's WaitingList, the user can add Contacts to the WaitingList based on the Contact's URI. (Note: This JEP uses the example of phone numbers via the 'tel' URI scheme, but the same rules apply to WaitingList items based on email addresses or other URI schemes.)</p>
+        <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='waitlist.service-provider.com'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">As described below, various error conditions may occur. (For information about error syntax, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256753">8</a>].)</p>
+        <p class="" style="">If the IM User provided a URI whose scheme is not supported, WaitingListService MUST return a &lt;bad-request/&gt; error to the IM User and MUST NOT add the Contact to the WaitingList.</p>
+        <p class="caption">Example 11. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tag'&gt;shakespeare.lit,2005-08:waitlist1&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User included a JID in the request, WaitingListService MUST return a &lt;bad-request/&gt; error to IM User and MUST NOT add the Contact to the WaitingList. (Note: A WaitingListService MUST NOT return a non-XMPP URI to an IM User based on the Contact's JID; see the <a href="#security">Security Considerations</a> section of this document.)</p>
+        <p class="caption">Example 12. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item jid='some-jid'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided an invalid URI (e.g., a phone number with too many digits or an email address with no '@' character), WaitingListService MUST return a &lt;not-acceptable/&gt; error to the IM User and MUST NOT add the Contact to the WaitingList.</p>
+        <p class="caption">Example 13. WaitingListService Returns &lt;not-acceptable/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If all of the InteropPartners return an &lt;item-not-found/&gt; error to WaitingListService, WaitingListService MUST return an &lt;item-not-found/&gt; error (or local equivalent) to the IM User (and IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 14. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact denies request, InteropPartner MUST return a &lt;not-authorized/&gt; error to WaitingListService, which MUST return a &lt;not-authorized/&gt; error (or local equivalent) to the IM User (and IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 15. WaitingListService Returns &lt;not-authorized/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided a URI that is not served by an InteropPartner (e.g., a phone number associated with a telephony provider that is not in the WaitingListService's whitelist of InteropPartners), WaitingListService SHOULD return a &lt;remote-server-not-found/&gt; error to IM User (and the IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 16. WaitingListService Returns &lt;remote-server-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;remote-server-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService does not receive a reply from InteropPartner within a certain amount of time or the connection to InteropPartner times out, WaitingListService SHOULD send a &lt;remote-server-timeout/&gt; error to IM User (and the IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 17. WaitingListService Returns &lt;remote-server-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='504' type='cancel'&gt;
+    &lt;remote-server-timeout xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If no error was generated but the WaitingListService does not immediately know the Contact JID, WaitingListService MUST inform the IM User that the request was successfully received, including a unique ID number for the new WaitingList item.</p>
+        <p class="caption">Example 18. WaitingListService Informs IM User that Request was Received</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID when the IQ result is returned to the user, it MAY include the WaitingList item in the IQ result:</p>
+        <p class="caption">Example 19. WaitingListService Returns IQ Result to IM User (With Contact JID)</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID (or learns Contact JID from InteropPartner), it MUST inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 20. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">Note: The JID push uses &lt;message/&gt; because the WaitingListService has no knowledge of the user's presence and therefore cannot assume that an &lt;iq/&gt; stanza will be received by the user at a specific resource.</p>
+        <p class="" style="">If WaitingListService learns that Contact's URI is not handled by any InteropPartner, it SHOULD inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 21. WaitingListService Informs IM User that No InteropPartner Handles Contact's URI</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;Sorry, we cannot find this contact.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' 
+          jid='contact@service-provider.com'
+          type='error'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+      &lt;error code='404' 
+             type='cancel'
+             xmlns='jabber:client'&gt;
+        &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;/error&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.3 <a name="protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+        <p class="" style="">In order to remove the item from the WaitingList, the IM User MUST complete the "Remove Contact from WaitingList" use case.</p>
+        <p class="caption">Example 22. IM User Sends Removal Request to WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='remove1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService previously recorded request, WaitingListService removes request from list and returns result to IM User.</p>
+        <p class="caption">Example 23. WaitingListService Returns Result to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='remove1'/&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService did not previously record this request, WaitingListService MUST return an &lt;item-not-found/&gt; error to the IM User.</p>
+        <p class="caption">Example 24. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='remove1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>5.2 <a name="protocol-service">WaitingListService Interaction With InteropPartners</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document describes the inter-domain protocol for communication between WaitingListServices. The protocol defined in this section MUST be implemented by ServiceProviders.</span>
+      </p>
+      <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartner's WaitingListServices with which it communicates. Therefore service discovery SHOULD NOT be necessary. However, if necessary it MAY use either the <span style="font-weight: bold">Agent Information</span> protocol or the <span style="font-weight: bold">Service Discovery</span> protocol as described in the following examples.</p>
+      <p class="" style="">Note: The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</p>
+      <div class="indent">
+<h3>5.2.1 <a name="protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</h3>
+        <p class="caption">Example 25. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Agent Information Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 26. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.interop-partner.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 27. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Service Discovery Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 28. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 29. Service Provider Queries InteropPartner's WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 30. InteropPartner's WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory'
+              type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.2.2 <a name="protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once a ServiceProvider's WaitingListService has discovered the InteropPartner's WaitingListService and requested its WaitingList, the ServiceProvider's WaitingListService can add items to its WaitingList based on URI.</p>
+        <p class="caption">Example 31. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is not associated with a person served by this InteropPartner, the InteropPartner MUST return an &lt;item-not-found/&gt; error to the ServiceProvider.</p>
+        <p class="caption">Example 32. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is associated with a person served by this InteropPartner, InteropPartner MUST return acknowledgement of the WaitingList addition to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 33. InteropPartner's WaitingListService Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact is an IM User served by InteropPartner, InteropPartner's WaitingListService pushes Contact's JID to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 34. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 35. ServiceProvider's WaitingListService Acknowledges Receipt of JID Push</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='jidpush1'/&gt;
+        </pre></div>
+        <p class="" style="">After receiving acknowledgement (but not before), InteropPartner's WaitingListService MUST remove that item from the WaitingList for the ServiceProvider's WaitingListService.</p>
+      </div>
+      <div class="indent">
+<h3>5.2.3 <a name="protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</h3>
+        <p class="caption">Example 36. ServiceProvider Requests Removal of Item from WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='remove2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If item exists on WaitingList, InteropPartner's WaitingListService removes item from list and returns result to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 37. InteropPartner Returns Result to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'/&gt;
+        </pre></div>
+        <p class="" style="">If item does not exist on WaitingList, InteropPartner's WaitingListService MUST return an &lt;item-not-found/&gt; error to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 38. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <ol start="1" type="1">
+      <li>Protocols and mechanisms for inviting a Contact to register as an IM User are out of scope for this proposal and shall be determined by each InteropPartner individually.</li>
+      <li>A ServiceProvider's WaitingListService MUST record which of its IM Users have requested the JID associated with Contact's URI, and an InteropPartner's WaitingListService MUST record that Service Provider's WaitingListService (not User) has requested JID associated with Contact's URI. Therefore when Contact registers, InteropPartner's WaitingListService informs its local users as well as ServiceProvider's WaitingListService, and ServiceProvider's WaitingListService informs its local users.</li>
+      <li>The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</li>
+      <li>Once an IM User learns a Contact's JID, the IM User MAY send a normal subscription request to the Contact, setting the "to" address to Contact's JID. This interaction is defined in the base XMPP specifications and is out of scope for this document.</li>
+      <li>For historical reasons, implementations MUST support the older <span style="font-weight: bold">Agent Information</span> protocol (JEP-0094) and SHOULD support <span style="font-weight: bold">Service Discovery</span> (JEP-0030). Note well that the <span style="font-weight: bold">Agent Information</span> protocol will eventually be deprecated in favor of <span style="font-weight: bold">Service Discovery</span>.</li>
+      <li>An IM User's client receives WaitingList information either through a "JID push" message (received from WaitingListService at any time) or in the IQ result received after requesting the WaitingList (since one or more of the WaitingList items may contain a JID). (The same rule applies to a ServiceProvider's WaitingListService that receives an IQ set from an InteropPartner's WaitingListService.)</li>
+      <li>When an IM User logs in, the user's client SHOULD request the current WaitingList.</li>
+      <li>Although the examples in this JEP show the hostname of the WaitingListService as 'waitlist.third-party.com' (etc.), this is for convenience only; the hostname MAY be any valid DNS hostname.</li>
+      <li>When sending JID pushes, an implementation MAY specify a message type of 'headline', which in some deployments will prevent such messages from being stored offline for later delivery.</li>
+    </ol>
+  <h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartners with which it communicates. The WaitingListService SHOULD NOT communicate with any InteropPartners that are not on the whitelist.</p>
+    <p class="" style="">Requesting JIDs via WaitingLists is not bidirectional; i.e., a service MUST NOT allow an IM User to discover a Contact's non-XMPP URI based on the Contact's JID.</p>
+    <p class="" style="">A service MAY require a Contact to approve the disclosure of the Contact's JID, either as a global preference or for each request; however, this is a local policy matter.</p>
+  <h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257743">9</a>].</p>
+  <h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257791">10</a>] shall include 'http://jabber.org/protocol/waitinglist' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>9.2 <a name="registrar-identities">Service Discovery Identities</a>
+</h3>
+      <p class="" style="">The Jabber Registar shall include a type of "waitinglist" in the "directory" category in its registry of service discovery identities.</p>
+    </div>
+    <div class="indent">
+<h3>9.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall include supported URI schemes in its registry of service discovery features. These features shall be of the form 'http://jabber.org/protocol/waitlist/schemes/SCHEME-NAME'.</p>
+      <p class="" style="">This JEP registers the following two namespace names for URI schemes, but others MAY be registered in the future using standard registration procedures:</p>
+      <ul>
+        <li>http://jabber.org/protocol/waitlist/schemes/mailto</li>
+        <li>http://jabber.org/protocol/waitlist/schemes/tel</li>
+      </ul>
+    </div>
+  <h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/waitinglist'
+    xmlns='http://jabber.org/protocol/waitinglist'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='jabber:client'/&gt;
+
+  &lt;xs:element name='waitlist'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='1'&gt;&gt;
+        &lt;xs:sequence xmlns:xmpp='jabber:client'&gt;
+          &lt;xs:element ref='uri' minOccurs='1' maxOccurs='1'/&gt;
+          &lt;xs:element ref='name' minOccurs='0' maxOccurs='1'/&gt;
+          &lt;xs:element ref='xmpp:error' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element ref='remove'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='jid'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='type'
+                    use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='uri' type='xs:string'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='scheme'
+                    type='xs:NCNAME'
+                    use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='name' type='string1023'/&gt;
+
+  &lt;xs:element name='remove' type='empty'/&gt;
+
+  &lt;xs:simpleType name='string1023'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:maxLength value='1023'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251260">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251324">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251444">3</a>. RFC 3966: The tel URI for Telephone Numbers &lt;<a href="http://www.ietf.org/rfc/rfc3966.txt">http://www.ietf.org/rfc/rfc3966.txt</a>&gt;.</p>
+<p><a name="nt-id2251414">4</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p><a name="nt-id2255709">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2256504">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256530">7</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2256753">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257743">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257791">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-08-16)</h4>
+<div class="indent">Added error case for remote server timeout; specified client and service responsibilities regarding removal of waiting list items in error cases. (psa)
+    </div>
+<h4>Version 0.5 (2005-05-16)</h4>
+<div class="indent">Corrected schema and IQ examples by changing root element for namespace from &lt;query/&gt; to &lt;waitlist/&gt; (this had been used for message examples but not IQ examples). (psa)
+    </div>
+<h4>Version 0.4 (2005-04-01)</h4>
+<div class="indent">Changed JEP type to Informational; corrected Remote Server Error example to use &lt;remote-server-not-found/&gt; rather than &lt;service-unavailable/&gt;; added service discovery identity to Jabber Registrar Considerations; corrected text regarding registration of service discovery features; corrected some small errors in the text, examples, and schema. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-27)</h4>
+<div class="indent">Corrected error syntax used when Contact URI is not handled by any InteropPartner. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-03)</h4>
+<div class="indent">Added alternate flow for situation in which Contact URI is not handled by any InteropPartner; changed headline message type for JID pushes from SHOULD to MAY; clarified semantics of item ID; added name child of item; corrected and updated the XML schema; updated examples to use XMPP error conditions. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-18)</h4>
+<div class="indent">Initial version (see XML source for earlier revisions). (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0130-1.0.html
+++ b/content/xep-0130-1.0.html
@@ -1,0 +1,1133 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0130: Waiting Lists</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Waiting Lists">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Yehezkel Dallal">
+<meta name="DC.Creator" content="Alexandre Nolle">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Mark Troyer">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-08-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0130">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0130: Waiting Lists</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in use within the Jabber/XMPP community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; however, it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0130<br>
+            Version: 1.0<br>
+            Last Updated: 2005-08-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0094, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: waitinglist<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/waitinglist/waitinglist.xsd">http://jabber.org/protocol/waitinglist/waitinglist.xsd</a>&gt;<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Waiting%20Lists%20(JEP-0130)">http://wiki.jabber.org/index.php/Waiting Lists (JEP-0130)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Yehezkel Dallal</h3>
+<p class="indent">
+        Email: yehezkeld@followap.com<br></p>
+<h3>Alexandre Nolle</h3>
+<p class="indent">
+        Email: anolle@francetelecom.com<br></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jean-louis.seguineau@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+<h3>Mark Troyer</h3>
+<p class="indent">
+        Email: mtroyer@jabber.com<br>
+        JID: mtroyer@corp.jabber.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#imuser-retrieve-primary">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#imuser-retrieve-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#imuser-add-primary">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#imuser-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#imuser-remove-primary">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#imuser-remove-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-imuser">IM User Interaction With WaitingListService</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dt>5.1.2.  <a href="#protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dt>5.1.3.  <a href="#protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#protocol-service">WaitingListService Interaction With InteropPartners</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</dt>
+<dt>5.2.2.  <a href="#protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</dt>
+<dt>5.2.3.  <a href="#protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-identities">Service Discovery Identities</a>
+</dt>
+<dt>9.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">An IM user may want to be informed when a contact creates an IM account. If the user knows some information about the contact (e.g., a phone number or email address), the user's service can use that information to place the contact on a "waiting list", then inform the user when the contact creates an IM account. This document defines an extension to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250608">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250672">2</a>] that enables such "waiting list" functionality, including the ability to add contacts on other domains if service providers agree to interoperate (e.g., to add a contact who uses a different mobile telephony service provider).</p>
+    <p class="" style=""><span style="font-style: italic">Note: The protocol defined herein is currently in use at several large service providers in Europe. Others are welcome to use the protocol.</span></p>
+  <h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+    <p class="caption">Table 1: Terms Used</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Contact</td>
+        <td align="" colspan="" rowspan="">A person with whom an IM User seeks to communicate, identified by a URI such as &lt;tel:PhoneNumber&gt; (see <span class="ref" style="">RFC 3966</span>  [<a href="#nt-id2250756">3</a>]) or &lt;mailto:EmailAddress&gt; (see <span class="ref" style="">RFC 2368</span>  [<a href="#nt-id2250779">4</a>]).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Customer</td>
+        <td align="" colspan="" rowspan="">A person who is contracted for services with a ServiceProvider.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">IM User</td>
+        <td align="" colspan="" rowspan="">Any Customer who has registered for instant messaging services.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">InteropPartner</td>
+        <td align="" colspan="" rowspan="">Any company that agrees to interoperate using the protocol defined herein.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">JID</td>
+        <td align="" colspan="" rowspan="">The unique identifier of an IM User in the XMPP protocol. Outside the context of an IM session, a JID is of the form &lt;user@domain&gt; ("bare JID"); within the context of an IM session, a JID is of the form &lt;user@domain/resource&gt; ("full JID").</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ServiceProvider</td>
+        <td align="" colspan="" rowspan="">A company that provides telephony or email services to a Customer.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">URI</td>
+        <td align="" colspan="" rowspan="">A Uniform Resource Identifier as defined in <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256333">5</a>]. Specific URI schemes that may be useful in this specification include 'tel:', 'mailto:', and 'sip:', but any URI scheme may be used.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Waiting List</td>
+        <td align="" colspan="" rowspan="">A list of Contacts whom an entity (IM User or InteropPartner) is waiting to hear about regarding their status as instant messaging users.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">WaitingListService</td>
+        <td align="" colspan="" rowspan="">An XMPP service that maintains Waiting lists for IM Users and/or InteropPartners.</td>
+      </tr>
+    </table>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This protocol is designed so that an IM User can:</p>
+    <ol start="1" type="1">
+      <li>Request the user's current Waiting List</li>
+      <li>Add a Contact to a local WaitingList (based on some URI associated with the Contact)</li>
+      <li>Receive notification from a local WaitingListService if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+    <p class="" style="">In addition, this protocol is designed so that a ServiceProvider can:</p>
+    <ol start="1" type="1">
+      <li>Request the service's current WaitingList</li>
+      <li>Add a Contact to a WaitingList at an InteroPartner (based on some URI associated with the Contact)</li>
+      <li>Receive notification from the InteropPartner if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+  <h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+      <p class="" style="">Before adding or removing Contacts from its WaitingList, an IM User SHOULD retrieve its current WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.1.1 <a name="imuser-retrieve-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User discovers WaitingListService hosted by ServiceProvider [A1]; it is RECOMMENDED to do this immediately after logging in.</li>
+          <li>IM User requests current WaitingList from WaitingListService.</li>
+          <li>WaitingListService returns WaitingList to IM User, including any items for which JIDs have been discovered [A2].</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.1.2 <a name="imuser-retrieve-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>ServiceProvider does not host a WaitingListService:
+          <ol start="1" type="1">
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>IM User does not have a Waiting List:
+          <ol start="1" type="1">
+              <li>WaitingListService returns &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may know a URI for a Contact (e.g., a phone number or email address) but not the Contact's JID. In order to subscribe to the Contact's presence or otherwise communicate with the Contact over an instant messaging system, the IM User first needs to discover the Contact's JID based on a URI for the Contact. However, the Contact may not yet have an IM account. Because the IM User may therefore need to wait until the Contact creates an account, the IM User needs to add the Contact to a WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.2.1 <a name="imuser-add-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User SHOULD first complete use case for "IM User Retrieves Current WaitingList".</li>
+          <li>IM User requests addition of Contact to WaitingList based on Contact's URI.</li>
+          <li>WaitingListService determines that the URI scheme is supported [A1].</li>
+          <li>WaitingListService determines that the information provided is a valid URI for that URI scheme [A2].</li>
+          <li>WaitingListService acknowledges addition of Contact to IM User's WaitingList.</li>
+          <li>WaitingListService determines that Contact's URI does not belong to a person served by ServiceProvider [A3].</li>
+          <li>WaitingListService discovers WaitingListServices hosted by one or more InteropPartners.</li>
+          <li>WaitingListService queries one or more InteropPartner's WaitingListServices for JID associated with URI.</li>
+          <li>InteropPartner's WaitingListService determines that Contact's URI belongs to a person served by that partner [A4].</li>
+          <li>InteropPartner's WaitingListService determines that Contact is an IM User [A5].</li>
+          <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of JID associated with Contact's URI. [A6]</li>
+          <li>ServiceProvider's WaitingListService informs IM User of Contact's JID. [A8]</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.2.2 <a name="imuser-add-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>The URI scheme is not supported:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;bad-request/&gt; error to IM User and does not add contact to WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>The information provided is not a valid URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;not-acceptable/&gt; error to IM User and does not add contact to WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>URI belongs to person served by ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService determines that Contact is an IM User registered with ServiceProvider [A7].</li>
+              <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+              <li>WaitingListService informs IM User of Contact's JID.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>URI does not belong to a person served by InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner sends &lt;item-not-found/&gt; error to WaitingListService.</li>
+              <li>If all InteropPartners queried return &lt;item-not-found/&gt; error, WaitingListService sends &lt;item-not-found/&gt; error (or local equivalent) to IM User and IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner records WaitingListService's request for JID associated with URI.</li>
+              <li>OPTIONALLY, InteropPartner invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>InteropPartner informs Service Provider's WaitingListService of JID associated with Contact's URI.</li>
+              <li>ServiceProvider's WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact denies request:
+            <ol start="1" type="1">
+              <li>InteropPartner's WaitingListService sends &lt;not-authorized/&gt; error to ServiceProvider's WaitingListService.</li>
+              <li>ServiceProvider's WaitingListService sends &lt;not-authorized/&gt; error (or local equivalent) to IM User.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService records IM User's request for JID associated with URI.</li>
+              <li>OPTIONALLY, WaitingListService invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact's URI is not handled by any ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI that no InteropPartner services Contact's URI.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Connection to ServiceProvider times out:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;remote-server-timeout/&gt; error (or local equivalent) to IM User.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3 <a name="imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may want to remove an item from its WaitingList (or removing the item may be recommended as part of an unsuccessful flow in the previous use case).</p>
+      <div class="indent">
+<h3>4.3.1 <a name="imuser-remove-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User sends removal request to WaitingListService.</li>
+          <li>WaitingListService removes IM User's request for JID associated with URI.</li>
+          <li>WaitingListService informs IM User of successful removal [A1].</li>
+          <li>WaitingListService sends removal request to appropriate InteropPartner's WaitingListService [A2].</li>
+          <li>InteropPartner's WaitingListService determines that URI belongs to a person served by that partner.</li>
+          <li>InteropPartner's WaitingListService removes ServiceProvider's WaitingListService's request for JID.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of successful removal.</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.3.2 <a name="imuser-remove-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User never requested JID associated with URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact URI is served by WaitingListService or IM User was not the only person who requested the JID:
+            <ol start="1" type="1">
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+  <h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="protocol-imuser">IM User Interaction With WaitingListService</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document is provided for the sake of domains that implement XMPP as their local protocol; domains that implement another protocol will use their service-specific protocol to complete the user-to-domain interaction. Support for the protocol defined in this section is NOT REQUIRED for services that do not implement XMPP as their local protocol.</span>
+      </p>
+      <div class="indent">
+<h3>5.1.1 <a name="protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+        <p class="" style="">It is RECOMMENDED for an IM User's client to retrieve the WaitingList immediately after logging in. However, first it must discover its local WaitingListService. An IM User MAY use either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257265">6</a>] or the deprecated <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2257288">7</a>] protocol.</p>
+        <p class="caption">Example 1. IM User Discovers WaitingListService by Sending Agent Information Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 2. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.service-provider.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. IM User Discovers WaitingListService by Sending Service Discovery Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 4. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 5. IM User Queries WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The WaitingListService SHOULD return detailed information about the service it provides, including the URI schemes it supports (see also the <a href="#registrar-features">Service Discovery Features</a> section of this document).</p>
+        <p class="caption">Example 6. WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory' type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/mailto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/tel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Once an IM User has discovered the WaitingListService, the user's client SHOULD request its current Waiting List:</p>
+        <p class="caption">Example 7. IM User Requests its Current WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Upon request, the WaitingListService MUST return the current WaitingList to the IM User:</p>
+        <p class="caption">Example 8. WaitingListService Returns WaitingList to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='request1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Each ItemID MUST be unique within the scope of the client's WaitingList items. The value of the ItemID is an opaque string; an implementation MAY assign semantic meaning to the ItemID (e.g., id="John Smith (mobile)" rather than id="12345"), but such meaning is implementation-specific and outside the scope of the protocol defined herein. The user MAY include a &lt;name/&gt; element containing a natural-language name for the Contact.</p>
+        <p class="" style="">The WaitingList MAY contain an item for which a JID has been discovered.</p>
+        <p class="caption">Example 9. IM User Asks for its WaitingList including Newly Discovered JID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='jidask1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='jidask1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345' jid='stpeter@jabber.org'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.2 <a name="protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once an IM User's client has discovered the WaitingListService and requested the user's WaitingList, the user can add Contacts to the WaitingList based on the Contact's URI. (Note: This JEP uses the example of phone numbers via the 'tel' URI scheme, but the same rules apply to WaitingList items based on email addresses or other URI schemes.)</p>
+        <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='waitlist.service-provider.com'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">As described below, various error conditions may occur. (For information about error syntax, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257514">8</a>].)</p>
+        <p class="" style="">If the IM User provided a URI whose scheme is not supported, WaitingListService MUST return a &lt;bad-request/&gt; error to the IM User and MUST NOT add the Contact to the WaitingList.</p>
+        <p class="caption">Example 11. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tag'&gt;shakespeare.lit,2005-08:waitlist1&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User included a JID in the request, WaitingListService MUST return a &lt;bad-request/&gt; error to IM User and MUST NOT add the Contact to the WaitingList. (Note: A WaitingListService MUST NOT return a non-XMPP URI to an IM User based on the Contact's JID; see the <a href="#security">Security Considerations</a> section of this document.)</p>
+        <p class="caption">Example 12. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item jid='some-jid'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided an invalid URI (e.g., a phone number with too many digits or an email address with no '@' character), WaitingListService MUST return a &lt;not-acceptable/&gt; error to the IM User and MUST NOT add the Contact to the WaitingList.</p>
+        <p class="caption">Example 13. WaitingListService Returns &lt;not-acceptable/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If all of the InteropPartners return an &lt;item-not-found/&gt; error to WaitingListService, WaitingListService MUST return an &lt;item-not-found/&gt; error (or local equivalent) to the IM User (and IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 14. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact denies request, InteropPartner MUST return a &lt;not-authorized/&gt; error to WaitingListService, which MUST return a &lt;not-authorized/&gt; error (or local equivalent) to the IM User (and IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 15. WaitingListService Returns &lt;not-authorized/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided a URI that is not served by an InteropPartner (e.g., a phone number associated with a telephony provider that is not in the WaitingListService's whitelist of InteropPartners), WaitingListService SHOULD return a &lt;remote-server-not-found/&gt; error to IM User (and the IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 16. WaitingListService Returns &lt;remote-server-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;remote-server-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService does not receive a reply from InteropPartner within a certain amount of time or the connection to InteropPartner times out, WaitingListService SHOULD send a &lt;remote-server-timeout/&gt; error to IM User (and the IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 17. WaitingListService Returns &lt;remote-server-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='504' type='cancel'&gt;
+    &lt;remote-server-timeout xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If no error was generated but the WaitingListService does not immediately know the Contact JID, WaitingListService MUST inform the IM User that the request was successfully received, including a unique ID number for the new WaitingList item.</p>
+        <p class="caption">Example 18. WaitingListService Informs IM User that Request was Received</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID when the IQ result is returned to the user, it MAY include the WaitingList item in the IQ result:</p>
+        <p class="caption">Example 19. WaitingListService Returns IQ Result to IM User (With Contact JID)</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID (or learns Contact JID from InteropPartner), it MUST inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 20. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">Note: The JID push uses &lt;message/&gt; because the WaitingListService has no knowledge of the user's presence and therefore cannot assume that an &lt;iq/&gt; stanza will be received by the user at a specific resource.</p>
+        <p class="" style="">If WaitingListService learns that Contact's URI is not handled by any InteropPartner, it SHOULD inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 21. WaitingListService Informs IM User that No InteropPartner Handles Contact's URI</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;Sorry, we cannot find this contact.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' 
+          jid='contact@service-provider.com'
+          type='error'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+      &lt;error code='404' 
+             type='cancel'
+             xmlns='jabber:client'&gt;
+        &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;/error&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.3 <a name="protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+        <p class="" style="">In order to remove the item from the WaitingList, the IM User MUST complete the "Remove Contact from WaitingList" use case.</p>
+        <p class="caption">Example 22. IM User Sends Removal Request to WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='remove1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService previously recorded request, WaitingListService removes request from list and returns result to IM User.</p>
+        <p class="caption">Example 23. WaitingListService Returns Result to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='remove1'/&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService did not previously record this request, WaitingListService MUST return an &lt;item-not-found/&gt; error to the IM User.</p>
+        <p class="caption">Example 24. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='remove1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>5.2 <a name="protocol-service">WaitingListService Interaction With InteropPartners</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document describes the inter-domain protocol for communication between WaitingListServices. The protocol defined in this section MUST be implemented by ServiceProviders.</span>
+      </p>
+      <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartner's WaitingListServices with which it communicates. Therefore service discovery SHOULD NOT be necessary. However, if necessary it MAY use either the <span style="font-weight: bold">Agent Information</span> protocol or the <span style="font-weight: bold">Service Discovery</span> protocol as described in the following examples.</p>
+      <p class="" style="">Note: The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</p>
+      <div class="indent">
+<h3>5.2.1 <a name="protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</h3>
+        <p class="caption">Example 25. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Agent Information Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 26. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.interop-partner.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 27. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Service Discovery Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 28. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 29. Service Provider Queries InteropPartner's WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 30. InteropPartner's WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory'
+              type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.2.2 <a name="protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once a ServiceProvider's WaitingListService has discovered the InteropPartner's WaitingListService and requested its WaitingList, the ServiceProvider's WaitingListService can add items to its WaitingList based on URI.</p>
+        <p class="caption">Example 31. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is not associated with a person served by this InteropPartner, the InteropPartner MUST return an &lt;item-not-found/&gt; error to the ServiceProvider.</p>
+        <p class="caption">Example 32. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is associated with a person served by this InteropPartner, InteropPartner MUST return acknowledgement of the WaitingList addition to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 33. InteropPartner's WaitingListService Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact is an IM User served by InteropPartner, InteropPartner's WaitingListService pushes Contact's JID to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 34. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush1'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 35. ServiceProvider's WaitingListService Acknowledges Receipt of JID Push</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='jidpush1'/&gt;
+        </pre></div>
+        <p class="" style="">After receiving acknowledgement (but not before), InteropPartner's WaitingListService MUST remove that item from the WaitingList for the ServiceProvider's WaitingListService.</p>
+      </div>
+      <div class="indent">
+<h3>5.2.3 <a name="protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</h3>
+        <p class="caption">Example 36. ServiceProvider Requests Removal of Item from WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='remove2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If item exists on WaitingList, InteropPartner's WaitingListService removes item from list and returns result to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 37. InteropPartner Returns Result to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'/&gt;
+        </pre></div>
+        <p class="" style="">If item does not exist on WaitingList, InteropPartner's WaitingListService MUST return an &lt;item-not-found/&gt; error to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 38. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <ol start="1" type="1">
+      <li>Protocols and mechanisms for inviting a Contact to register as an IM User are out of scope for this proposal and shall be determined by each InteropPartner individually.</li>
+      <li>A ServiceProvider's WaitingListService MUST record which of its IM Users have requested the JID associated with Contact's URI, and an InteropPartner's WaitingListService MUST record that Service Provider's WaitingListService (not User) has requested JID associated with Contact's URI. Therefore when Contact registers, InteropPartner's WaitingListService informs its local users as well as ServiceProvider's WaitingListService, and ServiceProvider's WaitingListService informs its local users.</li>
+      <li>The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</li>
+      <li>Once an IM User learns a Contact's JID, the IM User MAY send a normal subscription request to the Contact, setting the "to" address to Contact's JID. This interaction is defined in the base XMPP specifications and is out of scope for this document.</li>
+      <li>For historical reasons, implementations MUST support the older <span style="font-weight: bold">Agent Information</span> protocol (JEP-0094) and SHOULD support <span style="font-weight: bold">Service Discovery</span> (JEP-0030). Note well that the <span style="font-weight: bold">Agent Information</span> protocol will eventually be deprecated in favor of <span style="font-weight: bold">Service Discovery</span>.</li>
+      <li>An IM User's client receives WaitingList information either through a "JID push" message (received from WaitingListService at any time) or in the IQ result received after requesting the WaitingList (since one or more of the WaitingList items may contain a JID). (The same rule applies to a ServiceProvider's WaitingListService that receives an IQ set from an InteropPartner's WaitingListService.)</li>
+      <li>When an IM User logs in, the user's client SHOULD request the current WaitingList.</li>
+      <li>Although the examples in this JEP show the hostname of the WaitingListService as 'waitlist.third-party.com' (etc.), this is for convenience only; the hostname MAY be any valid DNS hostname.</li>
+      <li>When sending JID pushes, an implementation MAY specify a message type of 'headline', which in some deployments will prevent such messages from being stored offline for later delivery.</li>
+    </ol>
+  <h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartners with which it communicates. The WaitingListService SHOULD NOT communicate with any InteropPartners that are not on the whitelist.</p>
+    <p class="" style="">Requesting JIDs via WaitingLists is not bidirectional; i.e., a service MUST NOT allow an IM User to discover a Contact's non-XMPP URI based on the Contact's JID.</p>
+    <p class="" style="">A service MAY require a Contact to approve the disclosure of the Contact's JID, either as a global preference or for each request; however, this is a local policy matter.</p>
+  <h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258366">9</a>].</p>
+  <h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258417">10</a>] includes 'http://jabber.org/protocol/waitinglist' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>9.2 <a name="registrar-identities">Service Discovery Identities</a>
+</h3>
+      <p class="" style="">The Jabber Registar includes a type of "waitinglist" in the "directory" category in its registry of service discovery identities.</p>
+    </div>
+    <div class="indent">
+<h3>9.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+      <p class="" style="">The Jabber Registrar includes supported URI schemes in its registry of service discovery features. These features shall be of the form 'http://jabber.org/protocol/waitlist/schemes/SCHEME-NAME'.</p>
+      <p class="" style="">This JEP registers the following two namespace names for URI schemes, but others MAY be registered in the future using standard registration procedures:</p>
+      <ul>
+        <li>http://jabber.org/protocol/waitlist/schemes/mailto</li>
+        <li>http://jabber.org/protocol/waitlist/schemes/tel</li>
+      </ul>
+    </div>
+  <h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/waitinglist'
+    xmlns='http://jabber.org/protocol/waitinglist'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0130: http://www.jabber.org/jeps/jep-0130.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import namespace='jabber:client'/&gt;
+
+  &lt;xs:element name='waitlist'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='1'&gt;&gt;
+        &lt;xs:all xmlns:xmpp='jabber:client'&gt;
+          &lt;xs:element ref='uri'/&gt;
+          &lt;xs:element ref='name' minOccurs='0'/&gt;
+          &lt;xs:element ref='xmpp:error' minOccurs='0'/&gt;
+        &lt;/xs:all&gt;
+        &lt;xs:element ref='remove'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='jid'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='type'
+                    use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='uri' type='xs:string'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='scheme'
+                    type='xs:NCNAME'
+                    use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='name' type='string1023'/&gt;
+
+  &lt;xs:element name='remove' type='empty'/&gt;
+
+  &lt;xs:simpleType name='string1023'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:maxLength value='1023'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250608">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250672">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250756">3</a>. RFC 3966: The tel URI for Telephone Numbers &lt;<a href="http://www.ietf.org/rfc/rfc3966.txt">http://www.ietf.org/rfc/rfc3966.txt</a>&gt;.</p>
+<p><a name="nt-id2250779">4</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p><a name="nt-id2256333">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2257265">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257288">7</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2257514">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2258366">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258417">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2005-08-26)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Active. (psa)
+    </div>
+<h4>Version 0.6 (2005-08-16)</h4>
+<div class="indent">Added error case for remote server timeout; specified client and service responsibilities regarding removal of waiting list items in error cases. (psa)
+    </div>
+<h4>Version 0.5 (2005-05-16)</h4>
+<div class="indent">Corrected schema and IQ examples by changing root element for namespace from &lt;query/&gt; to &lt;waitlist/&gt; (this had been used for message examples but not IQ examples). (psa)
+    </div>
+<h4>Version 0.4 (2005-04-01)</h4>
+<div class="indent">Changed JEP type to Informational; corrected Remote Server Error example to use &lt;remote-server-not-found/&gt; rather than &lt;service-unavailable/&gt;; added service discovery identity to Jabber Registrar Considerations; corrected text regarding registration of service discovery features; corrected some small errors in the text, examples, and schema. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-27)</h4>
+<div class="indent">Corrected error syntax used when Contact URI is not handled by any InteropPartner. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-03)</h4>
+<div class="indent">Added alternate flow for situation in which Contact URI is not handled by any InteropPartner; changed headline message type for JID pushes from SHOULD to MAY; clarified semantics of item ID; added name child of item; corrected and updated the XML schema; updated examples to use XMPP error conditions. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-18)</h4>
+<div class="indent">Initial version (see XML source for earlier revisions). (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0130-1.1.html
+++ b/content/xep-0130-1.1.html
@@ -1,0 +1,1189 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0130: Waiting Lists</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Waiting Lists">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Yehezkel Dallal">
+<meta name="DC.Creator" content="Alexandre Nolle">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Mark Troyer">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0130">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0130: Waiting Lists</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in use within the Jabber/XMPP community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; however, it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0130<br>
+            Version: 1.1<br>
+            Last Updated: 2005-11-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0094, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: waitinglist<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/waitinglist/waitinglist.xsd">http://jabber.org/protocol/waitinglist/waitinglist.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Waiting%20Lists%20(JEP-0130)">http://wiki.jabber.org/index.php/Waiting Lists (JEP-0130)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Yehezkel Dallal</h3>
+<p class="indent">
+        Email: yehezkeld@followap.com<br></p>
+<h3>Alexandre Nolle</h3>
+<p class="indent">
+        Email: anolle@francetelecom.com<br></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jean-louis.seguineau@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+<h3>Mark Troyer</h3>
+<p class="indent">
+        Email: mtroyer@jabber.com<br>
+        JID: mtroyer@corp.jabber.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#imuser-retrieve-primary">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#imuser-retrieve-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#imuser-add-primary">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#imuser-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#imuser-remove-primary">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#imuser-remove-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-imuser">IM User Interaction With WaitingListService</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dt>5.1.2.  <a href="#protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dt>5.1.3.  <a href="#protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#protocol-service">WaitingListService Interaction With InteropPartners</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</dt>
+<dt>5.2.2.  <a href="#protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</dt>
+<dt>5.2.3.  <a href="#protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-identities">Service Discovery Identities</a>
+</dt>
+<dt>9.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">An IM user may want to be informed when a contact creates an IM account. If the user knows some information about the contact (e.g., a phone number or email address), the user's service can use that information to place the contact on a "waiting list", then inform the user when the contact creates an IM account. This document defines an extension to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250973">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2256305">2</a>] that enables such "waiting list" functionality, including the ability to add contacts on other domains if service providers agree to interoperate (e.g., to add a contact who uses a different mobile telephony service provider).</p>
+    <p class="" style=""><span style="font-style: italic">Note: The protocol defined herein is currently in use at several large service providers in Europe. Others are welcome to use the protocol.</span></p>
+  <h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+    <p class="caption">Table 1: Terms Used</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Contact</td>
+        <td align="" colspan="" rowspan="">A person with whom an IM User seeks to communicate, identified by a URI such as &lt;tel:PhoneNumber&gt; (see <span class="ref" style="">RFC 3966</span>  [<a href="#nt-id2256390">3</a>]) or &lt;mailto:EmailAddress&gt; (see <span class="ref" style="">RFC 2368</span>  [<a href="#nt-id2256412">4</a>]).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Customer</td>
+        <td align="" colspan="" rowspan="">A person who is contracted for services with a ServiceProvider.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">IM User</td>
+        <td align="" colspan="" rowspan="">Any Customer who has registered for instant messaging services.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">InteropPartner</td>
+        <td align="" colspan="" rowspan="">Any company that agrees to interoperate using the protocol defined herein.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">JID</td>
+        <td align="" colspan="" rowspan="">The unique identifier of an IM User in the XMPP protocol. Outside the context of an IM session, a JID is of the form &lt;user@domain&gt; ("bare JID"); within the context of an IM session, a JID is of the form &lt;user@domain/resource&gt; ("full JID").</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ServiceProvider</td>
+        <td align="" colspan="" rowspan="">A company that provides telephony or email services to a Customer.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">URI</td>
+        <td align="" colspan="" rowspan="">A Uniform Resource Identifier as defined in <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256562">5</a>]. Specific URI schemes that may be useful in this specification include 'tel:', 'mailto:', and 'sip:', but any URI scheme may be used.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Waiting List</td>
+        <td align="" colspan="" rowspan="">A list of Contacts whom an entity (IM User or InteropPartner) is waiting to hear about regarding their status as instant messaging users.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">WaitingListService</td>
+        <td align="" colspan="" rowspan="">An XMPP service that maintains Waiting lists for IM Users and/or InteropPartners.</td>
+      </tr>
+    </table>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This protocol is designed so that an IM User can:</p>
+    <ol start="1" type="1">
+      <li>Request the user's current Waiting List</li>
+      <li>Add a Contact to a local WaitingList (based on some URI associated with the Contact)</li>
+      <li>Receive notification from a local WaitingListService if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+    <p class="" style="">In addition, this protocol is designed so that a ServiceProvider can:</p>
+    <ol start="1" type="1">
+      <li>Request the service's current WaitingList</li>
+      <li>Add a Contact to a WaitingList at an InteroPartner (based on some URI associated with the Contact)</li>
+      <li>Receive notification from the InteropPartner if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+  <h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+      <p class="" style="">Before adding or removing Contacts from its WaitingList, an IM User SHOULD retrieve its current WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.1.1 <a name="imuser-retrieve-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User discovers WaitingListService hosted by ServiceProvider [A1]; it is RECOMMENDED to do this immediately after logging in.</li>
+          <li>IM User requests current WaitingList from WaitingListService.</li>
+          <li>WaitingListService returns WaitingList to IM User, including any items for which JIDs have been discovered [A2].</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.1.2 <a name="imuser-retrieve-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>ServiceProvider does not host a WaitingListService:
+          <ol start="1" type="1">
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>IM User does not have a Waiting List:
+          <ol start="1" type="1">
+              <li>WaitingListService returns &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may know a URI for a Contact (e.g., a phone number or email address) but not the Contact's JID. In order to subscribe to the Contact's presence or otherwise communicate with the Contact over an instant messaging system, the IM User first needs to discover the Contact's JID based on a URI for the Contact. However, the Contact may not yet have an IM account. Because the IM User may therefore need to wait until the Contact creates an account, the IM User needs to add the Contact to a WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.2.1 <a name="imuser-add-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User SHOULD first complete use case for "IM User Retrieves Current WaitingList".</li>
+          <li>IM User requests addition of Contact to WaitingList based on Contact's URI.</li>
+          <li>WaitingListService determines that the URI scheme is supported [A1].</li>
+          <li>WaitingListService determines that the information provided is a valid URI for that URI scheme [A2].</li>
+          <li>WaitingListService acknowledges addition of Contact to IM User's WaitingList.</li>
+          <li>WaitingListService determines that Contact's URI does not belong to a person served by ServiceProvider [A3].</li>
+          <li>WaitingListService discovers WaitingListServices hosted by one or more InteropPartners.</li>
+          <li>WaitingListService queries one or more InteropPartner's WaitingListServices for JID associated with URI.</li>
+          <li>InteropPartner's WaitingListService determines that Contact's URI belongs to a person served by that partner [A4].</li>
+          <li>InteropPartner's WaitingListService determines that Contact is an IM User [A5].</li>
+          <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of JID associated with Contact's URI. [A6]</li>
+          <li>ServiceProvider's WaitingListService informs IM User of Contact's JID. [A8]</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.2.2 <a name="imuser-add-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>The URI scheme is not supported:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;bad-request/&gt; error to IM User and does not add contact to WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>The information provided is not a valid URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;not-acceptable/&gt; error to IM User and does not add contact to WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>URI belongs to person served by ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService determines that Contact is an IM User registered with ServiceProvider [A7].</li>
+              <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+              <li>WaitingListService informs IM User of Contact's JID.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>URI does not belong to a person served by InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner sends &lt;item-not-found/&gt; error to WaitingListService.</li>
+              <li>If all InteropPartners queried return &lt;item-not-found/&gt; error, WaitingListService sends &lt;item-not-found/&gt; error (or local equivalent) to IM User and IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner records WaitingListService's request for JID associated with URI.</li>
+              <li>OPTIONALLY, InteropPartner invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>InteropPartner informs Service Provider's WaitingListService of JID associated with Contact's URI.</li>
+              <li>ServiceProvider's WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact denies request:
+            <ol start="1" type="1">
+              <li>InteropPartner's WaitingListService sends &lt;not-authorized/&gt; error to ServiceProvider's WaitingListService.</li>
+              <li>ServiceProvider's WaitingListService sends &lt;not-authorized/&gt; error (or local equivalent) to IM User.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService records IM User's request for JID associated with URI.</li>
+              <li>OPTIONALLY, WaitingListService invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact's URI is not handled by any ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI that no InteropPartner services Contact's URI.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Connection to ServiceProvider times out:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;remote-server-timeout/&gt; error (or local equivalent) to IM User.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3 <a name="imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may want to remove an item from its WaitingList (or removing the item may be recommended as part of an unsuccessful flow in the previous use case).</p>
+      <div class="indent">
+<h3>4.3.1 <a name="imuser-remove-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User sends removal request to WaitingListService.</li>
+          <li>WaitingListService removes IM User's request for JID associated with URI.</li>
+          <li>WaitingListService informs IM User of successful removal [A1].</li>
+          <li>WaitingListService sends removal request to appropriate InteropPartner's WaitingListService [A2].</li>
+          <li>InteropPartner's WaitingListService determines that URI belongs to a person served by that partner.</li>
+          <li>InteropPartner's WaitingListService removes ServiceProvider's WaitingListService's request for JID.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of successful removal.</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.3.2 <a name="imuser-remove-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User never requested JID associated with URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact URI is served by WaitingListService or IM User was not the only person who requested the JID:
+            <ol start="1" type="1">
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+  <h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="protocol-imuser">IM User Interaction With WaitingListService</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document is provided for the sake of domains that implement XMPP as their local protocol; domains that implement another protocol will use their service-specific protocol to complete the user-to-domain interaction. Support for the protocol defined in this section is NOT REQUIRED for services that do not implement XMPP as their local protocol.</span>
+      </p>
+      <div class="indent">
+<h3>5.1.1 <a name="protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+        <p class="" style="">It is RECOMMENDED for an IM User's client to retrieve the WaitingList immediately after logging in. However, first it must discover its local WaitingListService. An IM User MAY use either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257488">6</a>] or the deprecated <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2257512">7</a>] protocol.</p>
+        <p class="caption">Example 1. IM User Discovers WaitingListService by Sending Agent Information Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 2. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.service-provider.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. IM User Discovers WaitingListService by Sending Service Discovery Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 4. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 5. IM User Queries WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The WaitingListService SHOULD return detailed information about the service it provides, including the URI schemes it supports (see also the <a href="#registrar-features">Service Discovery Features</a> section of this document).</p>
+        <p class="caption">Example 6. WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory' type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/mailto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/tel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Once an IM User has discovered the WaitingListService, the user's client SHOULD request its current Waiting List. This is done by sending an IQ-get to the WaitingListService containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/waitinglist' namespace:</p>
+        <p class="caption">Example 7. IM User Requests its Current WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Upon request, the WaitingListService MUST return the current WaitingList to the IM User:</p>
+        <p class="caption">Example 8. WaitingListService Returns WaitingList to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Each ItemID MUST be unique within the scope of the client's WaitingList items. The value of the ItemID is an opaque string; an implementation MAY assign semantic meaning to the ItemID (e.g., id="John Smith (mobile)" rather than id="12345"), but such meaning is implementation-specific and outside the scope of the protocol defined herein. The user MAY include a &lt;name/&gt; element containing a natural-language name for the Contact.</p>
+        <p class="" style="">The WaitingList MAY contain an item for which a JID has been discovered.</p>
+        <p class="caption">Example 9. IM User Asks for its WaitingList including Newly Discovered JID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='jidask1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='jidask1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345' jid='stpeter@jabber.org'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.2 <a name="protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once an IM User's client has discovered the WaitingListService and requested the user's WaitingList, the user can add Contacts to the WaitingList based on the Contact's URI. (Note: This JEP uses the example of phone numbers via the 'tel' URI scheme, but the same rules apply to WaitingList items based on email addresses or other URI schemes.)</p>
+        <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='waitlist.service-provider.com'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">As described below, various error conditions may occur. (For information about error syntax, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257742">8</a>].)</p>
+        <p class="" style="">If the IM User provided a URI whose scheme is not supported, WaitingListService MUST return a &lt;bad-request/&gt; error to the IM User and MUST NOT add the Contact to the WaitingList.</p>
+        <p class="caption">Example 11. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tag'&gt;shakespeare.lit,2005-08:waitlist1&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User included a JID in the request, WaitingListService MUST return a &lt;bad-request/&gt; error to IM User and MUST NOT add the Contact to the WaitingList. (Note: A WaitingListService MUST NOT return a non-XMPP URI to an IM User based on the Contact's JID; see the <a href="#security">Security Considerations</a> section of this document.)</p>
+        <p class="caption">Example 12. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item jid='some-jid'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided an invalid URI (e.g., a phone number with too many digits or an email address with no '@' character), WaitingListService MUST return a &lt;not-acceptable/&gt; error to the IM User and MUST NOT add the Contact to the WaitingList.</p>
+        <p class="caption">Example 13. WaitingListService Returns &lt;not-acceptable/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If all of the InteropPartners return an &lt;item-not-found/&gt; error to WaitingListService, WaitingListService MUST return an &lt;item-not-found/&gt; error (or local equivalent) to the IM User (and IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 14. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact denies request, InteropPartner MUST return a &lt;not-authorized/&gt; error to WaitingListService, which MUST return a &lt;not-authorized/&gt; error (or local equivalent) to the IM User (and IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 15. WaitingListService Returns &lt;not-authorized/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided a URI that is not served by an InteropPartner (e.g., a phone number associated with a telephony provider that is not in the WaitingListService's whitelist of InteropPartners), WaitingListService SHOULD return a &lt;remote-server-not-found/&gt; error to IM User (and the IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 16. WaitingListService Returns &lt;remote-server-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;remote-server-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService does not receive a reply from InteropPartner within a certain amount of time or the connection to InteropPartner times out, WaitingListService SHOULD send a &lt;remote-server-timeout/&gt; error to IM User (and the IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 17. WaitingListService Returns &lt;remote-server-timeout/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='504' type='cancel'&gt;
+    &lt;remote-server-timeout xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If no error was generated but the WaitingListService does not immediately know the Contact JID, WaitingListService MUST inform the IM User that the request was successfully received, including a unique ID number for the new WaitingList item.</p>
+        <p class="caption">Example 18. WaitingListService Informs IM User that Request was Received</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID when the IQ result is returned to the user, it MAY include the WaitingList item in the IQ result:</p>
+        <p class="caption">Example 19. WaitingListService Returns IQ Result to IM User (With Contact JID)</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID (or learns Contact JID from InteropPartner), it MUST inform IM User through a "JID push" message, which consists of a message stanza that contains a &lt;waitlist/&gt; element qualified by the 'http://jabber.org/protocol/waitinglist' namespace:
+           [<a href="#nt-id2257996">9</a>]
+        </p>
+        <p class="caption">Example 20. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">Note: The JID push uses &lt;message/&gt; because the WaitingListService has no knowledge of the user's presence and therefore cannot assume that an &lt;iq/&gt; stanza will be received by the user at a specific resource.</p>
+        <p class="" style="">If WaitingListService learns that Contact's URI is not handled by any InteropPartner, it SHOULD inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 21. WaitingListService Informs IM User that No InteropPartner Handles Contact's URI</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;Sorry, we cannot find this contact.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' 
+          jid='contact@service-provider.com'
+          type='error'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+      &lt;error code='404' 
+             type='cancel'
+             xmlns='jabber:client'&gt;
+        &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;/error&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.3 <a name="protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+        <p class="" style="">In order to remove the item from the WaitingList, the IM User MUST complete the "Remove Contact from WaitingList" use case.</p>
+        <p class="caption">Example 22. IM User Sends Removal Request to WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='remove1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService previously recorded request, WaitingListService removes request from list and returns result to IM User.</p>
+        <p class="caption">Example 23. WaitingListService Returns Result to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='remove1'/&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService did not previously record this request, WaitingListService MUST return an &lt;item-not-found/&gt; error to the IM User.</p>
+        <p class="caption">Example 24. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='remove1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>5.2 <a name="protocol-service">WaitingListService Interaction With InteropPartners</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document describes the inter-domain protocol for communication between WaitingListServices. The protocol defined in this section MUST be implemented by ServiceProviders.</span>
+      </p>
+      <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartner's WaitingListServices with which it communicates. Therefore service discovery SHOULD NOT be necessary. However, if necessary it MAY use either the <span style="font-weight: bold">Agent Information</span> protocol or the <span style="font-weight: bold">Service Discovery</span> protocol as described in the following examples.</p>
+      <p class="" style="">Note: The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</p>
+      <div class="indent">
+<h3>5.2.1 <a name="protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</h3>
+        <p class="caption">Example 25. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Agent Information Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 26. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.interop-partner.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 27. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Service Discovery Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 28. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 29. Service Provider Queries InteropPartner's WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 30. InteropPartner's WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory'
+              type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.2.2 <a name="protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once a ServiceProvider's WaitingListService has discovered the InteropPartner's WaitingListService and requested its WaitingList, the ServiceProvider's WaitingListService can add items to its WaitingList based on URI.</p>
+        <p class="caption">Example 31. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is not associated with a person served by this InteropPartner, the InteropPartner MUST return an &lt;item-not-found/&gt; error to the ServiceProvider.</p>
+        <p class="caption">Example 32. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is associated with a person served by this InteropPartner, InteropPartner MUST return acknowledgement of the WaitingList addition to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 33. InteropPartner's WaitingListService Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact is an IM User served by InteropPartner, InteropPartner's WaitingListService pushes Contact's JID to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 34. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 35. ServiceProvider's WaitingListService Acknowledges Receipt of JID Push</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='jidpush1'/&gt;
+        </pre></div>
+        <p class="" style="">After receiving acknowledgement (but not before), InteropPartner's WaitingListService MUST remove that item from the WaitingList for the ServiceProvider's WaitingListService.</p>
+      </div>
+      <div class="indent">
+<h3>5.2.3 <a name="protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</h3>
+        <p class="caption">Example 36. ServiceProvider Requests Removal of Item from WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='remove2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If item exists on WaitingList, InteropPartner's WaitingListService removes item from list and returns result to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 37. InteropPartner Returns Result to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'/&gt;
+        </pre></div>
+        <p class="" style="">If item does not exist on WaitingList, InteropPartner's WaitingListService MUST return an &lt;item-not-found/&gt; error to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 38. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <ol start="1" type="1">
+      <li>Protocols and mechanisms for inviting a Contact to register as an IM User are out of scope for this proposal and shall be determined by each InteropPartner individually.</li>
+      <li>A ServiceProvider's WaitingListService MUST record which of its IM Users have requested the JID associated with Contact's URI, and an InteropPartner's WaitingListService MUST record that Service Provider's WaitingListService (not User) has requested JID associated with Contact's URI. Therefore when Contact registers, InteropPartner's WaitingListService informs its local users as well as ServiceProvider's WaitingListService, and ServiceProvider's WaitingListService informs its local users.</li>
+      <li>The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</li>
+      <li>Once an IM User learns a Contact's JID, the IM User MAY send a normal subscription request to the Contact, setting the "to" address to Contact's JID. This interaction is defined in the base XMPP specifications and is out of scope for this document.</li>
+      <li>For historical reasons, implementations MUST support the older <span style="font-weight: bold">Agent Information</span> protocol (JEP-0094) and SHOULD support <span style="font-weight: bold">Service Discovery</span> (JEP-0030). Note well that the <span style="font-weight: bold">Agent Information</span> protocol will eventually be deprecated in favor of <span style="font-weight: bold">Service Discovery</span>.</li>
+      <li>An IM User's client receives WaitingList information either through a "JID push" message (received from WaitingListService at any time) or in the IQ result received after requesting the WaitingList (since one or more of the WaitingList items may contain a JID). (The same rule applies to a ServiceProvider's WaitingListService that receives an IQ set from an InteropPartner's WaitingListService.)</li>
+      <li>When an IM User logs in, the user's client SHOULD request the current WaitingList.</li>
+      <li>Although the examples in this JEP show the hostname of the WaitingListService as 'waitlist.third-party.com' (etc.), this is for convenience only; the hostname MAY be any valid DNS hostname.</li>
+      <li>When sending JID pushes, an implementation MAY specify a message type of 'headline', which in some deployments will prevent such messages from being stored offline for later delivery.</li>
+    </ol>
+  <h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartners with which it communicates. The WaitingListService SHOULD NOT communicate with any InteropPartners that are not on the whitelist.</p>
+    <p class="" style="">Requesting JIDs via WaitingLists is not bidirectional; i.e., a service MUST NOT allow an IM User to discover a Contact's non-XMPP URI based on the Contact's JID.</p>
+    <p class="" style="">A service MAY require a Contact to approve the disclosure of the Contact's JID, either as a global preference or for each request; however, this is a local policy matter.</p>
+  <h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258620">10</a>].</p>
+  <h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258668">11</a>] includes 'http://jabber.org/protocol/waitinglist' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>9.2 <a name="registrar-identities">Service Discovery Identities</a>
+</h3>
+      <p class="" style="">The Jabber Registar includes a type of "waitinglist" in the "directory" category in its registry of service discovery identities.</p>
+    </div>
+    <div class="indent">
+<h3>9.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+      <p class="" style="">The Jabber Registrar includes supported URI schemes in its registry of service discovery features. These features shall be of the form 'http://jabber.org/protocol/waitlist/schemes/SCHEME-NAME'.</p>
+      <p class="" style="">This JEP registers the following two namespace names for URI schemes, but others MAY be registered in the future using standard registration procedures:</p>
+      <ul>
+        <li>http://jabber.org/protocol/waitlist/schemes/mailto</li>
+        <li>http://jabber.org/protocol/waitlist/schemes/tel</li>
+      </ul>
+    </div>
+  <h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/waitinglist'
+    xmlns='http://jabber.org/protocol/waitinglist'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0130: http://www.jabber.org/jeps/jep-0130.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import namespace='jabber:client'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      Note: there are two allowable root elements for the
+      'http://jabber.org/protocol/waitinglist' namespace,
+      query and waitlist. The query element is used within
+      IQ stanzas and the waitlist element is used within
+      message stanzas. See JEP-0130 for details.
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='waitlist'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='1'&gt;&gt;
+        &lt;xs:all xmlns:xmpp='jabber:client'&gt;
+          &lt;xs:element ref='uri'/&gt;
+          &lt;xs:element ref='name' minOccurs='0'/&gt;
+          &lt;xs:element ref='xmpp:error' minOccurs='0'/&gt;
+        &lt;/xs:all&gt;
+        &lt;xs:element ref='remove'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='jid'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='type'
+                    use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='uri' type='xs:string'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='scheme'
+                    type='xs:NCNAME'
+                    use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='name' type='string1023'/&gt;
+
+  &lt;xs:element name='remove' type='empty'/&gt;
+
+  &lt;xs:simpleType name='string1023'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:maxLength value='1023'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250973">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256305">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256390">3</a>. RFC 3966: The tel URI for Telephone Numbers &lt;<a href="http://www.ietf.org/rfc/rfc3966.txt">http://www.ietf.org/rfc/rfc3966.txt</a>&gt;.</p>
+<p><a name="nt-id2256412">4</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p><a name="nt-id2256562">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2257488">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257512">7</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2257742">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257996">9</a>. When waiting list information is included in a message stanza, the root element for the 'http://jabber.org/protocol/waitinglist' namespace is &lt;waitlist/&gt; rather than &lt;query/&gt; (as used within IQ stanzas). This disparity is historical and tracks the protocol syntax that was most widely implemented, as defined in version 0.4 of this specification. In the interest of interoperability, the IQ usage was changed back to &lt;query/&gt; in version 1.1 of this specification. If this JEP were not historical, the root element usage would be harmonized to use only the &lt;waitlist/&gt; element.</p>
+<p><a name="nt-id2258620">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258668">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2005-11-30)</h4>
+<div class="indent">Harmonized root element specification with implemented usage, reversing change made in version 0.5. (psa)
+    </div>
+<h4>Version 1.0 (2005-08-26)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Active. (psa)
+    </div>
+<h4>Version 0.6 (2005-08-16)</h4>
+<div class="indent">Added error case for remote server timeout; specified client and service responsibilities regarding removal of waiting list items in error cases. (psa)
+    </div>
+<h4>Version 0.5 (2005-05-16)</h4>
+<div class="indent">Corrected schema and IQ examples by changing root element for namespace from &lt;query/&gt; to &lt;waitlist/&gt; (this had been used for message examples but not IQ examples). (psa)
+    </div>
+<h4>Version 0.4 (2005-04-01)</h4>
+<div class="indent">Changed JEP type to Informational; corrected Remote Server Error example to use &lt;remote-server-not-found/&gt; rather than &lt;service-unavailable/&gt;; added service discovery identity to Jabber Registrar Considerations; corrected text regarding registration of service discovery features; corrected some small errors in the text, examples, and schema. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-27)</h4>
+<div class="indent">Corrected error syntax used when Contact URI is not handled by any InteropPartner. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-03)</h4>
+<div class="indent">Added alternate flow for situation in which Contact URI is not handled by any InteropPartner; changed headline message type for JID pushes from SHOULD to MAY; clarified semantics of item ID; added name child of item; corrected and updated the XML schema; updated examples to use XMPP error conditions. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-18)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.10 (2003-09-03)</h4>
+<div class="indent">Fixed several small errors in the examples. (psa)
+    </div>
+<h4>Version 0.0.9 (2003-08-22)</h4>
+<div class="indent">Specified optional use of message type 'headline'; fixed one small error in the examples. (psa)
+    </div>
+<h4>Version 0.0.8 (2003-07-23)</h4>
+<div class="indent">Changed client-server push mechanism to use &lt;message/&gt; rather than &lt;iq/&gt;, since client may not be online; allowed IQ result to include waitlist information if known; added more detailed disco#info lookup to support discovery of URI types supported. (psa)
+    </div>
+<h4>Version 0.0.7 (2003-07-02)</h4>
+<div class="indent">Modified to use a generic &lt;uri scheme=''/&gt; element. (psa)
+    </div>
+<h4>Version 0.0.6 (2003-06-26)</h4>
+<div class="indent">Refactored protocol to use IQ sets that are "pushed" to the component or client (similar to XMPP rosters); added service discovery and agents support; made text more generic; simplified error handling; change name to "Waiting Lists". (psa)
+    </div>
+<h4>Version 0.0.5 (2003-06-24)</h4>
+<div class="indent">Added remove use case and protocol; added XML schema. (psa)
+    </div>
+<h4>Version 0.0.4 (2003-06-19)</h4>
+<div class="indent">Specified protocol. (psa)
+    </div>
+<h4>Version 0.0.3 (2003-06-18)</h4>
+<div class="indent">Simplified requirements; defined main use case. (psa)
+    </div>
+<h4>Version 0.0.2 (2003-06-16)</h4>
+<div class="indent">Converted to JEP XML format; formalized use case definitions; minor editorial changes. (psa)
+    </div>
+<h4>Version 0.0.1 (2003-06-10)</h4>
+<div class="indent">First draft. (an)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0130-1.2.html
+++ b/content/xep-0130-1.2.html
@@ -1,0 +1,1199 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0130: Waiting Lists</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Waiting Lists">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Yehezkel Dallal">
+<meta name="DC.Creator" content="Alexandre Nolle">
+<meta name="DC.Creator" content="Jean-Louis Seguineau">
+<meta name="DC.Creator" content="Mark Troyer">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0130">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0130: Waiting Lists</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to add a non-IM user to a waiting list and be informed when the contact creates an IM account.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Historical JEP provides canonical documentation of a protocol that is in use within the Jabber/XMPP community. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; however, it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Historical<br>
+            Number: 0130<br>
+            Version: 1.2<br>
+            Last Updated: 2006-01-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0094, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: waitinglist<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/waitinglist/waitinglist.xsd">http://jabber.org/protocol/waitinglist/waitinglist.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Waiting%20Lists%20(JEP-0130)">http://wiki.jabber.org/index.php/Waiting Lists (JEP-0130)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Yehezkel Dallal</h3>
+<p class="indent">
+        Email: yehezkeld@followap.com<br></p>
+<h3>Alexandre Nolle</h3>
+<p class="indent">
+        Email: anolle@francetelecom.com<br></p>
+<h3>Jean-Louis Seguineau</h3>
+<p class="indent">
+        Email: jean-louis.seguineau@antepo.com<br>
+        JID: jlseguineau@im.antepo.com</p>
+<h3>Mark Troyer</h3>
+<p class="indent">
+        Email: mtroyer@jabber.com<br>
+        JID: mtroyer@corp.jabber.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#imuser-retrieve-primary">Primary Flow</a>
+</dt>
+<dt>4.1.2.  <a href="#imuser-retrieve-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#imuser-add-primary">Primary Flow</a>
+</dt>
+<dt>4.2.2.  <a href="#imuser-add-alt">Alternate Flows</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#imuser-remove-primary">Primary Flow</a>
+</dt>
+<dt>4.3.2.  <a href="#imuser-remove-alt">Alternate Flows</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-imuser">IM User Interaction With WaitingListService</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</dt>
+<dt>5.1.2.  <a href="#protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</dt>
+<dt>5.1.3.  <a href="#protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#protocol-service">WaitingListService Interaction With InteropPartners</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</dt>
+<dt>5.2.2.  <a href="#protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</dt>
+<dt>5.2.3.  <a href="#protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-identities">Service Discovery Identities</a>
+</dt>
+<dt>9.3.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">An IM user may want to be informed when a contact creates an IM account. If the user knows some information about the contact (e.g., a phone number or email address), the user's service can use that information to place the contact on a "waiting list", then inform the user when the contact creates an IM account. This document defines an extension to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2256458">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2256482">2</a>] that enables such "waiting list" functionality, including the ability to add contacts on other domains if service providers agree to interoperate (e.g., to add a contact who uses a different mobile telephony service provider).</p>
+    <p class="" style=""><span style="font-style: italic">Note: The protocol defined herein is currently in use at several large service providers in Europe. Others are welcome to use the protocol.</span></p>
+  <h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+    <p class="caption">Table 1: Terms Used</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Term</th>
+        <th colspan="" rowspan="">Definition</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Contact</td>
+        <td align="" colspan="" rowspan="">A person with whom an IM User seeks to communicate, identified by a URI such as &lt;tel:PhoneNumber&gt; (see <span class="ref" style="">RFC 3966</span>  [<a href="#nt-id2256601">3</a>]) or &lt;mailto:EmailAddress&gt; (see <span class="ref" style="">RFC 2368</span>  [<a href="#nt-id2256558">4</a>]).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Customer</td>
+        <td align="" colspan="" rowspan="">A person who is contracted for services with a ServiceProvider.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">IM User</td>
+        <td align="" colspan="" rowspan="">Any Customer who has registered for instant messaging services.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">InteropPartner</td>
+        <td align="" colspan="" rowspan="">Any company that agrees to interoperate using the protocol defined herein.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">JID</td>
+        <td align="" colspan="" rowspan="">The unique identifier of an IM User in the XMPP protocol. Outside the context of an IM session, a JID is of the form &lt;user@domain&gt; ("bare JID"); within the context of an IM session, a JID is of the form &lt;user@domain/resource&gt; ("full JID").</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">ServiceProvider</td>
+        <td align="" colspan="" rowspan="">A company that provides telephony or email services to a Customer.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">URI</td>
+        <td align="" colspan="" rowspan="">A Uniform Resource Identifier as defined in <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2256731">5</a>]. Specific URI schemes that may be useful in this specification include 'tel:', 'mailto:', and 'sip:', but any URI scheme may be used.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">Waiting List</td>
+        <td align="" colspan="" rowspan="">A list of Contacts whom an entity (IM User or InteropPartner) is waiting to hear about regarding their status as instant messaging users.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">WaitingListService</td>
+        <td align="" colspan="" rowspan="">An XMPP service that maintains Waiting lists for IM Users and/or InteropPartners.</td>
+      </tr>
+    </table>
+  <h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This protocol is designed so that an IM User can:</p>
+    <ol start="1" type="1">
+      <li>Request the user's current Waiting List</li>
+      <li>Add a Contact to a local WaitingList (based on some URI associated with the Contact)</li>
+      <li>Receive notification from a local WaitingListService if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+    <p class="" style="">In addition, this protocol is designed so that a ServiceProvider can:</p>
+    <ol start="1" type="1">
+      <li>Request the service's current WaitingList</li>
+      <li>Add a Contact to a WaitingList at an InteroPartner (based on some URI associated with the Contact)</li>
+      <li>Receive notification from the InteropPartner if the Contact has (or subsequently creates) an IM account</li>
+      <li>Remove a Contact from the Waiting List</li>
+    </ol>
+  <h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+      <p class="" style="">Before adding or removing Contacts from its WaitingList, an IM User SHOULD retrieve its current WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.1.1 <a name="imuser-retrieve-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User discovers WaitingListService hosted by ServiceProvider [A1]; it is RECOMMENDED to do this immediately after logging in.</li>
+          <li>IM User requests current WaitingList from WaitingListService.</li>
+          <li>WaitingListService returns WaitingList to IM User, including any items for which JIDs have been discovered [A2].</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.1.2 <a name="imuser-retrieve-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>ServiceProvider does not host a WaitingListService:
+          <ol start="1" type="1">
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>IM User does not have a Waiting List:
+          <ol start="1" type="1">
+              <li>WaitingListService returns &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may know a URI for a Contact (e.g., a phone number or email address) but not the Contact's JID. In order to subscribe to the Contact's presence or otherwise communicate with the Contact over an instant messaging system, the IM User first needs to discover the Contact's JID based on a URI for the Contact. However, the Contact may not yet have an IM account. Because the IM User may therefore need to wait until the Contact creates an account, the IM User needs to add the Contact to a WaitingList. The activity flow is as follows:</p>
+      <div class="indent">
+<h3>4.2.1 <a name="imuser-add-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User SHOULD first complete use case for "IM User Retrieves Current WaitingList".</li>
+          <li>IM User requests addition of Contact to WaitingList based on Contact's URI.</li>
+          <li>WaitingListService determines that the URI scheme is supported [A1].</li>
+          <li>WaitingListService determines that the information provided is a valid URI for that URI scheme [A2].</li>
+          <li>WaitingListService acknowledges addition of Contact to IM User's WaitingList.</li>
+          <li>WaitingListService determines that Contact's URI does not belong to a person served by ServiceProvider [A3].</li>
+          <li>WaitingListService discovers WaitingListServices hosted by one or more InteropPartners.</li>
+          <li>WaitingListService queries one or more InteropPartner's WaitingListServices for JID associated with URI.</li>
+          <li>InteropPartner's WaitingListService determines that Contact's URI belongs to a person served by that partner [A4].</li>
+          <li>InteropPartner's WaitingListService determines that Contact is an IM User [A5].</li>
+          <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of JID associated with Contact's URI. [A6]</li>
+          <li>ServiceProvider's WaitingListService informs IM User of Contact's JID. [A8]</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.2.2 <a name="imuser-add-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>The URI scheme is not supported:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;bad-request/&gt; error to IM User and does not add contact to WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>The information provided is not a valid URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;not-acceptable/&gt; error to IM User and does not add contact to WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>URI belongs to person served by ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService determines that Contact is an IM User registered with ServiceProvider [A7].</li>
+              <li>OPTIONALLY, WaitingListService requires that Contact approves request.</li>
+              <li>WaitingListService informs IM User of Contact's JID.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>URI does not belong to a person served by InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner sends &lt;item-not-found/&gt; error to WaitingListService.</li>
+              <li>If all InteropPartners queried return &lt;item-not-found/&gt; error, WaitingListService sends &lt;item-not-found/&gt; error (or local equivalent) to IM User and IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with InteropPartner:
+            <ol start="1" type="1">
+              <li>InteropPartner records WaitingListService's request for JID associated with URI.</li>
+              <li>OPTIONALLY, InteropPartner invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>InteropPartner informs Service Provider's WaitingListService of JID associated with Contact's URI.</li>
+              <li>ServiceProvider's WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact denies request:
+            <ol start="1" type="1">
+              <li>InteropPartner's WaitingListService sends &lt;not-authorized/&gt; error to ServiceProvider's WaitingListService.</li>
+              <li>ServiceProvider's WaitingListService sends &lt;not-authorized/&gt; error (or local equivalent) to IM User.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+          <li>Contact is not an IM User registered with ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService records IM User's request for JID associated with URI.</li>
+              <li>OPTIONALLY, WaitingListService invites Contact to register as an IM User.</li>
+              <li>Contact registers.</li>
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact's URI is not handled by any ServiceProvider:
+            <ol start="1" type="1">
+              <li>WaitingListService informs all IM Users who requested JID associated with Contact's URI that no InteropPartner services Contact's URI.</li>
+              <li>IM User removes item from WaitingList.</li>
+              <li>Use Case Ends unsuccessfully.</li>
+            </ol>
+          </li>
+           <li>Connection to ServiceProvider times out:          
+             <ol start="1" type="1">     
+               <li>WaitingListService sends &lt;remote-server-timeout/&gt; error (or local equivalent) to IM User.</li>       
+               <li>IM User removes item from WaitingList.</li>   
+               <li>Use Case Ends unsuccessfully.</li>    
+             </ol>       
+           </li>
+        </ol>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3 <a name="imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+      <p class="" style="">An IM User may want to remove an item from its WaitingList (or removing the item may be recommended as part of an unsuccessful flow in the previous use case).</p>
+      <div class="indent">
+<h3>4.3.1 <a name="imuser-remove-primary">Primary Flow</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User sends removal request to WaitingListService.</li>
+          <li>WaitingListService removes IM User's request for JID associated with URI.</li>
+          <li>WaitingListService informs IM User of successful removal [A1].</li>
+          <li>WaitingListService sends removal request to appropriate InteropPartner's WaitingListService [A2].</li>
+          <li>InteropPartner's WaitingListService determines that URI belongs to a person served by that partner.</li>
+          <li>InteropPartner's WaitingListService removes ServiceProvider's WaitingListService's request for JID.</li>
+          <li>InteropPartner's WaitingListService informs ServiceProvider's WaitingListService of successful removal.</li>
+          <li>Use Case Ends.</li>
+        </ol>
+      </div>
+      <div class="indent">
+<h3>4.3.2 <a name="imuser-remove-alt">Alternate Flows</a>
+</h3>
+        <ol start="1" type="1">
+          <li>IM User never requested JID associated with URI:
+            <ol start="1" type="1">
+              <li>WaitingListService sends &lt;item-not-found/&gt; error to IM User.</li>
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+          <li>Contact URI is served by WaitingListService or IM User was not the only person who requested the JID:
+            <ol start="1" type="1">
+              <li>Use Case Ends.</li>
+            </ol>
+          </li>
+        </ol>
+      </div>
+    </div>
+  <h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="protocol-imuser">IM User Interaction With WaitingListService</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document is provided for the sake of domains that implement XMPP as their local protocol; domains that implement another protocol will use their service-specific protocol to complete the user-to-domain interaction. Support for the protocol defined in this section is NOT REQUIRED for services that do not implement XMPP as their local protocol.</span>
+      </p>
+      <div class="indent">
+<h3>5.1.1 <a name="protocol-imuser-retrieve">IM User Retrieves Current WaitingList</a>
+</h3>
+        <p class="" style="">It is RECOMMENDED for an IM User's client to retrieve the WaitingList immediately after logging in. However, first it must discover its local WaitingListService. An IM User MAY use either <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257537">6</a>] or the deprecated <span class="ref" style="">Agent Information</span>  [<a href="#nt-id2257561">7</a>] protocol.</p>
+        <p class="caption">Example 1. IM User Discovers WaitingListService by Sending Agent Information Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 2. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='agent1'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.service-provider.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. IM User Discovers WaitingListService by Sending Service Discovery Request to its Server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 4. Server Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 5. IM User Queries WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The WaitingListService SHOULD return detailed information about the service it provides, including the URI schemes it supports (see also the <a href="#registrar-features">Service Discovery Features</a> section of this document).</p>
+        <p class="caption">Example 6. WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='disco2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory' type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/mailto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist/schemes/tel'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Once an IM User has discovered the WaitingListService, the user's client SHOULD request its current Waiting List. This is done by sending an IQ-get to the WaitingListService containing an empty &lt;query/&gt; element qualified by the 'http://jabber.org/protocol/waitinglist' namespace:</p>
+        <p class="caption">Example 7. IM User Requests its Current WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Upon request, the WaitingListService MUST return the current WaitingList to the IM User:</p>
+        <p class="caption">Example 8. WaitingListService Returns WaitingList to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='request1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Each ItemID MUST be unique within the scope of the client's WaitingList items. The value of the ItemID is an opaque string; an implementation MAY assign semantic meaning to the ItemID (e.g., id="John Smith (mobile)" rather than id="12345"), but such meaning is implementation-specific and outside the scope of the protocol defined herein. The user MAY include a &lt;name/&gt; element containing a natural-language name for the Contact.</p>
+        <p class="" style="">The WaitingList MAY contain an item for which a JID has been discovered.</p>
+        <p class="caption">Example 9. IM User Asks for its WaitingList including Newly Discovered JID</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='jidask1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='jidask1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='12345' jid='stpeter@jabber.org'&gt;
+      &lt;uri scheme='tel'&gt;3033083282&lt;/uri&gt;
+      &lt;name&gt;PSA&lt;/name&gt;
+    &lt;/item&gt;
+    &lt;item id='23456'&gt;
+      &lt;uri scheme='mailto'&gt;editor@jabber.org&lt;/uri&gt;
+      &lt;name&gt;JEP Editor&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.1.2 <a name="protocol-imuser-add">IM User Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once an IM User's client has discovered the WaitingListService and requested the user's WaitingList, the user can add Contacts to the WaitingList based on the Contact's URI. (Note: This JEP uses the example of phone numbers via the 'tel' URI scheme, but the same rules apply to WaitingList items based on email addresses or other URI schemes.)</p>
+        <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    to='waitlist.service-provider.com'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">As described below, various error conditions may occur. (For information about error syntax, refer to <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257792">8</a>].)</p>
+        <p class="" style="">If the IM User provided a URI whose scheme is not supported, WaitingListService MUST return a &lt;bad-request/&gt; error to the IM User and MUST NOT add the Contact to the WaitingList.</p>
+        <p class="caption">Example 11. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tag'&gt;shakespeare.lit,2005-08:waitlist1&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User included a JID in the request, WaitingListService MUST return a &lt;bad-request/&gt; error to IM User and MUST NOT add the Contact to the WaitingList. (Note: A WaitingListService MUST NOT return a non-XMPP URI to an IM User based on the Contact's JID; see the <a href="#security">Security Considerations</a> section of this document.)</p>
+        <p class="caption">Example 12. WaitingListService Returns &lt;bad-request/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item jid='some-jid'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='400' type='modify'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided an invalid URI (e.g., a phone number with too many digits or an email address with no '@' character), WaitingListService MUST return a &lt;not-acceptable/&gt; error to the IM User and MUST NOT add the Contact to the WaitingList.</p>
+        <p class="caption">Example 13. WaitingListService Returns &lt;not-acceptable/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If all of the InteropPartners return an &lt;item-not-found/&gt; error to WaitingListService, WaitingListService MUST return an &lt;item-not-found/&gt; error (or local equivalent) to the IM User (and IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 14. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact denies request, InteropPartner MUST return a &lt;not-authorized/&gt; error to WaitingListService, which MUST return a &lt;not-authorized/&gt; error (or local equivalent) to the IM User (and IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 15. WaitingListService Returns &lt;not-authorized/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+1234563033083283&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='401' type='auth'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the IM User provided a URI that is not served by an InteropPartner (e.g., a phone number associated with a telephony provider that is not in the WaitingListService's whitelist of InteropPartners), WaitingListService SHOULD return a &lt;remote-server-not-found/&gt; error to IM User (and the IM User SHOULD then remove the item from the WaitingList as described in the next use case).</p>
+        <p class="caption">Example 16. WaitingListService Returns &lt;remote-server-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;remote-server-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the connection to at least one of the InteropPartners times out (a &lt;remote-server-timeout/&gt; error), WaitingListService SHOULD NOT return an immediate error to IM User but instead SHOULD return an IQ-result (indicating that the request was received) and resend the request to the InteropPartners that timed out. If connections continue to time out (over some configurable time period and for some configurable number of retries), WaitingListService SHOULD then return a &lt;remote-server-timeout/&gt; error to IM User via a "JID push" message as shown below.</p>
+        <p class="" style="">If none of the foregoing errors was generated but the WaitingListService does not immediately know the Contact JID, WaitingListService MUST inform the IM User that the request was successfully received, including a unique ID number for the new WaitingList item.</p>
+        <p class="caption">Example 17. WaitingListService Informs IM User that Request was Received</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID when the IQ result is returned to the user, it MAY include the WaitingList item in the IQ result:</p>
+        <p class="caption">Example 18. WaitingListService Returns IQ Result to IM User (With Contact JID)</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='waitinglist1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService knows Contact JID (or learns Contact JID from InteropPartner), it MUST inform IM User through a "JID push" message, which consists of a message stanza that contains a &lt;waitlist/&gt; element qualified by the 'http://jabber.org/protocol/waitinglist' namespace:
+           [<a href="#nt-id2250364">9</a>]
+        </p>
+        <p class="caption">Example 19. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='contact@service-provider.com'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">Note: The JID push uses an XMPP &lt;message/&gt; stanza because the WaitingListService has no knowledge of the user's presence and therefore cannot assume that an &lt;iq/&gt; stanza will be received by the user at a specific resource.</p>
+        <p class="" style="">If WaitingListService learns that Contact's URI is not handled by any InteropPartner, it SHOULD inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 20. WaitingListService Informs IM User that No InteropPartner Handles Contact's URI</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;body&gt;Sorry, we cannot find this contact.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' 
+          jid='contact@service-provider.com'
+          type='error'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+      &lt;error code='404' 
+             type='cancel'
+             xmlns='jabber:client'&gt;
+        &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;/error&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">As mentioned above, if connections to at least one of the InteropPartners time out continuously, WaitingListService SHOULD inform IM User through a "JID push" message:</p>
+        <p class="caption">Example 21. WaitingListService Informs IM User of Remote Server Timeout</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com'&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' 
+          jid='contact@service-provider.com'
+          type='error'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;name&gt;contact-name&lt;/name&gt;
+      &lt;error code='504' type='cancel' xmlns='jabber:client'&gt;
+        &lt;remote-server-timeout xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+      &lt;/error&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+        </pre></div>
+        <p class="" style="">If IM User receives an error of any kind in a "JID push" message, IM User SHOULD remove Contact from WaitingList as described in the next use case.</p>
+      </div>
+      <div class="indent">
+<h3>5.1.3 <a name="protocol-imuser-remove">IM User Removes Contact from WaitingList</a>
+</h3>
+        <p class="" style="">In order to remove the item from the WaitingList, the IM User MUST complete the "Remove Contact from WaitingList" use case.</p>
+        <p class="caption">Example 22. IM User Sends Removal Request to WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='user@service-provider.com/resource'
+    to='waitlist.service-provider.com'
+    id='remove1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService previously recorded request, WaitingListService removes request from list and returns result to IM User.</p>
+        <p class="caption">Example 23. WaitingListService Returns Result to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='user@service-provider.com/resource'
+    id='remove1'/&gt;
+        </pre></div>
+        <p class="" style="">If WaitingListService did not previously record this request, WaitingListService MUST return an &lt;item-not-found/&gt; error to the IM User.</p>
+        <p class="caption">Example 24. WaitingListService Returns &lt;item-not-found/&gt; Error to IM User</p>
+<div class="indent"><pre>
+&lt;iq type='error' id='remove1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>5.2 <a name="protocol-service">WaitingListService Interaction With InteropPartners</a>
+</h3>
+      <p class="" style="">
+        <span style="font-style: italic">This section of the document describes the inter-domain protocol for communication between WaitingListServices. The protocol defined in this section MUST be implemented by ServiceProviders.</span>
+      </p>
+      <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartner's WaitingListServices with which it communicates. Therefore service discovery SHOULD NOT be necessary. However, if necessary it MAY use either the <span style="font-weight: bold">Agent Information</span> protocol or the <span style="font-weight: bold">Service Discovery</span> protocol as described in the following examples.</p>
+      <p class="" style="">Note: The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</p>
+      <div class="indent">
+<h3>5.2.1 <a name="protocol-service-retrieve">ServiceProvider's WaitingListService Retrieves Current WaitingList</a>
+</h3>
+        <p class="caption">Example 25. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Agent Information Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 26. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='agent2'&gt;
+  &lt;query xmlns='jabber:iq:agents'&gt;
+    ...
+    &lt;agent jid='waitlist.interop-partner.com'&gt;
+      &lt;name&gt;Waiting List Service&lt;/name&gt;
+      &lt;service&gt;waitinglist&lt;/service&gt;
+    &lt;/agent&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 27. ServiceProvider Discovers InteropPartner's WaitingListService by Sending Service Discovery Request to InteropPartner</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='interop-partner.com'
+    id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 28. InteropPartner Returns Address of its WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco3'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='waitlist.service-provider.com'
+          name='Waiting List Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 29. Service Provider Queries InteropPartner's WaitingListService for Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 30. InteropPartner's WaitingListService Returns Detailed Information</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='disco4'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='directory'
+              type='waitinglist'/&gt;
+    &lt;feature var='http://jabber.org/protocol/waitinglist'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>5.2.2 <a name="protocol-service-add">ServiceProvider's WaitingListService Adds Contact to WaitingList</a>
+</h3>
+        <p class="" style="">Once a ServiceProvider's WaitingListService has discovered the InteropPartner's WaitingListService and requested its WaitingList, the ServiceProvider's WaitingListService can add items to its WaitingList based on URI.</p>
+        <p class="caption">Example 31. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is not associated with a person served by this InteropPartner, the InteropPartner MUST return an &lt;item-not-found/&gt; error to the ServiceProvider.</p>
+        <p class="caption">Example 32. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact's URI is associated with a person served by this InteropPartner, InteropPartner MUST return acknowledgement of the WaitingList addition to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 33. InteropPartner's WaitingListService Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If Contact is an IM User served by InteropPartner, InteropPartner's WaitingListService pushes Contact's JID to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 34. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 35. ServiceProvider's WaitingListService Acknowledges Receipt of JID Push</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='jidpush1'/&gt;
+        </pre></div>
+        <p class="" style="">After receiving acknowledgement (but not before), InteropPartner's WaitingListService MUST remove that item from the WaitingList for the ServiceProvider's WaitingListService.</p>
+      </div>
+      <div class="indent">
+<h3>5.2.3 <a name="protocol-service-remove">ServiceProvider's WaitingListService Removes Contact from WaitingList</a>
+</h3>
+        <p class="caption">Example 36. ServiceProvider Requests Removal of Item from WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='remove2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If item exists on WaitingList, InteropPartner's WaitingListService removes item from list and returns result to ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 37. InteropPartner Returns Result to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'/&gt;
+        </pre></div>
+        <p class="" style="">If item does not exist on WaitingList, InteropPartner's WaitingListService MUST return an &lt;item-not-found/&gt; error to the ServiceProvider's WaitingListService.</p>
+        <p class="caption">Example 38. InteropPartner Returns &lt;item-not-found/&gt; Error to ServiceProvider</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='remove2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567'&gt;
+      &lt;remove/&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <ol start="1" type="1">
+      <li>Protocols and mechanisms for inviting a Contact to register as an IM User are out of scope for this proposal and shall be determined by each InteropPartner individually.</li>
+      <li>A ServiceProvider's WaitingListService MUST record which of its IM Users have requested the JID associated with Contact's URI, and an InteropPartner's WaitingListService MUST record that Service Provider's WaitingListService (not User) has requested JID associated with Contact's URI. Therefore when Contact registers, InteropPartner's WaitingListService informs its local users as well as ServiceProvider's WaitingListService, and ServiceProvider's WaitingListService informs its local users.</li>
+      <li>The InteropPartner's WaitingListService is NOT REQUIRED to be hosted by InteropPartner, and could be hosted by a third party (e.g., a neutral phone number translation service). In this case, InteropPartner would simply advertise 'waitlist.third-party.com' as its WaitingListService.</li>
+      <li>Once an IM User learns a Contact's JID, the IM User MAY send a normal subscription request to the Contact, setting the "to" address to Contact's JID. This interaction is defined in the base XMPP specifications and is out of scope for this document.</li>
+      <li>For historical reasons, implementations MUST support the older <span style="font-weight: bold">Agent Information</span> protocol (JEP-0094) and SHOULD support <span style="font-weight: bold">Service Discovery</span> (JEP-0030). Note well that the <span style="font-weight: bold">Agent Information</span> protocol will eventually be deprecated in favor of <span style="font-weight: bold">Service Discovery</span>.</li>
+      <li>An IM User's client receives WaitingList information either through a "JID push" message (received from WaitingListService at any time) or in the IQ result received after requesting the WaitingList (since one or more of the WaitingList items may contain a JID). (The same rule applies to a ServiceProvider's WaitingListService that receives an IQ set from an InteropPartner's WaitingListService.)</li>
+      <li>When an IM User logs in, the user's client SHOULD request the current WaitingList.</li>
+      <li>Although the examples in this JEP show the hostname of the WaitingListService as 'waitlist.third-party.com' (etc.), this is for convenience only; the hostname MAY be any valid DNS hostname.</li>
+      <li>When sending JID pushes, an implementation MAY specify a message type of 'headline', which in some deployments will prevent such messages from being stored offline for later delivery.</li>
+      <li>It can happen that WaitingListService does not receive a reply from InteropPartner within a certain amount of time or the connection to InteropPartner times out. Because such behavior is often transient, WaitingListService MAY attempt to reconnect and then resend the request (although any retry logic to handle these cases is a matter of implementation). However, WaitingListService SHOULD NOT return an &lt;item-not-found/&gt; error to IM User unless it knows definitively that the Contact's InteropPartner is permanently unavailable, since returning an &lt;item-not-found/&gt; error in response to temporary connection timeouts is likely to be misleading.</li>
+    </ol>
+  <h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">A ServiceProvider's WaitingListService MUST be configured with a "whitelist" of InteropPartners with which it communicates. The WaitingListService SHOULD NOT communicate with any InteropPartners that are not on the whitelist.</p>
+    <p class="" style="">Requesting JIDs via WaitingLists is not bidirectional; i.e., a service MUST NOT allow an IM User to discover a Contact's non-XMPP URI based on the Contact's JID.</p>
+    <p class="" style="">A service MAY require a Contact to approve the disclosure of the Contact's JID, either as a global preference or for each request; however, this is a local policy matter.</p>
+  <h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258845">10</a>].</p>
+  <h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258895">11</a>] includes 'http://jabber.org/protocol/waitinglist' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>9.2 <a name="registrar-identities">Service Discovery Identities</a>
+</h3>
+      <p class="" style="">The Jabber Registar includes a type of "waitinglist" in the "directory" category in its registry of service discovery identities.</p>
+    </div>
+    <div class="indent">
+<h3>9.3 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+      <p class="" style="">The Jabber Registrar includes supported URI schemes in its registry of service discovery features. These features shall be of the form 'http://jabber.org/protocol/waitlist/schemes/SCHEME-NAME'.</p>
+      <p class="" style="">This JEP registers the following two namespace names for URI schemes, but others MAY be registered in the future using standard registration procedures:</p>
+      <ul>
+        <li>http://jabber.org/protocol/waitlist/schemes/mailto</li>
+        <li>http://jabber.org/protocol/waitlist/schemes/tel</li>
+      </ul>
+    </div>
+  <h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/waitinglist'
+    xmlns='http://jabber.org/protocol/waitinglist'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0130: http://www.jabber.org/jeps/jep-0130.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:import namespace='jabber:client'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      Note: there are two allowable root elements for the
+      'http://jabber.org/protocol/waitinglist' namespace,
+      query and waitlist. The query element is used within
+      IQ stanzas and the waitlist element is used within
+      message stanzas. See JEP-0130 for details.
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='waitlist'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item'
+                    minOccurs='0'
+                    maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='1'&gt;&gt;
+        &lt;xs:all xmlns:xmpp='jabber:client'&gt;
+          &lt;xs:element ref='uri'/&gt;
+          &lt;xs:element ref='name' minOccurs='0'/&gt;
+          &lt;xs:element ref='xmpp:error' minOccurs='0'/&gt;
+        &lt;/xs:all&gt;
+        &lt;xs:element ref='remove'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='jid'
+                    type='xs:string'
+                    use='optional'/&gt;
+      &lt;xs:attribute name='type'
+                    use='optional'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='error'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='uri' type='xs:string'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='scheme'
+                    type='xs:NCNAME'
+                    use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='name' type='string1023'/&gt;
+
+  &lt;xs:element name='remove' type='empty'/&gt;
+
+  &lt;xs:simpleType name='string1023'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:maxLength value='1023'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2256458">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256482">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256601">3</a>. RFC 3966: The tel URI for Telephone Numbers &lt;<a href="http://www.ietf.org/rfc/rfc3966.txt">http://www.ietf.org/rfc/rfc3966.txt</a>&gt;.</p>
+<p><a name="nt-id2256558">4</a>. RFC 2368: The mailto URL scheme &lt;<a href="http://www.ietf.org/rfc/rfc2368.txt">http://www.ietf.org/rfc/rfc2368.txt</a>&gt;.</p>
+<p><a name="nt-id2256731">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2257537">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257561">7</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p><a name="nt-id2257792">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2250364">9</a>. When waiting list information is included in a message stanza, the root element for the 'http://jabber.org/protocol/waitinglist' namespace is &lt;waitlist/&gt; rather than &lt;query/&gt; (as used within IQ stanzas). This disparity is historical and tracks the protocol syntax that was most widely implemented, as defined in version 0.4 of this specification. In the interest of interoperability, the IQ usage was changed back to &lt;query/&gt; in version 1.1 of this specification. If this JEP were not historical, the root element usage would be harmonized to use only the &lt;waitlist/&gt; element.</p>
+<p><a name="nt-id2258845">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258895">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.2 (2006-01-24)</h4>
+<div class="indent">Adjusted remote-server-timeout flow to recommend IQ result followed by JID push message. (psa)
+    </div>
+<h4>Version 1.1 (2005-11-30)</h4>
+<div class="indent">Harmonized root element specification with implemented usage, reversing change made in version 0.5. (psa)
+    </div>
+<h4>Version 1.0 (2005-08-26)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Active. (psa)
+    </div>
+<h4>Version 0.6 (2005-08-16)</h4>
+<div class="indent">Added error case for remote server timeout; specified client and service responsibilities regarding removal of waiting list items in error cases. (psa)
+    </div>
+<h4>Version 0.5 (2005-05-16)</h4>
+<div class="indent">Corrected schema and IQ examples by changing root element for namespace from &lt;query/&gt; to &lt;waitlist/&gt; (this had been used for message examples but not IQ examples). (psa)
+    </div>
+<h4>Version 0.4 (2005-04-01)</h4>
+<div class="indent">Changed JEP type to Informational; corrected Remote Server Error example to use &lt;remote-server-not-found/&gt; rather than &lt;service-unavailable/&gt;; added service discovery identity to Jabber Registrar Considerations; corrected text regarding registration of service discovery features; corrected some small errors in the text, examples, and schema. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-27)</h4>
+<div class="indent">Corrected error syntax used when Contact URI is not handled by any InteropPartner. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-03)</h4>
+<div class="indent">Added alternate flow for situation in which Contact URI is not handled by any InteropPartner; changed headline message type for JID pushes from SHOULD to MAY; clarified semantics of item ID; added name child of item; corrected and updated the XML schema; updated examples to use XMPP error conditions. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-18)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.10 (2003-09-03)</h4>
+<div class="indent">Fixed several small errors in the examples. (psa)
+    </div>
+<h4>Version 0.0.9 (2003-08-22)</h4>
+<div class="indent">Specified optional use of message type 'headline'; fixed one small error in the examples. (psa)
+    </div>
+<h4>Version 0.0.8 (2003-07-23)</h4>
+<div class="indent">Changed client-server push mechanism to use &lt;message/&gt; rather than &lt;iq/&gt;, since client may not be online; allowed IQ result to include waitlist information if known; added more detailed disco#info lookup to support discovery of URI types supported. (psa)
+    </div>
+<h4>Version 0.0.7 (2003-07-02)</h4>
+<div class="indent">Modified to use a generic &lt;uri scheme=''/&gt; element. (psa)
+    </div>
+<h4>Version 0.0.6 (2003-06-26)</h4>
+<div class="indent">Refactored protocol to use IQ sets that are "pushed" to the component or client (similar to XMPP rosters); added service discovery and agents support; made text more generic; simplified error handling; change name to "Waiting Lists". (psa)
+    </div>
+<h4>Version 0.0.5 (2003-06-24)</h4>
+<div class="indent">Added remove use case and protocol; added XML schema. (psa)
+    </div>
+<h4>Version 0.0.4 (2003-06-19)</h4>
+<div class="indent">Specified protocol. (psa)
+    </div>
+<h4>Version 0.0.3 (2003-06-18)</h4>
+<div class="indent">Simplified requirements; defined main use case. (psa)
+    </div>
+<h4>Version 0.0.2 (2003-06-16)</h4>
+<div class="indent">Converted to JEP XML format; formalized use case definitions; minor editorial changes. (psa)
+    </div>
+<h4>Version 0.0.1 (2003-06-10)</h4>
+<div class="indent">First draft. (an)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0131-0.7.html
+++ b/content/xep-0131-0.7.html
@@ -1,0 +1,801 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0131: Stanza Headers and Internet Metadata (SHIM)</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stanza Headers and Internet Metadata (SHIM)">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This JEP defines a protocol extension for specifying headers about XMPP stanza content, including an XML representation of standard Internet metadata.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-20">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0131">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0131: Stanza Headers and Internet Metadata (SHIM)</h1>
+<p>This JEP defines a protocol extension for specifying headers about XMPP stanza content, including an XML representation of standard Internet metadata.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0131<br>
+            Version: 0.7<br>
+            Last Updated: 2004-09-20<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: shim<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#headers">Header Definitions</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#headers-classification">Classification</a>
+</dt>
+<dt>4.2.  <a href="#headers-created">Created</a>
+</dt>
+<dt>4.3.  <a href="#headers-distribute">Distribute</a>
+</dt>
+<dt>4.4.  <a href="#headers-store">Store</a>
+</dt>
+<dt>4.5.  <a href="#headers-ttl">TTL</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>7.2.  <a href="#registrar-shim">SHIM Headers Registry</a>
+</dt>
+<dl>
+<dt>7.2.1.  <a href="#registrar-shim-process">Process</a>
+</dt>
+<dt>7.2.2.  <a href="#registrar-shim-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In order to ensure proper processing by the recipient of an XML stanza, some Jabber protocols and other XMPP extensions may need to enable the sender to communicate non-addressing information about the stanza (this is especially true of protocols that translate from a foreign format to XMPP; a good example is <span class="ref">TINS</span>  [<a href="#nt-id2595660">1</a>]). Such information was formerly included in <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2595691">2</a>], but was removed from that specification when it was changed to focus on addressing information only. Therefore, this JEP defines a mechanism for encapsulating non-addressing &quot;header&quot; information about stanzas, including standard Internet metadata such as that defined by <span class="ref">RFC 822</span>  [<a href="#nt-id2595683">3</a>], <span class="ref">RFC 2045</span>  [<a href="#nt-id2595716">4</a>], <span class="ref">RFC 2616</span>  [<a href="#nt-id2595739">5</a>], and <span class="ref">RFC 3261</span>  [<a href="#nt-id2595759">6</a>].</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable the inclusion of any header information</li>
+    <li>Encapsulate all information in XML</li>
+    <li>Ensure interoperability with existing non-XMPP header and metadata formats (HTTP, MIME, SIP, SMTP, etc.)</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">In a fashion similar to the structure of <span style="font-weight: bold">Extended Stanza Addressing</span>, headers for &lt;message/&gt; and &lt;presence/&gt; stanzas are contained in a &lt;headers/&gt; wrapper element qualified by the 'http://jabber.org/protocol/shim' namespace; each header is a child of this wrapper element, and is encapsulated via a &lt;header/&gt; element whose 'name' attribute identifies the header and whose XML character data specifies the relevant value:
+     [<a href="#nt-id2595609">7</a>]
+  </p>
+  <p class="caption">Example 1. A basic example</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard'
+         to='juliet@capulet.com/balcony'&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='in-reply-to'&gt;123456789@capulet.com&lt;/header&gt;
+    &lt;header name='keywords'&gt;shakespeare,&amp;lt;xmpp/&amp;gt;&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">In accordance with <span class="ref">XMPP Core</span>  [<a href="#nt-id2601367">8</a>], an &lt;iq/&gt; stanza must not contain more than one non-error child element; this places constraints on the location of SHIM headers in the XML hierarchy. Specifically, the &lt;headers/&gt; wrapper element MUST NOT be a direct child of &lt;iq/&gt; and instead SHOULD be a grandchild of &lt;iq/&gt; and a direct child of the content-bearing child element of &lt;iq/&gt; (e.g., &lt;query/&gt;), <span style="font-style: italic">not</span> &lt;error/&gt;.</p>
+  <p class="caption">Example 2. An IQ example</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'
+    id='ping1'&gt;
+  &lt;query xmlns='jabber:iq:time'&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='Created'&gt;2004-09-21T03:01:52Z&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="headers">Header Definitions</a>
+</h2>
+  <p class="" style="">All allowable headers MUST be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2601335">9</a>] following the process specified in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document. Many such headers are defined by other protocol specifications, such as RFCs 822, 2045, 2616, and 3261; implementors MUST refer to those specifications for definition of the relevant headers.</p>
+  <p class="" style="">This JEP defines several additional headers that may prove useful within Jabber protocols and other XMPP extensions, as specified in the following sections; further headers shall be registered with the Jabber Registrar, either directly or via definition in Jabber Enhancement Proposals.</p>
+  <div class="indent">
+<h3>4.1 <a name="headers-classification">Classification</a>
+</h3>
+    <p class="" style="">The Classification header enables a sender or other entity to classify a stanza according to some classification scheme. The values of the XML character data contained within this header are out of scope for this document, since they are determined by the using application.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="headers-created">Created</a>
+</h3>
+    <p class="" style="">The Date header is defined by RFC 822 and therefore follows the date and time format defined by RFC 822; while this header is thus useful for translating email messages into XMPP stanzas, it is not consistent with <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2601533">10</a>]. Therefore we define the &quot;Created&quot; header, which specifies the date and time when a stanza was created by the originating entity, where the value conforms to the DateTime profile defined in JEP-0082.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="headers-distribute">Distribute</a>
+</h3>
+    <p class="" style="">The Distribute header enables a sender to specify whether the stanza may be further distributed by the recipient to other entities on the network. The allowable values for this header are &quot;true&quot; and &quot;false&quot;. If the sender specifies a value of &quot;false&quot;, the recipient MUST NOT further distribute the stanza or any information contained therein; if the sender specifies a value of &quot;true&quot;, the recipient MAY further distribute the stanza or any information contained therein; if the value is anything other than &quot;true&quot; or &quot;false&quot; and the recipient does not understand the value, the recipient MUST assume the default value of &quot;false&quot;. This header is semantically equivalent to the &quot;Distribute&quot; flag defined in <span class="ref">Geopriv Policy</span>  [<a href="#nt-id2601492">11</a>]. (Note: The HTTP &quot;Max-Forwards&quot; header is not appropriate for this usage, since it defines proxy and gateway behavior rather than recipient behavior.)</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="headers-store">Store</a>
+</h3>
+    <p class="" style="">The Store header enables a sender to specify whether the stanza may be stored or archived by the recipient or an interim processor such as a router. The allowable values for this header are &quot;true&quot; and &quot;false&quot;. If the sender specifies a value of &quot;false&quot;, the recipient or processor MUST NOT store the stanza; if the sender specifies a value of &quot;true&quot;, the recipient or processor MAY store the stanza; if the value is anything other than &quot;true&quot; or &quot;false&quot; and the recipient does not understand the value, the recipient MUST assume the default value of &quot;false&quot;.</p> 
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="headers-ttl">TTL</a>
+</h3>
+    <p class="" style="">It may be useful to specify that the information contained in a stanza is valid only for a limited period of time. Such is the function of the &quot;TTL&quot; header, the value of which is some number of seconds since the creation of the stanza. Note well that this header is purely informational and MUST NOT be used for routing or delivery of XML stanzas, since that function is already served by <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2601670">12</a>]. A stanza that includes the &quot;TTL&quot; header SHOULD also include a &quot;Created&quot; header so that the recipient can properly process the stanza.</p>
+    <p class="" style="">One situation in which both the &quot;Created&quot; and &quot;TTL&quot; headers might prove valuable is the broadcasting of structured presence information, such as a calendar-generated notification that a user will be in a meeting for the next hour:</p>
+    <p class="caption">Example 3. Time to Live for Presence Information</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;show&gt;dnd&lt;/status&gt;
+  &lt;status&gt;in a meeting&lt;/status&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2004-05-10T11:00Z&lt;/header&gt;
+    &lt;header name='TTL'&gt;3600&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Another potential application is specifying a time to live for <span class="ref">Service Discovery</span>  [<a href="#nt-id2601632">13</a>] results, which helps other entities know how long to cache such information:</p>
+    <p class="caption">Example 4. Time to Live for Disco Information</p>
+<div class="indent"><pre>
+&lt;iq from='example.com'
+    id='some-id'
+    to='example.org'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    ...
+  &lt;/query&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2004-05-17T20:47Z&lt;/header&gt;
+    &lt;header name='TTL'&gt;86400&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations are the responsibility of the using protocol.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2601809">14</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Draft, the Jabber Registrar shall add the 'http://jabber.org/protocol/shim' namespace to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="registrar-shim">SHIM Headers Registry</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Draft, the Jabber Registrar shall create a registry of SHIM headers.</p>
+    <div class="indent">
+<h3>7.2.1 <a name="registrar-shim-process">Process</a>
+</h3>
+      <p class="" style="">In order to register new values in this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;the value of the 'name' attribute&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the header&lt;/desc&gt;
+  &lt;doc&gt;the document in which this header is specified&lt;/doc&gt;
+&lt;/header&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one header at a time, each contained in a separate &lt;header/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.2.2 <a name="registrar-shim-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;Accept&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Charset&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Language&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Ranges&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Age&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Alert-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Allow&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Authentication-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Cache-Control&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Call-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Call-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Classification&lt;/name&gt;
+  &lt;desc&gt;a level within a classification scheme&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Connection&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Contact&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Description&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Disposition&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Language&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Length&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Location&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-MD5&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Transfer-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Type&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045 or RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045 or RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Created&lt;/name&gt;
+  &lt;desc&gt;date and time of stanza creation in ISO 8601 format&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;CSeq&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Date&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Distribute&lt;/name&gt;
+  &lt;desc&gt;whether or not the stanza may be further distributed&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Error-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;ETag&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Expect&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Expires&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Host&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Match&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Modified-Since&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-None-Match&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;In-Reply-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Unmodified-Since&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Keywords&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Last-Modified&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Location&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Max-Forwards&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Message-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;MIME-Version&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Organization&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Pragma&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Priority&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Proxy-Authenticate&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Proxy-Authorization&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Record-Route&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;References&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Referer&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Reply-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Require&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Retry-After&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Route&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Sender&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Server&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Store&lt;/name&gt;
+  &lt;desc&gt;whether or not the stanza may be stored or archived&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Subject&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Supported&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;TE&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Timestamp&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Trailer&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Transfer-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;TTL&lt;/name&gt;
+  &lt;desc&gt;a time to live for the stanza, in seconds&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Unsupported&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Upgrade&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;User-Agent&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Vary&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Via&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Warning&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;WWW-Authenticate&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/shim'
+    xmlns='http://jabber.org/protocol/shim'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='headers'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='header' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='header'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='name' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595660">1</a>. JEP-0111: TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595691">2</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595683">3</a>. RFC 822: Standard for the Format of ARPA Internet Text Messages &lt;<a href="http://www.ietf.org/rfc/rfc0822.txt">http://www.ietf.org/rfc/rfc0822.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595716">4</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595739">5</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595759">6</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595609">7</a>. Standard XML escaping rules apply to the XML character data, so that the characters &lt; &gt; ' &quot; &amp; MUST be escaped to &amp;lt; &amp;gt; &amp;apos; &amp;quot; &amp;amp; respectively when translating from non-XML protocols (such as MIME and SIP) to SHIM, and the escaped sequences (e.g., &amp;lt;) MUST be transformed to the equivalent non-escaped character (e.g., '&lt;') when translating from SHIM to the non-XML protocol. Escaping and unescaping will normally be performed by a gateway that translates between XMPP and a foreign protocol such as MIME or SIP.</p>
+<p>
+<a name="nt-id2601367">8</a>. XMPP Core &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2601335">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2601533">10</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601492">11</a>. Geopriv Policy &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-geopriv-policy-01.txt">http://www.ietf.org/internet-drafts/draft-ietf-geopriv-policy-01.txt</a>&gt;. Work in progress.</p>
+<p>
+<a name="nt-id2601670">12</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601632">13</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601809">14</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2004-09-20)</h4>
+<div class="indent">Specified location of headers in IQ stanzas. (psa)
+    </div>
+<h4>Version 0.6 (2004-07-06)</h4>
+<div class="indent">Added &quot;Store&quot; header. (psa)
+    </div>
+<h4>Version 0.5 (2004-06-28)</h4>
+<div class="indent">Added &quot;Distribute&quot; header. (psa)
+    </div>
+<h4>Version 0.4 (2004-05-27)</h4>
+<div class="indent">Added &quot;Classification&quot; header. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Added headers from RFCs 2045, 2616, and 3261 to initial registration. (psa)
+    </div>
+<h4>Version 0.2 (2004-05-09)</h4>
+<div class="indent">Specified registry process; added headers from RFC 822 to initial registration; defined &quot;Created&quot; and &quot;TTL&quot; headers. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-19)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0131-0.8.html
+++ b/content/xep-0131-0.8.html
@@ -1,0 +1,876 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0131: Stanza Headers and Internet Metadata (SHIM)</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stanza Headers and Internet Metadata (SHIM)">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This JEP defines a protocol extension for specifying headers about XMPP stanza content, including an XML representation of standard Internet metadata.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0131">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0131: Stanza Headers and Internet Metadata (SHIM)</h1>
+<p>This JEP defines a protocol extension for specifying headers about XMPP stanza content, including an XML representation of standard Internet metadata.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0131<br>
+            Version: 0.8<br>
+            Last Updated: 2004-09-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: shim<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco-proto">Protocol Support</a>
+</dt>
+<dt>3.2.  <a href="#disco-header">Header Support</a>
+</dt>
+</dl>
+<dt>4.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>5.  <a href="#headers">Header Definitions</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#headers-classification">Classification</a>
+</dt>
+<dt>5.2.  <a href="#headers-created">Created</a>
+</dt>
+<dt>5.3.  <a href="#headers-distribute">Distribute</a>
+</dt>
+<dt>5.4.  <a href="#headers-store">Store</a>
+</dt>
+<dt>5.5.  <a href="#headers-ttl">TTL</a>
+</dt>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>8.3.  <a href="#registrar-shim">SHIM Headers Registry</a>
+</dt>
+<dl>
+<dt>8.3.1.  <a href="#registrar-shim-process">Process</a>
+</dt>
+<dt>8.3.2.  <a href="#registrar-shim-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In order to ensure proper processing by the recipient of an XML stanza, some Jabber protocols and other XMPP extensions may need to enable the sender to communicate non-addressing information about the stanza (this is especially true of protocols that translate from a foreign format to XMPP; a good example is <span class="ref">TINS</span>  [<a href="#nt-id2596297">1</a>]). Such information was formerly included in <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2596328">2</a>], but was removed from that specification when it was changed to focus on addressing information only. Therefore, this JEP defines a mechanism for encapsulating non-addressing &quot;header&quot; information about stanzas, including standard Internet metadata such as that defined by <span class="ref">RFC 822</span>  [<a href="#nt-id2596350">3</a>], <span class="ref">RFC 2045</span>  [<a href="#nt-id2596372">4</a>], <span class="ref">RFC 2616</span>  [<a href="#nt-id2596394">5</a>], <span class="ref">RFC 2617</span>  [<a href="#nt-id2601878">6</a>], and <span class="ref">RFC 3261</span>  [<a href="#nt-id2601900">7</a>]. Such information is encapsulated in a protocol extension qualified by the 'http://jabber.org/protocol/shim' namespace, where &quot;SHIM&quot; stands for &quot;Stanza Headers and Internet Metadata&quot;.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable the inclusion of any header information</li>
+    <li>Encapsulate all information in XML</li>
+    <li>Ensure interoperability with existing non-XMPP header and metadata formats (HTTP, MIME, SIP, SMTP, etc.)</li>
+  </ol>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco-proto">Protocol Support</a>
+</h3>
+    <p class="" style="">In order to discover whether another entity supports this protocol, an entity MUST use <span class="ref">Service Discovery</span>  [<a href="#nt-id2601996">8</a>].</p>
+    <p class="caption">Example 1. Entity queries another entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Queried entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/shim'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="disco-header">Header Support</a>
+</h3>
+    <p class="" style="">It can be desirable (and, in some contexts, necessary) to determine if the intended recipient of an XML stanza supports a specific header (e.g., the &quot;Classification&quot; header) before sending information that may depend on that header. Therefore, implementations of this protocol MUST advertise which particular SHIM headers they support when queried via disco#info at the well-known service discovery node 'http://jabber.org/protocol/shim'.</p>
+    <p class="caption">Example 3. Entity queries another entity regarding header support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Queried entity communicates header support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/shim#Classification'/&gt;
+    &lt;feature var='http://jabber.org/protocol/shim#Distribute'/&gt;
+    &lt;feature var='http://jabber.org/protocol/shim#Store'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The values of the 'var' attribute MUST be of the form &quot;http://jabber.org/protocol/shim#header&quot;, where &quot;header&quot; is to be replaced with the name of the header as registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602105">9</a>] (see below).</p>
+  </div>
+<h2>4.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">In a fashion similar to the structure of <span style="font-weight: bold">Extended Stanza Addressing</span>, headers for &lt;message/&gt; and &lt;presence/&gt; stanzas are contained in a &lt;headers/&gt; wrapper element qualified by the 'http://jabber.org/protocol/shim' namespace; each header is a child of this wrapper element, and is encapsulated via a &lt;header/&gt; element whose 'name' attribute identifies the header and whose XML character data specifies the relevant value:
+     [<a href="#nt-id2602043">10</a>]
+  </p>
+  <p class="caption">Example 5. A basic example</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard'
+         to='juliet@capulet.com/balcony'&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='in-reply-to'&gt;123456789@capulet.com&lt;/header&gt;
+    &lt;header name='keywords'&gt;shakespeare,&amp;lt;xmpp/&amp;gt;&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">In accordance with <span class="ref">XMPP Core</span>  [<a href="#nt-id2602210">11</a>], an &lt;iq/&gt; stanza must not contain more than one non-error child element; this places constraints on the location of SHIM headers in the XML hierarchy. Specifically, the &lt;headers/&gt; wrapper element MUST NOT be a direct child of &lt;iq/&gt; and instead SHOULD be a grandchild of &lt;iq/&gt; and a direct child of the content-bearing child element of &lt;iq/&gt; (e.g., &lt;query/&gt;, <span style="font-style: italic">not</span> &lt;error/&gt;).</p>
+  <p class="caption">Example 6. An IQ example</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'
+    id='ping1'&gt;
+  &lt;query xmlns='jabber:iq:time'&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='Created'&gt;2004-09-21T03:01:52Z&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="headers">Header Definitions</a>
+</h2>
+  <p class="" style="">All public headers SHOULD be registered with the Jabber Registrar following the process specified in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document. Many such headers are defined by other protocol specifications, such as RFCs 822, 2045, 2616, 2617, and 3261; implementors MUST refer to those specifications for definition of the relevant headers.</p>
+  <p class="" style="">This JEP defines several additional headers that may prove useful within Jabber protocols and other XMPP extensions, as specified in the following sections; further headers may be registered with the Jabber Registrar, either directly or via definition in Jabber Enhancement Proposals.</p>
+  <div class="indent">
+<h3>5.1 <a name="headers-classification">Classification</a>
+</h3>
+    <p class="" style="">The Classification header enables a sender or other entity to classify a stanza according to some classification scheme. The values of the XML character data contained within this header are out of scope for this document, since they are determined by the using application. Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="headers-created">Created</a>
+</h3>
+    <p class="" style="">The Date header is defined by RFC 822 and therefore follows the date and time format defined by RFC 822; while this header is thus useful for translating email messages into XMPP stanzas, it is not consistent with <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2602358">12</a>]. Therefore we define the &quot;Created&quot; header, which specifies the date and time when a stanza was created by the originating entity, where the value conforms to the DateTime profile specified in JEP-0082.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="headers-distribute">Distribute</a>
+</h3>
+    <p class="" style="">The Distribute header enables a sender to specify whether the stanza may be further distributed by the recipient to other entities on the network. The allowable values for this header are &quot;true&quot; and &quot;false&quot;. If the sender specifies a value of &quot;false&quot;, the recipient MUST NOT further distribute the stanza or any information contained therein; if the sender specifies a value of &quot;true&quot;, the recipient MAY further distribute the stanza or any information contained therein; if the value is anything other than &quot;true&quot; or &quot;false&quot; and the recipient does not understand the value, the recipient MUST assume the default value of &quot;false&quot;. This header is semantically equivalent to the &quot;Distribute&quot; flag defined in <span class="ref">Geopriv Policy</span>  [<a href="#nt-id2602318">13</a>]. (The HTTP &quot;Max-Forwards&quot; header is not appropriate for this usage, since it defines proxy and gateway behavior rather than recipient behavior.) Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="headers-store">Store</a>
+</h3>
+    <p class="" style="">The Store header enables a sender to specify whether the stanza may be stored or archived by the recipient or an interim processor such as a router. The allowable values for this header are &quot;true&quot; and &quot;false&quot;. If the sender specifies a value of &quot;false&quot;, the recipient or processor MUST NOT store the stanza or any information contained therein; if the sender specifies a value of &quot;true&quot;, the recipient or processor MAY store the stanza or any information contained therein; if the value is anything other than &quot;true&quot; or &quot;false&quot; and the recipient does not understand the value, the recipient MUST assume the default value of &quot;false&quot;. Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p> 
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="headers-ttl">TTL</a>
+</h3>
+    <p class="" style="">It may be useful to specify that the information contained in a stanza is valid only for a limited period of time. Such is the function of the &quot;TTL&quot; header, the value of which is some number of seconds since the creation of the stanza. Note well that this header is purely informational and MUST NOT be used for routing or delivery of XML stanzas, since that function is already served by <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2602513">14</a>]. A stanza that includes the &quot;TTL&quot; header SHOULD also include a &quot;Created&quot; header so that the recipient can properly process the stanza.</p>
+    <p class="" style="">One situation in which both the &quot;Created&quot; and &quot;TTL&quot; headers might prove valuable is the broadcasting of structured presence information, such as a calendar-generated notification that a user will be in a meeting for the next hour:</p>
+    <p class="caption">Example 7. Time to Live for Presence Information</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;show&gt;dnd&lt;/status&gt;
+  &lt;status&gt;in a meeting&lt;/status&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2004-05-10T11:00Z&lt;/header&gt;
+    &lt;header name='TTL'&gt;3600&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Another potential application is specifying a time to live for <span style="font-weight: bold">Service Discovery</span> results, which helps other entities know how long to cache such information:</p>
+    <p class="caption">Example 8. Time to Live for Disco Information</p>
+<div class="indent"><pre>
+&lt;iq from='example.com'
+    id='some-id'
+    to='example.org'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    ...
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='Created'&gt;2004-05-17T20:47Z&lt;/header&gt;
+      &lt;header name='TTL'&gt;86400&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">In general, security considerations are the responsibility of the using protocol.</p>
+  <p class="" style="">Certain SHIM headers MAY be security-sensitive (e.g., the &quot;Classification&quot;, &quot;Distribute&quot;, and &quot;Store&quot; headers specified herein). If an entity plans to use such headers, it MUST determine whether the intended recipient supports both the SHIM protocol and the particular security-sensitive headers of interst, as described under <a href="#disco">Service Discovery</a>; furthermore, an implementation MUST warn a human user (if any) before use if the security-sensitive headers of interest are not supported.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602662">15</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/shim' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/shim' in its registry of well-known Service Discovery nodes.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="registrar-shim">SHIM Headers Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of SHIM headers.</p>
+    <div class="indent">
+<h3>8.3.1 <a name="registrar-shim-process">Process</a>
+</h3>
+      <p class="" style="">In order to register new values in this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;the value of the 'name' attribute&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the header&lt;/desc&gt;
+  &lt;doc&gt;the document in which this header is specified&lt;/doc&gt;
+&lt;/header&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one header at a time, each contained in a separate &lt;header/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>8.3.2 <a name="registrar-shim-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;Accept&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Charset&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Language&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Ranges&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Age&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Alert-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Allow&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Authentication-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 2617&lt;/desc&gt;
+  &lt;doc&gt;RFC 2617&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Cache-Control&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Call-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Call-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Classification&lt;/name&gt;
+  &lt;desc&gt;a level within a classification scheme&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Connection&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Contact&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Description&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Disposition&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Language&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Length&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Location&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-MD5&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Transfer-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Type&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045 or RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045 or RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Created&lt;/name&gt;
+  &lt;desc&gt;date and time of stanza creation in ISO 8601 format&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;CSeq&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Date&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Distribute&lt;/name&gt;
+  &lt;desc&gt;whether or not the stanza may be further distributed&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Error-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;ETag&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Expect&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Expires&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Host&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Match&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Modified-Since&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-None-Match&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;In-Reply-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Unmodified-Since&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Keywords&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Last-Modified&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Location&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Max-Forwards&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Message-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;MIME-Version&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Organization&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Pragma&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Priority&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Proxy-Authenticate&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Proxy-Authorization&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Record-Route&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;References&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Referer&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Reply-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Require&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Retry-After&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Route&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Sender&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Server&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Store&lt;/name&gt;
+  &lt;desc&gt;whether or not the stanza may be stored or archived&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Subject&lt;/name&gt;
+  &lt;desc&gt;see RFC 822&lt;/desc&gt;
+  &lt;doc&gt;RFC 822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Supported&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;TE&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Timestamp&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Trailer&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Transfer-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;TTL&lt;/name&gt;
+  &lt;desc&gt;a time to live for the stanza, in seconds&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Unsupported&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Upgrade&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;User-Agent&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Vary&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Via&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Warning&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;WWW-Authenticate&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/shim'
+    xmlns='http://jabber.org/protocol/shim'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='headers'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='header' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='header'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='name' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596297">1</a>. JEP-0111: TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596328">2</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596350">3</a>. RFC 822: Standard for the Format of ARPA Internet Text Messages &lt;<a href="http://www.ietf.org/rfc/rfc0822.txt">http://www.ietf.org/rfc/rfc0822.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596372">4</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596394">5</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601878">6</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601900">7</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601996">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602105">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2602043">10</a>. Standard XML escaping rules apply to the XML character data, so that the characters &lt; &gt; ' &quot; &amp; MUST be escaped to &amp;lt; &amp;gt; &amp;apos; &amp;quot; &amp;amp; respectively when translating from non-XML protocols (such as MIME and SIP) to SHIM, and the escaped sequences (e.g., &amp;lt;) MUST be transformed to the equivalent non-escaped character (e.g., '&lt;') when translating from SHIM to the non-XML protocol. Escaping and unescaping will normally be performed by a gateway that translates between XMPP and a foreign protocol such as MIME or SIP.</p>
+<p>
+<a name="nt-id2602210">11</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602358">12</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602318">13</a>. Geopriv Policy &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-geopriv-policy-01.txt">http://www.ietf.org/internet-drafts/draft-ietf-geopriv-policy-01.txt</a>&gt;. Work in progress.</p>
+<p>
+<a name="nt-id2602513">14</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602662">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-09-29)</h4>
+<div class="indent">Specified service discovery usage; corrected examples; further specified security considerations. (psa)
+    </div>
+<h4>Version 0.7 (2004-09-20)</h4>
+<div class="indent">Specified location of headers in IQ stanzas. (psa)
+    </div>
+<h4>Version 0.6 (2004-07-06)</h4>
+<div class="indent">Added &quot;Store&quot; header. (psa)
+    </div>
+<h4>Version 0.5 (2004-06-28)</h4>
+<div class="indent">Added &quot;Distribute&quot; header. (psa)
+    </div>
+<h4>Version 0.4 (2004-05-27)</h4>
+<div class="indent">Added &quot;Classification&quot; header. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Added headers from RFCs 2045, 2616, 2617, and 3261 to initial registration. (psa)
+    </div>
+<h4>Version 0.2 (2004-05-09)</h4>
+<div class="indent">Specified registry process; added headers from RFC 822 to initial registration; defined &quot;Created&quot; and &quot;TTL&quot; headers. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-19)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0131-1.0.html
+++ b/content/xep-0131-1.0.html
@@ -1,0 +1,951 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0131: Stanza Headers and Internet Metadata (SHIM)</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stanza Headers and Internet Metadata (SHIM)">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This JEP defines a protocol extension for specifying headers about XMPP stanza content, including an XML representation of standard Internet metadata.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0131">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0131: Stanza Headers and Internet Metadata (SHIM)</h1>
+<p>This JEP defines a protocol extension for specifying headers about XMPP stanza content, including an XML representation of standard Internet metadata.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0131<br>
+            Version: 1.0<br>
+            Last Updated: 2004-10-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: shim<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/shim/shim.xsd">http://jabber.org/protocol/shim/shim.xsd</a>&gt;<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/shim.html">http://www.jabber.org/registrar/shim.html</a>&gt;
+              <br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco-proto">Protocol Support</a>
+</dt>
+<dt>3.2.  <a href="#disco-header">Header Support</a>
+</dt>
+</dl>
+<dt>4.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>5.  <a href="#headers">Header Definitions</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#headers-classification">Classification</a>
+</dt>
+<dt>5.2.  <a href="#headers-created">Created</a>
+</dt>
+<dt>5.3.  <a href="#headers-distribute">Distribute</a>
+</dt>
+<dt>5.4.  <a href="#headers-store">Store</a>
+</dt>
+<dt>5.5.  <a href="#headers-ttl">TTL</a>
+</dt>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>8.3.  <a href="#registrar-shim">SHIM Headers Registry</a>
+</dt>
+<dl>
+<dt>8.3.1.  <a href="#registrar-shim-process">Process</a>
+</dt>
+<dt>8.3.2.  <a href="#registrar-shim-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In order to ensure proper processing by the recipient of an XML stanza, some Jabber protocols and other XMPP extensions may need to enable the sender to communicate non-addressing information about the stanza (this is especially true of protocols that translate from a foreign format to XMPP; a good example is <span class="ref">TINS</span>  [<a href="#nt-id2596346">1</a>]). Such information was formerly included in <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2596367">2</a>], but was removed from that specification when it was changed to focus on addressing information only. Therefore, this JEP defines a mechanism for encapsulating non-addressing &quot;header&quot; information about stanzas, including standard Internet metadata such as that defined by <span class="ref">RFC 2045</span>  [<a href="#nt-id2596393">3</a>], <span class="ref">RFC 2616</span>  [<a href="#nt-id2601913">4</a>], <span class="ref">RFC 2617</span>  [<a href="#nt-id2596268">5</a>], <span class="ref">RFC 2822</span>  [<a href="#nt-id2596289">6</a>], and <span class="ref">RFC 3261</span>  [<a href="#nt-id2596309">7</a>]. Such information is encapsulated in a protocol extension qualified by the 'http://jabber.org/protocol/shim' namespace, where &quot;SHIM&quot; stands for &quot;Stanza Headers and Internet Metadata&quot;.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable the inclusion of any header information</li>
+    <li>Encapsulate all information in XML</li>
+    <li>Ensure interoperability with existing non-XMPP header and metadata formats (HTTP, MIME, SIP, SMTP, etc.)</li>
+  </ol>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco-proto">Protocol Support</a>
+</h3>
+    <p class="" style="">In order to discover whether another entity supports this protocol, an entity MUST use <span class="ref">Service Discovery</span>  [<a href="#nt-id2602071">8</a>].</p>
+    <p class="caption">Example 1. Entity queries another entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Queried entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/shim'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="disco-header">Header Support</a>
+</h3>
+    <p class="" style="">It can be desirable (and, in some contexts, necessary) to determine if the intended recipient of an XML stanza supports a specific header (e.g., the &quot;Classification&quot; header) before sending information that may depend on that header. Therefore, implementations of this protocol MUST advertise which particular SHIM headers they support when queried via disco#info at the well-known service discovery node 'http://jabber.org/protocol/shim'.</p>
+    <p class="caption">Example 3. Entity queries another entity regarding header support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Queried entity communicates header support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/shim#Classification'/&gt;
+    &lt;feature var='http://jabber.org/protocol/shim#Distribute'/&gt;
+    &lt;feature var='http://jabber.org/protocol/shim#Store'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The values of the 'var' attribute MUST be of the form &quot;http://jabber.org/protocol/shim#header&quot;, where &quot;header&quot; is to be replaced with the name of the header as registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602181">9</a>] (see below).</p>
+  </div>
+<h2>4.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">In a fashion similar to the structure of <span style="font-weight: bold">Extended Stanza Addressing</span>, headers for &lt;message/&gt; and &lt;presence/&gt; stanzas are contained in a &lt;headers/&gt; wrapper element qualified by the 'http://jabber.org/protocol/shim' namespace; each header is a child of this wrapper element, and is encapsulated via a &lt;header/&gt; element whose 'name' attribute identifies the header and whose XML character data specifies the relevant value:
+     [<a href="#nt-id2602119">10</a>]
+  </p>
+  <p class="caption">Example 5. A basic example</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard'
+         to='juliet@capulet.com/balcony'&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='in-reply-to'&gt;123456789@capulet.com&lt;/header&gt;
+    &lt;header name='keywords'&gt;shakespeare,&amp;lt;xmpp/&amp;gt;&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">In accordance with <span class="ref">XMPP Core</span>  [<a href="#nt-id2602285">11</a>], an &lt;iq/&gt; stanza must not contain more than one non-error child element; this places constraints on the location of SHIM headers in the XML hierarchy. Specifically, the &lt;headers/&gt; wrapper element MUST NOT be a direct child of &lt;iq/&gt; and instead SHOULD be a grandchild of &lt;iq/&gt; and a direct child of the content-bearing child element of &lt;iq/&gt; (e.g., &lt;query/&gt;, <span style="font-style: italic">not</span> &lt;error/&gt;).</p>
+  <p class="caption">Example 6. An IQ example</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'
+    id='ping1'&gt;
+  &lt;query xmlns='jabber:iq:time'&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='Created'&gt;2004-09-21T03:01:52Z&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="headers">Header Definitions</a>
+</h2>
+  <p class="" style="">All public headers SHOULD be registered with the Jabber Registrar following the process specified in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document. Many such headers are defined by other protocol specifications, such as RFCs 2045, 2616, 2617, 2822, and 3261; implementors MUST refer to those specifications for definition of the relevant headers.</p>
+  <p class="" style="">This JEP defines several additional headers that may prove useful within Jabber protocols and other XMPP extensions, as specified in the following sections; further headers may be registered with the Jabber Registrar, either directly or via definition in Jabber Enhancement Proposals.</p>
+  <div class="indent">
+<h3>5.1 <a name="headers-classification">Classification</a>
+</h3>
+    <p class="" style="">The Classification header enables a sender or other entity to classify a stanza according to some classification scheme. The values of the XML character data contained within this header are out of scope for this document, since they are determined by the using application. Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="headers-created">Created</a>
+</h3>
+    <p class="" style="">The Date header is defined by RFC 2822 and therefore follows the date and time format defined by RFC 2822; while this header is thus useful for translating email messages into XMPP stanzas, it is not consistent with <span class="ref">Jabber Date and Time Profiles</span>  [<a href="#nt-id2602434">12</a>]. Therefore we define the &quot;Created&quot; header, which specifies the date and time when a stanza was created by the originating entity, where the value conforms to the DateTime profile specified in JEP-0082.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="headers-distribute">Distribute</a>
+</h3>
+    <p class="" style="">The Distribute header enables a sender to specify whether the stanza may be further distributed by the recipient to other entities on the network. The allowable values for this header are &quot;true&quot; and &quot;false&quot;. If the sender specifies a value of &quot;false&quot;, the recipient MUST NOT further distribute the stanza or any information contained therein; if the sender specifies a value of &quot;true&quot;, the recipient MAY further distribute the stanza or any information contained therein; if the value is anything other than &quot;true&quot; or &quot;false&quot; and the recipient does not understand the value, the recipient MUST assume the default value of &quot;false&quot;. This header is semantically equivalent to the &quot;Distribute&quot; flag defined in <span class="ref">Geopriv Policy</span>  [<a href="#nt-id2602393">13</a>]. (The HTTP &quot;Max-Forwards&quot; header is not appropriate for this usage, since it defines proxy and gateway behavior rather than recipient behavior.) Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="headers-store">Store</a>
+</h3>
+    <p class="" style="">The Store header enables a sender to specify whether the stanza may be stored or archived by the recipient or an interim processor such as a router. The allowable values for this header are &quot;true&quot; and &quot;false&quot;. If the sender specifies a value of &quot;false&quot;, the recipient or processor MUST NOT store the stanza or any information contained therein; if the sender specifies a value of &quot;true&quot;, the recipient or processor MAY store the stanza or any information contained therein; if the value is anything other than &quot;true&quot; or &quot;false&quot; and the recipient does not understand the value, the recipient MUST assume the default value of &quot;false&quot;. Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p> 
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="headers-ttl">TTL</a>
+</h3>
+    <p class="" style="">It may be useful to specify that the information contained in a stanza is valid only for a limited period of time. Such is the function of the &quot;TTL&quot; header, the value of which is some number of seconds since the creation of the stanza. Note well that this header is purely informational and MUST NOT be used for routing or delivery of XML stanzas, since that function is already served by <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2602602">14</a>]. A stanza that includes the &quot;TTL&quot; header SHOULD also include a &quot;Created&quot; header so that the recipient can properly process the stanza.</p>
+    <p class="" style="">One situation in which both the &quot;Created&quot; and &quot;TTL&quot; headers might prove valuable is the broadcasting of structured presence information, such as a calendar-generated notification that a user will be in a meeting for the next hour:</p>
+    <p class="caption">Example 7. Time to Live for Presence Information</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;show&gt;dnd&lt;/status&gt;
+  &lt;status&gt;in a meeting&lt;/status&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2004-05-10T11:00Z&lt;/header&gt;
+    &lt;header name='TTL'&gt;3600&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Another potential application is specifying a time to live for <span style="font-weight: bold">Service Discovery</span> results, which helps other entities know how long to cache such information:</p>
+    <p class="caption">Example 8. Time to Live for Disco Information</p>
+<div class="indent"><pre>
+&lt;iq from='example.com'
+    id='some-id'
+    to='example.org'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    ...
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='Created'&gt;2004-05-17T20:47Z&lt;/header&gt;
+      &lt;header name='TTL'&gt;86400&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">In general, security considerations are the responsibility of the using protocol.</p>
+  <p class="" style="">Certain SHIM headers MAY be security-sensitive (e.g., the &quot;Classification&quot;, &quot;Distribute&quot;, and &quot;Store&quot; headers specified herein). If an entity plans to use such headers, it MUST determine whether the intended recipient supports both the SHIM protocol and the particular security-sensitive headers of interst, as described under <a href="#disco">Service Discovery</a>; furthermore, an implementation MUST warn a human user (if any) before use if the security-sensitive headers of interest are not supported.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602750">15</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/shim' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/shim' in its registry of well-known Service Discovery nodes.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="registrar-shim">SHIM Headers Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of SHIM headers.</p>
+    <div class="indent">
+<h3>8.3.1 <a name="registrar-shim-process">Process</a>
+</h3>
+      <p>In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;the value of the 'name' attribute&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the header&lt;/desc&gt;
+  &lt;doc&gt;the document in which this header is specified&lt;/doc&gt;
+&lt;/header&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one header at a time, each contained in a separate &lt;header/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>8.3.2 <a name="registrar-shim-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;Accept&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Charset&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Language&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Ranges&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Age&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Alert-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Allow&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Authentication-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 2617&lt;/desc&gt;
+  &lt;doc&gt;RFC 2617&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Cache-Control&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Call-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Call-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Classification&lt;/name&gt;
+  &lt;desc&gt;a level within a classification scheme&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Comments&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Connection&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Contact&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Description&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Disposition&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Language&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Length&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Location&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-MD5&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Transfer-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Type&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045 or RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045 or RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Created&lt;/name&gt;
+  &lt;desc&gt;date and time of stanza creation in ISO 8601 format&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;CSeq&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Date&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Distribute&lt;/name&gt;
+  &lt;desc&gt;whether or not the stanza may be further distributed&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Error-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;ETag&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Expect&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Expires&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Host&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Match&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Modified-Since&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-None-Match&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Unmodified-Since&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;In-Reply-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Keywords&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Last-Modified&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Location&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Max-Forwards&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Message-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;MIME-Version&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Organization&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Pragma&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Priority&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Proxy-Authenticate&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Proxy-Authorization&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Received&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Record-Route&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;References&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Referer&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Reply-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Require&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Bcc&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Cc&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Date&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-From&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Message-Id&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Sender&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Retry-After&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Return-Path&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Route&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Sender&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Server&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Store&lt;/name&gt;
+  &lt;desc&gt;whether or not the stanza may be stored or archived&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Subject&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Supported&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;TE&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Timestamp&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Trailer&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Transfer-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;TTL&lt;/name&gt;
+  &lt;desc&gt;a time to live for the stanza, in seconds&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Unsupported&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Upgrade&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;User-Agent&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Vary&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Via&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Warning&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;WWW-Authenticate&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/shim'
+    xmlns='http://jabber.org/protocol/shim'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0131: http://www.jabber.org/jeps/jep-0131.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='headers'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='header' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='header'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='name' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596346">1</a>. JEP-0111: TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596367">2</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596393">3</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601913">4</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596268">5</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596289">6</a>. RFC 2822: Internet Message Format &lt;<a href="http://www.ietf.org/rfc/rfc2822.txt">http://www.ietf.org/rfc/rfc2822.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596309">7</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602071">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602181">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2602119">10</a>. Standard XML escaping rules apply to the XML character data, so that the characters &lt; &gt; ' &quot; &amp; MUST be escaped to &amp;lt; &amp;gt; &amp;apos; &amp;quot; &amp;amp; respectively when translating from non-XML protocols (such as MIME and SIP) to SHIM, and the escaped sequences (e.g., &amp;lt;) MUST be transformed to the equivalent non-escaped character (e.g., '&lt;') when translating from SHIM to the non-XML protocol. Escaping and unescaping will normally be performed by a gateway that translates between XMPP and a foreign protocol such as MIME or SIP.</p>
+<p>
+<a name="nt-id2602285">11</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602434">12</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602393">13</a>. Geopriv Policy &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-geopriv-policy-01.txt">http://www.ietf.org/internet-drafts/draft-ietf-geopriv-policy-01.txt</a>&gt;. Work in progress.</p>
+<p>
+<a name="nt-id2602602">14</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602750">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2004-10-22)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft; also added more headers from RFC 2822 to the initial registry submission. (psa)
+    </div>
+<h4>Version 0.8 (2004-09-29)</h4>
+<div class="indent">Specified service discovery usage; corrected examples; further specified security considerations. (psa)
+    </div>
+<h4>Version 0.7 (2004-09-20)</h4>
+<div class="indent">Specified location of headers in IQ stanzas. (psa)
+    </div>
+<h4>Version 0.6 (2004-07-06)</h4>
+<div class="indent">Added &quot;Store&quot; header. (psa)
+    </div>
+<h4>Version 0.5 (2004-06-28)</h4>
+<div class="indent">Added &quot;Distribute&quot; header. (psa)
+    </div>
+<h4>Version 0.4 (2004-05-27)</h4>
+<div class="indent">Added &quot;Classification&quot; header. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Added headers from RFCs 2045, 2616, 2617, and 3261 to initial registration. (psa)
+    </div>
+<h4>Version 0.2 (2004-05-09)</h4>
+<div class="indent">Specified registry process; added headers from RFC 2822 to initial registration; defined &quot;Created&quot; and &quot;TTL&quot; headers. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-19)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0131-1.1.html
+++ b/content/xep-0131-1.1.html
@@ -1,0 +1,1053 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0131: Stanza Headers and Internet Metadata (SHIM)</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stanza Headers and Internet Metadata (SHIM)">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This JEP defines a protocol extension for specifying headers about XMPP stanza content, including an XML representation of standard Internet metadata.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-08-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0131">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0131: Stanza Headers and Internet Metadata (SHIM)</h1>
+<p>This JEP defines a protocol extension for specifying headers about XMPP stanza content, including an XML representation of standard Internet metadata.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0131<br>
+            Version: 1.1<br>
+            Last Updated: 2005-08-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: shim<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/shim/shim.xsd">http://jabber.org/protocol/shim/shim.xsd</a>&gt;<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/shim.html">http://www.jabber.org/registrar/shim.html</a>&gt;
+              <br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Stanza%20Headers%20and%20Internet%20Metadata%20(SHIM)%20(JEP-0131)">http://wiki.jabber.org/index.php/Stanza Headers and Internet Metadata (SHIM) (JEP-0131)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco-proto">Protocol Support</a>
+</dt>
+<dt>3.2.  <a href="#disco-header">Header Support</a>
+</dt>
+</dl>
+<dt>4.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>5.  <a href="#headers">Header Definitions</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#headers-classification">Classification</a>
+</dt>
+<dt>5.2.  <a href="#headers-created">Created</a>
+</dt>
+<dt>5.3.  <a href="#headers-distribute">Distribute</a>
+</dt>
+<dt>5.4.  <a href="#headers-store">Store</a>
+</dt>
+<dt>5.5.  <a href="#headers-ttl">TTL</a>
+</dt>
+</dl>
+<dt>6.  <a href="#dates">A Note About Date-Related Headers</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-nodes">Well-Known Service Discovery Nodes</a>
+</dt>
+<dt>9.3.  <a href="#registrar-shim">SHIM Headers Registry</a>
+</dt>
+<dl>
+<dt>9.3.1.  <a href="#registrar-shim-process">Process</a>
+</dt>
+<dt>9.3.2.  <a href="#registrar-shim-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">In order to ensure proper processing by the recipient of an XML stanza, some Jabber protocols and other XMPP extensions may need to enable the sender to communicate non-addressing information about the stanza (this is especially true of protocols that translate from a foreign format to XMPP; a good example is <span class="ref" style="">A Transport for Initiating and Negotiating Sessions (TINS)</span>  [<a href="#nt-id2250588">1</a>]). Such information was formerly included in <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2250613">2</a>], but was removed from that specification when it was changed to focus on addressing information only. Therefore, this JEP defines a mechanism for encapsulating non-addressing "header" information about stanzas, including standard Internet metadata such as that defined by <span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2250777">3</a>], <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250809">4</a>], <span class="ref" style="">RFC 2617</span>  [<a href="#nt-id2250639">5</a>], <span class="ref" style="">RFC 2822</span>  [<a href="#nt-id2250659">6</a>], and <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250679">7</a>]. Such information is encapsulated in a protocol extension qualified by the 'http://jabber.org/protocol/shim' namespace, where "SHIM" stands for "Stanza Headers and Internet Metadata".</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This protocol addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable the inclusion of any header information</li>
+    <li>Encapsulate all information in XML</li>
+    <li>Ensure interoperability with existing non-XMPP header and metadata formats (HTTP, MIME, SIP, SMTP, etc.)</li>
+  </ol>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco-proto">Protocol Support</a>
+</h3>
+    <p class="" style="">In order to discover whether another entity supports this protocol, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250760">8</a>].</p>
+    <p class="caption">Example 1. Entity queries another entity regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Queried entity communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/shim'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="disco-header">Header Support</a>
+</h3>
+    <p class="" style="">It can be desirable (and, in some contexts, necessary) to determine if the intended recipient of an XML stanza supports a specific header (e.g., the "Classification" header) before sending information that may depend on that header. Therefore, implementations of this protocol MUST advertise which particular SHIM headers they support when queried via disco#info at the well-known service discovery node 'http://jabber.org/protocol/shim'.</p>
+    <p class="caption">Example 3. Entity queries another entity regarding header support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Queried entity communicates header support</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/shim#Classification'/&gt;
+    &lt;feature var='http://jabber.org/protocol/shim#Distribute'/&gt;
+    &lt;feature var='http://jabber.org/protocol/shim#Store'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The values of the 'var' attribute MUST be of the form "http://jabber.org/protocol/shim#header", where "header" is to be replaced with the name of the header as registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256313">9</a>] (see below).</p>
+  </div>
+<h2>4.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">In a fashion similar to the structure of <span style="font-weight: bold">Extended Stanza Addressing</span>, headers for &lt;message/&gt; and &lt;presence/&gt; stanzas are contained in a &lt;headers/&gt; wrapper element qualified by the 'http://jabber.org/protocol/shim' namespace; each header is a child of this wrapper element, and is encapsulated via a &lt;header/&gt; element whose 'name' attribute identifies the header and whose XML character data specifies the relevant value:
+     [<a href="#nt-id2256344">10</a>]
+  </p>
+  <p class="caption">Example 5. A basic example</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard'
+         to='juliet@capulet.com/balcony'&gt;
+  &lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='In-Reply-To'&gt;123456789@capulet.com&lt;/header&gt;
+    &lt;header name='Keywords'&gt;shakespeare,&amp;lt;xmpp/&amp;gt;&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">In accordance with <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2256402">11</a>], an &lt;iq/&gt; stanza must not contain more than one non-error child element; this places constraints on the location of SHIM headers in the XML hierarchy. Specifically, the &lt;headers/&gt; wrapper element MUST NOT be a direct child of &lt;iq/&gt; and instead SHOULD be a grandchild of &lt;iq/&gt; and a direct child of the content-bearing child element of &lt;iq/&gt; (e.g., &lt;query/&gt;, <span style="font-style: italic">not</span> &lt;error/&gt;).</p>
+  <p class="caption">Example 6. An IQ example</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com/balcony'
+    id='ping1'&gt;
+  &lt;query xmlns='jabber:iq:time'&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='Created'&gt;2004-09-21T03:01:52Z&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="headers">Header Definitions</a>
+</h2>
+  <p class="" style="">All public headers SHOULD be registered with the Jabber Registrar following the process specified in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document. Many such headers are defined by other protocol specifications, such as RFCs 2045, 2616, 2617, 2822, and 3261; implementors MUST refer to those specifications for definition of the relevant headers.</p>
+  <p class="" style="">This JEP defines several additional headers that may prove useful within Jabber protocols and other XMPP extensions, as specified in the following sections; further headers may be registered with the Jabber Registrar, either directly or via definition in Jabber Enhancement Proposals.</p>
+  <div class="indent">
+<h3>5.1 <a name="headers-classification">Classification</a>
+</h3>
+    <p class="" style="">The Classification header enables a sender or other entity to classify a stanza according to some classification scheme. The values of the XML character data contained within this header are out of scope for this document, since they are determined by the using application. Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="headers-created">Created</a>
+</h3>
+    <p class="" style="">The Date header is defined by RFC 2822 and therefore follows the date and time format defined by RFC 2822; while this header is thus useful for translating email messages into XMPP stanzas, it is not consistent with <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2256529">12</a>]. Therefore we define the "Created" header, which specifies the date and time when a stanza was created by the originating entity, where the value conforms to the DateTime profile specified in JEP-0082.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="headers-distribute">Distribute</a>
+</h3>
+    <p class="" style="">The Distribute header enables a sender to specify whether the stanza may be further distributed by the recipient to other entities on the network. The allowable values for this header are "true" and "false". If the sender specifies a value of "false", the recipient MUST NOT further distribute the stanza or any information contained therein; if the sender specifies a value of "true", the recipient MAY further distribute the stanza or any information contained therein; if the value is anything other than "true" or "false" and the recipient does not understand the value, the recipient MUST assume the default value of "false". This header is semantically equivalent to the "Distribute" flag defined in <span class="ref" style="">Geopriv Policy</span>  [<a href="#nt-id2256579">13</a>]. (The HTTP "Max-Forwards" header is not appropriate for this usage, since it defines proxy and gateway behavior rather than recipient behavior.) Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="headers-store">Store</a>
+</h3>
+    <p class="" style="">The Store header enables a sender to specify whether the stanza may be stored or archived by the recipient. The allowable values for this header are "true" and "false". If the sender specifies a value of "false", the recipient MUST NOT store the stanza or any information contained therein; if the sender specifies a value of "true", the recipient MAY store the stanza or any information contained therein; if the value is anything other than "true" or "false" and the recipient does not understand the value, the recipient MUST assume the default value of "false". Note: This header may be security-sensitive (see the <a href="#security">Security Considerations</a> for details).</p> 
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="headers-ttl">TTL</a>
+</h3>
+    <p class="" style="">It may be useful to specify that the information contained in a stanza is valid only for a limited period of time. Such is the function of the "TTL" header, the value of which is some number of seconds since the creation of the stanza. Note well that this header is purely informational and MUST NOT be used for routing or delivery of XML stanzas, since that function is already served by <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256678">14</a>]. A stanza that includes the "TTL" header SHOULD also include a "Created" header so that the recipient can properly process the stanza.</p>
+    <p class="" style="">One situation in which both the "Created" and "TTL" headers might prove valuable is the broadcasting of structured presence information, such as a calendar-generated notification that a user will be in a meeting for the next hour:</p>
+    <p class="caption">Example 7. Time to Live for Presence Information</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;show&gt;dnd&lt;/status&gt;
+  &lt;status&gt;in a meeting&lt;/status&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2004-05-10T11:00Z&lt;/header&gt;
+    &lt;header name='TTL'&gt;3600&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Another potential application is specifying a time to live for <span style="font-weight: bold">Service Discovery</span> results, which helps other entities know how long to cache such information:</p>
+    <p class="caption">Example 8. Time to Live for Disco Information</p>
+<div class="indent"><pre>
+&lt;iq from='example.com'
+    id='some-id'
+    to='example.org'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    ...
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='Created'&gt;2004-05-17T20:47Z&lt;/header&gt;
+      &lt;header name='TTL'&gt;86400&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="dates">A Note About Date-Related Headers</a>
+</h2>
+  <p class="" style="">Date formats differ widely. <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2256751">15</a>] defines the Date, DateTime, and Time profiles of <span class="ref" style="">ISO 8601</span>  [<a href="#nt-id2256782">16</a>], which correspond to the Date, DateTime, and Time headers registered herein. The SHIM Date header also corresponds to the Date metadata element used in <span class="ref" style="">Dublin Core Metadata Initiative (DCMI)</span>  [<a href="#nt-id2256808">17</a>] as specified in <span class="ref" style="">RFC 2413</span>  [<a href="#nt-id2256835">18</a>].</p>
+  <p class="" style="">However, many Internet standards use a different datetime format that ultimately derives from <span class="ref" style="">RFC 822</span>  [<a href="#nt-id2256871">19</a>] as updated by <span class="ref" style="">RFC 1123</span>  [<a href="#nt-id2256891">20</a>]; specifically, that format is used by email (<span style="font-weight: bold">RFC 2822</span>), the World Wide Web (<span style="font-weight: bold">RFC 2616</span>), and the Session Initiation Protocol (<span style="font-weight: bold">RFC 3261</span>). To map dates to and from these protocols, we define the SHIM RFC2822Date header.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">In general, security considerations are the responsibility of the using protocol.</p>
+  <p class="" style="">Certain SHIM headers MAY be security-sensitive (e.g., the "Classification", "Distribute", and "Store" headers specified herein). If an entity plans to use such headers, it MUST determine whether the intended recipient supports both the SHIM protocol and the particular security-sensitive headers of interst, as described under <a href="#disco">Service Discovery</a>; furthermore, an implementation MUST warn a human user (if any) before use if the security-sensitive headers of interest are not supported.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256974">21</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes 'http://jabber.org/protocol/shim' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="registrar-nodes">Well-Known Service Discovery Nodes</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes 'http://jabber.org/protocol/shim' in its registry of well-known Service Discovery nodes.</p>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="registrar-shim">SHIM Headers Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar maintains a registry of SHIM headers.</p>
+    <div class="indent">
+<h3>9.3.1 <a name="registrar-shim-process">Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;the value of the 'name' attribute&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the header&lt;/desc&gt;
+  &lt;doc&gt;the document in which this header is specified&lt;/doc&gt;
+&lt;/header&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one header at a time, each contained in a separate &lt;header/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>9.3.2 <a name="registrar-shim-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;Accept&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Charset&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Language&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Accept-Ranges&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Age&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Alert-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Allow&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Authentication-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 2617&lt;/desc&gt;
+  &lt;doc&gt;RFC 2617&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Cache-Control&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Call-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Call-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Classification&lt;/name&gt;
+  &lt;desc&gt;a level within a classification scheme&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Comments&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Connection&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Contact&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Description&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Disposition&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Language&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Length&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Location&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-MD5&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Transfer-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Content-Type&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045 or RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045 or RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Contributor&lt;/name&gt;
+  &lt;desc&gt;an entity other than the primary Creator who helped to create a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Coverage&lt;/name&gt;
+  &lt;desc&gt;the spatial or temporal characteristics of a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Created&lt;/name&gt;
+  &lt;desc&gt;date and time of stanza creation in ISO 8601 format&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Creator&lt;/name&gt;
+  &lt;desc&gt;the person or organization responsible for creating the content of a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;CSeq&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Date&lt;/name&gt;
+  &lt;desc&gt;a string that conforms to the Date profile specified in JEP-0082&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;DateTime&lt;/name&gt;
+  &lt;desc&gt;a string that conforms to the DateTime profile specified in JEP-0082&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Description&lt;/name&gt;
+  &lt;desc&gt;a textual description of the content of a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Distribute&lt;/name&gt;
+  &lt;desc&gt;whether or not the stanza may be further distributed&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Error-Info&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;ETag&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Expect&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Expires&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Format&lt;/name&gt;
+  &lt;desc&gt;the data format of a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Host&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Identifier&lt;/name&gt;
+  &lt;desc&gt;a string or number used to identity a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Match&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Modified-Since&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-None-Match&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;If-Unmodified-Since&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;In-Reply-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Keywords&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Language&lt;/name&gt;
+  &lt;desc&gt;the language in expressing the content of a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Last-Modified&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Location&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Max-Forwards&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Message-ID&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;MIME-Version&lt;/name&gt;
+  &lt;desc&gt;see RFC 2045&lt;/desc&gt;
+  &lt;doc&gt;RFC 2045&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Organization&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Pragma&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Priority&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Proxy-Authenticate&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Proxy-Authorization&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Publisher&lt;/name&gt;
+  &lt;desc&gt;the entity responsible for making a resource available&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Range&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Received&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Record-Route&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;References&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Referer&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Relation&lt;/name&gt;
+  &lt;desc&gt;the identifier of a second resource related to a primary resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Reply-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Require&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Bcc&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Cc&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Date&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-From&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Message-Id&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-Sender&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Resent-To&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Retry-After&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Return-Path&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;RFC2822Date&lt;/name&gt;
+  &lt;desc&gt;the datetime associated with an email message, SIP exchange, or HTTP request&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Rights&lt;/name&gt;
+  &lt;desc&gt;a rights management statement, identifier, or link&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Route&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Sender&lt;/name&gt;
+  &lt;desc&gt;see RFC 2822&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Server&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Source&lt;/name&gt;
+  &lt;desc&gt;information about the original source of the present resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Store&lt;/name&gt;
+  &lt;desc&gt;whether or not the stanza may be stored or archived&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Subject&lt;/name&gt;
+  &lt;desc&gt;the human-readable topic of a message or resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2822 or RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Supported&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;TE&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Time&lt;/name&gt;
+  &lt;desc&gt;a string that conforms to the Time profile specified in JEP-0082&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Timestamp&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Title&lt;/name&gt;
+  &lt;desc&gt;the name given to a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Trailer&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Transfer-Encoding&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;TTL&lt;/name&gt;
+  &lt;desc&gt;a time to live for the stanza, in seconds&lt;/desc&gt;
+  &lt;doc&gt;JEP-0131&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Type&lt;/name&gt;
+  &lt;desc&gt;the category of a resource&lt;/desc&gt;
+  &lt;doc&gt;RFC 2413&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Unsupported&lt;/name&gt;
+  &lt;desc&gt;see RFC 3261&lt;/desc&gt;
+  &lt;doc&gt;RFC 3261&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Upgrade&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;User-Agent&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Vary&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Via&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Warning&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;WWW-Authenticate&lt;/name&gt;
+  &lt;desc&gt;see RFC 2616&lt;/desc&gt;
+  &lt;doc&gt;RFC 2616&lt;/doc&gt;
+&lt;/header&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/shim'
+    xmlns='http://jabber.org/protocol/shim'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0131: http://www.jabber.org/jeps/jep-0131.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='headers'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='header' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='header'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='name' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250588">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2250613">2</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2250777">3</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2250809">4</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2250639">5</a>. RFC 2617: HTTP Authentication: Basic and Digest Access Authentication &lt;<a href="http://www.ietf.org/rfc/rfc2617.txt">http://www.ietf.org/rfc/rfc2617.txt</a>&gt;.</p>
+<p><a name="nt-id2250659">6</a>. RFC 2822: Internet Message Format &lt;<a href="http://www.ietf.org/rfc/rfc2822.txt">http://www.ietf.org/rfc/rfc2822.txt</a>&gt;.</p>
+<p><a name="nt-id2250679">7</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2250760">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256313">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256344">10</a>. Standard XML escaping rules apply to the XML character data, so that the characters &lt; &gt; ' " &amp; MUST be escaped to &amp;lt; &amp;gt; &amp;apos; &amp;quot; &amp;amp; respectively when translating from non-XML protocols (such as MIME and SIP) to SHIM, and the escaped sequences (e.g., &amp;lt;) MUST be transformed to the equivalent non-escaped character (e.g., '&lt;') when translating from SHIM to the non-XML protocol. Escaping and unescaping will normally be performed by a gateway that translates between XMPP and a foreign protocol such as MIME or SIP.</p>
+<p><a name="nt-id2256402">11</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256529">12</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2256579">13</a>. Geopriv Policy &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-geopriv-policy-06.txt">http://www.ietf.org/internet-drafts/draft-ietf-geopriv-policy-06.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256678">14</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256751">15</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2256782">16</a>. ISO 8601: Representation of Dates and Times (2000). This specification is not freely available; however, a good summary is located at &lt;<a href="http://www.cl.cam.ac.uk/~mgk25/iso-time.html">http://www.cl.cam.ac.uk/~mgk25/iso-time.html</a>&gt;.</p>
+<p><a name="nt-id2256808">17</a>. The Dublin Core Metadata Initiative (DCMI) is an organization dedicated to promoting the widespread adoption of interoperable metadata standards. For further information, see &lt;<a href="http://www.dublincore.org/">http://www.dublincore.org/</a>&gt;.</p>
+<p><a name="nt-id2256835">18</a>. RFC 2413: Dublin Core Metadata for Resource Discovery &lt;<a href="http://www.ietf.org/rfc/rfc2413.txt">http://www.ietf.org/rfc/rfc2413.txt</a>&gt;.</p>
+<p><a name="nt-id2256871">19</a>. RFC 822: Standard for the Format of ARPA Internet Text Messages &lt;<a href="http://www.ietf.org/rfc/rfc0822.txt">http://www.ietf.org/rfc/rfc0822.txt</a>&gt;.</p>
+<p><a name="nt-id2256891">20</a>. RFC 1123: Requirements for Internet Hosts -- Application and Support &lt;<a href="http://www.ietf.org/rfc/rfc1123.txt">http://www.ietf.org/rfc/rfc1123.txt</a>&gt;.</p>
+<p><a name="nt-id2256974">21</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2005-08-19)</h4>
+<div class="indent">Added Date, DateTime, and Time headers conforming to profiles from JEP-0082; renamed Date header to RFC2822Date; added note about date-related headers; added headers from RFC 2413 (Dublin Core). (psa)
+    </div>
+<h4>Version 1.0 (2004-10-22)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft; also added more headers from RFC 2822 to the initial registry submission. (psa)
+    </div>
+<h4>Version 0.8 (2004-09-29)</h4>
+<div class="indent">Specified service discovery usage; corrected examples; further specified security considerations. (psa)
+    </div>
+<h4>Version 0.7 (2004-09-20)</h4>
+<div class="indent">Specified location of headers in IQ stanzas. (psa)
+    </div>
+<h4>Version 0.6 (2004-07-06)</h4>
+<div class="indent">Added "Store" header. (psa)
+    </div>
+<h4>Version 0.5 (2004-06-28)</h4>
+<div class="indent">Added "Distribute" header. (psa)
+    </div>
+<h4>Version 0.4 (2004-05-27)</h4>
+<div class="indent">Added "Classification" header. (psa)
+    </div>
+<h4>Version 0.3 (2004-05-10)</h4>
+<div class="indent">Added headers from RFCs 2045, 2616, 2617, and 3261 to initial registration. (psa)
+    </div>
+<h4>Version 0.2 (2004-05-09)</h4>
+<div class="indent">Specified registry process; added headers from RFC 2822 to initial registration; defined "Created" and "TTL" headers. (psa)
+    </div>
+<h4>Version 0.1 (2004-03-19)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0133-0.2.html
+++ b/content/xep-0133-0.2.html
@@ -1,0 +1,2333 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0133: Service Administration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Administration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-07-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0133">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0133: Service Administration</h1>
+<p>This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0133<br>
+            Version: 0.2<br>
+            Last Updated: 2004-07-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: admin<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#add-user">Add a User</a>
+</dt>
+<dt>4.2.  <a href="#delete-user">Delete a User</a>
+</dt>
+<dt>4.3.  <a href="#disable-user">Disable a User</a>
+</dt>
+<dt>4.4.  <a href="#reenable-user">Re-Enable a User</a>
+</dt>
+<dt>4.5.  <a href="#end-user-session">End a User's Session</a>
+</dt>
+<dt>4.6.  <a href="#get-user-password">Get a User's Password</a>
+</dt>
+<dt>4.7.  <a href="#change-user-password">Change a User's Password</a>
+</dt>
+<dt>4.8.  <a href="#get-user-roster">Get a User's Roster</a>
+</dt>
+<dt>4.9.  <a href="#get-user-lastlogin">Get a User's Last Login Time</a>
+</dt>
+<dt>4.10.  <a href="#add-to-blacklist">Blacklist an Entity</a>
+</dt>
+<dt>4.11.  <a href="#whitelist">Whitelist an Entity</a>
+</dt>
+<dt>4.12.  <a href="#edit-blacklist">Edit the Blacklist</a>
+</dt>
+<dt>4.13.  <a href="#edit-whitelist">Edit the Whitelist</a>
+</dt>
+<dt>4.14.  <a href="#get-active-users">Get List of Active Users</a>
+</dt>
+<dt>4.15.  <a href="#get-all-users">Get List of All Users</a>
+</dt>
+<dt>4.16.  <a href="#announce">Send an Announcement to Active Users</a>
+</dt>
+<dt>4.17.  <a href="#set-motd">Set Message of the Day</a>
+</dt>
+<dt>4.18.  <a href="#delete-motd">Delete Message of the Day</a>
+</dt>
+<dt>4.19.  <a href="#set-welcome">Set Welcome Message</a>
+</dt>
+<dt>4.20.  <a href="#delete-welcome">Delete Welcome Message</a>
+</dt>
+<dt>4.21.  <a href="#grant-admin">Grant Administrative Privileges</a>
+</dt>
+<dt>4.22.  <a href="#revoke-admin">Revoke Administrative Privileges</a>
+</dt>
+<dt>4.23.  <a href="#edit-admin">Edit Admin List</a>
+</dt>
+<dt>4.24.  <a href="#restart">Restart Service</a>
+</dt>
+<dt>4.25.  <a href="#shutdown">Shut Down Service</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sect-id2605371">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists a set of common service-level tasks that administrators often need to perform in relation to Jabber/XMPP servers and components. Examples include creating users, disabling accounts, and blacklisting domains for inbound or outbound communications. Because such tasks can be performed with respect to a server or with respect to many kinds of add-on components (e.g., a text conferencing component that conforms to <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2595541">1</a>]), it makes sense to define a generic protocol for such interactions. This JEP describes such a protocol by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2595474">2</a>], rather than by defining a specialized and distinct protocol.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable users with appropriate privileges to perform common administrative tasks with respect to Jabber/XMPP servers and components.</li>
+    <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+  </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <p class="" style="">A server or component MUST advertise any administrative commands it supports via <span class="ref">Service Discovery</span>  [<a href="#nt-id2595644">3</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>); such commands exist as well-defined discovery nodes associated with the service in question.</p>
+  <p class="" style="">In order to interact with a particular component attached to a server, an administrator needs to first discover that component and the commands it support, then send the appropriate command to the component itself. A server SHOULD NOT process commands on behalf of associated components, just as it does not handle service discovery requests on behalf of such components.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> that enables a service-level administrator to complete the following use cases:</p>
+  <ol start="" type="">
+    <li>Add a User</li>
+    <li>Delete a User</li>
+    <li>Disable a User</li>
+    <li>Re-Enable a User</li>
+    <li>End a User's Session</li>
+    <li>Get a User's Password</li>
+    <li>Change a User's Password</li>
+    <li>Get a User's Roster</li>
+    <li>Get a User's Last Login Time</li>
+    <li>Blacklist an Entity</li>
+    <li>Whitelist an Entity</li>
+    <li>Edit the Blacklist</li>
+    <li>Edit the Whitelist</li>
+    <li>Get List of All Users</li>
+    <li>Get List of Active Users</li>
+    <li>Send an Announcement to Active Users</li>
+    <li>Set Message of the Day</li>
+    <li>Delete Message of the Day</li>
+    <li>Set Welcome Message</li>
+    <li>Delete Welcome Message</li>
+    <li>Grant Administrative Privileges</li>
+    <li>Revoke Administrative Privileges</li>
+    <li>Edit Admin List</li>
+    <li>Restart Service</li>
+    <li>Shut Down Service</li>
+  </ol>
+  <p class="" style="">Naturally, not all of these use cases apply to all service types (e.g., adding a user may not apply to a multi-user chat service). An implementation or deployment MAY support any subset of the use cases defined herein. In addition, although this JEP aims to define common use cases, an implementation or deployment MAY support additional commands not defined herein.</p>
+  <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementers have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> as well as <span class="ref">Data Forms</span>  [<a href="#nt-id2595783">4</a>] (on which JEP-0050 depends).</span></p>
+  <div class="indent">
+<h3>4.1 <a name="add-user">Add a User</a>
+</h3>
+    <p class="" style="">A user is defined as any entity that has a persistent relationship with a service (most commonly through the creation a registered account with the service) and whose account is in some sense hosted by the service. Adding a user MUST result in the creation of an account, along with any implementation-specific data for such an account (e.g., database entries or a roster file). The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#add-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 1. Admin Requests to Add a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 2. Service Returns Add User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Adding a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to add a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'/&gt;
+      &lt;field label='Retype password'
+             type='text-private'
+             var='password-verify'/&gt;
+      &lt;field label='Email address'
+             type='text-single'
+             var='email'/&gt;
+      &lt;field label='Given name'
+             type='text-single'
+             var='firstname'/&gt;
+      &lt;field label='Family name'
+             type='text-single'
+             var='surname'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Admin Submits Add User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password-verify'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='firstname'&gt;
+        &lt;value&gt;Juliet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='surname'&gt;
+        &lt;value&gt;Capulet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Notification of completion MAY include the processed data in a data form of type &quot;result&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="delete-user">Delete a User</a>
+</h3>
+    <p class="" style="">An administrator may need to permanently delete a user account. Deleting a user SHOULD result in the termination of any active sessions for the user and in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#delete-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 5. Admin Requests to Delete a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 6. Service Returns Delete User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Deleting a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to delete a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 7. Admin Submits Delete User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="disable-user">Disable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to temporarily disable a user account. Disabling a user MUST result in the termination of any active sessions for the user and in the prevention of further user logins until the account is re-enabled (this can be thought of as &quot;banning&quot; the user). However, it MUST NOT result in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#disable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 9. Admin Requests to Disable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#disable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 10. Service Returns Disable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Disabling a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to disable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 11. Admin Submits Disable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="reenable-user">Re-Enable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to re-enable a user account that had been temporarily disabled. Re-enabling a user MUST result in granting the user the ability to access the service again. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#reenable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 13. Admin Requests to Re-Enable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#reenable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 14. Service Returns Re-Enable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Re-Enable a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to re-enable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 15. Admin Submits Re-Enable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="end-user-session">End a User's Session</a>
+</h3>
+    <p class="" style="">An administrator may need to terminate one or all of the user's current sessions, but allow future logins (this can be thought of as &quot;kicking&quot; rather than &quot;banning&quot; the user). The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#end-user-session&quot;.</p> 
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 17. Admin Requests to End a User's Session</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#end-user-session'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 18. Service Returns End User Session Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Ending a User Session&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to end a user&amp;apos;s session.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the JID is of the form &lt;user@host&gt;, the service MUST end all of the user's sessions; if the JID is of the form &lt;user@host/resource&gt;, the service MUST end only the session associated with that resource.</p>
+    <p class="caption">Example 19. Admin Submits End User Session Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="get-user-password">Get a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's password. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#get-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 21. Admin Requests to Get a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 22. Service Returns Get User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 23. Admin Submits Get User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the data form included in the IQ result will include the user's password.</p>
+    <p class="caption">Example 24. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="change-user-password">Change a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to change a user's password. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#change-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 25. Admin Requests to Change a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#change-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 26. Service Returns Change User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Changing a User Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to change a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 27. Admin Submits Change User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;V3r0n4&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="get-user-roster">Get a User's Roster</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's roster (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#get-user-roster&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 29. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 30. Service Returns Get User Roster Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Roster&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s roster.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 31. Admin Submits Get User Roster Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's roster, formatted according to the 'jabber:iq:roster' protocol defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2601626">5</a>].</p>
+    <p class="caption">Example 32. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;query xmlns='jabber:iq:roster'&gt;
+        &lt;item jid='romeo@example.net'
+              name='Romeo'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+          &lt;group&gt;Lovers&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='mercutio@example.org'
+              name='Mercutio'
+              subscription='from'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='benvolio@example.org'
+              name='Benvolio'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+      &lt;/query&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="get-user-lastlogin">Get a User's Last Login Time</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#get-user-lastlogin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 33. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 34. Service Returns Get User Last Login Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Last Login Time&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s last login time.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 35. Admin Submits Get User Last Login Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's last login time.</p>
+    <p class="caption">Example 36. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lastlogin'&gt;
+        &lt;value&gt;1234&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.10 <a name="add-to-blacklist">Blacklist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide blacklists (lists of entities that are blocked from communications to or from the service). For example, a multi-user chat service may forbid a certain user from joining any room on the service, or may block entire domains from accessing the service. An entity added to a blacklist MAY be a JID of any form as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2603111">6</a>]; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of blacklisting an entity adds it to the blacklist but does not otherwise change the blacklist.</p>
+    <p class="" style="">A blacklist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#add-to-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 37. Admin Requests Blacklisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 38. Service Returns Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Blocking Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to block communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to block'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 39. Admin Submits Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.11 <a name="whitelist">Whitelist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide whitelists (lists of entities that are allowed to communicate the service). For example, a publish-subscribe may allow only a select list of users to publish or subscribe to nodes hosted on the service. An entity added to a whitelist MAY be a JID of any form as specified in <span style="font-weight: bold">XMPP Core</span>; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of whitelisting an entity adds it to the whitelist but does not otherwise change the whitelist. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot;.</p>
+    <p class="" style="">As with blacklists, a whitelist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 41. Admin Requests Whitelisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 42. Service Returns Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Allowing Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to allow communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to allow'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 43. Admin Submits Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 44. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.12 <a name="edit-blacklist">Edit the Blacklist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the blacklist rather than simply add an entity to it. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#edit-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 45. Admin Requests Editing of Blacklist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 46. Service Returns Edit Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Blacklist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are disallowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The blacklist'
+             type='jid-multi'
+             var='blacklist'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 47. Admin Submits Edit Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='blacklist'&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;france.lit&lt;/value&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 48. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.13 <a name="edit-whitelist">Edit the Whitelist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the whitelist rather than simply add an entity to it. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#edit-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 49. Admin Requests Editing of Whitelist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 50. Service Returns Edit Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Whitelist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are allowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The whitelist'
+             type='jid-multi'
+             var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 51. Admin Submits Edit Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+        &lt;value&gt;verona.it&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 52. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.14 <a name="get-active-users">Get List of Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to retrieve a list of all online users of the server; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). Obviously, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#get-active-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 53. Admin Requests List of Active Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-active-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply return the list of active users.</p>
+    <p class="caption">Example 54. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of active users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.15 <a name="get-all-users">Get List of All Users</a>
+</h3>
+    <p class="" style="">The concept of retrieving a list of active users can be extended even further to enable an administrator to retrieve a list of all users (not just active or online users). As with the previous use case, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#get-all-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 55. Admin Requests List of All Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-all-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-all-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the list of all users.</p>
+    <p class="caption">Example 56. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-all-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-all-users'
+           sessionid='get-all-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of all users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bernardo@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;cordelia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;emilia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;francisco@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;goneril@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;iago@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kingclaudius@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kinglear@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;laertes@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;macbeth@shakespeare.li&lt;/value&gt;
+        &lt;value&gt;mercutio@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;nestor@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;northumberland@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;painter@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;regan@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;timon@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.16 <a name="announce">Send an Announcement to Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send an announcement to all online users of the server (e.g., to announce a server shutdown); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The message shall be sent only to users who currently have a &quot;session&quot; with the service. Obviously there may be latency in sending the message if the number of active users is extremely large. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#announce&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 57. Admin Requests Announcement</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#announce'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 58. Service Returns Announce Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Making an Announcement&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to make an announcement to all
+          active users of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 59. Admin Submits Announce Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;Attention! This service will be going down for&lt;/value&gt;
+        &lt;value&gt;maintenance in 2 minutes. Please log off now!&lt;/value&gt;
+        &lt;value&gt;We apologize for the inconvenience.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 60. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.17 <a name="set-motd">Set Message of the Day</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send a &quot;message of the day&quot; that is delivered to any user who logs in to the server that day (e.g., to announce service changes); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#set-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 61. Admin Sets Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current message of the day if one has already been set.</p>
+    <p class="caption">Example 62. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Stuff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 63. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 64. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.18 <a name="delete-motd">Delete Message of the Day</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;message of the day&quot; is no longer appropriate and needs to be deleted. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#delete-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 65. Admin Deletes Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the message of the day.</p>
+    <p class="caption">Example 66. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-motd'
+           sessionid='delete-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.19 <a name="set-welcome">Set Welcome Message</a>
+</h3>
+    <p class="" style="">Some existing Jabber servers send an informative &quot;welcome message&quot; to newly registered users of the server when they first log in; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#set-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 67. Admin Sets Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current welcome message if one has already been set.</p>
+    <p class="caption">Example 68. Service Returns Welcome Message Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting Welcome Message&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the welcome message
+          for this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Welcome Message'
+             type='text-multi'
+             var='welcome'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 69. Admin Submits Welcome Message Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='welcome'&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+        &lt;value&gt;For helpful information about this service,&lt;/value&gt;
+        &lt;value&gt;hie thee to http://www.shakespeare.lit/&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 70. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.20 <a name="delete-welcome">Delete Welcome Message</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;welcome message&quot; is no longer appropriate and needs to be deleted. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#delete-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 71. Admin Deletes Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the welcome message.</p>
+    <p class="caption">Example 72. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-welcome'
+           sessionid='delete-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.21 <a name="grant-admin">Grant Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to grant administrative privileges to another user. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus which types of administrators are allowed to grant administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#grant-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 73. Admin Requests to Grant Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#grant-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 74. Service Returns Grant Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Granting Administrative Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to grant administrative privileges 
+          to another user.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the new admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 75. Admin Submits Grant Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 76. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.22 <a name="revoke-admin">Revoke Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to revoke another user's administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to revoke administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#revoke-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 77. Admin Requests to Revoke Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#revoke-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 78. Service Returns Revoke Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Revoking Admin Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to revoke another user&amp;apos; 
+          administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the soon-to-be former admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 79. Admin Submits Revoke Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 80. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.23 <a name="edit-admin">Edit Admin List</a>
+</h3>
+    <p class="" style="">An administrator may want to directly edit the list of users who have administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to edit administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#edit-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 81. Admin Requests Editing of Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 82. Service Returns Edit Admin List Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Admin List&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities who
+          have administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The admin list'
+             type='jid-multi'
+             var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;chris@marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Admin Submits Edit Admin List Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 84. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.24 <a name="restart">Restart Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to restart the service. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#restart&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 85. Admin Requests Restart of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#restart'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 86. Service Returns Restart Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Restarting the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to restart the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before restarting'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 87. Admin Submits Restart Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be restarted in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 88. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.25 <a name="shutdown">Shut Down Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to shut down the service. The command node for this use case MUST be &quot;http://jabber.org/protocol/admin#shutdown&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 89. Admin Requests Shut Down of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#shutdown'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 90. Service Returns Shut Down Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Shutting Down the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to shut down the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before shutting down'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 91. Admin Submits Shut Down Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be shut down in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 92. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">Several error conditions are possible when an entity sends a command request to the service, as defined in the following table. If one of these error conditions occurs, the service MUST return an error stanza to the requesting entity.</p>
+  <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Cause</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The command cannot be completed because of a data or system conflict (e.g., a user already exists with that username).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc commands protocol is).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to perform the command.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">No entity is allowed to perform the command (e.g., retrieve the CEO's roster).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+      <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported.</td>
+    </tr>
+  </table>
+  <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2605195">7</a>]. Naturally, other errors may be returned as well (e.g., &lt;internal-server-error/&gt; if the service cannot be shut down).</p> 
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The ability to complete the administrative tasks specified herein MUST NOT be granted to users who lack service-level administrative privileges.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2605341">8</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605284">9</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>8.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the Jabber Registrar shall add &quot;http://jabber.org/protocol/admin&quot; to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2605455">10</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. The reserved fields for the 'http://jabber.org/protocol/admin' namespace are specified below.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/admin&lt;/name&gt;
+  &lt;doc&gt;JEP-0133&lt;/doc&gt;
+  &lt;desc&gt;Forms used for administration of servers and components.&lt;/desc&gt;
+  &lt;field var='adminlist'
+         type='jid-multi'
+         var='A list of entities with administrative privileges'/&gt;
+  &lt;field var='announcement'
+         type='text-multi'
+         label='The text of an announcement to be sent to active users or all users'/&gt;
+  &lt;field var='blacklist'
+         type='jid-multi'
+         var='A list of entities with whom communication is blocked'/&gt;
+  &lt;field var='delay'
+         type='list-multi'
+         var='The number of seconds to delay before applying a change'/&gt;
+  &lt;field var='email'
+         type='text-single'
+         label='The email address for a user'/&gt;
+  &lt;field var='firstname'
+         type='text-single'
+         label='The given (first) name of a user'/&gt;
+  &lt;field var='jid'
+         type='jid-single'
+         label='The Jabber ID of a user or other entity'/&gt;
+  &lt;field var='motd'
+         type='text-multi'
+         label='The text of a message of the day'/&gt;
+  &lt;field var='password'
+         type='text-private'
+         label='The password for an account'/&gt;
+  &lt;field var='password-verify'
+         type='text-private'
+         label='Password verification'/&gt;
+  &lt;field var='surname'
+         type='text-single'
+         label='The family (last) name of a user'/&gt;
+  &lt;field var='userlist'
+         type='jid-multi'
+         var='A list of registered entities'/&gt;
+  &lt;field var='welcome'
+         type='text-multi'
+         label='The text of a welcome message'/&gt;
+  &lt;field var='whitelist'
+         type='jid-multi'
+         var='A list of entities with whom communication is allowed'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="sect-id2605371">XML Schema</a>
+</h2>
+  <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595541">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595474">2</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595644">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595783">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601626">5</a>. XMPP IM &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2603111">6</a>. XMPP Core &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2605195">7</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605341">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605284">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2605455">10</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-07-22)</h4>
+<div class="indent">Added several more use cases; defined complete protocol flows; specified Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-25)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0133-0.3.html
+++ b/content/xep-0133-0.3.html
@@ -1,0 +1,2336 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0133: Service Administration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Administration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0133">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0133: Service Administration</h1>
+<p>This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0133<br>
+            Version: 0.3<br>
+            Last Updated: 2004-09-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: admin<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#add-user">Add a User</a>
+</dt>
+<dt>4.2.  <a href="#delete-user">Delete a User</a>
+</dt>
+<dt>4.3.  <a href="#disable-user">Disable a User</a>
+</dt>
+<dt>4.4.  <a href="#reenable-user">Re-Enable a User</a>
+</dt>
+<dt>4.5.  <a href="#end-user-session">End a User's Session</a>
+</dt>
+<dt>4.6.  <a href="#get-user-password">Get a User's Password</a>
+</dt>
+<dt>4.7.  <a href="#change-user-password">Change a User's Password</a>
+</dt>
+<dt>4.8.  <a href="#get-user-roster">Get a User's Roster</a>
+</dt>
+<dt>4.9.  <a href="#get-user-lastlogin">Get a User's Last Login Time</a>
+</dt>
+<dt>4.10.  <a href="#add-to-blacklist">Blacklist an Entity</a>
+</dt>
+<dt>4.11.  <a href="#whitelist">Whitelist an Entity</a>
+</dt>
+<dt>4.12.  <a href="#edit-blacklist">Edit the Blacklist</a>
+</dt>
+<dt>4.13.  <a href="#edit-whitelist">Edit the Whitelist</a>
+</dt>
+<dt>4.14.  <a href="#get-active-users">Get List of Active Users</a>
+</dt>
+<dt>4.15.  <a href="#get-all-users">Get List of All Users</a>
+</dt>
+<dt>4.16.  <a href="#announce">Send an Announcement to Active Users</a>
+</dt>
+<dt>4.17.  <a href="#set-motd">Set Message of the Day</a>
+</dt>
+<dt>4.18.  <a href="#delete-motd">Delete Message of the Day</a>
+</dt>
+<dt>4.19.  <a href="#set-welcome">Set Welcome Message</a>
+</dt>
+<dt>4.20.  <a href="#delete-welcome">Delete Welcome Message</a>
+</dt>
+<dt>4.21.  <a href="#grant-admin">Grant Administrative Privileges</a>
+</dt>
+<dt>4.22.  <a href="#revoke-admin">Revoke Administrative Privileges</a>
+</dt>
+<dt>4.23.  <a href="#edit-admin">Edit Admin List</a>
+</dt>
+<dt>4.24.  <a href="#restart">Restart Service</a>
+</dt>
+<dt>4.25.  <a href="#shutdown">Shut Down Service</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sect-id2605726">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists a set of common service-level tasks that administrators often need to perform in relation to Jabber/XMPP servers and components. Examples include creating users, disabling accounts, and blacklisting domains for inbound or outbound communications. Because such tasks can be performed with respect to a server or with respect to many kinds of add-on components (e.g., a text conferencing component that conforms to <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596176">1</a>]), it makes sense to define a generic protocol for such interactions. This JEP describes such a protocol by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2596199">2</a>], rather than by defining a specialized and distinct protocol.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable users with appropriate privileges to perform common administrative tasks with respect to Jabber/XMPP servers and components.</li>
+    <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+  </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <p class="" style="">A server or component MUST advertise any administrative commands it supports via <span class="ref">Service Discovery</span>  [<a href="#nt-id2596150">3</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>); such commands exist as well-defined discovery nodes associated with the service in question.</p>
+  <p class="" style="">In order to interact with a particular component attached to a server, an administrator needs to first discover that component and the commands it support, then send the appropriate command to the component itself. A server SHOULD NOT process commands on behalf of associated components, just as it does not handle service discovery requests on behalf of such components.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> that enables a service-level administrator to complete the following use cases:</p>
+  <ol start="" type="">
+    <li>Add a User</li>
+    <li>Delete a User</li>
+    <li>Disable a User</li>
+    <li>Re-Enable a User</li>
+    <li>End a User's Session</li>
+    <li>Get a User's Password</li>
+    <li>Change a User's Password</li>
+    <li>Get a User's Roster</li>
+    <li>Get a User's Last Login Time</li>
+    <li>Blacklist an Entity</li>
+    <li>Whitelist an Entity</li>
+    <li>Edit the Blacklist</li>
+    <li>Edit the Whitelist</li>
+    <li>Get List of All Users</li>
+    <li>Get List of Active Users</li>
+    <li>Send an Announcement to Active Users</li>
+    <li>Set Message of the Day</li>
+    <li>Delete Message of the Day</li>
+    <li>Set Welcome Message</li>
+    <li>Delete Welcome Message</li>
+    <li>Grant Administrative Privileges</li>
+    <li>Revoke Administrative Privileges</li>
+    <li>Edit Admin List</li>
+    <li>Restart Service</li>
+    <li>Shut Down Service</li>
+  </ol>
+  <p class="" style="">Naturally, not all of these use cases apply to all service types (e.g., adding a user may not apply to a multi-user chat service). An implementation or deployment MAY support any subset of the use cases defined herein. In addition, although this JEP aims to define common use cases, an implementation or deployment MAY support additional commands not defined herein.</p>
+  <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementers have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> as well as <span class="ref">Data Forms</span>  [<a href="#nt-id2601968">4</a>] (on which JEP-0050 depends).</span></p>
+  <div class="indent">
+<h3>4.1 <a name="add-user">Add a User</a>
+</h3>
+    <p class="" style="">A user is defined as any entity that has a persistent relationship with a service (most commonly through the creation a registered account with the service) and whose account is in some sense hosted by the service. Adding a user MUST result in the creation of an account, along with any implementation-specific data for such an account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 1. Admin Requests to Add a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 2. Service Returns Add User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Adding a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to add a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'/&gt;
+      &lt;field label='Retype password'
+             type='text-private'
+             var='password-verify'/&gt;
+      &lt;field label='Email address'
+             type='text-single'
+             var='email'/&gt;
+      &lt;field label='Given name'
+             type='text-single'
+             var='firstname'/&gt;
+      &lt;field label='Family name'
+             type='text-single'
+             var='surname'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Admin Submits Add User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password-verify'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='firstname'&gt;
+        &lt;value&gt;Juliet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='surname'&gt;
+        &lt;value&gt;Capulet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Notification of completion MAY include the processed data in a data form of type &quot;result&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="delete-user">Delete a User</a>
+</h3>
+    <p class="" style="">An administrator may need to permanently delete a user account. Deleting a user SHOULD result in the termination of any active sessions for the user and in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 5. Admin Requests to Delete a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 6. Service Returns Delete User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Deleting a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to delete a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 7. Admin Submits Delete User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="disable-user">Disable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to temporarily disable a user account. Disabling a user MUST result in the termination of any active sessions for the user and in the prevention of further user logins until the account is re-enabled (this can be thought of as &quot;banning&quot; the user). However, it MUST NOT result in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#disable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 9. Admin Requests to Disable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#disable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 10. Service Returns Disable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Disabling a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to disable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 11. Admin Submits Disable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="reenable-user">Re-Enable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to re-enable a user account that had been temporarily disabled. Re-enabling a user MUST result in granting the user the ability to access the service again. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#reenable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 13. Admin Requests to Re-Enable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#reenable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 14. Service Returns Re-Enable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Re-Enable a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to re-enable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 15. Admin Submits Re-Enable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="end-user-session">End a User's Session</a>
+</h3>
+    <p class="" style="">An administrator may need to terminate one or all of the user's current sessions, but allow future logins (this can be thought of as &quot;kicking&quot; rather than &quot;banning&quot; the user). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#end-user-session&quot;.</p> 
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 17. Admin Requests to End a User's Session</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#end-user-session'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 18. Service Returns End User Session Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Ending a User Session&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to end a user&amp;apos;s session.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the JID is of the form &lt;user@host&gt;, the service MUST end all of the user's sessions; if the JID is of the form &lt;user@host/resource&gt;, the service MUST end only the session associated with that resource.</p>
+    <p class="caption">Example 19. Admin Submits End User Session Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="get-user-password">Get a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 21. Admin Requests to Get a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 22. Service Returns Get User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 23. Admin Submits Get User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the data form included in the IQ result will include the user's password.</p>
+    <p class="caption">Example 24. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="change-user-password">Change a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to change a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#change-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 25. Admin Requests to Change a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#change-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 26. Service Returns Change User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Changing a User Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to change a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 27. Admin Submits Change User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;V3r0n4&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="get-user-roster">Get a User's Roster</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's roster (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-roster&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 29. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 30. Service Returns Get User Roster Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Roster&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s roster.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 31. Admin Submits Get User Roster Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's roster, formatted according to the 'jabber:iq:roster' protocol defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2603233">5</a>].</p>
+    <p class="caption">Example 32. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;query xmlns='jabber:iq:roster'&gt;
+        &lt;item jid='romeo@example.net'
+              name='Romeo'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+          &lt;group&gt;Lovers&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='mercutio@example.org'
+              name='Mercutio'
+              subscription='from'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='benvolio@example.org'
+              name='Benvolio'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+      &lt;/query&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="get-user-lastlogin">Get a User's Last Login Time</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-lastlogin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 33. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 34. Service Returns Get User Last Login Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Last Login Time&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s last login time.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 35. Admin Submits Get User Last Login Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's last login time.</p>
+    <p class="caption">Example 36. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lastlogin'&gt;
+        &lt;value&gt;1234&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.10 <a name="add-to-blacklist">Blacklist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide blacklists (lists of entities that are blocked from communications to or from the service). For example, a multi-user chat service may forbid a certain user from joining any room on the service, or may block entire domains from accessing the service. An entity added to a blacklist MAY be a JID of any form as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2603470">6</a>]; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of blacklisting an entity adds it to the blacklist but does not otherwise change the blacklist.</p>
+    <p class="" style="">A blacklist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 37. Admin Requests Blacklisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 38. Service Returns Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Blocking Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to block communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to block'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 39. Admin Submits Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.11 <a name="whitelist">Whitelist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide whitelists (lists of entities that are allowed to communicate the service). For example, a publish-subscribe may allow only a select list of users to publish or subscribe to nodes hosted on the service. An entity added to a whitelist MAY be a JID of any form as specified in <span style="font-weight: bold">XMPP Core</span>; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of whitelisting an entity adds it to the whitelist but does not otherwise change the whitelist. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot;.</p>
+    <p class="" style="">As with blacklists, a whitelist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 41. Admin Requests Whitelisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 42. Service Returns Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Allowing Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to allow communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to allow'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 43. Admin Submits Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 44. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.12 <a name="edit-blacklist">Edit the Blacklist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the blacklist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 45. Admin Requests Editing of Blacklist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 46. Service Returns Edit Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Blacklist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are disallowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The blacklist'
+             type='jid-multi'
+             var='blacklist'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 47. Admin Submits Edit Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='blacklist'&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;france.lit&lt;/value&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 48. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.13 <a name="edit-whitelist">Edit the Whitelist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the whitelist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 49. Admin Requests Editing of Whitelist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 50. Service Returns Edit Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Whitelist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are allowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The whitelist'
+             type='jid-multi'
+             var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 51. Admin Submits Edit Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+        &lt;value&gt;verona.it&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 52. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.14 <a name="get-active-users">Get List of Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to retrieve a list of all online users of the server; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). Obviously, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-active-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 53. Admin Requests List of Active Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-active-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply return the list of active users.</p>
+    <p class="caption">Example 54. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of active users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.15 <a name="get-all-users">Get List of All Users</a>
+</h3>
+    <p class="" style="">The concept of retrieving a list of active users can be extended even further to enable an administrator to retrieve a list of all users (not just active or online users). As with the previous use case, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-all-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 55. Admin Requests List of All Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-all-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-all-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the list of all users.</p>
+    <p class="caption">Example 56. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-all-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-all-users'
+           sessionid='get-all-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of all users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bernardo@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;cordelia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;emilia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;francisco@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;goneril@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;iago@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kingclaudius@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kinglear@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;laertes@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;macbeth@shakespeare.li&lt;/value&gt;
+        &lt;value&gt;mercutio@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;nestor@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;northumberland@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;painter@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;regan@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;timon@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.16 <a name="announce">Send an Announcement to Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send an announcement to all online users of the server (e.g., to announce a server shutdown); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The message shall be sent only to users who currently have a &quot;session&quot; with the service. Obviously there may be latency in sending the message if the number of active users is extremely large. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#announce&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 57. Admin Requests Announcement</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#announce'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 58. Service Returns Announce Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Making an Announcement&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to make an announcement to all
+          active users of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 59. Admin Submits Announce Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;Attention! This service will be going down for&lt;/value&gt;
+        &lt;value&gt;maintenance in 2 minutes. Please log off now!&lt;/value&gt;
+        &lt;value&gt;We apologize for the inconvenience.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 60. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.17 <a name="set-motd">Set Message of the Day</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send a &quot;message of the day&quot; that is delivered to any user who logs in to the server that day (e.g., to announce service changes); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 61. Admin Sets Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current message of the day if one has already been set.</p>
+    <p class="caption">Example 62. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Stuff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 63. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 64. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.18 <a name="delete-motd">Delete Message of the Day</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;message of the day&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 65. Admin Deletes Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the message of the day.</p>
+    <p class="caption">Example 66. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-motd'
+           sessionid='delete-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.19 <a name="set-welcome">Set Welcome Message</a>
+</h3>
+    <p class="" style="">Some existing Jabber servers send an informative &quot;welcome message&quot; to newly registered users of the server when they first log in; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 67. Admin Sets Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current welcome message if one has already been set.</p>
+    <p class="caption">Example 68. Service Returns Welcome Message Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting Welcome Message&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the welcome message
+          for this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Welcome Message'
+             type='text-multi'
+             var='welcome'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 69. Admin Submits Welcome Message Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='welcome'&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+        &lt;value&gt;For helpful information about this service,&lt;/value&gt;
+        &lt;value&gt;hie thee to http://www.shakespeare.lit/&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 70. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.20 <a name="delete-welcome">Delete Welcome Message</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;welcome message&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 71. Admin Deletes Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the welcome message.</p>
+    <p class="caption">Example 72. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-welcome'
+           sessionid='delete-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.21 <a name="grant-admin">Grant Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to grant administrative privileges to another user. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus which types of administrators are allowed to grant administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#grant-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 73. Admin Requests to Grant Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#grant-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 74. Service Returns Grant Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Granting Administrative Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to grant administrative privileges 
+          to another user.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the new admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 75. Admin Submits Grant Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 76. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.22 <a name="revoke-admin">Revoke Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to revoke another user's administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to revoke administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#revoke-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 77. Admin Requests to Revoke Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#revoke-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 78. Service Returns Revoke Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Revoking Admin Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to revoke another user&amp;apos; 
+          administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the soon-to-be former admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 79. Admin Submits Revoke Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 80. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.23 <a name="edit-admin">Edit Admin List</a>
+</h3>
+    <p class="" style="">An administrator may want to directly edit the list of users who have administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to edit administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 81. Admin Requests Editing of Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 82. Service Returns Edit Admin List Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Admin List&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities who
+          have administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The admin list'
+             type='jid-multi'
+             var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;chris@marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Admin Submits Edit Admin List Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 84. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.24 <a name="restart">Restart Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to restart the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#restart&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 85. Admin Requests Restart of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#restart'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 86. Service Returns Restart Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Restarting the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to restart the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before restarting'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 87. Admin Submits Restart Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be restarted in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 88. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.25 <a name="shutdown">Shut Down Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to shut down the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#shutdown&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 89. Admin Requests Shut Down of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#shutdown'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 90. Service Returns Shut Down Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Shutting Down the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to shut down the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before shutting down'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 91. Admin Submits Shut Down Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be shut down in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 92. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">Several error conditions are possible when an entity sends a command request to the service, as defined in the following table. If one of these error conditions occurs, the service MUST return an error stanza to the requesting entity.</p>
+  <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Cause</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The command cannot be completed because of a data or system conflict (e.g., a user already exists with that username).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc commands protocol is).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to perform the command.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">No entity is allowed to perform the command (e.g., retrieve the CEO's roster).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+      <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported.</td>
+    </tr>
+  </table>
+  <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2605550">7</a>]. Naturally, other errors may be returned as well (e.g., &lt;internal-server-error/&gt; if the service cannot be shut down).</p> 
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The ability to complete the administrative tasks specified herein MUST NOT be granted to users who lack service-level administrative privileges.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2605697">8</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605639">9</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>8.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the Jabber Registrar shall add &quot;http://jabber.org/protocol/admin&quot; to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2605810">10</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. The reserved fields for the 'http://jabber.org/protocol/admin' namespace are specified below.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/admin&lt;/name&gt;
+  &lt;doc&gt;JEP-0133&lt;/doc&gt;
+  &lt;desc&gt;Forms used for administration of servers and components.&lt;/desc&gt;
+  &lt;field var='adminlist'
+         type='jid-multi'
+         var='A list of entities with administrative privileges'/&gt;
+  &lt;field var='announcement'
+         type='text-multi'
+         label='The text of an announcement to be sent to active users or all users'/&gt;
+  &lt;field var='blacklist'
+         type='jid-multi'
+         var='A list of entities with whom communication is blocked'/&gt;
+  &lt;field var='delay'
+         type='list-multi'
+         var='The number of seconds to delay before applying a change'/&gt;
+  &lt;field var='email'
+         type='text-single'
+         label='The email address for a user'/&gt;
+  &lt;field var='firstname'
+         type='text-single'
+         label='The given (first) name of a user'/&gt;
+  &lt;field var='jid'
+         type='jid-single'
+         label='The Jabber ID of a user or other entity'/&gt;
+  &lt;field var='motd'
+         type='text-multi'
+         label='The text of a message of the day'/&gt;
+  &lt;field var='password'
+         type='text-private'
+         label='The password for an account'/&gt;
+  &lt;field var='password-verify'
+         type='text-private'
+         label='Password verification'/&gt;
+  &lt;field var='surname'
+         type='text-single'
+         label='The family (last) name of a user'/&gt;
+  &lt;field var='userlist'
+         type='jid-multi'
+         var='A list of registered entities'/&gt;
+  &lt;field var='welcome'
+         type='text-multi'
+         label='The text of a welcome message'/&gt;
+  &lt;field var='whitelist'
+         type='jid-multi'
+         var='A list of entities with whom communication is allowed'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="sect-id2605726">XML Schema</a>
+</h2>
+  <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596176">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596199">2</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596150">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601968">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603233">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603470">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2605550">7</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605697">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605639">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2605810">10</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2004-09-30)</h4>
+<div class="indent">Changed command naming requirement from MUST to SHOULD. (psa)
+    </div>
+<h4>Version 0.2 (2004-07-22)</h4>
+<div class="indent">Added several more use cases; defined complete protocol flows; specified Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-25)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0133-0.4.html
+++ b/content/xep-0133-0.4.html
@@ -1,0 +1,2343 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0133: Service Administration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Administration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0133">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0133: Service Administration</h1>
+<p>This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0133<br>
+            Version: 0.4<br>
+            Last Updated: 2004-11-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: admin<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#add-user">Add a User</a>
+</dt>
+<dt>4.2.  <a href="#delete-user">Delete a User</a>
+</dt>
+<dt>4.3.  <a href="#disable-user">Disable a User</a>
+</dt>
+<dt>4.4.  <a href="#reenable-user">Re-Enable a User</a>
+</dt>
+<dt>4.5.  <a href="#end-user-session">End a User's Session</a>
+</dt>
+<dt>4.6.  <a href="#get-user-password">Get a User's Password</a>
+</dt>
+<dt>4.7.  <a href="#change-user-password">Change a User's Password</a>
+</dt>
+<dt>4.8.  <a href="#get-user-roster">Get a User's Roster</a>
+</dt>
+<dt>4.9.  <a href="#get-user-lastlogin">Get a User's Last Login Time</a>
+</dt>
+<dt>4.10.  <a href="#add-to-blacklist">Blacklist an Entity</a>
+</dt>
+<dt>4.11.  <a href="#whitelist">Whitelist an Entity</a>
+</dt>
+<dt>4.12.  <a href="#edit-blacklist">Edit the Blacklist</a>
+</dt>
+<dt>4.13.  <a href="#edit-whitelist">Edit the Whitelist</a>
+</dt>
+<dt>4.14.  <a href="#get-active-users">Get List of Active Users</a>
+</dt>
+<dt>4.15.  <a href="#get-all-users">Get List of All Users</a>
+</dt>
+<dt>4.16.  <a href="#announce">Send an Announcement to Active Users</a>
+</dt>
+<dt>4.17.  <a href="#set-motd">Set Message of the Day</a>
+</dt>
+<dt>4.18.  <a href="#delete-motd">Delete Message of the Day</a>
+</dt>
+<dt>4.19.  <a href="#set-welcome">Set Welcome Message</a>
+</dt>
+<dt>4.20.  <a href="#delete-welcome">Delete Welcome Message</a>
+</dt>
+<dt>4.21.  <a href="#grant-admin">Grant Administrative Privileges</a>
+</dt>
+<dt>4.22.  <a href="#revoke-admin">Revoke Administrative Privileges</a>
+</dt>
+<dt>4.23.  <a href="#edit-admin">Edit Admin List</a>
+</dt>
+<dt>4.24.  <a href="#restart">Restart Service</a>
+</dt>
+<dt>4.25.  <a href="#shutdown">Shut Down Service</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sect-id2606067">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists a set of common service-level tasks that administrators often need to perform in relation to Jabber/XMPP servers and components. Examples include creating users, disabling accounts, and blacklisting domains for inbound or outbound communications. Because such tasks can be performed with respect to a server or with respect to many kinds of add-on components (e.g., a text conferencing component that conforms to <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596199">1</a>]), it makes sense to define a generic protocol for such interactions. This JEP describes such a protocol by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2596221">2</a>], rather than by defining a specialized and distinct protocol.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable users with appropriate privileges to perform common administrative tasks with respect to Jabber/XMPP servers and components.</li>
+    <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+  </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <p class="" style="">A server or component MUST advertise any administrative commands it supports via <span class="ref">Service Discovery</span>  [<a href="#nt-id2596167">3</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>); such commands exist as well-defined discovery nodes associated with the service in question.</p>
+  <p class="" style="">In order to interact with a particular component attached to a server, an administrator needs to first discover that component and the commands it support, then send the appropriate command to the component itself. A server SHOULD NOT process commands on behalf of associated components, just as it does not handle service discovery requests on behalf of such components.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> that enables a service-level administrator to complete the following use cases:</p>
+  <ol start="" type="">
+    <li>Add a User</li>
+    <li>Delete a User</li>
+    <li>Disable a User</li>
+    <li>Re-Enable a User</li>
+    <li>End a User's Session</li>
+    <li>Get a User's Password</li>
+    <li>Change a User's Password</li>
+    <li>Get a User's Roster</li>
+    <li>Get a User's Last Login Time</li>
+    <li>Blacklist an Entity</li>
+    <li>Whitelist an Entity</li>
+    <li>Edit the Blacklist</li>
+    <li>Edit the Whitelist</li>
+    <li>Get List of All Users</li>
+    <li>Get List of Active Users</li>
+    <li>Send an Announcement to Active Users</li>
+    <li>Set Message of the Day</li>
+    <li>Delete Message of the Day</li>
+    <li>Set Welcome Message</li>
+    <li>Delete Welcome Message</li>
+    <li>Grant Administrative Privileges</li>
+    <li>Revoke Administrative Privileges</li>
+    <li>Edit Admin List</li>
+    <li>Restart Service</li>
+    <li>Shut Down Service</li>
+  </ol>
+  <p class="" style="">Naturally, not all of these use cases apply to all service types (e.g., adding a user may not apply to a multi-user chat service). An implementation or deployment MAY support any subset of the use cases defined herein. In addition, although this JEP aims to define common use cases, an implementation or deployment MAY support additional commands not defined herein.</p>
+  <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementers have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> as well as <span class="ref">Data Forms</span>  [<a href="#nt-id2601990">4</a>] (on which JEP-0050 depends).</span></p>
+  <div class="indent">
+<h3>4.1 <a name="add-user">Add a User</a>
+</h3>
+    <p class="" style="">A user is defined as any entity that has a persistent relationship with a service (most commonly through the creation a registered account with the service) and whose account is in some sense hosted by the service. Adding a user MUST result in the creation of an account, along with any implementation-specific data for such an account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 1. Admin Requests to Add a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 2. Service Returns Add User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Adding a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to add a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'/&gt;
+      &lt;field label='Retype password'
+             type='text-private'
+             var='password-verify'/&gt;
+      &lt;field label='Email address'
+             type='text-single'
+             var='email'/&gt;
+      &lt;field label='Given name'
+             type='text-single'
+             var='firstname'/&gt;
+      &lt;field label='Family name'
+             type='text-single'
+             var='surname'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Admin Submits Add User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password-verify'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='firstname'&gt;
+        &lt;value&gt;Juliet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='surname'&gt;
+        &lt;value&gt;Capulet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Notification of completion MAY include the processed data in a data form of type &quot;result&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="delete-user">Delete a User</a>
+</h3>
+    <p class="" style="">An administrator may need to permanently delete a user account. Deleting a user SHOULD result in the termination of any active sessions for the user and in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 5. Admin Requests to Delete a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 6. Service Returns Delete User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Deleting a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to delete a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 7. Admin Submits Delete User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="disable-user">Disable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to temporarily disable a user account. Disabling a user MUST result in the termination of any active sessions for the user and in the prevention of further user logins until the account is re-enabled (this can be thought of as &quot;banning&quot; the user). However, it MUST NOT result in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#disable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 9. Admin Requests to Disable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#disable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 10. Service Returns Disable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Disabling a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to disable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 11. Admin Submits Disable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="reenable-user">Re-Enable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to re-enable a user account that had been temporarily disabled. Re-enabling a user MUST result in granting the user the ability to access the service again. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#reenable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 13. Admin Requests to Re-Enable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#reenable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 14. Service Returns Re-Enable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Re-Enable a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to re-enable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 15. Admin Submits Re-Enable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="end-user-session">End a User's Session</a>
+</h3>
+    <p class="" style="">An administrator may need to terminate one or all of the user's current sessions, but allow future logins (this can be thought of as &quot;kicking&quot; rather than &quot;banning&quot; the user). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#end-user-session&quot;.</p> 
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 17. Admin Requests to End a User's Session</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#end-user-session'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 18. Service Returns End User Session Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Ending a User Session&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to end a user&amp;apos;s session.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the JID is of the form &lt;user@host&gt;, the service MUST end all of the user's sessions; if the JID is of the form &lt;user@host/resource&gt;, the service MUST end only the session associated with that resource.</p>
+    <p class="caption">Example 19. Admin Submits End User Session Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="get-user-password">Get a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 21. Admin Requests to Get a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 22. Service Returns Get User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 23. Admin Submits Get User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the data form included in the IQ result will include the user's password.</p>
+    <p class="caption">Example 24. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="change-user-password">Change a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to change a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#change-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 25. Admin Requests to Change a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#change-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 26. Service Returns Change User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Changing a User Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to change a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 27. Admin Submits Change User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;V3r0n4&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="get-user-roster">Get a User's Roster</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's roster (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-roster&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 29. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 30. Service Returns Get User Roster Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Roster&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s roster.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 31. Admin Submits Get User Roster Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's roster, formatted according to the 'jabber:iq:roster' protocol defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2603255">5</a>].</p>
+    <p class="caption">Example 32. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;query xmlns='jabber:iq:roster'&gt;
+        &lt;item jid='romeo@example.net'
+              name='Romeo'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+          &lt;group&gt;Lovers&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='mercutio@example.org'
+              name='Mercutio'
+              subscription='from'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='benvolio@example.org'
+              name='Benvolio'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+      &lt;/query&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="get-user-lastlogin">Get a User's Last Login Time</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-lastlogin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 33. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 34. Service Returns Get User Last Login Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Last Login Time&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s last login time.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 35. Admin Submits Get User Last Login Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's last login time.</p>
+    <p class="caption">Example 36. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lastlogin'&gt;
+        &lt;value&gt;1234&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.10 <a name="add-to-blacklist">Blacklist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide blacklists (lists of entities that are blocked from communications to or from the service). For example, a multi-user chat service may forbid a certain user from joining any room on the service, or may block entire domains from accessing the service. An entity added to a blacklist MAY be a JID of any form as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2603402">6</a>]; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of blacklisting an entity adds it to the blacklist but does not otherwise change the blacklist.</p>
+    <p class="" style="">A blacklist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 37. Admin Requests Blacklisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 38. Service Returns Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Blocking Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to block communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to block'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 39. Admin Submits Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.11 <a name="whitelist">Whitelist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide whitelists (lists of entities that are allowed to communicate the service). For example, a publish-subscribe may allow only a select list of users to publish or subscribe to nodes hosted on the service. An entity added to a whitelist MAY be a JID of any form as specified in <span style="font-weight: bold">XMPP Core</span>; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of whitelisting an entity adds it to the whitelist but does not otherwise change the whitelist. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot;.</p>
+    <p class="" style="">As with blacklists, a whitelist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 41. Admin Requests Whitelisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 42. Service Returns Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Allowing Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to allow communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to allow'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 43. Admin Submits Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 44. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.12 <a name="edit-blacklist">Edit the Blacklist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the blacklist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 45. Admin Requests Editing of Blacklist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 46. Service Returns Edit Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Blacklist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are disallowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The blacklist'
+             type='jid-multi'
+             var='blacklist'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 47. Admin Submits Edit Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='blacklist'&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;france.lit&lt;/value&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 48. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.13 <a name="edit-whitelist">Edit the Whitelist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the whitelist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 49. Admin Requests Editing of Whitelist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 50. Service Returns Edit Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Whitelist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are allowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The whitelist'
+             type='jid-multi'
+             var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 51. Admin Submits Edit Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+        &lt;value&gt;verona.it&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 52. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.14 <a name="get-active-users">Get List of Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to retrieve a list of all online users of the server; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). Obviously, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-active-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 53. Admin Requests List of Active Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-active-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply return the list of active users.</p>
+    <p class="caption">Example 54. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of active users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.15 <a name="get-all-users">Get List of All Users</a>
+</h3>
+    <p class="" style="">The concept of retrieving a list of active users can be extended even further to enable an administrator to retrieve a list of all users (not just active or online users). As with the previous use case, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-all-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 55. Admin Requests List of All Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-all-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-all-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the list of all users.</p>
+    <p class="caption">Example 56. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-all-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-all-users'
+           sessionid='get-all-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of all users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bernardo@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;cordelia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;emilia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;francisco@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;goneril@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;iago@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kingclaudius@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kinglear@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;laertes@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;macbeth@shakespeare.li&lt;/value&gt;
+        &lt;value&gt;mercutio@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;nestor@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;northumberland@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;painter@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;regan@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;timon@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.16 <a name="announce">Send an Announcement to Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send an announcement to all online users of the server (e.g., to announce a server shutdown); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The message shall be sent only to users who currently have a &quot;session&quot; with the service. Obviously there may be latency in sending the message if the number of active users is extremely large. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#announce&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 57. Admin Requests Announcement</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#announce'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 58. Service Returns Announce Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Making an Announcement&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to make an announcement to all
+          active users of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 59. Admin Submits Announce Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;Attention! This service will be going down for&lt;/value&gt;
+        &lt;value&gt;maintenance in 2 minutes. Please log off now!&lt;/value&gt;
+        &lt;value&gt;We apologize for the inconvenience.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 60. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.17 <a name="set-motd">Set Message of the Day</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send a &quot;message of the day&quot; that is delivered to any user who logs in to the server that day (e.g., to announce service changes); 
+       [<a href="#nt-id2604627">7</a>]
+     this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 61. Admin Sets Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current message of the day if one has already been set.</p>
+    <p class="caption">Example 62. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Stuff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 63. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 64. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.18 <a name="delete-motd">Delete Message of the Day</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;message of the day&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 65. Admin Deletes Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the message of the day.</p>
+    <p class="caption">Example 66. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-motd'
+           sessionid='delete-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.19 <a name="set-welcome">Set Welcome Message</a>
+</h3>
+    <p class="" style="">Some existing Jabber servers send an informative &quot;welcome message&quot; to newly registered users of the server when they first log in; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 67. Admin Sets Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current welcome message if one has already been set.</p>
+    <p class="caption">Example 68. Service Returns Welcome Message Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting Welcome Message&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the welcome message
+          for this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Welcome Message'
+             type='text-multi'
+             var='welcome'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 69. Admin Submits Welcome Message Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='welcome'&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+        &lt;value&gt;For helpful information about this service,&lt;/value&gt;
+        &lt;value&gt;hie thee to http://www.shakespeare.lit/&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 70. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.20 <a name="delete-welcome">Delete Welcome Message</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;welcome message&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 71. Admin Deletes Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the welcome message.</p>
+    <p class="caption">Example 72. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-welcome'
+           sessionid='delete-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.21 <a name="grant-admin">Grant Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to grant administrative privileges to another user. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus which types of administrators are allowed to grant administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#grant-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 73. Admin Requests to Grant Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#grant-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 74. Service Returns Grant Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Granting Administrative Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to grant administrative privileges 
+          to another user.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the new admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 75. Admin Submits Grant Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 76. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.22 <a name="revoke-admin">Revoke Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to revoke another user's administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to revoke administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#revoke-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 77. Admin Requests to Revoke Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#revoke-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 78. Service Returns Revoke Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Revoking Admin Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to revoke another user&amp;apos; 
+          administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the soon-to-be former admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 79. Admin Submits Revoke Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 80. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.23 <a name="edit-admin">Edit Admin List</a>
+</h3>
+    <p class="" style="">An administrator may want to directly edit the list of users who have administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to edit administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 81. Admin Requests Editing of Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 82. Service Returns Edit Admin List Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Admin List&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities who
+          have administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The admin list'
+             type='jid-multi'
+             var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;chris@marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Admin Submits Edit Admin List Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 84. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.24 <a name="restart">Restart Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to restart the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#restart&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 85. Admin Requests Restart of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#restart'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 86. Service Returns Restart Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Restarting the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to restart the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before restarting'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 87. Admin Submits Restart Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be restarted in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 88. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.25 <a name="shutdown">Shut Down Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to shut down the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#shutdown&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 89. Admin Requests Shut Down of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#shutdown'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 90. Service Returns Shut Down Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Shutting Down the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to shut down the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before shutting down'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 91. Admin Submits Shut Down Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be shut down in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 92. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">Several error conditions are possible when an entity sends a command request to the service, as defined in the following table. If one of these error conditions occurs, the service MUST return an error stanza to the requesting entity.</p>
+  <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Cause</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The command cannot be completed because of a data or system conflict (e.g., a user already exists with that username).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc commands protocol is).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to perform the command.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">No entity is allowed to perform the command (e.g., retrieve the CEO's roster).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+      <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported.</td>
+    </tr>
+  </table>
+  <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2605893">8</a>]. Naturally, other errors may be returned as well (e.g., &lt;internal-server-error/&gt; if the service cannot be shut down).</p> 
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The ability to complete the administrative tasks specified herein MUST NOT be granted to users who lack service-level administrative privileges.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2606040">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605982">10</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>8.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the Jabber Registrar shall add &quot;http://jabber.org/protocol/admin&quot; to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2606153">11</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. The reserved fields for the 'http://jabber.org/protocol/admin' namespace are specified below.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/admin&lt;/name&gt;
+  &lt;doc&gt;JEP-0133&lt;/doc&gt;
+  &lt;desc&gt;Forms used for administration of servers and components.&lt;/desc&gt;
+  &lt;field var='adminlist'
+         type='jid-multi'
+         var='A list of entities with administrative privileges'/&gt;
+  &lt;field var='announcement'
+         type='text-multi'
+         label='The text of an announcement to be sent to active users or all users'/&gt;
+  &lt;field var='blacklist'
+         type='jid-multi'
+         var='A list of entities with whom communication is blocked'/&gt;
+  &lt;field var='delay'
+         type='list-multi'
+         var='The number of seconds to delay before applying a change'/&gt;
+  &lt;field var='email'
+         type='text-single'
+         label='The email address for a user'/&gt;
+  &lt;field var='firstname'
+         type='text-single'
+         label='The given (first) name of a user'/&gt;
+  &lt;field var='jid'
+         type='jid-single'
+         label='The Jabber ID of a user or other entity'/&gt;
+  &lt;field var='motd'
+         type='text-multi'
+         label='The text of a message of the day'/&gt;
+  &lt;field var='password'
+         type='text-private'
+         label='The password for an account'/&gt;
+  &lt;field var='password-verify'
+         type='text-private'
+         label='Password verification'/&gt;
+  &lt;field var='surname'
+         type='text-single'
+         label='The family (last) name of a user'/&gt;
+  &lt;field var='userlist'
+         type='jid-multi'
+         var='A list of registered entities'/&gt;
+  &lt;field var='welcome'
+         type='text-multi'
+         label='The text of a welcome message'/&gt;
+  &lt;field var='whitelist'
+         type='jid-multi'
+         var='A list of entities with whom communication is allowed'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="sect-id2606067">XML Schema</a>
+</h2>
+  <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596199">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596221">2</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596167">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601990">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603255">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603402">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2604627">7</a>. Typically, a message of the day is sent after session initiation (e.g., server login or chatroom join) to any user of a server or a service on a certain calendar day (i.e., until 23:59 local server time) or 24-hour period. Whether to send such a message only once to any given JID (which would require keeping track of all JIDs that access the server or service) is up to the implementation.</p>
+<p>
+<a name="nt-id2605893">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606040">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605982">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2606153">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2004-11-02)</h4>
+<div class="indent">Added note clarifying concept of message of the day. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-30)</h4>
+<div class="indent">Changed command naming requirement from MUST to SHOULD. (psa)
+    </div>
+<h4>Version 0.2 (2004-07-22)</h4>
+<div class="indent">Added several more use cases; defined complete protocol flows; specified Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-25)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0133-0.5.html
+++ b/content/xep-0133-0.5.html
@@ -1,0 +1,2346 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0133: Service Administration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Administration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-17">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0133">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0133: Service Administration</h1>
+<p>This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0133<br>
+            Version: 0.5<br>
+            Last Updated: 2004-11-17<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: admin<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#add-user">Add a User</a>
+</dt>
+<dt>4.2.  <a href="#delete-user">Delete a User</a>
+</dt>
+<dt>4.3.  <a href="#disable-user">Disable a User</a>
+</dt>
+<dt>4.4.  <a href="#reenable-user">Re-Enable a User</a>
+</dt>
+<dt>4.5.  <a href="#end-user-session">End a User's Session</a>
+</dt>
+<dt>4.6.  <a href="#get-user-password">Get a User's Password</a>
+</dt>
+<dt>4.7.  <a href="#change-user-password">Change a User's Password</a>
+</dt>
+<dt>4.8.  <a href="#get-user-roster">Get a User's Roster</a>
+</dt>
+<dt>4.9.  <a href="#get-user-lastlogin">Get a User's Last Login Time</a>
+</dt>
+<dt>4.10.  <a href="#add-to-blacklist">Blacklist an Entity</a>
+</dt>
+<dt>4.11.  <a href="#whitelist">Whitelist an Entity</a>
+</dt>
+<dt>4.12.  <a href="#edit-blacklist">Edit the Blacklist</a>
+</dt>
+<dt>4.13.  <a href="#edit-whitelist">Edit the Whitelist</a>
+</dt>
+<dt>4.14.  <a href="#get-active-users">Get List of Active Users</a>
+</dt>
+<dt>4.15.  <a href="#get-all-users">Get List of All Users</a>
+</dt>
+<dt>4.16.  <a href="#announce">Send an Announcement to Active Users</a>
+</dt>
+<dt>4.17.  <a href="#set-motd">Set Message of the Day</a>
+</dt>
+<dt>4.18.  <a href="#delete-motd">Delete Message of the Day</a>
+</dt>
+<dt>4.19.  <a href="#set-welcome">Set Welcome Message</a>
+</dt>
+<dt>4.20.  <a href="#delete-welcome">Delete Welcome Message</a>
+</dt>
+<dt>4.21.  <a href="#grant-admin">Grant Administrative Privileges</a>
+</dt>
+<dt>4.22.  <a href="#revoke-admin">Revoke Administrative Privileges</a>
+</dt>
+<dt>4.23.  <a href="#edit-admin">Edit Admin List</a>
+</dt>
+<dt>4.24.  <a href="#restart">Restart Service</a>
+</dt>
+<dt>4.25.  <a href="#shutdown">Shut Down Service</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sect-id2606127">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists a set of common service-level tasks that administrators often need to perform in relation to Jabber/XMPP servers and components. Examples include creating users, disabling accounts, and blacklisting domains for inbound or outbound communications. Because such tasks can be performed with respect to a server or with respect to many kinds of add-on components (e.g., a text conferencing component that conforms to <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596226">1</a>]), it makes sense to define a generic protocol for such interactions. This JEP describes such a protocol by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2596248">2</a>], rather than by defining a specialized and distinct protocol.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable users with appropriate privileges to perform common administrative tasks with respect to Jabber/XMPP servers and components.</li>
+    <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+  </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <p class="" style="">A server or component MUST advertise any administrative commands it supports via <span class="ref">Service Discovery</span>  [<a href="#nt-id2596200">3</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>); such commands exist as well-defined discovery nodes associated with the service in question.</p>
+  <p class="" style="">In order to interact with a particular component attached to a server, an administrator needs to first discover that component and the commands it support, then send the appropriate command to the component itself. A server SHOULD NOT process commands on behalf of associated components, just as it does not handle service discovery requests on behalf of such components.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> that enables a service-level administrator to complete the following use cases:</p>
+  <ol start="" type="">
+    <li>Add a User</li>
+    <li>Delete a User</li>
+    <li>Disable a User</li>
+    <li>Re-Enable a User</li>
+    <li>End a User's Session</li>
+    <li>Get a User's Password</li>
+    <li>Change a User's Password</li>
+    <li>Get a User's Roster</li>
+    <li>Get a User's Last Login Time</li>
+    <li>Blacklist an Entity</li>
+    <li>Whitelist an Entity</li>
+    <li>Edit the Blacklist</li>
+    <li>Edit the Whitelist</li>
+    <li>Get List of All Users</li>
+    <li>Get List of Active Users</li>
+    <li>Send an Announcement to Active Users</li>
+    <li>Set Message of the Day</li>
+    <li>Delete Message of the Day</li>
+    <li>Set Welcome Message</li>
+    <li>Delete Welcome Message</li>
+    <li>Grant Administrative Privileges</li>
+    <li>Revoke Administrative Privileges</li>
+    <li>Edit Admin List</li>
+    <li>Restart Service</li>
+    <li>Shut Down Service</li>
+  </ol>
+  <p class="" style="">Naturally, not all of these use cases apply to all service types (e.g., adding a user may not apply to a multi-user chat service). An implementation or deployment MAY support any subset of the use cases defined herein. In addition, although this JEP aims to define common use cases, an implementation or deployment MAY support additional commands not defined herein, which may or may not be publicly registered.</p>
+  <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementors have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> as well as <span class="ref">Data Forms</span>  [<a href="#nt-id2602049">4</a>] (on which JEP-0050 depends).</span></p>
+  <div class="indent">
+<h3>4.1 <a name="add-user">Add a User</a>
+</h3>
+    <p class="" style="">A user is defined as any entity that has a persistent relationship with a service (most commonly through the creation a registered account with the service) and whose account is in some sense hosted by the service. Adding a user MUST result in the creation of an account, along with any implementation-specific data for such an account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 1. Admin Requests to Add a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 2. Service Returns Add User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Adding a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to add a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'/&gt;
+      &lt;field label='Retype password'
+             type='text-private'
+             var='password-verify'/&gt;
+      &lt;field label='Email address'
+             type='text-single'
+             var='email'/&gt;
+      &lt;field label='Given name'
+             type='text-single'
+             var='given_name'/&gt;
+      &lt;field label='Family name'
+             type='text-single'
+             var='surname'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Admin Submits Add User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password-verify'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='given_name'&gt;
+        &lt;value&gt;Juliet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='surname'&gt;
+        &lt;value&gt;Capulet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Notification of completion MAY include the processed data in a data form of type &quot;result&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="delete-user">Delete a User</a>
+</h3>
+    <p class="" style="">An administrator may need to permanently delete a user account. Deleting a user SHOULD result in the termination of any active sessions for the user and in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 5. Admin Requests to Delete a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 6. Service Returns Delete User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Deleting a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to delete a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 7. Admin Submits Delete User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="disable-user">Disable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to temporarily disable a user account. Disabling a user MUST result in the termination of any active sessions for the user and in the prevention of further user logins until the account is re-enabled (this can be thought of as &quot;banning&quot; the user). However, it MUST NOT result in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#disable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 9. Admin Requests to Disable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#disable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 10. Service Returns Disable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Disabling a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to disable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 11. Admin Submits Disable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="reenable-user">Re-Enable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to re-enable a user account that had been temporarily disabled. Re-enabling a user MUST result in granting the user the ability to access the service again. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#reenable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 13. Admin Requests to Re-Enable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#reenable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 14. Service Returns Re-Enable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Re-Enable a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to re-enable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 15. Admin Submits Re-Enable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="end-user-session">End a User's Session</a>
+</h3>
+    <p class="" style="">An administrator may need to terminate one or all of the user's current sessions, but allow future logins (this can be thought of as &quot;kicking&quot; rather than &quot;banning&quot; the user). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#end-user-session&quot;.</p> 
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 17. Admin Requests to End a User's Session</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#end-user-session'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 18. Service Returns End User Session Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Ending a User Session&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to end a user&amp;apos;s session.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the JID is of the form &lt;user@host&gt;, the service MUST end all of the user's sessions; if the JID is of the form &lt;user@host/resource&gt;, the service MUST end only the session associated with that resource.</p>
+    <p class="caption">Example 19. Admin Submits End User Session Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="get-user-password">Get a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 21. Admin Requests to Get a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 22. Service Returns Get User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 23. Admin Submits Get User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the data form included in the IQ result will include the user's password.</p>
+    <p class="caption">Example 24. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="change-user-password">Change a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to change a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#change-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 25. Admin Requests to Change a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#change-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 26. Service Returns Change User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Changing a User Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to change a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 27. Admin Submits Change User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;V3r0n4&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="get-user-roster">Get a User's Roster</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's roster (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-roster&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 29. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 30. Service Returns Get User Roster Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Roster&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s roster.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 31. Admin Submits Get User Roster Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's roster, formatted according to the 'jabber:iq:roster' protocol defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2603314">5</a>].</p>
+    <p class="caption">Example 32. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;query xmlns='jabber:iq:roster'&gt;
+        &lt;item jid='romeo@example.net'
+              name='Romeo'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+          &lt;group&gt;Lovers&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='mercutio@example.org'
+              name='Mercutio'
+              subscription='from'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='benvolio@example.org'
+              name='Benvolio'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+      &lt;/query&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="get-user-lastlogin">Get a User's Last Login Time</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-lastlogin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 33. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 34. Service Returns Get User Last Login Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Last Login Time&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s last login time.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 35. Admin Submits Get User Last Login Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's last login time.</p>
+    <p class="caption">Example 36. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lastlogin'&gt;
+        &lt;value&gt;1234&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.10 <a name="add-to-blacklist">Blacklist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide blacklists (lists of entities that are blocked from communications to or from the service). For example, a multi-user chat service may forbid a certain user from joining any room on the service, or may block entire domains from accessing the service. An entity added to a blacklist MAY be a JID of any form as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2603462">6</a>]; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of blacklisting an entity adds it to the blacklist but does not otherwise change the blacklist.</p>
+    <p class="" style="">A blacklist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 37. Admin Requests Blacklisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 38. Service Returns Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Blocking Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to block communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to block'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 39. Admin Submits Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.11 <a name="whitelist">Whitelist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide whitelists (lists of entities that are allowed to communicate the service). For example, a publish-subscribe may allow only a select list of users to publish or subscribe to nodes hosted on the service. An entity added to a whitelist MAY be a JID of any form as specified in <span style="font-weight: bold">XMPP Core</span>; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of whitelisting an entity adds it to the whitelist but does not otherwise change the whitelist. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot;.</p>
+    <p class="" style="">As with blacklists, a whitelist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 41. Admin Requests Whitelisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 42. Service Returns Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Allowing Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to allow communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to allow'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 43. Admin Submits Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 44. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.12 <a name="edit-blacklist">Edit the Blacklist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the blacklist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 45. Admin Requests Editing of Blacklist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 46. Service Returns Edit Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Blacklist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are disallowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The blacklist'
+             type='jid-multi'
+             var='blacklist'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 47. Admin Submits Edit Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='blacklist'&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;france.lit&lt;/value&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 48. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.13 <a name="edit-whitelist">Edit the Whitelist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the whitelist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 49. Admin Requests Editing of Whitelist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 50. Service Returns Edit Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Whitelist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are allowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The whitelist'
+             type='jid-multi'
+             var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 51. Admin Submits Edit Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+        &lt;value&gt;verona.it&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 52. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.14 <a name="get-active-users">Get List of Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to retrieve a list of all online users of the server; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). Obviously, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-active-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 53. Admin Requests List of Active Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-active-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply return the list of active users.</p>
+    <p class="caption">Example 54. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of active users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.15 <a name="get-all-users">Get List of All Users</a>
+</h3>
+    <p class="" style="">The concept of retrieving a list of active users can be extended even further to enable an administrator to retrieve a list of all users (not just active or online users). As with the previous use case, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-all-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 55. Admin Requests List of All Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-all-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-all-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the list of all users.</p>
+    <p class="caption">Example 56. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-all-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-all-users'
+           sessionid='get-all-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of all users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bernardo@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;cordelia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;emilia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;francisco@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;goneril@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;iago@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kingclaudius@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kinglear@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;laertes@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;macbeth@shakespeare.li&lt;/value&gt;
+        &lt;value&gt;mercutio@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;nestor@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;northumberland@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;painter@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;regan@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;timon@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.16 <a name="announce">Send an Announcement to Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send an announcement to all online users of the server (e.g., to announce a server shutdown); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The message shall be sent only to users who currently have a &quot;session&quot; with the service. Obviously there may be latency in sending the message if the number of active users is extremely large. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#announce&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 57. Admin Requests Announcement</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#announce'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 58. Service Returns Announce Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Making an Announcement&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to make an announcement to all
+          active users of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 59. Admin Submits Announce Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;Attention! This service will be going down for&lt;/value&gt;
+        &lt;value&gt;maintenance in 2 minutes. Please log off now!&lt;/value&gt;
+        &lt;value&gt;We apologize for the inconvenience.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 60. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.17 <a name="set-motd">Set Message of the Day</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send a &quot;message of the day&quot; that is delivered to any user who logs in to the server that day (e.g., to announce service changes); 
+       [<a href="#nt-id2604686">7</a>]
+     this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 61. Admin Sets Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current message of the day if one has already been set.</p>
+    <p class="caption">Example 62. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Stuff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 63. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 64. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.18 <a name="delete-motd">Delete Message of the Day</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;message of the day&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 65. Admin Deletes Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the message of the day.</p>
+    <p class="caption">Example 66. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-motd'
+           sessionid='delete-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.19 <a name="set-welcome">Set Welcome Message</a>
+</h3>
+    <p class="" style="">Some existing Jabber servers send an informative &quot;welcome message&quot; to newly registered users of the server when they first log in; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 67. Admin Sets Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current welcome message if one has already been set.</p>
+    <p class="caption">Example 68. Service Returns Welcome Message Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting Welcome Message&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the welcome message
+          for this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Welcome Message'
+             type='text-multi'
+             var='welcome'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 69. Admin Submits Welcome Message Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='welcome'&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+        &lt;value&gt;For helpful information about this service,&lt;/value&gt;
+        &lt;value&gt;hie thee to http://www.shakespeare.lit/&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 70. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.20 <a name="delete-welcome">Delete Welcome Message</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;welcome message&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 71. Admin Deletes Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the welcome message.</p>
+    <p class="caption">Example 72. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-welcome'
+           sessionid='delete-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.21 <a name="grant-admin">Grant Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to grant administrative privileges to another user. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus which types of administrators are allowed to grant administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#grant-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 73. Admin Requests to Grant Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#grant-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 74. Service Returns Grant Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Granting Administrative Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to grant administrative privileges 
+          to another user.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the new admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 75. Admin Submits Grant Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 76. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.22 <a name="revoke-admin">Revoke Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to revoke another user's administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to revoke administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#revoke-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 77. Admin Requests to Revoke Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#revoke-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 78. Service Returns Revoke Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Revoking Admin Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to revoke another user&amp;apos; 
+          administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the soon-to-be former admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 79. Admin Submits Revoke Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 80. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.23 <a name="edit-admin">Edit Admin List</a>
+</h3>
+    <p class="" style="">An administrator may want to directly edit the list of users who have administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to edit administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 81. Admin Requests Editing of Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 82. Service Returns Edit Admin List Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Admin List&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities who
+          have administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The admin list'
+             type='jid-multi'
+             var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;chris@marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Admin Submits Edit Admin List Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 84. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.24 <a name="restart">Restart Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to restart the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#restart&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 85. Admin Requests Restart of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#restart'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 86. Service Returns Restart Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Restarting the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to restart the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before restarting'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 87. Admin Submits Restart Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be restarted in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 88. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.25 <a name="shutdown">Shut Down Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to shut down the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#shutdown&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 89. Admin Requests Shut Down of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#shutdown'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 90. Service Returns Shut Down Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Shutting Down the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to shut down the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before shutting down'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 91. Admin Submits Shut Down Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be shut down in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 92. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">Several error conditions are possible when an entity sends a command request to the service, as defined in the following table. If one of these error conditions occurs, the service MUST return an error stanza to the requesting entity.</p>
+  <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Cause</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The command cannot be completed because of a data or system conflict (e.g., a user already exists with that username).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc commands protocol is).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to perform the command.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">No entity is allowed to perform the command (e.g., retrieve the CEO's roster).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+      <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported.</td>
+    </tr>
+  </table>
+  <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2605952">8</a>]. Naturally, other errors may be returned as well (e.g., &lt;internal-server-error/&gt; if the service cannot be shut down).</p> 
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The ability to complete the administrative tasks specified herein MUST NOT be granted to users who lack service-level administrative privileges.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2606099">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2606042">10</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>8.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the Jabber Registrar shall add &quot;http://jabber.org/protocol/admin&quot; to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2606213">11</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. The reserved fields for the 'http://jabber.org/protocol/admin' namespace are specified below.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/admin&lt;/name&gt;
+  &lt;doc&gt;JEP-0133&lt;/doc&gt;
+  &lt;desc&gt;Forms used for administration of servers and components.&lt;/desc&gt;
+  &lt;field var='adminlist'
+         type='jid-multi'
+         var='A list of entities with administrative privileges'/&gt;
+  &lt;field var='announcement'
+         type='text-multi'
+         label='The text of an announcement to be sent to active users or all users'/&gt;
+  &lt;field var='blacklist'
+         type='jid-multi'
+         var='A list of entities with whom communication is blocked'/&gt;
+  &lt;field var='delay'
+         type='list-multi'
+         var='The number of seconds to delay before applying a change'/&gt;
+  &lt;field var='email'
+         type='text-single'
+         label='The email address for a user'/&gt;
+  &lt;field var='given_name'
+         type='text-single'
+         label='The given (first) name of a user'/&gt;
+  &lt;field var='jid'
+         type='jid-single'
+         label='The Jabber ID of a user or other entity'/&gt;
+  &lt;field var='motd'
+         type='text-multi'
+         label='The text of a message of the day'/&gt;
+  &lt;field var='password'
+         type='text-private'
+         label='The password for an account'/&gt;
+  &lt;field var='password-verify'
+         type='text-private'
+         label='Password verification'/&gt;
+  &lt;field var='surname'
+         type='text-single'
+         label='The family (last) name of a user'/&gt;
+  &lt;field var='userlist'
+         type='jid-multi'
+         var='A list of registered entities'/&gt;
+  &lt;field var='welcome'
+         type='text-multi'
+         label='The text of a welcome message'/&gt;
+  &lt;field var='whitelist'
+         type='jid-multi'
+         var='A list of entities with whom communication is allowed'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="sect-id2606127">XML Schema</a>
+</h2>
+  <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596226">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596248">2</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596200">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602049">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603314">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603462">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2604686">7</a>. Typically, a message of the day is sent after session initiation (e.g., server login or chatroom join) to any user of a server or a service on a certain calendar day (i.e., until 23:59 local server time) or 24-hour period. Whether to send such a message only once to any given JID (which would require keeping track of all JIDs that access the server or service) is up to the implementation.</p>
+<p>
+<a name="nt-id2605952">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606099">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2606042">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2606213">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2004-11-17)</h4>
+<div class="indent">Changed firstname to given_name. (psa)
+    </div>
+<h4>Version 0.4 (2004-11-02)</h4>
+<div class="indent">Added note clarifying concept of message of the day. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-30)</h4>
+<div class="indent">Changed command naming requirement from MUST to SHOULD. (psa)
+    </div>
+<h4>Version 0.2 (2004-07-22)</h4>
+<div class="indent">Added several more use cases; defined complete protocol flows; specified Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-25)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0133-0.6.html
+++ b/content/xep-0133-0.6.html
@@ -1,0 +1,2349 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0133: Service Administration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Administration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0133">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0133: Service Administration</h1>
+<p>This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0133<br>
+            Version: 0.6<br>
+            Last Updated: 2004-11-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: admin<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#add-user">Add a User</a>
+</dt>
+<dt>4.2.  <a href="#delete-user">Delete a User</a>
+</dt>
+<dt>4.3.  <a href="#disable-user">Disable a User</a>
+</dt>
+<dt>4.4.  <a href="#reenable-user">Re-Enable a User</a>
+</dt>
+<dt>4.5.  <a href="#end-user-session">End a User's Session</a>
+</dt>
+<dt>4.6.  <a href="#get-user-password">Get a User's Password</a>
+</dt>
+<dt>4.7.  <a href="#change-user-password">Change a User's Password</a>
+</dt>
+<dt>4.8.  <a href="#get-user-roster">Get a User's Roster</a>
+</dt>
+<dt>4.9.  <a href="#get-user-lastlogin">Get a User's Last Login Time</a>
+</dt>
+<dt>4.10.  <a href="#add-to-blacklist">Blacklist an Entity</a>
+</dt>
+<dt>4.11.  <a href="#whitelist">Whitelist an Entity</a>
+</dt>
+<dt>4.12.  <a href="#edit-blacklist">Edit the Blacklist</a>
+</dt>
+<dt>4.13.  <a href="#edit-whitelist">Edit the Whitelist</a>
+</dt>
+<dt>4.14.  <a href="#get-active-users">Get List of Active Users</a>
+</dt>
+<dt>4.15.  <a href="#get-all-users">Get List of All Users</a>
+</dt>
+<dt>4.16.  <a href="#announce">Send an Announcement to Active Users</a>
+</dt>
+<dt>4.17.  <a href="#set-motd">Set Message of the Day</a>
+</dt>
+<dt>4.18.  <a href="#delete-motd">Delete Message of the Day</a>
+</dt>
+<dt>4.19.  <a href="#set-welcome">Set Welcome Message</a>
+</dt>
+<dt>4.20.  <a href="#delete-welcome">Delete Welcome Message</a>
+</dt>
+<dt>4.21.  <a href="#grant-admin">Grant Administrative Privileges</a>
+</dt>
+<dt>4.22.  <a href="#revoke-admin">Revoke Administrative Privileges</a>
+</dt>
+<dt>4.23.  <a href="#edit-admin">Edit Admin List</a>
+</dt>
+<dt>4.24.  <a href="#restart">Restart Service</a>
+</dt>
+<dt>4.25.  <a href="#shutdown">Shut Down Service</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sect-id2606132">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists a set of common service-level tasks that administrators often need to perform in relation to Jabber/XMPP servers and components. Examples include creating users, disabling accounts, and blacklisting domains for inbound or outbound communications. Because such tasks can be performed with respect to a server or with respect to many kinds of add-on components (e.g., a text conferencing component that conforms to <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596248">1</a>]), it makes sense to define a generic protocol for such interactions. This JEP describes such a protocol by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2596270">2</a>], rather than by defining a specialized and distinct protocol.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable users with appropriate privileges to perform common administrative tasks with respect to Jabber/XMPP servers and components.</li>
+    <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+  </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <p class="" style="">A server or component MUST advertise any administrative commands it supports via <span class="ref">Service Discovery</span>  [<a href="#nt-id2596222">3</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>); such commands exist as well-defined discovery nodes associated with the service in question.</p>
+  <p class="" style="">In order to interact with a particular component attached to a server, an administrator needs to first discover that component and the commands it support, then send the appropriate command to the component itself. A server SHOULD NOT process commands on behalf of associated components, just as it does not handle service discovery requests on behalf of such components.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> that enables a service-level administrator to complete the following use cases:</p>
+  <ol start="" type="">
+    <li>Add a User</li>
+    <li>Delete a User</li>
+    <li>Disable a User</li>
+    <li>Re-Enable a User</li>
+    <li>End a User's Session</li>
+    <li>Get a User's Password</li>
+    <li>Change a User's Password</li>
+    <li>Get a User's Roster</li>
+    <li>Get a User's Last Login Time</li>
+    <li>Blacklist an Entity</li>
+    <li>Whitelist an Entity</li>
+    <li>Edit the Blacklist</li>
+    <li>Edit the Whitelist</li>
+    <li>Get List of All Users</li>
+    <li>Get List of Active Users</li>
+    <li>Send an Announcement to Active Users</li>
+    <li>Set Message of the Day</li>
+    <li>Delete Message of the Day</li>
+    <li>Set Welcome Message</li>
+    <li>Delete Welcome Message</li>
+    <li>Grant Administrative Privileges</li>
+    <li>Revoke Administrative Privileges</li>
+    <li>Edit Admin List</li>
+    <li>Restart Service</li>
+    <li>Shut Down Service</li>
+  </ol>
+  <p class="" style="">Naturally, not all of these use cases apply to all service types (e.g., adding a user may not apply to a multi-user chat service). An implementation or deployment MAY support any subset of the use cases defined herein. In addition, although this JEP aims to define common use cases, an implementation or deployment MAY support additional commands not defined herein, which may or may not be publicly registered.</p>
+  <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementors have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> as well as <span class="ref">Data Forms</span>  [<a href="#nt-id2602071">4</a>] (on which JEP-0050 depends).</span></p>
+  <div class="indent">
+<h3>4.1 <a name="add-user">Add a User</a>
+</h3>
+    <p class="" style="">A user is defined as any entity that has a persistent relationship with a service (most commonly through the creation a registered account with the service) and whose account is in some sense hosted by the service. Adding a user MUST result in the creation of an account, along with any implementation-specific data for such an account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 1. Admin Requests to Add a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 2. Service Returns Add User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Adding a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to add a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'/&gt;
+      &lt;field label='Retype password'
+             type='text-private'
+             var='password-verify'/&gt;
+      &lt;field label='Email address'
+             type='text-single'
+             var='email'/&gt;
+      &lt;field label='Given name'
+             type='text-single'
+             var='given_name'/&gt;
+      &lt;field label='Family name'
+             type='text-single'
+             var='surname'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Admin Submits Add User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password-verify'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='given_name'&gt;
+        &lt;value&gt;Juliet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='surname'&gt;
+        &lt;value&gt;Capulet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Notification of completion MAY include the processed data in a data form of type &quot;result&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="delete-user">Delete a User</a>
+</h3>
+    <p class="" style="">An administrator may need to permanently delete a user account. Deleting a user SHOULD result in the termination of any active sessions for the user and in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 5. Admin Requests to Delete a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 6. Service Returns Delete User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Deleting a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to delete a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 7. Admin Submits Delete User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="disable-user">Disable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to temporarily disable a user account. Disabling a user MUST result in the termination of any active sessions for the user and in the prevention of further user logins until the account is re-enabled (this can be thought of as &quot;banning&quot; the user). However, it MUST NOT result in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#disable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 9. Admin Requests to Disable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#disable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 10. Service Returns Disable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Disabling a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to disable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 11. Admin Submits Disable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="reenable-user">Re-Enable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to re-enable a user account that had been temporarily disabled. Re-enabling a user MUST result in granting the user the ability to access the service again. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#reenable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 13. Admin Requests to Re-Enable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#reenable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 14. Service Returns Re-Enable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Re-Enable a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to re-enable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 15. Admin Submits Re-Enable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="end-user-session">End a User's Session</a>
+</h3>
+    <p class="" style="">An administrator may need to terminate one or all of the user's current sessions, but allow future logins (this can be thought of as &quot;kicking&quot; rather than &quot;banning&quot; the user). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#end-user-session&quot;.</p> 
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 17. Admin Requests to End a User's Session</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#end-user-session'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 18. Service Returns End User Session Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Ending a User Session&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to end a user&amp;apos;s session.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the JID is of the form &lt;user@host&gt;, the service MUST end all of the user's sessions; if the JID is of the form &lt;user@host/resource&gt;, the service MUST end only the session associated with that resource.</p>
+    <p class="caption">Example 19. Admin Submits End User Session Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="get-user-password">Get a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 21. Admin Requests to Get a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 22. Service Returns Get User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 23. Admin Submits Get User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the data form included in the IQ result will include the user's password.</p>
+    <p class="caption">Example 24. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="change-user-password">Change a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to change a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#change-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 25. Admin Requests to Change a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#change-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 26. Service Returns Change User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Changing a User Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to change a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 27. Admin Submits Change User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;V3r0n4&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="get-user-roster">Get a User's Roster</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's roster (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-roster&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 29. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 30. Service Returns Get User Roster Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Roster&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s roster.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 31. Admin Submits Get User Roster Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's roster, formatted according to the 'jabber:iq:roster' protocol defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2603336">5</a>].</p>
+    <p class="caption">Example 32. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;query xmlns='jabber:iq:roster'&gt;
+        &lt;item jid='romeo@example.net'
+              name='Romeo'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+          &lt;group&gt;Lovers&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='mercutio@example.org'
+              name='Mercutio'
+              subscription='from'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='benvolio@example.org'
+              name='Benvolio'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+      &lt;/query&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="get-user-lastlogin">Get a User's Last Login Time</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-lastlogin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 33. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 34. Service Returns Get User Last Login Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Last Login Time&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s last login time.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 35. Admin Submits Get User Last Login Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's last login time.</p>
+    <p class="caption">Example 36. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lastlogin'&gt;
+        &lt;value&gt;1234&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.10 <a name="add-to-blacklist">Blacklist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide blacklists (lists of entities that are blocked from communications to or from the service). For example, a multi-user chat service may forbid a certain user from joining any room on the service, or may block entire domains from accessing the service. An entity added to a blacklist MAY be a JID of any form as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2603565">6</a>]; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of blacklisting an entity adds it to the blacklist but does not otherwise change the blacklist.</p>
+    <p class="" style="">A blacklist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 37. Admin Requests Blacklisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 38. Service Returns Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Blocking Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to block communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to block'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 39. Admin Submits Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.11 <a name="whitelist">Whitelist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide whitelists (lists of entities that are allowed to communicate the service). For example, a publish-subscribe may allow only a select list of users to publish or subscribe to nodes hosted on the service. An entity added to a whitelist MAY be a JID of any form as specified in <span style="font-weight: bold">XMPP Core</span>; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of whitelisting an entity adds it to the whitelist but does not otherwise change the whitelist. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot;.</p>
+    <p class="" style="">As with blacklists, a whitelist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 41. Admin Requests Whitelisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 42. Service Returns Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Allowing Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to allow communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to allow'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 43. Admin Submits Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 44. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.12 <a name="edit-blacklist">Edit the Blacklist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the blacklist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 45. Admin Requests Editing of Blacklist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 46. Service Returns Edit Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Blacklist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are disallowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The blacklist'
+             type='jid-multi'
+             var='blacklist'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 47. Admin Submits Edit Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='blacklist'&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;france.lit&lt;/value&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 48. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.13 <a name="edit-whitelist">Edit the Whitelist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the whitelist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 49. Admin Requests Editing of Whitelist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 50. Service Returns Edit Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Whitelist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are allowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The whitelist'
+             type='jid-multi'
+             var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 51. Admin Submits Edit Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+        &lt;value&gt;verona.it&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 52. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.14 <a name="get-active-users">Get List of Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to retrieve a list of all online users of the server; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). Obviously, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-active-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 53. Admin Requests List of Active Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-active-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply return the list of active users.</p>
+    <p class="caption">Example 54. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of active users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.15 <a name="get-all-users">Get List of All Users</a>
+</h3>
+    <p class="" style="">The concept of retrieving a list of active users can be extended even further to enable an administrator to retrieve a list of all users (not just active or online users). As with the previous use case, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-all-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 55. Admin Requests List of All Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-all-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-all-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the list of all users.</p>
+    <p class="caption">Example 56. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-all-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-all-users'
+           sessionid='get-all-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of all users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bernardo@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;cordelia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;emilia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;francisco@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;goneril@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;iago@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kingclaudius@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kinglear@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;laertes@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;macbeth@shakespeare.li&lt;/value&gt;
+        &lt;value&gt;mercutio@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;nestor@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;northumberland@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;painter@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;regan@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;timon@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.16 <a name="announce">Send an Announcement to Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send an announcement to all online users of the server (e.g., to announce a server shutdown); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The message shall be sent only to users who currently have a &quot;session&quot; with the service. Obviously there may be latency in sending the message if the number of active users is extremely large. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#announce&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 57. Admin Requests Announcement</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#announce'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 58. Service Returns Announce Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Making an Announcement&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to make an announcement to all
+          active users of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 59. Admin Submits Announce Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;Attention! This service will be going down for&lt;/value&gt;
+        &lt;value&gt;maintenance in 2 minutes. Please log off now!&lt;/value&gt;
+        &lt;value&gt;We apologize for the inconvenience.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 60. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.17 <a name="set-motd">Set Message of the Day</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send a &quot;message of the day&quot; that is delivered to any user who logs in to the server that day (e.g., to announce service changes); 
+       [<a href="#nt-id2604700">7</a>]
+     this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 61. Admin Sets Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current message of the day if one has already been set.</p>
+    <p class="caption">Example 62. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Stuff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 63. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 64. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.18 <a name="delete-motd">Delete Message of the Day</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;message of the day&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 65. Admin Deletes Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the message of the day.</p>
+    <p class="caption">Example 66. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-motd'
+           sessionid='delete-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.19 <a name="set-welcome">Set Welcome Message</a>
+</h3>
+    <p class="" style="">Some existing Jabber servers send an informative &quot;welcome message&quot; to newly registered users of the server when they first log in; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 67. Admin Sets Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current welcome message if one has already been set.</p>
+    <p class="caption">Example 68. Service Returns Welcome Message Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting Welcome Message&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the welcome message
+          for this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Welcome Message'
+             type='text-multi'
+             var='welcome'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 69. Admin Submits Welcome Message Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='welcome'&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+        &lt;value&gt;For helpful information about this service,&lt;/value&gt;
+        &lt;value&gt;hie thee to http://www.shakespeare.lit/&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 70. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.20 <a name="delete-welcome">Delete Welcome Message</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;welcome message&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 71. Admin Deletes Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the welcome message.</p>
+    <p class="caption">Example 72. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-welcome'
+           sessionid='delete-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.21 <a name="grant-admin">Grant Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to grant administrative privileges to another user. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus which types of administrators are allowed to grant administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#grant-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 73. Admin Requests to Grant Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#grant-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 74. Service Returns Grant Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Granting Administrative Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to grant administrative privileges 
+          to another user.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the new admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 75. Admin Submits Grant Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 76. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.22 <a name="revoke-admin">Revoke Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to revoke another user's administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to revoke administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#revoke-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 77. Admin Requests to Revoke Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#revoke-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 78. Service Returns Revoke Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Revoking Admin Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to revoke another user&amp;apos; 
+          administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the soon-to-be former admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 79. Admin Submits Revoke Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 80. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.23 <a name="edit-admin">Edit Admin List</a>
+</h3>
+    <p class="" style="">An administrator may want to directly edit the list of users who have administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to edit administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 81. Admin Requests Editing of Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 82. Service Returns Edit Admin List Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Admin List&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities who
+          have administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The admin list'
+             type='jid-multi'
+             var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;chris@marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Admin Submits Edit Admin List Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 84. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.24 <a name="restart">Restart Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to restart the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#restart&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 85. Admin Requests Restart of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#restart'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 86. Service Returns Restart Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Restarting the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to restart the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before restarting'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 87. Admin Submits Restart Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be restarted in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 88. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.25 <a name="shutdown">Shut Down Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to shut down the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#shutdown&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 89. Admin Requests Shut Down of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#shutdown'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 90. Service Returns Shut Down Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Shutting Down the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to shut down the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before shutting down'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 91. Admin Submits Shut Down Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be shut down in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 92. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">Several error conditions are possible when an entity sends a command request to the service, as defined in the following table. If one of these error conditions occurs, the service MUST return an error stanza to the requesting entity.</p>
+  <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Cause</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The command cannot be completed because of a data or system conflict (e.g., a user already exists with that username).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc commands protocol is).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to perform the command.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">No entity is allowed to perform the command (e.g., retrieve the CEO's roster).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+      <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported.</td>
+    </tr>
+  </table>
+  <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2605956">8</a>]. Naturally, other errors may be returned as well (e.g., &lt;internal-server-error/&gt; if the service cannot be shut down).</p> 
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The ability to complete the administrative tasks specified herein MUST NOT be granted to users who lack service-level administrative privileges.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2606103">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2606045">10</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>8.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the Jabber Registrar shall add &quot;http://jabber.org/protocol/admin&quot; to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2606216">11</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. The reserved fields for the 'http://jabber.org/protocol/admin' namespace are specified below.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/admin&lt;/name&gt;
+  &lt;doc&gt;JEP-0133&lt;/doc&gt;
+  &lt;desc&gt;Forms used for administration of servers and components.&lt;/desc&gt;
+  &lt;field var='adminlist'
+         type='jid-multi'
+         var='A list of entities with administrative privileges'/&gt;
+  &lt;field var='announcement'
+         type='text-multi'
+         label='The text of an announcement to be sent to active users or all users'/&gt;
+  &lt;field var='blacklist'
+         type='jid-multi'
+         var='A list of entities with whom communication is blocked'/&gt;
+  &lt;field var='delay'
+         type='list-multi'
+         var='The number of seconds to delay before applying a change'/&gt;
+  &lt;field var='email'
+         type='text-single'
+         label='The email address for a user'/&gt;
+  &lt;field var='given_name'
+         type='text-single'
+         label='The given (first) name of a user'/&gt;
+  &lt;field var='jid'
+         type='jid-single'
+         label='The Jabber ID of a user or other entity'/&gt;
+  &lt;field var='motd'
+         type='text-multi'
+         label='The text of a message of the day'/&gt;
+  &lt;field var='password'
+         type='text-private'
+         label='The password for an account'/&gt;
+  &lt;field var='password-verify'
+         type='text-private'
+         label='Password verification'/&gt;
+  &lt;field var='surname'
+         type='text-single'
+         label='The family (last) name of a user'/&gt;
+  &lt;field var='userlist'
+         type='jid-multi'
+         var='A list of registered entities'/&gt;
+  &lt;field var='welcome'
+         type='text-multi'
+         label='The text of a welcome message'/&gt;
+  &lt;field var='whitelist'
+         type='jid-multi'
+         var='A list of entities with whom communication is allowed'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="sect-id2606132">XML Schema</a>
+</h2>
+  <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596248">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596270">2</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596222">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602071">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603336">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603565">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2604700">7</a>. Typically, a &quot;message of the day&quot; is sent once to all users of a server or a service. The message is sent immediately to users who are online when the message is set, or after the next session initiation for other users (e.g., on server login or chatroom join).</p>
+<p>
+<a name="nt-id2605956">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606103">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2606045">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2606216">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2004-11-19)</h4>
+<div class="indent">Further clarified message of the day per list discussion. (psa)
+    </div>
+<h4>Version 0.5 (2004-11-17)</h4>
+<div class="indent">Changed firstname to given_name. (psa)
+    </div>
+<h4>Version 0.4 (2004-11-02)</h4>
+<div class="indent">Added note clarifying concept of message of the day. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-30)</h4>
+<div class="indent">Changed command naming requirement from MUST to SHOULD. (psa)
+    </div>
+<h4>Version 0.2 (2004-07-22)</h4>
+<div class="indent">Added several more use cases; defined complete protocol flows; specified Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-25)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0133-0.7.html
+++ b/content/xep-0133-0.7.html
@@ -1,0 +1,2440 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0133: Service Administration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Administration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-12-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0133">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0133: Service Administration</h1>
+<p>This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0133<br>
+            Version: 0.7<br>
+            Last Updated: 2004-12-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: admin<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#add-user">Add a User</a>
+</dt>
+<dt>4.2.  <a href="#delete-user">Delete a User</a>
+</dt>
+<dt>4.3.  <a href="#disable-user">Disable a User</a>
+</dt>
+<dt>4.4.  <a href="#reenable-user">Re-Enable a User</a>
+</dt>
+<dt>4.5.  <a href="#end-user-session">End a User's Session</a>
+</dt>
+<dt>4.6.  <a href="#get-user-password">Get a User's Password</a>
+</dt>
+<dt>4.7.  <a href="#change-user-password">Change a User's Password</a>
+</dt>
+<dt>4.8.  <a href="#get-user-roster">Get a User's Roster</a>
+</dt>
+<dt>4.9.  <a href="#get-user-lastlogin">Get a User's Last Login Time</a>
+</dt>
+<dt>4.10.  <a href="#add-to-blacklist">Blacklist an Entity</a>
+</dt>
+<dt>4.11.  <a href="#whitelist">Whitelist an Entity</a>
+</dt>
+<dt>4.12.  <a href="#edit-blacklist">Edit Blacklist</a>
+</dt>
+<dt>4.13.  <a href="#edit-whitelist">Edit Whitelist</a>
+</dt>
+<dt>4.14.  <a href="#get-active-users">Get List of Active Users</a>
+</dt>
+<dt>4.15.  <a href="#get-all-users">Get List of All Users</a>
+</dt>
+<dt>4.16.  <a href="#announce">Send an Announcement to Active Users</a>
+</dt>
+<dt>4.17.  <a href="#set-motd">Set Message of the Day</a>
+</dt>
+<dt>4.18.  <a href="#edit-motd">Edit Message of the Day</a>
+</dt>
+<dt>4.19.  <a href="#delete-motd">Delete Message of the Day</a>
+</dt>
+<dt>4.20.  <a href="#set-welcome">Set Welcome Message</a>
+</dt>
+<dt>4.21.  <a href="#delete-welcome">Delete Welcome Message</a>
+</dt>
+<dt>4.22.  <a href="#grant-admin">Grant Administrative Privileges</a>
+</dt>
+<dt>4.23.  <a href="#revoke-admin">Revoke Administrative Privileges</a>
+</dt>
+<dt>4.24.  <a href="#edit-admin">Edit Admin List</a>
+</dt>
+<dt>4.25.  <a href="#restart">Restart Service</a>
+</dt>
+<dt>4.26.  <a href="#shutdown">Shut Down Service</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sect-id2605997">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists a set of common service-level tasks that administrators often need to perform in relation to Jabber/XMPP servers and components. Examples include creating users, disabling accounts, and blacklisting domains for inbound or outbound communications. Because such tasks can be performed with respect to a server or with respect to many kinds of add-on components (e.g., a text conferencing component that conforms to <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596270">1</a>]), it makes sense to define a generic protocol for such interactions. This JEP describes such a protocol by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2596292">2</a>], rather than by defining a specialized and distinct protocol.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable users with appropriate privileges to perform common administrative tasks with respect to Jabber/XMPP servers and components.</li>
+    <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+  </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <p class="" style="">A server or component MUST advertise any administrative commands it supports via <span class="ref">Service Discovery</span>  [<a href="#nt-id2596394">3</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>); such commands exist as well-defined discovery nodes associated with the service in question.</p>
+  <p class="" style="">In order to interact with a particular component attached to a server, an administrator needs to first discover that component and the commands it support, then send the appropriate command to the component itself. A server SHOULD NOT process commands on behalf of associated components, just as it does not handle service discovery requests on behalf of such components.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> that enables a service-level administrator to complete the following use cases:</p>
+  <ol start="" type="">
+    <li>Add a User</li>
+    <li>Delete a User</li>
+    <li>Disable a User</li>
+    <li>Re-Enable a User</li>
+    <li>End a User's Session</li>
+    <li>Get a User's Password</li>
+    <li>Change a User's Password</li>
+    <li>Get a User's Roster</li>
+    <li>Get a User's Last Login Time</li>
+    <li>Blacklist an Entity</li>
+    <li>Whitelist an Entity</li>
+    <li>Edit Blacklist</li>
+    <li>Edit Whitelist</li>
+    <li>Get List of All Users</li>
+    <li>Get List of Active Users</li>
+    <li>Send an Announcement to Active Users</li>
+    <li>Set Message of the Day</li>
+    <li>Edit Message of the Day</li>
+    <li>Delete Message of the Day</li>
+    <li>Set Welcome Message</li>
+    <li>Delete Welcome Message</li>
+    <li>Grant Administrative Privileges</li>
+    <li>Revoke Administrative Privileges</li>
+    <li>Edit Admin List</li>
+    <li>Restart Service</li>
+    <li>Shut Down Service</li>
+  </ol>
+  <p class="" style="">Naturally, not all of these use cases apply to all service types (e.g., adding a user may not apply to a multi-user chat service). An implementation or deployment MAY support any subset of the use cases defined herein. In addition, although this JEP aims to define common use cases, an implementation or deployment MAY support additional commands not defined herein, which may or may not be publicly registered.</p>
+  <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementors have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> as well as <span class="ref">Data Forms</span>  [<a href="#nt-id2602097">4</a>] (on which JEP-0050 depends).</span></p>
+  <div class="indent">
+<h3>4.1 <a name="add-user">Add a User</a>
+</h3>
+    <p class="" style="">A user is defined as any entity that has a persistent relationship with a service (most commonly through the creation a registered account with the service) and whose account is in some sense hosted by the service. Adding a user MUST result in the creation of an account, along with any implementation-specific data for such an account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 1. Admin Requests to Add a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 2. Service Returns Add User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Adding a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to add a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'/&gt;
+      &lt;field label='Retype password'
+             type='text-private'
+             var='password-verify'/&gt;
+      &lt;field label='Email address'
+             type='text-single'
+             var='email'/&gt;
+      &lt;field label='Given name'
+             type='text-single'
+             var='given_name'/&gt;
+      &lt;field label='Family name'
+             type='text-single'
+             var='surname'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Admin Submits Add User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password-verify'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='given_name'&gt;
+        &lt;value&gt;Juliet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='surname'&gt;
+        &lt;value&gt;Capulet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Notification of completion MAY include the processed data in a data form of type &quot;result&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="delete-user">Delete a User</a>
+</h3>
+    <p class="" style="">An administrator may need to permanently delete a user account. Deleting a user SHOULD result in the termination of any active sessions for the user and in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 5. Admin Requests to Delete a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 6. Service Returns Delete User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Deleting a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to delete a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 7. Admin Submits Delete User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="disable-user">Disable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to temporarily disable a user account. Disabling a user MUST result in the termination of any active sessions for the user and in the prevention of further user logins until the account is re-enabled (this can be thought of as &quot;banning&quot; the user). However, it MUST NOT result in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#disable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 9. Admin Requests to Disable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#disable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 10. Service Returns Disable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Disabling a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to disable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 11. Admin Submits Disable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="reenable-user">Re-Enable a User</a>
+</h3>
+    <p class="" style="">An administrator may need to re-enable a user account that had been temporarily disabled. Re-enabling a user MUST result in granting the user the ability to access the service again. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#reenable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 13. Admin Requests to Re-Enable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#reenable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 14. Service Returns Re-Enable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Re-Enable a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to re-enable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 15. Admin Submits Re-Enable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="end-user-session">End a User's Session</a>
+</h3>
+    <p class="" style="">An administrator may need to terminate one or all of the user's current sessions, but allow future logins (this can be thought of as &quot;kicking&quot; rather than &quot;banning&quot; the user). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#end-user-session&quot;.</p> 
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 17. Admin Requests to End a User's Session</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#end-user-session'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 18. Service Returns End User Session Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Ending a User Session&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to end a user&amp;apos;s session.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the JID is of the form &lt;user@host&gt;, the service MUST end all of the user's sessions; if the JID is of the form &lt;user@host/resource&gt;, the service MUST end only the session associated with that resource.</p>
+    <p class="caption">Example 19. Admin Submits End User Session Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="get-user-password">Get a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 21. Admin Requests to Get a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 22. Service Returns Get User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 23. Admin Submits Get User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the data form included in the IQ result will include the user's password.</p>
+    <p class="caption">Example 24. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="change-user-password">Change a User's Password</a>
+</h3>
+    <p class="" style="">An administrator may need to change a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#change-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 25. Admin Requests to Change a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#change-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 26. Service Returns Change User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Changing a User Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to change a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 27. Admin Submits Change User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;V3r0n4&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="get-user-roster">Get a User's Roster</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's roster (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-roster&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 29. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 30. Service Returns Get User Roster Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Roster&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s roster.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 31. Admin Submits Get User Roster Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's roster, formatted according to the 'jabber:iq:roster' protocol defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2603364">5</a>].</p>
+    <p class="caption">Example 32. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;query xmlns='jabber:iq:roster'&gt;
+        &lt;item jid='romeo@example.net'
+              name='Romeo'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+          &lt;group&gt;Lovers&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='mercutio@example.org'
+              name='Mercutio'
+              subscription='from'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='benvolio@example.org'
+              name='Benvolio'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+      &lt;/query&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="get-user-lastlogin">Get a User's Last Login Time</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-lastlogin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 33. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 34. Service Returns Get User Last Login Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Last Login Time&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s last login time.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 35. Admin Submits Get User Last Login Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's last login time.</p>
+    <p class="caption">Example 36. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lastlogin'&gt;
+        &lt;value&gt;1234&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.10 <a name="add-to-blacklist">Blacklist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide blacklists (lists of entities that are blocked from communications to or from the service). For example, a multi-user chat service may forbid a certain user from joining any room on the service, or may block entire domains from accessing the service. An entity added to a blacklist MAY be a JID of any form as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2603592">6</a>]; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of blacklisting an entity adds it to the blacklist but does not otherwise change the blacklist.</p>
+    <p class="" style="">A blacklist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 37. Admin Requests Blacklisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 38. Service Returns Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Blocking Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to block communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to block'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 39. Admin Submits Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-blacklist'
+           sessionid='add-to-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.11 <a name="whitelist">Whitelist an Entity</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide whitelists (lists of entities that are allowed to communicate the service). For example, a publish-subscribe may allow only a select list of users to publish or subscribe to nodes hosted on the service. An entity added to a whitelist MAY be a JID of any form as specified in <span style="font-weight: bold">XMPP Core</span>; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>. The act of whitelisting an entity adds it to the whitelist but does not otherwise change the whitelist. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot;.</p>
+    <p class="" style="">As with blacklists, a whitelist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 41. Admin Requests Whitelisting of an Entity</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-to-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 42. Service Returns Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Allowing Communications With an Entity&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to allow communications with an entity.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The entity to allow'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 43. Admin Submits Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-to-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 44. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-to-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-to-whitelist'
+           sessionid='add-to-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.12 <a name="edit-blacklist">Edit Blacklist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the blacklist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 45. Admin Requests Editing of Blacklist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 46. Service Returns Edit Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Blacklist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are disallowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The blacklist'
+             type='jid-multi'
+             var='blacklist'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 47. Admin Submits Edit Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='blacklist'&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;france.lit&lt;/value&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 48. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.13 <a name="edit-whitelist">Edit Whitelist</a>
+</h3>
+    <p class="" style="">An administrator may need to edit the whitelist rather than simply add an entity to it. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#edit-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#edit-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 49. Admin Requests Editing of Whitelist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 50. Service Returns Edit Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Whitelist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are allowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The whitelist'
+             type='jid-multi'
+             var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 51. Admin Submits Edit Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='whitelist'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+        &lt;value&gt;verona.it&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 52. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.14 <a name="get-active-users">Get List of Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to retrieve a list of all online users of the server; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). Obviously, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-active-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 53. Admin Requests List of Active Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-active-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply return the list of active users.</p>
+    <p class="caption">Example 54. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of active users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.15 <a name="get-all-users">Get List of All Users</a>
+</h3>
+    <p class="" style="">The concept of retrieving a list of active users can be extended even further to enable an administrator to retrieve a list of all users (not just active or online users). As with the previous use case, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-all-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 55. Admin Requests List of All Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-all-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-all-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the list of all users.</p>
+    <p class="caption">Example 56. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-all-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-all-users'
+           sessionid='get-all-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of all users'
+             type='jid-multi'
+             var='userlist'&gt;
+        &lt;value&gt;bernardo@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;cordelia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;emilia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;francisco@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;goneril@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;iago@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kingclaudius@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kinglear@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;laertes@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;macbeth@shakespeare.li&lt;/value&gt;
+        &lt;value&gt;mercutio@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;nestor@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;northumberland@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;painter@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;regan@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;timon@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.16 <a name="announce">Send an Announcement to Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send an announcement to all online users of the server (e.g., to announce a server shutdown); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The message shall be sent only to users who currently have a &quot;session&quot; with the service. Obviously there may be latency in sending the message if the number of active users is extremely large. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#announce&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 57. Admin Requests Announcement</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#announce'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 58. Service Returns Announce Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Making an Announcement&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to make an announcement to all
+          active users of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 59. Admin Submits Announce Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;Attention! This service will be going down for&lt;/value&gt;
+        &lt;value&gt;maintenance in 2 minutes. Please log off now!&lt;/value&gt;
+        &lt;value&gt;We apologize for the inconvenience.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 60. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.17 <a name="set-motd">Set Message of the Day</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send a &quot;message of the day&quot; that is delivered to any user who logs in to the server that day (e.g., to announce service changes); 
+       [<a href="#nt-id2604428">7</a>]
+     this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 61. Admin Sets Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 62. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'/&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 63. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 64. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.18 <a name="edit-motd">Edit Message of the Day</a>
+</h3>
+    <p class="" style="">After setting a message of the day, an administrator may want to edit that message (e.g., in order to correct an error). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 65. Admin Edits Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current message of the day if one has already been set.</p>
+    <p class="caption">Example 66. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Stuff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 67. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-motd-2'
+    to='shakespeare.lit'
+    type='edit'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 68. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.19 <a name="delete-motd">Delete Message of the Day</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;message of the day&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 69. Admin Deletes Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the message of the day.</p>
+    <p class="caption">Example 70. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-motd'
+           sessionid='delete-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.20 <a name="set-welcome">Set Welcome Message</a>
+</h3>
+    <p class="" style="">Some existing Jabber servers send an informative &quot;welcome message&quot; to newly registered users of the server when they first log in; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 71. Admin Sets Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current welcome message if one has already been set.</p>
+    <p class="caption">Example 72. Service Returns Welcome Message Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting Welcome Message&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the welcome message
+          for this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Welcome Message'
+             type='text-multi'
+             var='welcome'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 73. Admin Submits Welcome Message Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='welcome'&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+        &lt;value&gt;For helpful information about this service,&lt;/value&gt;
+        &lt;value&gt;hie thee to http://www.shakespeare.lit/&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 74. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.21 <a name="delete-welcome">Delete Welcome Message</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;welcome message&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 75. Admin Deletes Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the welcome message.</p>
+    <p class="caption">Example 76. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-welcome'
+           sessionid='delete-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.22 <a name="grant-admin">Grant Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to grant administrative privileges to another user. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus which types of administrators are allowed to grant administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#grant-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 77. Admin Requests to Grant Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#grant-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 78. Service Returns Grant Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Granting Administrative Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to grant administrative privileges 
+          to another user.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the new admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 79. Admin Submits Grant Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='grant-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 80. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='grant-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#grant-admin'
+           sessionid='grant-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.23 <a name="revoke-admin">Revoke Administrative Privileges</a>
+</h3>
+    <p class="" style="">An administrator may want to revoke another user's administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to revoke administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#revoke-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 81. Admin Requests to Revoke Admin Privileges</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#revoke-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 82. Service Returns Revoke Admin Privileges Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Revoking Admin Privileges&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to revoke another user&amp;apos; 
+          administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID of the soon-to-be former admin'
+             type='jid-single'
+             var='jid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Admin Submits Revoke Admin Privileges Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='revoke-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='jid'&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 84. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='revoke-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#revoke-admin'
+           sessionid='revoke-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.24 <a name="edit-admin">Edit Admin List</a>
+</h3>
+    <p class="" style="">An administrator may want to directly edit the list of users who have administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to edit administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 85. Admin Requests Editing of Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 86. Service Returns Edit Admin List Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Admin List&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities who
+          have administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The admin list'
+             type='jid-multi'
+             var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;chris@marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 87. Admin Submits Edit Admin List Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='adminlist'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 88. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.25 <a name="restart">Restart Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to restart the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#restart&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 89. Admin Requests Restart of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#restart'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 90. Service Returns Restart Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Restarting the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to restart the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before restarting'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 91. Admin Submits Restart Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be restarted in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 92. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.26 <a name="shutdown">Shut Down Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to shut down the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#shutdown&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 93. Admin Requests Shut Down of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#shutdown'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 94. Service Returns Shut Down Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Shutting Down the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to shut down the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before shutting down'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 95. Admin Submits Shut Down Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be shut down in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 96. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">Several error conditions are possible when an entity sends a command request to the service, as defined in the following table. If one of these error conditions occurs, the service MUST return an error stanza to the requesting entity.</p>
+  <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Cause</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The command cannot be completed because of a data or system conflict (e.g., a user already exists with that username).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc commands protocol is).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to perform the command.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">No entity is allowed to perform the command (e.g., retrieve the CEO's roster).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+      <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported.</td>
+    </tr>
+  </table>
+  <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2605821">8</a>]. Naturally, other errors may be returned as well (e.g., &lt;internal-server-error/&gt; if the service cannot be shut down).</p> 
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The ability to complete the administrative tasks specified herein MUST NOT be granted to users who lack service-level administrative privileges.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2605968">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605910">10</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>8.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the Jabber Registrar shall add &quot;http://jabber.org/protocol/admin&quot; to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2606081">11</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. The reserved fields for the 'http://jabber.org/protocol/admin' namespace are specified below.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/admin&lt;/name&gt;
+  &lt;doc&gt;JEP-0133&lt;/doc&gt;
+  &lt;desc&gt;Forms used for administration of servers and components.&lt;/desc&gt;
+  &lt;field var='adminlist'
+         type='jid-multi'
+         var='A list of entities with administrative privileges'/&gt;
+  &lt;field var='announcement'
+         type='text-multi'
+         label='The text of an announcement to be sent to active users or all users'/&gt;
+  &lt;field var='blacklist'
+         type='jid-multi'
+         var='A list of entities with whom communication is blocked'/&gt;
+  &lt;field var='delay'
+         type='list-multi'
+         var='The number of seconds to delay before applying a change'/&gt;
+  &lt;field var='email'
+         type='text-single'
+         label='The email address for a user'/&gt;
+  &lt;field var='given_name'
+         type='text-single'
+         label='The given (first) name of a user'/&gt;
+  &lt;field var='jid'
+         type='jid-single'
+         label='The Jabber ID of a user or other entity'/&gt;
+  &lt;field var='motd'
+         type='text-multi'
+         label='The text of a message of the day'/&gt;
+  &lt;field var='password'
+         type='text-private'
+         label='The password for an account'/&gt;
+  &lt;field var='password-verify'
+         type='text-private'
+         label='Password verification'/&gt;
+  &lt;field var='surname'
+         type='text-single'
+         label='The family (last) name of a user'/&gt;
+  &lt;field var='userlist'
+         type='jid-multi'
+         var='A list of registered entities'/&gt;
+  &lt;field var='welcome'
+         type='text-multi'
+         label='The text of a welcome message'/&gt;
+  &lt;field var='whitelist'
+         type='jid-multi'
+         var='A list of entities with whom communication is allowed'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="sect-id2605997">XML Schema</a>
+</h2>
+  <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596270">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596292">2</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596394">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602097">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603364">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603592">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2604428">7</a>. Typically, a &quot;message of the day&quot; is an announcement that is sent once to all users of a server or a service until and unless the message is deleted; it can be thought of as a &quot;standing announcement&quot; as opposed to the &quot;one-time announcement&quot; sent to all online users in the previous use cases. The announcement is sent immediately to users who are online when the message is set, or after the next session initiation for other users (e.g., on server login or chatroom join).</p>
+<p>
+<a name="nt-id2605821">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605968">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605910">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2606081">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2004-12-02)</h4>
+<div class="indent">Added use case for editing message of the day. (psa)
+    </div>
+<h4>Version 0.6 (2004-11-19)</h4>
+<div class="indent">Further clarified message of the day per list discussion. (psa)
+    </div>
+<h4>Version 0.5 (2004-11-17)</h4>
+<div class="indent">Changed firstname to given_name. (psa)
+    </div>
+<h4>Version 0.4 (2004-11-02)</h4>
+<div class="indent">Added note clarifying concept of message of the day. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-30)</h4>
+<div class="indent">Changed command naming requirement from MUST to SHOULD. (psa)
+    </div>
+<h4>Version 0.2 (2004-07-22)</h4>
+<div class="indent">Added several more use cases; defined complete protocol flows; specified Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-25)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0133-0.8.html
+++ b/content/xep-0133-0.8.html
@@ -1,0 +1,2248 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0133: Service Administration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Administration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-12-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0133">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0133: Service Administration</h1>
+<p>This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0133<br>
+            Version: 0.8<br>
+            Last Updated: 2004-12-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: admin<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#add-user">Add User</a>
+</dt>
+<dt>4.2.  <a href="#delete-user">Delete User</a>
+</dt>
+<dt>4.3.  <a href="#disable-user">Disable User</a>
+</dt>
+<dt>4.4.  <a href="#reenable-user">Re-Enable User</a>
+</dt>
+<dt>4.5.  <a href="#end-user-session">End User Session</a>
+</dt>
+<dt>4.6.  <a href="#get-user-password">Get User Password</a>
+</dt>
+<dt>4.7.  <a href="#change-user-password">Change User Password</a>
+</dt>
+<dt>4.8.  <a href="#get-user-roster">Get User Roster</a>
+</dt>
+<dt>4.9.  <a href="#get-user-lastlogin">Get User Last Login Time</a>
+</dt>
+<dt>4.10.  <a href="#edit-blacklist">Edit Blacklist</a>
+</dt>
+<dt>4.11.  <a href="#edit-whitelist">Edit Whitelist</a>
+</dt>
+<dt>4.12.  <a href="#get-active-users">Get List of Active Users</a>
+</dt>
+<dt>4.13.  <a href="#get-registered-users">Get List of Registered Users</a>
+</dt>
+<dt>4.14.  <a href="#announce">Send Announcement to Active Users</a>
+</dt>
+<dt>4.15.  <a href="#set-motd">Set Message of the Day</a>
+</dt>
+<dt>4.16.  <a href="#edit-motd">Edit Message of the Day</a>
+</dt>
+<dt>4.17.  <a href="#delete-motd">Delete Message of the Day</a>
+</dt>
+<dt>4.18.  <a href="#set-welcome">Set Welcome Message</a>
+</dt>
+<dt>4.19.  <a href="#delete-welcome">Delete Welcome Message</a>
+</dt>
+<dt>4.20.  <a href="#edit-admin">Edit Admin List</a>
+</dt>
+<dt>4.21.  <a href="#restart">Restart Service</a>
+</dt>
+<dt>4.22.  <a href="#shutdown">Shut Down Service</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sect-id2605995">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists a set of common service-level tasks that administrators often need to perform in relation to Jabber/XMPP servers and components. Examples include creating users, disabling accounts, and blacklisting domains for inbound or outbound communications. Because such tasks can be performed with respect to a server or with respect to many kinds of add-on components (e.g., a text conferencing component that conforms to <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596298">1</a>]), it makes sense to define a generic protocol for such interactions. This JEP describes such a protocol by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2596321">2</a>] and associated <span class="ref">Data Forms</span>  [<a href="#nt-id2596214">3</a>] fields, rather than by defining a specialized and distinct protocol.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable users with appropriate privileges to perform common administrative tasks with respect to Jabber/XMPP servers and components.</li>
+    <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+  </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <p class="" style="">A server or component MUST advertise any administrative commands it supports via <span class="ref">Service Discovery</span>  [<a href="#nt-id2601932">4</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>); such commands exist as well-defined discovery nodes associated with the service in question.</p>
+  <p class="" style="">In order to interact with a particular component attached to a server, an administrator needs to first discover that component and the commands it support, then send the appropriate command to the component itself. A server SHOULD NOT process commands on behalf of associated components, just as it does not handle service discovery requests on behalf of such components.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> that enables a service-level administrator to complete the following use cases:</p>
+  <ol start="" type="">
+    <li>Add User</li>
+    <li>Delete User</li>
+    <li>Disable User</li>
+    <li>Re-Enable User</li>
+    <li>End User Session</li>
+    <li>Get User Password</li>
+    <li>Change User Password</li>
+    <li>Get User Roster</li>
+    <li>Get User Last Login Time</li>
+    <li>Edit Blacklist</li>
+    <li>Edit Whitelist</li>
+    <li>Get List of Active Users</li>
+    <li>Get List of Registered Users</li>
+    <li>Send Announcement to Active Users</li>
+    <li>Set Message of the Day</li>
+    <li>Edit Message of the Day</li>
+    <li>Delete Message of the Day</li>
+    <li>Set Welcome Message</li>
+    <li>Delete Welcome Message</li>
+    <li>Edit Admin List</li>
+    <li>Restart Service</li>
+    <li>Shut Down Service</li>
+  </ol>
+  <p class="" style="">Naturally, not all of these use cases apply to all service types (e.g., adding a user may not apply to a multi-user chat service). An implementation or deployment MAY support any subset of the use cases defined herein. In addition, although this JEP aims to define common use cases, an implementation or deployment MAY support additional commands not defined herein, which may or may not be publicly registered.</p>
+  <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementors have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> and <span style="font-weight: bold">JEP-0004: Data Forms</span>.</span></p>
+  <div class="indent">
+<h3>4.1 <a name="add-user">Add User</a>
+</h3>
+    <p class="" style="">A user is defined as any entity that has a persistent relationship with a service (most commonly through the creation a registered account with the service) and whose account is in some sense hosted by the service. Adding a user MUST result in the creation of an account, along with any implementation-specific data for such an account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 1. Admin Requests to Add a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 2. Service Returns Add User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Adding a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to add a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for the account to be added'
+             type='jid-single'
+             var='accountjid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'/&gt;
+      &lt;field label='Retype password'
+             type='text-private'
+             var='password-verify'/&gt;
+      &lt;field label='Email address'
+             type='text-single'
+             var='email'/&gt;
+      &lt;field label='Given name'
+             type='text-single'
+             var='given_name'/&gt;
+      &lt;field label='Family name'
+             type='text-single'
+             var='surname'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Admin Submits Add User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password-verify'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='given_name'&gt;
+        &lt;value&gt;Juliet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='surname'&gt;
+        &lt;value&gt;Capulet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Notification of completion MAY include the processed data in a data form of type &quot;result&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="delete-user">Delete User</a>
+</h3>
+    <p class="" style="">An administrator may need to permanently delete a user account. Deleting a user SHOULD result in the termination of any active sessions for the user and in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 5. Admin Requests to Delete a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 6. Service Returns Delete User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Deleting a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to delete a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) to delete'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 7. Admin Submits Delete User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="disable-user">Disable User</a>
+</h3>
+    <p class="" style="">An administrator may need to temporarily disable a user account. Disabling a user MUST result in the termination of any active sessions for the user and in the prevention of further user logins until the account is re-enabled (this can be thought of as &quot;banning&quot; the user). However, it MUST NOT result in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#disable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 9. Admin Requests to Disable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#disable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 10. Service Returns Disable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Disabling a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to disable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) to disable'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 11. Admin Submits Disable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="reenable-user">Re-Enable User</a>
+</h3>
+    <p class="" style="">An administrator may need to re-enable a user account that had been temporarily disabled. Re-enabling a user MUST result in granting the user the ability to access the service again. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#reenable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 13. Admin Requests to Re-Enable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#reenable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 14. Service Returns Re-Enable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Re-Enable a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to re-enable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) to re-enable 
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 15. Admin Submits Re-Enable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="end-user-session">End User Session</a>
+</h3>
+    <p class="" style="">An administrator may need to terminate one or all of the user's current sessions, but allow future logins (this can be thought of as &quot;kicking&quot; rather than &quot;banning&quot; the user). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#end-user-session&quot;.</p> 
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 17. Admin Requests to End a User's Session</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#end-user-session'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 18. Service Returns End User Session Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Ending a User Session&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to end a user&amp;apos;s session.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) for which to end sessions'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the JID is of the form &lt;user@host&gt;, the service MUST end all of the user's sessions; if the JID is of the form &lt;user@host/resource&gt;, the service MUST end only the session associated with that resource.</p>
+    <p class="caption">Example 19. Admin Submits End User Session Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="get-user-password">Get User Password</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 21. Admin Requests to Get a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 22. Service Returns Get User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) for which to retrieve the password'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 23. Admin Submits Get User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the data form included in the IQ result will include the user's password.</p>
+    <p class="caption">Example 24. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="change-user-password">Change User Password</a>
+</h3>
+    <p class="" style="">An administrator may need to change a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#change-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 25. Admin Requests to Change a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#change-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 26. Service Returns Change User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Changing a User Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to change a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='accountjid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 27. Admin Submits Change User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;V3r0n4&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="get-user-roster">Get User Roster</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's roster (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-roster&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 29. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 30. Service Returns Get User Roster Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Roster&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s roster.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) for which to retrieve the roster'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 31. Admin Submits Get User Roster Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's roster, formatted according to the 'jabber:iq:roster' protocol defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2603396">5</a>].</p>
+    <p class="caption">Example 32. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;query xmlns='jabber:iq:roster'&gt;
+        &lt;item jid='romeo@example.net'
+              name='Romeo'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+          &lt;group&gt;Lovers&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='mercutio@example.org'
+              name='Mercutio'
+              subscription='from'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='benvolio@example.org'
+              name='Benvolio'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+      &lt;/query&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="get-user-lastlogin">Get User Last Login Time</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-lastlogin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 33. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 34. Service Returns Get User Last Login Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Last Login Time&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s last login time.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) for which to retrieve the last login time'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 35. Admin Submits Get User Last Login Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's last login time.</p>
+    <p class="caption">Example 36. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lastlogin'&gt;
+        &lt;value&gt;1234&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.10 <a name="edit-blacklist">Edit Blacklist</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide blacklists (lists of entities that are blocked from communications to or from the service). For example, a multi-user chat service may forbid a certain user from joining any room on the service, or may block entire domains from accessing the service. An entity specified on the blacklist MAY be a JID of any form as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2603626">6</a>]; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>.</p>
+    <p class="" style="">A blacklist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 37. Admin Requests Editing of Blacklist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 38. Service Returns Edit Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Blacklist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are disallowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The blacklist'
+             type='jid-multi'
+             var='blacklist'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 39. Admin Submits Edit Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='blacklist'&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;france.lit&lt;/value&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.11 <a name="edit-whitelist">Edit Whitelist</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide whitelists (lists of entities that are allowed to communicate the service). For example, a publish-subscribe may allow only a select list of users to publish or subscribe to nodes hosted on the service. An entity added to a whitelist MAY be a JID of any form as specified in <span style="font-weight: bold">XMPP Core</span>; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>.</p>
+    <p class="" style="">As with blacklists, a whitelist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 41. Admin Requests Editing of Whitelist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 42. Service Returns Edit Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Whitelist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are allowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The whitelist'
+             type='jid-multi'
+             var='whitelistjids'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 43. Admin Submits Edit Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='whitelistjids'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+        &lt;value&gt;verona.it&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 44. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.12 <a name="get-active-users">Get List of Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to retrieve a list of all online users of the server; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). Obviously, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-active-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 45. Admin Requests List of Active Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-active-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD do one of the following:</p>
+    <ol start="" type="">
+      <li>If there are not many active users, the service MAY simply return the list of active users.</li>
+      <li>However, the service MAY also return a form so that the admin can specify more detailed information about the search (e.g., number of users to show).</li>
+    </ol>
+    <p class="caption">Example 46. Service Returns Get Active Users Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Requesting List of Active Users&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to request the active users
+	  of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Maximum number of items to show'
+             type='list-single'
+             var='max_items'&gt;
+        &lt;option label='25'&gt;&lt;value&gt;25&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='75'&gt;&lt;value&gt;75&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='150'&gt;&lt;value&gt;150&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='200'&gt;&lt;value&gt;200&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 47. Admin Submits Get Active Users Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='get-active-users:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='max_items'&gt;
+        &lt;value&gt;100&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 48. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of active users'
+             type='jid-multi'
+             var='activeuserjids'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MAY return an error (rather than a list) if the number of items is excessive or the max_items value is unnacceptable.</p>
+    <p class="" style="">The service MAY specify additional fields that restrict the scope of the user list (e.g., regular expression matching for Jabber IDs), and such fields MAY be registered in the future with the Jabber Registrar; however, such fields are not defined herein.</p>
+  </div>
+  <div class="indent">
+<h3>4.13 <a name="get-registered-users">Get List of Registered Users</a>
+</h3>
+    <p class="" style="">The concept of retrieving a list of active users can be extended even further to enable an administrator to retrieve a list of all users (not just active or online users). As with the previous use case, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-registered-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 49. Admin Requests List of Registered Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-registered-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-registered-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD do one of the following:</p>
+    <ol start="" type="">
+      <li>If there are not many registered users, the service MAY simply return the list of registered users.</li>
+      <li>However, the service MAY also return a form so that the admin can specify more detailed information about the search (e.g., number of users to show).</li>
+    </ol>
+    <p class="caption">Example 50. Service Returns Get Registered Users Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Requesting List of Registered Users&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to request the registered users
+	  of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Maximum number of items to show'
+             type='list-single'
+             var='max_items'&gt;
+        &lt;option label='25'&gt;&lt;value&gt;25&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='75'&gt;&lt;value&gt;75&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='150'&gt;&lt;value&gt;150&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='200'&gt;&lt;value&gt;200&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 51. Admin Submits Get Registered Users Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-registered-users-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='get-registered-users:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='max_items'&gt;
+        &lt;value&gt;100&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 52. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-registered-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-registered-users'
+           sessionid='get-registered-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of all users'
+             type='jid-multi'
+             var='registereduserjids'&gt;
+        &lt;value&gt;bernardo@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;cordelia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;emilia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;francisco@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;goneril@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;iago@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kingclaudius@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kinglear@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;laertes@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;macbeth@shakespeare.li&lt;/value&gt;
+        &lt;value&gt;mercutio@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;nestor@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;northumberland@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;painter@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;regan@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;timon@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MAY return an error (rather than a list) if the number of items is excessive or the max_items value is unnacceptable.</p>
+    <p class="" style="">The service MAY specify additional fields that restrict the scope of the user list (e.g., regular expression matching for Jabber IDs), and such fields MAY be registered in the future with the Jabber Registrar; however, such fields are not defined herein.</p>
+  </div>
+  <div class="indent">
+<h3>4.14 <a name="announce">Send Announcement to Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send an announcement to all online users of the server (e.g., to announce a server shutdown); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The message shall be sent only to users who currently have a &quot;session&quot; with the service. Obviously there may be latency in sending the message if the number of active users is extremely large. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#announce&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 53. Admin Requests Announcement</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#announce'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 54. Service Returns Announce Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Making an Announcement&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to make an announcement to all
+          active users of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 55. Admin Submits Announce Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;Attention! This service will be going down for&lt;/value&gt;
+        &lt;value&gt;maintenance in 2 minutes. Please log off now!&lt;/value&gt;
+        &lt;value&gt;We apologize for the inconvenience.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 56. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.15 <a name="set-motd">Set Message of the Day</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send a &quot;message of the day&quot; that is delivered to any user who logs in to the server that day (e.g., to announce service changes); 
+       [<a href="#nt-id2604684">7</a>]
+     this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 57. Admin Sets Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 58. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'/&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 59. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 60. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.16 <a name="edit-motd">Edit Message of the Day</a>
+</h3>
+    <p class="" style="">After setting a message of the day, an administrator may want to edit that message (e.g., in order to correct an error). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 61. Admin Edits Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current message of the day if one has already been set.</p>
+    <p class="caption">Example 62. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Stuff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 63. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-motd-2'
+    to='shakespeare.lit'
+    type='edit'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 64. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.17 <a name="delete-motd">Delete Message of the Day</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;message of the day&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 65. Admin Deletes Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the message of the day.</p>
+    <p class="caption">Example 66. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-motd'
+           sessionid='delete-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.18 <a name="set-welcome">Set Welcome Message</a>
+</h3>
+    <p class="" style="">Some existing Jabber servers send an informative &quot;welcome message&quot; to newly registered users of the server when they first log in; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 67. Admin Sets Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current welcome message if one has already been set.</p>
+    <p class="caption">Example 68. Service Returns Welcome Message Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting Welcome Message&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the welcome message
+          for this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Welcome Message'
+             type='text-multi'
+             var='welcome'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 69. Admin Submits Welcome Message Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='welcome'&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+        &lt;value&gt;For helpful information about this service,&lt;/value&gt;
+        &lt;value&gt;hie thee to http://www.shakespeare.lit/&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 70. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.19 <a name="delete-welcome">Delete Welcome Message</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;welcome message&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 71. Admin Deletes Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the welcome message.</p>
+    <p class="caption">Example 72. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-welcome'
+           sessionid='delete-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.20 <a name="edit-admin">Edit Admin List</a>
+</h3>
+    <p class="" style="">An administrator may want to directly edit the list of users who have administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to edit administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 73. Admin Requests Editing of Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 74. Service Returns Edit Admin List Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Admin List&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities who
+          have administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The admin list'
+             type='jid-multi'
+             var='adminjids'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;chris@marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 75. Admin Submits Edit Admin List Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='adminjids'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 76. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.21 <a name="restart">Restart Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to restart the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#restart&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 77. Admin Requests Restart of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#restart'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 78. Service Returns Restart Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Restarting the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to restart the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before restarting'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 79. Admin Submits Restart Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be restarted in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 80. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.22 <a name="shutdown">Shut Down Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to shut down the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#shutdown&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 81. Admin Requests Shut Down of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#shutdown'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 82. Service Returns Shut Down Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Shutting Down the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to shut down the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before shutting down'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Admin Submits Shut Down Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be shut down in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 84. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">Several error conditions are possible when an entity sends a command request to the service, as defined in the following table. If one of these error conditions occurs, the service MUST return an error stanza to the requesting entity.</p>
+  <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Cause</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The command cannot be completed because of a data or system conflict (e.g., a user already exists with that username).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc commands protocol is).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to perform the command.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">No entity is allowed to perform the command (e.g., retrieve the CEO's roster).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+      <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported.</td>
+    </tr>
+  </table>
+  <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2605814">8</a>]. Naturally, other errors may be returned as well (e.g., &lt;internal-server-error/&gt; if the service cannot be shut down).</p> 
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The ability to complete the administrative tasks specified herein MUST NOT be granted to users who lack service-level administrative privileges.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2605965">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605907">10</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>8.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the Jabber Registrar shall add &quot;http://jabber.org/protocol/admin&quot; to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2606077">11</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. The reserved fields for the 'http://jabber.org/protocol/admin' namespace are specified below.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/admin&lt;/name&gt;
+  &lt;doc&gt;JEP-0133&lt;/doc&gt;
+  &lt;desc&gt;Forms used for administration of servers and components.&lt;/desc&gt;
+  &lt;field var='accountjid'
+         type='jid-multi'
+         label='The Jabber ID of one or more entities to which an operation applies'/&gt;
+  &lt;field var='accountjids'
+         type='jid-single'
+         label='The Jabber ID of a single entity to which an operation applies'/&gt;
+  &lt;field var='activeuserjids'
+         type='jid-multi'
+         var='The Jabber IDs associated with active sessions'/&gt;
+  &lt;field var='adminjids'
+         type='jid-multi'
+         var='A list of entities with administrative privileges'/&gt;
+  &lt;field var='announcement'
+         type='text-multi'
+         label='The text of an announcement to be sent to active users or all users'/&gt;
+  &lt;field var='blacklistjids'
+         type='jid-multi'
+         var='A list of entities with whom communication is blocked'/&gt;
+  &lt;field var='delay'
+         type='list-multi'
+         var='The number of seconds to delay before applying a change'/&gt;
+  &lt;field var='email'
+         type='text-single'
+         label='The email address for a user'/&gt;
+  &lt;field var='given_name'
+         type='text-single'
+         label='The given (first) name of a user'/&gt;
+  &lt;field var='max_items'
+         type='list-single'
+         label='The maximum number of items associated with a search or list'/&gt;
+  &lt;field var='motd'
+         type='text-multi'
+         label='The text of a message of the day'/&gt;
+  &lt;field var='password'
+         type='text-private'
+         label='The password for an account'/&gt;
+  &lt;field var='password-verify'
+         type='text-private'
+         label='Password verification'/&gt;
+  &lt;field var='surname'
+         type='text-single'
+         label='The family (last) name of a user'/&gt;
+  &lt;field var='registereduserjids'
+         type='jid-multi'
+         var='A list of registered entities'/&gt;
+  &lt;field var='welcome'
+         type='text-multi'
+         label='The text of a welcome message'/&gt;
+  &lt;field var='whitelistjids'
+         type='jid-multi'
+         var='A list of entities with whom communication is allowed'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="sect-id2605995">XML Schema</a>
+</h2>
+  <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596298">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596321">2</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596214">3</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601932">4</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603396">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603626">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2604684">7</a>. Typically, a &quot;message of the day&quot; is an announcement that is sent once to all users of a server or a service until and unless the message is deleted; it can be thought of as a &quot;standing announcement&quot; as opposed to the &quot;one-time announcement&quot; sent to all online users in the previous use cases. The announcement is sent immediately to users who are online when the message is set, or after the next session initiation for other users (e.g., on server login or chatroom join).</p>
+<p>
+<a name="nt-id2605814">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2605965">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605907">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2606077">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2004-12-06)</h4>
+<div class="indent">Addressed Council feedback: folded add blacklist use case into edit blacklist use case; folded add whitelist use case into edit whitelist use case; changed jid-single to jid-multi in many of the use cases; added accountjid field to change password use case; removed grant administrative privileges and revoke administrative privileges use cases (need edit admin list use case only); added max_items field to get active users and get registered users use case. (psa)
+    </div>
+<h4>Version 0.7 (2004-12-02)</h4>
+<div class="indent">Added use case for editing message of the day. (psa)
+    </div>
+<h4>Version 0.6 (2004-11-19)</h4>
+<div class="indent">Further clarified message of the day per list discussion. (psa)
+    </div>
+<h4>Version 0.5 (2004-11-17)</h4>
+<div class="indent">Changed firstname to given_name. (psa)
+    </div>
+<h4>Version 0.4 (2004-11-02)</h4>
+<div class="indent">Added note clarifying concept of message of the day. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-30)</h4>
+<div class="indent">Changed command naming requirement from MUST to SHOULD. (psa)
+    </div>
+<h4>Version 0.2 (2004-07-22)</h4>
+<div class="indent">Added several more use cases; defined complete protocol flows; specified Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-25)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0133-1.0.html
+++ b/content/xep-0133-1.0.html
@@ -1,0 +1,2251 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0133: Service Administration</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Service Administration">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-12-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0133">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0133: Service Administration</h1>
+<p>This JEP defines recommended best practices for service-level administration of servers and components using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Informational JEP defines a best practice or protocol profile that has been approved by the Jabber Council and/or the JSF Board of Directors. Implementations are encouraged and the best practice or protocol profile is appropriate for deployment in production systems.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Informational<br>
+            Number: 0133<br>
+            Version: 1.0<br>
+            Last Updated: 2004-12-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: admin<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#add-user">Add User</a>
+</dt>
+<dt>4.2.  <a href="#delete-user">Delete User</a>
+</dt>
+<dt>4.3.  <a href="#disable-user">Disable User</a>
+</dt>
+<dt>4.4.  <a href="#reenable-user">Re-Enable User</a>
+</dt>
+<dt>4.5.  <a href="#end-user-session">End User Session</a>
+</dt>
+<dt>4.6.  <a href="#get-user-password">Get User Password</a>
+</dt>
+<dt>4.7.  <a href="#change-user-password">Change User Password</a>
+</dt>
+<dt>4.8.  <a href="#get-user-roster">Get User Roster</a>
+</dt>
+<dt>4.9.  <a href="#get-user-lastlogin">Get User Last Login Time</a>
+</dt>
+<dt>4.10.  <a href="#edit-blacklist">Edit Blacklist</a>
+</dt>
+<dt>4.11.  <a href="#edit-whitelist">Edit Whitelist</a>
+</dt>
+<dt>4.12.  <a href="#get-active-users">Get List of Active Users</a>
+</dt>
+<dt>4.13.  <a href="#get-registered-users">Get List of Registered Users</a>
+</dt>
+<dt>4.14.  <a href="#announce">Send Announcement to Active Users</a>
+</dt>
+<dt>4.15.  <a href="#set-motd">Set Message of the Day</a>
+</dt>
+<dt>4.16.  <a href="#edit-motd">Edit Message of the Day</a>
+</dt>
+<dt>4.17.  <a href="#delete-motd">Delete Message of the Day</a>
+</dt>
+<dt>4.18.  <a href="#set-welcome">Set Welcome Message</a>
+</dt>
+<dt>4.19.  <a href="#delete-welcome">Delete Welcome Message</a>
+</dt>
+<dt>4.20.  <a href="#edit-admin">Edit Admin List</a>
+</dt>
+<dt>4.21.  <a href="#restart">Restart Service</a>
+</dt>
+<dt>4.22.  <a href="#shutdown">Shut Down Service</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#sect-id2606071">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists a set of common service-level tasks that administrators often need to perform in relation to Jabber/XMPP servers and components. Examples include creating users, disabling accounts, and blacklisting domains for inbound or outbound communications. Because such tasks can be performed with respect to a server or with respect to many kinds of add-on components (e.g., a text conferencing component that conforms to <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596349">1</a>]), it makes sense to define a generic protocol for such interactions. This JEP describes such a protocol by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2596261">2</a>] and associated <span class="ref">Data Forms</span>  [<a href="#nt-id2596287">3</a>] fields, rather than by defining a specialized and distinct protocol.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable users with appropriate privileges to perform common administrative tasks with respect to Jabber/XMPP servers and components.</li>
+    <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+  </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+  <p class="" style="">A server or component MUST advertise any administrative commands it supports via <span class="ref">Service Discovery</span>  [<a href="#nt-id2596388">4</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>); such commands exist as well-defined discovery nodes associated with the service in question.</p>
+  <p class="" style="">In order to interact with a particular component attached to a server, an administrator needs to first discover that component and the commands it support, then send the appropriate command to the component itself. A server SHOULD NOT process commands on behalf of associated components, just as it does not handle service discovery requests on behalf of such components.</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> that enables a service-level administrator to complete the following use cases:</p>
+  <ol start="" type="">
+    <li>Add User</li>
+    <li>Delete User</li>
+    <li>Disable User</li>
+    <li>Re-Enable User</li>
+    <li>End User Session</li>
+    <li>Get User Password</li>
+    <li>Change User Password</li>
+    <li>Get User Roster</li>
+    <li>Get User Last Login Time</li>
+    <li>Edit Blacklist</li>
+    <li>Edit Whitelist</li>
+    <li>Get List of Active Users</li>
+    <li>Get List of Registered Users</li>
+    <li>Send Announcement to Active Users</li>
+    <li>Set Message of the Day</li>
+    <li>Edit Message of the Day</li>
+    <li>Delete Message of the Day</li>
+    <li>Set Welcome Message</li>
+    <li>Delete Welcome Message</li>
+    <li>Edit Admin List</li>
+    <li>Restart Service</li>
+    <li>Shut Down Service</li>
+  </ol>
+  <p class="" style="">Naturally, not all of these use cases apply to all service types (e.g., adding a user may not apply to a multi-user chat service). An implementation or deployment MAY support any subset of the use cases defined herein. In addition, although this JEP aims to define common use cases, an implementation or deployment MAY support additional commands not defined herein, which may or may not be publicly registered.</p>
+  <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementors have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span> and <span style="font-weight: bold">JEP-0004: Data Forms</span>.</span></p>
+  <div class="indent">
+<h3>4.1 <a name="add-user">Add User</a>
+</h3>
+    <p class="" style="">A user is defined as any entity that has a persistent relationship with a service (most commonly through the creation a registered account with the service) and whose account is in some sense hosted by the service. Adding a user MUST result in the creation of an account, along with any implementation-specific data for such an account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 1. Admin Requests to Add a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#add-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 2. Service Returns Add User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Adding a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to add a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for the account to be added'
+             type='jid-single'
+             var='accountjid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'/&gt;
+      &lt;field label='Retype password'
+             type='text-private'
+             var='password-verify'/&gt;
+      &lt;field label='Email address'
+             type='text-single'
+             var='email'/&gt;
+      &lt;field label='Given name'
+             type='text-single'
+             var='given_name'/&gt;
+      &lt;field label='Family name'
+             type='text-single'
+             var='surname'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Admin Submits Add User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='add-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password-verify'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;juliet@capulet.com&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='given_name'&gt;
+        &lt;value&gt;Juliet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='surname'&gt;
+        &lt;value&gt;Capulet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='add-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#add-user'
+           sessionid='add-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Notification of completion MAY include the processed data in a data form of type &quot;result&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="delete-user">Delete User</a>
+</h3>
+    <p class="" style="">An administrator may need to permanently delete a user account. Deleting a user SHOULD result in the termination of any active sessions for the user and in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 5. Admin Requests to Delete a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 6. Service Returns Delete User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Deleting a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to delete a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) to delete'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 7. Admin Submits Delete User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-user'
+           sessionid='delete-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="disable-user">Disable User</a>
+</h3>
+    <p class="" style="">An administrator may need to temporarily disable a user account. Disabling a user MUST result in the termination of any active sessions for the user and in the prevention of further user logins until the account is re-enabled (this can be thought of as &quot;banning&quot; the user). However, it MUST NOT result in the destruction of any implementation-specific data for the account (e.g., database entries or a roster file). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#disable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 9. Admin Requests to Disable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#disable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 10. Service Returns Disable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Disabling a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to disable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) to disable'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 11. Admin Submits Disable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='disable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='disable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#disable-user'
+           sessionid='disable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="reenable-user">Re-Enable User</a>
+</h3>
+    <p class="" style="">An administrator may need to re-enable a user account that had been temporarily disabled. Re-enabling a user MUST result in granting the user the ability to access the service again. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#reenable-user&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 13. Admin Requests to Re-Enable a User</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#reenable-user'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 14. Service Returns Re-Enable User Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Re-Enable a User&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to re-enable a user.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) to re-enable 
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 15. Admin Submits Re-Enable User Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='reenable-user-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 16. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='reenable-user-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#reenable-user'
+           sessionid='reenable-user:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="end-user-session">End User Session</a>
+</h3>
+    <p class="" style="">An administrator may need to terminate one or all of the user's current sessions, but allow future logins (this can be thought of as &quot;kicking&quot; rather than &quot;banning&quot; the user). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#end-user-session&quot;.</p> 
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 17. Admin Requests to End a User's Session</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#end-user-session'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 18. Service Returns End User Session Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Ending a User Session&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to end a user&amp;apos;s session.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) for which to end sessions'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the JID is of the form &lt;user@host&gt;, the service MUST end all of the user's sessions; if the JID is of the form &lt;user@host/resource&gt;, the service MUST end only the session associated with that resource.</p>
+    <p class="caption">Example 19. Admin Submits End User Session Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='end-user-session-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='end-user-session-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#end-user-session'
+           sessionid='end-user-session:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="get-user-password">Get User Password</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 21. Admin Requests to Get a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 22. Service Returns Get User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) for which to retrieve the password'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 23. Admin Submits Get User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the data form included in the IQ result will include the user's password.</p>
+    <p class="caption">Example 24. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-password'
+           sessionid='get-user-password:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;R0m30&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="change-user-password">Change User Password</a>
+</h3>
+    <p class="" style="">An administrator may need to change a user's password. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#change-user-password&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 25. Admin Requests to Change a User's Password</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#change-user-password'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 26. Service Returns Change User Password Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Changing a User Password&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to change a user&amp;apos;s password.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID for this account'
+             type='jid-single'
+             var='accountjid'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='The password for this account'
+             type='text-private'
+             var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 27. Admin Submits Change User Password Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='change-user-password-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjid'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='password'&gt;
+        &lt;value&gt;V3r0n4&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='change-user-password-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#change-user-password'
+           sessionid='change-user-password:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="get-user-roster">Get User Roster</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's roster (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-roster&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 29. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 30. Service Returns Get User Roster Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Roster&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s roster.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) for which to retrieve the roster'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 31. Admin Submits Get User Roster Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-roster-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's roster, formatted according to the 'jabber:iq:roster' protocol defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2603472">5</a>].</p>
+    <p class="caption">Example 32. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-roster-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-roster'
+           sessionid='get-user-roster:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;query xmlns='jabber:iq:roster'&gt;
+        &lt;item jid='romeo@example.net'
+              name='Romeo'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+          &lt;group&gt;Lovers&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='mercutio@example.org'
+              name='Mercutio'
+              subscription='from'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+        &lt;item jid='benvolio@example.org'
+              name='Benvolio'
+              subscription='both'&gt;
+          &lt;group&gt;Friends&lt;/group&gt;
+        &lt;/item&gt;
+      &lt;/query&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="get-user-lastlogin">Get User Last Login Time</a>
+</h3>
+    <p class="" style="">An administrator may need to retrieve a user's last login time (e.g., to help verify the user's ownership of the account before reminding the user of the password). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-user-lastlogin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 33. Admin Requests to Get a User's Roster</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 34. Service Returns Get User Last Login Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Getting a User's Last Login Time&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to get a user&amp;apos;s last login time.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The Jabber ID(s) for which to retrieve the last login time'
+             type='jid-multi'
+             var='accountjids'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: If the entity is an end user, the JID SHOULD be of the form &lt;user@host&gt;, not &lt;user@host/resource&gt;.</p>
+    <p class="caption">Example 35. Admin Submits Get User Last Login Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-user-lastlogin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The data form included in the IQ result will include the user's last login time.</p>
+    <p class="caption">Example 36. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-user-lastlogin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-user-lastlogin'
+           sessionid='get-user-lastlogin:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accountjids'&gt;
+        &lt;value&gt;juliet@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lastlogin'&gt;
+        &lt;value&gt;1234&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/completed&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.10 <a name="edit-blacklist">Edit Blacklist</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide blacklists (lists of entities that are blocked from communications to or from the service). For example, a multi-user chat service may forbid a certain user from joining any room on the service, or may block entire domains from accessing the service. An entity specified on the blacklist MAY be a JID of any form as specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2603702">6</a>]; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>.</p>
+    <p class="" style="">A blacklist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-blacklist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-blacklist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-blacklist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 37. Admin Requests Editing of Blacklist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-blacklist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 38. Service Returns Edit Blacklist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Blacklist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are disallowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The blacklist'
+             type='jid-multi'
+             var='blacklist'&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 39. Admin Submits Edit Blacklist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-blacklist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='blacklist'&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;france.lit&lt;/value&gt;
+        &lt;value&gt;marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-blacklist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-blacklist'
+           sessionid='edit-blacklist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.11 <a name="edit-whitelist">Edit Whitelist</a>
+</h3>
+    <p class="" style="">The service may enable an administrator to define one or more service-wide whitelists (lists of entities that are allowed to communicate the service). For example, a publish-subscribe may allow only a select list of users to publish or subscribe to nodes hosted on the service. An entity added to a whitelist MAY be a JID of any form as specified in <span style="font-weight: bold">XMPP Core</span>; the order of JID matching SHOULD be that specified for privacy lists in Section 10 of <span style="font-weight: bold">XMPP IM</span>.</p>
+    <p class="" style="">As with blacklists, a whitelist may prevent inbound communications, outbound communications, or both; whether to offer only bidirectional blocking or a more granular choice of inbound or outbound blocking is a matter of implementation or deployment policy. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#add-to-whitelist&quot; if blocking is bidirectional; &quot;http://jabber.org/protocol/admin#add-to-whitelist-in&quot; for inbound blocking only; and &quot;http://jabber.org/protocol/admin#add-to-whitelist-out&quot; for outbound blocking only.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 41. Admin Requests Editing of Whitelist</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-whitelist'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 42. Service Returns Edit Whitelist Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Whitelist&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities with whom
+          communications are allowed.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The whitelist'
+             type='jid-multi'
+             var='whitelistjids'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;denmark.lit&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 43. Admin Submits Edit Whitelist Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-whitelist-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='whitelistjids'&gt;
+        &lt;value&gt;capulet.com&lt;/value&gt;
+        &lt;value&gt;england.lit&lt;/value&gt;
+        &lt;value&gt;montague.net&lt;/value&gt;
+        &lt;value&gt;verona.it&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 44. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-whitelist-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='edit-whitelist:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.12 <a name="get-active-users">Get List of Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to retrieve a list of all online users of the server; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). Obviously, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-active-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 45. Admin Requests List of Active Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-active-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD do one of the following:</p>
+    <ol start="" type="">
+      <li>If there are not many active users, the service MAY simply return the list of active users.</li>
+      <li>However, the service MAY also return a form so that the admin can specify more detailed information about the search (e.g., number of users to show).</li>
+    </ol>
+    <p class="caption">Example 46. Service Returns Get Active Users Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Requesting List of Active Users&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to request the active users
+	  of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Maximum number of items to show'
+             type='list-single'
+             var='max_items'&gt;
+        &lt;option label='25'&gt;&lt;value&gt;25&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='75'&gt;&lt;value&gt;75&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='150'&gt;&lt;value&gt;150&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='200'&gt;&lt;value&gt;200&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 47. Admin Submits Get Active Users Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-active-users-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='get-active-users:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='max_items'&gt;
+        &lt;value&gt;100&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 48. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of active users'
+             type='jid-multi'
+             var='activeuserjids'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MAY return an error (rather than a list) if the number of items is excessive or the max_items value is unnacceptable.</p>
+    <p class="" style="">The service MAY specify additional fields that restrict the scope of the user list (e.g., regular expression matching for Jabber IDs), and such fields MAY be registered in the future with the Jabber Registrar; however, such fields are not defined herein.</p>
+  </div>
+  <div class="indent">
+<h3>4.13 <a name="get-registered-users">Get List of Registered Users</a>
+</h3>
+    <p class="" style="">The concept of retrieving a list of active users can be extended even further to enable an administrator to retrieve a list of all users (not just active or online users). As with the previous use case, the service may need to truncate the result-set, since it could be quite large; furthermore, any ability to limit or page through the result-set is outside the scope of this JEP. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#get-registered-users&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 49. Admin Requests List of Registered Users</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-registered-users-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#get-registered-users'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD do one of the following:</p>
+    <ol start="" type="">
+      <li>If there are not many registered users, the service MAY simply return the list of registered users.</li>
+      <li>However, the service MAY also return a form so that the admin can specify more detailed information about the search (e.g., number of users to show).</li>
+    </ol>
+    <p class="caption">Example 50. Service Returns Get Registered Users Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-active-users-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-active-users'
+           sessionid='get-active-users:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Requesting List of Registered Users&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to request the registered users
+	  of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Maximum number of items to show'
+             type='list-single'
+             var='max_items'&gt;
+        &lt;option label='25'&gt;&lt;value&gt;25&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='50'&gt;&lt;value&gt;50&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='75'&gt;&lt;value&gt;75&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='100'&gt;&lt;value&gt;100&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='150'&gt;&lt;value&gt;150&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='200'&gt;&lt;value&gt;200&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='None'&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 51. Admin Submits Get Registered Users Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='get-registered-users-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-whitelist'
+           sessionid='get-registered-users:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='max_items'&gt;
+        &lt;value&gt;100&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 52. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='get-registered-users-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#get-registered-users'
+           sessionid='get-registered-users:20040408T0337Z'
+           status='completed'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The list of all users'
+             type='jid-multi'
+             var='registereduserjids'&gt;
+        &lt;value&gt;bernardo@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;cordelia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;crone1@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;emilia@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;francisco@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;goneril@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hag66@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;iago@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kingclaudius@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;kinglear@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;laertes@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;macbeth@shakespeare.li&lt;/value&gt;
+        &lt;value&gt;mercutio@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;nestor@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;northumberland@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;painter@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;regan@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;timon@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;wiccarocks@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service MAY return an error (rather than a list) if the number of items is excessive or the max_items value is unnacceptable.</p>
+    <p class="" style="">The service MAY specify additional fields that restrict the scope of the user list (e.g., regular expression matching for Jabber IDs), and such fields MAY be registered in the future with the Jabber Registrar; however, such fields are not defined herein.</p>
+  </div>
+  <div class="indent">
+<h3>4.14 <a name="announce">Send Announcement to Active Users</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send an announcement to all online users of the server (e.g., to announce a server shutdown); this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The message shall be sent only to users who currently have a &quot;session&quot; with the service. Obviously there may be latency in sending the message if the number of active users is extremely large. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#announce&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 53. Admin Requests Announcement</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#announce'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 54. Service Returns Announce Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Making an Announcement&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to make an announcement to all
+          active users of this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 55. Admin Submits Announce Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='announce-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;Attention! This service will be going down for&lt;/value&gt;
+        &lt;value&gt;maintenance in 2 minutes. Please log off now!&lt;/value&gt;
+        &lt;value&gt;We apologize for the inconvenience.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 56. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='announce-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#announce'
+           sessionid='announce:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.15 <a name="set-motd">Set Message of the Day</a>
+</h3>
+    <p class="" style="">Administrators of some existing Jabber servers have found it useful to be able to send a &quot;message of the day&quot; that is delivered to any user who logs in to the server that day (e.g., to announce service changes); 
+       [<a href="#nt-id2604760">7</a>]
+     this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 57. Admin Sets Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 58. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'/&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 59. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-motd-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 60. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-motd'
+           sessionid='set-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.16 <a name="edit-motd">Edit Message of the Day</a>
+</h3>
+    <p class="" style="">After setting a message of the day, an administrator may want to edit that message (e.g., in order to correct an error). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 61. Admin Edits Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current message of the day if one has already been set.</p>
+    <p class="caption">Example 62. Service Returns MOTD Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-motd-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Message of the Day&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the message of the day.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Message of the Day'
+             type='text-multi'
+             var='motd'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Stuff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 63. Admin Submits MOTD Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-motd-2'
+    to='shakespeare.lit'
+    type='edit'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='motd'&gt;
+        &lt;value&gt;Don&amp;apos;t forget: the grand re-opening of the&lt;/value&gt;
+        &lt;value&gt;Globe Theatre will occur tomorrow night.&lt;/value&gt;
+        &lt;value&gt;The festivities will begin right after tea&lt;/value&gt;
+        &lt;value&gt;and extend far into the night. Don&amp;apos;t miss it!&lt;/value&gt;
+        &lt;value&gt;--The Globe Staff&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 64. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-motd'
+           sessionid='edit-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.17 <a name="delete-motd">Delete Message of the Day</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;message of the day&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-motd&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 65. Admin Deletes Message of the Day</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-motd-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-motd'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the message of the day.</p>
+    <p class="caption">Example 66. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-motd-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-motd'
+           sessionid='delete-motd:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.18 <a name="set-welcome">Set Welcome Message</a>
+</h3>
+    <p class="" style="">Some existing Jabber servers send an informative &quot;welcome message&quot; to newly registered users of the server when they first log in; this concept can be extended to any service (such as a multi-user chat service or a gateway to a foreign IM service). The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#set-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 67. Admin Sets Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#set-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form, which SHOULD include the current welcome message if one has already been set.</p>
+    <p class="caption">Example 68. Service Returns Welcome Message Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting Welcome Message&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to set the welcome message
+          for this service.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Welcome Message'
+             type='text-multi'
+             var='welcome'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 69. Admin Submits Welcome Message Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='set-welcome-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='welcome'&gt;
+        &lt;value&gt;Welcome to Shakespeare.lit, your home for&lt;/value&gt;
+        &lt;value&gt;instant messaging with a literary touch.&lt;/value&gt;
+        &lt;value&gt;For helpful information about this service,&lt;/value&gt;
+        &lt;value&gt;hie thee to http://www.shakespeare.lit/&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 70. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='set-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#set-welcome'
+           sessionid='set-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.19 <a name="delete-welcome">Delete Welcome Message</a>
+</h3>
+    <p class="" style="">Sometimes a previously-set &quot;welcome message&quot; is no longer appropriate and needs to be deleted. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#delete-welcome&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 71. Admin Deletes Welcome Message</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='delete-welcome-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#delete-welcome'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD simply delete the welcome message.</p>
+    <p class="caption">Example 72. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='delete-welcome-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#delete-welcome'
+           sessionid='delete-welcome:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.20 <a name="edit-admin">Edit Admin List</a>
+</h3>
+    <p class="" style="">An administrator may want to directly edit the list of users who have administrative privileges. Whether there are distinctions between service-level administrators (e.g., owner, admin, moderator), and thus in what types of administrators are allowed to edit administrative privileges, is a matter for the implementation or local service policy and is not specified herein. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#edit-admin&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 73. Admin Requests Editing of Admin List</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#edit-admin'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 74. Service Returns Edit Admin List Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Editing the Admin List&lt;/title&gt;
+      &lt;instructions&gt;
+          Fill out this form to edit the list of entities who
+          have administrative privileges.
+      &lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='The admin list'
+             type='jid-multi'
+             var='adminjids'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;chris@marlowe.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 75. Admin Submits Edit Admin List Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='edit-admin-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='adminjids'&gt;
+        &lt;value&gt;bill@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;hecate@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 76. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='edit-admin-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#edit-admin'
+           sessionid='edit-admin:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.21 <a name="restart">Restart Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to restart the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#restart&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 77. Admin Requests Restart of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#restart'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 78. Service Returns Restart Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Restarting the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to restart the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before restarting'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 79. Admin Submits Restart Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='restart-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be restarted in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 80. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='restart-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#restart'
+           sessionid='restart:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.22 <a name="shutdown">Shut Down Service</a>
+</h3>
+    <p class="" style="">A service may allow an administrator to shut down the service. The command node for this use case SHOULD be &quot;http://jabber.org/protocol/admin#shutdown&quot;.</p>
+    <p class="" style="">A sample protocol flow for this use case is shown below.</p>
+    <p class="caption">Example 81. Admin Requests Shut Down of Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-1'
+    to='shakespeare.lit'
+    type='get'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/admin#shutdown'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Unless an error occurs (see the <a href="#errors">Error Handling</a> section below), the service SHOULD return the appropriate form.</p>
+    <p class="caption">Example 82. Service Returns Shut Down Form to Admin</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-1'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Shutting Down the Service&lt;/title&gt;
+      &lt;instructions&gt;Fill out this form to shut down the service.&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Time delay before shutting down'
+             type='list-multi'
+             var='delay'&gt;
+        &lt;option label='30 seconds'&gt;&lt;value&gt;30&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='60 seconds'&gt;&lt;value&gt;60&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='90 seconds'&gt;&lt;value&gt;90&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='2 minutes'&gt;&lt;value&gt;120&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='3 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='4 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+        &lt;option label='5 minutes'&gt;&lt;value&gt;180&lt;/value&gt;&lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Announcement'
+             type='text-multi'
+             var='announcement'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 83. Admin Submits Shut Down Form to Service</p>
+<div class="indent"><pre>
+&lt;iq from='bill@shakespeare.lit/globe'
+    id='shutdown-2'
+    to='shakespeare.lit'
+    type='set'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/admin&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='delay'&gt;
+        &lt;value&gt;120&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='announcement'&gt;
+        &lt;value&gt;The service will be shut down in 2 minutes!&lt;/value&gt;
+        &lt;value&gt;Please log off now. --The Admins&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 84. Service Informs Admin of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    id='shutdown-2'
+    to='bill@shakespeare.lit/globe'
+    type='result'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/admin#shutdown'
+           sessionid='shutdown:20040408T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">Several error conditions are possible when an entity sends a command request to the service, as defined in the following table. If one of these error conditions occurs, the service MUST return an error stanza to the requesting entity.</p>
+  <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Condition</th>
+      <th colspan="" rowspan="">Cause</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+      <td align="" colspan="" rowspan="">The command cannot be completed because of a data or system conflict (e.g., a user already exists with that username).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+      <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc commands protocol is).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+      <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to perform the command.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;not-allowed/&gt;</td>
+      <td align="" colspan="" rowspan="">No entity is allowed to perform the command (e.g., retrieve the CEO's roster).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+      <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported.</td>
+    </tr>
+  </table>
+  <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2605890">8</a>]. Naturally, other errors may be returned as well (e.g., &lt;internal-server-error/&gt; if the service cannot be shut down).</p> 
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The ability to complete the administrative tasks specified herein MUST NOT be granted to users who lack service-level administrative privileges.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2606040">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605983">10</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>8.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon advancement of this JEP to a status of Active, the Jabber Registrar shall add &quot;http://jabber.org/protocol/admin&quot; to its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2606153">11</a>] defines a process for standardizing the fields used within Data Forms scoped by a particular namespace. The reserved fields for the 'http://jabber.org/protocol/admin' namespace are specified below.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/admin&lt;/name&gt;
+  &lt;doc&gt;JEP-0133&lt;/doc&gt;
+  &lt;desc&gt;Forms used for administration of servers and components.&lt;/desc&gt;
+  &lt;field var='accountjid'
+         type='jid-multi'
+         label='The Jabber ID of one or more entities to which an operation applies'/&gt;
+  &lt;field var='accountjids'
+         type='jid-single'
+         label='The Jabber ID of a single entity to which an operation applies'/&gt;
+  &lt;field var='activeuserjids'
+         type='jid-multi'
+         label='The Jabber IDs associated with active sessions'/&gt;
+  &lt;field var='adminjids'
+         type='jid-multi'
+         label='A list of entities with administrative privileges'/&gt;
+  &lt;field var='announcement'
+         type='text-multi'
+         label='The text of an announcement to be sent to active users or all users'/&gt;
+  &lt;field var='blacklistjids'
+         type='jid-multi'
+         label='A list of entities with whom communication is blocked'/&gt;
+  &lt;field var='delay'
+         type='list-multi'
+         label='The number of seconds to delay before applying a change'/&gt;
+  &lt;field var='email'
+         type='text-single'
+         label='The email address for a user'/&gt;
+  &lt;field var='given_name'
+         type='text-single'
+         label='The given (first) name of a user'/&gt;
+  &lt;field var='max_items'
+         type='list-single'
+         label='The maximum number of items associated with a search or list'/&gt;
+  &lt;field var='motd'
+         type='text-multi'
+         label='The text of a message of the day'/&gt;
+  &lt;field var='password'
+         type='text-private'
+         label='The password for an account'/&gt;
+  &lt;field var='password-verify'
+         type='text-private'
+         label='Password verification'/&gt;
+  &lt;field var='surname'
+         type='text-single'
+         label='The family (last) name of a user'/&gt;
+  &lt;field var='registereduserjids'
+         type='jid-multi'
+         label='A list of registered entities'/&gt;
+  &lt;field var='welcome'
+         type='text-multi'
+         label='The text of a welcome message'/&gt;
+  &lt;field var='whitelistjids'
+         type='jid-multi'
+         label='A list of entities with whom communication is allowed'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="sect-id2606071">XML Schema</a>
+</h2>
+  <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596349">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596261">2</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596287">3</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596388">4</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603472">5</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603702">6</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2604760">7</a>. Typically, a &quot;message of the day&quot; is an announcement that is sent once to all users of a server or a service until and unless the message is deleted; it can be thought of as a &quot;standing announcement&quot; as opposed to the &quot;one-time announcement&quot; sent to all online users in the previous use cases. The announcement is sent immediately to users who are online when the message is set, or after the next session initiation for other users (e.g., on server login or chatroom join).</p>
+<p>
+<a name="nt-id2605890">8</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2606040">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605983">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2606153">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2004-12-09)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Active. (psa)
+    </div>
+<h4>Version 0.8 (2004-12-06)</h4>
+<div class="indent">Addressed Council feedback: folded add blacklist use case into edit blacklist use case; folded add whitelist use case into edit whitelist use case; changed jid-single to jid-multi in many of the use cases; added accountjid field to change password use case; removed grant administrative privileges and revoke administrative privileges use cases (need edit admin list use case only); added max_items field to get active users and get registered users use case. (psa)
+    </div>
+<h4>Version 0.7 (2004-12-02)</h4>
+<div class="indent">Added use case for editing message of the day. (psa)
+    </div>
+<h4>Version 0.6 (2004-11-19)</h4>
+<div class="indent">Further clarified message of the day per list discussion. (psa)
+    </div>
+<h4>Version 0.5 (2004-11-17)</h4>
+<div class="indent">Changed firstname to given_name. (psa)
+    </div>
+<h4>Version 0.4 (2004-11-02)</h4>
+<div class="indent">Added note clarifying concept of message of the day. (psa)
+    </div>
+<h4>Version 0.3 (2004-09-30)</h4>
+<div class="indent">Changed command naming requirement from MUST to SHOULD. (psa)
+    </div>
+<h4>Version 0.2 (2004-07-22)</h4>
+<div class="indent">Added several more use cases; defined complete protocol flows; specified Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-25)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0134-0.2.html
+++ b/content/xep-0134-0.2.html
@@ -1,0 +1,286 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0134: Protocol Design Guidelines</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Protocol Design Guidelines">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines best practices for the intelligent design of Jabber protocols and other XMPP extensions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-31">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0134">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0134: Protocol Design Guidelines</h1>
+<p>This JEP defines best practices for the intelligent design of Jabber protocols and other XMPP extensions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0134<br>
+            Version: 0.2<br>
+            Last Updated: 2004-08-31<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#guidelines">Guidelines</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#xmpp">XMPP is Sacred</a>
+</dt>
+<dt>2.2.  <a href="#simple">Keep Clients Simple</a>
+</dt>
+<dt>2.3.  <a href="#reuse">Re-Use Existing Protocols</a>
+</dt>
+<dt>2.4.  <a href="#modular">Modular is Better</a>
+</dt>
+<dt>2.5.  <a href="#strengths">Know Your Strengths</a>
+</dt>
+<dt>2.6.  <a href="#explicit">Be Explicit</a>
+</dt>
+<dt>2.7.  <a href="#flexible">Stay Flexible</a>
+</dt>
+<dt>2.8.  <a href="#privacy">Privacy and Security Matter</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Extensible Messaging and Presence Protocol (XMPP) provides a solid, flexible foundation for a wide variety of applications on top of XMPP's core XML streaming technology. With the advancement of <span class="ref">XMPP Core</span>  [<a href="#nt-id2595427">1</a>] and <span class="ref">XMPP IM</span>  [<a href="#nt-id2595432">2</a>] within the Internet Standards Process, interest in building XMPP-based applications and extensions has accelerated even further. Unfortunately, not everyone who wants to build public or private XMPP extensions is familiar with the key design criteria that motivated the original developers of the Jabber technologies or that guide successful XMPP-based protocol design today. Thus there is value in attempting to translate the often-implicit knowledge held by long-time Jabber developers and protocol designers into more explicit policies and principles to which others can adhere (for more general insights into Internet protocol design, see <span class="ref">RFC 3117</span>  [<a href="#nt-id2595554">3</a>]). The end result of explicating &quot;The Jabber Way&quot; will hopefully be a wider and deeper understanding of good protocol design practices within the Jabber/XMPP community.</p>
+<h2>2.
+       <a name="guidelines">Guidelines</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="xmpp">XMPP is Sacred</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">When the <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2595644">4</a>] submitted the <span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span> specifications to the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2595680">5</a>], it ceded change control over the core XML streaming technology developed by the Jabber community. However, the JSF has reserved the right to define extensions to XMPP; furthermore, that right is not exclusive to the JSF, since anyone can define their own public or private extensions to XMPP. These extensions are usually in the form of structured XML data that is qualified by a unique namespace other than those currently reserved by the IETF or the JSF.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">When we say that &quot;XMPP is Sacred&quot;, we mean that good protocol design must work within the context of XMPP and not require changes to the core protocols. For one thing, any such changes would need to be pursued within the IETF. Further, the core semantics most likely provide everything that a protocol designer needs. If you think that you need to define a new kind of top-level stanza (other than &lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;) or a new value of the 'type' attribute for any stanza kind, then you probably need to think again. Use XMPP as a set of building blocks and don't modify the foundation when you are working on higher-level structures; instead, treat XMPP as a transport layer and build extensions on top of that layer. A further implication of respecting XMPP is using structured data formats (e.g., applications of <span class="ref">XML 1.0</span>  [<a href="#nt-id2595519">6</a>] rather than binary or plaintext formats) whenever possible.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">A good example of honoring the XMPP specifications is <span class="ref">Invisibility</span>  [<a href="#nt-id2601248">7</a>]; while the Jabber community had informally defined &lt;presence type='invisible'/&gt; at one point, that protocol was abandoned in favor of an XMPP-compliant approach. Another example is <span class="ref">XHTML-IM</span>  [<a href="#nt-id2595723">8</a>], which re-uses <span class="ref">XHTML 1.0</span>  [<a href="#nt-id2595743">9</a>] (a structured format that shares with XMPP a common root in XML) rather than <span class="ref">Rich Text Format (RTF)</span>  [<a href="#nt-id2595759">10</a>] (an unstructured format that does not derive from XML).</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="simple">Keep Clients Simple</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">Almost all Jabber technologies are implemented in a client-server architecture. While that's not necessary (and there do exist some peer-to-peer applications of XMPP), it usually makes good sense. Among other things, a client-server architecture has enabled the Jabber community to force most of the complexity onto servers and components, thus keeping clients relatively simple. This principle has served the Jabber community well since the very beginning, and forms an important basis for further innovation.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">The principle of &quot;keep clients simple&quot; has many implications, among them:</p>
+    <ul>
+      <li>Don't multiply protocols beyond necessity (the more protocols you define, the harder it is to write a client).</li>
+      <li>Degrade gracefully so that simpler or older clients can still participate in the network.</li>
+      <li>If intensive processing is required, make a server or component do it.</li>
+      <li>Don't force additional requirements (such as XSLT processors) onto clients unless absolutely necessary.</li>
+    </ul>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">One good example of keeping clients simple is the presence stanza: the client has only to send &lt;presence/&gt; and the server takes care of presence probes, broadcasts, and appropriate routing decisions. Another example is <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2601451">11</a>]: although the protocol involves some complexity, it was written so that older clients can join and participate in MUC rooms even if they don't understand the more advanced MUC extensions.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="reuse">Re-Use Existing Protocols</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">The Jabber community has been developing wire protocols for XML streaming, presence, and instant messaging since 1999. In that time, members of the community have defined a number of building blocks that can be used as the basis for further development. Furthermore, many smart people have created open protocols within other standards development organizations, including the IETF, the <span class="ref">World Wide Web Consortium (W3C)</span>  [<a href="#nt-id2601415">12</a>], <span class="ref">OASIS</span>  [<a href="#nt-id2601440">13</a>], the <span class="ref">International Telecommunication Union (ITU)</span>  [<a href="#nt-id2601562">14</a>], and the <span class="ref">Dublin Core Metadata Initiative (DCMI)</span>  [<a href="#nt-id2601587">15</a>].</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">Good protocol designers &quot;stand on the shoulders of giants&quot; by re-using protocols that have been defined within the JSF and within other standards development organizations. That does not mean we don't define new protocols, because sometimes that is necessary. However, we are aware of work completed by others and we make use of it, especially when that work is outside the Jabber community's core competence areas (e.g., security or multimedia data formats rather than XML streaming, presence, and real-time messaging). Furthermore, the JSF prefers to re-use open protocols wherever possible.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">Examples of re-using existing Jabber protocols include <span class="ref">Stream Initiation</span>  [<a href="#nt-id2601525">16</a>] (which re-uses <span class="ref">Feature Negotiation</span>  [<a href="#nt-id2601686">17</a>]) and <span style="font-weight: bold">JEP-0126: Invisibility</span> (which re-uses the privacy lists protocol defined in <span style="font-weight: bold">XMPP IM</span>). Examples of re-using non-Jabber protocols include <span class="ref">SOCKS5 Bytestreams</span>  [<a href="#nt-id2601621">18</a>] (which makes use of <span class="ref">RFC 1928</span>  [<a href="#nt-id2601641">19</a>]) and <span class="ref">Common Alerting Protocol (CAP) over XMPP</span>  [<a href="#nt-id2601662">20</a>] (which defines a way to send <span class="ref">Common Alerting Protocol</span>  [<a href="#nt-id2601778">21</a>] data via Jabber). Here again JEP-0071 provides an example: it re-uses XHTML 1.0 (an open protocol developed by a recognized standards development organization) rather than RTF (a closed protocol maintained by Microsoft).</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="modular">Modular is Better</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">Most Jabber implementations are built using modular architectures, wherein pieces of functionality are coded as separate components and then assembled into larger wholes, with core routing logic that integrates the system (examples include clients that enable the development of plugins and servers that enable the attachment of external components). We can view many Jabber protocols the same way: each one specifies a well-defined domain of functionality that is loosely connected to other domains and integrated by the core transport layer provided by XMPP.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">The best Jabber protocols are quite focused and provide limited but powerful functionality that can be applied in a specific domain or, sometimes, re-used by other Jabber protocols. Even if the domain is more complex, a protocol that addresses it needs to clearly define its scope, limit that scope as much as possible, and specify only the protocols necessary to meet the core requirements.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">
+<span class="ref">Service Discovery</span>  [<a href="#nt-id2601901">22</a>] and <span class="ref">Data Forms</span>  [<a href="#nt-id2601921">23</a>] are good examples of focused, single-purpose protocols. By contrast, <span style="font-weight: bold">Multi-User Chat</span> is more complex, but it limits itself to the domain of text conferencing in the context of virtual rooms (e.g., it does not address service-level administration) and consists of separate namespaces for end-user, moderator, and room owner functionality. A good example of a protocol that is focused on a smaller domain is <span class="ref">Roster Item Exchange</span>  [<a href="#nt-id2601834">24</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="strengths">Know Your Strengths</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">The core strength of Jabber technologies is the streaming of relatively small XML fragments between presence-aware network endpoints. As is usually the case, our greatest strength is also our greatest weakness. Thus XMPP is not optimized for binary data, large XML files, multimedia streaming, or other such applications.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">It's not a bad thing that we don't solve the problems of exchanging binary data, transferring large files, or streaming multimedia, because other protocols and technologies have addressed those domains. But it's important to recognize what we do well and what we don't. For example, the average size of an XMPP stanza is probably on the order of 200 bytes, and in general the largest effective size for stanzas is perhaps ten times that large; although stanzas can be much larger than that, normally it is not wise to consistently generate larger stanzas, and applications that might depend on large stanzas would do better to communicate their data outside of the Jabber band.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">
+<span class="ref">File Transfer</span>  [<a href="#nt-id2602061">25</a>] is a good example of respecting the strengths and weaknesses of XMPP, since it specifies that going out of band is the preferred mechanism for bandwidth-heavy data transfers.</p>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="explicit">Be Explicit</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">In the beginning was the code (mainly <span class="ref">jabberd</span>  [<a href="#nt-id2602019">26</a>]). Although code is explicit in its own way, not everyone reads code, and detailed specifications are necessary in order to make functionality reproducible in different codebases. The Jabber community has learned that lesson the hard way.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">Detailed, explicit specifications are good specifications. Define your terms. Use conformance terminology such as MUST and SHOULD rather than loose English words such as &quot;does&quot; and &quot;will&quot;. Follow the <span class="ref">Guidelines for JEP Authors</span>  [<a href="#nt-id2602168">27</a>]. Specify error conditions. Include lots of examples. Restrict the allowable XML via schemas and datatypes as specified in <span class="ref">XML Schema Part 1</span>  [<a href="#nt-id2602079">28</a>] and <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602115">29</a>].</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">
+<span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span> are large documents that define the Extensible Messaging and Presence Protocol in excruciating detail. Although such specifications are not fun to write, they provide a model for good protocol design and documentation.</p>
+  </div>
+  <div class="indent">
+<h3>2.7 <a name="flexible">Stay Flexible</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">The need for explicit definition must be balanced against the need for flexibility. A completely rigid protocol may break under stress or when conditions change, whereas a more flexible protocol may bend and adapt. Knowing when to be explicit and when to be flexible is a key to good protocol design.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">In general, a protocol needs to define the skeleton of functionality, but not necessarily specific parameters or values to be used within a certain domain. In order to allow for growth and changes, it often makes sense to specify that the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602323">30</a>] shall keep track of certain parameters and values, rather than to explicitly limit them in the protocol itself.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">Whereas the old <span class="ref">Agent Information</span>  [<a href="#nt-id2602266">31</a>] and <span class="ref">Jabber Browsing</span>  [<a href="#nt-id2602287">32</a>] protocols defined certain hardcoded values for entity types and categories, <span style="font-weight: bold">Service Discovery</span> has left that function up to the Jabber Registrar. Similarly, <span class="ref">Stream Initiation</span>  [<a href="#nt-id2602301">33</a>] defines a registry for its profiles, <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2602439">34</a>] defines registries for processing conditions and actions, and a number of JEPs register FORM_TYPE values as specified in <span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2602365">35</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.8 <a name="privacy">Privacy and Security Matter</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">Since the beginning, privacy and security have been important priorities within the Jabber community. That must not change.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">Good protocols respect the confidentiality of data generated or communicated by users and applications as well as the security of the system or network as a whole. Although privacy and security considerations have been dealt with at the core XMPP layer, application-level protocols must not compromise privacy and security. Attention to these matters, along with rigorous cross-area review and close scrutiny by protocol designers and reviewers, will help ensure that the protocols we develop will provide a strong foundation for communication over the Internet.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">As is well-known, the presence subscription model developed by the Jabber community and specified in <span style="font-weight: bold">XMPP IM</span> requires approval before a contact can view a user's presence. Similarly, Jabber has always included strong authentication methods, which have been further improved through the use of SASL (<span class="ref">RFC 2222</span>  [<a href="#nt-id2602576">36</a>]).</p>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns directly related to this proposal, which is informational in nature. However, as discussed above, protocols that are developed following these guidelines should appropriately address privacy and security considerations. Helpful guidelines for security in relation to Internet protocol design can be found in <span class="ref">RFC 3552</span>  [<a href="#nt-id2602524">37</a>].</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602668">38</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the Jabber Registrar.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595427">1</a>. XMPP Core &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2595432">2</a>. XMPP IM &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2595554">3</a>. RFC 3117: On the Design of Application Protocols &lt;<a href="http://www.ietf.org/rfc/rfc3117.txt">http://www.ietf.org/rfc/rfc3117.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2595644">4</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2595680">5</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2595519">6</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p>
+<a name="nt-id2601248">7</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595723">8</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595743">9</a>. XHTML 1.0 &lt;<a href="http://www.w3.org/TR/xhtml1">http://www.w3.org/TR/xhtml1</a>&gt;.</p>
+<p>
+<a name="nt-id2595759">10</a>. Rich Text Format (RTF) Version 1.5 Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp">http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp</a>&gt;.</p>
+<p>
+<a name="nt-id2601451">11</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601415">12</a>. The World Wide Web Consortium defines data formats and markup languages (such as HTML and XML) for use over the Internet. For further information, see &lt;<a href="http://www.w3.org/">http://www.w3.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601440">13</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601562">14</a>. The International Telecommunication Union develops technical and operating standards (such as H.323) for international telecommunication services. For further information, see &lt;<a href="http://www.itu.int/">http://www.itu.int/</a>&gt;.</p>
+<p>
+<a name="nt-id2601587">15</a>. The Dublin Core Metadata Initiative (DCMI) is an organization dedicated to promoting the widespread adoption of interoperable metadata standards. For further information, see &lt;<a href="http://www.dublincore.org/">http://www.dublincore.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601525">16</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601686">17</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601621">18</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601641">19</a>. RFC 1928: SOCKS Protocol Version 5 &lt;<a href="http://www.ietf.org/rfc/rfc1928.txt">http://www.ietf.org/rfc/rfc1928.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2601662">20</a>. JEP-0127: Common Alerting Protocol (CAP) over XMPP &lt;<a href="http://www.jabber.org/jeps/jep-0127.html">http://www.jabber.org/jeps/jep-0127.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601778">21</a>. Common Alerting Protocol, v. 1.0 &lt;<a href="http://www.oasis-open.org/committees/documents.php?wg_abbrev=emergency">http://www.oasis-open.org/committees/documents.php?wg_abbrev=emergency</a>&gt;.</p>
+<p>
+<a name="nt-id2601901">22</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601921">23</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601834">24</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602061">25</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602019">26</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602168">27</a>. JEP-0143: Guidelines for JEP Authors &lt;<a href="http://www.jabber.org/jeps/jep-0143.html">http://www.jabber.org/jeps/jep-0143.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602079">28</a>. XML Schema Part 1: Structures &lt;<a href="http://www.w3.org/TR/xmlschema-1/">http://www.w3.org/TR/xmlschema-1/</a>&gt;.</p>
+<p>
+<a name="nt-id2602115">29</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2602323">30</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2602266">31</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602287">32</a>. JEP-0011: Jabber Browsing &lt;<a href="http://www.jabber.org/jeps/jep-0011.html">http://www.jabber.org/jeps/jep-0011.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602301">33</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602439">34</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602365">35</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602576">36</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602524">37</a>. RFC 3552: Guidelines for Writing RFC Text on Security Considerations &lt;<a href="http://www.ietf.org/rfc/rfc3552.txt">http://www.ietf.org/rfc/rfc3552.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602668">38</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-08-31)</h4>
+<div class="indent">Added references to several additional RFCs and JEPs. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-28)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0134-0.3.html
+++ b/content/xep-0134-0.3.html
@@ -1,0 +1,299 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0134: Protocol Design Guidelines</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Protocol Design Guidelines">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines best practices for the intelligent design of Jabber protocols and other XMPP extensions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0134">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0134: Protocol Design Guidelines</h1>
+<p>This JEP defines best practices for the intelligent design of Jabber protocols and other XMPP extensions.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0134<br>
+            Version: 0.3<br>
+            Last Updated: 2004-09-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#guidelines">Guidelines</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#xmpp">XMPP is Sacred</a>
+</dt>
+<dt>2.2.  <a href="#simple">Keep Clients Simple</a>
+</dt>
+<dt>2.3.  <a href="#reuse">Re-Use Existing Protocols</a>
+</dt>
+<dt>2.4.  <a href="#modular">Modular is Better</a>
+</dt>
+<dt>2.5.  <a href="#strengths">Know Your Strengths</a>
+</dt>
+<dt>2.6.  <a href="#explicit">Be Explicit</a>
+</dt>
+<dt>2.7.  <a href="#flexible">Stay Flexible</a>
+</dt>
+<dt>2.8.  <a href="#privacy">Privacy and Security Matter</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Extensible Messaging and Presence Protocol (XMPP) provides a solid, flexible foundation for a wide variety of applications on top of XMPP's core XML streaming technology. With the advancement of <span class="ref">XMPP Core</span>  [<a href="#nt-id2596150">1</a>] and <span class="ref">XMPP IM</span>  [<a href="#nt-id2596180">2</a>] within the Internet Standards Process, interest in building XMPP-based applications and extensions has accelerated even further. Unfortunately, not everyone who wants to build public or private XMPP extensions is familiar with the key design criteria that motivated the original developers of the Jabber technologies or that guide successful XMPP-based protocol design today. Thus there is value in attempting to translate the often-implicit knowledge held by long-time Jabber developers and protocol designers into more explicit policies and principles to which others can adhere.  [<a href="#nt-id2596019">3</a>] The end result of explicating &quot;The Jabber Way&quot; will hopefully be a wider and deeper understanding of good protocol design practices within the Jabber/XMPP community.</p>
+<h2>2.
+       <a name="guidelines">Guidelines</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="xmpp">XMPP is Sacred</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">When the <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596282">5</a>] submitted the <span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span> specifications to the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2596316">6</a>], it ceded change control over the core XML streaming technology developed by the Jabber community. However, the JSF has reserved the right to define extensions to XMPP; furthermore, that right is not exclusive to the JSF, since anyone can define their own public or private extensions to XMPP. These extensions are usually in the form of structured XML data that is qualified by a unique namespace other than those currently reserved by the IETF or the JSF.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">When we say that &quot;XMPP is Sacred&quot;, we mean that good protocol design must work within the context of XMPP and not require changes to the core protocols. For one thing, any such changes would need to be pursued within the IETF. Further, the core semantics most likely provide everything that a protocol designer needs. If you think that you need to define a new kind of top-level stanza (other than &lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt;) or a new value of the 'type' attribute for any stanza kind, then you probably need to think again. Use XMPP as a set of building blocks and don't modify the foundation when you are working on higher-level structures; instead, treat XMPP as a transport layer and build extensions on top of that layer. A further implication of respecting XMPP is using structured data formats (e.g., applications of <span class="ref">XML 1.0</span>  [<a href="#nt-id2596390">7</a>] rather than binary or plaintext formats) whenever possible. Finally, as explained in <span style="font-weight: bold">XMPP Core</span>, the &lt;presence/&gt; stanza exists to broadcast network and communications availability only; for more advanced information publishing, use <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596206">8</a>].</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">A good example of honoring the XMPP specifications is <span class="ref">Invisibility</span>  [<a href="#nt-id2596253">9</a>]; while the Jabber community had informally defined &lt;presence type='invisible'/&gt; at one point, that protocol was abandoned in favor of an XMPP-compliant approach. Another example is <span class="ref">XHTML-IM</span>  [<a href="#nt-id2595886">10</a>], which re-uses <span class="ref">XHTML 1.0</span>  [<a href="#nt-id2595905">11</a>] (a structured format that shares with XMPP a common root in XML) rather than <span class="ref">Rich Text Format (RTF)</span>  [<a href="#nt-id2595924">12</a>] (an unstructured format that does not derive from XML). Further examples are the &quot;extended presence&quot; JEPS (see <span class="ref">Extended Presence Protocol Suite</span>  [<a href="#nt-id2595948">13</a>]), which are built on top of JEP-0060 rather than overloading the &lt;presence/&gt; stanza.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="simple">Keep Clients Simple</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">Almost all Jabber technologies are implemented in a client-server architecture. While that's not necessary (and there do exist some peer-to-peer applications of XMPP), it usually makes good sense. Among other things, a client-server architecture has enabled the Jabber community to force most of the complexity onto servers and components, thus keeping clients relatively simple. This principle has served the Jabber community well since the very beginning, and forms an important basis for further innovation.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">The principle of &quot;keep clients simple&quot; has many implications, among them:</p>
+    <ul>
+      <li>Don't multiply protocols beyond necessity (the more protocols you define, the harder it is to write a client).</li>
+      <li>Degrade gracefully so that simpler or older clients can still participate in the network.</li>
+      <li>If intensive processing is required, make a server or component do it.</li>
+      <li>Don't force additional requirements (such as XSLT processors) onto clients unless absolutely necessary.</li>
+    </ul>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">One good example of keeping clients simple is the presence stanza: the client has only to send &lt;presence/&gt; and the server takes care of presence probes, broadcasts, and appropriate routing decisions. Another example is <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602305">14</a>]: although the protocol involves some complexity, it was written so that older clients can join and participate in MUC rooms even if they don't understand the more advanced MUC extensions.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="reuse">Re-Use Existing Protocols</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">The Jabber community has been developing wire protocols for XML streaming, presence, and instant messaging since 1999. In that time, members of the community have defined a number of building blocks that can be used as the basis for further development. Furthermore, many smart people have created open protocols within other standards development organizations, including the IETF, the <span class="ref">World Wide Web Consortium (W3C)</span>  [<a href="#nt-id2602269">15</a>], <span class="ref">OASIS</span>  [<a href="#nt-id2602294">16</a>], the <span class="ref">International Telecommunication Union (ITU)</span>  [<a href="#nt-id2602416">17</a>], and the <span class="ref">Dublin Core Metadata Initiative (DCMI)</span>  [<a href="#nt-id2602441">18</a>].</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">Good protocol designers &quot;stand on the shoulders of giants&quot; by re-using protocols that have been defined within the JSF and within other standards development organizations. That does not mean we don't define new protocols, because sometimes that is necessary. However, we are aware of work completed by others and we make use of it, especially when that work is outside the Jabber community's core competence areas (e.g., security or multimedia data formats rather than XML streaming, presence, and real-time messaging). Furthermore, the JSF prefers to re-use open protocols wherever possible.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">Examples of re-using existing Jabber protocols include <span class="ref">Stream Initiation</span>  [<a href="#nt-id2602379">19</a>] (which re-uses <span class="ref">Feature Negotiation</span>  [<a href="#nt-id2602540">20</a>]) and <span style="font-weight: bold">JEP-0126: Invisibility</span> (which re-uses the privacy lists protocol defined in <span style="font-weight: bold">XMPP IM</span>). Examples of re-using non-Jabber protocols include <span class="ref">SOCKS5 Bytestreams</span>  [<a href="#nt-id2602475">21</a>] (which makes use of <span class="ref">RFC 1928</span>  [<a href="#nt-id2602496">22</a>]) and <span class="ref">Common Alerting Protocol (CAP) over XMPP</span>  [<a href="#nt-id2602516">23</a>] (which defines a way to send <span class="ref">Common Alerting Protocol</span>  [<a href="#nt-id2602632">24</a>] data via Jabber). Here again JEP-0071 provides an example: it re-uses XHTML 1.0 (an open protocol developed by a recognized standards development organization) rather than RTF (a closed protocol under the control of the Microsoft Corporation).</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="modular">Modular is Better</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">Most Jabber implementations are built using modular architectures, wherein pieces of functionality are coded as separate components and then assembled into larger wholes, with core routing logic that integrates the system (examples include clients that enable the development of plugins and servers that enable the attachment of external components). We can view many Jabber protocols the same way: each one specifies a well-defined domain of functionality that is loosely connected to other domains and integrated by the core transport layer provided by XMPP.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">The best Jabber protocols are quite focused and provide limited but powerful functionality that can be applied in a specific domain or, sometimes, re-used by other Jabber protocols. Even if the domain is more complex, a protocol that addresses it needs to clearly define its scope, limit that scope as much as possible, and specify only the protocols necessary to meet the core requirements.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">
+<span class="ref">Service Discovery</span>  [<a href="#nt-id2602746">25</a>] and <span class="ref">Data Forms</span>  [<a href="#nt-id2602766">26</a>] are good examples of focused, single-purpose protocols. By contrast, <span style="font-weight: bold">Multi-User Chat</span> is more complex, but it limits itself to the domain of text conferencing in the context of virtual rooms (e.g., it does not address service-level administration) and consists of separate namespaces for end-user, moderator, and room owner functionality. A good example of a protocol that is focused on a smaller domain is <span class="ref">Roster Item Exchange</span>  [<a href="#nt-id2602681">27</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="strengths">Know Your Strengths</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">The core strength of Jabber technologies is the streaming of relatively small XML fragments between presence-aware network endpoints. As is usually the case, our greatest strength is also our greatest weakness. Thus XMPP is not optimized for binary data, large XML files, multimedia streaming, or other such applications.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">It's not a bad thing that we don't solve the problems of exchanging binary data, transferring large files, or streaming multimedia, because other protocols and technologies have addressed those domains. But it's important to recognize what we do well and what we don't. For example, the average size of an XMPP stanza is probably on the order of 200 bytes, and in general the largest effective size for stanzas is perhaps ten times that large; although stanzas can be much larger than that, normally it is not wise to consistently generate larger stanzas, and applications that might depend on large stanzas would do better to communicate their data outside of the Jabber band.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">
+<span class="ref">File Transfer</span>  [<a href="#nt-id2602904">28</a>] is a good example of respecting the strengths and weaknesses of XMPP, since it specifies that going out of band is the preferred mechanism for bandwidth-heavy data transfers.</p>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="explicit">Be Explicit</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">In the beginning was the code (mainly <span class="ref">jabberd</span>  [<a href="#nt-id2602862">29</a>]). Although code is explicit in its own way, not everyone reads code, and detailed specifications are necessary in order to make functionality reproducible in different codebases. The Jabber community has learned that lesson the hard way.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">Detailed, explicit specifications are good specifications. Define your terms. Use conformance terminology such as MUST and SHOULD rather than loose English words such as &quot;does&quot; and &quot;will&quot;. Follow the <span class="ref">Guidelines for JEP Authors</span>  [<a href="#nt-id2603012">30</a>]. Specify error conditions. Include lots of examples. Restrict the allowable XML via schemas and datatypes as specified in <span class="ref">XML Schema Part 1</span>  [<a href="#nt-id2602938">31</a>] and <span class="ref">XML Schema Part 2</span>  [<a href="#nt-id2602957">32</a>].</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">
+<span style="font-weight: bold">XMPP Core</span> and <span style="font-weight: bold">XMPP IM</span> are large documents that define the Extensible Messaging and Presence Protocol in excruciating detail. Although such specifications are not fun to write, they provide a model for good protocol design and documentation.</p>
+  </div>
+  <div class="indent">
+<h3>2.7 <a name="flexible">Stay Flexible</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">The need for explicit definition must be balanced against the need for flexibility. A completely rigid protocol may break under stress or when conditions change, whereas a more flexible protocol may bend and adapt. Knowing when to be explicit and when to be flexible is a key to good protocol design.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">In general, a protocol needs to define the skeleton of functionality, but not necessarily specific parameters or values to be used within a certain domain. In order to allow for growth and change, it often makes sense to specify that the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603166">33</a>] shall keep track of certain parameters and values, rather than to explicitly limit them in the protocol itself.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">Whereas the old <span class="ref">Agent Information</span>  [<a href="#nt-id2603110">34</a>] and <span class="ref">Jabber Browsing</span>  [<a href="#nt-id2603131">35</a>] protocols defined certain hardcoded values for entity types and categories, <span style="font-weight: bold">Service Discovery</span> has left that function up to the Jabber Registrar. Similarly, <span class="ref">Stream Initiation</span>  [<a href="#nt-id2603145">36</a>] defines a registry for its profiles, <span class="ref">Advanced Message Processing</span>  [<a href="#nt-id2603281">37</a>] defines registries for processing conditions and actions, and a number of JEPs register FORM_TYPE values as specified in <span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2603207">38</a>].</p>
+  </div>
+  <div class="indent">
+<h3>2.8 <a name="privacy">Privacy and Security Matter</a>
+</h3>
+    <p class="" style=""><span style="font-style: italic">Background</span></p>
+    <p class="" style="">Since the beginning, privacy and security have been important priorities within the Jabber community. That must not change.</p>
+    <p class="" style=""><span style="font-style: italic">Meaning</span></p>
+    <p class="" style="">Good protocols respect the confidentiality of data generated or communicated by users and applications as well as the security of the system or network as a whole. Although privacy and security considerations have been dealt with at the core XMPP layer, application-level protocols must not compromise privacy and security. Attention to these matters, along with rigorous cross-area review and close scrutiny by protocol designers (in the form of the <span class="ref">Jabber Council</span>  [<a href="#nt-id2603388">39</a>] and <span class="ref">Standards JIG</span>  [<a href="#nt-id2603416">40</a>]), will help ensure that the protocols we develop will provide a strong foundation for communication over the Internet.</p>
+    <p class="" style=""><span style="font-style: italic">Examples</span></p>
+    <p class="" style="">As is well-known, the presence subscription model developed by the Jabber community and specified in <span style="font-weight: bold">XMPP IM</span> requires approval before a contact can view a user's presence. Similarly, Jabber has always included strong authentication methods, which have been further improved through the use of SASL (<span class="ref">RFC 2222</span>  [<a href="#nt-id2603342">41</a>]).</p>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns directly related to this proposal, which is informational in nature. However, as discussed above, protocols that are developed following these guidelines should appropriately address privacy and security considerations. Helpful guidelines for security in relation to Internet protocol design can be found in <span class="ref">RFC 3552</span>  [<a href="#nt-id2603527">42</a>].</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603476">43</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the Jabber Registrar.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596150">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596180">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596019">3</a>. For more general insights into Internet protocol design, see <span class="ref">RFC 3117</span>  [<a href="#nt-id2596088">4</a>].</p>
+<p>
+<a name="nt-id2596088">4</a>. RFC 3117: On the Design of Application Protocols &lt;<a href="http://www.ietf.org/rfc/rfc3117.txt">http://www.ietf.org/rfc/rfc3117.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596282">5</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596316">6</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596390">7</a>. Extensible Markup Language (XML) 1.0 (Third Edition) &lt;<a href="http://www.w3.org/TR/REC-xml/">http://www.w3.org/TR/REC-xml/</a>&gt;.</p>
+<p>
+<a name="nt-id2596206">8</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596253">9</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595886">10</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595905">11</a>. XHTML 1.0 &lt;<a href="http://www.w3.org/TR/xhtml1">http://www.w3.org/TR/xhtml1</a>&gt;.</p>
+<p>
+<a name="nt-id2595924">12</a>. Rich Text Format (RTF) Version 1.5 Specification &lt;<a href="http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp">http://msdn.microsoft.com/library/en-us/dnrtfspec/html/rtfspec.asp</a>&gt;.</p>
+<p>
+<a name="nt-id2595948">13</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602305">14</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602269">15</a>. The World Wide Web Consortium defines data formats and markup languages (such as HTML and XML) for use over the Internet. For further information, see &lt;<a href="http://www.w3.org/">http://www.w3.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602294">16</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602416">17</a>. The International Telecommunication Union develops technical and operating standards (such as H.323) for international telecommunication services. For further information, see &lt;<a href="http://www.itu.int/">http://www.itu.int/</a>&gt;.</p>
+<p>
+<a name="nt-id2602441">18</a>. The Dublin Core Metadata Initiative (DCMI) is an organization dedicated to promoting the widespread adoption of interoperable metadata standards. For further information, see &lt;<a href="http://www.dublincore.org/">http://www.dublincore.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602379">19</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602540">20</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602475">21</a>. JEP-0065: SOCKS5 Bytestreams &lt;<a href="http://www.jabber.org/jeps/jep-0065.html">http://www.jabber.org/jeps/jep-0065.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602496">22</a>. RFC 1928: SOCKS Protocol Version 5 &lt;<a href="http://www.ietf.org/rfc/rfc1928.txt">http://www.ietf.org/rfc/rfc1928.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602516">23</a>. JEP-0127: Common Alerting Protocol (CAP) over XMPP &lt;<a href="http://www.jabber.org/jeps/jep-0127.html">http://www.jabber.org/jeps/jep-0127.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602632">24</a>. Common Alerting Protocol, v. 1.0 &lt;<a href="http://www.oasis-open.org/committees/documents.php?wg_abbrev=emergency">http://www.oasis-open.org/committees/documents.php?wg_abbrev=emergency</a>&gt;.</p>
+<p>
+<a name="nt-id2602746">25</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602766">26</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602681">27</a>. JEP-0144: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0144.html">http://www.jabber.org/jeps/jep-0144.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602904">28</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602862">29</a>. The jabberd server is the original server implementation of the Jabber protocols, first developed by Jeremie Miller, inventor of Jabber. For further information, see &lt;<a href="http://jabberd.jabberstudio.org/">http://jabberd.jabberstudio.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603012">30</a>. JEP-0143: Guidelines for JEP Authors &lt;<a href="http://www.jabber.org/jeps/jep-0143.html">http://www.jabber.org/jeps/jep-0143.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602938">31</a>. XML Schema Part 1: Structures &lt;<a href="http://www.w3.org/TR/xmlschema-1/">http://www.w3.org/TR/xmlschema-1/</a>&gt;.</p>
+<p>
+<a name="nt-id2602957">32</a>. XML Schema Part 2: Datatypes &lt;<a href="http://www.w3.org/TR/xmlschema-2/">http://www.w3.org/TR/xmlschema-2/</a>&gt;.</p>
+<p>
+<a name="nt-id2603166">33</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2603110">34</a>. JEP-0094: Agent Information &lt;<a href="http://www.jabber.org/jeps/jep-0094.html">http://www.jabber.org/jeps/jep-0094.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603131">35</a>. JEP-0011: Jabber Browsing &lt;<a href="http://www.jabber.org/jeps/jep-0011.html">http://www.jabber.org/jeps/jep-0011.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603145">36</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603281">37</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603207">38</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603388">39</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p>
+<a name="nt-id2603416">40</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p>
+<a name="nt-id2603342">41</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603527">42</a>. RFC 3552: Guidelines for Writing RFC Text on Security Considerations &lt;<a href="http://www.ietf.org/rfc/rfc3552.txt">http://www.ietf.org/rfc/rfc3552.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603476">43</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2004-09-29)</h4>
+<div class="indent">Added note about presence vs. pubsub. (psa)
+    </div>
+<h4>Version 0.2 (2004-08-31)</h4>
+<div class="indent">Added references to several additional RFCs and JEPs. (psa)
+    </div>
+<h4>Version 0.1 (2004-04-28)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0136-0.1.html
+++ b/content/xep-0136-0.1.html
@@ -1,0 +1,272 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0136: Message Archiving</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Archiving">
+<meta name="DC.Creator" content="Justin Karneges">
+<meta name="DC.Description" content="This JEP defines a storage protocol and common disk format for archiving of messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-06-04">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0136">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0136: Message Archiving</h1>
+<p>This JEP defines a storage protocol and common disk format for archiving of messages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0136<br>
+            Version: 0.1<br>
+            Last Updated: 2004-06-04<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: archive<br>
+</p>
+<h2>Author Information</h2>
+<h3>Justin Karneges</h3>
+<p class="indent">
+        Email: justin@affinix.com<br>
+        JID: justin@andbit.net</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2595992">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2596015">Storing Messages</a>
+</dt>
+<dt>3.  <a href="#sect-id2596244">Retrieving Messages</a>
+</dt>
+<dt>4.  <a href="#sect-id2596366">File Format</a>
+</dt>
+<dt>5.  <a href="#sect-id2601942">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2601963">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2595992">Introduction</a>
+</h2>
+  <p class="" style="">This specification defines a protocol for storing and retrieving messages on a server.  Each storage item consists of a collection of messages, usually the message thread.  Clients are able to add/update/remove items from the server.  A disk format is also specified, so that IM clients can share message archive files, similar in the way that email clients share common formats like mbox and Maildir.</p>
+<h2>2.
+       <a name="sect-id2596015">Storing Messages</a>
+</h2>
+  <p class="" style="">All messages are stored in a message collection.  The client specifies whether or not a message is part of a new collection by using a 'cid' (collection ID).  If the 'cid' is omitted (unspecified), then a new collection is to be started.  If the 'cid' is present, then it indicates to the server that the message is to be appended to an existing collection.  Messages are encapsulated in the &lt;archive&gt; element.  The message MUST have a 'from' or a 'to' attribute that is not the same JID as the client, and MUST contain a &lt;body&gt; element (other elements MAY be stored).  A 'name' attribute of &lt;archive&gt; MAY be provided, which specifies a friendly name for this message collection.  If the specified collection already has a name, then it is simply replaced.</p>
+  <p class="caption">Example 1. Storing a message in a new collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' id='a1' to='server'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive' name='Battle for today'&gt;
+    &lt;message xmlns='jabber:client' from='zz@boyzzbrigade.org/hideout'&gt;
+      &lt;body&gt;It's laser time!&lt;/body&gt;
+    &lt;/message&gt;
+  &lt;/archive&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The server will then set up a session for this message collection, and return a suitable 'cid' for the client to use in future requests.</p>
+  <p class="caption">Example 2. Successful server reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a1' to='client'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive'
+    cid='fasdingainbadnfknbdlfnkalfknbldnfnnlq'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">Subsequent requests MUST be 'from' or 'to' the same bare-JID as the first:</p>
+  <p class="caption">Example 3. Storing another message in this collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' id='a2' to='server'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive'
+    cid='fasdingainbadnfknbdlfnkalfknbldnfnnlq'&gt;
+      &lt;message xmlns='jabber:client' from='zz@boyzzbrigade.org/hideout'&gt;
+        &lt;body&gt;Put on the 3D shades.&lt;/body&gt;
+      &lt;/message&gt;
+  &lt;/archive&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The reply from the server does not need to specify the cid in this case:</p>
+  <p class="caption">Example 4. Successful server reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a2' to='client'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">It is also possible to simply rename the collection:</p>
+  <p class="caption">Example 5. Renaming this collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' id='a3' to='server'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive'
+    cid='fasdingainbadnfknbdlfnkalfknbldnfnnlq' name='Battle in 3D!&quot;/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 6. Successful server reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a3' to='client'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">In all types of requests, it is possible that the server might not be able to service it.  In that case, it MUST return a Not Acceptable error:</p>
+  <p class="caption">Example 7. Successful server reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' id='a1' to='client'&gt;
+  &lt;error code='406' type='auth'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">When a client is finished recording messages for a given collection, it SHOULD send a &lt;done&gt; element.  The server MAY assume a collection is finished based on a timeout or if the client is disconnected.</p>
+  <p class="caption">Example 8. Closing a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' id='a4' to='server'&gt;
+  &lt;done xmlns='http://jabber.org/protocol/archive'
+    cid='fasdingainbadnfknbdlfnkalfknbldnfnnlq'/&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>3.
+       <a name="sect-id2596244">Retrieving Messages</a>
+</h2>
+  <p class="" style="">Retrieving messages consists of two steps: 1) Obtaining a list of collections, and 2) Downloading the collection.</p>
+  <p class="" style="">To request a list of collection items, use the &lt;archive&gt; element.  The 'start' and 'end' elements can be specified to indicate a date range for the items that the client is interested in.  If only 'start' is provided, then all items after that date should be returned.  If only 'end' is provided, then all items prior to that date should be returned.  If neither attribute is provided, then all items are to be returned.</p>
+  <p class="caption">Example 9. Requesting items</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' id='a1' to='server'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive' start='20040426T00:00:00'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 10. Server reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a1' to='client'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item
+      cid='asdfsdfjsdjfsjdkfjsdjfskdjfdsfjdskfjd'
+      jid='ceo@example.com'
+      name='Meeting from yesterday'
+      start='20020910T23:08:25'
+      end='20020910T23:09:25'/&gt;
+    &lt;item
+      cid='fasdingainbadnfknbdlfnkalfknbldnfnnlq'
+      jid='zz@boyzzbrigade.org'
+      name='Battle in 3D!'
+      start='20020912T23:08:25'
+      end='20020912T23:09:25'/&gt;
+    &lt;item
+      cid='hufgipqjrejbxzcnnsheqegoppgppadnbnndd'
+      jid='hotgirl@classmates.com'
+      name='Hey what is up?  I have not seen you in a long time.  How are ...'
+      start='20020913T23:08:25'
+      end='20020913T23:09:25'/&gt;
+  &lt;/archive&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">Each item in the reply has a 'cid' (same as the one used during the storage process), the bare-JID with which the messages were exchanged, a 'name' (also indicated during the storage process, otherwise it is a preview generated from the collection text), and the start and end dates of the collection.</p>
+  <p class="" style="">At this point, the client can now request a collection:</p>
+  <p class="caption">Example 11. Requesting a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' id='a2' to='server'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive'
+    cid='fasdingainbadnfknbdlfnkalfknbldnfnnlq'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 12. Server reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a2' to='client'&gt;
+  &lt;archive xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;message xmlns='jabber:client' from='zz@boyzzbrigade.org/hideout'&gt;
+      &lt;body&gt;It's laser time!&lt;/body&gt;
+    &lt;/message&gt;
+    &lt;message xmlns='jabber:client' from='zz@boyzzbrigade.org/hideout'&gt;
+      &lt;body&gt;Put on the 3D shades.&lt;/body&gt;
+    &lt;/message&gt;
+  &lt;/archive&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>4.
+       <a name="sect-id2596366">File Format</a>
+</h2>
+  <p class="" style="">The file format uses the same XML constructs as the protocol.</p>
+  <p class="caption">Example 13. Example file</p>
+<div class="indent"><pre>
+    
+&lt;?xml version='1.0'?&gt;
+&lt;archive xmlns='http://jabber.org/protocol/archive'&gt;
+  &lt;item
+    cid='fasdingainbadnfknbdlfnkalfknbldnfnnlq'
+    jid='zz@boyzzbrigade.org'
+    name='Battle in 3D!'
+    start='20020912T23:08:25'
+    end='20020912T23:09:25'/&gt;
+      &lt;message xmlns='jabber:client' from='zz@boyzzbrigade.org/hideout'&gt;
+        &lt;body&gt;It's laser time!&lt;/body&gt;
+      &lt;/message&gt;
+      &lt;message xmlns='jabber:client' from='zz@boyzzbrigade.org/hideout'&gt;
+        &lt;body&gt;Put on the 3D shades.&lt;/body&gt;
+      &lt;/message&gt;
+      [...]
+      &lt;message/&gt;
+  &lt;/item&gt;
+  &lt;item/&gt;
+  &lt;item/&gt;
+  &lt;item/&gt;
+  [...]
+  &lt;item/&gt;
+&lt;/archive&gt;
+</pre></div>
+  <p class="" style="">Any number of items may be stored in an archive file.  For efficiency, it is recommended that implementations spread out the items across many files (such as through a log rotation facility).</p>
+<h2>5.
+       <a name="sect-id2601942">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602060">1</a>] is required as a result of this JEP.</p>
+<h2>6.
+       <a name="sect-id2601963">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602002">2</a>] shall register the 'http://jabber.org/protocol/archive' namespace as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2602060">1</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602002">2</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-06-04)</h4>
+<div class="indent">Initial version. (jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0136-0.2.html
+++ b/content/xep-0136-0.2.html
@@ -1,0 +1,425 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0136: Message Archiving</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Archiving">
+<meta name="DC.Creator" content="Justin Karneges">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This JEP defines a storage protocol and common disk format for archiving of messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0136">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0136: Message Archiving</h1>
+<p>This JEP defines a storage protocol and common disk format for archiving of messages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0136<br>
+            Version: 0.2<br>
+            Last Updated: 2005-04-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: archive<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Justin Karneges</h3>
+<p class="indent">
+        Email: justin@affinix.com<br>
+        JID: justin@andbit.net</p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#sect-id2251522">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2251584">Concepts</a>
+</dt>
+<dt>3.  <a href="#sect-id2251375">Determining Server Support</a>
+</dt>
+<dt>4.  <a href="#sect-id2251443">Storing Messages</a>
+</dt>
+<dt>5.  <a href="#sect-id2250568">Retrieving a Collection</a>
+</dt>
+<dt>6.  <a href="#sect-id2255877">Removing Collections</a>
+</dt>
+<dt>7.  <a href="#sect-id2255975">Obtaining a List of Collections</a>
+</dt>
+<dt>8.  <a href="#sect-id2256062">Encryption</a>
+</dt>
+<dt>9.  <a href="#sect-id2256369">File Format</a>
+</dt>
+<dt>10.  <a href="#sect-id2256393">Implementation Notes</a>
+</dt>
+<dt>11.  <a href="#sect-id2256511">Privacy Considerations</a>
+</dt>
+<dt>12.  <a href="#sect-id2256567">Known Issues</a>
+</dt>
+<dt>13.  <a href="#sect-id2256591">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#sect-id2256654">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2251522">Introduction</a>
+</h2>
+  <p class="" style="">Historically, clients have archived messages in local storage. However, that is clearly inconvenient for people who use more than one client machine (home, work, mobile) and whenever people upgrade to a new machine. Furthermore, security and resource limitations often prevent clients that run in constrained environments from accessing (sufficient) local storage.</p>
+  <p class="" style="">This specification defines a protocol for storing and retrieving messages on a server. Each storage item consists of a collection of messages. This is usually a message thread. Clients are able to add/update/remove collections from the server. This document also specifies a disk format. This allows clients to share message archive files, in a way similar to email clients sharing common formats like mbox and Maildir.</p>
+  <p class="" style="">A server autoarchiving approach would have eliminated the need to submit collections to the server. However, this specification empowers clients instead. This approach enables them to store out-of-band messages like email as well. Also, since end-to-end encryption schemes typically use evanescent keys that are discarded immediately after use, server autoarchived encrypted messages would not be decryptable.</p>
+  <p class="" style="">The protocol is designed to minimise the size of collections. This is necessary to mitigate the memory and bandwidth limitations of constrained clients and to alleviate karma issues.</p>
+<h2>2.
+       <a name="sect-id2251584">Concepts</a>
+</h2>
+  <p class="" style="">Messages are stored in message collections on the server. The client uniquely specifies a collection using the pair of attributes: 'with' (bare JID with which the messages were exchanged) and 'start' (thread start-time).</p>
+  <p class="" style="">The content of each individual message MUST be encapsulated in a &lt;to/&gt; or &lt;from/&gt; element. The time in seconds of the message relative to the start-time of the collection SHOULD be specified with a 'secs' attribute. The content SHOULD include a &lt;body/&gt; element. Other elements MAY be included, but they are NOT RECOMMENDED. To conserve bandwidth and storage, elements scoped by the 'http://jabber.org/protocol/xhtml-im' namespace SHOULD NOT be included. &lt;thread/&gt; elements and elements scoped by the 'jabber:x:delay', 'jabber:x:event' and 'http://jabber.org/protocol/chatstates' namespaces MUST NOT be included.</p>
+  <p class="" style="">Complying with <span style="font-weight: bold">XMPP Core</span>, the server MUST respond to all &lt;iq/&gt; elements. However, most 'successful' reponses have been omitted from this document in the interest of conciseness.</p>
+  <p class="" style="">All times MUST be in the UTC time zone.</p>
+<h2>3.
+       <a name="sect-id2251375">Determining Server Support</a>
+</h2>
+  <p class="" style="">The client discovers whether the server supports this protocol using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251411">1</a>].</p>
+  <p class="caption">Example 1. Client Service Discovery request</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the server supports this protocol, it MUST return a &lt;feature/&gt; element in the result with the 'var' attribute set to 'http://jabber.org/protocol/archive'.</p>
+  <p class="caption">Example 2. Server Service Discovery response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result'
+    from='montague.net'
+    to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/archive'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>4.
+       <a name="sect-id2251443">Storing Messages</a>
+</h2>
+  <p class="" style="">The messages to be stored are encapsulated in the &lt;store/&gt; element.</p>
+  <p class="caption">Example 3. Storing messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST create a new collection. If the collection already exists then the server MUST append the messages to the existing collection.</p>
+  <p class="" style="">A friendly name for the collection MAY be specified with a 'subject' attribute. If the collection already has a 'subject' then it is simply replaced.</p>
+  <p class="caption">Example 4. Successful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' to='romeo@montague.net/orchard'/&gt;
+</pre></div>
+  <p class="" style="">If the server cannot service a store request because the collection is too large then it MUST return a Not Acceptable error:</p>
+  <p class="caption">Example 5. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client MAY specify an absolute time for any message by providing a longer 'utc' attribute instead of a 'secs' attribute:</p>
+  <p class="caption">Example 6. Storing offline messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from utc='1469-07-21T00:32:29Z'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client SHOULD include the 'name' attribute to specify the 'resource' of all messages that it received from a room:</p>
+  <p class="caption">Example 7. Storing groupchat messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='balcony@house.capulet.com'
+         start='1469-07-21T03:16:37Z'&gt;
+    &lt;from secs='0' name='benvolio'&gt;&lt;body&gt;She will indite him to some supper.&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='5' name='mercutio'&gt;&lt;body&gt;A bawd, a bawd, a bawd! So ho!&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='11' name='romeo'&gt;&lt;body&gt;What hast thou found?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>5.
+       <a name="sect-id2250568">Retrieving a Collection</a>
+</h2>
+  <p class="" style="">The client sends an empty &lt;retrieve/&gt; element to request the download of a collection:</p>
+  <p class="caption">Example 8. Requesting a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com'
+            start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 9. Receiving a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST return a Not Found error:</p>
+  <p class="caption">Example 10. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>6.
+       <a name="sect-id2255877">Removing Collections</a>
+</h2>
+  <p class="" style="">To request the removal of a collection the client sends an empty &lt;remove/&gt; element.</p>
+  <p class="caption">Example 11. Removing a single collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST return a Not Found error:</p>
+  <p class="caption">Example 12. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client may remove several collections at once. The 'start' and 'end' elements MAY be specified to indicate a date range.</p>
+  <p class="caption">Example 13. Removing all collections with a specified JID between two times</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+   <p class="" style="">If the 'with' attribute is omitted then collections with any JID are removed. If only 'start' is specified then all collections after that date should be removed. If only 'end' is specified then all collections prior to that date should be removed.</p>
+  <p class="caption">Example 14. Removing all collections</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>7.
+       <a name="sect-id2255975">Obtaining a List of Collections</a>
+</h2>
+  <p class="" style="">To request a list of collections the client sends an empty &lt;list/&gt; element. The 'start' and 'end' elements MAY be specified to indicate a date range.</p>
+  <p class="" style="">If the 'with' attribute is omitted then collections with any JID are returned. If only 'start' is specified then all collections after that date should be returned. If only 'end' is specified then all collections prior to that date should be returned.</p>
+  <p class="caption">Example 15. Requesting a list</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'
+        start='1469-07-21T02:00:00Z'
+        end='1479-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 16. Requesting a list of all collections with a JID</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client MAY limit the number of items returned by the server with the 'maxitems' attribute.</p>
+  <p class="caption">Example 17. Requesting a list of all collections</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        maxitems='50'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 18. Receiving a list</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'/&gt;
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    ...
+  &lt;/list&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>8.
+       <a name="sect-id2256062">Encryption</a>
+</h2>
+  <p class="" style="">Most of the examples in this document are not encrypted for clarity. However, this protocol strongly RECOMMENDS the encryption of all collections.</p>
+  <p class="" style="">To generate a secret symmetric encryption key, K, and an RSA-encrypted version of the key, C, the client SHOULD use the RSA-KEM key encapsulation mechanism (see ISO 18033-2) along with the user's public RSA key.</p>
+  <p class="" style="">The client SHOULD encrypt the complete sequence of &lt;from/&gt; and &lt;to/&gt; elements, M, that it wants to store with the encryption key, K, and a randomly generated public label, L, employing the DEM1 data encapsulation mechanism with the SC2 symmetric encryption algorithm (see ISO 18033-2).</p>
+  <p class="" style="">Note that the client MAY use same key, K, for more than one collection. But it MUST use the label, L, with only one plain text, M.</p>
+  <p class="" style="">The client SHOULD base64 encode the encrypted messages, wrap them in a single &lt;crypt/&gt; element and set the 'label' attribute to the base64 encoded random label L.</p>
+  <p class="" style="">The client MUST set the 'keyalg=' attribute of the &lt;store/&gt; element to 'RSA-KEM-KDF2-SHA256' and the 'dataalg' attribute to 'DEM1-SC2-SHA256'. The 'key' attribute MUST also be set to the base64 encoded encrypted version of the key, C.</p>
+  <p class="caption">Example 19. Storing encrypted messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'&gt;
+    &lt;crypt label='VROLURBVEFDb3JwU0dDL'&gt;E5Qbvfa2gI5lBZMAHryv4g+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/crypt&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The NESSIE-recommended RSA-KEM (with KDF2/SHA-256) key encapsulation scheme (see ISO 18033-2 at http://www.shoup.net/iso/std5.pdf, or ANSI-X9.44) was specified because its security is tightly proven (unlike RSA-OAEP or PKCS #1 v1.5) and it is very simple to implement.</p>
+  <p class="" style="">The SHA-256 hash was specified since SHA-1 is broken (assuming the attacker has plenty of computing power). Other standard hashes are not optimised for 32-bit processors (e.g. Whirlpool, SHA-384, SHA-512).</p>
+  <p class="" style="">The client SHOULD support the mechanisms specified in this document. The client MAY support other mechanisms. Future versions of this document MAY be modified to recommend other mechanisims.</p>
+  <p class="" style="">The mechanisms for the publishing of public keys and the storage and retrieval of private keys are beyond the scope of this document. A future JEP will specify how clients may do this in an interoperable way.</p>
+<h2>9.
+       <a name="sect-id2256369">File Format</a>
+</h2>
+  <p class="" style="">The file format uses the same XML constructs as the protocol. Each file may contain messages exchanged with a single JID. Any number of items may be stored in an archive file.</p>
+  <p class="caption">Example 20. Example file</p>
+<div class="indent"><pre>
+    
+&lt;?xml version='1.0'?&gt;
+&lt;archive xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'&gt;
+  &lt;store start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+  &lt;store start='1469-07-21T09:56:15Z'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'&gt;
+    &lt;crypt label='VROLURBVEFDb3JwU0dDL'&gt;E5Qbvfa2gI5lBZMAHryv4g+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/crypt&gt;
+  &lt;/store&gt;
+  &lt;store start='1469-07-23T23:08:25Z'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='VQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxITAfBgNVBAsTGGh0dHA6Ly93d3cu'&gt;
+    &lt;crypt label='nVzdC5jb20xGzAZBgNVB'&gt;j98C5OBxOvG0I3KgqgHf35g+FFCgMSa9KOlaMCZ1+XtgHI3zzVAmbQQnmt/VDUVHQ2AswkDwf9c3V6aPryuvEeKaq&lt;/crypt&gt;
+  &lt;/store&gt;
+&lt;/archive&gt;
+</pre></div>
+<h2>10.
+       <a name="sect-id2256393">Implementation Notes</a>
+</h2>
+  <p class="" style="">Clients should not store one message at a time on the server since this increases both bandwidth consumption and the total number of transactions. It is instead RECOMMENDED that clients store messages only when the conversation thread appears to be terminated, i.e. when the user closes the chat window. If the user reopens the window and the thread continues then the client should append the new messages to the collection when the user closes the window again.</p>
+  <p class="" style="">When appending messages to a collection clients SHOULD try to ensure that the total size of the collection will not exceed karma limits when it is retrieved later. This may be achieved by starting a new collection whenever a message thread becomes too long.</p>
+  <p class="" style="">It is RECOMMENDED that the client synchronises all the times it sends to the server with server time. The client can achieve this using <span class="ref" style="">Entity Time</span>  [<a href="#nt-id2256495">2</a>] to estimate the difference between the server and client clocks.</p>
+  <p class="" style="">Server implementations SHOULD give system administrators the option to disable support for this protocol since archived conversations can consume significant storage space.</p>
+<h2>11.
+       <a name="sect-id2256511">Privacy Considerations</a>
+</h2>
+  <p class="" style="">The client that originates a message MAY specify a 'false' value for the 'store' header (see <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2256549">3</a>]). The recipient MUST NOT archive such a message or any of the information it contains. If the sender plans to use 'store' headers it MUST use Service Discovery to determine whether or not the recipient supports them. If not, the sender MUST warn its human user (if any) before sending the message.</p>
+<h2>12.
+       <a name="sect-id2256567">Known Issues</a>
+</h2>
+  <p class="" style="">The subject of each collection is not encrypted (like S/MIME?). The client MUST warn its human user (if any) before including 'subject' attributes on encrypted collections.</p>
+  <p class="" style="">Servers will not be able to search the content of encrypted collections.</p>
+  <p class="" style="">The 'Encryption' section is a work in progress.</p>
+<h2>13.
+       <a name="sect-id2256591">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256618">4</a>] is required as a result of this JEP.</p>
+<h2>14.
+       <a name="sect-id2256654">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256674">5</a>] shall register the 'http://jabber.org/protocol/archive' namespace as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251411">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256495">2</a>. JEP-0090: Entity Time &lt;<a href="http://www.jabber.org/jeps/jep-0090.html">http://www.jabber.org/jeps/jep-0090.html</a>&gt;.</p>
+<p><a name="nt-id2256549">3</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2256618">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256674">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-04-18)</h4>
+<div class="indent">Complete rewrite. (ip)
+    </div>
+<h4>Version 0.1 (2004-06-04)</h4>
+<div class="indent">Initial version. (jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0136-0.3.html
+++ b/content/xep-0136-0.3.html
@@ -1,0 +1,450 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0136: Message Archiving</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Archiving">
+<meta name="DC.Creator" content="Justin Karneges">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This JEP defines a storage protocol and common disk format for archiving of messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0136">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0136: Message Archiving</h1>
+<p>This JEP defines a storage protocol and common disk format for archiving of messages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0136<br>
+            Version: 0.3<br>
+            Last Updated: 2005-10-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: archive<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Message%20Archiving%20(JEP-0136)">http://wiki.jabber.org/index.php/Message Archiving (JEP-0136)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Justin Karneges</h3>
+<p class="indent">
+        Email: justin@affinix.com<br>
+        JID: justin@andbit.net</p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#sect-id2251612">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2251674">Concepts</a>
+</dt>
+<dt>3.  <a href="#sect-id2250547">Determining Server Support</a>
+</dt>
+<dt>4.  <a href="#sect-id2250612">Storing Messages</a>
+</dt>
+<dt>5.  <a href="#sect-id2250752">Retrieving a Collection</a>
+</dt>
+<dt>6.  <a href="#sect-id2256231">Removing Collections</a>
+</dt>
+<dt>7.  <a href="#sect-id2256384">Obtaining a List of Collections</a>
+</dt>
+<dt>8.  <a href="#sect-id2256471">Encryption</a>
+</dt>
+<dt>9.  <a href="#sect-id2256641">File Format</a>
+</dt>
+<dt>10.  <a href="#sect-id2256666">Implementation Notes</a>
+</dt>
+<dt>11.  <a href="#sect-id2256783">Privacy Considerations</a>
+</dt>
+<dt>12.  <a href="#sect-id2256806">Known Issues</a>
+</dt>
+<dt>13.  <a href="#sect-id2256867">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#sect-id2256890">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2251612">Introduction</a>
+</h2>
+  <p class="" style="">Historically, clients have archived messages in local storage. However, that is clearly inconvenient for people who use more than one client machine (home, work, mobile) and whenever people upgrade to a new machine. Furthermore, security and resource limitations often prevent clients that run in constrained environments from accessing (sufficient) local storage.</p>
+  <p class="" style="">This specification defines a protocol for storing and retrieving messages on a server. Each storage item consists of a collection of messages. This is usually a message thread. Clients are able to add/update/remove collections from the server. This document also specifies a disk format. This allows clients to share message archive files, in a way similar to email clients sharing common formats like mbox and Maildir.</p>
+  <p class="" style="">A server autoarchiving approach would have eliminated the need to submit collections to the server. However, this specification empowers clients instead. This approach enables them to store out-of-band messages like email as well. Also, since end-to-end encryption schemes typically use evanescent keys that are discarded immediately after use, server autoarchived encrypted messages would not be decryptable.</p>
+  <p class="" style="">The protocol is designed to minimise the size of collections. This is necessary to mitigate the memory and bandwidth limitations of constrained clients and to alleviate karma issues.</p>
+<h2>2.
+       <a name="sect-id2251674">Concepts</a>
+</h2>
+  <p class="" style="">Messages are stored in message collections on the server. The client uniquely specifies a collection using the pair of attributes: 'with' (bare JID with which the messages were exchanged) and 'start' (thread start-time).</p>
+  <p class="" style="">The content of each individual message MUST be encapsulated in a &lt;to/&gt; or &lt;from/&gt; element. The time in seconds of the message relative to the start-time of the collection SHOULD be specified with a 'secs' attribute. The content SHOULD include a &lt;body/&gt; element. Other elements MAY be included, but they are NOT RECOMMENDED. To conserve bandwidth and storage, elements scoped by the 'http://jabber.org/protocol/xhtml-im' namespace SHOULD NOT be included. &lt;thread/&gt; elements and elements scoped by the 'jabber:x:delay', 'jabber:x:event' and 'http://jabber.org/protocol/chatstates' namespaces MUST NOT be included.</p>
+  <p class="" style="">Complying with <span style="font-weight: bold">XMPP Core</span>, the server MUST respond to all &lt;iq/&gt; elements. However, most 'successful' reponses have been omitted from this document in the interest of conciseness.</p>
+  <p class="" style="">All times MUST be in the UTC time zone.</p>
+<h2>3.
+       <a name="sect-id2250547">Determining Server Support</a>
+</h2>
+  <p class="" style="">The client discovers whether the server supports this protocol using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250582">1</a>].</p>
+  <p class="caption">Example 1. Client Service Discovery request</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the server supports this protocol, it MUST return a &lt;feature/&gt; element in the result with the 'var' attribute set to 'http://jabber.org/protocol/archive'.</p>
+  <p class="caption">Example 2. Server Service Discovery response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result'
+    from='montague.net'
+    to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/archive'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>4.
+       <a name="sect-id2250612">Storing Messages</a>
+</h2>
+  <p class="" style="">The messages to be stored are encapsulated in the &lt;store/&gt; element.</p>
+  <p class="caption">Example 3. Storing messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST create a new collection. If the collection already exists then the server MUST append the messages to the existing collection.</p>
+  <p class="" style="">A friendly name for the collection MAY be specified with a 'subject' attribute. If the collection already has a 'subject' then it is simply replaced.</p>
+  <p class="caption">Example 4. Successful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' to='romeo@montague.net/orchard'/&gt;
+</pre></div>
+  <p class="" style="">If the server cannot service a store request because the collection is too large then it MUST return a Not Acceptable error:</p>
+  <p class="caption">Example 5. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client MAY specify an absolute time for any message by providing a longer 'utc' attribute instead of a 'secs' attribute:</p>
+  <p class="caption">Example 6. Storing offline messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from utc='1469-07-21T00:32:29Z'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client SHOULD include the 'name' attribute to specify the 'resource' of all messages that it received from a room:</p>
+  <p class="caption">Example 7. Storing groupchat messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='balcony@house.capulet.com'
+         start='1469-07-21T03:16:37Z'&gt;
+    &lt;from secs='0' name='benvolio'&gt;&lt;body&gt;She will indite him to some supper.&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='5' name='mercutio'&gt;&lt;body&gt;A bawd, a bawd, a bawd! So ho!&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='11' name='romeo'&gt;&lt;body&gt;What hast thou found?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>5.
+       <a name="sect-id2250752">Retrieving a Collection</a>
+</h2>
+  <p class="" style="">The client sends an empty &lt;retrieve/&gt; element to request the download of a collection:</p>
+  <p class="caption">Example 8. Requesting a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com'
+            start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 9. Receiving a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST return a Not Found error:</p>
+  <p class="caption">Example 10. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>6.
+       <a name="sect-id2256231">Removing Collections</a>
+</h2>
+  <p class="" style="">To request the removal of a collection the client sends an empty &lt;remove/&gt; element.</p>
+  <p class="caption">Example 11. Removing a single collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST return a Not Found error:</p>
+  <p class="caption">Example 12. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client may remove several collections at once. The 'start' and 'end' elements MAY be specified to indicate a date range.</p>
+  <p class="caption">Example 13. Removing all collections with a specified JID between two times</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+   <p class="" style="">If the 'with' attribute is omitted then collections with any JID are removed.</p>
+   <p class="" style="">If the end date is in the future then then all collections after the start date are removed.</p>
+  <p class="caption">Example 14. Removing all collections after a date</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='1469-07-21T02:00:00Z'
+          end='2038-01-01T00:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+   <p class="" style="">If the start date is in the past then all collections prior to the end date are removed.</p>
+  <p class="caption">Example 15. Removing all collections before a date</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='0000-01-01T00:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 16. Removing all collections</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>7.
+       <a name="sect-id2256384">Obtaining a List of Collections</a>
+</h2>
+  <p class="" style="">To request a list of collections the client sends an empty &lt;list/&gt; element. The 'start' and 'end' elements MAY be specified to indicate a date range.</p>
+  <p class="" style="">If the 'with' attribute is omitted then collections with any JID are returned. If only 'start' is specified then all collections after that date should be returned. If only 'end' is specified then all collections prior to that date should be returned.</p>
+  <p class="caption">Example 17. Requesting a list</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'
+        start='1469-07-21T02:00:00Z'
+        end='1479-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 18. Requesting a list of all collections with a JID</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client MAY limit the number of items returned by the server with the 'maxitems' attribute.</p>
+  <p class="caption">Example 19. Requesting a list of all collections</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        maxitems='50'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 20. Receiving a list</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'/&gt;
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    ...
+  &lt;/list&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>8.
+       <a name="sect-id2256471">Encryption</a>
+</h2>
+  <p class="" style="">Most of the examples in this document are not encrypted for clarity. However, this protocol strongly RECOMMENDS the encryption of all collections.</p>
+  <p class="" style="">To generate a secret symmetric encryption key, K, and an RSA-encrypted version of the key, C, the client SHOULD use the RSA-KEM key encapsulation mechanism (see ISO 18033-2) along with the user's public RSA key.</p>
+  <p class="" style="">The client SHOULD encrypt the complete sequence of &lt;from/&gt; and &lt;to/&gt; elements, M, that it wants to store with the encryption key, K, and a randomly generated public label, L, employing the DEM1 data encapsulation mechanism with the SC2 symmetric encryption algorithm (see ISO 18033-2).</p>
+  <p class="" style="">Note that the client MAY use same key, K, for more than one collection. But it MUST use the label, L, with only one plain text, M.</p>
+  <p class="" style="">The client SHOULD base64 encode the encrypted messages, wrap them in a single &lt;crypt/&gt; element and set the 'label' attribute to the base64 encoded random label L.</p>
+  <p class="" style="">The client MUST set the 'keyalg=' attribute of the &lt;store/&gt; element to 'RSA-KEM-KDF2-SHA256' and the 'dataalg' attribute to 'DEM1-SC2-SHA256'. The 'key' attribute MUST also be set to the base64 encoded encrypted version of the key, C.</p>
+  <p class="caption">Example 21. Storing encrypted messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'&gt;
+    &lt;crypt label='VROLURBVEFDb3JwU0dDL'&gt;E5Qbvfa2gI5lBZMAHryv4g+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/crypt&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The NESSIE-recommended RSA-KEM (with KDF2/SHA-256) key encapsulation scheme (see ISO 18033-2 at http://www.shoup.net/iso/std5.pdf, or ANSI-X9.44) was specified because its security is tightly proven (unlike RSA-OAEP or PKCS #1 v1.5) and it is very simple to implement.</p>
+  <p class="" style="">The SHA-256 hash was specified since SHA-1 is broken (assuming the attacker has plenty of computing power). Other standard hashes are not optimised for 32-bit processors (e.g. Whirlpool, SHA-384, SHA-512).</p>
+  <p class="" style="">The client SHOULD support the mechanisms specified in this document. The client MAY support other mechanisms. Future versions of this document MAY be modified to recommend other mechanisims.</p>
+  <p class="" style="">The mechanisms for the publishing of public keys and the storage and retrieval of private keys are beyond the scope of this document. A future JEP will specify how clients may do this in an interoperable way.</p>
+<h2>9.
+       <a name="sect-id2256641">File Format</a>
+</h2>
+  <p class="" style="">The file format uses the same XML constructs as the protocol. Each file may contain messages exchanged with a single JID. Any number of items may be stored in an archive file.</p>
+  <p class="caption">Example 22. Example file</p>
+<div class="indent"><pre>
+    
+&lt;?xml version='1.0'?&gt;
+&lt;archive xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'&gt;
+  &lt;store start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+  &lt;store start='1469-07-21T09:56:15Z'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'&gt;
+    &lt;crypt label='VROLURBVEFDb3JwU0dDL'&gt;E5Qbvfa2gI5lBZMAHryv4g+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/crypt&gt;
+  &lt;/store&gt;
+  &lt;store start='1469-07-23T23:08:25Z'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='VQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxITAfBgNVBAsTGGh0dHA6Ly93d3cu'&gt;
+    &lt;crypt label='nVzdC5jb20xGzAZBgNVB'&gt;j98C5OBxOvG0I3KgqgHf35g+FFCgMSa9KOlaMCZ1+XtgHI3zzVAmbQQnmt/VDUVHQ2AswkDwf9c3V6aPryuvEeKaq&lt;/crypt&gt;
+  &lt;/store&gt;
+&lt;/archive&gt;
+</pre></div>
+<h2>10.
+       <a name="sect-id2256666">Implementation Notes</a>
+</h2>
+  <p class="" style="">Clients should not store one message at a time on the server since this increases both bandwidth consumption and the total number of transactions. It is instead RECOMMENDED that clients store messages only when the conversation thread appears to be terminated, i.e. when the user closes the chat window. If the user reopens the window and the thread continues then the client should append the new messages to the collection when the user closes the window again.</p>
+  <p class="" style="">When appending messages to a collection clients SHOULD try to ensure that the total size of the collection will not exceed karma limits when it is retrieved later. This may be achieved by starting a new collection whenever a message thread becomes too long.</p>
+  <p class="" style="">It is RECOMMENDED that the client synchronises all the times it sends to the server with server time. The client can achieve this using <span class="ref" style="">Entity Time</span>  [<a href="#nt-id2256768">2</a>] to estimate the difference between the server and client clocks.</p>
+  <p class="" style="">Server implementations SHOULD give system administrators the option to disable support for this protocol since archived conversations can consume significant storage space.</p>
+<h2>11.
+       <a name="sect-id2256783">Privacy Considerations</a>
+</h2>
+  <p class="" style="">The client that originates a message MAY specify a 'false' value for the 'store' header (see <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2256821">3</a>]). The recipient MUST NOT archive such a message or any of the information it contains. If the sender plans to use 'store' headers it MUST use Service Discovery to determine whether or not the recipient supports them. If not, the sender MUST warn its human user (if any) before sending the message.</p>
+<h2>12.
+       <a name="sect-id2256806">Known Issues</a>
+</h2>
+  <p class="" style="">The subject of each collection is not encrypted (like S/MIME?). The client MUST warn its human user (if any) before including 'subject' attributes on encrypted collections.</p>
+  <p class="" style="">Servers will not be able to search the content of encrypted collections.</p>
+  <p class="" style="">The 'Encryption' section is a work in progress.</p>
+<h2>13.
+       <a name="sect-id2256867">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256902">4</a>] is required as a result of this JEP.</p>
+<h2>14.
+       <a name="sect-id2256890">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256944">5</a>] shall register the 'http://jabber.org/protocol/archive' namespace as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250582">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256768">2</a>. JEP-0090: Entity Time &lt;<a href="http://www.jabber.org/jeps/jep-0090.html">http://www.jabber.org/jeps/jep-0090.html</a>&gt;.</p>
+<p><a name="nt-id2256821">3</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2256902">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256944">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-10-21)</h4>
+<div class="indent">Added more examples to Removing Collections (ip)
+    </div>
+<h4>Version 0.2 (2005-04-18)</h4>
+<div class="indent">Complete rewrite. (ip)
+    </div>
+<h4>Version 0.1 (2004-06-04)</h4>
+<div class="indent">Initial version. (jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0136-0.4.html
+++ b/content/xep-0136-0.4.html
@@ -1,0 +1,553 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0136: Message Archiving</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Archiving">
+<meta name="DC.Creator" content="Justin Karneges">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This JEP defines a storage protocol and common disk format for archiving of messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0136">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0136: Message Archiving</h1>
+<p>This JEP defines a storage protocol and common disk format for archiving of messages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0136<br>
+            Version: 0.4<br>
+            Last Updated: 2005-12-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: archive<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Message%20Archiving%20(JEP-0136)">http://wiki.jabber.org/index.php/Message Archiving (JEP-0136)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Justin Karneges</h3>
+<p class="indent">
+        Email: justin@affinix.com<br>
+        JID: justin@andbit.net</p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#introduction">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2251535">Concepts</a>
+</dt>
+<dt>3.  <a href="#sect-id2250703">Determining Server Support</a>
+</dt>
+<dt>4.  <a href="#sect-id2250786">Storing Messages in a Collection</a>
+</dt>
+<dt>5.  <a href="#retrieve">Retrieving a Collection</a>
+</dt>
+<dt>6.  <a href="#sect-id2250328">Removing Collections</a>
+</dt>
+<dt>7.  <a href="#list">Obtaining a List of Collections</a>
+</dt>
+<dt>8.  <a href="#sect-id2256824">Encryption</a>
+</dt>
+<dt>9.  <a href="#sect-id2257022">Replication and Searching</a>
+</dt>
+<dt>10.  <a href="#sect-id2257127">File Format</a>
+</dt>
+<dt>11.  <a href="#sect-id2257157">Implementation Notes</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#implement-bandwidth">Bandwidth Considerations</a>
+</dt>
+<dt>11.2.  <a href="#implement-karma">Karma Considerations</a>
+</dt>
+<dt>11.3.  <a href="#implement-synch">Synchronization</a>
+</dt>
+<dt>11.4.  <a href="#implement-storage">Storage Considerations</a>
+</dt>
+</dl>
+<dt>12.  <a href="#sect-id2257303">Privacy Considerations</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#sect-id2257314">Store Headers</a>
+</dt>
+<dt>12.2.  <a href="#privacy-subject">Subject Attributes</a>
+</dt>
+</dl>
+<dt>13.  <a href="#sect-id2257377">IANA Considerations</a>
+</dt>
+<dt>14.  <a href="#sect-id2257440">Jabber Registrar Considerations</a>
+</dt>
+<dt>15.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt>16.  <a href="#sect-id2257482">To Do</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="introduction">Introduction</a>
+</h2>
+  <p class="" style="">Historically, clients have archived messages in local storage. However, that is clearly inconvenient for people who use more than one client machine (home, work, mobile) and whenever people upgrade to a new machine. Furthermore, security and resource limitations often prevent clients that run in constrained environments from accessing (sufficient) local storage.</p>
+  <p class="" style="">This specification defines a protocol for storing and retrieving messages on a server. Each storage item consists of a collection of messages. This is usually a message thread. Clients are able to add/update/remove collections from the server. This document also specifies a disk format. This allows clients to share message archive files, in a way similar to email clients sharing common formats like mbox and Maildir.</p>
+  <p class="" style="">A server autoarchiving approach would have eliminated the need to submit collections to the server. However, this specification empowers clients instead. This approach enables them to store out-of-band messages like email as well. Also, since end-to-end encryption schemes typically use evanescent keys that are discarded immediately after use, server autoarchived encrypted messages would not be decryptable.</p>
+  <p class="" style="">The protocol is designed to minimise the size of collections. This is necessary to mitigate the memory and bandwidth limitations of constrained clients and to alleviate karma issues.</p>
+<h2>2.
+       <a name="sect-id2251535">Concepts</a>
+</h2>
+  <p class="" style="">Messages are stored in message collections on the server. The client uniquely specifies a collection using the pair of attributes: 'with' (bare JID with which the messages were exchanged) and 'start' (thread start-time).</p>
+  <p class="" style="">The content of each individual message MUST be encapsulated in a &lt;to/&gt; or &lt;from/&gt; element. The time in seconds of the message relative to the start-time of the collection SHOULD be specified with a 'secs' attribute. The content SHOULD include a &lt;body/&gt; element. Other elements MAY be included, but they are NOT RECOMMENDED. To conserve bandwidth and storage, elements scoped by the 'http://jabber.org/protocol/xhtml-im' namespace SHOULD NOT be included. &lt;thread/&gt; elements and elements scoped by the 'jabber:x:delay', 'jabber:x:event' and 'http://jabber.org/protocol/chatstates' namespaces MUST NOT be included.</p>
+  <p class="" style="">Complying with <span style="font-weight: bold">XMPP Core</span>, the server MUST respond to all &lt;iq/&gt; elements. However, most 'successful' reponses have been omitted from this document in the interest of conciseness.</p>
+  <p class="" style="">All times MUST be in the UTC time zone.</p>
+<h2>3.
+       <a name="sect-id2250703">Determining Server Support</a>
+</h2>
+  <p class="" style="">The client discovers whether the server supports this protocol using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250757">1</a>].</p>
+  <p class="caption">Example 1. Client Service Discovery request</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the server supports this protocol, it MUST return a &lt;feature/&gt; element in the result with the 'var' attribute set to 'http://jabber.org/protocol/archive'.</p>
+  <p class="caption">Example 2. Server Service Discovery response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result'
+    from='montague.net'
+    to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/archive'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>4.
+       <a name="sect-id2250786">Storing Messages in a Collection</a>
+</h2>
+  <p class="" style="">The messages to be stored are encapsulated in the &lt;store/&gt; element.</p>
+  <p class="caption">Example 3. Storing messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST create a new collection. If the collection already exists then the server MUST append the messages to the existing collection.</p>
+  <p class="" style="">A friendly name for the collection MAY be specified with a 'subject' attribute. If the collection already has a 'subject' then it is simply replaced. Note the <a href="#privacy-subject">Privacy Considerations</a> for subject attributes.</p>
+  <p class="caption">Example 4. Successful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' to='romeo@montague.net/orchard'/&gt;
+</pre></div>
+  <p class="" style="">If the server cannot service a store request because the collection is too large then it MUST return a Not Acceptable error:</p>
+  <p class="caption">Example 5. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client MAY specify an absolute time for any message by providing a longer 'utc' attribute instead of a 'secs' attribute:</p>
+  <p class="caption">Example 6. Storing offline messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from utc='1469-07-21T00:32:29Z'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client SHOULD include the 'name' attribute to specify the 'resource' of all messages that it received from a room:</p>
+  <p class="caption">Example 7. Storing groupchat messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='balcony@house.capulet.com'
+         start='1469-07-21T03:16:37Z'&gt;
+    &lt;from secs='0' name='benvolio'&gt;&lt;body&gt;She will indite him to some supper.&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='5' name='mercutio'&gt;&lt;body&gt;A bawd, a bawd, a bawd! So ho!&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='11' name='romeo'&gt;&lt;body&gt;What hast thou found?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>5.
+       <a name="retrieve">Retrieving a Collection</a>
+</h2>
+  <p class="" style="">The client sends an empty &lt;retrieve/&gt; element to request the download of a collection:</p>
+  <p class="caption">Example 8. Requesting a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com'
+            start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 9. Receiving a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST return a Not Found error:</p>
+  <p class="caption">Example 10. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>6.
+       <a name="sect-id2250328">Removing Collections</a>
+</h2>
+  <p class="" style="">To request the removal of a collection the client sends an empty &lt;remove/&gt; element.</p>
+  <p class="caption">Example 11. Removing a single collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">If the collection does not exist then the server MUST return a Not Found error:</p>
+  <p class="caption">Example 12. Unsuccessful reply</p>
+<div class="indent"><pre>
+    
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client may remove several collections at once. The 'start' and 'end' elements MAY be specified to indicate a date range.</p>
+  <p class="caption">Example 13. Removing all collections with a specified JID between two times</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+   <p class="" style="">If the 'with' attribute is omitted then collections with any JID are removed.</p>
+   <p class="" style="">If the end date is in the future then then all collections after the start date are removed.</p>
+  <p class="caption">Example 14. Removing all collections after a date</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='1469-07-21T02:00:00Z'
+          end='2038-01-01T00:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+   <p class="" style="">If the start date is before all the collections in the archive then all collections prior to the end date are removed.</p>
+  <p class="caption">Example 15. Removing all collections before a date</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='0000-01-01T00:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 16. Removing all collections</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>7.
+       <a name="list">Obtaining a List of Collections</a>
+</h2>
+  <p class="" style="">To request a list of collections the client sends an empty &lt;list/&gt; element. The 'start' and 'end' elements MAY be specified to indicate a date range.</p>
+  <p class="" style="">If the 'with' attribute is omitted then collections with any JID are returned. If only 'start' is specified then all collections on or after that date should be returned. If only 'end' is specified then all collections prior to that date should be returned.</p>
+  <p class="caption">Example 17. Requesting a list</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'
+        start='1469-07-21T02:00:00Z'
+        end='1479-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="caption">Example 18. Requesting a list of all collections with a JID</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client MAY limit the number of items returned by the server with the 'maxitems' attribute.</p>
+  <p class="caption">Example 19. Requesting a list of all collections</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        maxitems='50'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The collections (empty &lt;store/&gt; elements) in the result MUST be listed in chronological order.</p>
+  <p class="caption">Example 20. Receiving a list</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'/&gt;
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    ...
+  &lt;/list&gt;
+&lt;/iq&gt;
+  </pre></div>
+
+  <p class="" style="">If the requested list would be too long to return in its entirety without exceeding karma limits (or any other limit specified by an administrator), then the server SHOULD only return the first part of the list. In this case the server MUST indicate that the list is incomplete by setting the optional 'partial' attribute of the &lt;list/&gt; element to 'true'. The client MAY then request the remainder of the list, taking care to set the value of the 'start' attribute to one second after the time of the last collection in the partial list that it received.</p>
+  <p class="caption">Example 21. Receiving a partial list</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;list partial='true' xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'/&gt;
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    ...
+  &lt;/list&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>8.
+       <a name="sect-id2256824">Encryption</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is a work in progress.</span></p>
+  <p class="" style="">Most of the examples in this document are not encrypted for clarity. However, this protocol strongly RECOMMENDS the encryption of all collections.</p>
+  <p class="" style="">To generate a secret symmetric encryption key, K, and an RSA-encrypted version of the key, C, the client SHOULD use the RSA-KEM key encapsulation mechanism (see ISO 18033-2) along with the user's public RSA key.</p>
+  <p class="" style="">The client SHOULD encrypt the complete sequence of &lt;from/&gt; and &lt;to/&gt; elements, M, that it wants to store with the encryption key, K, and a randomly generated public label, L, employing the DEM1 data encapsulation mechanism with the SC2 symmetric encryption algorithm (see ISO 18033-2).</p>
+  <p class="" style="">Note that the client MAY use same key, K, for more than one collection. But it MUST use the label, L, with only one plain text, M.</p>
+  <p class="" style="">The client MUST base64 encode the encrypted messages, wrap them in a <span style="font-style: italic">single</span> &lt;crypt/&gt; element and set the 'label' attribute to the base64 encoded random label L.</p>
+  <p class="" style="">The client MUST set the 'keyalg=' attribute of the &lt;store/&gt; element to 'RSA-KEM-KDF2-SHA256' and the 'dataalg' attribute to 'DEM1-SC2-SHA256'. The 'key' attribute MUST also be set to the base64 encoded encrypted version of the key, C.</p>
+  <p class="caption">Example 22. Storing encrypted messages in a collection</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'&gt;
+    &lt;crypt label='VROLURBVEFDb3JwU0dDL'&gt;E5Qbvfa2gI5lBZMAHryv4g+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/crypt&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client MAY append messages to a collection in exactly the same way. In this case the client MUST use the same symmetric encryption key, K, and the same algorithms, but it MUST NOT use the same label, L. Note: when an encrypted collection is retrieved it may contain more than one &lt;crypt/&gt; element.</p>
+
+
+  <p class="" style="">The NESSIE-recommended RSA-KEM (with KDF2/SHA-256) key encapsulation scheme (see ISO 18033-2 at http://www.shoup.net/iso/std5.pdf, or ANSI-X9.44) was specified because its security is tightly proven (unlike RSA-OAEP or PKCS #1 v1.5) and it is very simple to implement.</p>
+  <p class="" style="">The SHA-256 hash was specified since SHA-1 is broken (assuming the attacker has plenty of computing power). Other standard hashes are not optimised for 32-bit processors (e.g. Whirlpool, SHA-384, SHA-512).</p>
+  <p class="" style="">The client SHOULD support the mechanisms specified in this document. The client MAY support other mechanisms. Future versions of this document MAY be modified to recommend other mechanisims.</p>
+  <p class="" style="">The mechanisms for the publishing of public keys and the storage and retrieval of private keys are beyond the scope of this document. A future JEP will specify how clients may do this in an interoperable way.</p>
+<h2>9.
+       <a name="sect-id2257022">Replication and Searching</a>
+</h2>
+  <p class="" style="">Since collections should be stored in encrypted form on the server, this protocol does not provide for server-side searching of the content of messages.
+     Although it is inconvenient for people who use more than one client machine, the historical approach of archiving to local storage offers significantly better performance when searching content.
+     This section describes how an implementation could combine the two approaches to provide the benefits of both. The basic concept is that archived collections are 'replicated' locally.  [<a href="#nt-id2257045">2</a>]</p>
+  <p class="" style="">Each time the client connects to the server it 'synchronizes' its local archive with the 'master' archive on the server.
+     It simply notes the time of the most recent collection in its local storage, adds one second, and retrieves the list of all the collections from the server on or after that time (see <a href="#list">Obtaining a List of Collections</a>). It then retrieves all the listed collections (see <a href="#retrieve">Retrieving a Collection</a>) and adds them to its local copy of the archive.</p>
+  <p class="caption">Example 23. Requesting the List of Changes Since the Last Synchronization</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+            start='1469-07-21T02:56:16Z'
+            end='2038-01-01T00:00:00Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">The client can then use its local copy of the archive to perform efficient content searches of all collections (which may have been archived by any of the user's clients).</p>
+  <p class="" style="">Before presenting the results of a search to its user the client SHOULD confirm that each of the collections it has found has not been deleted or modified by another of the user's clients.  [<a href="#nt-id2257111">3</a>]</p>
+  <p class="caption">Example 24. Verifying a Search Result</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com'
+            start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+</pre></div>
+
+<h2>10.
+       <a name="sect-id2257127">File Format</a>
+</h2>
+  <p class="" style="">The file format uses the same XML constructs as the protocol. Each file may contain messages exchanged with a single JID. Any number of items may be stored in an archive file.</p>
+  <p class="caption">Example 25. Example file</p>
+<div class="indent"><pre>
+    
+&lt;?xml version='1.0'?&gt;
+&lt;archive xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'&gt;
+  &lt;store start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+  &lt;store start='1469-07-21T09:56:15Z'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'&gt;
+    &lt;crypt label='VROLURBVEFDb3JwU0dDL'&gt;E5Qbvfa2gI5lBZMAHryv4g+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/crypt&gt;
+  &lt;/store&gt;
+  &lt;store start='1469-07-23T23:08:25Z'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         dataalg='DEM1-SC2-SHA256'
+         key='VQQKExVUaGUgVVNFUlRSVVNUIE5ldHdvcmsxITAfBgNVBAsTGGh0dHA6Ly93d3cu'&gt;
+    &lt;crypt label='nVzdC5jb20xGzAZBgNVB'&gt;j98C5OBxOvG0I3KgqgHf35g+FFCgMSa9KOlaMCZ1+XtgHI3zzVAmbQQnmt/VDUVHQ2AswkDwf9c3V6aPryuvEeKaq&lt;/crypt&gt;
+  &lt;/store&gt;
+&lt;/archive&gt;
+</pre></div>
+<h2>11.
+       <a name="sect-id2257157">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="implement-bandwidth">Bandwidth Considerations</a>
+</h3>
+    <p class="" style="">Clients should not store one message at a time on the server since this increases both bandwidth consumption and the total number of transactions. It is instead RECOMMENDED that clients store messages only when the conversation thread appears to be terminated, i.e. when the user closes the chat window. If the user reopens the window and the thread continues then the client should append the new messages to the collection when the user closes the window again.</p>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="implement-karma">Karma Considerations</a>
+</h3>
+    <p class="" style="">When appending messages to a collection clients SHOULD try to ensure that the total size of the collection will not exceed karma limits when it is retrieved later. This may be achieved by starting a new collection whenever a message thread becomes too long.</p>
+  </div>
+  <div class="indent">
+<h3>11.3 <a name="implement-synch">Synchronization</a>
+</h3>
+    <p class="" style="">It is RECOMMENDED that the client synchronises all the times it sends to the server with server time. The client can achieve this using <span class="ref" style="">Entity Time</span>  [<a href="#nt-id2257282">4</a>] to estimate the difference between the server and client clocks.</p>
+  </div>
+  <div class="indent">
+<h3>11.4 <a name="implement-storage">Storage Considerations</a>
+</h3>
+    <p class="" style="">Server implementations SHOULD give system administrators the option to disable support for this protocol since archived conversations can consume significant storage space.</p>
+  </div>
+<h2>12.
+       <a name="sect-id2257303">Privacy Considerations</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="sect-id2257314">Store Headers</a>
+</h3>
+    <p class="" style="">The client that originates a message MAY specify a 'false' value for the 'store' header (see <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2257351">5</a>]). The recipient MUST NOT archive such a message or any of the information it contains. If the sender plans to use 'store' headers it MUST use Service Discovery to determine whether or not the recipient supports them. If not, the sender MUST warn its human user (if any) before sending the message.</p>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="privacy-subject">Subject Attributes</a>
+</h3>
+    <p class="" style="">Since the subject of each collection is not encrypted, the client MUST warn its human user (if any) before including 'subject' attributes on encrypted collections.</p>
+  </div>
+<h2>13.
+       <a name="sect-id2257377">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257404">6</a>] is required as a result of this JEP.</p>
+<h2>14.
+       <a name="sect-id2257440">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257459">7</a>] shall register the 'http://jabber.org/protocol/archive' namespace as a result of this JEP.</p>
+<h2>15.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>16.
+       <a name="sect-id2257482">To Do</a>
+</h2>
+  <p class="" style="">Encryption Section</p>
+  <p class="" style="">XML Schemas</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250757">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257045">2</a>. Clients that run in constrained environments may not be able to implement the 'replication' technique if they are prevented from accessing (sufficient) local storage.</p>
+<p><a name="nt-id2257111">3</a>. The replication mechanism described here is not perfect. For example, even if a client has removed a collection from its local archive and from the server's 'master' archive, then that change would not be reflected in any other local copies of the archive maintained by clients on other machines.</p>
+<p><a name="nt-id2257282">4</a>. JEP-0090: Entity Time &lt;<a href="http://www.jabber.org/jeps/jep-0090.html">http://www.jabber.org/jeps/jep-0090.html</a>&gt;.</p>
+<p><a name="nt-id2257351">5</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2257404">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257459">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2005-12-21)</h4>
+<div class="indent">Added Replication and Searching section, partial attribute; minor improvements (ip)
+    </div>
+<h4>Version 0.3 (2005-10-21)</h4>
+<div class="indent">Added more examples to Removing Collections (ip)
+    </div>
+<h4>Version 0.2 (2005-04-18)</h4>
+<div class="indent">Complete rewrite. (ip)
+    </div>
+<h4>Version 0.1 (2004-06-04)</h4>
+<div class="indent">Initial version. (jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0136-0.5.html
+++ b/content/xep-0136-0.5.html
@@ -1,0 +1,971 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0136: Message Archiving</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Archiving">
+<meta name="DC.Creator" content="Justin Karneges">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Jon Perlow">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines mechanisms for server-side archiving of XMPP messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-05-03">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0136">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0136: Message Archiving</h1>
+<p>This document defines mechanisms for server-side archiving of XMPP messages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0136<br>
+            Version: 0.5<br>
+            Last Updated: 2006-05-03<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: archive<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Message%20Archiving%20(JEP-0136)">http://wiki.jabber.org/index.php/Message Archiving (JEP-0136)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Justin Karneges</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:justin@affinix.com">justin@affinix.com</a><br>
+        JID: 
+        <a href="xmpp:justin@andbit.net">justin@andbit.net</a></p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+<h3>Jon Perlow</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jonp@google.com">jonp@google.com</a><br>
+        JID: 
+        <a href="xmpp:jonp@google.com">jonp@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#disco">Determining Server Support</a>
+</dt>
+<dt>3.  <a href="#auto">Automated Archiving</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#save">Save Mode</a>
+</dt>
+<dl>
+<dt>3.1.1.  <a href="#save-reqs">Requirements</a>
+</dt>
+<dt>3.1.2.  <a href="#otr-determine">Determining Save Mode States</a>
+</dt>
+<dt>3.1.3.  <a href="#otr-default">Toggling Default Save Mode State</a>
+</dt>
+<dt>3.1.4.  <a href="#otr-jid">Toggling Save Mode State for a Contact</a>
+</dt>
+</dl>
+<dt>3.2.  <a href="#otr">Off-the-Record Mode</a>
+</dt>
+<dl>
+<dt>3.2.1.  <a href="#otr-reqs">Requirements</a>
+</dt>
+<dt>3.2.2.  <a href="#otr-determine">Determining Off-the-Record Mode for a Contact</a>
+</dt>
+<dt>3.2.3.  <a href="#otr-toggle">Toggling Off-the-Record Mode State for a Contact</a>
+</dt>
+<dt>3.2.4.  <a href="#otr-message">Sending Message Stanzas</a>
+</dt>
+</dl>
+</dl>
+<dt>4.  <a href="#manual">Manual Archiving</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#manual-req">Requirements</a>
+</dt>
+<dt>4.2.  <a href="#manual-upload">Uploading Messages to a Collection</a>
+</dt>
+</dl>
+<dt>5.  <a href="#manage">Archive Management</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#manage-list">Obtaining a List of Collections</a>
+</dt>
+<dt>5.2.  <a href="#manage-retrieve">Retrieving a Collection</a>
+</dt>
+<dt>5.3.  <a href="#manage-remove">Removing a Collection</a>
+</dt>
+</dl>
+<dt>6.  <a href="#fileformat">File Format</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#impl-bandwidth">Bandwidth Considerations</a>
+</dt>
+<dt>7.2.  <a href="#impl-karma">Karma Considerations</a>
+</dt>
+<dt>7.3.  <a href="#impl-sync">Synchronization</a>
+</dt>
+<dt>7.4.  <a href="#impl-storage">Storage Considerations</a>
+</dt>
+<dt>7.5.  <a href="#impl-muc">Groupchat Messages</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-encrypt">Encryption of Archived Messages</a>
+</dt>
+<dt>8.2.  <a href="#security-store">Store Headers</a>
+</dt>
+<dt>8.3.  <a href="#security-subject">Subject Attributes</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many XMPP clients implement some form of client-side message archiving. However, it is not always convenient or even possible to archive messages locally, e.g., because it is easier to keep all archives in one place (not scattered around on multiple computers or devices) or because the client operates in a web browser or resides on a mobile device that does not have sufficient local storage for message archiving. In addition, server-side archiving makes it possible to offer new services such as integration of IM and email. Therefore it is beneficial to define methods for server-side archiving of XMPP messages.</p>
+  <p class="" style="">There are two main approaches to this problem:</p>
+  <ol start="1" type="">
+    <li>Enable the server (at the client's request) to archive messages as they pass through the server; we call this automated archiving.</li>
+    <li>Enable the client to send individual messages or entire conversations to the server for archiving (optionally after encryption); we call this manual archiving.</li>
+  </ol>
+  <p class="" style="">So that client and server developers can refer to one specification, both approaches are defined in this document. In addition, this document defines common methods for retrieving archived messages.</p>
+<h2>2.
+       <a name="disco">Determining Server Support</a>
+</h2>
+  <p class="" style="">A client discovers whether its server supports this protocol using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251025">1</a>].</p>
+  <p class="caption">Example 1. Client Service Discovery request</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">For each feature defined herein, if the server supports that feature it MUST return a &lt;feature/&gt; element with the 'var' attribute set to 'http://jabber.org/protocol/archive#name', where "name" is "save" for the <a href="#save">Save Mode</a> feature, "otr" for the <a href="#otr">Off-the-Record Mode</a> feature, "manual" for the <a href="#manual">Manual Archiving</a> feature, or "manage" for the <a href="#manage">Archive Management</a> feature.</p>
+  <p class="caption">Example 2. Server Service Discovery response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result'
+    from='montague.net'
+    to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/archive#manage'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#manual'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#otr'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#save'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>3.
+       <a name="auto">Automated Archiving</a>
+</h2>
+  <p class="" style="">There are two features related to automated archiving:</p>
+  <ol start="1" type="">
+    <li>Being able to turn on and turn off automated archiving; this is called "Save Mode".</li>
+    <li>Being able to take certain conversations (or conversations with certain contacts) "off-the-record" for both the user and the contact with whom the user is chatting (i.e., neither party's server shall archive the conversation); this is called "Off-the-Record Mode".</li>
+  </ol>
+  <p class="" style="">Requirements and protocol flows for these features are defined below.</p>
+  <div class="indent">
+<h3>3.1 <a name="save">Save Mode</a>
+</h3>
+    <div class="indent">
+<h3>3.1.1 <a name="save-reqs">Requirements</a>
+</h3>
+      <p class="" style="">Automated server-side archiving of XMPP messages eases the burden on clients. However, not all users may want to archive messages on the server. Therefore, a client should be able to toggle archiving (here referred to as Save Mode) on a default basis (i.e., specify whether by default all conversations are to be saved on the server or not). In addition, a user may want to override the default setting for a particular contact. Therefore this document addresses the following requirements for Save Mode:</p>
+      <ol start="1" type="">
+        <li>A user must be able to toggle default Save Mode.</li>
+        <li>A user must be able to toggle Save Mode for a particular contact.</li>
+        <li>A user must be able to determine the current Save Mode (default and for particular contacts).</li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>3.1.2 <a name="otr-determine">Determining Save Mode States</a>
+</h3>
+      <p class="" style="">In order to determine the current Save Mode states both for the default and for particular contacts, a user sends a query to the user's server:</p>
+      <p class="caption">Example 3. Client Requests Save Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='save1' from='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The server sends the Save Mode state(s) to the user.</p>
+      <p class="" style="">The state may be set only for the default.</p>
+      <p class="caption">Example 4. Server Returns Save Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The state may also include settings for particular contacts.</p>
+      <p class="caption">Example 5. Client Requests Save Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+    &lt;item jid='romeo@montague.net' save='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The server also remembers that the requesting resource is "save-mode aware" and will broadcast it any changes in the Save Mode state.</p>
+      <p class="" style="">Note: It is STRONGLY RECOMMENDED for the value of the 'jid' attribute to be a bare JID (&lt;node@domain.tld&gt;).</p>
+    </div>
+    <div class="indent">
+<h3>3.1.3 <a name="otr-default">Toggling Default Save Mode State</a>
+</h3>
+      <p class="" style="">A user may toggle the default Save Mode state by updating the setting:</p>
+      <p class="caption">Example 6. Client Toggles Default Save Mode State</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='save2' from='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the server can process the request, it acknowledges the change:</p>
+      <p class="caption">Example 7. Server Acknowledges Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save2' to='juliet@capulet.com/chamber'/&gt;
+      </pre></div>
+      <p class="" style="">The server then MUST inform all of the user's connected resources:</p>
+      <p class="caption">Example 8. Server Pushes New Save Mode State</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='savepush1' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' id='savepush2' to='juliet@capulet.com/pda'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Note: Error cases to follow.</p>
+    </div>
+    <div class="indent">
+<h3>3.1.4 <a name="otr-jid">Toggling Save Mode State for a Contact</a>
+</h3>
+      <p class="" style="">A user may toggle the Save Mode state for a particular contact by updating the setting:</p>
+      <p class="caption">Example 9. Client Toggles Save Mode State for a Contact</p>
+<div class="indent"><pre>
+&lt;iq type='set' item='save3' from='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the server can process the request, it acknowledges the change:</p>
+      <p class="caption">Example 10. Server Acknowleges Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save3' to='juliet@capulet.com/chamber'/&gt;
+      </pre></div>
+      <p class="" style="">The server then MUST inform all of the user's connected resources:</p>
+      <p class="caption">Example 11. Server Pushes New Save Mode State</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='savepush3' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' id='savepush4' to='juliet@capulet.com/pda'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Note: Error cases to follow.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="otr">Off-the-Record Mode</a>
+</h3>
+    <div class="indent">
+<h3>3.2.1 <a name="otr-reqs">Requirements</a>
+</h3>
+      <p class="" style="">Even if a user does not save chat conversations with a particular contact, the user may also want to request that the contact also not save their chat conversations; this is in effect a shared off-the-record state that can be enabled and disabled by either user. Therefore, a client should be able to take a chat "off the record" by requesting use of the Off-the-Record Mode with that contact. Therefore this document addresses the following requirements for Off-the-Record Mode:</p>
+      <ol start="1" type="">
+        <li>A user must be able to determine the current Off-the-Record Mode for a particular contact.</li>
+        <li>A user must be able to toggle Off-the-Record Mode for a particular contact.</li>
+        <li>The user's server must be able to inform the contact's server of any change in the Off-the-Record Mode (from true to false or from false to true).</li>
+        <li>The contact's server must toggle the state appropriately on request and inform the contact's resources.</li>
+        <li>If the servers get out of sync regarding the Off-the-Record Mode state, they must be able to quickly converge again.</li>
+      </ol>
+      <p class="" style="">Note: a similar Off-the-Record Mode for <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2259901">2</a>] conversations is out of scope.</p>
+      <p class="" style="">It is understood that at this time most clients will not be compatible with this document. It is expected that clients and servers will adopt this specification over time. Servers that save chats in a server-side store should implement this specification as soon as possible since server-side archiving of messages is more sensitive than client-side archiving.</p>
+      <p class="" style=""><span class="ref" style="">Stanza Headers and Internet Metadata</span>  [<a href="#nt-id2259949">3</a>] introduces the Store header, which indicates whether the stanza may be stored or archived by the recipient. This is a partial solution to the problem we're trying to solve. First, it doesn't create a way for the two users to negotiate whether a chat conversation can be saved. Second, it only applies to the recipient of a chat, not the recipient's server. In real world scenarios, we want to make sure that the recipient's server also respects the negotiation of Off-the-Record Mode between the two parties.</p>
+    </div>
+    <div class="indent">
+<h3>3.2.2 <a name="otr-determine">Determining Off-the-Record Mode for a Contact</a>
+</h3>
+      <p class="" style="">The user (romeo@montague.net) wishes to find out which contacts have Off-the-Record Mode enabled. This process is very similar to how roster requests, updates, and broadcasts work.</p>
+      <p class="caption">Example 12. Client Requests the Off-the-Record Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='otr1' from='romeo@montague.net/castle'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The server responds with the list of contacts whose Off-the-Record Mode state is "true".</p>
+      <p class="caption">Example 13. Server Returns Off-the-Record Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='otr1' to='juliet@capulet.com/chamber'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;record jid='priest@church.org' otr='true'/&gt;
+  &lt;/otr&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The server also remembers that the requesting resource is now "OTR aware" and will broadcast it any changes in the OTR states. </p>
+      <p class="" style="">Note: Error cases to follow.</p>
+    </div>
+    <div class="indent">
+<h3>3.2.3 <a name="otr-toggle">Toggling Off-the-Record Mode State for a Contact</a>
+</h3>
+      <p class="" style="">The user (juliet@capulet.com) wishes to enter Off-the-Record Mode with contact (romeo@montague.net).</p>
+      <p class="caption">Example 14. Client Enters Off-the-Record Mode</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='otr2' from='juliet@capulet.com/chamber'&gt;
+ &lt;record xmlns='http://jabber.org/protocol/archive'
+         jid='romeo@montague.net' otr='true'/&gt;
+/iq&gt;
+      </pre></div>
+      <p class="" style="">The user's server (capulet.com) updates its state so that chats with romeo@montague.net are not saved. It also sends a message to the contact's server that chats with Juliet are not to be saved.</p>
+      <p class="caption">Example 15. User's Server Informs Contact's Server of Change</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com' to='romeo@montague.net' id='notify1'&gt;
+  &lt;record xmlns='http://jabber.org/protocol/archive' otr='true'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The user's server also broadcasts to all of the user's otr-aware resources that the state has changed:</p>
+      <p class="caption">Example 16. OTR Broadcast to User</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='juliet@capulet.com/chamber' id='update1'&gt;
+  &lt;record xmlns='http://jabber.org/protocol/archive'
+          jid='romeo@montague.net' otr='true'/&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' to='juliet@capulet.com/pda' id='update2'&gt;
+  &lt;record xmlns='http://jabber.org/protocol/archive'
+          jid='romeo@montague.net' otr='true'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The user's server then sends the result for the IQ-set.</p>
+      <p class="caption">Example 17. IQ Result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='otr2' to='juliet@capulet.com/chamber'&gt;
+      </pre></div>
+      <p class="" style="">The contact's server receives the notification, swaps the JIDs in the &lt;item/&gt; element, and broadcasts the change to all of the contact's otr-aware resources:</p>
+      <p class="caption">Example 18. OTR Broadcast for Contact</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='romeo@montague.net/orchard' id='update3'&gt;
+  &lt;record xmlns='http://jabber.org/protocol/archive'
+          jid='juliet@capulet.com' otr='true'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Note: Error cases to follow.</p>
+      <p class="" style="">Some deployments (especially in enterprise settings) are required to archive all messages sent through the server, for example to comply with various government regulations. Such a deployment MUST return a &lt;not-allowed/&gt; error in response to a request to enter Off-the-Record mode and SHOULD stamp all message stanzas with &lt;record otr='false'/&gt;.</p>
+    </div>
+    <div class="indent">
+<h3>3.2.4 <a name="otr-message">Sending Message Stanzas</a>
+</h3>
+      <p class="" style="">The archiving-aware server stamps all messages with the current OTR state as demonstrated by the following examples. This allows servers that become out of sync to update each other on the current state as soon as a message is sent.</p>
+      <p class="" style="">Rome sends a message to Juliet.</p>
+      <p class="caption">Example 19. Client sends a normal text message</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;body&gt;Juliet, can you sneak out tonight?&lt;/body&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">(Optionally the sender's client MAY also include the SHIM Store header.)</p>
+      <p class="" style="">Romeo's server adds an element to the message stanza indicating the current Off-the-Record Mode state before routing it to Juliet's server.</p>
+      <p class="caption">Example 20. Server stamps message with current Off-the-Record Mode state.</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;body&gt;Juliet, can you sneak out tonight?&lt;/body&gt;
+  &lt;record xmlns='http://jabber.org/protocol/archive' otr='true'/&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">When the contact's server receives the message, it MAY compare the user's Off-the-Record Mode state with its own Off-the-Record Mode state for the contact. If the two states are out of sync, it SHOULD update its state and broadcast an updated IQ set to the contact's connected resources.</p>
+    </div>
+  </div>
+<h2>4.
+       <a name="manual">Manual Archiving</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="manual-req">Requirements</a>
+</h3>
+    <p class="" style="">While automated archiving is easy for the client and server to implement, there are contexts in which automated archiving is unacceptable (e.g., because the client does not trust the server) or unworkable (e.g., when messages are encrypted using evanscent keys, as in <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2260330">4</a>]). Therefore, often a client will want to receive a message, optionally process it (e.g., encrypt it), then ask the server to store the message.</p>
+    <p class="" style="">Such messages SHOULD be stored in the form of a "collection", i.e., a set of messages from the same user that are received near each other in time. A collection is intended to mimic the natural flow of human conversations, which in instant messaging (IM) systems tend to occur in bursts (e.g., a five-minute conversation one day, followed by a ten-minute conversation the next). However, sometimes IM message exchange does not follow this conversational pattern; in that case, collections SHOULD be arbitrarily truncated so that transferring them does not violate common rate limiting restrictions (in Jabber systems, often called "karma") or memory limitations for constrained devices.</p>
+    <p class="" style="">Messages are stored in message collections on the server. The client uniquely specifies a collection using the pair of attributes: 'with' (the bare JID with which the messages were exchanged) and 'start' (the UTC start time of the conversation thread, which MUST adhere to the DateTime format specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2260351">5</a>]).</p>
+    <p class="" style="">The content of each individual message MUST be encapsulated in a &lt;to/&gt; or &lt;from/&gt; element. The time in seconds of the message relative to the start-time of the collection SHOULD be specified with a 'secs' attribute. The content SHOULD include a &lt;body/&gt; element. Other elements MAY be included, but they are NOT RECOMMENDED. To conserve bandwidth and storage space, elements qualified by the 'http://jabber.org/protocol/xhtml-im' namespace SHOULD NOT be included. &lt;thread/&gt; elements and elements qualified by the 'jabber:x:delay', 'jabber:x:event' and 'http://jabber.org/protocol/chatstates' namespaces MUST NOT be included.</p>
+    <p class="" style="">Complying with <span style="font-weight: bold">XMPP Core</span>, the server MUST respond to all &lt;iq/&gt; element of type 'get' or 'set'. However, most successful responses have been omitted from this document in the interest of conciseness.</p>
+    <p class="" style="">All times MUST be set to UTC.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="manual-upload">Uploading Messages to a Collection</a>
+</h3>
+    <p class="" style="">The messages to be uploaded are encapsulated in the &lt;store/&gt; element.</p>
+    <p class="caption">Example 21. Storing messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection does not exist then the server MUST create a new collection. If the collection already exists then the server MUST append the messages to the existing collection.</p>
+    <p class="" style="">A friendly name for the collection MAY be specified with a 'subject' attribute. If the collection already has a 'subject' then it is simply replaced. Note the <a href="#security-subject">Security Considerations</a> regarding the subject attribute.</p>
+    <p class="caption">Example 22. Successful reply</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' id='up1'/&gt;
+    </pre></div>
+    <p class="" style="">If the server cannot service a store request because the collection is too large then it MUST return a &lt;not-acceptable/&gt; error:</p>
+    <p class="caption">Example 23. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client MAY specify an absolute time for any message by providing a longer 'utc' attribute instead of a 'secs' attribute:</p>
+    <p class="caption">Example 24. Storing offline messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up2'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from utc='1469-07-21T00:32:29Z'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="manage">Archive Management</a>
+</h2>
+  <p class="" style="">There are three main areas of functionality related to management of saved or uploaded archives:</p>
+  <ol start="1" type="">
+    <li>Obtaining a list of collections.</li>
+    <li>Retrieving a collection.</li>
+    <li>Removing a collection.</li>
+  </ol>
+  <p class="" style="">Requirements and protocol flows for these use cases are defined below.</p>
+  <div class="indent">
+<h3>5.1 <a name="manage-list">Obtaining a List of Collections</a>
+</h3>
+    <p class="" style="">To request a list of collections the client sends an empty &lt;list/&gt; element. The 'start' and 'end' attributes MAY be specified to indicate a date range (the values of these attributes MUST adhere to the DateTime format specified in <span style="font-weight: bold">JEP-0082</span>).</p>
+    <p class="" style="">If the 'with' attribute is omitted then collections with any JID are returned. If only 'start' is specified then all collections on or after that date should be returned. If only 'end' is specified then all collections prior to that date should be returned.</p>
+    <p class="caption">Example 25. Requesting a list</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'
+        start='1469-07-21T02:00:00Z'
+        end='1479-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 26. Requesting a list of all collections with a JID</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client MAY limit the number of items returned by the server with the 'maxitems' attribute.</p>
+    <p class="caption">Example 27. Requesting a list of all collections</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        maxitems='50'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The collections (empty &lt;store/&gt; elements) in the result MUST be listed in chronological order.</p>
+    <p class="caption">Example 28. Receiving a list</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'/&gt;
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    ...
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested list would be too long to return in its entirety without exceeding karma limits (or any other limit specified by an administrator), then the server SHOULD only return the first part of the list. In this case the server MUST indicate that the list is incomplete by setting the optional 'partial' attribute of the &lt;list/&gt; element to 'true'.</p>
+    <p class="caption">Example 29. Receiving a partial list</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;list partial='true' xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'/&gt;
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    ...
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If it has received a partial list, the client MAY then request the remainder of the list, taking care to set the value of the 'start' attribute to one second after the time of the last collection in the partial list that it received.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="manage-retrieve">Retrieving a Collection</a>
+</h3>
+    <p class="" style="">The client sends an empty &lt;retrieve/&gt; element to request the download of a collection:</p>
+    <p class="caption">Example 30. Requesting a collection</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='down1'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com'
+            start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 31. Receiving a collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection does not exist then the server MUST return an &lt;item-not-found/&gt; error:</p>
+    <p class="caption">Example 32. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection would be too long to return in its entirety without exceeding karma limits (or any other limit specified by an administrator), then the server SHOULD return only the first part of the collection. In this case the server MUST indicate that the collection is incomplete by setting the optional 'partial' attribute of the &lt;list/&gt; element to 'true'.</p>
+    <p class="caption">Example 33. Receiving a partial collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         partial='true'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'
+         with='juliet@capulet.com'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If it has received a partial collection, the client MAY then request the remainder of the collection, taking care to set the value of the 'start' attribute to one second after the time of the last &lt;from/&gt; or &lt;to/&gt; element in the partial collection that it received.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="manage-remove">Removing a Collection</a>
+</h3>
+    <p class="" style="">To request the removal of a collection the client sends an empty &lt;remove/&gt; element.</p>
+    <p class="caption">Example 34. Removing a single collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection does not exist then the server MUST return a Not Found error:</p>
+    <p class="caption">Example 35. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client may remove several collections at once. The 'start' and 'end' elements MAY be specified to indicate a date range.</p>
+    <p class="caption">Example 36. Removing all collections with a specified JID between two times</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the 'with' attribute is omitted then collections with any JID are removed.</p>
+    <p class="" style="">If the end date is in the future then then all collections after the start date are removed.</p>
+    <p class="caption">Example 37. Removing all collections after a date</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='1469-07-21T02:00:00Z'
+          end='2038-01-01T00:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the start date is before all the collections in the archive then all collections prior to the end date are removed.</p>
+    <p class="caption">Example 38. Removing all collections before a date</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='0000-01-01T00:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 39. Removing all collections</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="fileformat">File Format</a>
+</h2>
+  <p class="" style="">So that clients can share archived messages, this document specifies a common format for storage on disk (similar to email formats like mbox and Maildir). The file format uses the same XML constructs as the protocol. Each file may contain messages exchanged with a single JID. Any number of items may be stored in an archive file.</p>
+  <p class="caption">Example 40. Example file</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0'?&gt;
+&lt;archive xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'&gt;
+  &lt;store start='1469-07-21T02:56:15Z' subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/archive&gt;
+  </pre></div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-bandwidth">Bandwidth Considerations</a>
+</h3>
+    <p class="" style="">When uploading messages using manual archiving, a client SHOULD NOT store one message at a time on the server since this increases both bandwidth consumption and the total number of transactions. It is instead RECOMMENDED that clients store messages only when the conversation thread appears to be terminated, i.e. when the user closes the chat window. If the user reopens the window and the thread continues then the client should append the new messages to the collection when the user closes the window again.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="impl-karma">Karma Considerations</a>
+</h3>
+    <p class="" style="">When appending messages to a collection clients SHOULD try to ensure that the total size of the collection will not exceed karma limits when it is retrieved later. This may be achieved by starting a new collection whenever a message thread becomes too long.</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="impl-sync">Synchronization</a>
+</h3>
+    <p class="" style="">It is RECOMMENDED for the client synchronize all the times it sends to the server with server time. The client can achieve this using <span class="ref" style="">Entity Time</span>  [<a href="#nt-id2260911">6</a>] to estimate the difference between the server and client clocks.</p>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="impl-storage">Storage Considerations</a>
+</h3>
+    <p class="" style="">Server implementations SHOULD give system administrators the option to disable support for both automated and manual archiving, since archived conversations can consume significant storage space.</p>
+  </div>
+  <div class="indent">
+<h3>7.5 <a name="impl-muc">Groupchat Messages</a>
+</h3>
+    <p class="" style="">A client MAY archive messages that it receives in the context of <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2261225">7</a>] rooms. The client SHOULD include a 'name' attribute to specify the room nickname of all messages:</p>
+    <p class="caption">Example 41. Storing groupchat messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up3'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='balcony@house.capulet.com'
+         start='1469-07-21T03:16:37Z'&gt;
+    &lt;from secs='0' name='benvolio'&gt;&lt;body&gt;She will indite him to some supper.&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='5' name='mercutio'&gt;&lt;body&gt;A bawd, a bawd, a bawd! So ho!&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='11' name='romeo'&gt;&lt;body&gt;What hast thou found?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="security-encrypt">Encryption of Archived Messages</a>
+</h3>
+    <p class="" style="">Because a server can be compromised, it is RECOMMENDED to encrypt archived messages. Methods for doing so are under development and will be specified in a separate document or in a new section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-store">Store Headers</a>
+</h3>
+    <p class="" style="">The client that originates a message MAY specify a 'false' value for the 'store' header (see <span class="ref" style="">Stanza Headers and Internet Metadata</span>  [<a href="#nt-id2261301">8</a>]). The recipient MUST NOT archive such a message or any of the information it contains. If the sender plans to use 'store' headers it MUST use Service Discovery to determine whether or not the recipient supports them. If not, the sender MUST warn its human user (if any) before sending the message.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="security-subject">Subject Attributes</a>
+</h3>
+    <p class="" style="">Since the subject of each collection is not encrypted, the client MUST warn its human user (if any) before including 'subject' attributes on encrypted collections.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261377">9</a>] is required as a result of this JEP.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261428">10</a>] shall include 'http://jabber.org/protocol/archive' in its registry of protocol namespaces (see &lt;<a href="http://www.jabber.org/registrar/namespaces.html">http://www.jabber.org/registrar/namespaces.html</a>&gt;):</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the following features in its registry of service discovery features (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;):</p>
+    <ul>
+      <li>http://jabber.org/protocol/archive#manage</li>
+      <li>http://jabber.org/protocol/archive#manual</li>
+      <li>http://jabber.org/protocol/archive#otr</li>
+      <li>http://jabber.org/protocol/archive#save</li>
+    </ul>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/archive'
+    xmlns='http://jabber.org/protocol/archive'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The allowable root element for the namespace defined
+      herein are:
+        - archive
+        - list
+        - otr
+        - record
+        - remove
+        - retrieve
+        - save
+        - store
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='archive'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='list'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='end' type='xs:dateTime' use='optional'/&gt;
+      &lt;xs:attribute name='maxitems' type='xs:positiveInteger' use='optional'/&gt;
+      &lt;xs:attribute name='partial' type='xs:boolean' use='optional'/&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='optional'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='otr'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='record' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='record'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' use='optional' type='xs:string'/&gt;
+          &lt;xs:attribute name='otr' use='required' type='xs:boolean'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='remove'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='end' type='xs:dateTime' use='optional'/&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='retrieve'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='save'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='default' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='store'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element name='from' type='messageType'/&gt;
+        &lt;xs:element name='to' type='messageType'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='partial' type='xs:boolean' use='optional'/&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+      &lt;xs:attribute name='subject' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='default'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='save' use='required' type='xs:boolean'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' use='required' type='xs:string'/&gt;
+          &lt;xs:attribute name='save' use='required' type='xs:boolean'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:complexType name='messageType'&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element name='body' type='xs:string' maxOccurs='unbounded'/&gt;
+    &lt;/xs:sequence&gt;
+    &lt;xs:attribute name='secs' type='xs:nonNegativeInteger' use='required'/&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251025">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259901">2</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259949">3</a>. JEP-0131: Stanza Headers and Internet Metadata &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2260330">4</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2260351">5</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2260911">6</a>. JEP-0090: Entity Time &lt;<a href="http://www.jabber.org/jeps/jep-0090.html">http://www.jabber.org/jeps/jep-0090.html</a>&gt;.</p>
+<p><a name="nt-id2261225">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2261301">8</a>. JEP-0131: Stanza Headers and Internet Metadata &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2261377">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261428">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2006-05-03)</h4>
+<div class="indent">
+<p class="" style="">Integrated text from server-side archiving proposal; added partial support to collection retrieval; harmonized XML formats and namespaces; defined Jabber Registrar considerations and XML schema.</p> (psa/jp/ip/jk)
+    </div>
+<h4>Version 0.4 (2005-12-21)</h4>
+<div class="indent">
+<p class="" style="">Added Replication and Searching section, partial attribute; minor improvements</p> (ip)
+    </div>
+<h4>Version 0.3 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Added more examples to Removing Collections</p> (ip)
+    </div>
+<h4>Version 0.2 (2005-04-18)</h4>
+<div class="indent">
+<p class="" style="">Complete rewrite.</p> (ip)
+    </div>
+<h4>Version 0.1 (2004-06-04)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0136-0.6.html
+++ b/content/xep-0136-0.6.html
@@ -1,0 +1,1004 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0136: Message Archiving</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Archiving">
+<meta name="DC.Creator" content="Justin Karneges">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Jon Perlow">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines mechanisms for server-side archiving of XMPP messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0136">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0136: Message Archiving</h1>
+<p>This document defines mechanisms for server-side archiving of XMPP messages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0136<br>
+            Version: 0.6<br>
+            Last Updated: 2006-08-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: archive<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Message%20Archiving%20(JEP-0136)">http://wiki.jabber.org/index.php/Message Archiving (JEP-0136)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Justin Karneges</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:justin@affinix.com">justin@affinix.com</a><br>
+        JID: 
+        <a href="xmpp:justin@andbit.net">justin@andbit.net</a></p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+<h3>Jon Perlow</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jonp@google.com">jonp@google.com</a><br>
+        JID: 
+        <a href="xmpp:jonp@google.com">jonp@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#disco">Determining Server Support</a>
+</dt>
+<dt>3.  <a href="#auto">Automated Archiving</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#save">Save Mode</a>
+</dt>
+<dl>
+<dt>3.1.1.  <a href="#save-reqs">Requirements</a>
+</dt>
+<dt>3.1.2.  <a href="#otr-determine">Determining Save Mode States</a>
+</dt>
+<dt>3.1.3.  <a href="#otr-default">Toggling Default Save Mode State</a>
+</dt>
+<dt>3.1.4.  <a href="#otr-jid">Toggling Save Mode State for a Contact</a>
+</dt>
+</dl>
+<dt>3.2.  <a href="#otr">Off-the-Record Mode</a>
+</dt>
+<dl>
+<dt>3.2.1.  <a href="#otr-reqs">Requirements</a>
+</dt>
+<dt>3.2.2.  <a href="#otr-determine">Determining Off-the-Record Mode for a Contact</a>
+</dt>
+<dt>3.2.3.  <a href="#otr-toggle">Toggling Off-the-Record Mode State for a Contact</a>
+</dt>
+<dt>3.2.4.  <a href="#otr-message">Sending Message Stanzas</a>
+</dt>
+</dl>
+</dl>
+<dt>4.  <a href="#manual">Manual Archiving</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#manual-req">Requirements</a>
+</dt>
+<dt>4.2.  <a href="#manual-upload">Uploading Messages to a Collection</a>
+</dt>
+</dl>
+<dt>5.  <a href="#manage">Archive Management</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#manage-list">Obtaining a List of Collections</a>
+</dt>
+<dt>5.2.  <a href="#manage-retrieve">Retrieving a Collection</a>
+</dt>
+<dt>5.3.  <a href="#manage-remove">Removing a Collection</a>
+</dt>
+</dl>
+<dt>6.  <a href="#fileformat">File Format</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#impl-bandwidth">Bandwidth Considerations</a>
+</dt>
+<dt>7.2.  <a href="#impl-karma">Karma Considerations</a>
+</dt>
+<dt>7.3.  <a href="#impl-sync">Synchronization</a>
+</dt>
+<dt>7.4.  <a href="#impl-storage">Storage Considerations</a>
+</dt>
+<dt>7.5.  <a href="#impl-muc">Groupchat Messages</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-encrypt">Encryption of Archived Messages</a>
+</dt>
+<dt>8.2.  <a href="#security-store">Store Headers</a>
+</dt>
+<dt>8.3.  <a href="#security-subject">Subject Attributes</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many XMPP clients implement some form of client-side message archiving. However, it is not always convenient or even possible to archive messages locally, e.g., because it is easier to keep all archives in one place (not scattered around on multiple computers or devices) or because the client operates in a web browser or resides on a mobile device that does not have sufficient local storage for message archiving. In addition, server-side archiving makes it possible to offer new services such as integration of IM and email. Therefore it is beneficial to define methods for server-side archiving of XMPP messages.</p>
+  <p class="" style="">There are two main approaches to this problem:</p>
+  <ol start="1" type="">
+    <li>Enable the server (at the client's request) to archive messages as they pass through the server; we call this automated archiving.</li>
+    <li>Enable the client to send individual messages or entire conversations to the server for archiving (optionally after encryption); we call this manual archiving.</li>
+  </ol>
+  <p class="" style="">So that client and server developers can refer to one specification, both approaches are defined in this document. In addition, this document defines common methods for retrieving archived messages.</p>
+<h2>2.
+       <a name="disco">Determining Server Support</a>
+</h2>
+  <p class="" style="">A client discovers whether its server supports this protocol using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250871">1</a>].</p>
+  <p class="caption">Example 1. Client Service Discovery request</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">For each feature defined herein, if the server supports that feature it MUST return a &lt;feature/&gt; element with the 'var' attribute set to 'http://jabber.org/protocol/archive#name', where "name" is "save" for the <a href="#save">Save Mode</a> feature, "otr" for the <a href="#otr">Off-the-Record Mode</a> feature, "manual" for the <a href="#manual">Manual Archiving</a> feature, or "manage" for the <a href="#manage">Archive Management</a> feature.</p>
+  <p class="caption">Example 2. Server Service Discovery response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result'
+    from='montague.net'
+    to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/archive#manage'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#manual'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#otr'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#save'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>3.
+       <a name="auto">Automated Archiving</a>
+</h2>
+  <p class="" style="">There are two features related to automated archiving:</p>
+  <ol start="1" type="">
+    <li>Being able to turn on and turn off automated archiving; this is called "Save Mode".</li>
+    <li>Being able to take certain conversations (or conversations with certain contacts) "off-the-record" for both the user and the contact with whom the user is chatting (i.e., neither party's server shall archive the conversation); this is called "Off-the-Record Mode".</li>
+  </ol>
+  <p class="" style="">Requirements and protocol flows for these features are defined below.</p>
+  <div class="indent">
+<h3>3.1 <a name="save">Save Mode</a>
+</h3>
+    <div class="indent">
+<h3>3.1.1 <a name="save-reqs">Requirements</a>
+</h3>
+      <p class="" style="">Automated server-side archiving of XMPP messages eases the burden on clients. However, not all users may want to archive messages on the server. Therefore, a client should be able to toggle archiving (here referred to as Save Mode) on a default basis (i.e., specify whether by default all conversations are to be saved on the server or not). In addition, a user may want to override the default setting for a particular contact. Therefore this document addresses the following requirements for Save Mode:</p>
+      <ol start="1" type="">
+        <li>A user must be able to toggle default Save Mode.</li>
+        <li>A user must be able to determine the current default Save Mode.</li>
+        <li>A user should be able to toggle Save Mode for a particular contact.</li>
+        <li>A user should be able to determine the current Save Mode for particular contacts.</li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>3.1.2 <a name="otr-determine">Determining Save Mode States</a>
+</h3>
+      <p class="" style="">In order to determine the current Save Mode states both for the default and for particular contacts, a user sends a query to the user's server:</p>
+      <p class="caption">Example 3. Client Requests Save Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='save1' from='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The server sends the Save Mode state(s) to the user.</p>
+      <p class="" style="">The state may be set only for the default.</p>
+      <p class="caption">Example 4. Server Returns Save Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the user has never set the save mode, the value of the 'save' attribute SHOULD be "unset" and the server SHOULD include a 'service' attribute that specifies the default service-wide setting (either "true" or "false").</p>
+      <p class="caption">Example 5. Server Returns Save Mode State With Service Default</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='unset' service='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The state may also include settings for particular contacts.</p>
+      <p class="caption">Example 6. Client Requests Save Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+    &lt;item jid='romeo@montague.net' save='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The server also remembers that the requesting resource is "save-mode aware" and will broadcast it any changes in the Save Mode state.</p>
+      <p class="" style="">Note: It is STRONGLY RECOMMENDED for the value of the 'jid' attribute to be a bare JID (&lt;node@domain.tld&gt;).</p>
+    </div>
+    <div class="indent">
+<h3>3.1.3 <a name="otr-default">Toggling Default Save Mode State</a>
+</h3>
+      <p class="" style="">A user may toggle the default Save Mode state by updating the setting:</p>
+      <p class="caption">Example 7. Client Toggles Default Save Mode State</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='save2' from='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the server can process the request, it acknowledges the change:</p>
+      <p class="caption">Example 8. Server Acknowledges Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save2' to='juliet@capulet.com/chamber'/&gt;
+      </pre></div>
+      <p class="" style="">The server then MUST inform all of the user's connected resources:</p>
+      <p class="caption">Example 9. Server Pushes New Save Mode State</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='savepush1' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' id='savepush2' to='juliet@capulet.com/pda'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='true'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Note: Error cases to follow.</p>
+    </div>
+    <div class="indent">
+<h3>3.1.4 <a name="otr-jid">Toggling Save Mode State for a Contact</a>
+</h3>
+      <p class="" style="">A user may toggle the Save Mode state for a particular contact by updating the setting:</p>
+      <p class="caption">Example 10. Client Toggles Save Mode State for a Contact</p>
+<div class="indent"><pre>
+&lt;iq type='set' item='save3' from='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the server can process the request, it acknowledges the change:</p>
+      <p class="caption">Example 11. Server Acknowleges Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save3' to='juliet@capulet.com/chamber'/&gt;
+      </pre></div>
+      <p class="" style="">The server then MUST inform all of the user's connected resources:</p>
+      <p class="caption">Example 12. Server Pushes New Save Mode State</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='savepush3' to='juliet@capulet.com/chamber'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' id='savepush4' to='juliet@capulet.com/pda'&gt;
+  &lt;save xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='false'/&gt;
+  &lt;/save&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Note: Error cases to follow.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="otr">Off-the-Record Mode</a>
+</h3>
+    <div class="indent">
+<h3>3.2.1 <a name="otr-reqs">Requirements</a>
+</h3>
+      <p class="" style="">Even if a user does not save chat conversations with a particular contact, the user may also want to request that the contact also not save their chat conversations; this is in effect a shared off-the-record state that can be enabled and disabled by either user. Therefore, a client should be able to take a chat "off the record" by requesting use of the Off-the-Record Mode with that contact. Therefore this document addresses the following requirements for Off-the-Record Mode:</p>
+      <ol start="1" type="">
+        <li>A user must be able to determine the current Off-the-Record Mode for a particular contact.</li>
+        <li>A user must be able to toggle Off-the-Record Mode for a particular contact.</li>
+        <li>The user's server must be able to inform the contact's server of any change in the Off-the-Record Mode (from true to false or from false to true).</li>
+        <li>The contact's server must toggle the state appropriately on request and inform the contact's resources.</li>
+        <li>If the servers get out of sync regarding the Off-the-Record Mode state, they must be able to quickly converge again.</li>
+      </ol>
+      <p class="" style="">Note: a similar Off-the-Record Mode for <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2260143">2</a>] conversations is out of scope.</p>
+      <p class="" style="">It is understood that at this time most clients will not be compatible with this document. It is expected that clients and servers will adopt this specification over time. Servers that save chats in a server-side store should implement this specification as soon as possible since server-side archiving of messages is more sensitive than client-side archiving.</p>
+      <p class="" style=""><span class="ref" style="">Stanza Headers and Internet Metadata</span>  [<a href="#nt-id2260190">3</a>] introduces the Store header, which indicates whether the stanza may be stored or archived by the recipient. This is a partial solution to the problem we're trying to solve. First, it doesn't create a way for the two users to negotiate whether a chat conversation can be saved. Second, it only applies to the recipient of a chat, not the recipient's server. In real world scenarios, we want to make sure that the recipient's server also respects the negotiation of Off-the-Record Mode between the two parties.</p>
+    </div>
+    <div class="indent">
+<h3>3.2.2 <a name="otr-determine">Determining Off-the-Record Mode for a Contact</a>
+</h3>
+      <p class="" style="">The user (romeo@montague.net) wishes to find out which contacts have Off-the-Record Mode enabled. This process is very similar to how roster requests, updates, and broadcasts work.</p>
+      <p class="caption">Example 13. Client Requests the Off-the-Record Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='otr1' from='romeo@montague.net/castle'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The server responds with the list of contacts whose Off-the-Record Mode state is "true". The &lt;record/&gt; element SHOULD include a 'source' attribute that specifies which entity set the Off-the-Record mode.</p>
+      <p class="caption">Example 14. Server Returns Off-the-Record Mode States</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='otr1' to='juliet@capulet.com/chamber'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;record jid='priest@church.org' otr='true' source='juliet@capulet.com'/&gt;
+  &lt;/otr&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The server also remembers that the requesting resource is now "OTR aware" and will broadcast it any changes in the OTR states. </p>
+      <p class="" style="">Note: Error cases to follow.</p>
+    </div>
+    <div class="indent">
+<h3>3.2.3 <a name="otr-toggle">Toggling Off-the-Record Mode State for a Contact</a>
+</h3>
+      <p class="" style="">The user (juliet@capulet.com) wishes to enter Off-the-Record Mode with contact (romeo@montague.net).</p>
+      <p class="caption">Example 15. Client Enters Off-the-Record Mode</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='otr2' from='juliet@capulet.com/chamber'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;record jid='romeo@montague.net' otr='true' source='juliet@capulet.com'/&gt;
+  &lt;/otr&gt;
+/iq&gt;
+      </pre></div>
+      <p class="" style="">The user's server (capulet.com) updates its state so that chats with romeo@montague.net are not saved. It also informs the contact's server that chats with Juliet are not to be saved (this is done by sending an IQ-set from the user's bare JID to the user's bare JID; these IQs are handled by the servers rather than any connected clients).</p>
+      <p class="caption">Example 16. User's Server Informs Contact's Server of Change</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com' to='romeo@montague.net' id='notify1'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;record otr='true' source='juliet@capulet.com'/&gt;
+  &lt;/otr&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result' from='romeo@montague.net' to='juliet@capulet.com' id='notify1'/&gt;
+      </pre></div>
+      <p class="" style="">The user's server also broadcasts to all of the user's otr-aware resources that the state has changed:</p>
+      <p class="caption">Example 17. OTR Broadcast to User</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='juliet@capulet.com/chamber' id='update1'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;record jid='romeo@montague.net' otr='true' source='juliet@capulet.com'/&gt;
+  &lt;/otr&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' to='juliet@capulet.com/pda' id='update2'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;record jid='romeo@montague.net' otr='true' source='juliet@capulet.com'/&gt;
+  &lt;/otr&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The user's server then sends the result for the IQ-set.</p>
+      <p class="caption">Example 18. IQ Result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='otr2' to='juliet@capulet.com/chamber'&gt;
+      </pre></div>
+      <p class="" style="">The contact's server receives the notification, swaps the JIDs in the &lt;record/&gt; element, and broadcasts the change to all of the contact's otr-aware resources:</p>
+      <p class="caption">Example 19. OTR Broadcast for Contact</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='romeo@montague.net/orchard' id='update3'&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;record jid='juliet@capulet.com' otr='true' source='juliet@capulet.com'/&gt;
+  &lt;/otr&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Note: Error cases to follow.</p>
+      <p class="" style="">Some deployments (especially in enterprise settings) are required to archive all messages sent through the server, for example to comply with various government regulations. Such a deployment MUST return a &lt;not-allowed/&gt; error in response to a request to enter Off-the-Record mode and SHOULD stamp all message stanzas with &lt;record otr='false'/&gt;.</p>
+    </div>
+    <div class="indent">
+<h3>3.2.4 <a name="otr-message">Sending Message Stanzas</a>
+</h3>
+      <p class="" style="">The archiving-aware server stamps all messages with the current OTR state as demonstrated by the following examples. This allows servers that become out of sync to update each other on the current state as soon as a message is sent.</p>
+      <p class="" style="">Rome sends a message to Juliet.</p>
+      <p class="caption">Example 20. Client sends a normal text message</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;body&gt;Juliet, can you sneak out tonight?&lt;/body&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">(Optionally the sender's client MAY also include the SHIM Store header.)</p>
+      <p class="" style="">Romeo's server adds an element to the message stanza indicating the current Off-the-Record Mode state before routing it to Juliet's server.</p>
+      <p class="caption">Example 21. Server stamps message with current Off-the-Record Mode state.</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;body&gt;Juliet, can you sneak out tonight?&lt;/body&gt;
+  &lt;otr xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;record otr='true' source='juliet@capulet.com'/&gt;
+  &lt;/otr&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">When the contact's server receives the message, it MAY compare the user's Off-the-Record Mode state with its own Off-the-Record Mode state for the contact. If the two states are out of sync, it SHOULD update its state and broadcast an updated IQ set to the contact's connected resources.</p>
+    </div>
+  </div>
+<h2>4.
+       <a name="manual">Manual Archiving</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="manual-req">Requirements</a>
+</h3>
+    <p class="" style="">While automated archiving is easy for the client and server to implement, there are contexts in which automated archiving is unacceptable (e.g., because the client does not trust the server) or unworkable (e.g., when messages are encrypted using evanscent keys, as in <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2260578">4</a>]). Therefore, often a client will want to receive a message, optionally process it (e.g., encrypt it), then ask the server to store the message.</p>
+    <p class="" style="">Such messages SHOULD be stored in the form of a "collection", i.e., a set of messages from the same user that are received near each other in time. A collection is intended to mimic the natural flow of human conversations, which in instant messaging (IM) systems tend to occur in bursts (e.g., a five-minute conversation one day, followed by a ten-minute conversation the next). However, sometimes IM message exchange does not follow this conversational pattern; in that case, collections SHOULD be arbitrarily truncated so that transferring them does not violate common rate limiting restrictions (in Jabber systems, often called "karma") or memory limitations for constrained devices.</p>
+    <p class="" style="">Messages are stored in message collections on the server. The client uniquely specifies a collection using the pair of attributes: 'with' (the bare JID with which the messages were exchanged) and 'start' (the UTC start time of the conversation thread, which MUST adhere to the DateTime format specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2260606">5</a>]).</p>
+    <p class="" style="">The content of each individual message MUST be encapsulated in a &lt;to/&gt; or &lt;from/&gt; element. The time in seconds of the message relative to the start-time of the collection SHOULD be specified with a 'secs' attribute. The content SHOULD include a &lt;body/&gt; element. Other elements MAY be included, but they are NOT RECOMMENDED. To conserve bandwidth and storage space, elements qualified by the 'http://jabber.org/protocol/xhtml-im' namespace SHOULD NOT be included. &lt;thread/&gt; elements and elements qualified by the 'jabber:x:delay', 'jabber:x:event' and 'http://jabber.org/protocol/chatstates' namespaces MUST NOT be included.</p>
+    <p class="" style="">Complying with <span style="font-weight: bold">XMPP Core</span>, the server MUST respond to all &lt;iq/&gt; element of type 'get' or 'set'. However, most successful responses have been omitted from this document in the interest of conciseness.</p>
+    <p class="" style="">All times MUST be set to UTC.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="manual-upload">Uploading Messages to a Collection</a>
+</h3>
+    <p class="" style="">The messages to be uploaded are encapsulated in the &lt;store/&gt; element.</p>
+    <p class="caption">Example 22. Storing messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection does not exist then the server MUST create a new collection. If the collection already exists then the server MUST append the messages to the existing collection.</p>
+    <p class="" style="">A friendly name for the collection MAY be specified with a 'subject' attribute. If the collection already has a 'subject' then it is simply replaced. Note the <a href="#security-subject">Security Considerations</a> regarding the subject attribute.</p>
+    <p class="caption">Example 23. Successful reply</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' id='up1'/&gt;
+    </pre></div>
+    <p class="" style="">If the server cannot service a store request because the collection is too large then it MUST return a &lt;not-acceptable/&gt; error:</p>
+    <p class="caption">Example 24. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client MAY specify an absolute time for any message by providing a longer 'utc' attribute instead of a 'secs' attribute:</p>
+    <p class="caption">Example 25. Storing offline messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up2'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from utc='1469-07-21T00:32:29Z'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="manage">Archive Management</a>
+</h2>
+  <p class="" style="">There are three main areas of functionality related to management of saved or uploaded archives:</p>
+  <ol start="1" type="">
+    <li>Obtaining a list of collections.</li>
+    <li>Retrieving a collection.</li>
+    <li>Removing a collection.</li>
+  </ol>
+  <p class="" style="">Requirements and protocol flows for these use cases are defined below.</p>
+  <div class="indent">
+<h3>5.1 <a name="manage-list">Obtaining a List of Collections</a>
+</h3>
+    <p class="" style="">To request a list of collections the client sends an empty &lt;list/&gt; element. The 'start' and 'end' attributes MAY be specified to indicate a date range (the values of these attributes MUST adhere to the DateTime format specified in <span style="font-weight: bold">JEP-0082</span>).</p>
+    <p class="" style="">If the 'with' attribute is omitted then collections with any JID are returned. If only 'start' is specified then all collections on or after that date should be returned. If only 'end' is specified then all collections prior to that date should be returned.</p>
+    <p class="caption">Example 26. Requesting a list</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'
+        start='1469-07-21T02:00:00Z'
+        end='1479-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 27. Requesting a list of all collections with a JID</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client MAY limit the number of items returned by the server with the 'maxitems' attribute.</p>
+    <p class="caption">Example 28. Requesting a list of all collections</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        maxitems='50'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The collections (empty &lt;store/&gt; elements) in the result MUST be listed in chronological order.</p>
+    <p class="caption">Example 29. Receiving a list</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'/&gt;
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    ...
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested list would be too long to return in its entirety without exceeding karma limits (or any other limit specified by an administrator), then the server SHOULD only return the first part of the list. In this case the server MUST indicate that the list is incomplete by setting the optional 'partial' attribute of the &lt;list/&gt; element to 'true'.</p>
+    <p class="caption">Example 30. Receiving a partial list</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;list partial='true' xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'/&gt;
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    ...
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If it has received a partial list, the client MAY then request the remainder of the list, taking care to set the value of the 'start' attribute to one second after the time of the last collection in the partial list that it received.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="manage-retrieve">Retrieving a Collection</a>
+</h3>
+    <p class="" style="">The client sends an empty &lt;retrieve/&gt; element to request the download of a collection:</p>
+    <p class="caption">Example 31. Requesting a collection</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='down1'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com'
+            start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 32. Receiving a collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='montague.net'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection does not exist then the server MUST return an &lt;item-not-found/&gt; error:</p>
+    <p class="caption">Example 33. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection would be too long to return in its entirety without exceeding karma limits (or any other limit specified by an administrator), then the server SHOULD return only the first part of the collection. In this case the server MUST indicate that the collection is incomplete by setting the optional 'partial' attribute of the &lt;list/&gt; element to 'true'.</p>
+    <p class="caption">Example 34. Receiving a partial collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='a1' to='romeo@montague.net/orchard'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         partial='true'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'
+         with='juliet@capulet.com'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If it has received a partial collection, the client MAY then request the remainder of the collection, taking care to set the value of the 'start' attribute to one second after the time of the last &lt;from/&gt; or &lt;to/&gt; element in the partial collection that it received.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="manage-remove">Removing a Collection</a>
+</h3>
+    <p class="" style="">To request the removal of a collection the client sends an empty &lt;remove/&gt; element.</p>
+    <p class="caption">Example 35. Removing a single collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection does not exist then the server MUST return a Not Found error:</p>
+    <p class="caption">Example 36. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client may remove several collections at once. The 'start' and 'end' elements MAY be specified to indicate a date range.</p>
+    <p class="caption">Example 37. Removing all collections with a specified JID between two times</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the 'with' attribute is omitted then collections with any JID are removed.</p>
+    <p class="" style="">If the end date is in the future then then all collections after the start date are removed.</p>
+    <p class="caption">Example 38. Removing all collections after a date</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='1469-07-21T02:00:00Z'
+          end='2038-01-01T00:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the start date is before all the collections in the archive then all collections prior to the end date are removed.</p>
+    <p class="caption">Example 39. Removing all collections before a date</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='0000-01-01T00:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 40. Removing all collections</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="fileformat">File Format</a>
+</h2>
+  <p class="" style="">So that clients can share archived messages, this document specifies a common format for storage on disk (similar to email formats like mbox and Maildir). The file format uses the same XML constructs as the protocol. Each file may contain messages exchanged with a single JID. Any number of items may be stored in an archive file.</p>
+  <p class="caption">Example 41. Example file</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0'?&gt;
+&lt;archive xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'&gt;
+  &lt;store start='1469-07-21T02:56:15Z' subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/archive&gt;
+  </pre></div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-bandwidth">Bandwidth Considerations</a>
+</h3>
+    <p class="" style="">When uploading messages using manual archiving, a client SHOULD NOT store one message at a time on the server since this increases both bandwidth consumption and the total number of transactions. It is instead RECOMMENDED that clients store messages only when the conversation thread appears to be terminated, i.e. when the user closes the chat window. If the user reopens the window and the thread continues then the client should append the new messages to the collection when the user closes the window again.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="impl-karma">Karma Considerations</a>
+</h3>
+    <p class="" style="">When appending messages to a collection clients SHOULD try to ensure that the total size of the collection will not exceed karma limits when it is retrieved later. This may be achieved by starting a new collection whenever a message thread becomes too long.</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="impl-sync">Synchronization</a>
+</h3>
+    <p class="" style="">It is RECOMMENDED for the client synchronize all the times it sends to the server with server time. The client can achieve this using <span class="ref" style="">Entity Time</span>  [<a href="#nt-id2261302">6</a>] to estimate the difference between the server and client clocks.</p>
+  </div>
+  <div class="indent">
+<h3>7.4 <a name="impl-storage">Storage Considerations</a>
+</h3>
+    <p class="" style="">Server implementations SHOULD give system administrators the option to disable support for both automated and manual archiving, since archived conversations can consume significant storage space.</p>
+  </div>
+  <div class="indent">
+<h3>7.5 <a name="impl-muc">Groupchat Messages</a>
+</h3>
+    <p class="" style="">A client MAY archive messages that it receives in the context of <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2261349">7</a>] rooms. The client SHOULD include a 'name' attribute to specify the room nickname of all messages:</p>
+    <p class="caption">Example 42. Storing groupchat messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up3'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='balcony@house.capulet.com'
+         start='1469-07-21T03:16:37Z'&gt;
+    &lt;from secs='0' name='benvolio'&gt;&lt;body&gt;She will indite him to some supper.&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='5' name='mercutio'&gt;&lt;body&gt;A bawd, a bawd, a bawd! So ho!&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='11' name='romeo'&gt;&lt;body&gt;What hast thou found?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="security-encrypt">Encryption of Archived Messages</a>
+</h3>
+    <p class="" style="">Because a server can be compromised, it is RECOMMENDED to encrypt archived messages. Methods for doing so are under development and will be specified in a separate document or in a new section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-store">Store Headers</a>
+</h3>
+    <p class="" style="">The client that originates a message MAY specify a 'false' value for the 'store' header (see <span class="ref" style="">Stanza Headers and Internet Metadata</span>  [<a href="#nt-id2261425">8</a>]). The recipient MUST NOT archive such a message or any of the information it contains. If the sender plans to use 'store' headers it MUST use Service Discovery to determine whether or not the recipient supports them. If not, the sender MUST warn its human user (if any) before sending the message.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="security-subject">Subject Attributes</a>
+</h3>
+    <p class="" style="">Since the subject of each collection is not encrypted, the client MUST warn its human user (if any) before including 'subject' attributes on encrypted collections.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261506">9</a>] is required as a result of this JEP.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261557">10</a>] shall include 'http://jabber.org/protocol/archive' in its registry of protocol namespaces (see &lt;<a href="http://www.jabber.org/registrar/namespaces.html">http://www.jabber.org/registrar/namespaces.html</a>&gt;):</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the following features in its registry of service discovery features (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;):</p>
+    <ul>
+      <li>http://jabber.org/protocol/archive#manage</li>
+      <li>http://jabber.org/protocol/archive#manual</li>
+      <li>http://jabber.org/protocol/archive#otr</li>
+      <li>http://jabber.org/protocol/archive#save</li>
+    </ul>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/archive'
+    xmlns='http://jabber.org/protocol/archive'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The allowable root element for the namespace defined
+      herein are:
+        - archive
+        - list
+        - otr
+        - remove
+        - retrieve
+        - save
+        - store
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='archive'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='list'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='end' type='xs:dateTime' use='optional'/&gt;
+      &lt;xs:attribute name='maxitems' type='xs:positiveInteger' use='optional'/&gt;
+      &lt;xs:attribute name='partial' type='xs:boolean' use='optional'/&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='optional'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='otr'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='record' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='record'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' use='optional' type='xs:string'/&gt;
+          &lt;xs:attribute name='otr' use='required' type='xs:boolean'/&gt;
+          &lt;xs:attribute name='source' use='optional' type='xs:string'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='remove'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='end' type='xs:dateTime' use='optional'/&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='retrieve'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='save'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='default' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='store'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element name='from' type='messageType'/&gt;
+        &lt;xs:element name='to' type='messageType'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='partial' type='xs:boolean' use='optional'/&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+      &lt;xs:attribute name='subject' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='default'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='save' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='false'/&gt;
+                &lt;xs:enumeration value='true'/&gt;
+                &lt;xs:enumeration value='unset'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='service' use='optional' type='xs:boolean'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' use='required' type='xs:string'/&gt;
+          &lt;xs:attribute name='save' use='required' type='xs:boolean'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:complexType name='messageType'&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element name='body' type='xs:string' maxOccurs='unbounded'/&gt;
+    &lt;/xs:sequence&gt;
+    &lt;xs:attribute name='secs' type='xs:nonNegativeInteger' use='required'/&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250871">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260143">2</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2260190">3</a>. JEP-0131: Stanza Headers and Internet Metadata &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2260578">4</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2260606">5</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2261302">6</a>. JEP-0090: Entity Time &lt;<a href="http://www.jabber.org/jeps/jep-0090.html">http://www.jabber.org/jeps/jep-0090.html</a>&gt;.</p>
+<p><a name="nt-id2261349">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2261425">8</a>. JEP-0131: Stanza Headers and Internet Metadata &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2261506">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261557">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2006-08-18)</h4>
+<div class="indent">
+<p class="" style="">Added unset value for save attribute and added service attribute on default element; added source attribute on record element; specified that services should (not must) support save mode for particular contacts.</p> (jp/psa)
+    </div>
+<h4>Version 0.5 (2006-05-03)</h4>
+<div class="indent">
+<p class="" style="">Integrated text from server-side archiving proposal; added partial support to collection retrieval; harmonized XML formats and namespaces; defined Jabber Registrar considerations and XML schema.</p> (psa/jp/ip/jk)
+    </div>
+<h4>Version 0.4 (2005-12-21)</h4>
+<div class="indent">
+<p class="" style="">Added Replication and Searching section, partial attribute; minor improvements</p> (ip)
+    </div>
+<h4>Version 0.3 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Added more examples to Removing Collections</p> (ip)
+    </div>
+<h4>Version 0.2 (2005-04-18)</h4>
+<div class="indent">
+<p class="" style="">Complete rewrite.</p> (ip)
+    </div>
+<h4>Version 0.1 (2004-06-04)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0136-0.7.html
+++ b/content/xep-0136-0.7.html
@@ -1,0 +1,1214 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0136: Message Archiving</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Archiving">
+<meta name="DC.Creator" content="Justin Karneges">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Jon Perlow">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines mechanisms for server-side archiving of XMPP messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-09-08">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0136">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0136: Message Archiving</h1>
+<p>This document defines mechanisms for server-side archiving of XMPP messages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0136<br>
+            Version: 0.7<br>
+            Last Updated: 2006-09-08<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0059, JEP-0155<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: archive<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Message%20Archiving%20(JEP-0136)">http://wiki.jabber.org/index.php/Message Archiving (JEP-0136)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Justin Karneges</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:justin@affinix.com">justin@affinix.com</a><br>
+        JID: 
+        <a href="xmpp:justin@andbit.net">justin@andbit.net</a></p>
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+<h3>Jon Perlow</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jonp@google.com">jonp@google.com</a><br>
+        JID: 
+        <a href="xmpp:jonp@google.com">jonp@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#disco">Determining Server Support</a>
+</dt>
+<dt>3.  <a href="#pref">Archiving Preferences</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#pref-reqs">Introducton</a>
+</dt>
+<dt>3.2.  <a href="#pref-determine">Determining Modes</a>
+</dt>
+<dt>3.3.  <a href="#pref-default">Setting Default Modes</a>
+</dt>
+<dt>3.4.  <a href="#pref-jid">Setting Modes for a Contact</a>
+</dt>
+</dl>
+<dt>4.  <a href="#otr">Off The Record</a>
+</dt>
+<dt>5.  <a href="#manual">Manual Archiving</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#manual-intro">Introduction</a>
+</dt>
+<dt>5.2.  <a href="#manual-collection">Collections</a>
+</dt>
+<dt>5.3.  <a href="#manual-upload">Uploading Messages to a Collection</a>
+</dt>
+<dt>5.4.  <a href="#impl-muc">Groupchat Messages</a>
+</dt>
+<dt>5.5.  <a href="#crypt">Encryption</a>
+</dt>
+<dt>5.6.  <a href="#crypt">Updating Collection Attributes</a>
+</dt>
+</dl>
+<dt>6.  <a href="#auto">Automated Archiving</a>
+</dt>
+<dt>7.  <a href="#manage">Archive Management</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#manage-list">Retrieving a List of Collections</a>
+</dt>
+<dt>7.2.  <a href="#manage-retrieve">Retrieving a Collection</a>
+</dt>
+<dt>7.3.  <a href="#manage-remove">Removing a Collection</a>
+</dt>
+</dl>
+<dt>8.  <a href="#sect-id2259771">Replication</a>
+</dt>
+<dt>9.  <a href="#fileformat">File Format</a>
+</dt>
+<dt>10.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#impl-sync">Time Synchronization</a>
+</dt>
+<dt>10.2.  <a href="#impl-bandwidth">Bandwidth Considerations</a>
+</dt>
+<dt>10.3.  <a href="#impl-storage">Storage Considerations</a>
+</dt>
+</dl>
+<dt>11.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#security-encrypt">Plain Text Subject</a>
+</dt>
+<dt>11.2.  <a href="#security-store">Store Headers</a>
+</dt>
+</dl>
+<dt>12.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>13.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>13.2.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>13.3.  <a href="#registrar-crypt">Cryptography Scheme Names</a>
+</dt>
+<dl>
+<dt>13.3.1.  <a href="#registrar-kemkdf2">RSA-KEM-KDF2-SHA256</a>
+</dt>
+<dt>13.3.2.  <a href="#registrar-dem1sc2">DEM1-SC2-KDF2-SHA256</a>
+</dt>
+</dl>
+</dl>
+<dt>14.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many XMPP clients implement some form of client-side message archiving. However, it is not always convenient or even possible to archive messages locally, e.g., because it is easier to keep all archives in one universally accessable place (not scattered around on multiple computers or devices) or because the client operates in a web browser or resides on a mobile device that does not have sufficient local storage for message archiving. In addition, server-side archiving makes it possible to offer new services such as integration of IM and email. Therefore it is beneficial to define methods for server-side archiving of XMPP messages.</p>
+  <p class="" style="">There are two main approaches to this problem:</p>
+  <ol start="1" type="">
+    <li>Enable the client to send individual messages or entire conversations to the server for archiving (optionally after encryption); we call this manual archiving.</li>
+    <li>Enable the server (at the client's request) to archive messages as they pass through the server; we call this automated archiving.</li>
+  </ol>
+  <p class="" style="">So that client and server developers can refer to one specification, both approaches are defined in this document. In addition, this document defines common methods for retrieving and managing archived messages.</p>
+    <p class="" style="">Complying with <span style="font-weight: bold">XMPP Core</span>, the server MUST respond to all &lt;iq/&gt; element of type 'get' or 'set'. However, most successful responses have been omitted from this document in the interest of conciseness.</p>
+<h2>2.
+       <a name="disco">Determining Server Support</a>
+</h2>
+  <p class="" style="">A client discovers whether its server supports this protocol using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250950">1</a>].</p>
+  <p class="caption">Example 1. Client Service Discovery request</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">For each feature defined herein, if the server supports that feature it MUST return a &lt;feature/&gt; element with the 'var' attribute set to 'http://jabber.org/protocol/archive#name', where "name" is "auto" for the <a href="#auto">Automated Archiving</a> feature, "encrypt" for the <span style="font-style: italic">server-side</span> encryption feature (see <a href="#auto">Automated Archiving</a>), "manage" for the <a href="#manage">Archive Management</a> feature, "manual" for the <a href="#manual">Manual Archiving</a> feature, or "pref" for the <a href="#pref">Archiving Preferences</a> feature.</p>
+  <p class="caption">Example 2. Server Service Discovery response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result'
+    from='montague.net'
+    to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/archive#auto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#encrypt'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#manage'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#manual'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#pref'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>3.
+       <a name="pref">Archiving Preferences</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="pref-reqs">Introducton</a>
+</h3>
+    <p class="" style="">Not all users want to archive messages. A client SHOULD save its user's default archiving preference (or "Save Mode") to its own server (i.e., specify whether by default all conversations should be archived or not). In addition, a client MAY save different preferences for particular contacts.</p>
+    <p class="" style="">Some users may also prefer that the messages they exchange with contacts are "<a href="#otr">Off The Record</a>" (OTR). A client SHOULD save its user's default and contact-specific OTR preferences (or "OTR Modes") to its own server.</p>
+    <p class="" style="">Whichever archiving method a client uses (e.g., local archiving, or automatic or manual archiving to a server), it SHOULD adhere to its user's archiving preferences.</p>
+    <p class="" style="">This section addresses the following use cases:</p>
+    <ol start="1" type="">
+      <li>A client determines its user's current default Save Mode and OTR Mode, and the Modes for particular contacts.</li>
+      <li>A client sets the default Save Mode and OTR Mode.</li>
+      <li>A client sets the Save Mode and OTR Mode for a particular contact.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="pref-determine">Determining Modes</a>
+</h3>
+    <p class="" style="">In order to determine its user's current Save Mode(s) and OTR Mode(s), a client sends this query to its server:</p>
+    <p class="caption">Example 3. Client Requests Modes</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='save1' from='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server responds with the default Save Mode and OTR Mode (&lt;default/&gt; element) and any Save Modes and OTR Modes for specific contacts (&lt;item/&gt; elements).</p>
+    <p class="" style="">Each child element in the response MUST include a 'save' attribute, whose value MAY be 'false' (the client MUST save no messages), 'body' (the client SHOULD save only &lt;body/&gt; elements) or 'all' (the client SHOULD save the full XML content of each &lt;message/&gt; element).</p>
+    <p class="" style="">Note: Support for the 'all' value is optional and, to conserve bandwidth and storage space, it is RECOMMENDED that client implementations do not specify the 'all' value.</p>
+    <p class="" style="">Note: When archiving <span style="font-style: italic">locally</span> a client MAY save the full XML content of each &lt;message/&gt; element even if the Save Mode is 'body'.</p>
+    <p class="" style="">Each child element in the response MUST include an 'otr' attribute, whose value MAY be 'deny' (if <a href="#otr">Off The Record</a> is <span style="font-style: italic">required</span> by the contact the client MUST send no messages), 'allow' (the client MAY save messages unless the contact requests OTR), 'try' (the client MUST try to negotiate OTR with the contact) or 'require' (the client MUST send no messages unless the contact explicitly agrees to OTR).</p>
+    <p class="" style="">Note: If the OTR Mode is 'require' then the Save Mode MUST be 'false'.</p>
+    <p class="caption">Example 4. Server Returns Modes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='body' otr='allow'/&gt;
+    &lt;item jid='romeo@montague.net' save='false' otr='require'/&gt;
+    &lt;item jid='benvolio@montague.net' save='all' otr='deny'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user has never set the default Modes, the 'save' and 'otr' attributes SHOULD specify the server's default settings, and the 'unset' attribute SHOULD be set to "true". Note: The 'unset' attribute defaults to "false".</p>
+    <p class="caption">Example 5. Server Returns Service Default Modes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='false' otr='allow' unset='true'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Once it has received a request for archiving preferences from the client, the server MUST send any subsequent changes to any of the user's archiving preferences to the client until the stream is closed (see below).</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="pref-default">Setting Default Modes</a>
+</h3>
+    <p class="" style="">A client may set the default Modes:</p>
+    <p class="caption">Example 6. Client Sets Default Modes</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='save2' from='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='false' otr='try'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can process the request, it acknowledges the change:</p>
+    <p class="caption">Example 7. Server Acknowledges Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save2' to='juliet@capulet.com/chamber'/&gt;
+    </pre></div>
+    <p class="" style="">The server then MUST inform all of the user's connected resources that have previously requested the user's archiving preferences:</p>
+    <p class="caption">Example 8. Server Pushes New Modes</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='savepush1' to='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='false' otr='try'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' id='savepush2' to='juliet@capulet.com/pda'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='false' otr='try'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server MAY be configured to return a &lt;feature-not-implemented/&gt; error in the following cases:</p>
+    <ul>
+      <li><p class="" style="">If it does not allow the saving of full message stanza content, and the client set the value of the 'save' attribute to "all", and any of the user's connected resources have <a href="#auto">Automated Archiving</a> enabled.</p></li>
+      <li><p class="" style="">If administrator policies require that at least the &lt;body/&gt; (or the full content) of every message is logged automatically, and the client sets the value of the 'save' attribute to "false" (or "body").</p></li>
+    </ul>
+    <p class="" style="">Note: More error cases to follow.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="pref-jid">Setting Modes for a Contact</a>
+</h3>
+    <p class="" style="">A client may use a similar protocol to set the Modes for a particular contact or domain of contacts (bare JID, full JID or domain). Note: It is STRONGLY RECOMMENDED for the value of the 'jid' attribute to be a bare JID (&lt;node@domain.tld&gt;).</p>
+    <p class="caption">Example 9. Client Sets Modes for a Contact</p>
+<div class="indent"><pre>
+&lt;iq type='set' item='save3' from='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='body' otr='allow'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 10. Server Acknowleges Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save3' to='juliet@capulet.com/chamber'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. Server Pushes New Modes</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='savepush3' to='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='body' otr='allow'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' id='savepush4' to='juliet@capulet.com/pda'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='body' otr='allow'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The same error cases apply as when <a href="#auto">Setting Default Modes</a>.</p>
+  </div>
+<h2>4.
+       <a name="otr">Off The Record</a>
+</h2>
+  <p class="" style="">A user will sometimes exchange messages with contacts who prefer that their conversations are not archived by either party. Any client that archives messages SHOULD support <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2258246">2</a>] and its 'logging' field both to give other contacts the opportunity to indicate this preference, and to negotiate an "Off The Record" (OTR) policy that complies with its user's own <a href="#pref">Archiving Preferences</a>.</p>
+  <p class="" style="">If a Chat Session Negotiation agreed to enable OTR (disable logging) then the clients MUST NOT allow messages sent in <span style="font-style: italic">either</span> direction to be archived in any way (including <a href="#manual">Manual Archiving</a> and <a href="#auto">Automated Archiving</a>).  [<a href="#nt-id2258281">3</a>]</p>
+  <p class="" style="">Note: If a contact does not include a 'logging' field in its initial Chat Session Negotiation request, and a user's Archiving Preferences indicate that OTR is <span style="font-style: italic">required</span>, then the client MUST refuse the request. It MAY then send its own Chat Session Negotiation request with a 'logging' field.</p>
+  <p class="" style="">Note: Chat Session Negotiation messages SHOULD NOT be saved, since they are exchanged before clients have been able to negotiate OTR mode and disable archiving.</p>
+  <p class="" style="">If a user's OTR preference for a contact changes during a Chat Session that has been negotiated with the contact, and if the new preference would affect the value of the 'logging' field that was previously negotiated, then the client MUST immediately terminate the Chat Session and try to negotiate a new one according to the user's new OTR preference.</p>
+<h2>5.
+       <a name="manual">Manual Archiving</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="manual-intro">Introduction</a>
+</h3>
+    <p class="" style="">While automated archiving is easy for the client and server to implement, there are many contexts in which automated archiving is required. For examples, when:</p>
+    <ul>
+      <li>Messages are encrypted using evanscent keys, as in <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2258379">4</a>]</li>
+      <li>A client's own server does not support automated archiving but it (or another server) does support manual archiving</li>
+      <li>A server does not support encryption of auto-archived collections</li>
+      <li>A client wants to maintain a unified archive for messages that were transmitted both in and out-of-band (e.g. SMS or email)</li>
+      <li>A client wants to append private notes to a conversation</li>
+    </ul>
+    <p class="" style="">Therefore, often a client will want to send or receive a sequence of messages, optionally add private notes to the sequence, optionally encrypt the sequence, and then ask the server to store it.</p>
+    <p class="" style="">Such messages and notes SHOULD be stored on the server in the form of a "collection", i.e., a set of messages to/from the same user that are received near each other in time or as part of the same conversation thread. A collection is intended to mimic the natural flow of human conversations, which in instant messaging (IM) systems tend to occur in bursts (e.g., a five-minute conversation one day, followed by a ten-minute conversation the next).</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="manual-collection">Collections</a>
+</h3>
+    <p class="" style="">The client uniquely specifies a collection using a pair of attributes:</p>
+    <ul>
+      <li>'with' (the full JID with which the messages were exchanged)</li>
+      <li>'start' (the UTC start time of the conversation thread, which MUST be UTC and adhere to the DateTime format specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2258473">5</a>])</li>
+    </ul>
+    <p class="" style="">A friendly name for the collection MAY be specified with a 'subject' attribute. Note the <a href="#security-subject">Security Considerations</a> regarding the subject attribute.</p>
+    <p class="" style="">Each collection MAY contain &lt;note/&gt;, &lt;to/&gt; or &lt;from/&gt; elements (or &lt;crypt/&gt; elements - see <a href="#crypt">Encryption</a>).</p>
+    <p class="" style="">The text of each individual private note MUST be encapsulated in a &lt;note/&gt; element. The absolute time the note was created SHOULD be specified with a 'utc' attribute (which MUST be UTC and adhere to the DateTime format specified in <span style="font-weight: bold">Jabber Date and Time Profiles</span>).</p>
+    <p class="" style="">The content of each individual message MUST be encapsulated in a &lt;to/&gt; or &lt;from/&gt; element. The time in seconds of the message relative to the previous message in the collection (or, for the first message, relative to the start of the collection) SHOULD be specified with a 'secs' attribute. The content of each &lt;to/&gt; or &lt;from/&gt; element SHOULD include a &lt;body/&gt; element.</p>
+    <p class="" style="">Note: Other elements MAY be included, but they are NOT RECOMMENDED. To conserve bandwidth and storage space  [<a href="#nt-id2258553">6</a>], elements qualified by the 'http://jabber.org/protocol/xhtml-im' namespace SHOULD NOT be included. &lt;thread/&gt; elements and elements qualified by the 'jabber:x:delay', 'jabber:x:event' and 'http://jabber.org/protocol/chatstates' namespaces MUST NOT be included. The server MAY be configured to return a &lt;feature-not-implemented/&gt; error if any &lt;to/&gt; or &lt;from/&gt; element contains anything other than a single &lt;body/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="manual-upload">Uploading Messages to a Collection</a>
+</h3>
+    <p class="" style="">The collection of messages and notes to be uploaded are encapsulated in the &lt;store/&gt; element.</p>
+    <p class="caption">Example 12. Storing messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+    &lt;note utc='1469-07-21T03:04:35Z'&gt;I think she might fancy me.&lt;/note&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection does not exist then the server MUST create a new collection. If the collection already exists then the server MUST append the messages to the existing collection.</p>
+    <p class="" style="">Note: Clients MUST take care to append each sequence of messages to the collection before the sequence becomes so large that uploading it may violate common rate limiting restrictions (in Jabber systems, often called "karma").</p>
+    <p class="caption">Example 13. Successful reply</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' id='up1'/&gt;
+    </pre></div>
+    <p class="" style="">If the server cannot service a store request because the collection is too large then it MUST return a &lt;not-acceptable/&gt; error:</p>
+    <p class="caption">Example 14. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client MAY specify an absolute time for any message by providing a longer 'utc' attribute (which MUST be UTC and adhere to the DateTime format specified in <span style="font-weight: bold">Jabber Date and Time Profiles</span>) instead of a 'secs' attribute:</p>
+    <p class="caption">Example 15. Storing offline messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up2'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from utc='1469-07-21T00:32:29Z'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="impl-muc">Groupchat Messages</a>
+</h3>
+    <p class="" style="">A client MAY archive messages that it receives from <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2258716">7</a>] rooms. The 'with' attribute MUST be the bare JID of the room. The client MUST include a 'name' attribute for each &lt;from/&gt; element to specify the room nickname of the message sender:</p>
+    <p class="caption">Example 16. Storing groupchat messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up3'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='balcony@house.capulet.com'
+         start='1469-07-21T03:16:37Z'&gt;
+    &lt;from secs='0' name='benvolio'&gt;&lt;body&gt;She will indite him to some supper.&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='5' name='mercutio'&gt;&lt;body&gt;A bawd, a bawd, a bawd! So ho!&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='11' name='romeo'&gt;&lt;body&gt;What hast thou found?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="crypt">Encryption</a>
+</h3>
+    <p class="" style="">The examples above are not encrypted for clarity. However, clients SHOULD encrypt manually-archived collections, and the encryption of auto-archived collections (see <a href="#auto">Automated Archiving</a>) is strongly RECOMMENDED.</p>
+    <p class="" style="">Before uploading a sequence of messages to a collection, the client SHOULD encrypt and encapsulate the joined sequence of &lt;to/&gt;, &lt;from/&gt; and &lt;note/&gt; elements, base64 encode the resulting sequence of bytes, and wrap it inside a &lt;crypt/&gt; element. If a randomly generated unique public label was used to encapsulate the encrypted messages then the 'label' attribute of &lt;crypt/&gt; element MUST be set to that base64 encoded label.</p>
+    <p class="" style="">Note: Entities MUST support the SHA-256 hash  [<a href="#nt-id2258786">8</a>] and the DEM1 (with SC2/SHA-256) data encapsulation mechanism (see ISO 18033-2 at http://www.shoup.net/iso/std6.pdf, or ANSI-X9.44). Entities MAY support other hashes and algorithms (see <a href="#registrar">Jabber Registrar Considerations</a>).  [<a href="#nt-id2258801">9</a>]</p>
+    <p class="" style="">Clients MAY add one or more &lt;crypt/&gt; elements to a collection using exactly the same method as for &lt;to/&gt;, &lt;from/&gt; and &lt;note/&gt; elements (see <a href="#manual-upload">Uploading Messages to a Collection</a>). Note: a collection that contains &lt;crypt/&gt; elements MUST NOT contain &lt;to/&gt; or &lt;from/&gt; or &lt;note/&gt; elements.</p>
+    <p class="" style="">When an encrypted collection is created (or when a &lt;crypt/&gt; element is added to an <span style="font-style: italic">empty non-encrypted</span> collection) four extra attributes MUST be specified for the &lt;store/&gt; element:</p>
+    <ul>
+      <li>'dataalg' - the name of the encryption/encapsulation algorithm (see <a href="#registrar">Jabber Registrar Considerations</a>) used (with the messages encryption key - see below) to generate the content of all the &lt;crypt/&gt; elements in the collection</li>
+      <li>'key' - the <span style="font-style: italic">encrypted</span> (see below) and base64 encoded version of the messages encryption key used (with the messages encryption algorithm above) to generate the content of all the &lt;crypt/&gt; elements in the collection</li>
+      <li>'keyalg' - the name of the encryption/encapsulation algorithm (see <a href="#registrar">Jabber Registrar Considerations</a>) used to transform the messages encryption key into the 'key' attribute (see above)</li>
+      <li>'master' - the identity (fingerprint) of the private key used (with the <span style="font-style: italic">key</span> encryption algorithm above) to transform the messages encryption key into the 'key' attribute (see above)  [<a href="#nt-id2258890">10</a>]</li>
+    </ul>
+    <p class="" style="">Note: Clients MUST support the SHA-256 hash and the RSA-KEM (with KDF2/SHA-256) key encapsulation scheme (see ISO 18033-2 at http://www.shoup.net/iso/std6.pdf, or ANSI-X9.44).  [<a href="#nt-id2258906">11</a>] The client MAY support other hashes and algorithms (see <a href="#registrar">Jabber Registrar Considerations</a>).  [<a href="#nt-id2258920">12</a>]</p>
+    <p class="caption">Example 17. Storing encrypted messages in a new collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='crypt1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'
+         dataalg='DEM1-SC2-KDF2-SHA256'
+         key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'
+         keyalg='RSA-KEM-KDF2-SHA256'
+         master='acc3594e844c77696f7a7ba9367ae324b6b958ad'&gt;
+    &lt;crypt label='VROLURBVEFDb3JwU0dDL'&gt;E5Qbvfa2gI5lBZMAHryv4g+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/crypt&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="crypt">Updating Collection Attributes</a>
+</h3>
+    <p class="" style="">If the client specifies a new value for the 'subject' attribute of any existing collection, or new values for the 'key', 'keyalg' or 'master' attributes of an existing <span style="font-style: italic">encrypted</span> collection then the server MUST update the existing values. This enables a client to change the subject of a collection, to remove any dependencies on an obsolete private key, or to change the decryption key encryption algorithm.</p>
+    <p class="" style="">Note: The client MUST NOT specify new values for the 'dataalg', 'with' or 'start' attributes. The only way to change these values is to delete the collection (see <a href="#manage-remove">Removing a Collection</a>) and then create a new one.</p>
+    <p class="caption">Example 18. Changing the private key for a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='private1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         key='IHNpbmd1bGFyIHBhc3Npb24gZnJvbSBvdGhlciBhbmltYWxzLCB3aGljaCBpcyBhIGx1c3Qgb2Yg'
+         master='3fb37d8e817c673dfa60637351926d564ce65629'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 19. Changing the subject of an encrypted collection while appending messages</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='subject1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks twice!'
+    &lt;crypt label='TWFuIGlzIGRpc3Rpbmd1'&gt;dGhlIG1pbmQsIHRoYXQgYnkgYSBwZXJzZXZlcmFuY2Ugb2YgZGVsaWdodCBpbiB0aGUgY29udGlu&lt;/crypt&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="auto">Automated Archiving</a>
+</h2>
+  <p class="" style="">A client MAY enable or disable automatic archiving for messages sent over its stream. Automatic archiving SHOULD default to disabled for each new stream that is opened. Once automatic archiving is switched on then the server MUST automatically archive messages only according to the user's general <a href="#pref">Archiving Preferences</a>.</p>
+  <p class="" style="">Note: Both parties to an ESession (see <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2259052">13</a>]) MUST disable automatic archiving, since ESession decryption keys are short-lived - making it impossible to decrypt automatically archived messages.</p>
+  <p class="caption">Example 20. Client Enables Auto Archiving</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auto1'&gt;
+  &lt;auto save='true' xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The server MAY be configured to return a &lt;feature-not-implemented/&gt; error in the following cases:</p>
+  <ul>
+    <li><p class="" style="">If the client is trying to enable automatic archiving, but the server does not allow the saving of full message stanza content, and the user has specified the 'all' Save Mode in one of its <a href="#pref">Archiving Preferences</a>.</p></li>
+    <li><p class="" style="">If administrator policies require that every message is logged automatically, and the client is trying to disable automatic archiving.</p></li>
+  </ul>
+  <p class="" style="">Whenever the client enables auto-archiving it MAY also specify a 'secret' attribute, this is a base64 encoded secret symmetric encryption key that the server SHOULD use to encrypt all <span style="font-style: italic">new</span> automatically archived collections. It should also specify the 'dataalg', 'key', 'keyalg' and 'master' attributes (see <a href="#crypt">Encryption</a>) that will eventually be downloaded by clients and used to decrypt collections (the 'dataalg' attribute is also required by the server to encrypt collections).</p>
+  <p class="caption">Example 21. Client Enables Auto Archiving and Sets Encryption Parameters</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auto2'&gt;
+  &lt;auto save='true'
+        secret='dWVkIGFuZCBpbmRlZmF0aWdhYmxl'
+        dataalg='DEM1-SC2-KDF2-SHA256'
+        key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'
+        keyalg='RSA-KEM-KDF2-SHA256'
+        master='acc3594e844c77696f7a7ba9367ae324b6b958ad'
+        xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">As soon as the client specifies a new secret symmetric encryption key (or switches off all auto-archiving - thus completing all active collections), the server MUST securely destroy all its copies of the old secret key.</p>
+  <p class="" style="">Note: If the client uses this protocol to change the secret key regularly (e.g. immediately after the start of every conversation) then, if the server is compromised, only the messages stored during the attack will be compromised (i.e. only those messages that would have been compromised even if they had not been stored).</p>
+<h2>7.
+       <a name="manage">Archive Management</a>
+</h2>
+  <p class="" style="">Manually uploaded and automatically saved collections are managed in the same way. There are three main areas of functionality related to archive management:</p>
+  <ol start="1" type="">
+    <li>Retrieving a list of collections</li>
+    <li>Retrieving a collection</li>
+    <li>Removing a collection</li>
+  </ol>
+  <p class="" style="">Requirements and protocol flows for each of these use cases are defined below. The protocols to retrieve a list of collections and an indivdual collection both make extensive use of <span class="ref" style="">Result Set Management</span>  [<a href="#nt-id2259249">14</a>]. Clients and servers SHOULD support all the features defined in that protocol.</p>
+  <div class="indent">
+<h3>7.1 <a name="manage-list">Retrieving a List of Collections</a>
+</h3>
+    <p class="" style="">To request a list of collections the client sends a &lt;list/&gt; element. The 'start' and 'end' attributes MAY be specified to indicate a date range (the values of these attributes MUST be UTC and adhere to the DateTime format specified in <span style="font-weight: bold">Jabber Date and Time Profiles</span>). The 'with' attribute MAY be specified to limit the list to a single participating full JID, bare JID or domain.</p>
+    <p class="" style="">If the 'with' attribute is omitted then collections with any JID are returned. If only 'start' is specified then all collections on or after that date should be returned. If only 'end' is specified then all collections prior to that date should be returned.</p>
+    <p class="" style="">The client SHOULD use <span style="font-weight: bold">Result Set Management</span> to limit the number of collections returned by the server in a single stanza, taking care not to request a page of collections that is so big it might exceed karma limits.</p>
+    <p class="caption">Example 22. Requesting the first page of a list with same JID</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='juliet1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 23. Requesting the first page of a list with same JID between two times</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='period1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'
+        start='1469-07-21T02:00:00Z'
+        end='1479-07-21T04:00:00Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 24. Requesting the first page of a list after a time</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='list1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        start='1469-07-21T02:00:00Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server MUST list the collections (empty &lt;store/&gt; elements including all attributes) in chronological order when responding to any request:</p>
+    <p class="caption">Example 25. Receiving the first page of a list</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='list1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com/chamber'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'
+           dataalg='DEM1-SC2-KDF2-SHA256'
+           key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'
+           keyalg='RSA-KEM-KDF2-SHA256'
+           master='acc3594e844c77696f7a7ba9367ae324b6b958ad'/&gt;
+    .
+    [28 more collections]
+    .
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;1469-07-21T02:56:15Zjuliet@capulet.com&lt;/first&gt;
+      &lt;last&gt;1469-07-21T03:16:37Zbalcony@house.capulet.com&lt;/last&gt;
+      &lt;count&gt;1372&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: In accordance with <span style="font-weight: bold">Result Set Management</span>, the client MUST assume the unique IDs it receives in the &lt;first/&gt; and &lt;last/&gt; elements are opaque. Servers MAY adopt a unique ID format other than the one suggested in the example above.</p>
+    <p class="" style="">If no collections correspond to the request the server MUST return an empty &lt;list/&gt; element:</p>
+    <p class="caption">Example 26. Receiving an empty list</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='list1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 27. Requesting the second page of a list</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='list2'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        start='1469-07-21T02:00:00Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+      &lt;after&gt;1469-07-21T03:16:37Zbalcony@house.capulet.com&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Refer to <span style="font-weight: bold">Result Set Management</span> to learn more about the various ways that the pages of the list may be accessed.</p>
+    <p class="" style="">The 'master' attribute MAY be included to limit the list to encrypted collections whose messages decryption key was encrypted with the specified private key. This feature enables a client to find any collections that depend on an obsolete private key:</p>
+    <p class="caption">Example 28. Requesting the first page of a list with a private key ID</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='master1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        master='acc3594e844c77696f7a7ba9367ae324b6b958ad'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 29. Receiving the first page of a list with a private key ID</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='master1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store xmlns='http://jabber.org/protocol/archive'
+           with='juliet@capulet.com/chamber'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'
+           dataalg='DEM1-SC2-KDF2-SHA256'
+           key='bfXv33i+Ybqypa4ETLyorGkVl73v67SMvzX41MPRKA5cOp9wGDMgd8SirwIDAQAB'
+           keyalg='RSA-KEM-KDF2-SHA256'
+           master='acc3594e844c77696f7a7ba9367ae324b6b958ad'/&gt;
+    .
+    [29 more encrypted collections]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;1469-07-21T02:56:15Zjuliet@capulet.com&lt;/first&gt;
+      &lt;last&gt;1469-07-21T03:16:37Zbalcony@house.capulet.com&lt;/last&gt;
+      &lt;count&gt;142&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="manage-retrieve">Retrieving a Collection</a>
+</h3>
+    <p class="" style="">To request a page of messages from a collection the client sends a &lt;retrieve/&gt; element. The 'with' and 'start' attributes specify the participating full JID and the start time (see <span style="font-weight: bold">Jabber Date and Time Profiles</span>). Both attributes MUST be included to uniquely identify a collection:</p>
+    <p class="" style="">The client SHOULD use <span style="font-weight: bold">Result Set Management</span> to limit the number of messages returned by the server in a single stanza, taking care not to request a page of messages that is so big it might exceed karma limits.</p>
+    <p class="caption">Example 30. Requesting the first page of a collection</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='page1'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com/chamber'
+            start='1469-07-21T02:56:15Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;100&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/retrieve&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 31. Receiving the first page of a collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='page1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    .
+    [98 more messages]
+    .
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;0&lt;/first&gt;
+      &lt;last&gt;99&lt;/last&gt;
+      &lt;count&gt;217&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: In accordance with <span style="font-weight: bold">Result Set Management</span>, the client MUST assume the unique IDs it receives in the &lt;first/&gt; and &lt;last/&gt; elements are opaque. Servers MAY adopt a unique ID format other than the one suggested in the example above.</p>
+    <p class="" style="">If the specified collection does not exist then the server MUST return an &lt;item-not-found/&gt; error:</p>
+    <p class="caption">Example 32. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard' from='montague.net' id='page1'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested collection is empty the server MUST return an empty &lt;store/&gt; element:</p>
+    <p class="caption">Example 33. Receiving an empty collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='page1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 34. Requesting the second page of a collection</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='page2'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com/chamber'
+            start='1469-07-21T02:56:15Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;100&lt;/max&gt;
+      &lt;after&gt;99&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/retrieve&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Refer to <span style="font-weight: bold">Result Set Management</span> to learn more about the various ways that the pages of the collection may be accessed.</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="manage-remove">Removing a Collection</a>
+</h3>
+    <p class="" style="">To request the removal of a single collection the client sends an empty &lt;remove/&gt; element. The 'with' (full JID) and 'start' attributes MUST be included to uniquely identify the collection.</p>
+    <p class="caption">Example 35. Removing a single collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com/chamber'
+          start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client may remove several collections at once. The 'start' and 'end' elements MAY be specified to indicate a date range. The 'with' attribute MAY be a full JID, bare JID or domain.</p>
+    <p class="caption">Example 36. Removing all collections with a specified bare JID between two times</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the 'with' attribute is omitted then collections with any JID are removed.</p>
+    <p class="" style="">If the end date is in the future then then all collections after the start date are removed.</p>
+    <p class="caption">Example 37. Removing all collections after a date</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='1469-07-21T02:00:00Z'
+          end='2038-01-01T00:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the start date is before all the collections in the archive then all collections prior to the end date are removed.</p>
+    <p class="caption">Example 38. Removing all collections before a date</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='0000-01-01T00:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 39. Removing all collections</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the specified collection (or collections) do not exist then the server MUST return an &lt;item-not-found/&gt; error:</p>
+    <p class="caption">Example 40. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="sect-id2259771">Replication</a>
+</h2>
+  <p class="" style="">This section describes how a client MAY replicate an archive locally.  [<a href="#nt-id2259784">15</a>] The existance of a local copy of the archive enables clients to search the content of all messages (including collections saved by another client machine).  [<a href="#nt-id2259792">16</a>]</p>
+  <p class="" style="">The client MAY 'synchronize' its local copy of the archive with the 'master' archive on the server at any time. The first step is to request the list of collections that the server has changed (created, modified or removed) in its master archive since the last update to the client's copy of the archive.</p>
+  <p class="" style="">The client MUST request each page of the list using the <span style="font-weight: bold">Result Set Management</span> protocol embeded in a &lt;modified/&gt; element. The content of the &lt;after/&gt; element SHOULD be a UTC time (see <span style="font-weight: bold">Jabber Date and Time Profiles</span>) that it has previously received from the server (see below). When synchronizing for the first time, the client MAY choose a suitable time for the first page request (e.g. 1970-01-01T00:00:00Z).</p>
+  <p class="caption">Example 41. Requesting a page of modifications</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net' id='sync1'&gt;
+  &lt;modified xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;50&lt;/max&gt;
+      &lt;after&gt;1469-07-21T01:14:47Z&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/modified&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The server MUST return the changed collections in the chronological order that they were changed (most recent last). If a collection has been modified, created or removed <span style="font-style: italic">after</span> the time specified by the &lt;after/&gt; element then the server MUST include it in the returned result set page of collections (unless the specified maximum page size would be exceeded). Each &lt;changed/&gt; or &lt;removed/&gt; collection element (for modified/created, or removed collections respectively) in the returned list MUST include only 'with' and 'start' attribues. The server MUST set the content of the &lt;last/&gt; element to the UTC time (see <span style="font-weight: bold">Jabber Date and Time Profiles</span>) that the last collection on the page was modified.</p>
+  <p class="caption">Example 42. Receiving a page of modifications</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='sync1'&gt;
+  &lt;modified xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;changed with='juliet@capulet.com/chamber'
+           start='1469-07-21T02:56:15Z'/&gt;
+    .
+    [up to 48 more collections]
+    .
+    &lt;removed with='balcony@house.capulet.com'
+             start='1469-07-21T03:16:37Z'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;last&gt;1469-07-21T04:22:39Z&lt;/last&gt;
+      &lt;count&gt;1372&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/modified&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Note: The server should remember the 'with' and 'start' attribues and the time of removal of all deleted collections. If this 'state' cannot be maintained indefinitely, then unless all the user's clients replicate before the server deletes its memory of a removal then it will not be reflected in all the local copies of the archive.</p>
+  <p class="" style="">Note: Along with its copy of the archive the client SHOULD store the most recent &lt;last/&gt; time that it received from the server. The next time it synchronizes with the server it SHOULD specify that time when requesting the first result set page (see above).</p>
+  <p class="" style="">After receiving each result set page the client SHOULD delete from its local archive any collections that have been removed from the master archive. The client should also retrieve from the server the content of each collection that has been modified (see <a href="#retrieve">Retrieving a Collection</a>) and add it to its local copy of the archive (deleting any older version of the same collection that it may already have).</p>
+<h2>9.
+       <a name="fileformat">File Format</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note the file format specified in this section is likely to be depricated once a standards-based format has been published in a separate JEP.</span></p>
+  <p class="" style="">So that clients can share archived messages, this document specifies a common format for storage on disk (similar to email formats like mbox and Maildir). The file format uses the same XML constructs as the protocol. Each file may contain messages exchanged with a single JID. Any number of items may be stored in an archive file.</p>
+  <p class="caption">Example 43. Example file</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0'?&gt;
+&lt;archive xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'&gt;
+  &lt;store start='1469-07-21T02:56:15Z' subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/archive&gt;
+  </pre></div>
+<h2>10.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="impl-sync">Time Synchronization</a>
+</h3>
+    <p class="" style="">When creating a new collection, it is RECOMMENDED that the client synchronizes the collection start time that it sends to the server with server time. This is important since the user may subsequently retrieve the stored collection using client machines whose UTC clocks are not synchronized with the client machine that stored the collection. (i.e. Either or both of the clients' UTC clocks may be wrong.) The client can achieve this synchronization with server time by using <span class="ref" style="">Entity Time</span>  [<a href="#nt-id2260046">17</a>] to estimate the difference between the server and client UTC clocks.</p>
+    <p class="" style="">When retrieving collections, it is RECOMMENDED that the client adjusts the start times of the collections it receives from server to be synchronized with the clock of the client machine.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="impl-bandwidth">Bandwidth Considerations</a>
+</h3>
+    <p class="" style="">When uploading messages using manual archiving, a client SHOULD NOT store one message at a time on the server since this increases both bandwidth consumption and the total number of transactions. It is instead RECOMMENDED that clients store messages only when the conversation thread <span style="font-style: italic">appears</span> to be terminated, e.g. when the user closes the chat window. If the user reopens the window and the thread continues then the client should append the new messages to the collection when the user closes the window again.</p>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="impl-storage">Storage Considerations</a>
+</h3>
+    <p class="" style="">Server implementations SHOULD give system administrators the option to disable support for both automated and manual archiving, since archived conversations can consume significant storage space.</p>
+  </div>
+<h2>11.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="security-encrypt">Plain Text Subject</a>
+</h3>
+    <p class="" style="">Since the subject of each collection will not be encrypted, the client MUST warn its human user (if any) before including 'subject' attributes on encrypted collections.</p>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="security-store">Store Headers</a>
+</h3>
+    <p class="" style="">The client that originates a message MAY specify a 'false' value for the 'store' header (see <span class="ref" style="">Stanza Headers and Internet Metadata</span>  [<a href="#nt-id2260158">18</a>]). The recipient MUST NOT archive such a message or any of the information it contains.</p>
+    <p class="" style="">If the sender plans to use 'store' headers it MUST use Service Discovery to determine whether or not the recipient supports them. Note: Since servers are not required to check the content of message stanzas for headers, if the recipient is using automatic archiving then it MUST indicate that it does not support 'store' headers.</p>
+    <p class="" style="">If the recipient does not support 'store' headers, then the sender MUST confirm with its human user (if any) before sending such a message.</p>
+  </div>
+<h2>12.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260238">19</a>] is required as a result of this JEP.</p>
+<h2>13.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260284">20</a>] shall include 'http://jabber.org/protocol/archive' in its registry of protocol namespaces (see &lt;<a href="http://www.jabber.org/registrar/namespaces.html">http://www.jabber.org/registrar/namespaces.html</a>&gt;):</p>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the following features in its registry of service discovery features (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;):</p>
+    <ul>
+      <li>http://jabber.org/protocol/archive#auto</li>
+      <li>http://jabber.org/protocol/archive#encrypt</li>
+      <li>http://jabber.org/protocol/archive#manage</li>
+      <li>http://jabber.org/protocol/archive#manual</li>
+      <li>http://jabber.org/protocol/archive#pref</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>13.3 <a name="registrar-crypt">Cryptography Scheme Names</a>
+</h3>
+    <div class="indent">
+<h3>13.3.1 <a name="registrar-kemkdf2">RSA-KEM-KDF2-SHA256</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall include 'RSA-KEM-KDF2-SHA256' in its registry of cryptography scheme names with the following description:</p>
+      <p class="" style="">The encrypting entity uses the <span style="font-style: italic">RSA-KEM.Encrypt</span> algorithm and the <span style="font-style: italic">KDF2</span> key derivation function and the SHA256-based HMAC algorithm (see ISO 18033-2) along with the entity's <span style="font-style: italic">public</span> RSA key (i.e. the key whose identity is the 'master' attribute of the &lt;store/&gt; element) to generate a secret symmetric encryption key, K, and an RSA-encrypted version of the key, C (i.e. the 'key' attribute of the &lt;store/&gt; element).</p>
+      <p class="" style="">The decrypting entity uses <span style="font-style: italic">RSA-KEM.Decrypt</span> algorithm and the <span style="font-style: italic">KDF2</span> key derivation function and the SHA256-based HMAC algorithm (see ISO 18033-2) along with the entity's <span style="font-style: italic">private</span> RSA key to decrypt C to K.</p>
+    </div>
+    <div class="indent">
+<h3>13.3.2 <a name="registrar-dem1sc2">DEM1-SC2-KDF2-SHA256</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall include 'DEM1-SC2-KDF2-SHA256' in its registry of cryptography scheme names with the following description:</p>
+      <p class="" style="">The encrypting entity uses the <span style="font-style: italic">DEM1.Encrypt</span> algorithm with the <span style="font-style: italic">SC2.Encrypt</span> symmetric encryption algorithm and the <span style="font-style: italic">KDF2</span> key derivation function and the SHA256-based HMAC algorithm (see ISO 18033-2) to encrypt the data, M (i.e. the complete sequence of &lt;from/&gt;, &lt;to/&gt; and &lt;note/&gt; elements), with the secret symmetric encryption key, K, and a randomly generated public label, L (i.e. the 'label' attribute of the &lt;crypt/&gt; element).</p>
+      <p class="" style="">Note that the encrypting entity MAY use same key, K, for more than one collection. But it MUST use the label, L, with only one plain text, M.</p>
+      <p class="" style="">The decrypting entity uses the <span style="font-style: italic">DEM1.Decrypt</span> algorithm with the <span style="font-style: italic">SC2.Decrypt</span> symmetric decryption algorithm and the <span style="font-style: italic">KDF2</span> key derivation function and the SHA256-based HMAC algorithm (see ISO 18033-2) to decrypt the data with K and L.</p>
+    </div>
+  </div>
+<h2>14.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/archive'
+    xmlns='http://jabber.org/protocol/archive'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The allowable root element for the namespace defined
+      herein are:
+        - archive
+        - list
+        - otr
+        - remove
+        - retrieve
+        - save
+        - store
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='archive'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='auto'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='dataalg' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='key' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='keyalg' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='master' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='save' type='xs:boolean' use='required'/&gt;
+          &lt;xs:attribute name='secret' use='optional' type='xs:string'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='changed'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='crypt'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='default'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='otr' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='allow'/&gt;
+                &lt;xs:enumeration value='deny'/&gt;
+                &lt;xs:enumeration value='require'/&gt;
+                &lt;xs:enumeration value='try'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='save' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='all'/&gt;
+                &lt;xs:enumeration value='body'/&gt;
+                &lt;xs:enumeration value='false'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='unset' use='optional' type='xs:boolean'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' use='required' type='xs:string'/&gt;
+          &lt;xs:attribute name='otr' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='allow'/&gt;
+                &lt;xs:enumeration value='deny'/&gt;
+                &lt;xs:enumeration value='require'/&gt;
+                &lt;xs:enumeration value='try'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='save' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='all'/&gt;
+                &lt;xs:enumeration value='body'/&gt;
+                &lt;xs:enumeration value='false'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='list'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='end' type='xs:dateTime' use='optional'/&gt;
+      &lt;xs:attribute name='master' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='optional'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='modified'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='changed' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='removed' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='pref'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='default' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='remove'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='end' type='xs:dateTime' use='optional'/&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='removed'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='retrieve'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='store'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='crypt'/&gt;
+        &lt;xs:element name='from' type='messageType'/&gt;
+        &lt;xs:element name='note' type='xs:string'/&gt;
+        &lt;xs:element name='to' type='messageType'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='dataalg' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='key' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='keyalg' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='master' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+      &lt;xs:attribute name='subject' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:complexType name='messageType'&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element name='body' type='xs:string' maxOccurs='unbounded'/&gt;
+    &lt;/xs:sequence&gt;
+    &lt;xs:attribute name='secs' type='xs:nonNegativeInteger' use='required'/&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250950">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2258246">2</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2258281">3</a>. If a client (or user) acts in bad faith then its contacts cannot prevent it archiving conversations.</p>
+<p><a name="nt-id2258379">4</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2258473">5</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2258553">6</a>. Stream compression typically does not mitigate bandwidth and storage issues since collections SHOULD be encrypted, and since clients running in constrained runtime environments typically cannot take advantage of stream compression (no binary data, only XML, may be transfered).</p>
+<p><a name="nt-id2258716">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2258786">8</a>. SHA-1 is broken (assuming the attacker has plenty of computing power) and many other standard hashes are not optimised for 32-bit processors (e.g. Whirlpool, SHA-384, SHA-512).</p>
+<p><a name="nt-id2258801">9</a>. Future versions of this document MAY be modified to recommend other algorithms.</p>
+<p><a name="nt-id2258890">10</a>. Mechanisms for the storage and retrieval of private keys are beyond the scope of this document.</p>
+<p><a name="nt-id2258906">11</a>. RSA-KEM is the only required encapsulation scheme since it is NESSIE-recommended, its security is tightly proven (unlike RSA-OAEP or PKCS #1 v1.5), and it is very simple to implement.</p>
+<p><a name="nt-id2258920">12</a>. Future versions of this document MAY be modified to recommend other algorithms.</p>
+<p><a name="nt-id2259052">13</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2259249">14</a>. JEP-0059: Result Set Management &lt;<a href="http://www.jabber.org/jeps/jep-0059.html">http://www.jabber.org/jeps/jep-0059.html</a>&gt;.</p>
+<p><a name="nt-id2259784">15</a>. Clients that run in constrained environments may not be able to implement replication if they are prevented from accessing (sufficient) local storage.</p>
+<p><a name="nt-id2259792">16</a>. Since collections should be stored in encrypted form on the server, server-side searching of the content of messages is beyond the scope of this protocol.</p>
+<p><a name="nt-id2260046">17</a>. JEP-0090: Entity Time &lt;<a href="http://www.jabber.org/jeps/jep-0090.html">http://www.jabber.org/jeps/jep-0090.html</a>&gt;.</p>
+<p><a name="nt-id2260158">18</a>. JEP-0131: Stanza Headers and Internet Metadata &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2260238">19</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260284">20</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2006-09-08)</h4>
+<div class="indent">
+<p class="" style="">Added preferences, results set management and notes; reinstated encryption and replication; simplified auto-archiving and off-the-record (with JEP-0155); many minor changes</p> (ip)
+    </div>
+<h4>Version 0.6 (2006-08-18)</h4>
+<div class="indent">
+<p class="" style="">Added unset value for save attribute and added service attribute on default element; added source attribute on record element; specified that services should (not must) support save mode for particular contacts.</p> (jp/psa)
+    </div>
+<h4>Version 0.5 (2006-05-03)</h4>
+<div class="indent">
+<p class="" style="">Integrated text from server-side archiving proposal; added partial support to collection retrieval; harmonized XML formats and namespaces; defined Jabber Registrar considerations and XML schema.</p> (psa/jp/jk)
+    </div>
+<h4>Version 0.4 (2005-12-21)</h4>
+<div class="indent">
+<p class="" style="">Added Replication and Searching section, partial attribute; minor improvements</p> (ip)
+    </div>
+<h4>Version 0.3 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Added more examples to Removing Collections</p> (ip)
+    </div>
+<h4>Version 0.2 (2005-04-18)</h4>
+<div class="indent">
+<p class="" style="">Complete rewrite.</p> (ip)
+    </div>
+<h4>Version 0.1 (2004-06-04)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0136-0.8.html
+++ b/content/xep-0136-0.8.html
@@ -1,0 +1,1424 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0136: Message Archiving</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Archiving">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Creator" content="Jon Perlow">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Justin Karneges">
+<meta name="DC.Description" content="This document defines mechanisms for server-side archiving of XMPP messages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-09-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0136">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0136: Message Archiving</h1>
+<p>This document defines mechanisms for server-side archiving of XMPP messages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0136<br>
+            Version: 0.8<br>
+            Last Updated: 2006-09-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0059, JEP-0060, JEP-0155, JEP-0163, W3C XML Encryption, W3C XML Signature<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: archive<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Message%20Archiving%20(JEP-0136)">http://wiki.jabber.org/index.php/Message Archiving (JEP-0136)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+<h3>Jon Perlow</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jonp@google.com">jonp@google.com</a><br>
+        JID: 
+        <a href="xmpp:jonp@google.com">jonp@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Justin Karneges</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:justin@affinix.com">justin@affinix.com</a><br>
+        JID: 
+        <a href="xmpp:justin@andbit.net">justin@andbit.net</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#disco">Determining Server Support</a>
+</dt>
+<dt>3.  <a href="#pref">Archiving Preferences</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#pref-reqs">Introducton</a>
+</dt>
+<dt>3.2.  <a href="#pref-determine">Determining Modes</a>
+</dt>
+<dt>3.3.  <a href="#pref-default">Setting Default Modes</a>
+</dt>
+<dt>3.4.  <a href="#pref-jid">Setting Modes for a Contact</a>
+</dt>
+</dl>
+<dt>4.  <a href="#otr">Off The Record</a>
+</dt>
+<dt>5.  <a href="#manual">Manual Archiving</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#manual-intro">Introduction</a>
+</dt>
+<dt>5.2.  <a href="#manual-collection">Collections</a>
+</dt>
+<dt>5.3.  <a href="#manual-upload">Uploading Messages to a Collection</a>
+</dt>
+<dt>5.4.  <a href="#impl-muc">Offline Messages</a>
+</dt>
+<dt>5.5.  <a href="#impl-muc">Groupchat Messages</a>
+</dt>
+<dt>5.6.  <a href="#crypt">Changing the Subject of a Collection</a>
+</dt>
+</dl>
+<dt>6.  <a href="#crypt">Encryption</a>
+</dt>
+<dt>7.  <a href="#auto">Automated Archiving</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#auto-toggle">Toggling Auto-Archiving</a>
+</dt>
+<dt>7.2.  <a href="#auto-crypt">Enabling Auto-Archiving with Encryption</a>
+</dt>
+<dt>7.3.  <a href="#auto-crypt">Not-Implemented Responses</a>
+</dt>
+</dl>
+<dt>8.  <a href="#manage">Archive Management</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#manage-list">Retrieving a List of Collections</a>
+</dt>
+<dt>8.2.  <a href="#manage-retrieve">Retrieving a Collection</a>
+</dt>
+<dt>8.3.  <a href="#manage-remove">Removing a Collection</a>
+</dt>
+</dl>
+<dt>9.  <a href="#rekey">Replacing EncryptedKey Elements</a>
+</dt>
+<dt>10.  <a href="#sect-id2260655">Replication</a>
+</dt>
+<dt>11.  <a href="#fileformat">File Format</a>
+</dt>
+<dt>12.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>12.1.  <a href="#impl-sync">Time Synchronization</a>
+</dt>
+<dt>12.2.  <a href="#impl-bandwidth">Bandwidth Considerations</a>
+</dt>
+<dt>12.3.  <a href="#impl-storage">Storage Considerations</a>
+</dt>
+</dl>
+<dt>13.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>13.1.  <a href="#security-autoon">Automatic Archiving Defaulting to On</a>
+</dt>
+<dt>13.2.  <a href="#security-encrypt">Plain Text Subject</a>
+</dt>
+<dt>13.3.  <a href="#security-store">Store Headers</a>
+</dt>
+</dl>
+<dt>14.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>15.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>15.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>15.2.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>16.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Many XMPP clients implement some form of client-side message archiving. However, it is not always convenient or even possible to archive messages locally, e.g., because it is easier to keep all archives in one universally accessable place (not scattered around on multiple computers or devices) or because the client operates in a web browser or resides on a mobile device that does not have sufficient local storage for message archiving. In addition, server-side archiving makes it possible to offer new services such as integration of IM and email. Therefore it is beneficial to define methods for server-side archiving of XMPP messages.</p>
+  <p class="" style="">There are two main approaches to this problem:</p>
+  <ol start="1" type="">
+    <li>Enable the client to send individual messages or entire conversations to the server for archiving (optionally after encryption); we call this manual archiving.</li>
+    <li>Enable the server (at the client's request) to archive messages as they pass through the server; we call this automated archiving.</li>
+  </ol>
+  <p class="" style="">So that client and server developers can refer to one specification, both approaches are defined in this document. In addition, this document defines common methods for retrieving and managing archived messages.</p>
+    <p class="" style="">Complying with <span style="font-weight: bold">XMPP Core</span>, the server MUST respond to all &lt;iq/&gt; element of type 'get' or 'set'. However, most successful responses have been omitted from this document in the interest of conciseness.</p>
+<h2>2.
+       <a name="disco">Determining Server Support</a>
+</h2>
+  <p class="" style="">A client discovers whether its server supports this protocol using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250989">1</a>].</p>
+  <p class="caption">Example 1. Client Service Discovery request</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+</pre></div>
+  <p class="" style="">For each feature defined herein, if the server supports that feature it MUST return a &lt;feature/&gt; element with the 'var' attribute set to 'http://jabber.org/protocol/archive#name', where "name" is "auto" for the <a href="#auto">Automated Archiving</a> feature, "encrypt" for the <span style="font-style: italic">server-side</span> encryption feature (see <a href="#auto">Automated Archiving</a>), "manage" for the <a href="#manage">Archive Management</a> feature, "manual" for the <a href="#manual">Manual Archiving</a> feature, or "pref" for the <a href="#pref">Archiving Preferences</a> feature.</p>
+  <p class="caption">Example 2. Server Service Discovery response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result'
+    from='montague.net'
+    to='romeo@montague.net/orchard'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/archive#auto'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#encrypt'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#manage'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#manual'/&gt;
+    &lt;feature var='http://jabber.org/protocol/archive#pref'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+<h2>3.
+       <a name="pref">Archiving Preferences</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="pref-reqs">Introducton</a>
+</h3>
+    <p class="" style="">Not all users want to archive messages. A client SHOULD save its user's default archiving preference (or "Save Mode") to its own server (i.e., specify whether by default all conversations should be archived or not). In addition, a client MAY save different preferences for particular contacts.</p>
+    <p class="" style="">Some users may also prefer that the messages they exchange with contacts are "<a href="#otr">Off The Record</a>" (OTR). A client SHOULD save its user's default and contact-specific OTR preferences (or "OTR Modes") to its own server.</p>
+    <p class="" style="">Whichever archiving method a client uses (e.g., local archiving, or automatic or manual archiving to a server), it SHOULD adhere to its user's archiving preferences. However, a client MAY maintain a set of preferences in a local file which takes precedence over the preferences stored on the server for both local archiving and manual archiving.</p>
+    <p class="" style="">This section addresses the following use cases:</p>
+    <ol start="1" type="">
+      <li>A client determines its user's current default Save Mode and OTR Mode, and the Modes for particular contacts.</li>
+      <li>A client sets the default Save Mode and OTR Mode.</li>
+      <li>A client sets the Save Mode and OTR Mode for a particular contact.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="pref-determine">Determining Modes</a>
+</h3>
+    <p class="" style="">In order to determine its user's current Save Mode(s) and OTR Mode(s), a client sends this query to its server:</p>
+    <p class="caption">Example 3. Client Requests Modes</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='save1' from='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server responds with the default Save Mode and OTR Mode (&lt;default/&gt; element) and any Save Modes and OTR Modes for specific contacts (&lt;item/&gt; elements).</p>
+    <p class="" style="">Each child element in the response MUST include a 'save' attribute, whose value MAY be 'false' (the client MUST save no messages), 'body' (the client SHOULD save only &lt;body/&gt; elements) or 'all' (the client SHOULD save the full XML content of each &lt;message/&gt; element).</p>
+    <p class="" style="">Note: Support for the 'all' value is optional and, to conserve bandwidth and storage space, it is RECOMMENDED that client implementations do not specify the 'all' value.</p>
+    <p class="" style="">Note: When archiving <span style="font-style: italic">locally</span> a client MAY save the full XML content of each &lt;message/&gt; element even if the Save Mode is 'body'.</p>
+    <p class="" style="">Each child element in the response MUST include an 'otr' attribute, whose value MAY be 'deny' (if <a href="#otr">Off The Record</a> is <span style="font-style: italic">required</span> by the contact the client MUST send no messages), 'allow' (the client MAY save messages unless the contact requests OTR), 'try' (the client MUST try to negotiate OTR with the contact) or 'require' (the client MUST send no messages unless the contact explicitly agrees to OTR).</p>
+    <p class="" style="">Note: If the OTR Mode is 'require' then the Save Mode MUST be 'false'.</p>
+    <p class="" style="">The server also includes an &lt;auto/&gt; element with the current <a href="#auto">Automated Archiving</a> settings for <span style="font-style: italic">this stream</span>.</p>
+    <p class="caption">Example 4. Server Returns Modes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='body' otr='allow'/&gt;
+    &lt;item jid='romeo@montague.net' save='false' otr='require'/&gt;
+    &lt;item jid='benvolio@montague.net' save='all' otr='deny'/&gt;
+    &lt;auto save='false'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user has never set the default Modes, the 'save' and 'otr' attributes SHOULD specify the server's default settings, and the 'unset' attribute SHOULD be set to "true". Note: The 'unset' attribute defaults to "false".</p>
+    <p class="caption">Example 5. Server Returns Service Default Modes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save1' to='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='false' otr='allow' unset='true'/&gt;
+    &lt;auto save='false'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Once it has received a request for archiving preferences from the client, the server MUST send any subsequent changes to any of the user's archiving preferences to the client until the stream is closed (see below).</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="pref-default">Setting Default Modes</a>
+</h3>
+    <p class="" style="">A client may set the default Modes:</p>
+    <p class="caption">Example 6. Client Sets Default Modes</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='save2' from='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='false' otr='try'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can process the request, it acknowledges the change:</p>
+    <p class="caption">Example 7. Server Acknowledges Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save2' to='juliet@capulet.com/chamber'/&gt;
+    </pre></div>
+    <p class="" style="">The server then MUST inform all of the user's connected resources that have previously requested the user's archiving preferences:</p>
+    <p class="caption">Example 8. Server Pushes New Modes</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='savepush1' to='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='false' otr='try'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' id='savepush2' to='juliet@capulet.com/pda'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;default save='false' otr='try'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server MAY be configured to return a &lt;feature-not-implemented/&gt; error in the following cases:</p>
+    <ul>
+      <li><p class="" style="">If it does not allow the saving of full message stanza content, and the client set the value of the 'save' attribute to "all", and any of the user's connected resources have <a href="#auto">Automated Archiving</a> enabled.</p></li>
+      <li><p class="" style="">If administrator policies require that at least the &lt;body/&gt; (or the full content) of every message is logged automatically, and the client sets the value of the 'save' attribute to "false" (or "body").</p></li>
+    </ul>
+    <p class="" style="">Note: More error cases to follow.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="pref-jid">Setting Modes for a Contact</a>
+</h3>
+    <p class="" style="">A client may use a similar protocol to set the Modes for a particular contact or domain of contacts (bare JID, full JID or domain). Note: It is STRONGLY RECOMMENDED for the value of the 'jid' attribute to be a bare JID (&lt;node@domain.tld&gt;).</p>
+    <p class="caption">Example 9. Client Sets Modes for a Contact</p>
+<div class="indent"><pre>
+&lt;iq type='set' item='save3' from='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='body' otr='allow'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 10. Server Acknowleges Change</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='save3' to='juliet@capulet.com/chamber'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. Server Pushes New Modes</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='savepush3' to='juliet@capulet.com/chamber'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='body' otr='allow'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+
+&lt;iq type='set' id='savepush4' to='juliet@capulet.com/pda'&gt;
+  &lt;pref xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;item jid='romeo@montague.net' save='body' otr='allow'/&gt;
+  &lt;/pref&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The same error cases apply as when <a href="#auto">Setting Default Modes</a>.</p>
+  </div>
+<h2>4.
+       <a name="otr">Off The Record</a>
+</h2>
+  <p class="" style="">A user will sometimes exchange messages with contacts who prefer that their conversations are not archived by either party. Any client that archives messages SHOULD support <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2258310">2</a>] and its 'otr' field both to give other contacts the opportunity to indicate this preference, and to negotiate an "Off The Record" (OTR) policy that complies with its user's own <a href="#pref">Archiving Preferences</a>.</p>
+  <p class="" style="">A client MUST NOT agree to enable OTR unless it has confirmed that its server will allow it to switch off <a href="#auto">Automated Archiving</a>.</p>
+  <p class="" style="">If a Chat Session Negotiation agreed to enable OTR then the clients MUST NOT allow messages sent in <span style="font-style: italic">either</span> direction to be archived in any way (including <a href="#manual">Manual Archiving</a> and <a href="#auto">Automated Archiving</a>).  [<a href="#nt-id2258360">3</a>]</p>
+  <p class="" style="">Note: If a contact does not include an 'otr' field in its initial Chat Session Negotiation request, and a user's Archiving Preferences indicate that OTR is <span style="font-style: italic">required</span>, then the client MUST refuse the request. It MAY then send its own Chat Session Negotiation request with an 'otr' field.</p>
+  <p class="" style="">If a Chat Session Negotiation agreed to enable OTR then both clients MUST ensure that the Chat Session Negotiation messages themselves are not archived. For example, if <a href="#auto">Automated Archiving</a> was enabled when the client received the initial Chat Session Negotiation request, then the client MUST immediately ask its server to delete its copy of the request (see <a href="#manage-remove">Removing a Collection</a> for a description of how to remove the messages currently being recorded by the server).</p>
+  <p class="" style="">If a user's OTR preference for a contact changes during a Chat Session that has been negotiated with the contact, and if the new preference would affect the value of the 'otr' field that was previously negotiated, then the client MUST immediately terminate the Chat Session and try to negotiate a new one according to the user's new OTR preference.</p>
+<h2>5.
+       <a name="manual">Manual Archiving</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="manual-intro">Introduction</a>
+</h3>
+    <p class="" style="">While automated archiving is easy for the client and server to implement, there are many contexts in which manual archiving is required. For examples, when:</p>
+    <ul>
+      <li>Messages are encrypted using evanscent keys, as in <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2258473">4</a>]</li>
+      <li>A client's own server does not support automated archiving but it (or another server) does support manual archiving</li>
+      <li>A server does not support encryption of auto-archived collections</li>
+      <li>A client wants to maintain a unified archive for messages that were transmitted both in and out-of-band (e.g. SMS or email)</li>
+      <li>A client wants to append private notes to a conversation</li>
+    </ul>
+    <p class="" style="">Therefore, often a client will want to send or receive a sequence of messages, optionally add private notes to the sequence, optionally encrypt the sequence, and then ask the server to store it. Such messages and notes SHOULD be stored on the server in the form of a "collection".</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="manual-collection">Collections</a>
+</h3>
+    <p class="" style="">A "collection" is a set of messages to/from the same user that are received near each other in time or as part of the same conversation thread. A collection is intended to mimic the natural flow of human conversations, which in instant messaging (IM) systems tend to occur in bursts (e.g., a five-minute conversation one day, followed by a ten-minute conversation the next).</p>
+    <p class="" style="">The client uniquely specifies a collection using a pair of attributes:</p>
+    <ul>
+      <li>'with' (the full JID with which the messages were exchanged)</li>
+      <li>'start' (the UTC start time of the conversation thread, which MUST be UTC and adhere to the DateTime format specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2258568">5</a>])</li>
+    </ul>
+    <p class="" style="">A friendly name for the collection MAY be specified with a 'subject' attribute. Note the <a href="#security-subject">Security Considerations</a> regarding the subject attribute.</p>
+    <p class="" style="">Each collection MAY contain &lt;note/&gt;, &lt;to/&gt; or &lt;from/&gt; elements (or &lt;EncryptedData/&gt; and &lt;EncryptedKey/&gt; elements - see <a href="#crypt">Encryption</a>).</p>
+    <p class="" style="">The text of each individual private note MUST be encapsulated in a &lt;note/&gt; element. The absolute time the note was created SHOULD be specified with a 'utc' attribute (which MUST be UTC and adhere to the DateTime format specified in <span style="font-weight: bold">Jabber Date and Time Profiles</span>).</p>
+    <p class="" style="">The content of each individual message MUST be encapsulated in a &lt;to/&gt; or &lt;from/&gt; element. The time in whole seconds of the message relative to the previous message in the collection (or, for the first message, relative to the start of the collection) SHOULD be specified with a 'secs' attribute. Note: When deciding whether to round up or down to a number of whole seconds, entities MUST ensure that the sum of the 'secs' attribute and the 'secs' attributes of the preceeding messages will accurately reflect the absolute time of the message. (e.g., if a sequence of messages occur at exactly 0.51-second intervals then the 'secs' attributes should generally alternate between '0' or '1'.)</p>
+    <p class="" style="">The content of each &lt;to/&gt; or &lt;from/&gt; element SHOULD include a &lt;body/&gt; element. Note: Other elements MAY be included, but they are NOT RECOMMENDED. To conserve bandwidth and storage space  [<a href="#nt-id2258672">6</a>], elements qualified by the 'http://jabber.org/protocol/xhtml-im' namespace SHOULD NOT be included. &lt;thread/&gt; elements and elements qualified by the 'jabber:x:delay', 'jabber:x:event' and 'http://jabber.org/protocol/chatstates' namespaces MUST NOT be included. The server MAY be configured to return a &lt;feature-not-implemented/&gt; error if any &lt;to/&gt; or &lt;from/&gt; element contains anything other than a single &lt;body/&gt; element.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="manual-upload">Uploading Messages to a Collection</a>
+</h3>
+    <p class="" style="">The collection of messages and notes to be uploaded are encapsulated in the &lt;store/&gt; element.</p>
+    <p class="caption">Example 12. Storing messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+    &lt;note utc='1469-07-21T03:04:35Z'&gt;I think she might fancy me.&lt;/note&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the collection does not exist then the server MUST create a new collection. If the collection already exists then the server MUST append the messages to the existing collection.</p>
+    <p class="" style="">Note: Clients MUST take care to append each sequence of messages to the collection before the sequence becomes so large that uploading it may violate common rate limiting restrictions (in Jabber systems, often called "karma").</p>
+    <p class="caption">Example 13. Successful reply</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' id='up1'/&gt;
+    </pre></div>
+    <p class="" style="">If the server cannot service a store request because the collection is too large then it MUST return a &lt;not-acceptable/&gt; error:</p>
+    <p class="caption">Example 14. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="impl-muc">Offline Messages</a>
+</h3>
+    <p class="" style="">The client MAY specify an absolute time for any message by providing a longer 'utc' attribute (which MUST be UTC and adhere to the DateTime format specified in <span style="font-weight: bold">Jabber Date and Time Profiles</span>) instead of a 'secs' attribute. The absolute time MAY be before the start time of the collection:</p>
+    <p class="caption">Example 15. Storing offline messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up2'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from utc='1469-07-21T00:32:29Z'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="impl-muc">Groupchat Messages</a>
+</h3>
+    <p class="" style="">A client MAY archive messages that it receives from <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2258847">7</a>] rooms. The 'with' attribute MUST be the bare JID of the room. The client MUST include a 'name' attribute for each &lt;from/&gt; element to specify the room nickname of the message sender:</p>
+    <p class="caption">Example 16. Storing groupchat messages in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='up3'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='balcony@house.capulet.com'
+         start='1469-07-21T03:16:37Z'&gt;
+    &lt;from secs='0' name='benvolio'&gt;&lt;body&gt;She will indite him to some supper.&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='5' name='mercutio'&gt;&lt;body&gt;A bawd, a bawd, a bawd! So ho!&lt;/body&gt;&lt;/from&gt;
+    &lt;from secs='11' name='romeo'&gt;&lt;body&gt;What hast thou found?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="crypt">Changing the Subject of a Collection</a>
+</h3>
+    <p class="" style="">If the client specifies a new value for the 'subject' attribute of any existing collection then the server MUST update the existing value. Note: The client cannot specify new values for the 'with' or 'start' attributes. The only way to change these values is to delete the collection (see <a href="#manage-remove">Removing a Collection</a>) and then create a new one.</p>
+    <p class="caption">Example 17. Changing the subject of a collection without appending messages</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='subject1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks twice!'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="crypt">Encryption</a>
+</h2>
+  <p class="" style="">The examples above are not encrypted for clarity. However, clients SHOULD encrypt manually-archived collections.</p>
+  <p class="" style="">Before uploading a sequence of messages to a collection, the client SHOULD select a symmetric data encryption algorithm, generate a suitable random encryption key, give the key a unique (for the user) name, encrypt the symmetric key with one of the user's public keys, and wrap the result inside one or more &lt;EncryptedKey/&gt; elements, as specified in <span class="ref" style="">XML Encryption</span>  [<a href="#nt-id2258953">8</a>].</p>
+  <p class="" style="">To ensure that all its user's clients will be able to decrypt the collection, the client SHOULD create one &lt;EncryptedKey/&gt; element for each of its user's public keys that are being published using <span class="ref" style="">Public Key Publishing</span>  [<a href="#nt-id2258983">9</a>]. However, the client MUST NOT create an &lt;EncryptedKey/&gt; element for any public key until it has confirmed that it belongs to the user. Note: The fact that a public key is being published using <span style="font-weight: bold">Public Key Publishing</span> is <span style="font-style: italic">not</span> sufficient proof of ownership, since the user's server may have been compromised at some stage. The method of confirmation is beyond the scope of this document.</p>
+  <p class="" style="">The client SHOULD use the symmetric key to encrypt the joined sequence of &lt;to/&gt;, &lt;from/&gt; and &lt;note/&gt; elements, base64 encode the resulting sequence of bytes, and wrap it inside an &lt;EncryptedData/&gt; element, as described in <span style="font-weight: bold">XML Encryption</span>.</p>
+  <p class="" style="">Clients may add one or more &lt;EncryptedData/&gt; or &lt;EncryptedKey/&gt; elements to a collection using exactly the same method as for &lt;to/&gt;, &lt;from/&gt; and &lt;note/&gt; elements (see <a href="#manual-upload">Uploading Messages to a Collection</a>). One collection may contain &lt;EncryptedData/&gt; elements encrypted with different symmetric keys.</p>
+  <p class="" style="">When appending &lt;EncryptedData/&gt; elements to a collection, the client MAY reuse a symmetric KEY that has already been uploaded to the collection. In this case the client SHOULD NOT resend &lt;EncryptedKey/&gt; elements.</p>
+  <p class="" style="">Note: A collection that contains &lt;EncryptedData/&gt; or &lt;EncryptedKey/&gt; elements MUST NOT contain &lt;to/&gt; or &lt;from/&gt; or &lt;note/&gt; elements.</p>
+  <p class="caption">Example 18. Storing encrypted messages and keys in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='crypt1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-23T19:22:31Z'
+         subject='She speaks!'&gt;
+    &lt;EncryptedData xmlns='http://www.w3.org/2001/04/xmlenc#'
+                   Type='http://www.w3.org/2001/04/xmlenc#Content'&gt;
+      &lt;EncryptionMethod Algorithm='http://www.w3.org/2001/04/xmlenc#aes128-cbc'/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;dataKey1&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedData&gt;
+    &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+      &lt;CarriedKeyName&gt;dataKey1&lt;/CarriedKeyName&gt;
+      &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;romeoPublicKey1fingerprint&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedKey&gt;
+    &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+      &lt;CarriedKeyName&gt;dataKey1&lt;/CarriedKeyName&gt;
+      &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;romeoPublicKey2fingerprint&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedKey&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The &lt;CipherData/&gt; child of each &lt;EncryptedData/&gt; element contains the base64-encoded symmetric-encrypted messages. The &lt;EncryptionMethod/&gt; and &lt;KeyInfo/&gt; children specify the symmetric encryption algorithm and the name of the symmetric key used to encrypt the messages.</p>
+  <p class="" style="">The &lt;CarriedKeyName/&gt; child of each &lt;EncryptedKey/&gt; element contains the name of the symmetric key it contains. The name is referenced by the &lt;KeyName/&gt; child of the &lt;KeyInfo/&gt; child of an &lt;EncryptedData/&gt; element. The &lt;CipherData/&gt; child of each &lt;EncryptedKey/&gt; element contains the base64-encoded public-key-encrypted symmetric key. The &lt;EncryptionMethod/&gt; and &lt;KeyInfo/&gt; children specify the public key encryption algorithm and the name of the public key used to encrypt the symmetric key. The name of the public key MAY refer to the name in the &lt;KeyName/&gt; child of one of the &lt;KeyInfo/&gt; elements that are being published using <span style="font-weight: bold">Public Key Publishing</span>.</p>
+<h2>7.
+       <a name="auto">Automated Archiving</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="auto-toggle">Toggling Auto-Archiving</a>
+</h3>
+    <p class="" style="">A client MAY enable or disable automatic archiving for messages sent over its stream. Automatic archiving MUST default to disabled for each new stream that is opened, unless administrator policies <span style="font-style: italic">require</span> that every message is logged automatically (see <a href="#security">Security Considerations</a>). Once automatic archiving is switched on then the server MUST automatically archive messages only according to the user's general <a href="#pref">Archiving Preferences</a>.</p>
+    <p class="" style="">Note: Both parties to an ESession (see <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2250596">10</a>]) MUST either disable archiving or use an archiving method other than automatic, since ESession decryption keys are short-lived - making it impossible to decrypt automatically archived messages.</p>
+    <p class="caption">Example 19. Client enables auto archiving</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auto1'&gt;
+  &lt;auto save='true' xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the client switches off all auto-archiving then the server MUST close and store all active collections.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="auto-crypt">Enabling Auto-Archiving with Encryption</a>
+</h3>
+    <p class="" style="">Whenever the client enables auto-archiving it is stongly RECOMMENDED that it sets the optional 'encrypt' attribute to 'true'. After receiving such a request, if the server supports encryption (see <a href="#disco">Determining Server Support</a>), it MUST encrypt all the messages that it archives automatically (including any message collections that are currently being recorded) by following exactly the same proceedure as clients use when manually archiving collections (see <a href="#crypt">Encryption</a>).</p>
+    <p class="" style="">The client MAY also specify one or more public keys (in addition to any public keys that the user may be publishing using <span style="font-weight: bold">Public Key Publishing</span>). The server MUST use them all to encrypt all the symmetric keys it generates and add these to the collection wrapped in &lt;EncryptedKey/&gt; elements.</p>
+    <p class="caption">Example 20. Client enables auto archiving with encryption</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='auto2'&gt;
+  &lt;auto save='true'
+        encrypt='true'
+        xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+      &lt;KeyValue&gt;
+        &lt;KeyName&gt;romeoPublicKey3fingerprint&lt;/KeyName&gt;
+        &lt;RSAKeyValue&gt;
+          &lt;Modulus&gt;xA7SEU+e0yQH5rm9kbCDN9o3aPIo7HbP7tX6WOocLZAtNfyxSZDU16ksL6W
+            jubafOqNEpcwR3RdFsT7bCqnXPBe5ELh5u4VEy19MzxkXRgrMvavzyBpVRgBUwUlV
+            5foK5hhmbktQhyNdy/6LpQRhDUDsTvK+g9Ucj47es9AQJ3U=
+          &lt;/Modulus&gt;
+          &lt;Exponent&gt;AQAB&lt;/Exponent&gt;
+        &lt;/RSAKeyValue&gt;
+      &lt;/KeyValue&gt;
+    &lt;/KeyInfo&gt;
+  &lt;/auto&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As soon as the server has finished storing a collection, it MUST securely destroy all copies of the symmetric key it used to encrypt the messages. Note: If the security of the server is compromised, then only the collections being recorded during the attack will be revealed (i.e. only those messages that would have been compromised even if they had not been stored).</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="auto-crypt">Not-Implemented Responses</a>
+</h3>
+    <p class="" style="">The server MUST return a &lt;feature-not-implemented/&gt; error in the following cases:</p>
+    <ul>
+      <li><p class="" style="">If the client is trying to enable automatic archiving, but the server does not allow the saving of full message stanza content, and the user has specified the 'all' Save Mode in one of its <a href="#pref">Archiving Preferences</a>.</p></li>
+      <li><p class="" style="">If administrator policies require that every message is logged automatically, and the client is trying to disable automatic archiving.</p></li>
+      <li><p class="" style="">If the client is trying to enable encryption, but the server does not support encryption or the user did not specify a public key and is not publishing any keys using <span style="font-weight: bold">Public Key Publishing</span>.</p></li>
+    </ul>
+  </div>
+<h2>8.
+       <a name="manage">Archive Management</a>
+</h2>
+  <p class="" style="">Manually uploaded and automatically saved collections are managed in the same way. There are three main areas of functionality related to archive management:</p>
+  <ol start="1" type="">
+    <li>Retrieving a list of collections</li>
+    <li>Retrieving a collection</li>
+    <li>Removing a collection</li>
+  </ol>
+  <p class="" style="">Requirements and protocol flows for each of these use cases are defined below. The protocols to retrieve a list of collections and an indivdual collection both make extensive use of <span class="ref" style="">Result Set Management</span>  [<a href="#nt-id2259591">11</a>]. Clients and servers SHOULD support all the features defined in that protocol.</p>
+  <div class="indent">
+<h3>8.1 <a name="manage-list">Retrieving a List of Collections</a>
+</h3>
+    <p class="" style="">To request a list of collections the client sends a &lt;list/&gt; element. The 'start' and 'end' attributes MAY be specified to indicate a date range (the values of these attributes MUST be UTC and adhere to the DateTime format specified in <span style="font-weight: bold">Jabber Date and Time Profiles</span>). The 'with' attribute MAY be specified to limit the list to a single participating full JID, bare JID or domain.</p>
+    <p class="" style="">If the 'with' attribute is omitted then collections with any JID are returned. If only 'start' is specified then all collections on or after that date should be returned. If only 'end' is specified then all collections prior to that date should be returned.</p>
+    <p class="" style="">The client SHOULD use <span style="font-weight: bold">Result Set Management</span> to limit the number of collections returned by the server in a single stanza, taking care not to request a page of collections that is so big it might exceed karma limits.</p>
+    <p class="caption">Example 21. Requesting the first page of a list with same JID</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='juliet1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 22. Requesting the first page of a list with same JID between two times</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='period1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        with='juliet@capulet.com'
+        start='1469-07-21T02:00:00Z'
+        end='1479-07-21T04:00:00Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 23. Requesting the first page of a list after a time</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='list1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        start='1469-07-21T02:00:00Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server MUST list the collections (empty &lt;store/&gt; elements including all attributes) in chronological order when responding to any request. If the collection contains &lt;EncryptedData/&gt; or &lt;EncryptedKey/&gt; elements then the 'crypt' attribute of the &lt;store/&gt; element MUST be set to 'true':</p>
+    <p class="caption">Example 24. Receiving the first page of a list</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='list1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com/chamber'
+           start='1469-07-21T02:56:15Z'
+           subject='She speaks!'
+           crypt='true'/&gt;
+    .
+    [28 more collections]
+    .
+    &lt;store with='balcony@house.capulet.com'
+           start='1469-07-21T03:16:37Z'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;1469-07-21T02:56:15Zjuliet@capulet.com&lt;/first&gt;
+      &lt;last&gt;1469-07-21T03:16:37Zbalcony@house.capulet.com&lt;/last&gt;
+      &lt;count&gt;1372&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: In accordance with <span style="font-weight: bold">Result Set Management</span>, the client MUST assume the unique IDs it receives in the &lt;first/&gt; and &lt;last/&gt; elements are opaque. Servers MAY adopt a unique ID format other than the one suggested in the example above.</p>
+    <p class="" style="">If no collections correspond to the request the server MUST return an empty &lt;list/&gt; element:</p>
+    <p class="caption">Example 25. Receiving an empty list</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='list1'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 26. Requesting the second page of a list</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='list2'&gt;
+  &lt;list xmlns='http://jabber.org/protocol/archive'
+        start='1469-07-21T02:00:00Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;30&lt;/max&gt;
+      &lt;after&gt;1469-07-21T03:16:37Zbalcony@house.capulet.com&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/list&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Refer to <span style="font-weight: bold">Result Set Management</span> to learn more about the various ways that the pages of the list may be accessed.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="manage-retrieve">Retrieving a Collection</a>
+</h3>
+    <p class="" style="">To request a page of messages from a collection the client sends a &lt;retrieve/&gt; element. The 'with' and 'start' attributes specify the participating full JID and the start time (see <span style="font-weight: bold">Jabber Date and Time Profiles</span>). Both attributes MUST be included to uniquely identify a collection:</p>
+    <p class="" style="">The client SHOULD use <span style="font-weight: bold">Result Set Management</span> to limit the number of messages returned by the server in a single stanza, taking care not to request a page of messages that is so big it might exceed karma limits.</p>
+    <p class="caption">Example 27. Requesting the first page of a collection</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='page1'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com/chamber'
+            start='1469-07-21T02:56:15Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;100&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/retrieve&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Receiving the first page of a collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='page1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    .
+    [98 more messages]
+    .
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;0&lt;/first&gt;
+      &lt;last&gt;99&lt;/last&gt;
+      &lt;count&gt;217&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: In accordance with <span style="font-weight: bold">Result Set Management</span>, the client MUST assume the unique IDs it receives in the &lt;first/&gt; and &lt;last/&gt; elements are opaque. Servers MAY adopt a unique ID format other than the one suggested in the example above.</p>
+    <p class="" style="">If the specified collection does not exist then the server MUST return an &lt;item-not-found/&gt; error:</p>
+    <p class="caption">Example 29. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard' from='montague.net' id='page1'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested collection is empty the server MUST return an empty &lt;store/&gt; element:</p>
+    <p class="caption">Example 30. Receiving an empty collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='page1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-21T02:56:15Z'
+         subject='She speaks!'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 31. Requesting the second page of a collection</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='page2'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com/chamber'
+            start='1469-07-21T02:56:15Z'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;100&lt;/max&gt;
+      &lt;after&gt;99&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/retrieve&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The items in encrypted collections are typically larger - since each &lt;EncryptedData/&gt; element typically contains many messages. So the client SHOULD take even more care not to request a page of &lt;EncryptedData/&gt; elements that is so big it might exceed karma limits.</p>
+    <p class="caption">Example 32. Requesting the first page of an encrypted collection with all versions of keys</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='page1'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com/chamber'
+            start='1469-07-23T19:22:31Z'
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;5&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/retrieve&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">In addition to the requested &lt;EncryptedData/&gt; elements, the server MUST return all the &lt;EncryptedKey/&gt; elements that it possesses for the user whose symmetric key name (wrapped in its &lt;CarriedKeyName/&gt; child) is referenced by the &lt;KeyName/&gt; child of the &lt;KeyInfo/&gt; child of any of the &lt;EncryptedData/&gt; elements in the returned page.</p>
+    <p class="caption">Example 33. Receiving the first page of an encrypted collection</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='page1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-23T19:22:31Z'
+         subject='She speaks!'&gt;
+    &lt;EncryptedData xmlns='http://www.w3.org/2001/04/xmlenc#'
+                   Type='http://www.w3.org/2001/04/xmlenc#Content'&gt;
+      &lt;EncryptionMethod Algorithm='http://www.w3.org/2001/04/xmlenc#aes128-cbc'/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;dataKey1&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedData&gt;
+    .
+    [3 more &lt;EncryptedData/&gt; elements]
+    .
+    &lt;EncryptedData xmlns='http://www.w3.org/2001/04/xmlenc#'
+                   Type='http://www.w3.org/2001/04/xmlenc#Content'&gt;
+      &lt;EncryptionMethod Algorithm='http://www.w3.org/2001/04/xmlenc#aes128-cbc'/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;dataKey2&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;+OGQ0SR+ysraP6LnD43m77VkIVni5c7yPeIbkFdicZ&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedData&gt;
+    &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+      &lt;CarriedKeyName&gt;dataKey1&lt;/CarriedKeyName&gt;
+      &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;romeoPublicKey1fingerprint&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedKey&gt;
+    &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+      &lt;CarriedKeyName&gt;dataKey1&lt;/CarriedKeyName&gt;
+      &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;romeoPublicKey2fingerprint&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedKey&gt;
+    &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+      &lt;CarriedKeyName&gt;dataKey2&lt;/CarriedKeyName&gt;
+      &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;romeoPublicKey1fingerprint&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedKey&gt;
+    &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+      &lt;CarriedKeyName&gt;dataKey2&lt;/CarriedKeyName&gt;
+      &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;romeoPublicKey2fingerprint&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedKey&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;0&lt;/first&gt;
+      &lt;last&gt;4&lt;/last&gt;
+      &lt;count&gt;7&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client MAY limit the number of &lt;EncryptedKey/&gt; elements that it receives by specifying the name of one or more public keys for which it holds the associated private keys. The name of each public key MUST be wrapped in a &lt;KeyName/&gt; element.</p>
+    <p class="caption">Example 34. Requesting the first page of an encrypted collection with specified version of keys</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='page1'&gt;
+  &lt;retrieve xmlns='http://jabber.org/protocol/archive'
+            with='juliet@capulet.com/chamber'
+            start='1469-07-23T19:22:31Z'&gt;
+    &lt;KeyName xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;romeoPublicKey1fingerprint&lt;/KeyName&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;1&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/retrieve&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the request includes one or more &lt;KeyName/&gt; elements then the server MUST only return those &lt;EncryptedKey/&gt; elements whose public key name (wrapped in the &lt;KeyName/&gt; child of the &lt;KeyInfo/&gt; child) is specified in the request.</p>
+    <p class="" style="">Refer to <span style="font-weight: bold">Result Set Management</span> to learn more about the various ways that the pages of a collection may be accessed.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="manage-remove">Removing a Collection</a>
+</h3>
+    <p class="" style="">To request the removal of a single collection the client sends an empty &lt;remove/&gt; element. The 'with' (full JID) and 'start' attributes MUST be included to uniquely identify the collection.</p>
+    <p class="caption">Example 35. Removing a single collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com/chamber'
+          start='1469-07-21T02:56:15Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client may remove several collections at once. The 'start' and 'end' elements MAY be specified to indicate a date range. The 'with' attribute MAY be a full JID, bare JID or domain.</p>
+    <p class="caption">Example 36. Removing all collections with a specified bare JID between two times</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com'
+          start='1469-07-21T02:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the 'with' attribute is omitted then collections with any JID are removed.</p>
+    <p class="" style="">If the end date is in the future then then all collections after the start date are removed.</p>
+    <p class="caption">Example 37. Removing all collections after a date</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='1469-07-21T02:00:00Z'
+          end='2038-01-01T00:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the start date is before all the collections in the archive then all collections prior to the end date are removed.</p>
+    <p class="caption">Example 38. Removing all collections before a date</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          start='0000-01-01T00:00:00Z'
+          end='1469-07-21T04:00:00Z'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 39. Removing all collections</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the value of the optional 'open' attribute is set to 'true' then only collections that are currently being recorded automatically by the server (see <a href="#auto">Automated Archiving</a>) are removed.</p>
+    <p class="caption">Example 40. Removing a collection being recorded by the server</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          with='juliet@capulet.com/chamber'
+          open='true'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 41. Removing all collections being recorded by the server</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net'&gt;
+  &lt;remove xmlns='http://jabber.org/protocol/archive'
+          open='true'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the specified collection (or collections) do not exist then the server MUST return an &lt;item-not-found/&gt; error:</p>
+    <p class="caption">Example 42. Unsuccessful reply</p>
+<div class="indent"><pre>
+&lt;iq type='error' to='romeo@montague.net/orchard'&gt;
+  &lt;error code='404' type='cancel'&gt;
+    &lt;item-not-found xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="rekey">Replacing EncryptedKey Elements</a>
+</h2>
+  <p class="" style="">If a private key becomes obsolete or compromised then it may be necessary for a client to replace all &lt;EncryptedKey/&gt; elements that contain symmetric keys encrypted with the public key that is associated with the obsolete private key.</p>
+  <p class="" style="">The client first requests a list of the affected &lt;EncryptedKey/&gt; elements from all collections by sending a &lt;keys/&gt; element to the server:</p>
+  <p class="caption">Example 43. Requesting the first page of a list of keys</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='pubkey1'&gt;
+  &lt;keys xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;KeyName xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;romeoPublicKey1fingerprint&lt;/KeyName&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;50&lt;/max&gt;
+    &lt;/set&gt;
+  &lt;/keys&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The server MUST return only &lt;EncryptedKey/&gt; elements whose symmetric encryption key is encrypted with the obsolete public key specified in the &lt;KeyName/&gt; child of the request:</p>
+  <p class="caption">Example 44. Receiving the first page of a list of keys</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='pubkey1'&gt;
+  &lt;keys xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;store with='juliet@capulet.com/chamber'
+           start='1469-07-23T19:22:31Z'&gt;
+      &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+        &lt;CarriedKeyName&gt;dataKey1&lt;/CarriedKeyName&gt;
+        &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+        &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+          &lt;KeyName&gt;romeoPublicKey1fingerprint&lt;/KeyName&gt;
+        &lt;/KeyInfo&gt;
+        &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+      &lt;/EncryptedKey&gt;
+      &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+        &lt;CarriedKeyName&gt;dataKey2&lt;/CarriedKeyName&gt;
+        &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+        &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+          &lt;KeyName&gt;romeoPublicKey1fingerprint&lt;/KeyName&gt;
+        &lt;/KeyInfo&gt;
+        &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+      &lt;/EncryptedKey&gt;
+    &lt;/store&gt;
+    .
+    [49 more sets of collection keys]
+    .
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;first index='0'&gt;1469-07-23T19:22:31Zjuliet@capulet.com&lt;/first&gt;
+      &lt;last&gt;1469-08-03T13:24:06Zbalcony@house.capulet.com&lt;/last&gt;
+      &lt;count&gt;3810&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/keys&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The client decrypts each symmetric key with the obsolete private key and encrypts it again with the new public key. The client then wraps each symmetric key in an &lt;EncryptedKey/&gt; element and asks the server to store it in its associated collection on the server (see <a href="#crypt">Encryption</a>):</p>
+  <p class="caption">Example 45. Storing encrypted keys in a collection</p>
+<div class="indent"><pre>
+&lt;iq type='set' to='montague.net' id='crypt1'&gt;
+  &lt;store xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-23T19:22:31Z'&gt;
+    &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+      &lt;CarriedKeyName&gt;dataKey1&lt;/CarriedKeyName&gt;
+      &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;romeoPublicKey2fingerprint&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedKey&gt;
+    &lt;EncryptedKey xmlns='http://www.w3.org/2001/04/xmlenc#'&gt;
+      &lt;CarriedKeyName&gt;dataKey2&lt;/CarriedKeyName&gt;
+      &lt;EncryptionMethod Algorithm="http://www.w3.org/2001/04/xmlenc#rsa-1_5"/&gt;
+      &lt;KeyInfo xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;
+        &lt;KeyName&gt;romeoPublicKey2fingerprint&lt;/KeyName&gt;
+      &lt;/KeyInfo&gt;
+      &lt;CipherData&gt;&lt;CipherValue&gt;E5Qbvfa2gI5lBZMAHryv4g&lt;/CipherValue&gt;&lt;/CipherData&gt;
+    &lt;/EncryptedKey&gt;
+  &lt;/store&gt;
+&lt;/iq&gt;
+.
+[49 more sets of collection keys]
+.
+  </pre></div>
+  <p class="" style="">Finally, the client asks the server to delete from each collection all &lt;EncryptedKey/&gt; elements whose symmetric encryption key is encrypted with the obsolete public key:</p>
+  <p class="caption">Example 46. Requesting the first page of a list of keys</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='montague.net' id='pubkey1'&gt;
+  &lt;delete xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com/chamber'
+         start='1469-07-23T19:22:31Z'&gt;
+    &lt;KeyName xmlns='http://www.w3.org/2000/09/xmldsig#'&gt;romeoPublicKey1fingerprint&lt;/KeyName&gt;
+  &lt;/delete&gt;
+&lt;/iq&gt;
+.
+[49 more delete requests]
+.
+  </pre></div>
+<h2>10.
+       <a name="sect-id2260655">Replication</a>
+</h2>
+  <p class="" style="">This section describes how a client MAY replicate an archive locally.  [<a href="#nt-id2260695">12</a>] The existence of a local copy of the archive enables clients to search the content of all messages (including collections saved by another client machine).  [<a href="#nt-id2260703">13</a>]</p>
+  <p class="" style="">The client MAY 'synchronize' its local copy of the archive with the 'master' archive on the server at any time. The first step is to request the list of collections that the server has changed (created, modified or removed) in its master archive since the last update to the client's copy of the archive.</p>
+  <p class="" style="">The client MUST request each page of the list using the <span style="font-weight: bold">Result Set Management</span> protocol embeded in a &lt;modified/&gt; element. The content of the &lt;after/&gt; element SHOULD be a UTC time (see <span style="font-weight: bold">Jabber Date and Time Profiles</span>) that it has previously received from the server (see below). When synchronizing for the first time, the client MAY choose a suitable time for the first page request (e.g. 1970-01-01T00:00:00Z).</p>
+  <p class="caption">Example 47. Requesting a page of modifications</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' to='montague.net' id='sync1'&gt;
+  &lt;modified xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;max&gt;50&lt;/max&gt;
+      &lt;after&gt;1469-07-21T01:14:47Z&lt;/after&gt;
+    &lt;/set&gt;
+  &lt;/modified&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The server MUST return the changed collections in the chronological order that they were changed (most recent last). If a collection has been modified, created or removed <span style="font-style: italic">after</span> the time specified by the &lt;after/&gt; element then the server MUST include it in the returned result set page of collections (unless the specified maximum page size would be exceeded). Each &lt;changed/&gt; or &lt;removed/&gt; collection element (for modified/created, or removed collections respectively) in the returned list MUST include only 'with' and 'start' attribues. The server MUST set the content of the &lt;last/&gt; element to the UTC time (see <span style="font-weight: bold">Jabber Date and Time Profiles</span>) that the last collection on the page was modified.</p>
+  <p class="caption">Example 48. Receiving a page of modifications</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/orchard' from='montague.net' id='sync1'&gt;
+  &lt;modified xmlns='http://jabber.org/protocol/archive'&gt;
+    &lt;changed with='juliet@capulet.com/chamber'
+           start='1469-07-21T02:56:15Z'/&gt;
+    .
+    [up to 48 more collections]
+    .
+    &lt;removed with='balcony@house.capulet.com'
+             start='1469-07-21T03:16:37Z'/&gt;
+    &lt;set xmlns='http://jabber.org/protocol/rsm'&gt;
+      &lt;last&gt;1469-07-21T04:22:39Z&lt;/last&gt;
+      &lt;count&gt;1372&lt;/count&gt;
+    &lt;/set&gt;
+  &lt;/modified&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Note: The server should remember the 'with' and 'start' attribues and the time of removal of all deleted collections. If this 'state' cannot be maintained indefinitely, then unless all the user's clients replicate before the server deletes its memory of a removal then it will not be reflected in all the local copies of the archive.</p>
+  <p class="" style="">Note: Along with its copy of the archive the client SHOULD store the most recent &lt;last/&gt; time that it received from the server. The next time it synchronizes with the server it SHOULD specify that time when requesting the first result set page (see above).</p>
+  <p class="" style="">After receiving each result set page the client SHOULD delete from its local archive any collections that have been removed from the master archive. The client should also retrieve from the server the content of each collection that has been modified (see <a href="#retrieve">Retrieving a Collection</a>) and add it to its local copy of the archive (deleting any older version of the same collection that it may already have).</p>
+<h2>11.
+       <a name="fileformat">File Format</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note the file format specified in this section is likely to be deprecated once a standards-based format has been published in a separate JEP.</span></p>
+  <p class="" style="">So that clients can share archived messages, this document specifies a common format for storage on disk (similar to email formats like mbox and Maildir). The file format uses the same XML constructs as the protocol. Each file may contain messages exchanged with a single JID. Any number of items may be stored in an archive file.</p>
+  <p class="caption">Example 49. Example file</p>
+<div class="indent"><pre>
+&lt;?xml version='1.0'?&gt;
+&lt;archive xmlns='http://jabber.org/protocol/archive'
+         with='juliet@capulet.com'&gt;
+  &lt;store start='1469-07-21T02:56:15Z' subject='She speaks!'&gt;
+    &lt;from secs='0'&gt;&lt;body&gt;Art thou not Romeo, and a Montague?&lt;/body&gt;&lt;/from&gt;
+    &lt;to secs='11'&gt;&lt;body&gt;Neither, fair saint, if either thee dislike.&lt;/body&gt;&lt;/to&gt;
+    &lt;from secs='14'&gt;&lt;body&gt;How cam'st thou hither, tell me, and wherefore?&lt;/body&gt;&lt;/from&gt;
+  &lt;/store&gt;
+&lt;/archive&gt;
+  </pre></div>
+<h2>12.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>12.1 <a name="impl-sync">Time Synchronization</a>
+</h3>
+    <p class="" style="">When creating a new collection, it is RECOMMENDED that the client synchronizes the collection start time that it sends to the server with server time. This is important since the user may subsequently retrieve the stored collection using client machines whose UTC clocks are not synchronized with the client machine that stored the collection. (i.e. Either or both of the clients' UTC clocks may be wrong.) The client can achieve this synchronization with server time by using <span class="ref" style="">Entity Time</span>  [<a href="#nt-id2260956">14</a>] to estimate the difference between the server and client UTC clocks.</p>
+    <p class="" style="">When retrieving collections, it is RECOMMENDED that the client adjusts the start times of the collections it receives from server to be synchronized with the clock of the client machine.</p>
+  </div>
+  <div class="indent">
+<h3>12.2 <a name="impl-bandwidth">Bandwidth Considerations</a>
+</h3>
+    <p class="" style="">When uploading messages using manual archiving, a client SHOULD NOT store one message at a time on the server since this increases both bandwidth consumption and the total number of transactions. It is instead RECOMMENDED that clients store messages only when the conversation thread <span style="font-style: italic">appears</span> to be terminated, e.g. when the user closes the chat window. If the user reopens the window and the thread continues then the client should append the new messages to the collection when the user closes the window again.</p>
+  </div>
+  <div class="indent">
+<h3>12.3 <a name="impl-storage">Storage Considerations</a>
+</h3>
+    <p class="" style="">Server implementations SHOULD give system administrators the option to disable support for both automated and manual archiving, since archived conversations can consume significant storage space.</p>
+  </div>
+<h2>13.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="security-autoon">Automatic Archiving Defaulting to On</a>
+</h3>
+    <p class="" style="">If automatic archiving defaults to enabled then that creates serious privacy issues for users of legacy clients that do not support this protocol, and (more seriously) for those contacts who they unwittingly mislead by agreeing to disable logging (via the 'otr' field defined in JEP-0155).</p>
+  </div>
+  <div class="indent">
+<h3>13.2 <a name="security-encrypt">Plain Text Subject</a>
+</h3>
+    <p class="" style="">Since the subject of each collection will not be encrypted, the client MUST warn its human user (if any) before including 'subject' attributes on encrypted collections.</p>
+  </div>
+  <div class="indent">
+<h3>13.3 <a name="security-store">Store Headers</a>
+</h3>
+    <p class="" style="">The client that originates a message MAY specify a 'false' value for the 'store' header (see <span class="ref" style="">Stanza Headers and Internet Metadata</span>  [<a href="#nt-id2261106">15</a>]). The recipient MUST NOT archive such a message or any of the information it contains.</p>
+    <p class="" style="">If the sender plans to use 'store' headers it MUST use Service Discovery to determine whether or not the recipient supports them. Note: Since servers are not required to check the content of message stanzas for headers, if the recipient is using automatic archiving then it MUST indicate that it does not support 'store' headers.</p>
+    <p class="" style="">If the recipient does not support 'store' headers, then the sender MUST confirm with its human user (if any) before sending such a message.</p>
+  </div>
+<h2>14.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261168">16</a>] is required as a result of this JEP.</p>
+<h2>15.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>15.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261216">17</a>] shall include 'http://jabber.org/protocol/archive' in its registry of protocol namespaces (see &lt;<a href="http://www.jabber.org/registrar/namespaces.html">http://www.jabber.org/registrar/namespaces.html</a>&gt;):</p>
+  </div>
+  <div class="indent">
+<h3>15.2 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the following features in its registry of service discovery features (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;):</p>
+    <ul>
+      <li>http://jabber.org/protocol/archive#auto</li>
+      <li>http://jabber.org/protocol/archive#encrypt</li>
+      <li>http://jabber.org/protocol/archive#manage</li>
+      <li>http://jabber.org/protocol/archive#manual</li>
+      <li>http://jabber.org/protocol/archive#pref</li>
+    </ul>
+  </div>
+<h2>16.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/archive'
+    xmlns='http://jabber.org/protocol/archive'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The allowable root elements for the namespace defined
+      herein are:
+        - archive
+        - auto
+        - delete
+        - keys
+        - list
+        - modified
+        - pref
+        - remove
+        - retrieve
+        - store
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='archive'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='auto'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;any processContents='lax' namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='encrypt' type='xs:boolean' use='optional'/&gt;
+      &lt;xs:attribute name='save' type='xs:boolean' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='changed'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='default'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='otr' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='allow'/&gt;
+                &lt;xs:enumeration value='deny'/&gt;
+                &lt;xs:enumeration value='require'/&gt;
+                &lt;xs:enumeration value='try'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='save' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='all'/&gt;
+                &lt;xs:enumeration value='body'/&gt;
+                &lt;xs:enumeration value='false'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='unset' use='optional' type='xs:boolean'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='delete'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;any processContents='lax' namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='jid' use='required' type='xs:string'/&gt;
+          &lt;xs:attribute name='otr' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='allow'/&gt;
+                &lt;xs:enumeration value='deny'/&gt;
+                &lt;xs:enumeration value='require'/&gt;
+                &lt;xs:enumeration value='try'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='save' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='all'/&gt;
+                &lt;xs:enumeration value='body'/&gt;
+                &lt;xs:enumeration value='false'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='keys'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;any processContents='lax' namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='list'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='store' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;any processContents='lax' namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='end' type='xs:dateTime' use='optional'/&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='optional'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='modified'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='changed' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='removed' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;any processContents='lax' namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='note'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='utc' type='xs:dateTime' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='pref'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='default' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='remove'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='end' type='xs:dateTime' use='optional'/&gt;
+          &lt;xs:attribute name='open' use='optional' type='xs:boolean'/&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='removed'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+          &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='retrieve'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;any processContents='lax' namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='store'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element name='from' type='messageType'/&gt;
+        &lt;xs:element ref='note'/&gt;
+        &lt;xs:element name='to' type='messageType'/&gt;
+        &lt;any processContents='lax' namespace='##other'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='crypt' use='optional' type='xs:boolean'/&gt;
+      &lt;xs:attribute name='start' type='xs:dateTime' use='required'/&gt;
+      &lt;xs:attribute name='subject' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='with' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:complexType name='messageType'&gt;
+    &lt;xs:sequence&gt;
+      &lt;xs:element name='body' type='xs:string' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;any processContents='lax' namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+    &lt;/xs:sequence&gt;
+    &lt;xs:attribute name='secs' type='xs:nonNegativeInteger' use='optional'/&gt;
+    &lt;xs:attribute name='utc' type='xs:dateTime' use='optional'/&gt;
+  &lt;/xs:complexType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250989">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2258310">2</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2258360">3</a>. If a client (or user) acts in bad faith then its contacts cannot prevent it archiving conversations.</p>
+<p><a name="nt-id2258473">4</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2258568">5</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2258672">6</a>. Stream compression typically does not mitigate bandwidth and storage issues since collections SHOULD be encrypted, and since clients running in constrained runtime environments typically cannot take advantage of stream compression (no binary data, only XML, may be transfered).</p>
+<p><a name="nt-id2258847">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2258953">8</a>. XML Encryption Syntax and Processing &lt;<a href="http://www.w3.org/TR/2002/REC-xmlenc-core-20021210/">http://www.w3.org/TR/2002/REC-xmlenc-core-20021210/</a>&gt;.</p>
+<p><a name="nt-id2258983">9</a>. JEP-0189: Public Key Publishing &lt;<a href="http://www.jabber.org/jeps/jep-0189.html">http://www.jabber.org/jeps/jep-0189.html</a>&gt;.</p>
+<p><a name="nt-id2250596">10</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2259591">11</a>. JEP-0059: Result Set Management &lt;<a href="http://www.jabber.org/jeps/jep-0059.html">http://www.jabber.org/jeps/jep-0059.html</a>&gt;.</p>
+<p><a name="nt-id2260695">12</a>. Clients that run in constrained environments may not be able to implement replication if they are prevented from accessing (sufficient) local storage.</p>
+<p><a name="nt-id2260703">13</a>. Since collections SHOULD be stored on the server in a form that it cannot decrypt, server-side searching of the content of messages is beyond the scope of this protocol.</p>
+<p><a name="nt-id2260956">14</a>. JEP-0090: Entity Time &lt;<a href="http://www.jabber.org/jeps/jep-0090.html">http://www.jabber.org/jeps/jep-0090.html</a>&gt;.</p>
+<p><a name="nt-id2261106">15</a>. JEP-0131: Stanza Headers and Internet Metadata &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2261168">16</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261216">17</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2006-09-11)</h4>
+<div class="indent">
+<p class="" style="">Server generates encryption secrets for auto-archiving; specified use of W3C XML Encryption standard; enabled replacement of keys encrypted with an obsolete public key; enabled removal of open collections</p> (ip)
+    </div>
+<h4>Version 0.7 (2006-09-08)</h4>
+<div class="indent">
+<p class="" style="">Added preferences, results set management and notes; reinstated encryption and replication; simplified auto-archiving and off-the-record (with JEP-0155); many minor changes</p> (ip)
+    </div>
+<h4>Version 0.6 (2006-08-18)</h4>
+<div class="indent">
+<p class="" style="">Added unset value for save attribute and added service attribute on default element; added source attribute on record element; specified that services should (not must) support save mode for particular contacts.</p> (jp/psa)
+    </div>
+<h4>Version 0.5 (2006-05-03)</h4>
+<div class="indent">
+<p class="" style="">Integrated text from server-side archiving proposal; added partial support to collection retrieval; harmonized XML formats and namespaces; defined Jabber Registrar considerations and XML schema.</p> (psa/jp/jk)
+    </div>
+<h4>Version 0.4 (2005-12-21)</h4>
+<div class="indent">
+<p class="" style="">Added Replication and Searching section, partial attribute; minor improvements</p> (ip)
+    </div>
+<h4>Version 0.3 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Added more examples to Removing Collections</p> (ip)
+    </div>
+<h4>Version 0.2 (2005-04-18)</h4>
+<div class="indent">
+<p class="" style="">Complete rewrite.</p> (ip)
+    </div>
+<h4>Version 0.1 (2004-06-04)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0137-0.1.html
+++ b/content/xep-0137-0.1.html
@@ -1,0 +1,398 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0137: Publishing SI Requests</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Publishing SI Requests">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Description" content="This JEP defines protocol for publishing the availability of a particular Stream Initiation request, such as a file.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-06-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0137">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0137: Publishing SI Requests</h1>
+<p>This JEP defines protocol for publishing the availability of a particular Stream Initiation request, such as a file.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0137<br>
+            Version: 0.1<br>
+            Last Updated: 2004-06-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0095<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: sipub<br>
+</p>
+<h2>Author Information</h2>
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#requirements">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecase">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#usecase.publish">Publishing an SI Request</a>
+</dt>
+<dt>4.2.  <a href="#usecase.xdata">Integrating with Data Forms</a>
+</dt>
+<dt>4.3.  <a href="#usecase.trigger">Triggering the SI Request</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sect-id2602049">Implementation Notes</a>
+</dt>
+<dl><dt>5.1.  <a href="#sect-id2602057">Publish ID versus SI ID</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar.namespaces">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar.xdata-validate">Data Form Validation Datatypes</a>
+</dt>
+</dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">Stream Initiation</span>  [<a href="#nt-id2595930">1</a>] is a protocol to initiate a data stream within Jabber/XMPP. However, the sender is still responsible for informing receivers about this stream. This JEP provides a standardized way for a sender to announce a stream's availability without initiating the data transfer. The purpose is to provide a &quot;pull&quot; protocol for a receiver to request a transfer from a sender.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in <span class="ref">RFC 2119</span>  [<a href="#nt-id2596106">2</a>].</p>
+<h2>3.
+       <a name="requirements">Requirements</a>
+</h2>
+  <ul>
+    <li>Allow a potential receiver to start a data stream.</li>
+    <li>Integrate SI with <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596055">3</a>].</li>
+    <li>Integrate SI with <span class="ref">Data Forms</span>  [<a href="#nt-id2596081">4</a>].</li>
+  </ul>
+<h2>4.
+       <a name="usecase">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="usecase.publish">Publishing an SI Request</a>
+</h3>
+    <p class="" style="">A stream owner uses the &lt;sipub/&gt; element to announce it can perform a specific SI request. This element can be used with pubsub, or sent directly to potential recipients within a &lt;message/&gt;. The following represents the format of &lt;sipub/&gt;.</p>
+    <p class="caption">Example 1. Sample &lt;sipub/&gt;</p>
+<div class="indent"><pre>
+  &lt;sipub xmlns='http://jabber.org/protocol/sipub'
+      from='sender-jid'
+      id='publish-0123'
+      profile='si-profile'
+      mime-type='mime/type'&gt;
+    &lt;profile xmlns='si-profile' ...&gt;...&lt;/profile&gt;
+  &lt;/sipub&gt;
+    </pre></div>
+    <p class="" style="">The format for sipub is nearly identical to that for SI. The major difference is the lack of the feature negogiation for the stream methods, and the addition of a &quot;from&quot; attribute.</p>
+    <p class="" style="">The &quot;from&quot; attribute SHOULD normally be present, and MUST be present if the stanza containing the &lt;sipub/&gt; is not from the sipub sender. If present, this attribute MUST be the valid JID for the actual sipub sender.</p>
+    <p class="" style="">The &quot;id&quot; attribute is an opaque identifier. This attribute MUST be present, and MUST be a valid non-empty string. It uniquely identifies the published request for the potential sender.</p>
+    <p class="" style="">As with SI, the &quot;profile&quot; attribute MUST be present, and MUST be the namespace URI governing the profile information. It identifies the format for the SI profile.</p>
+    <p class="" style="">As with SI, the &quot;mime-type&quot; attribute SHOULD be present, and MUST be a valid mime-type. It provides the receiver with additional information about what the data stream will be.</p>
+    <p class="" style="">The &lt;sipub/&gt; MUST contain an element in the namespace specified by &quot;profile&quot;. This is the additional information about the data stream.</p>
+    <p class="" style="">The &lt;sipub/&gt; information is typically provided via pubsub:</p>
+    <p class="caption">Example 2. Subscribers informed of the &lt;sipub/&gt;'s availability</p>
+<div class="indent"><pre>
+  &lt;message to=&quot;receiver&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+    &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+      &lt;items node=&quot;generic/si-publish&quot;&gt;
+        &lt;item id=&quot;current&quot;&gt;
+          &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+              from='sender'
+              id='publish-0123'
+              mime-type='text/plain'
+              profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+            &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+                  name='special.txt'
+                  size='1024'
+                  date='2004-01-28T10:07:00-07:00'&gt;
+              &lt;desc&gt;The special file&lt;/desc&gt;
+            &lt;/file&gt;
+          &lt;/sipub&gt;
+        &lt;/item&gt;
+      &lt;/items&gt;
+    &lt;/event&gt;
+  &lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Since the announcement did not come directly from the sender, the &lt;sipub/&gt; MUST specify that using the &quot;from&quot; attribute.</p>
+    <p class="" style="">The &lt;sipub/&gt; MAY also be used directly within a &lt;message/&gt; [<a href="#nt-id2596292">5</a>]:</p>
+    <p class="caption">Example 3. Sending &lt;sipub/&gt; directly</p>
+<div class="indent"><pre>
+  &lt;message from='sender' to='receiver'&gt;
+    &lt;body&gt;Here is the file you requested...&lt;/body&gt;
+    &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+        id='publish-0123'
+        mime-type='text/plain'
+        profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+      &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='special.txt'
+          size='1024'
+          date='2004-01-28T10:07:00-07:00'&gt;
+        &lt;desc&gt;The special file&lt;/desc&gt;
+      &lt;/file&gt;
+    &lt;/sipub&gt;
+  &lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Since the announcement came directly from the sender, the &quot;from&quot; attribute is OPTIONAL.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="usecase.xdata">Integrating with Data Forms</a>
+</h3>
+    <p class="" style="">One of the goals of sipub is to integrate SI with Data Forms to provide a &quot;file upload&quot; capability. this is accomplished via the datatypes specified in <span class="ref">Data Forms Validation</span>  [<a href="#nt-id2601898">6</a>]. Each datatype is specific to the profile desired.</p>
+    <p class="" style="">For example the datatype &quot;sipub:file-transfer&quot; is used to identify the file upload field(s) (corresponding to <span class="ref">File Transfer</span>  [<a href="#nt-id2601827">7</a>]):</p>
+    <p class="caption">Example 4. &quot;Upload File&quot; Data Forms Field</p>
+<div class="indent"><pre>
+  &lt;field var='file' type='text-single' label='File to Upload'&gt;
+    &lt;validate xmlns='http://jabber.org/protocol/xdata-validate' datatype='sipub:file-transfer'/&gt;
+  &lt;/field&gt;
+    </pre></div>
+    <p class="" style="">
+    When submitting such a form, field's value(s) MUST be the &lt;sipub/&gt; identier(s). Also, the submitter MUST provide a &lt;sipub/&gt; within the data form for each file to be uploaded:</p>
+    <p class="caption">Example 5. Submitting an &quot;Upload File&quot; form</p>
+<div class="indent"><pre>
+  &lt;x xmlns='jabber:x:data' type='submit'&gt;
+    &lt;field var='file'&gt;&lt;value&gt;publish-0123&lt;/value&gt;
+    ...
+    &lt;sipub xmlns='http://jabber.org/protocol/sipub'
+        id='publish-0123'
+        mime-type='text/plain'
+        profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+      &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='special.txt'
+          size='1024'
+          date='2004-01-28T10:07:00-07:00'/&gt;
+  &lt;/x&gt;
+    </pre></div>
+    <p class="" style="">The form processor will use this to retrieve the file(s) to be uploaded.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="usecase.trigger">Triggering the SI Request</a>
+</h3>
+    <p class="" style="">A potential receiver starts the SI session by performing an IQ-GET to the sender, using the &lt;start xmlns='http://jabber.org/protocol/sipub'/&gt; element. This element contains the attribute &quot;id&quot; to indicate the published SI to retrieve:</p>
+    <p class="caption">Example 6. Receiver requests the start of SI</p>
+<div class="indent"><pre>
+  &lt;iq type='get' id='sipub-request-0' to='sender' from='receiver'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'
+        id='publish-0123'/&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the sender accepts the request, it responds with an IQ-RESULT containing a &lt;starting/&gt; element. This element indicates the SI identifier to be used:</p>
+    <p class="caption">Example 7. Sender accepts request to start SI</p>
+<div class="indent"><pre>
+  &lt;iq type='result' id='sipub-request-0' from='sender' to='receiver'&gt;
+    &lt;starting xmlns='http://jabber.org/protocol/sipub'
+        sid='session-87651234'/&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Then the sender begins the SI negotiation:</p>
+    <p class="caption">Example 8. Sender starts SI</p>
+<div class="indent"><pre>
+  &lt;iq type='set' id='si-0' from='sender' to='receiver'&gt;
+    &lt;si xmlns='http://jabber.org/protocol/si'
+        id='session-87651234'
+        mime-type='text/plain'
+        profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+      &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='special.txt'
+          size='1024'
+          date='2004-01-28T10:07:00-07:00'&gt;
+        &lt;desc&gt;The special file&lt;/desc&gt;
+      &lt;/file&gt;
+    &lt;/si&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested identifier is not valid, the sender SHOULD respond with a &quot;not-acceptable&quot; error:</p>
+    <p class="caption">Example 9. Sender denies because of invalid id</p>
+<div class="indent"><pre>
+  &lt;iq type='error' id='sipub-requeset-0' from='sender' to='receiver'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'&gt;publish-0123&lt;/start&gt;
+    &lt;error code='405' type='modify'&gt;
+      &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the receiver does not have permission to request the data stream, the sender SHOULD respond with a &quot;forbidden&quot; error:</p>
+    <p class="caption">Example 10. Sender denies because receiver is forbidden</p>
+<div class="indent"><pre>
+  &lt;iq type='error' id='sipub-requeset-0' from='sender' to='receiver'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'&gt;publish-0123&lt;/start&gt;
+    &lt;error code='403' type='auth'&gt;
+      &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="sect-id2602049">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sect-id2602057">Publish ID versus SI ID</a>
+</h3>
+    <p class="" style="">When publishing a &lt;sipub/&gt;, the identifier SHOULD NOT be used as-is for the &lt;si/&gt;. A single publication will likely result in multiple &lt;si/&gt; requests, possibly from the same receiver.</p>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602223">8</a>]</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar.namespaces">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">SI Publication uses the following protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/sipub</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar.xdata-validate">Data Form Validation Datatypes</a>
+</h3>
+    <p class="" style="">The &quot;sipub&quot; datatype prefix shall be registered with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602199">9</a>].</p>
+    <p class="" style="">Normally, each SI profile that wishes to be considered for use with Data Forms MUST register their own datatype qualified by &quot;sipub&quot;. However, this JEP provides an initial seed, based on the currently accepted SI profiles. The following datatypes shall be registered for use with Data Forms Validation:</p>
+    <p class="caption">Data Forms Validation Datatypes Registry Submission</p>
+<div class="indent"><pre>
+&lt;datatype&gt;
+  &lt;name&gt;sipub:file-transfer&lt;/name&gt;
+  &lt;desc&gt;Datatype for publishing an SI using the File Transfer Profile&lt;/desc&gt;
+  &lt;doc&gt;JEP-0096&lt;/doc&gt;
+&lt;/datatype&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/sipub'
+    xmlns='http://jabber.org/protocol/sipub'
+    elementFormDefault='qualified'&gt;
+  
+  &lt;xs:import 
+      namespace='http://jabber.org/protocol/si'
+      schemaLocation='http://jabber.org/protocol/si/si.xsd'/&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0xxx: http://www.jabber.org/jeps/jep-0xxx.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='sipub'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the root content element for publication.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:any namespace='##other' minOccurs='1'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='mime-type' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='profile' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='start'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the element for requesting an SI be retrieved.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  &lt;xs:element name='starting'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the element for indicating the SI to be retrieved.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595930">1</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596106">2</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596055">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596081">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596292">5</a>. This is most useful for informing an offline entity about an SI request.</p>
+<p>
+<a name="nt-id2601898">6</a>. JEP-0122: Data Forms Validation &lt;<a href="http://www.jabber.org/jeps/jep-0122.html">http://www.jabber.org/jeps/jep-0122.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601827">7</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602223">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602199">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-06-16)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0137-0.2.html
+++ b/content/xep-0137-0.2.html
@@ -1,0 +1,386 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0137: Publishing SI Requests</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Publishing SI Requests">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Description" content="This JEP defines protocol for publishing the availability of a particular Stream Initiation request, such as a file.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-03">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0137">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0137: Publishing SI Requests</h1>
+<p>This JEP defines protocol for publishing the availability of a particular Stream Initiation request, such as a file.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0137<br>
+            Version: 0.2<br>
+            Last Updated: 2004-11-03<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0095<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: sipub<br>
+</p>
+<h2>Author Information</h2>
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#requirements">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecase">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#usecase.publish">Publishing an SI Request</a>
+</dt>
+<dt>3.2.  <a href="#usecase.xdata">Integration with Data Forms</a>
+</dt>
+<dt>3.3.  <a href="#usecase.trigger">Triggering the Stream Initiation Request</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2602221">Implementation Notes</a>
+</dt>
+<dl><dt>4.1.  <a href="#sect-id2602236">Publish ID versus SI ID</a>
+</dt></dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar.namespaces">Protocol Namespaces</a>
+</dt>
+<dt>7.2.  <a href="#registrar.xdata-validate">Data Form Validation Datatypes</a>
+</dt>
+</dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">Stream Initiation</span>  [<a href="#nt-id2596051">1</a>] is a protocol to initiate a data stream within Jabber/XMPP. However, the sender is still responsible for informing receivers about this stream. This JEP provides a standardized way for a sender to announce a stream's availability without initiating the data transfer. The purpose is to provide a &quot;pull&quot; protocol for a receiver to request a transfer from a sender.</p>
+<h2>2.
+       <a name="requirements">Requirements</a>
+</h2>
+  <p class="" style="">This proposal addresses the following requirements:</p>
+  <ul>
+    <li>Allow a potential receiver (rather than the sender) to initiate a data stream.</li>
+    <li>Integrate SI with <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596157">2</a>].</li>
+    <li>Integrate SI with <span class="ref">Data Forms</span>  [<a href="#nt-id2596183">3</a>].</li>
+  </ul>
+<h2>3.
+       <a name="usecase">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="usecase.publish">Publishing an SI Request</a>
+</h3>
+    <p class="" style="">A stream owner uses the &lt;sipub/&gt; element to announce that it can perform a specific SI request. This element can be sent to a publish-subscribe (JEP-0060) node, or sent directly to potential recipients within a &lt;message/&gt; stanza.</p>
+    <p class="" style="">The format of the &lt;sipub/&gt; element is as follows:</p>
+    <p class="caption">Example 1. Sample &lt;sipub/&gt;</p>
+<div class="indent"><pre>
+  &lt;sipub xmlns='http://jabber.org/protocol/sipub'
+         from='sender-jid'
+         id='publish-0123'
+      profile='si-profile'
+      mime-type='mime/type'&gt;
+    &lt;profile xmlns='si-profile' ...&gt;...&lt;/profile&gt;
+  &lt;/sipub&gt;
+    </pre></div>
+    <p class="" style="">This format is nearly identical to that for the stream initiation &lt;si/&gt; element (see JEP-0095). The major difference is the lack of the feature negotiation for the stream methods, and the addition of a 'from' attribute.</p>
+    <p class="" style="">The 'from' attribute SHOULD normally be present, and MUST be present if the stanza containing the &lt;sipub/&gt; is not from the stream owner (e.g., if the stream is advertised at a publish-subscribe node). If present, this attribute MUST be the valid JID for the stream owner.</p>
+    <p class="" style="">The 'id' attribute is an opaque identifier. This attribute MUST be present, and MUST be a valid non-empty string. It uniquely identifies the published request for the potential sender.</p>
+    <p class="" style="">As with stream initiation, the 'profile' attribute MUST be present, and MUST be the namespace URI governing the profile information. It identifies the format for the SI profile.</p>
+    <p class="" style="">As with stream initiation, the 'mime-type' attribute SHOULD be present, and MUST be a valid mime-type. It provides the receiver with additional information about what the data stream will be.</p>
+    <p class="" style="">The &lt;sipub/&gt; element MUST contain an element qualified by the namespace specified by 'profile'. This is the additional information about the data stream.</p>
+    <p class="" style="">The &lt;sipub/&gt; information is typically provided via pubsub:</p>
+    <p class="caption">Example 2. Advertising a stream via publish-subscribe</p>
+<div class="indent"><pre>
+&lt;message to=&quot;receiver&quot; from=&quot;pubsub.jabber.org&quot;&gt;
+  &lt;event xmlns=&quot;http://jabber.org/protocol/pubsub#event&quot;&gt;
+    &lt;items node=&quot;generic/si-publish&quot;&gt;
+      &lt;item id=&quot;current&quot;&gt;
+        &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+            from='sender'
+            id='publish-0123'
+            mime-type='text/plain'
+            profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+          &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+                name='special.txt'
+                size='1024'
+                date='2004-01-28T10:07:00-07:00'&gt;
+            &lt;desc&gt;The special file&lt;/desc&gt;
+          &lt;/file&gt;
+        &lt;/sipub&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Since the announcement did not come directly from the sender, the &lt;sipub/&gt; element MUST specify the stream owner in the 'from' attribute.</p>
+    <p class="" style="">The &lt;sipub/&gt; element MAY also be included directly within a &lt;message/&gt; stanza sent to another entity (or multiple entities, e.g., in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2601969">4</a>] or via <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2601988">5</a>]). This can be especially useful for informing an offline entity about an available stream.</p>
+    <p class="caption">Example 3. Advertising a stream in a message stanza</p>
+<div class="indent"><pre>
+&lt;message from='sender' to='receiver'&gt;
+  &lt;body&gt;Here is the file you requested...&lt;/body&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+         id='publish-0123'
+         mime-type='text/plain'
+         profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='special.txt'
+          size='1024'
+          date='2004-01-28T10:07:00-07:00'&gt;
+      &lt;desc&gt;The special file&lt;/desc&gt;
+    &lt;/file&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Since the announcement came directly from the sender, the 'from' attribute is OPTIONAL.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="usecase.xdata">Integration with Data Forms</a>
+</h3>
+    <p class="" style="">One of the goals of sipub is to integrate <span style="font-weight: bold">Stream Initiation</span> with <span style="font-weight: bold">Data Forms</span> to provide a &quot;file upload&quot; capability. This is accomplished via the datatypes specified in <span class="ref">Data Forms Validation</span>  [<a href="#nt-id2601953">6</a>]. Each datatype is specific to the profile desired.</p>
+    <p class="" style="">For example the datatype &quot;sipub:file-transfer&quot; is used to identify the file upload field(s) (corresponding to <span class="ref">File Transfer</span>  [<a href="#nt-id2602015">7</a>]):</p>
+    <p class="caption">Example 4. &quot;Upload File&quot; Data Forms Field</p>
+<div class="indent"><pre>
+  &lt;field var='file' type='text-single' label='File to Upload'&gt;
+    &lt;validate xmlns='http://jabber.org/protocol/xdata-validate' 
+              datatype='sipub:file-transfer'/&gt;
+  &lt;/field&gt;
+    </pre></div>
+    <p class="" style="">When submitting such a form, a field's value(s) MUST be the &lt;sipub/&gt; identifier(s). Also, the submitter MUST provide an &lt;sipub/&gt; element within the data form for each file to be uploaded:</p>
+    <p class="caption">Example 5. Submitting an &quot;Upload File&quot; form</p>
+<div class="indent"><pre>
+  &lt;x xmlns='jabber:x:data' type='submit'&gt;
+    &lt;field var='file'&gt;
+      &lt;value&gt;publish-0123&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;sipub xmlns='http://jabber.org/protocol/sipub'
+           id='publish-0123'
+           mime-type='text/plain'
+           profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+      &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+            name='special.txt'
+            size='1024'
+            date='2004-01-28T10:07:00-07:00'/&gt;
+    &lt;/sipub&gt;
+  &lt;/x&gt;
+    </pre></div>
+    <p class="" style="">The form processor will use this to retrieve the file(s) to be uploaded.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="usecase.trigger">Triggering the Stream Initiation Request</a>
+</h3>
+    <p class="" style="">A potential receiver starts the stream initiation session by performing an IQ-GET to the sender, using the &lt;start xmlns='http://jabber.org/protocol/sipub'/&gt; element. This element contains the 'id' attribute to specify which published stream to retrieve:</p>
+    <p class="caption">Example 6. Receiver requests start of stream</p>
+<div class="indent"><pre>
+  &lt;iq type='get' id='sipub-request-0' to='sender' from='receiver'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'
+           id='publish-0123'/&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the sender accepts the request, it responds with an IQ-result containing a &lt;starting/&gt; element. This element indicates the stream initiation identifier to be used:</p>
+    <p class="caption">Example 7. Sender accepts request to start stream</p>
+<div class="indent"><pre>
+  &lt;iq type='result' id='sipub-request-0' from='sender' to='receiver'&gt;
+    &lt;starting xmlns='http://jabber.org/protocol/sipub'
+              sid='session-87651234'/&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Then the sender begins the stream initiation negotiation:</p>
+    <p class="caption">Example 8. Sender starts negotiation</p>
+<div class="indent"><pre>
+  &lt;iq type='set' id='si-0' from='sender' to='receiver'&gt;
+    &lt;si xmlns='http://jabber.org/protocol/si'
+        id='session-87651234'
+        mime-type='text/plain'
+        profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+      &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='special.txt'
+          size='1024'
+          date='2004-01-28T10:07:00-07:00'&gt;
+        &lt;desc&gt;The special file&lt;/desc&gt;
+      &lt;/file&gt;
+    &lt;/si&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested identifier is not valid, the sender SHOULD respond with a &lt;not-acceptable/&gt; error:</p>
+    <p class="caption">Example 9. Sender denies because of invalid id</p>
+<div class="indent"><pre>
+  &lt;iq type='error' id='sipub-requeset-0' from='sender' to='receiver'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'&gt;publish-0123&lt;/start&gt;
+    &lt;error code='405' type='modify'&gt;
+      &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the receiver does not have permission to request the data stream, the sender SHOULD respond with a &lt;forbidden/&gt; error:</p>
+    <p class="caption">Example 10. Sender denies because receiver is forbidden</p>
+<div class="indent"><pre>
+  &lt;iq type='error' id='sipub-requeset-0' from='sender' to='receiver'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'&gt;publish-0123&lt;/start&gt;
+    &lt;error code='403' type='auth'&gt;
+      &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="sect-id2602221">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="sect-id2602236">Publish ID versus SI ID</a>
+</h3>
+    <p class="" style="">When publishing a stream via the &lt;sipub/&gt; element, the identifier SHOULD NOT be used as-is for the &lt;si/&gt; element, since a single publication will likely result in multiple &lt;si/&gt; requests, possibly from the same receiver.</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security features or concerns related to this proposal.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602400">8</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar.namespaces">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602351">9</a>] shall include 'http://jabber.org/protocol/sipub' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="registrar.xdata-validate">Data Form Validation Datatypes</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include 'sipub:' in its registry of Data Forms Validation Datatype Prefixes.</p>
+    <p class="" style="">Normally, each SI profile that wishes to be considered for use with Data Forms MUST register its own datatype qualified by the &quot;sipub:&quot; prefix. However, this JEP provides an initial seed, based on the currently accepted SI profiles. The following datatypes shall be registered for use with Data Forms Validation:</p>
+    <p class="caption">Data Forms Validation Datatypes Registry Submission</p>
+<div class="indent"><pre>
+&lt;datatype&gt;
+  &lt;name&gt;sipub:file-transfer&lt;/name&gt;
+  &lt;desc&gt;Datatype for publishing an SI using the File Transfer Profile&lt;/desc&gt;
+  &lt;doc&gt;JEP-0096&lt;/doc&gt;
+&lt;/datatype&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/sipub'
+    xmlns='http://jabber.org/protocol/sipub'
+    elementFormDefault='qualified'&gt;
+  
+  &lt;xs:element name='sipub'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the root content element for advertising a stream.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:any namespace='##other' minOccurs='1'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='mime-type' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='profile' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='start'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the element for requesting retrieval of a stream.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='starting'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the element for specifying the stream to be retrieved.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596051">1</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596157">2</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596183">3</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601969">4</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601988">5</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601953">6</a>. JEP-0122: Data Forms Validation &lt;<a href="http://www.jabber.org/jeps/jep-0122.html">http://www.jabber.org/jeps/jep-0122.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602015">7</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602400">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602351">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-11-03)</h4>
+<div class="indent">Editorial review: clarified text throughout and corrected several errors in the examples. (psa)
+    </div>
+<h4>Version 0.1 (2004-06-16)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0137-0.3.html
+++ b/content/xep-0137-0.3.html
@@ -1,0 +1,418 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0137: Publishing SI Requests</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Publishing SI Requests">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Creator" content="Thomas Muldowney">
+<meta name="DC.Description" content="This JEP defines protocol for publishing the availability of a particular Stream Initiation request, such as a file.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0137">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0137: Publishing SI Requests</h1>
+<p>This JEP defines protocol for publishing the availability of a particular Stream Initiation request, such as a file.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0137<br>
+            Version: 0.3<br>
+            Last Updated: 2005-07-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0095<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: sipub<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h3>Thomas Muldowney</h3>
+<p class="indent">
+        Email: temas@jabber.org<br>
+        JID: temas@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#requirements">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecase">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#usecase.publish">Publishing an SI Request</a>
+</dt>
+<dt>3.2.  <a href="#usecase.xdata">Integration with Data Forms</a>
+</dt>
+<dt>3.3.  <a href="#usecase.trigger">Triggering the Stream Initiation Request</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2255790">Implementation Notes</a>
+</dt>
+<dl><dt>4.1.  <a href="#sect-id2255803">Publish ID versus SI ID</a>
+</dt></dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar.namespaces">Protocol Namespaces</a>
+</dt>
+<dt>7.2.  <a href="#registrar.xdata-validate">Data Form Validation Datatypes</a>
+</dt>
+</dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Stream Initiation</span>  [<a href="#nt-id2251444">1</a>] defines a protocol to initiate a data stream between two Jabber/XMPP entities (e.g., for the purpose of <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2251412">2</a>]). However, the sender is still responsible for informing potential receivers about the existence of a given stream. This JEP provides an automated way for a sender to announce the availability of a stream without initiating the data transfer. The purpose is to provide a "pull" protocol that enables a receiver to then request initiation of the stream from the sender.</p>
+<h2>2.
+       <a name="requirements">Requirements</a>
+</h2>
+  <p class="" style="">This proposal addresses the following requirements:</p>
+  <ul>
+    <li>Allow a potential receiver (rather than the sender) to initiate a data stream.</li>
+    <li>Integrate Stream Initiation (SI) with <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250460">3</a>].</li>
+    <li>Integrate Stream Initiation with <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250484">4</a>].</li>
+  </ul>
+<h2>3.
+       <a name="usecase">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="usecase.publish">Publishing an SI Request</a>
+</h3>
+    <p class="" style="">A stream owner uses the &lt;sipub/&gt; element to announce that it can perform a specific SI request. This element can be sent to a publish-subscribe (JEP-0060) node, or sent directly to potential recipients within a &lt;message/&gt; stanza.</p>
+    <p class="" style="">The format of the &lt;sipub/&gt; element is as follows:</p>
+    <p class="caption">Example 1. Sample &lt;sipub/&gt;</p>
+<div class="indent"><pre>
+  &lt;sipub xmlns='http://jabber.org/protocol/sipub'
+         from='sender-jid'
+         id='publish-0123'
+         profile='si-profile'
+         mime-type='mime/type'&gt;
+    &lt;profile xmlns='si-profile' ...&gt;...&lt;/profile&gt;
+  &lt;/sipub&gt;
+    </pre></div>
+    <p class="" style="">This format is nearly identical to that for the stream initiation &lt;si/&gt; element (see <span style="font-weight: bold">JEP-0095</span>). The major difference is the lack of the feature negotiation for the stream methods, and the addition of a 'from' attribute.</p>
+    <p class="" style="">The 'from' attribute SHOULD be present, and MUST be present if the stanza containing the &lt;sipub/&gt; is not from the stream owner (e.g., if the stream is advertised at a publish-subscribe node). If present, this attribute MUST be the valid JID for the stream owner.</p>
+    <p class="" style="">The 'id' attribute is an opaque identifier. This attribute MUST be present, and MUST be a valid non-empty string. It uniquely identifies the published request at the potential sender.</p>
+    <p class="" style="">As with stream initiation, the 'profile' attribute MUST be present, and MUST be the namespace URI governing the profile information. It identifies the format for the SI profile.</p>
+    <p class="" style="">As with stream initiation, the 'mime-type' attribute SHOULD be present, and MUST be an IANA-registered content type.  [<a href="#nt-id2251205">5</a>] It provides the receiver with additional information about what the data stream will be.</p>
+    <p class="" style="">The &lt;sipub/&gt; element MUST contain an element qualified by the namespace specified by the 'profile' attribute (e.g., &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'/&gt; for file transfer). This is the additional information about the data stream.</p>
+    <p class="" style="">The &lt;sipub/&gt; information is typically provided via pubsub:</p>
+    <p class="caption">Example 2. Sender advertises stream via publish-subscribe</p>
+<div class="indent"><pre>
+&lt;iq from='bard@shakespeare.lit/globe'
+    to='pubsub.shakespeare.lit'
+    id='ps1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='characters'&gt;
+      &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+          from='bard@shakespeare.lit'
+          id='publish-0123'
+          mime-type='text/plain'
+          profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+        &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+              name='NDA.pdf'
+              size='138819'
+              date='2004-01-28T10:07Z'&gt;
+          &lt;desc&gt;All Shakespearean characters must sign and return this NDA ASAP&lt;/desc&gt;
+        &lt;/file&gt;
+      &lt;/sipub&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 3. Pubsub service pushes announcement to all subscribers</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' to='juliet@capulet.com/balcony'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='characters'&gt;
+      &lt;item id='current'&gt;
+        &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+            from='bard@shakespeare.lit'
+            id='publish-0123'
+            mime-type='text/plain'
+            profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+          &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+                name='NDA'
+                size='1024'
+                date='2004-01-28T10:07Z'&gt;
+            &lt;desc&gt;All Shakespearean characters must sign and return this NDA ASAP&lt;/desc&gt;
+          &lt;/file&gt;
+        &lt;/sipub&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The &lt;sipub/&gt; element MAY also be included directly within a &lt;message/&gt; stanza sent to another entity (or multiple entities, e.g., in <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2255532">6</a>] or via <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2255550">7</a>]). This can be especially useful for informing an offline entity about an available stream.</p>
+    <p class="caption">Example 4. Advertising a stream in a message stanza</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/pda' to='juliet@capulet.com'&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+      id='publish-0123'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='missive.html'
+          size='1024'
+          date='2005-07-21T11:21Z'&gt;
+      &lt;desc&gt;All Shakespearean characters must sign and return this NDA ASAP&lt;/desc&gt;
+    &lt;/file&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="usecase.xdata">Integration with Data Forms</a>
+</h3>
+    <p class="" style="">One of the goals of sipub is to integrate <span style="font-weight: bold">Stream Initiation</span> with <span style="font-weight: bold">Data Forms</span> to provide a "file upload" capability. This is accomplished via the datatypes specified in <span class="ref" style="">Data Forms Validation</span>  [<a href="#nt-id2255605">8</a>]. Each datatype is specific to the profile desired.</p>
+    <p class="" style="">For example the datatype "sipub:file-transfer" is used to identify the file upload field(s) corresponding to <span style="font-weight: bold">JEP-0096</span>:</p>
+    <p class="caption">Example 5. "Upload File" Data Forms Field</p>
+<div class="indent"><pre>
+  &lt;field var='file' type='text-single' label='File to Upload'&gt;
+    &lt;validate xmlns='http://jabber.org/protocol/xdata-validate'
+              datatype='sipub:file-transfer'/&gt;
+  &lt;/field&gt;
+    </pre></div>
+    <p class="" style="">When submitting such a form, a field's value(s) MUST be the &lt;sipub/&gt; identifier(s). Also, the submitter MUST provide an &lt;sipub/&gt; element within the data form for each file to be uploaded:</p>
+    <p class="caption">Example 6. Submitting an "Upload File" form</p>
+<div class="indent"><pre>
+  &lt;x xmlns='jabber:x:data' type='submit'&gt;
+    &lt;field var='file'&gt;
+      &lt;value&gt;publish-0123&lt;/value&gt;
+    &lt;/field&gt;
+    &lt;sipub xmlns='http://jabber.org/protocol/sipub'
+           id='publish-0123'
+           mime-type='text/plain'
+           profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+      &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+            name='missive.html'
+            size='1024'
+            date='2005-07-21T11:21Z'/&gt;
+    &lt;/sipub&gt;
+  &lt;/x&gt;
+    </pre></div>
+    <p class="" style="">The form processor will use this to retrieve the file(s) to be uploaded.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="usecase.trigger">Triggering the Stream Initiation Request</a>
+</h3>
+    <p class="" style="">A potential receiver starts the stream initiation session by sending an IQ-get to the sender, using the &lt;start xmlns='http://jabber.org/protocol/sipub'/&gt; element. This element contains the 'id' attribute to specify which published stream to retrieve:</p>
+    <p class="caption">Example 7. Receiver requests start of stream</p>
+<div class="indent"><pre>
+  &lt;iq type='get'
+      id='sipub-request-0'
+      from='juliet@capulet.com/balcony'
+      to='romeo@montague.net/pda'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'
+           id='publish-0123'/&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the sender accepts the request, it responds with an IQ-result containing a &lt;starting/&gt; element. This element indicates the stream initiation identifier to be used:</p>
+    <p class="caption">Example 8. Sender accepts request to start stream</p>
+<div class="indent"><pre>
+  &lt;iq type='result'
+      id='sipub-request-0'
+      from='romeo@montague.net/pda'
+      to='juliet@capulet.com/balcony'&gt;
+    &lt;starting xmlns='http://jabber.org/protocol/sipub'
+              sid='session-87651234'/&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Then the sender begins the stream initiation negotiation:</p>
+    <p class="caption">Example 9. Sender starts negotiation</p>
+<div class="indent"><pre>
+  &lt;iq type='set'
+      id='sipub-set-1'
+      from='romeo@montague.net/pda'
+      to='juliet@capulet.com/balcony'&gt;
+    &lt;si xmlns='http://jabber.org/protocol/si'
+        id='session-87651234'
+        mime-type='text/plain'
+        profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+      &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='missive.html'
+          size='1024'
+          date='2005-07-21T11:21Z'&gt;
+        &lt;desc&gt;A love letter&lt;/desc&gt;
+      &lt;/file&gt;
+    &lt;/si&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested identifier is not valid, the sender SHOULD respond with a &lt;not-acceptable/&gt; error:</p>
+    <p class="caption">Example 10. Sender denies because of invalid id</p>
+<div class="indent"><pre>
+  &lt;iq type='error'
+      id='sipub-set-1'
+      from='romeo@montague.net/pda'
+      to='juliet@capulet.com/balcony'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'&gt;publish-0123&lt;/start&gt;
+    &lt;error code='405' type='modify'&gt;
+      &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the receiver does not have permission to request the data stream, the sender SHOULD respond with a &lt;forbidden/&gt; error:</p>
+    <p class="caption">Example 11. Sender denies because receiver is forbidden</p>
+<div class="indent"><pre>
+  &lt;iq type='error'
+      id='sipub-set-1'
+      from='romeo@montague.net/pda'
+      to='juliet@capulet.com/balcony'&gt;
+    &lt;start xmlns='http://jabber.org/protocol/sipub'&gt;publish-0123&lt;/start&gt;
+    &lt;error code='403' type='auth'&gt;
+      &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;/error&gt;
+  &lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="sect-id2255790">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="sect-id2255803">Publish ID versus SI ID</a>
+</h3>
+    <p class="" style="">When publishing a stream via the &lt;sipub/&gt; element, the identifier SHOULD NOT be used as-is for the &lt;si/&gt; element, since a single publication will likely result in multiple &lt;si/&gt; requests, possibly from the same receiver.</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security concerns beyond those specified in <span style="font-weight: bold">JEP-0060</span> and the relevant Stream Initiation profile in use.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255923">9</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar.namespaces">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255901">10</a>] shall include 'http://jabber.org/protocol/sipub' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="registrar.xdata-validate">Data Form Validation Datatypes</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include 'sipub:' in its registry of Data Forms Validation Datatype Prefixes.</p>
+    <p class="" style="">Normally, each SI profile that wishes to be considered for use with Data Forms MUST register its own datatype qualified by the "sipub:" prefix. However, this JEP provides an initial seed, based on the currently accepted SI profiles. The following datatypes shall be registered for use with Data Forms Validation:</p>
+    <p class="caption">Data Forms Validation Datatypes Registry Submission</p>
+<div class="indent"><pre>
+&lt;datatype&gt;
+  &lt;name&gt;sipub:file-transfer&lt;/name&gt;
+  &lt;desc&gt;Datatype for publishing an SI using the File Transfer Profile&lt;/desc&gt;
+  &lt;doc&gt;JEP-0096&lt;/doc&gt;
+&lt;/datatype&gt;
+    </pre></div>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/sipub'
+    xmlns='http://jabber.org/protocol/sipub'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='sipub'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the root content element for advertising a stream.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:any namespace='##other' minOccurs='1'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='from' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='mime-type' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='profile' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='start'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the element for requesting retrieval of a stream.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='id' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='starting'&gt;
+    &lt;xs:annotation&gt;
+      &lt;xs:documentation&gt;This is the element for specifying the stream to be retrieved.&lt;/xs:documentation&gt;
+    &lt;/xs:annotation&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:attribute name='sid' type='xs:string' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251444">1</a>. JEP-0095: Stream Initiation &lt;<a href="http://www.jabber.org/jeps/jep-0095.html">http://www.jabber.org/jeps/jep-0095.html</a>&gt;.</p>
+<p><a name="nt-id2251412">2</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2250460">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250484">4</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2251205">5</a>. The IANA registry of content types is located at &lt;<a href="http://www.iana.org/assignments/media-types/">http://www.iana.org/assignments/media-types/</a>&gt;.</p>
+<p><a name="nt-id2255532">6</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2255550">7</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2255605">8</a>. JEP-0122: Data Forms Validation &lt;<a href="http://www.jabber.org/jeps/jep-0122.html">http://www.jabber.org/jeps/jep-0122.html</a>&gt;.</p>
+<p><a name="nt-id2255923">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255901">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-07-21)</h4>
+<div class="indent">Corrected several errors in the text and examples. (psa)
+    </div>
+<h4>Version 0.2 (2004-11-03)</h4>
+<div class="indent">Editorial review: clarified text throughout and corrected several errors in the examples. (psa)
+    </div>
+<h4>Version 0.1 (2004-06-16)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0138-0.2.html
+++ b/content/xep-0138-0.2.html
@@ -1,0 +1,243 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0138: Stream Compression</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stream Compression">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a mechanism for compressing XML streams.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0138">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0138: Stream Compression</h1>
+<p>This JEP defines a mechanism for compressing XML streams.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0138<br>
+            Version: 0.2<br>
+            Last Updated: 2004-09-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: compress<br>
+</p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecase">Use Case</a>
+</dt>
+<dt>3.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>3.1.  <a href="#impl-zlib">zlib</a>
+</dt></dl>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+<dt>6.2.  <a href="#registrar">Protocol Namespaces</a>
+</dt>
+</dl>
+<dt>7.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#schemas-stream">Stream Feature</a>
+</dt>
+<dt>7.2.  <a href="#schemas-protocol">Protocol Namespace</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">
+<span class="ref">XMPP Core</span>  [<a href="#nt-id2595946">1</a>] specifies the use of Transport Layer Security (see <span class="ref">RFC 2246</span>  [<a href="#nt-id2596098">2</a>]) for encryption of XML streams, and TLS includes the ability to compress encrypted traffic (see <span class="ref">RFC 3749</span>  [<a href="#nt-id2596121">3</a>]). However, not all devices are able to implement TLS, and traffic compression may be desirable for communication by such devices. This JEP defines a mechanism for compressing XML streams outside the context of TLS. Such compression could be performed using any number of compression methods, but the only method required by this JEP is ZLIB as specified in <span class="ref">RFC 1950</span>  [<a href="#nt-id2596022">4</a>].</p>
+  <h2>2.
+       <a name="usecase">Use Case</a>
+</h2>
+    <p class="" style="">The protocol flow is as follows:</p>
+    <p class="caption">Example 1. Server Offers Stream Compression Feature</p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+  &lt;compression xmlns='http://jabber.org/features/compress'&gt;
+    &lt;method&gt;zlib&lt;/method&gt;
+  &lt;/compression&gt;
+&lt;/stream:features&gt;
+    </pre></div>
+    <p class="caption">Example 2. Client Requests Stream Compression</p>
+<div class="indent"><pre>
+&lt;compress xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;method&gt;zlib&lt;/method&gt;
+&lt;/compress&gt;
+    </pre></div>
+    <p class="caption">Example 3. Server Acknowledges Stream Compression</p>
+<div class="indent"><pre>
+&lt;compressed xmlns='http://jabber.org/features/compress'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the previous stream to be null and void, just as with TLS negotiation and SASL negotiation (as specified in <span style="font-weight: bold">XMPP Core</span>). Therefore the client MUST initiate a new stream to the server:</p>
+    <p class="caption">Example 4. Client Initiates New Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream
+    xmlns='jabber:client'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    to='shakespeare.lit'&gt;
+    </pre></div>
+    <p class="" style="">Note well the following:</p>
+    <ul>
+      <li>The only compression method defined herein is ZLIB; however, other methods may be defined in the future.</li>
+      <li>If stream compression is negotiated, it MUST be used in both directions.</li>
+      <li>TLS compression and stream compression SHOULD NOT be used simultaneously. However, if both TLS (whether including TLS compression or not) and stream compression are used, then TLS MUST be negotiated first, followed by negotiation of stream compression.</li>
+    </ul>
+  <h2>3.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <div class="indent">
+<h3>3.1 <a name="impl-zlib">zlib</a>
+</h3>
+      <p class="" style="">When using zlib for compression, the sending application SHOULD complete a partial flush of zlib when its current send is complete. Note that this statement is deliberately somewhat vague: the sending application may end up performing this partial flush after sending every XML stanza, but on the other hand may perform the partial flush only after sending a group of stanzas that have been queued up for delivery. When to flush the state of the compression application is up to the sending application.</p>
+    </div>
+  <h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Stream encryption via TLS (as defined in <span style="font-weight: bold">XMPP Core</span>) and stream compression (as defined herein) are not mutually exclusive, but stream encryption via TLS MUST be negotiated before negotiation of stream compression in order to secure the stream.</p>
+  <h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2596284">5</a>]. </p>
+  <h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>6.1 <a name="registrar-stream">Stream Features</a>
+</h3>
+      <p class="" style="">Upon approval of this JEP, the Jabber Registrar shall add 'http://jabber.org/features/compress' to its registry of stream features.</p>
+    </div>
+    <div class="indent">
+<h3>6.2 <a name="registrar">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">Upon advancement of this JEP to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2601892">6</a>] shall add 'http://jabber.org/protocol/compress' to its registry of protocol namespaces.</p>
+    </div>
+  <h2>7.
+       <a name="schemas">XML Schemas</a>
+</h2>
+    <div class="indent">
+<h3>7.1 <a name="schemas-stream">Stream Feature</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/compress'
+    xmlns='http://jabber.org/features/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='compression'/&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='method' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='method' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>7.2 <a name="schemas-protocol">Protocol Namespace</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/compress'
+    xmlns='http://jabber.org/protocol/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='compress' type='empty'/&gt;
+  &lt;xs:element name='compressed' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595946">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596098">2</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596121">3</a>. RFC 3749: Transport Layer Security Protocol Compression Methods &lt;<a href="http://www.ietf.org/rfc/rfc3749.txt">http://www.ietf.org/rfc/rfc3749.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596022">4</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596284">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601892">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-09-28)</h4>
+<div class="indent">Fixed TLS text per list discussion. (psa)
+    </div>
+<h4>Version 0.1 (2004-07-16)</h4>
+<div class="indent">Initial version. (jjh/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0138-0.3.html
+++ b/content/xep-0138-0.3.html
@@ -1,0 +1,280 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0138: Stream Compression</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stream Compression">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a mechanism for compressing XML streams.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0138">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0138: Stream Compression</h1>
+<p>This JEP defines a mechanism for compressing XML streams.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0138<br>
+            Version: 0.3<br>
+            Last Updated: 2005-03-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: compress<br></p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecase">Use Case</a>
+</dt>
+<dt>3.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>4.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>4.1.  <a href="#impl-zlib">zlib</a>
+</dt></dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+<dt>7.2.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>7.3.  <a href="#registrar-methods">Compression Methods Registry</a>
+</dt>
+<dl>
+<dt>7.3.1.  <a href="#registrar-methods-process">Process</a>
+</dt>
+<dt>7.3.2.  <a href="#registrar-shim-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>8.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#schemas-stream">Stream Feature</a>
+</dt>
+<dt>8.2.  <a href="#schemas-protocol">Protocol Namespace</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251359">1</a>] specifies the use of Transport Layer Security (see <span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2251308">2</a>]) for encryption of XML streams, and TLS includes the ability to compress encrypted traffic (see <span class="ref" style="">RFC 3749</span>  [<a href="#nt-id2251330">3</a>]). However, not all devices are able to implement TLS, and traffic compression may be desirable for communication by such devices. This JEP defines a mechanism for compressing XML streams outside the context of TLS.</p>
+    <p class="" style="">Such compression could be performed using any number of compression methods. While the only method required by this JEP is ZLIB (as specified in <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2251126">4</a>]), other methods MAY be defined in future JEPs or by registration as described in the <a href="#registrar-methods">Compression Methods Registry</a> section of this document.</p>
+  <h2>2.
+       <a name="usecase">Use Case</a>
+</h2>
+    <p class="" style="">The protocol flow is as follows:</p>
+    <p class="caption">Example 1. Server Offers Stream Compression Feature</p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+  &lt;compression xmlns='http://jabber.org/features/compress'&gt;
+    &lt;method&gt;zlib&lt;/method&gt;
+  &lt;/compression&gt;
+&lt;/stream:features&gt;
+    </pre></div>
+    <p class="caption">Example 2. Client Requests Stream Compression</p>
+<div class="indent"><pre>
+&lt;compress xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;method&gt;zlib&lt;/method&gt;
+&lt;/compress&gt;
+    </pre></div>
+    <p class="caption">Example 3. Server Acknowledges Stream Compression</p>
+<div class="indent"><pre>
+&lt;compressed xmlns='http://jabber.org/features/compress'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the previous stream to be null and void, just as with TLS negotiation and SASL negotiation (as specified in <span style="font-weight: bold">XMPP Core</span>). Therefore the client MUST initiate a new stream to the server:</p>
+    <p class="caption">Example 4. Client Initiates New Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream
+    xmlns='jabber:client'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    to='shakespeare.lit'&gt;
+    </pre></div>
+  <h2>3.
+       <a name="bizrules">Business Rules</a>
+</h2>
+    <p class="" style="">The following business rules apply:</p>
+    <ul>
+      <li>If stream compression is negotiated, it MUST be used in both directions.</li>
+      <li>TLS compression and stream compression SHOULD NOT be used simultaneously. However, if both TLS (whether including TLS compression or not) and stream compression are used, then TLS MUST be negotiated first, followed by negotiation of stream compression.</li>
+    </ul>
+  <h2>4.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="impl-zlib">zlib</a>
+</h3>
+      <p class="" style="">When using zlib for compression, the sending application SHOULD complete a partial flush of zlib when its current send is complete. Note that this statement is deliberately somewhat vague: the sending application may end up performing this partial flush after sending every XML stanza, but on the other hand may perform the partial flush only after sending a group of stanzas that have been queued up for delivery. When to flush the state of the compression application is up to the sending application.</p>
+    </div>
+  <h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Stream encryption via TLS (as defined in <span style="font-weight: bold">XMPP Core</span>) and stream compression (as defined herein) are not mutually exclusive, but stream encryption via TLS MUST be negotiated before negotiation of stream compression in order to secure the stream.</p>
+  <h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250495">5</a>]. </p>
+  <h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>7.1 <a name="registrar-stream">Stream Features</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255092">6</a>] shall include 'http://jabber.org/features/compress' in its registry of stream features.</p>
+    </div>
+    <div class="indent">
+<h3>7.2 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/compress' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>7.3 <a name="registrar-methods">Compression Methods Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall maintain a registry of compression methods.</p>
+      <div class="indent">
+<h3>7.3.1 <a name="registrar-methods-process">Process</a>
+</h3>
+        <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;method&gt;
+  &lt;name&gt;the XML character data of the method element&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the compression method&lt;/desc&gt;
+  &lt;doc&gt;the document that specifies or registers the compression method&lt;/doc&gt;
+&lt;/method&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one compression method at a time, each contained in a separate &lt;method/&gt; element.</p>
+      </div>
+      <div class="indent">
+<h3>7.3.2 <a name="registrar-shim-init">Initial Registration</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;method&gt;
+  &lt;name&gt;zlib&lt;/name&gt;
+  &lt;desc&gt;the ZLIB compression method as specified in RFC 1950&lt;/desc&gt;
+  &lt;doc&gt;JEP-0138&lt;/doc&gt;
+&lt;/method&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>8.
+       <a name="schemas">XML Schemas</a>
+</h2>
+    <div class="indent">
+<h3>8.1 <a name="schemas-stream">Stream Feature</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/compress'
+    xmlns='http://jabber.org/features/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='compression'/&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='method' type='xs:NCName' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>8.2 <a name="schemas-protocol">Protocol Namespace</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/compress'
+    xmlns='http://jabber.org/protocol/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='compress' type='empty'/&gt;
+  &lt;xs:element name='compressed' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251359">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251308">2</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2251330">3</a>. RFC 3749: Transport Layer Security Protocol Compression Methods &lt;<a href="http://www.ietf.org/rfc/rfc3749.txt">http://www.ietf.org/rfc/rfc3749.txt</a>&gt;.</p>
+<p><a name="nt-id2251126">4</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2250495">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255092">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-03-28)</h4>
+<div class="indent">Specified compression methods registry. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-28)</h4>
+<div class="indent">Fixed TLS text per list discussion. (psa)
+    </div>
+<h4>Version 0.1 (2004-07-16)</h4>
+<div class="indent">Initial version. (jjh/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0138-0.4.html
+++ b/content/xep-0138-0.4.html
@@ -1,0 +1,290 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0138: Stream Compression</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stream Compression">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a mechanism for compressing XML streams.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0138">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0138: Stream Compression</h1>
+<p>This JEP defines a mechanism for compressing XML streams.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0138<br>
+            Version: 0.4<br>
+            Last Updated: 2005-05-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: compress<br></p>
+<h2>Author Information</h2>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecase">Use Case</a>
+</dt>
+<dt>3.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>4.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>4.1.  <a href="#impl-zlib">zlib</a>
+</dt></dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+<dt>7.2.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>7.3.  <a href="#registrar-methods">Compression Methods Registry</a>
+</dt>
+<dl>
+<dt>7.3.1.  <a href="#registrar-methods-process">Process</a>
+</dt>
+<dt>7.3.2.  <a href="#registrar-shim-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>8.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#schemas-stream">Stream Feature</a>
+</dt>
+<dt>8.2.  <a href="#schemas-protocol">Protocol Namespace</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251376">1</a>] specifies the use of Transport Layer Security (TLS; see <span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2251347">2</a>]) for encryption of XML streams, and TLS includes the ability to compress encrypted traffic (see <span class="ref" style="">RFC 3749</span>  [<a href="#nt-id2250375">3</a>]). However, not all devices are able to implement TLS, and traffic compression may be desirable for communication by such devices. This JEP defines a mechanism for compressing XML streams outside the context of TLS.</p>
+    <p class="" style="">Such compression could be performed using any number of compression methods. While the only method required by this JEP is ZLIB (as specified in <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2250407">4</a>]), other methods MAY be defined in future JEPs or by registration as described in the <a href="#registrar-methods">Compression Methods Registry</a> section of this document.</p>
+  <h2>2.
+       <a name="usecase">Use Case</a>
+</h2>
+    <p class="" style="">The protocol flow is as follows:</p>
+    <p class="caption">Example 1. Server Offers Stream Compression Feature</p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+  &lt;compression xmlns='http://jabber.org/features/compress'&gt;
+    &lt;method&gt;zlib&lt;/method&gt;
+  &lt;/compression&gt;
+&lt;/stream:features&gt;
+    </pre></div>
+    <p class="caption">Example 2. Client Requests Stream Compression</p>
+<div class="indent"><pre>
+&lt;compress xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;method&gt;zlib&lt;/method&gt;
+&lt;/compress&gt;
+    </pre></div>
+    <p class="caption">Example 3. Server Acknowledges Stream Compression</p>
+<div class="indent"><pre>
+&lt;compressed xmlns='http://jabber.org/features/compress'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the previous stream to be null and void, just as with TLS negotiation and SASL negotiation (as specified in <span style="font-weight: bold">XMPP Core</span>). Therefore the client MUST initiate a new stream to the server:</p>
+    <p class="caption">Example 4. Client Initiates New Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream
+    xmlns='jabber:client'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    to='shakespeare.lit'&gt;
+    </pre></div>
+  <h2>3.
+       <a name="bizrules">Business Rules</a>
+</h2>
+    <p class="" style="">The following business rules apply:</p>
+    <ul>
+      <li>If stream compression is negotiated, it MUST be used in both directions.</li>
+      <li>TLS compression and stream compression SHOULD NOT be used simultaneously. However, if both TLS (whether including TLS compression or not) and stream compression are used, then TLS MUST be negotiated first, followed by negotiation of stream compression.</li>
+    </ul>
+  <h2>4.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <div class="indent">
+<h3>4.1 <a name="impl-zlib">zlib</a>
+</h3>
+      <p class="" style="">When using ZLIB for compression, the sending application SHOULD complete a partial flush of ZLIB when its current send is complete. Note that this statement is deliberately somewhat vague: the sending application may end up performing this partial flush after sending every XML stanza, but on the other hand may perform the partial flush only after sending a group of stanzas that have been queued up for delivery. When to flush the state of the compression application is up to the sending application.</p>
+    </div>
+  <h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Stream encryption via TLS (as defined in <span style="font-weight: bold">XMPP Core</span>) and stream compression (as defined herein) are not mutually exclusive, but stream encryption via TLS MUST be negotiated before negotiation of stream compression in order to secure the stream.</p>
+  <h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2251240">5</a>]. </p>
+  <h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>7.1 <a name="registrar-stream">Stream Features</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255138">6</a>] shall include 'http://jabber.org/features/compress' in its registry of stream features.</p>
+    </div>
+    <div class="indent">
+<h3>7.2 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/compress' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>7.3 <a name="registrar-methods">Compression Methods Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall maintain a registry of compression methods.</p>
+      <div class="indent">
+<h3>7.3.1 <a name="registrar-methods-process">Process</a>
+</h3>
+        <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;method&gt;
+  &lt;name&gt;the XML character data of the method element&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the compression method&lt;/desc&gt;
+  &lt;doc&gt;the document that specifies or registers the compression method&lt;/doc&gt;
+&lt;/method&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one compression method at a time, each contained in a separate &lt;method/&gt; element.</p>
+      </div>
+      <div class="indent">
+<h3>7.3.2 <a name="registrar-shim-init">Initial Registration</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;method&gt;
+  &lt;name&gt;zlib&lt;/name&gt;
+  &lt;desc&gt;the ZLIB compression method as specified in RFC 1950&lt;/desc&gt;
+  &lt;doc&gt;JEP-0138&lt;/doc&gt;
+&lt;/method&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>8.
+       <a name="schemas">XML Schemas</a>
+</h2>
+    <div class="indent">
+<h3>8.1 <a name="schemas-stream">Stream Feature</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/compress'
+    xmlns='http://jabber.org/features/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='compression'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='method' type='xs:NCName' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>8.2 <a name="schemas-protocol">Protocol Namespace</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/compress'
+    xmlns='http://jabber.org/protocol/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='compress'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='method' type='xs:NCName'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='compressed' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2251376">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251347">2</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2250375">3</a>. RFC 3749: Transport Layer Security Protocol Compression Methods &lt;<a href="http://www.ietf.org/rfc/rfc3749.txt">http://www.ietf.org/rfc/rfc3749.txt</a>&gt;.</p>
+<p><a name="nt-id2250407">4</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2251240">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255138">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2005-05-11)</h4>
+<div class="indent">Corrected several errors in the schemas. (psa)
+    </div>
+<h4>Version 0.3 (2005-03-28)</h4>
+<div class="indent">Specified compression methods registry. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-28)</h4>
+<div class="indent">Fixed TLS text per list discussion. (psa)
+    </div>
+<h4>Version 0.1 (2004-07-16)</h4>
+<div class="indent">Initial version. (jjh/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0138-0.5.html
+++ b/content/xep-0138-0.5.html
@@ -1,0 +1,341 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0138: Stream Compression</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stream Compression">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a mechanism for compressing XML streams.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0138">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0138: Stream Compression</h1>
+<p>This JEP defines a mechanism for compressing XML streams.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0138<br>
+            Version: 0.5<br>
+            Last Updated: 2005-05-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: compress<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecase">Use Case</a>
+</dt>
+<dt>3.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>4.  <a href="#mandatory">Mandatory-to-Implement Technologies</a>
+</dt>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>5.1.  <a href="#impl-zlib">ZLIB</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+<dt>8.2.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.3.  <a href="#registrar-methods">Compression Methods Registry</a>
+</dt>
+<dl>
+<dt>8.3.1.  <a href="#registrar-methods-process">Process</a>
+</dt>
+<dt>8.3.2.  <a href="#registrar-shim-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schemas-stream">Stream Feature</a>
+</dt>
+<dt>9.2.  <a href="#schemas-protocol">Protocol Namespace</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251427">1</a>] specifies the use of Transport Layer Security (TLS; see <span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2251182">2</a>]) for encryption of XML streams, and TLS includes the ability to compress encrypted traffic (see <span class="ref" style="">RFC 3749</span>  [<a href="#nt-id2251205">3</a>]). However, not all computing platforms are able to implement TLS, and traffic compression may be desirable for communication by applications on such computing platforms. This JEP defines a mechanism for compressing XML streams outside the context of TLS.</p>
+  <h2>2.
+       <a name="usecase">Use Case</a>
+</h2>
+    <p class="" style="">The protocol flow is as follows:</p>
+    <p class="caption">Example 1. Receiving Entity Offers Stream Compression Feature</p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+  &lt;compression xmlns='http://jabber.org/features/compress'&gt;
+    &lt;method&gt;zlib&lt;/method&gt;
+  &lt;/compression&gt;
+&lt;/stream:features&gt;
+    </pre></div>
+    <p class="" style="">Note: The &lt;compression/&gt; element MUST contain at least one &lt;method/&gt; child element. Each &lt;method/&gt; element MUST contain XML character data that specifies the name of a compression method, and such method names SHOULD be registered as described in the <a href="#registrar-methods">Compression Methods Registry</a> section of this document.</p>
+    <p class="" style="">The initiating entity then MAY request compression by specifying one of the methods advertised by the receiving entity:</p>
+    <p class="caption">Example 2. Initiating Entity Requests Stream Compression</p>
+<div class="indent"><pre>
+&lt;compress xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;method&gt;zlib&lt;/method&gt;
+&lt;/compress&gt;
+    </pre></div>
+    <p class="" style="">Note: If the initiating entity did not understand any of the advertised compression methods, it SHOULD ignore the compression option and proceed as if no compression methods were advertised.</p>
+    <p class="" style="">If the initiating entity requests a stream compression method that is not supported by the receiving entity, the receiving entity MUST return an &lt;unsupported-method/&gt; error:</p>
+    <p class="caption">Example 3. Receiving Entity Reports That Method is Unsupported</p>
+<div class="indent"><pre>
+&lt;failure xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;unsupported-method/&gt;
+&lt;/failure&gt;
+    </pre></div>
+    <p class="" style="">If the receiving entity cannot establish compression using the requested method for any other reason, it MUST return a &lt;setup-failed/&gt; error:</p>
+    <p class="caption">Example 4. Receiving Entity Reports That Compression Setup Failed</p>
+<div class="indent"><pre>
+&lt;failure xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;setup-failed/&gt;
+&lt;/failure&gt;
+    </pre></div>
+    <p class="" style="">If no error occurs, the receiving entity MUST inform the initiating entity that compression has been established:</p>
+    <p class="caption">Example 5. Receiving Entity Acknowledges Stream Compression</p>
+<div class="indent"><pre>
+&lt;compressed xmlns='http://jabber.org/protocol/compress'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the previous stream to be null and void, just as with TLS negotiation and SASL negotiation (as specified in <span style="font-weight: bold">RFC 3920</span>). Therefore the initiating entity MUST initiate a new stream to the receiving entity:</p>
+    <p class="caption">Example 6. Initiating Entity Initiates New Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream
+    xmlns='jabber:client'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    to='shakespeare.lit'&gt;
+    </pre></div>
+    <p class="" style="">If compression processing fails after the stream has been established, the entity that detects the error SHOULD generate a stream error and close the stream:</p>
+    <p class="caption">Example 7. Entity Closes Stream Because of a Processing Error</p>
+<div class="indent"><pre>
+&lt;stream:error&gt;
+  &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+  &lt;failure xmlns='http://jabber.org/protocol/compress'/&gt;
+    &lt;processing-failed/&gt;
+  &lt;/failure&gt;
+&lt;/stream:error&gt;
+&lt;/stream:stream&gt;
+    </pre></div>
+  <h2>3.
+       <a name="bizrules">Business Rules</a>
+</h2>
+    <p class="" style="">The following business rules apply:</p>
+    <ul>
+      <li>If stream compression is negotiated, it MUST be used in both directions.</li>
+      <li>TLS compression and stream compression SHOULD NOT be used simultaneously. However, if both TLS (whether including TLS compression or not) and stream compression are used, then TLS MUST be negotiated first, followed by negotiation of stream compression.</li>
+    </ul>
+  <h2>4.
+       <a name="mandatory">Mandatory-to-Implement Technologies</a>
+</h2>
+    <p class="" style="">A compliant implementation MUST implement the ZLIB compression method as specified in <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2255221">4</a>]. All other methods are OPTIONAL; such methods may be defined in future JEPs or by registration as described in the <a href="#registrar-methods">Compression Methods Registry</a> section of this document.</p>
+  <h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="impl-zlib">ZLIB</a>
+</h3>
+      <p class="" style="">When using ZLIB for compression, the sending application SHOULD complete a partial flush of ZLIB when its current send is complete. Note that this statement is deliberately somewhat vague: the sending application may end up performing this partial flush after sending every XML stanza, but on the other hand may perform the partial flush only after sending a group of stanzas that have been queued up for delivery. When to flush the state of the compression application is up to the sending application.</p>
+    </div>
+  <h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Stream encryption via TLS (as defined in <span style="font-weight: bold">RFC 3920</span>) and stream compression (as defined herein) are not mutually exclusive, but stream encryption via TLS MUST be negotiated before negotiation of stream compression in order to secure the stream.</p>
+  <h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255316">5</a>]. </p>
+  <h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>8.1 <a name="registrar-stream">Stream Features</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255367">6</a>] shall include 'http://jabber.org/features/compress' in its registry of stream features.</p>
+    </div>
+    <div class="indent">
+<h3>8.2 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/compress' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>8.3 <a name="registrar-methods">Compression Methods Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar shall maintain a registry of compression methods.</p>
+      <div class="indent">
+<h3>8.3.1 <a name="registrar-methods-process">Process</a>
+</h3>
+        <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;method&gt;
+  &lt;name&gt;the XML character data of the method element&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the compression method&lt;/desc&gt;
+  &lt;doc&gt;the document that specifies or registers the compression method&lt;/doc&gt;
+&lt;/method&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one compression method at a time, each contained in a separate &lt;method/&gt; element.</p>
+      </div>
+      <div class="indent">
+<h3>8.3.2 <a name="registrar-shim-init">Initial Registration</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;method&gt;
+  &lt;name&gt;zlib&lt;/name&gt;
+  &lt;desc&gt;the ZLIB compression method as specified in RFC 1950&lt;/desc&gt;
+  &lt;doc&gt;JEP-0138&lt;/doc&gt;
+&lt;/method&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>9.
+       <a name="schemas">XML Schemas</a>
+</h2>
+    <div class="indent">
+<h3>9.1 <a name="schemas-stream">Stream Feature</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/compress'
+    xmlns='http://jabber.org/features/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='compression'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='method' type='xs:NCName' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>9.2 <a name="schemas-protocol">Protocol Namespace</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/compress'
+    xmlns='http://jabber.org/protocol/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='compress'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='method' type='xs:NCName'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='compressed' type='empty'/&gt;
+
+  &lt;xs:element name='failure'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element name='setup-failed' type='empty'/&gt;
+        &lt;xs:element name='processing-failed' type='empty'/&gt;
+        &lt;xs:element name='unsupported-method' type='empty'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251427">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251182">2</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2251205">3</a>. RFC 3749: Transport Layer Security Protocol Compression Methods &lt;<a href="http://www.ietf.org/rfc/rfc3749.txt">http://www.ietf.org/rfc/rfc3749.txt</a>&gt;.</p>
+<p><a name="nt-id2255221">4</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2255316">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255367">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2005-05-18)</h4>
+<div class="indent">Modifications to address Council feedback: used RFC 3920 terminology; specified error conditions; specified ZLIB as mandatory to implement. (psa)
+    </div>
+<h4>Version 0.4 (2005-05-11)</h4>
+<div class="indent">Corrected several errors in the schemas. (psa)
+    </div>
+<h4>Version 0.3 (2005-03-28)</h4>
+<div class="indent">Specified compression methods registry. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-28)</h4>
+<div class="indent">Fixed TLS text per list discussion. (psa)
+    </div>
+<h4>Version 0.1 (2004-07-16)</h4>
+<div class="indent">Initial version. (jjh/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0138-1.0.html
+++ b/content/xep-0138-1.0.html
@@ -1,0 +1,366 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0138: Stream Compression</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Stream Compression">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a mechanism for compressing XML streams.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0138">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0138: Stream Compression</h1>
+<p>This JEP defines a mechanism for compressing XML streams.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: The protocol defined herein is a Draft Standard of the Jabber Software Foundation. Implementations are encouraged and the protocol is appropriate for deployment in production systems, but some changes to the protocol are possible before it becomes a Final Standard.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Draft<br>
+            Type: Standards Track<br>
+            Number: 0138<br>
+            Version: 1.0<br>
+            Last Updated: 2005-06-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: compress<br>
+        Schema for feature: &lt;<a href="http://jabber.org/protocol/compress/feature.xsd">http://jabber.org/protocol/compress/feature.xsd</a>&gt;<br>
+        Schema for compress: &lt;<a href="http://jabber.org/protocol/compress/compress.xsd">http://jabber.org/protocol/compress/compress.xsd</a>&gt;<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/compress.html">http://www.jabber.org/registrar/compress.html</a>&gt;
+              <br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Stream%20Compression%20(JEP-0138)">http://wiki.jabber.org/index.php/Stream Compression (JEP-0138)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecase">Use Case</a>
+</dt>
+<dt>3.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>4.  <a href="#mandatory">Mandatory-to-Implement Technologies</a>
+</dt>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>5.1.  <a href="#impl-zlib">ZLIB</a>
+</dt></dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-stream">Stream Features</a>
+</dt>
+<dt>8.2.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.3.  <a href="#registrar-methods">Compression Methods Registry</a>
+</dt>
+<dl>
+<dt>8.3.1.  <a href="#registrar-methods-process">Process</a>
+</dt>
+<dt>8.3.2.  <a href="#registrar-shim-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schemas-stream">Stream Feature</a>
+</dt>
+<dt>9.2.  <a href="#schemas-protocol">Protocol Namespace</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250523">1</a>] specifies the use of Transport Layer Security (TLS; see <span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2250546">2</a>]) for encryption of XML streams, and TLS includes the ability to compress encrypted traffic (see <span class="ref" style="">RFC 3749</span>  [<a href="#nt-id2250566">3</a>]). However, not all computing platforms are able to implement TLS, and traffic compression may be desirable for communication by applications on such computing platforms. This JEP defines a mechanism for compressing XML streams outside the context of TLS.</p>
+  <h2>2.
+       <a name="usecase">Use Case</a>
+</h2>
+    <p class="" style="">The protocol flow is as follows:</p>
+    <p class="caption">Example 1. Receiving Entity Offers Stream Compression Feature</p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+  &lt;compression xmlns='http://jabber.org/features/compress'&gt;
+    &lt;method&gt;zlib&lt;/method&gt;
+  &lt;/compression&gt;
+&lt;/stream:features&gt;
+    </pre></div>
+    <p class="" style="">Note: The &lt;compression/&gt; element MUST contain at least one &lt;method/&gt; child element. Each &lt;method/&gt; element MUST contain XML character data that specifies the name of a compression method, and such method names SHOULD be registered as described in the <a href="#registrar-methods">Compression Methods Registry</a> section of this document.</p>
+    <p class="" style="">The initiating entity then MAY request compression by specifying one of the methods advertised by the receiving entity:</p>
+    <p class="caption">Example 2. Initiating Entity Requests Stream Compression</p>
+<div class="indent"><pre>
+&lt;compress xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;method&gt;zlib&lt;/method&gt;
+&lt;/compress&gt;
+    </pre></div>
+    <p class="" style="">Note: If the initiating entity did not understand any of the advertised compression methods, it SHOULD ignore the compression option and proceed as if no compression methods were advertised.</p>
+    <p class="" style="">If the initiating entity requests a stream compression method that is not supported by the receiving entity, the receiving entity MUST return an &lt;unsupported-method/&gt; error:</p>
+    <p class="caption">Example 3. Receiving Entity Reports That Method is Unsupported</p>
+<div class="indent"><pre>
+&lt;failure xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;unsupported-method/&gt;
+&lt;/failure&gt;
+    </pre></div>
+    <p class="" style="">If the receiving entity cannot establish compression using the requested method for any other reason, it MUST return a &lt;setup-failed/&gt; error:</p>
+    <p class="caption">Example 4. Receiving Entity Reports That Compression Setup Failed</p>
+<div class="indent"><pre>
+&lt;failure xmlns='http://jabber.org/protocol/compress'&gt;
+  &lt;setup-failed/&gt;
+&lt;/failure&gt;
+    </pre></div>
+    <p class="" style="">If no error occurs, the receiving entity MUST inform the initiating entity that compression has been established:</p>
+    <p class="caption">Example 5. Receiving Entity Acknowledges Stream Compression</p>
+<div class="indent"><pre>
+&lt;compressed xmlns='http://jabber.org/protocol/compress'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the previous stream to be null and void, just as with TLS negotiation and SASL negotiation (as specified in <span style="font-weight: bold">RFC 3920</span>). Therefore the initiating entity MUST initiate a new stream to the receiving entity:</p>
+    <p class="caption">Example 6. Initiating Entity Initiates New Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream
+    xmlns='jabber:client'
+    xmlns:stream='http://etherx.jabber.org/streams'
+    to='shakespeare.lit'&gt;
+    </pre></div>
+    <p class="" style="">If compression processing fails after the stream has been established, the entity that detects the error SHOULD generate a stream error and close the stream:</p>
+    <p class="caption">Example 7. Entity Closes Stream Because of a Processing Error</p>
+<div class="indent"><pre>
+&lt;stream:error&gt;
+  &lt;undefined-condition xmlns='urn:ietf:params:xml:ns:xmpp-streams'/&gt;
+  &lt;failure xmlns='http://jabber.org/protocol/compress'/&gt;
+    &lt;processing-failed/&gt;
+  &lt;/failure&gt;
+&lt;/stream:error&gt;
+&lt;/stream:stream&gt;
+    </pre></div>
+  <h2>3.
+       <a name="bizrules">Business Rules</a>
+</h2>
+    <p class="" style="">The following business rules apply:</p>
+    <ul>
+      <li>If stream compression is negotiated, it MUST be used in both directions.</li>
+      <li>TLS compression and stream compression SHOULD NOT be used simultaneously. However, if both TLS (whether including TLS compression or not) and stream compression are used, then TLS MUST be negotiated first, followed by negotiation of stream compression.</li>
+    </ul>
+  <h2>4.
+       <a name="mandatory">Mandatory-to-Implement Technologies</a>
+</h2>
+    <p class="" style="">A compliant implementation MUST implement the ZLIB compression method as specified in <span class="ref" style="">RFC 1950</span>  [<a href="#nt-id2256234">4</a>]. All other methods are OPTIONAL; such methods may be defined in future JEPs or by registration as described in the <a href="#registrar-methods">Compression Methods Registry</a> section of this document.</p>
+  <h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="impl-zlib">ZLIB</a>
+</h3>
+      <p class="" style="">When using ZLIB for compression, the sending application SHOULD complete a partial flush of ZLIB when its current send is complete. Note that this statement is deliberately somewhat vague: the sending application may end up performing this partial flush after sending every XML stanza, but on the other hand may perform the partial flush only after sending a group of stanzas that have been queued up for delivery. When to flush the state of the compression application is up to the sending application.</p>
+    </div>
+  <h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Stream encryption via TLS (as defined in <span style="font-weight: bold">RFC 3920</span>) and stream compression (as defined herein) are not mutually exclusive, but stream encryption via TLS MUST be negotiated before negotiation of stream compression in order to secure the stream.</p>
+  <h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256328">5</a>]. </p>
+  <h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>8.1 <a name="registrar-stream">Stream Features</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256379">6</a>] includes 'http://jabber.org/features/compress' in its registry of stream features.</p>
+    </div>
+    <div class="indent">
+<h3>8.2 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The Jabber Registrar includes 'http://jabber.org/protocol/compress' in its registry of protocol namespaces.</p>
+    </div>
+    <div class="indent">
+<h3>8.3 <a name="registrar-methods">Compression Methods Registry</a>
+</h3>
+      <p class="" style="">The Jabber Registrar maintains a registry of compression methods at &lt;<a href="http://www.jabber.org/registrar/compress.html">http://www.jabber.org/registrar/compress.html</a>&gt;.</p>
+      <div class="indent">
+<h3>8.3.1 <a name="registrar-methods-process">Process</a>
+</h3>
+        <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;method&gt;
+  &lt;name&gt;the XML character data of the method element&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the compression method&lt;/desc&gt;
+  &lt;doc&gt;the document that specifies or registers the compression method&lt;/doc&gt;
+&lt;/method&gt;
+        </pre></div>
+        <p class="" style="">The registrant may register more than one compression method at a time, each contained in a separate &lt;method/&gt; element.</p>
+      </div>
+      <div class="indent">
+<h3>8.3.2 <a name="registrar-shim-init">Initial Registration</a>
+</h3>
+        <p class="caption"></p>
+<div class="indent"><pre>
+&lt;method&gt;
+  &lt;name&gt;zlib&lt;/name&gt;
+  &lt;desc&gt;the ZLIB compression method as specified in RFC 1950&lt;/desc&gt;
+  &lt;doc&gt;JEP-0138&lt;/doc&gt;
+&lt;/method&gt;
+        </pre></div>
+      </div>
+    </div>
+  <h2>9.
+       <a name="schemas">XML Schemas</a>
+</h2>
+    <div class="indent">
+<h3>9.1 <a name="schemas-stream">Stream Feature</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/features/compress'
+    xmlns='http://jabber.org/features/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0138: http://www.jabber.org/jeps/jep-0138.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='compression'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='method' type='xs:NCName' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>9.2 <a name="schemas-protocol">Protocol Namespace</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/compress'
+    xmlns='http://jabber.org/protocol/compress'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0138: http://www.jabber.org/jeps/jep-0138.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='compress'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='method' type='xs:NCName'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='compressed' type='empty'/&gt;
+
+  &lt;xs:element name='failure'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:element name='setup-failed' type='empty'/&gt;
+        &lt;xs:element name='processing-failed' type='empty'/&gt;
+        &lt;xs:element name='unsupported-method' type='empty'/&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+      </pre></div>
+    </div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250523">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250546">2</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2250566">3</a>. RFC 3749: Transport Layer Security Protocol Compression Methods &lt;<a href="http://www.ietf.org/rfc/rfc3749.txt">http://www.ietf.org/rfc/rfc3749.txt</a>&gt;.</p>
+<p><a name="nt-id2256234">4</a>. RFC 1950: ZLIB Compressed Data Format Specification version 3.3 &lt;<a href="http://www.ietf.org/rfc/rfc1950.txt">http://www.ietf.org/rfc/rfc1950.txt</a>&gt;.</p>
+<p><a name="nt-id2256328">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256379">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2005-06-16)</h4>
+<div class="indent">Per a vote of the Jabber Council, advanced status to Draft. (psa)
+    </div>
+<h4>Version 0.5 (2005-05-18)</h4>
+<div class="indent">Modifications to address Council feedback: used RFC 3920 terminology; specified error conditions; specified ZLIB as mandatory to implement. (psa)
+    </div>
+<h4>Version 0.4 (2005-05-11)</h4>
+<div class="indent">Corrected several errors in the schemas. (psa)
+    </div>
+<h4>Version 0.3 (2005-03-28)</h4>
+<div class="indent">Specified compression methods registry. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-28)</h4>
+<div class="indent">Fixed TLS text per list discussion. (psa)
+    </div>
+<h4>Version 0.1 (2004-07-16)</h4>
+<div class="indent">Initial version. (jjh/psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0140-0.1.html
+++ b/content/xep-0140-0.1.html
@@ -1,0 +1,340 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0140: Shared Groups</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Shared Groups">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol profile for centrally defined and administered roster groups.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-07-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0140">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0140: Shared Groups</h1>
+<p>This JEP defines a protocol profile for centrally defined and administered roster groups.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0140<br>
+            Version: 0.1<br>
+            Last Updated: 2004-07-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060, JEP-0093<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: groups<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#create">Creating a Shared Group</a>
+</dt>
+<dt>3.2.  <a href="#add">Adding a Member to the Group</a>
+</dt>
+<dt>3.3.  <a href="#remove">Removing a Member from the Group</a>
+</dt>
+</dl>
+<dt>4.  <a href="#impl">Implementation Guidelines</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#impl-hier">Group Hierarchies</a>
+</dt>
+<dt>4.2.  <a href="#impl-pres">Exchanging Presence</a>
+</dt>
+<dt>4.3.  <a href="#impl-msg">Sending Messages</a>
+</dt>
+<dt>4.4.  <a href="#impl-gc">Sending Groupchat Invites</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">XMPP IM</span>  [<a href="#nt-id2595932">1</a>] defines a protocol for personal rosters (also known as contact lists). So far all Jabber rosters are personal rosters that are defined by a single user and accessed only by that user. However, in some contexts it would be helpful to centrally define and administer roster groups so that they can be shared among a user population in an organized fashion. This functionality is often called &quot;shared groups&quot;.</p>
+  <p class="" style="">One context in which shared groups might be useful is the enterprise environment. For example, when Alice is hired by the marketing department of Big Company Enterprises, it makes sense for her to automatically have the other members of the marketing department in her roster the first time she logs in, and for the rest of the marketing department to have Alice in their rosters as soon as her account has been set up. Similarly, when Bob in logistics gets fired, it makes sense for him to disappear from the rosters of everyone else in the logistics department.</p>
+  <p class="" style="">This functionality is not limited to the enterprise environment. It could prove quite useful in academic settings, social networking applications, consumer IM services, and anywhere else that it is important to build and manage small communities of users.</p>
+  <p class="" style="">Although <span class="ref">Roster Item Exchange</span>  [<a href="#nt-id2596119">2</a>] defines a format for sharing roster items between two users and therefore enables one user to send roster items to another user, it does not currently provide a way to share or coordinate a group of roster items in an organized fashion. To make that possible, this document extends JEP-0093 by defining <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596038">3</a>] as the distribution mechanism, resulting in a basic solution for shared groups over Jabber.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following use cases:</p>
+  <ol start="" type="">
+    <li>Creating a shared group.</li>
+    <li>Adding a member to the group.</li>
+    <li>Removing a member from the group.</li>
+  </ol>
+  <p class="" style="">This JEP does not address the following use cases, which instead are discussed in the <a href="#impl">Implementation Guidelines</a> section of this document:</p>
+  <ul>
+    <li>Exchanging presence with members of a shared group.</li>
+    <li>Sending a message to all members of a shared group.</li>
+    <li>Inviting all members of a shared group to a groupchat room.</li>
+  </ul>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">The following examples show the protocol flow for an administrator to complete the use cases defined above. Naturally, these tasks could be performed just as well by an automated application that is tied to an existing user database (e.g., LDAP).</p>
+  <div class="indent">
+<h3>3.1 <a name="create">Creating a Shared Group</a>
+</h3>
+    <p class="" style="">A group is implemented as a pubsub node. If a contact is a member of multiple groups, the contact MUST be added to each pubsub node separately. There is a one-to-one relationship between a group and a node. It is OPTIONAL for the NodeID to include the name of the group (e.g., &quot;groups/Marketing&quot;), although in general it is best not to overload NodeIDs and this is unnecessary given the structure of the groups protocol as described below.</p>
+    <p class="caption">Example 1. Admin Creates a Group</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bofh@example.com/daygig'
+    to='pubsub.example.com'
+    id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node-id='groups/Marketing/Europe'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.example.com'
+    to='bofh@example.com/daygig'
+    id='create1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="add">Adding a Member to the Group</a>
+</h3>
+    <p class="" style="">There are two steps to adding a member to a group, which SHOULD be performed in this order:</p>
+    <ol start="" type="">
+      <li>Add new member to subscriber list. (OPTIONAL)</li>
+      <li>Publish member information to node.</li>
+    </ol>
+    <p class="caption">Example 3. Admin Adds Member to Subscriber List</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bofh@example.com/daygig'
+    to='pubsub.example.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;entities node='groups/Marketing/Europe'&gt;
+      &lt;entity jid='alice@example.com'
+              affiliation='none'
+              subscription='subscribed'/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.example.com'
+    to='bofh@example.com/daygig'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">(Naturally, a member of a shared group need not be informed of changes to the group, and an entity that is informed of changes to the group need not be a member of the group. However, in most applications a group member will be a pubsub subscriber and vice-versa.)</p>
+    <p class="" style="">Now the admin publishes information about the member to the group node.</p>
+    <p class="caption">Example 5. Admin Publishes Member Information</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bofh@example.com/daygig'
+    to='pubsub.example.com'
+    id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='groups/Marketing/Europe'&gt;
+      &lt;item id='alice@example.com'&gt;
+        &lt;x xmlns='jabber:x:roster'
+           jid='alice@example.com' 
+           name='Alice Rosenbaum'&gt;
+          &lt;group&gt;Marketing/Europe&lt;/group&gt;
+        &lt;/x&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The member information is then delivered to all subscribers:</p>
+    <p class="caption">Example 6. Member Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.example.com'
+    to='cathy@example.com'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='groups/Marketing/Europe'&gt;
+      &lt;item id='alice@example.com'&gt;
+        &lt;x xmlns='jabber:x:roster'
+           jid='alice@example.com' 
+           name='Alice Rosenbaum'&gt;
+          &lt;group&gt;Marketing/Europe&lt;/group&gt;
+        &lt;/x&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">Note: It is the receiving application's responsibility to add the newly-published roster item to the recipient's roster by following the protocols defined in <span style="font-weight: bold">XMPP IM</span>. The receiving application SHOULD NOT prompt the recipient regarding whether or not to add the roster item, but if and only the roster item is received via pubsub (i.e., it SHOULD prompt the user when roster items are received from individual users and not via pubsub).</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="remove">Removing a Member from the Group</a>
+</h3>
+    <p class="" style="">There are two steps to adding a member to a group, which SHOULD be performed in this order:</p>
+    <ol start="" type="">
+      <li>Remove member from subscriber list.</li>
+      <li>Purge member information from node.</li>
+    </ol>
+    <p class="caption">Example 7. Admin Removes Member from Subscriber List</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bofh@example.com/daygig'
+    to='pubsub.example.com'
+    id='del1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;entities node='groups/Marketing/Europe'&gt;
+      &lt;entity jid='alice@example.com'
+              affiliation='none'
+              subscription='none'/&gt;
+    &lt;/entities&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Service Informs Admin of Success</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pubsub.example.com'
+    to='bofh@example.com/daygig'
+    id='del1'/&gt;
+    </pre></div>
+    <p class="" style="">(As noted, the group member need not be a pubsub subscriber, in which case the foregoing step may not be necessary.)</p>
+    <p class="" style="">Now admin can remove the member from the shared group.</p>
+    <p class="caption">Example 9. Admin Removes Member</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bofh@example.com/daygig'
+    to='pubsub.example.com'
+    id='purge1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;retract node='groups/Marketing/Europe'&gt;
+      &lt;item id='alice@example.com'/&gt;
+    &lt;/retract&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">All remaining subscribers are then informed that the node has been deleted:</p>
+    <p class="caption">Example 10. Tune Information is Delivered to All Subscribers</p>
+<div class="indent"><pre>
+&lt;message
+    from='pubsub.example.com'
+    to='cathy@example.com'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;retract node='groups/Marketing/Europe'&gt;
+      &lt;item id='alice@example.com'/&gt;
+    &lt;/retract&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="impl">Implementation Guidelines</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="impl-hier">Group Hierarchies</a>
+</h3>
+    <p class="" style="">An administrator may wish to define a hierarchy of shared groups (e.g., &quot;Marketing/Europe&quot; and &quot;Marketing/North America&quot;). This can be done using collection nodes as defined in Section 9 of JEP-0060. The receiving application MAY use <span class="ref">Nested Roster Groups</span>  [<a href="#nt-id2602076">4</a>] to define the roster group names.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="impl-pres">Exchanging Presence</a>
+</h3>
+    <p class="" style="">Presence is exchanged via the normal mechanisms defined in <span style="font-weight: bold">XMPP IM</span>.</p> 
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="impl-msg">Sending Messages</a>
+</h3>
+    <p class="" style="">In order to send a message to all members of a shared group, a group member's sending application (usually an end-user client) SHOULD either send multiple messages or use <span class="ref">Extended Stanza Addressing</span>  [<a href="#nt-id2602042">5</a>].</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="impl-gc">Sending Groupchat Invites</a>
+</h3>
+    <p class="" style="">In order to invite all members of a shared group to a groupchat room, a group member's sending application SHOULD use the mechanisms defined in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602185">6</a>].</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This protocol introduces no security considerations above and beyond those defined in <span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> and <span style="font-weight: bold">JEP-0093: Roster Item Exchange</span>.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602160">7</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602227">8</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595932">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596119">2</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596038">3</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602076">4</a>. JEP-0083: Nested Roster Groups &lt;<a href="http://www.jabber.org/jeps/jep-0083.html">http://www.jabber.org/jeps/jep-0083.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602042">5</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602185">6</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602160">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602227">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-07-26)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0141-0.1.html
+++ b/content/xep-0141-0.1.html
@@ -1,0 +1,418 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0141: Data Forms Layout</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Data Forms Layout">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Description" content="This JEP defines an extension to the Data Forms protocol enabling an application to specify form layouts.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-08-10">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0141">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0141: Data Forms Layout</h1>
+<p>This JEP defines an extension to the Data Forms protocol enabling an application to specify form layouts.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0141<br>
+            Version: 0.1<br>
+            Last Updated: 2004-08-10<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: xdata-layout<br>
+</p>
+<h2>Author Information</h2>
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#sect-id2595900">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2595945">Requirements</a>
+</dt>
+<dt>3.  <a href="#sect-id2596003">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2596040">Paging Fields</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2595754">Sectioning Fields</a>
+</dt>
+<dt>3.3.  <a href="#sect-id2596092">Including Tables</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2596132">Implementation Notes</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#sect-id2596141">Discovery</a>
+</dt>
+<dt>4.2.  <a href="#sect-id2596161">Field Distribution</a>
+</dt>
+<dt>4.3.  <a href="#sect-id2596178">Page Labels and Descriptions</a>
+</dt>
+<dt>4.4.  <a href="#sect-id2596217">Section Labels and Descriptions</a>
+</dt>
+<dt>4.5.  <a href="#sect-id2602094">Internationalization/Localization</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sect-id2602119">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2602135">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2602151">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2602227">Formal Definition</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#sect-id2602235">&lt;page/&gt; Root Element</a>
+</dt>
+<dt>8.2.  <a href="#sect-id2602277">&lt;section/&gt; Element</a>
+</dt>
+<dt>8.3.  <a href="#sect-id2602351">&lt;fieldref/&gt; Element</a>
+</dt>
+<dt>8.4.  <a href="#sect-id2602387">&lt;reportedref/&gt; Element</a>
+</dt>
+<dt>8.5.  <a href="#sect-id2602409">&lt;desc/&gt; Element</a>
+</dt>
+<dt>8.6.  <a href="#sect-id2602431">XML Schema</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2595900">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">Data Forms</span>  [<a href="#nt-id2595927">1</a>] (&quot;x:data&quot;) provides a simple and interoperable way to request and present information for both applications and humans. However, the simple nature of &quot;x:data&quot; requires the form renderer to use a generic &quot;key/value&quot; format. This JEP builds upon &quot;x:data&quot; to provide this additional layout information.</p>
+<h2>2.
+       <a name="sect-id2595945">Requirements</a>
+</h2>
+  <p class="" style="">The requirements for this JEP are:</p>
+  <ul>
+    <li>Backwards compatible with the existing &quot;x:data&quot; protocol.</li>
+    <li>Provide hints for paging/tabifying fields</li>
+    <li>Provide hints for sectioning/grouping fields</li>
+  </ul>
+<h2>3.
+       <a name="sect-id2596003">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a new namespace, &quot;http://jabber.org/protocol/xdata-layout&quot;. All layout is defined by &quot;pages&quot; and &quot;sections&quot;.</p>
+  <p class="" style="">All of the use cases refer to the following form:</p>
+  <p class="caption">Example 1. Sample form</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  &lt;title&gt;JSF Application&lt;/title&gt;
+  &lt;instructions&gt;Please fill out this form&lt;/instructions&gt;
+  
+  &lt;field var='name.first' type='text-single' label='First Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='name.last' type='text-single' label='Last Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='email' type='text-single' label='E-mail Address'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='jid' type='jid-single' label='Jabber JID'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  
+  &lt;field var='background' type='text-multi' label='Background Information'&gt;
+  &lt;/field&gt;
+  &lt;field var='future' type='text-multi' label='Jabber Plans for the Next Six Months'&gt;
+  &lt;/field&gt;
+  &lt;field var='reasoning' type='text-multi' label='Reasons for Joining'&gt;
+  &lt;/field&gt;
+  
+  &lt;field var='activity.mailing-lists' type='text-multi' label='Recent Mailing List Activity'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.jeps' type='text-multi' label='JEPs Authored or Co-Authored'&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+  </pre></div>
+  <div class="indent">
+<h3>3.1 <a name="sect-id2596040">Paging Fields</a>
+</h3>
+    <p class="" style="">One of the simplest layout usages is to separate fields into pages. This is done by including one or more &lt;page/&gt; elements within the x:data form. Each &lt;page/&gt; SHOULD have a &quot;label&quot; attribute to label the page, MAY include a &lt;desc/&gt; for additional information, and SHOULD include a &lt;fieldref/&gt; for each field to be included in the page. To reference an x:data field, the &lt;fieldref/&gt; element's &quot;var&quot; attribute MUST equal the intended &lt;field/&gt;s &quot;var&quot; attribute.</p>
+    <p class="caption">Example 2. Pages of fields</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  ...
+  
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout' label='Personal Information'&gt;
+    &lt;fieldref var='name.first'/&gt;
+    &lt;fieldref var='name.last'/&gt;
+    &lt;fieldref var='email'/&gt;
+    &lt;fieldref var='jid'/&gt;
+    &lt;fieldref var='background'/&gt;
+  &lt;/page&gt;
+  &lt;page label='Community Activity'&gt;
+    &lt;fieldref var='activity.mailing-lists'/&gt;
+    &lt;fieldref var='activity.jeps'/&gt;
+  &lt;/page&gt;
+  &lt;page label='Plans and Reasonings'&gt;
+    &lt;fieldref var='future'/&gt;
+    &lt;fieldref var='reasoning'/&gt;
+  &lt;/page&gt;
+  
+  ...
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">The preceding example partitions the fields into three pages; labeled &quot;Personal Information&quot;, &quot;Community Activity&quot;, and &quot;Plans and Reasonings&quot;.</p>
+    <p class="" style="">If a &lt;fieldref/&gt; within a &lt;page/&gt; references a non-existent &lt;field/&gt;, that reference MUST be ignored.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sect-id2595754">Sectioning Fields</a>
+</h3>
+    <p class="" style="">The next usage of layout is by sections within pages. This is done by including one or more &lt;section/&gt; elements within each &lt;page/&gt;. Each &lt;section/&gt; SHOULD have a &quot;label&quot; attribute to identify the section, MAY include a &lt;desc/&gt; for additional information, and SHOULD include a &lt;fieldref/&gt; for each field to be included in the section. A &lt;section/&gt; MUST contain at least one &lt;fieldref/&gt; or &lt;reportedref/&gt;. To reference an x:data field, the &lt;fieldref/&gt; element's &quot;var&quot; attribute MUST equal the intended &lt;field/&gt; element's &quot;var&quot; attribute.</p>
+    <p class="caption">Example 3. Sections of fields</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  ...
+  
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout'&gt;
+    &lt;section label='Personal Information'&gt;
+      &lt;fieldref var='name.first'/&gt;
+      &lt;fieldref var='name.last'/&gt;
+      &lt;fieldref var='email'/&gt;
+      &lt;fieldref var='jid'/&gt;
+      &lt;fieldref var='background'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Community Activity'&gt;
+      &lt;fieldref var='activity.mailing-lists'/&gt;
+      &lt;fieldref var='activity.jeps'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Plans and Reasoning'&gt;
+      &lt;fieldref var='future'/&gt;
+      &lt;fieldref var='reasoning'/&gt;
+    &lt;/section&gt;
+  &lt;/page&gt;
+  
+  ...
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">The preceeding example demonstrates a similar layout to the one previous, but using sections instead of pages.</p>
+    <p class="" style="">Sections MAY be nested, to produce a more granular partitioning of fields.</p>
+    <p class="caption">Example 4. Sections of fields (nested)</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  ...
+  
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout'&gt;
+    &lt;section label='Personal Information'&gt;
+      &lt;section label='Name'&gt;
+        &lt;fieldref var='name.first'/&gt;
+        &lt;fieldref var='name.last'/&gt;
+      &lt;/section&gt;
+      &lt;section label='Contact Information'&gt;
+        &lt;fieldref var='email'/&gt;
+        &lt;fieldref var='jid'/&gt;
+      &lt;/section&gt;
+      &lt;fieldref var='background'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Community Activity'&gt;
+      &lt;fieldref var='activity.mailing-lists'/&gt;
+      &lt;fieldref var='activity.jeps'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Plans and Reasoning'&gt;
+      &lt;fieldref var='future'/&gt;
+      &lt;fieldref var='reasoning'/&gt;
+    &lt;/section&gt;
+  &lt;/page&gt;
+  
+  ...
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">If a &lt;fieldref/&gt; within a &lt;section/&gt; references a non-existent &lt;field/&gt;, that reference MUST be ignored.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="sect-id2596092">Including Tables</a>
+</h3>
+    <p class="" style="">Data forms tables (the &lt;reported/&gt; and &lt;item/&gt; elements) can also be included in the layout, using the &lt;reportedref/&gt; element. This element MAY be included anywhere the &lt;fieldref/&gt; is allowed, and MUST appear once at most.</p>
+    <p class="" style="">If a &lt;reportedref/&gt; is specified when no &lt;reported/&gt; is available, the reference MUST be ignored.</p>
+  </div>
+<h2>4.
+       <a name="sect-id2596132">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="sect-id2596141">Discovery</a>
+</h3>
+    <p class="" style="">Form providers MAY attempt to discover if the recipient of a form supports styling, although implementations are NOT REQUIRED to do so. Discovery is implemened as defined in <span class="ref">Service Discovery</span>  [<a href="#nt-id2596257">2</a>], using the namespace &quot;http://jabber.org/protocol/xdata-layout&quot; as a feature.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="sect-id2596161">Field Distribution</a>
+</h3>
+    <p class="" style="">In order to prevent the processing from becoming too complex, there are some restrictions in how fields are distributed within the layout.</p>
+    <p class="" style="">First, all displayable, modifiable fields (e.g. all except fields of type &quot;FIXED&quot; or &quot;HIDDEN&quot;) SHOULD be referenced by a page or section. Any that are not referenced MAY NOT be rendered, although implementations MAY provide some support for this. To have a &quot;FIXED&quot; field included in the layout, it  MUST have a &quot;var&quot; attribute.</p>
+    <p class="" style="">Second, the same field SHOULD NOT be referenced by more than one page or section. Additionally, a field SHOULD NOT be referenced by the same page or section more than once.</p>
+    <p class="" style="">Finally, the order of layout elements SHOULD be maintained.  Pages SHOULD be rendered in the order they are defined within the x:data form, and sections and fields SHOULD be rendered in the order they are defined or referenced within a page or section.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="sect-id2596178">Page Labels and Descriptions</a>
+</h3>
+    <p class="" style="">The &quot;label&quot; attribute for &lt;page/&gt; is OPTIONAL, although RECOMMENDED. If it is missing, the renderer MAY use whatever it deems appropriate (including nothing).  Usually the containing form's &lt;title/&gt; is used.</p>
+    <p class="" style="">The &lt;desc/&gt; element for &lt;page/&gt; is OPTIONAL. If it is missing, the renderer MAY use whatever it deems appropriate (including nothing).  Usually the containing form's &lt;instructions/&gt; is used.</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="sect-id2596217">Section Labels and Descriptions</a>
+</h3>
+    <p class="" style="">The &quot;label&quot; attribute for &lt;section/&gt; is OPTIONAL, although RECOMMENDED. If it is missing, the renderer MAY use whatever it deems appropriate (including nothing).</p>
+    <p class="" style="">The &lt;desc/&gt; element for &lt;section/&gt; is OPTIONAL. If it is missing, the renderer MAY use whatever it deems appropriate (including nothing).</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="sect-id2602094">Internationalization/Localization</a>
+</h3>
+    <p class="" style="">This JEP relies on the internationalization/localization mechanisms provided by <span class="ref">XMPP Core</span>  [<a href="#nt-id2602205">3</a>]. Specifically, labels and descriptions MUST be appropriate for the locale indicated by the containing &lt;form/&gt; or stanza.</p>
+  </div>
+<h2>5.
+       <a name="sect-id2602119">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security considerations introduced by this JEP.</p>
+<h2>6.
+       <a name="sect-id2602135">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602175">4</a>].</p>
+<h2>7.
+       <a name="sect-id2602151">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602319">5</a>] shall register the namespace &quot;http://jabber.org/protocol/xdata-layout&quot; as a feature namespace.</p>
+<h2>8.
+       <a name="sect-id2602227">Formal Definition</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="sect-id2602235">&lt;page/&gt; Root Element</a>
+</h3>
+    <p class="" style="">The &lt;page/&gt; element is the root layout element for &quot;http://jabber.org/protocol/xdata-layout&quot; namespace. One &lt;page/&gt; elements are contained within the &lt;x xmlns='jabber:x:data'/&gt; element for each rendering page. The &lt;page/&gt; element possesses an attribute for its label, and contains child elements for its description, sections, and field and table references.</p>
+    <p class="" style="">The 'label' attribute specifies the label for this &lt;page/&gt;. This attribute is OPTIONAL. Its value is any string.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="sect-id2602277">&lt;section/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;section/&gt; element is used to further partition the layout within a &lt;page/&gt;. The &lt;section/&gt; element possesses an attribute for its label, and contains child elements for its description, sections, and field and table references.</p>
+    <p class="" style="">The 'label' attribute specifies the label for this &lt;section/&gt;. This attribute is OPTIONAL. Its value is any string.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="sect-id2602351">&lt;fieldref/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;fieldref/&gt; element is used to place a form field within the layout. The &lt;fieldref/&gt; possesses a single attribute to identify the field it references, and is otherwise empty.</p>
+    <p class="" style="">The 'var' attribute specifies the form field being referenced. This attribute is REQUIRED, and its value SHOULD be equal to one of the &lt;field/&gt; &quot;var&quot; attributes in the containing form.</p>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="sect-id2602387">&lt;reportedref/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;reportedref/&gt; element is used to place a form &quot;table&quot; (as described by the &lt;reported/&lt; and &lt;item/&gt; elements) within the layout. The &lt;reportedref/&gt; element has no attributes or children.</p>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="sect-id2602409">&lt;desc/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;desc/&gt; element is used to provide additional textual information for a &lt;page/&gt; or &lt;section/&gt;. Its XML character data is the description text.</p>
+  </div>
+  <div class="indent">
+<h3>8.6 <a name="sect-id2602431">XML Schema</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/xdata-layout'
+    xmlns='http://jabber.org/protocol/xdata-validate'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='page'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='desc' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='fieldref' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='reportedref' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:element name='section'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='desc' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section'/&gt;
+        &lt;xs:element ref='fieldref'/&gt;
+        &lt;xs:element ref='reportedref'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='fieldref'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='var' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:element name='reportedref' type='empty'/&gt;
+
+  &lt;xs:element name='desc' type='xs:string'/&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595927">1</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596257">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602205">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602175">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602319">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-08-10)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0141-0.2.html
+++ b/content/xep-0141-0.2.html
@@ -1,0 +1,455 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0141: Data Forms Layout</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Data Forms Layout">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Description" content="This JEP defines an extension to the Data Forms protocol enabling an application to specify form layouts.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0141">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0141: Data Forms Layout</h1>
+<p>This JEP defines an extension to the Data Forms protocol enabling an application to specify form layouts.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0141<br>
+            Version: 0.2<br>
+            Last Updated: 2005-03-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: xdata-layout<br></p>
+<h2>Author Information</h2>
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#paging">Paging Fields</a>
+</dt>
+<dt>3.2.  <a href="#sectioning">Sectioning Fields</a>
+</dt>
+<dt>3.3.  <a href="#tables">Including Tables</a>
+</dt>
+</dl>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-distribution">Field Distribution</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-pages">Page Labels and Descriptions</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-sections">Section Labels and Descriptions</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-i18n">Internationalization/Localization</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#def">Formal Definition</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#def-page">&lt;page/&gt; Root Element</a>
+</dt>
+<dt>8.2.  <a href="#def-section">&lt;section/&gt; Element</a>
+</dt>
+<dt>8.3.  <a href="#def-fieldref">&lt;fieldref/&gt; Element</a>
+</dt>
+<dt>8.4.  <a href="#def-reportedref">&lt;reportedref/&gt; Element</a>
+</dt>
+<dt>8.5.  <a href="#def-desc">&lt;desc/&gt; Element</a>
+</dt>
+<dt>8.6.  <a href="#schema">XML Schema</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250412">1</a>] ("x:data") provides a simple and interoperable way to request and present information for both applications and humans. However, the simple nature of "x:data" requires the form renderer to use a generic "key/value" format. This JEP builds upon "x:data" to enable applications to specify additional layout information.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The requirements for this JEP are:</p>
+  <ul>
+    <li>Provide hints for laying out form fields in pages.</li>
+    <li>Provide hints for laying out pages in sections.</li>
+    <li>Provide hints for laying out sections in subsections.</li>
+    <li>Ensure backwards-compatibility with the existing "x:data" protocol.</li>
+  </ul>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a new namespace, "http://jabber.org/protocol/xdata-layout". All layout is defined by "pages" and "sections".</p>
+  <p class="" style="">All of the use cases refer to the following form:</p>
+  <p class="caption">Example 1. Sample form</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  &lt;title&gt;JSF Application&lt;/title&gt;
+  &lt;instructions&gt;Please fill out this form&lt;/instructions&gt;
+  
+  &lt;field var='name.first' type='text-single' label='First Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='name.last' type='text-single' label='Last Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='email' type='text-single' label='E-mail Address'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='jid' type='jid-single' label='Jabber JID'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  
+  &lt;field var='background' type='text-multi' label='Background Information'&gt;
+  &lt;/field&gt;
+  &lt;field var='future' type='text-multi' label='Jabber Plans for the Next Six Months'&gt;
+  &lt;/field&gt;
+  &lt;field var='reasoning' type='text-multi' label='Reasons for Joining'&gt;
+  &lt;/field&gt;
+  
+  &lt;field var='activity.mailing-lists' type='text-multi' label='Recent Mailing List Activity'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.jeps' type='text-multi' label='JEPs Authored or Co-Authored'&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+  </pre></div>
+  <div class="indent">
+<h3>3.1 <a name="paging">Paging Fields</a>
+</h3>
+    <p class="" style="">One of the simplest layout usages is to partition fields into pages. This is done by including one or more &lt;page/&gt; elements within the x:data form. Each &lt;page/&gt; element SHOULD possess a "label" attribute to label the page, MAY contain a &lt;desc/&gt; child element for additional information, and SHOULD contain a &lt;fieldref/&gt; element for each field to be included in the page. To reference an x:data field, the &lt;fieldref/&gt; element's "var" attribute MUST be the same as the intended &lt;field/&gt; element's "var" attribute.</p>
+    <p class="caption">Example 2. Pages of fields</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  &lt;title&gt;JSF Application&lt;/title&gt;
+  &lt;instructions&gt;Please fill out this form&lt;/instructions&gt;
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout' label='Personal Information'&gt;
+    &lt;fieldref var='name.first'/&gt;
+    &lt;fieldref var='name.last'/&gt;
+    &lt;fieldref var='email'/&gt;
+    &lt;fieldref var='jid'/&gt;
+    &lt;fieldref var='background'/&gt;
+  &lt;/page&gt;
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout' label='Community Activity'&gt;
+    &lt;fieldref var='activity.mailing-lists'/&gt;
+    &lt;fieldref var='activity.jeps'/&gt;
+  &lt;/page&gt;
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout' label='Plans and Reasonings'&gt;
+    &lt;fieldref var='future'/&gt;
+    &lt;fieldref var='reasoning'/&gt;
+  &lt;/page&gt;
+  &lt;field var='name.first' type='text-single' label='First Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='name.last' type='text-single' label='Last Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='email' type='text-single' label='E-mail Address'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='jid' type='jid-single' label='Jabber JID'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='background' type='text-multi' label='Background Information'&gt;
+  &lt;/field&gt;
+  &lt;field var='future' type='text-multi' label='Jabber Plans for the Next Six Months'&gt;
+  &lt;/field&gt;
+  &lt;field var='reasoning' type='text-multi' label='Reasons for Joining'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.mailing-lists' type='text-multi' label='Recent Mailing List Activity'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.jeps' type='text-multi' label='JEPs Authored or Co-Authored'&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">The preceding example partitions the fields into three pages, labeled "Personal Information", "Community Activity", and "Plans and Reasonings".</p>
+    <p class="" style="">If a &lt;fieldref/&gt; element within a &lt;page/&gt; references a non-existent field, then that reference MUST be ignored.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sectioning">Sectioning Fields</a>
+</h3>
+    <p class="" style="">The next usage of layout is to partition pages into sections. This is done by including one or more &lt;section/&gt; elements within each &lt;page/&gt; element. Each &lt;section/&gt; element SHOULD possess a "label" attribute to identify the section, MAY contain a &lt;desc/&gt; child element for additional information, and SHOULD contain a &lt;fieldref/&gt; element for each field to be included in the section. A &lt;section/&gt; element MUST contain at least one &lt;fieldref/&gt; element or &lt;reportedref/&gt; element. To reference an x:data field, the &lt;fieldref/&gt; element's "var" attribute MUST be the same as the intended &lt;field/&gt; element's "var" attribute.</p>
+    <p class="caption">Example 3. Sections of fields</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  &lt;title&gt;JSF Application&lt;/title&gt;
+  &lt;instructions&gt;Please fill out this form&lt;/instructions&gt;
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout'&gt;
+    &lt;section label='Personal Information'&gt;
+      &lt;fieldref var='name.first'/&gt;
+      &lt;fieldref var='name.last'/&gt;
+      &lt;fieldref var='email'/&gt;
+      &lt;fieldref var='jid'/&gt;
+      &lt;fieldref var='background'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Community Activity'&gt;
+      &lt;fieldref var='activity.mailing-lists'/&gt;
+      &lt;fieldref var='activity.jeps'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Plans and Reasoning'&gt;
+      &lt;fieldref var='future'/&gt;
+      &lt;fieldref var='reasoning'/&gt;
+    &lt;/section&gt;
+  &lt;/page&gt;
+  &lt;field var='name.first' type='text-single' label='First Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='name.last' type='text-single' label='Last Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='email' type='text-single' label='E-mail Address'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='jid' type='jid-single' label='Jabber JID'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='background' type='text-multi' label='Background Information'&gt;
+  &lt;/field&gt;
+  &lt;field var='future' type='text-multi' label='Jabber Plans for the Next Six Months'&gt;
+  &lt;/field&gt;
+  &lt;field var='reasoning' type='text-multi' label='Reasons for Joining'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.mailing-lists' type='text-multi' label='Recent Mailing List Activity'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.jeps' type='text-multi' label='JEPs Authored or Co-Authored'&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">The preceding example demonstrates a layout similar to the one previous, but using three sections within one page instead of three pages.</p>
+    <p class="" style="">Sections MAY be nested, to produce a more granular partitioning of fields.</p>
+    <p class="caption">Example 4. Sections of fields (nested)</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  ...
+  
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout'&gt;
+    &lt;section label='Personal Information'&gt;
+      &lt;section label='Name'&gt;
+        &lt;fieldref var='name.first'/&gt;
+        &lt;fieldref var='name.last'/&gt;
+      &lt;/section&gt;
+      &lt;section label='Contact Information'&gt;
+        &lt;fieldref var='email'/&gt;
+        &lt;fieldref var='jid'/&gt;
+      &lt;/section&gt;
+      &lt;fieldref var='background'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Community Activity'&gt;
+      &lt;fieldref var='activity.mailing-lists'/&gt;
+      &lt;fieldref var='activity.jeps'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Plans and Reasoning'&gt;
+      &lt;fieldref var='future'/&gt;
+      &lt;fieldref var='reasoning'/&gt;
+    &lt;/section&gt;
+  &lt;/page&gt;
+  
+  ...
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">If a &lt;fieldref/&gt; element within a &lt;section/&gt; element references a non-existent field, then that reference MUST be ignored.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="tables">Including Tables</a>
+</h3>
+    <p class="" style="">Data forms tables (the &lt;reported/&gt; and &lt;item/&gt; elements) can also be included in the layout, using the &lt;reportedref/&gt; element. This element MAY be included anywhere that the &lt;fieldref/&gt; element is allowed, but MUST NOT appear more than once.</p>
+    <p class="" style="">If a &lt;reportedref/&gt; element is specified when no &lt;reported/&gt; element is included, then the reference MUST be ignored.</p>
+  </div>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery</a>
+</h3>
+    <p class="" style="">Form providers MAY attempt to discover if the recipient of a form supports the data forms layout protocol extension, although implementations are not required to do so. If implemented, Discovery MUST be implemened as defined in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250065">2</a>], using the namespace "http://jabber.org/protocol/xdata-layout" as a feature.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-distribution">Field Distribution</a>
+</h3>
+    <p class="" style="">In order to prevent the processing from becoming too complex, there are some restrictions in how fields are distributed within the layout.</p>
+    <p class="" style="">First, all displayable, modifiable fields (e.g. all except fields of type "FIXED" or "HIDDEN") SHOULD be referenced by a page or section. Any that are not referenced MAY NOT be rendered, although implementations MAY provide some support for this. To include a "FIXED" field in the layout, it MUST possess a "var" attribute.</p>
+    <p class="" style="">Second, the same field SHOULD NOT be referenced by more than one page or section. Additionally, a field SHOULD NOT be referenced by the same page or section more than once.</p>
+    <p class="" style="">Finally, the order of layout elements SHOULD be maintained.  Pages SHOULD be rendered in the order they are defined within the x:data form, and sections and fields SHOULD be rendered in the order they are defined or referenced within a page or section.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-pages">Page Labels and Descriptions</a>
+</h3>
+    <p class="" style="">The "label" attribute of the &lt;page/&gt; element is RECOMMENDED (although not required). If it is missing, the renderer MAY display whatever it deems appropriate (including nothing or character data of the containing form's &lt;title/&gt; element).</p>
+    <p class="" style="">The &lt;desc/&gt; child element of the &lt;page/&gt; element is OPTIONAL. If it is missing, the renderer MAY display whatever it deems appropriate (including nothing or character data of the containing form's &lt;instructions/&gt; element).</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-sections">Section Labels and Descriptions</a>
+</h3>
+    <p class="" style="">The "label" attribute of the &lt;section/&gt; element RECOMMENDED (but not required). If it is missing, the renderer MAY use whatever it deems appropriate (including nothing).</p>
+    <p class="" style="">The &lt;desc/&gt; child element of the &lt;section/&gt; element is OPTIONAL. If it is missing, the renderer MAY use whatever it deems appropriate (including nothing).</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-i18n">Internationalization/Localization</a>
+</h3>
+    <p class="" style="">This JEP relies on the internationalization/localization mechanisms provided by <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2255328">3</a>]. Specifically, labels and descriptions MUST be appropriate for the locale indicated by the containing stanza or &lt;form/&gt; element.</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security considerations introduced by this JEP.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255388">4</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255432">5</a>] shall register the namespace "http://jabber.org/protocol/xdata-layout" as a feature namespace.</p>
+<h2>8.
+       <a name="def">Formal Definition</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="def-page">&lt;page/&gt; Root Element</a>
+</h3>
+    <p class="" style="">The &lt;page/&gt; element is the root layout element for "http://jabber.org/protocol/xdata-layout" namespace. One &lt;page/&gt; elements is contained within the &lt;x xmlns='jabber:x:data'/&gt; element for each page to be rendered. The &lt;page/&gt; element MAY possess an attribute that specifies a natural-language label for the page, and MAY contain child elements specifying a description, sections of the page, and field and table references.</p>
+    <p class="" style="">The 'label' attribute specifies the label for this page. This attribute is OPTIONAL. Its value is any string.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="def-section">&lt;section/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;section/&gt; element is used to further partition the layout within a page. The &lt;section/&gt; element MAY possess an attribute that specifies a natural-language label for the section, and MAY contain child elements specifying a description, subsections, and field and table references.</p>
+    <p class="" style="">The 'label' attribute specifies the label for this section. This attribute is OPTIONAL. Its value is any string.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="def-fieldref">&lt;fieldref/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;fieldref/&gt; element is used to situate a form field within the layout. The &lt;fieldref/&gt; element MUST possess a single attribute to identify the field it references, and is otherwise empty.</p>
+    <p class="" style="">The 'var' attribute specifies the form field being referenced. This attribute is REQUIRED, and its value SHOULD be the same as the "var" attribute of one of the &lt;field/&gt; elements in the containing form.</p>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="def-reportedref">&lt;reportedref/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;reportedref/&gt; element is used to situate a form "table" (as described by the &lt;reported/&lt; and &lt;item/&gt; elements) within the layout. The &lt;reportedref/&gt; element has no attributes or children.</p>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="def-desc">&lt;desc/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;desc/&gt; element is used to provide additional textual information for a page or section. Its XML character data is the natural-language text that describes the page or section.</p>
+  </div>
+  <div class="indent">
+<h3>8.6 <a name="schema">XML Schema</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/xdata-layout'
+    xmlns='http://jabber.org/protocol/xdata-layout'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='page'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='desc' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='fieldref' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='reportedref' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:element name='section'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='desc' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='fieldref' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='reportedref' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='fieldref'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='var' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:element name='reportedref' type='empty'/&gt;
+
+  &lt;xs:element name='desc' type='xs:string'/&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2250412">1</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2250065">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255328">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2255388">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255432">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-03-28)</h4>
+<div class="indent">JEP Editor review: cleanup of text, examples, and schema. (psa)
+    </div>
+<h4>Version 0.1 (2004-08-10)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0141-0.3.html
+++ b/content/xep-0141-0.3.html
@@ -1,0 +1,508 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0141: Data Forms Layout</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Data Forms Layout">
+<meta name="DC.Creator" content="Matthew Miller">
+<meta name="DC.Description" content="This JEP defines an extension to the Data Forms protocol enabling an application to specify form layouts.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-05-03">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0141">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0141: Data Forms Layout</h1>
+<p>This JEP defines an extension to the Data Forms protocol enabling an application to specify form layouts.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0141<br>
+            Version: 0.3<br>
+            Last Updated: 2005-05-03<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: xdata-layout<br></p>
+<h2>Author Information</h2>
+<h3>Matthew Miller</h3>
+<p class="indent">
+        Email: linuxwolf@outer-planes.net<br>
+        JID: linuxwolf@outer-planes.net</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#paging">Paging Fields</a>
+</dt>
+<dt>3.2.  <a href="#sectioning">Sectioning Fields</a>
+</dt>
+<dt>3.3.  <a href="#tables">Including Tables</a>
+</dt>
+</dl>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-disco">Discovery</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-distribution">Field Distribution</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-pages">Page Labels and Descriptions</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-sections">Section Labels and Descriptions</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-i18n">Internationalization/Localization</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#def">Formal Definition</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#def-page">&lt;page/&gt; Root Element</a>
+</dt>
+<dt>8.2.  <a href="#def-section">&lt;section/&gt; Element</a>
+</dt>
+<dt>8.3.  <a href="#def-fieldref">&lt;fieldref/&gt; Element</a>
+</dt>
+<dt>8.4.  <a href="#def-reportedref">&lt;reportedref/&gt; Element</a>
+</dt>
+<dt>8.5.  <a href="#def-text">&lt;text/&gt; Element</a>
+</dt>
+<dt>8.6.  <a href="#schema">XML Schema</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250436">1</a>] ("x:data") provides a simple and interoperable way to request and present information for both applications and humans. However, the simple nature of "x:data" requires the form renderer to use a generic "key/value" format. This JEP builds upon "x:data" to enable applications to specify additional layout information.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The requirements for this JEP are:</p>
+  <ul>
+    <li>Provide hints for laying out form fields in pages.</li>
+    <li>Provide hints for laying out pages in sections.</li>
+    <li>Provide hints for laying out sections in subsections.</li>
+    <li>Ensure backwards-compatibility with the existing "x:data" protocol.</li>
+  </ul>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">This JEP defines a new namespace, "http://jabber.org/protocol/xdata-layout". All layout is defined by "pages" and "sections".</p>
+  <p class="" style="">All of the use cases refer to the following form:</p>
+  <p class="caption">Example 1. Sample form</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  &lt;title&gt;JSF Application&lt;/title&gt;
+  &lt;instructions&gt;Please fill out this form&lt;/instructions&gt;
+  
+  &lt;field var='name.first' type='text-single' label='First Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='name.last' type='text-single' label='Last Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='email' type='text-single' label='E-mail Address'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='jid' type='jid-single' label='Jabber JID'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  
+  &lt;field var='background' type='text-multi' label='Background Information'&gt;
+  &lt;/field&gt;
+  &lt;field var='future' type='text-multi' label='Jabber Plans for the Next Six Months'&gt;
+  &lt;/field&gt;
+  &lt;field var='reasoning' type='text-multi' label='Reasons for Joining'&gt;
+  &lt;/field&gt;
+  
+  &lt;field var='activity.mailing-lists' type='text-multi' label='Recent Mailing List Activity'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.jeps' type='text-multi' label='JEPs Authored or Co-Authored'&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+  </pre></div>
+  <p class="" style="">Note: Any newlines in the following examples are provided for the purpose of legibility only.</p>
+  <div class="indent">
+<h3>3.1 <a name="paging">Paging Fields</a>
+</h3>
+    <p class="" style="">One of the simplest layout usages is to partition fields into pages. This is done by including one or more &lt;page/&gt; elements within the x:data form. Each &lt;page/&gt; element SHOULD possess a "label" attribute to label the page, MAY contain a &lt;text/&gt; child element for additional information, and SHOULD contain a &lt;fieldref/&gt; element for each field to be included in the page. To reference an x:data field, the &lt;fieldref/&gt; element's "var" attribute MUST be the same as the intended &lt;field/&gt; element's "var" attribute.</p>
+    <p class="caption">Example 2. Pages of fields</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  &lt;title&gt;JSF Application&lt;/title&gt;
+  &lt;instructions&gt;Please fill out this form&lt;/instructions&gt;
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout' label='Personal Information'&gt;
+    &lt;text&gt;This is page one of three.&lt;/text&gt;
+    &lt;text&gt;
+      Note: In accordance with the JSF privacy policy, your personal information will 
+      never be shared outside the organization in any way for any purpose; however, 
+      your name and JID may be published in the JSF membership directory.
+    &lt;/text&gt;
+    &lt;fieldref var='name.first'/&gt;
+    &lt;fieldref var='name.last'/&gt;
+    &lt;fieldref var='email'/&gt;
+    &lt;fieldref var='jid'/&gt;
+    &lt;fieldref var='background'/&gt;
+  &lt;/page&gt;
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout' label='Community Activity'&gt;
+    &lt;text&gt;This is page two of three.&lt;/text&gt;
+    &lt;text&gt;
+      We use this page to gather information about any JEPs you&amp;apos;ve worked on, 
+      as well as your mailing list activity.
+    &lt;/text&gt;
+    &lt;text&gt;You do post to the mailing lists, don't you?&lt;/text&gt;
+    &lt;fieldref var='activity.mailing-lists'/&gt;
+    &lt;fieldref var='activity.jeps'/&gt;
+  &lt;/page&gt;
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout' label='Plans and Reasonings'&gt;
+    &lt;text&gt;This is page three of three.&lt;/text&gt;
+    &lt;text&gt;You're almost done!&lt;/text&gt;
+    &lt;text&gt;
+      This is where you describe your future plans and why you think you 
+      deserve to be a member of the Jabber Software Foundation.
+    &lt;/text&gt;
+    &lt;fieldref var='future'/&gt;
+    &lt;fieldref var='reasoning'/&gt;
+  &lt;/page&gt;
+  &lt;field var='name.first' type='text-single' label='First Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='name.last' type='text-single' label='Last Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='email' type='text-single' label='E-mail Address'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='jid' type='jid-single' label='Jabber JID'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='background' type='text-multi' label='Background Information'&gt;
+  &lt;/field&gt;
+  &lt;field var='future' type='text-multi' label='Jabber Plans for the Next Six Months'&gt;
+  &lt;/field&gt;
+  &lt;field var='reasoning' type='text-multi' label='Reasons for Joining'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.mailing-lists' type='text-multi' label='Recent Mailing List Activity'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.jeps' type='text-multi' label='JEPs Authored or Co-Authored'&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">Note: The preceding example partitions the fields into three pages, labeled "Personal Information", "Community Activity", and "Plans and Reasonings".</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="sectioning">Sectioning Fields</a>
+</h3>
+    <p class="" style="">The next usage of layout is to partition pages into sections. This is done by including one or more &lt;section/&gt; elements within each &lt;page/&gt; element. Each &lt;section/&gt; element SHOULD possess a "label" attribute to identify the section, MAY contain a &lt;text/&gt; child element for additional information, and SHOULD contain a &lt;fieldref/&gt; element for each field to be included in the section. A &lt;section/&gt; element MUST contain at least one &lt;fieldref/&gt; element or &lt;reportedref/&gt; element. To reference an x:data field, the &lt;fieldref/&gt; element's "var" attribute MUST be the same as the intended &lt;field/&gt; element's "var" attribute.</p>
+    <p class="caption">Example 3. Sections of fields</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  &lt;title&gt;JSF Application&lt;/title&gt;
+  &lt;instructions&gt;Please fill out this form&lt;/instructions&gt;
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout'&gt;
+    &lt;section label='Personal Information'&gt;
+      &lt;text&gt;
+        Note: In accordance with the JSF privacy policy, your personal information will 
+        never be shared outside the organization in any way for any purpose; however, 
+        your name and JID may be published in the JSF membership directory.
+      &lt;/text&gt;
+      &lt;fieldref var='name.first'/&gt;
+      &lt;fieldref var='name.last'/&gt;
+      &lt;fieldref var='email'/&gt;
+      &lt;fieldref var='jid'/&gt;
+      &lt;fieldref var='background'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Community Activity'&gt;
+      &lt;text&gt;
+        We use this page to gather information about any JEPs you&amp;apos;ve worked on, 
+        as well as your mailing list activity.
+      &lt;/text&gt;
+      &lt;text&gt;You do post to the mailing lists, don't you?&lt;/text&gt;
+      &lt;fieldref var='activity.mailing-lists'/&gt;
+      &lt;fieldref var='activity.jeps'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Plans and Reasoning'&gt;
+      &lt;text&gt;You're almost done!&lt;/text&gt;
+      &lt;text&gt;
+        This is where you describe your future plans and why you think you 
+        deserve to be a member of the Jabber Software Foundation.
+      &lt;/text&gt;
+      &lt;fieldref var='future'/&gt;
+      &lt;fieldref var='reasoning'/&gt;
+    &lt;/section&gt;
+  &lt;/page&gt;
+  &lt;field var='name.first' type='text-single' label='First Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='name.last' type='text-single' label='Last Name'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='email' type='text-single' label='E-mail Address'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='jid' type='jid-single' label='Jabber JID'&gt;
+    &lt;required/&gt;
+  &lt;/field&gt;
+  &lt;field var='background' type='text-multi' label='Background Information'&gt;
+  &lt;/field&gt;
+  &lt;field var='future' type='text-multi' label='Jabber Plans for the Next Six Months'&gt;
+  &lt;/field&gt;
+  &lt;field var='reasoning' type='text-multi' label='Reasons for Joining'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.mailing-lists' type='text-multi' label='Recent Mailing List Activity'&gt;
+  &lt;/field&gt;
+  &lt;field var='activity.jeps' type='text-multi' label='JEPs Authored or Co-Authored'&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">Note: The preceding example demonstrates a layout similar to the previous example, but using three sections within one page instead of three pages.</p>
+    <p class="" style="">As shown in the following example, sections may be nested to produce a more granular partitioning of fields.</p>
+    <p class="caption">Example 4. Sections of fields (nested)</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='form'&gt;
+  ...
+  
+  &lt;page xmlns='http://jabber.org/protocol/xdata-layout'&gt;
+    &lt;section label='Personal Information'&gt;
+      &lt;text&gt;
+        Note: In accordance with the JSF privacy policy, your personal information will 
+        never be shared outside the organization in any way for any purpose; however, 
+        your name and JID may be published in the JSF membership directory.
+      &lt;/text&gt;
+      &lt;section label='Name'&gt;
+        &lt;text&gt;Who are you?&lt;/text&gt;
+        &lt;fieldref var='name.first'/&gt;
+        &lt;fieldref var='name.last'/&gt;
+      &lt;/section&gt;
+      &lt;section label='Contact Information'&gt;
+        &lt;text&gt;How can we contact you?&lt;/text&gt;
+        &lt;fieldref var='email'/&gt;
+        &lt;fieldref var='jid'/&gt;
+      &lt;/section&gt;
+      &lt;fieldref var='background'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Community Activity'&gt;
+      &lt;text&gt;
+        We use this page to gather information about any JEPs you&amp;apos;ve worked on, 
+        as well as your mailing list activity.
+      &lt;/text&gt;
+      &lt;text&gt;You do post to the mailing lists, don't you?&lt;/text&gt;
+      &lt;fieldref var='activity.mailing-lists'/&gt;
+      &lt;fieldref var='activity.jeps'/&gt;
+    &lt;/section&gt;
+    &lt;section label='Plans and Reasoning'&gt;
+      &lt;text&gt;
+        This is where you describe your future plans and why you think you 
+        deserve to be a member of the Jabber Software Foundation.
+      &lt;/text&gt;
+      &lt;fieldref var='future'/&gt;
+      &lt;fieldref var='reasoning'/&gt;
+    &lt;/section&gt;
+  &lt;/page&gt;
+  
+  ...
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">Note: The preceding example partitions the fields into one page and three sections, with the first section being further partitioned into two sub-sections and one free-standing field reference.</p> 
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="tables">Including Tables</a>
+</h3>
+    <p class="" style="">Data forms tables (the &lt;reported/&gt; and &lt;item/&gt; elements) can also be included in the layout, using the &lt;reportedref/&gt; element. This element MAY be included anywhere that the &lt;fieldref/&gt; element is allowed, but MUST NOT appear more than once.</p>
+    <p class="" style="">If a &lt;reportedref/&gt; element is specified when no &lt;reported/&gt; element is included, then the reference MUST be ignored.</p>
+  </div>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-disco">Discovery</a>
+</h3>
+    <p class="" style="">Form providers MAY attempt to discover if the recipient of a form supports the data forms layout protocol extension, although implementations are not required to do so. If implemented, Discovery MUST be implemened as defined in <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250117">2</a>], using the namespace "http://jabber.org/protocol/xdata-layout" as a feature.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-distribution">Field Distribution</a>
+</h3>
+    <p class="" style="">In order to prevent the processing from becoming too complex, there are some restrictions in how fields are distributed within the layout.</p>
+    <p class="" style="">First, all displayable, modifiable fields (e.g. all except fields of type "FIXED" or "HIDDEN") SHOULD be referenced by a page or section. Any that are not referenced MAY NOT be rendered, although implementations MAY provide some support for this. To include a "FIXED" field in the layout, it MUST possess a "var" attribute.</p>
+    <p class="" style="">Second, the same field SHOULD NOT be referenced by more than one page or section. Additionally, a field SHOULD NOT be referenced by the same page or section more than once.</p>
+    <p class="" style="">Finally, the order of layout elements SHOULD be maintained.  Pages SHOULD be rendered in the order they are defined within the x:data form, and sections and fields SHOULD be rendered in the order they are defined or referenced within a page or section.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-pages">Page Labels and Descriptions</a>
+</h3>
+    <p class="" style="">The "label" attribute of the &lt;page/&gt; element is RECOMMENDED (although not required). If it is missing, the renderer MAY display whatever it deems appropriate (including nothing or character data of the containing form's &lt;title/&gt; element).</p>
+    <p class="" style="">The &lt;text/&gt; child element of the &lt;page/&gt; element is OPTIONAL. If it is missing, the renderer MAY display whatever it deems appropriate (including nothing or character data of the containing form's &lt;instructions/&gt; element).</p>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-sections">Section Labels and Descriptions</a>
+</h3>
+    <p class="" style="">The "label" attribute of the &lt;section/&gt; element RECOMMENDED (but not required). If it is missing, the renderer MAY use whatever it deems appropriate (including nothing).</p>
+    <p class="" style="">The &lt;text/&gt; child element of the &lt;section/&gt; element is OPTIONAL. If it is missing, the renderer MAY use whatever it deems appropriate (including nothing).</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-i18n">Internationalization/Localization</a>
+</h3>
+    <p class="" style="">This JEP relies on the internationalization/localization mechanisms provided by <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2255452">3</a>]. Specifically, labels and descriptions MUST be appropriate for the locale indicated by the containing stanza or &lt;form/&gt; element.</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">There are no security considerations introduced by this JEP.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255510">4</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255554">5</a>] shall register the namespace "http://jabber.org/protocol/xdata-layout" as a feature namespace.</p>
+<h2>8.
+       <a name="def">Formal Definition</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="def-page">&lt;page/&gt; Root Element</a>
+</h3>
+    <p class="" style="">The &lt;page/&gt; element is the root layout element for "http://jabber.org/protocol/xdata-layout" namespace. One &lt;page/&gt; elements is contained within the &lt;x xmlns='jabber:x:data'/&gt; element for each page to be rendered. The &lt;page/&gt; element MAY possess an attribute that specifies a natural-language label for the page, and MAY contain child elements specifying a description, sections of the page, and field and table references.</p>
+    <p class="" style="">The 'label' attribute specifies the label for this page. This attribute is OPTIONAL. Its value is any string.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="def-section">&lt;section/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;section/&gt; element is used to further partition the layout within a page. The &lt;section/&gt; element MAY possess an attribute that specifies a natural-language label for the section, and MAY contain child elements specifying a description, subsections, and field and table references.</p>
+    <p class="" style="">The 'label' attribute specifies the label for this section. This attribute is OPTIONAL. Its value is any string.</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="def-fieldref">&lt;fieldref/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;fieldref/&gt; element is used to situate a form field within the layout. The &lt;fieldref/&gt; element MUST possess a single attribute to identify the field it references, and is otherwise empty.</p>
+    <p class="" style="">If a &lt;fieldref/&gt; element within a &lt;page/&gt; or &lt;section/&gt; references a non-existent field, then that reference MUST be ignored.</p>
+    <p class="" style="">The 'var' attribute specifies the form field being referenced. This attribute is REQUIRED, and its value SHOULD be the same as the "var" attribute of one of the &lt;field/&gt; elements in the containing form.</p>
+  </div>
+  <div class="indent">
+<h3>8.4 <a name="def-reportedref">&lt;reportedref/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;reportedref/&gt; element is used to situate a form "table" (as described by the &lt;reported/&lt; and &lt;item/&gt; elements) within the layout. The &lt;reportedref/&gt; element has no attributes or children.</p>
+  </div>
+  <div class="indent">
+<h3>8.5 <a name="def-text">&lt;text/&gt; Element</a>
+</h3>
+    <p class="" style="">The &lt;text/&gt; element is used to provide natural-language text that describes a page or section, provides instructions or notes about the page or section, and the like. A &lt;page/&gt; or &lt;section/&gt; element MAY contain an unbounded number of &lt;text/&gt; child elements. The XML character data of this element SHOULD NOT contain newlines (the \n and \r characters), and any handling of newlines (e.g., presentation in a user interface) is unspecified herein.</p>
+  </div>
+  <div class="indent">
+<h3>8.6 <a name="schema">XML Schema</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/xdata-layout'
+    xmlns='http://jabber.org/protocol/xdata-layout'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='page'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='text' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='fieldref' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='reportedref' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:element name='section'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0' maxOccurs='unbounded'&gt;
+        &lt;xs:element ref='text' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='section' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='fieldref' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;xs:element ref='reportedref' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='label' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='fieldref'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='var' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  
+  &lt;xs:element name='reportedref' type='empty'/&gt;
+
+  &lt;xs:element name='text' type='xs:string'/&gt;
+  
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2250436">1</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2250117">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255452">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2255510">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2255554">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-05-03)</h4>
+<div class="indent">Renamed &lt;desc/&gt; element to &lt;text/&gt; to avoid confusion with JEP-0004 element names; clarified formal definition of &lt;text/&gt; element; added &lt;text/&gt; elements to examples. (psa)
+    </div>
+<h4>Version 0.2 (2005-03-28)</h4>
+<div class="indent">JEP Editor review: cleanup of text, examples, and schema. (psa)
+    </div>
+<h4>Version 0.1 (2004-08-10)</h4>
+<div class="indent">Initial version. (lw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0142-0.1.html
+++ b/content/xep-0142-0.1.html
@@ -1,0 +1,1260 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0142: Workgroups</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Workgroups">
+<meta name="DC.Creator" content="Iain Shigeoka">
+<meta name="DC.Creator" content="Matt Tucker">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension that enables a user to communicate with a representative of an organization, department, or workgroup (e.g., the support group).">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-03">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0142">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0142: Workgroups</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to communicate with a representative of an organization, department, or workgroup (e.g., the support group).</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0142<br>
+            Version: 0.1<br>
+            Last Updated: 2004-09-03<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: workgroup<br>
+</p>
+<h2>Author Information</h2>
+<h3>Iain Shigeoka</h3>
+<p class="indent">
+        Email: iain@jivesoftware.com<br>
+        JID: smirk@jabber.org</p>
+<h3>Matt Tucker</h3>
+<p class="indent">
+        Email: matt@jivesoftware.com<br>
+        JID: jivematt@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dl>
+<dt>1.1.  <a href="#intro-over">Overview</a>
+</dt>
+<dt>1.2.  <a href="#intro-motive">Motivation</a>
+</dt>
+<dt>1.3.  <a href="#intro-concepts">Concepts</a>
+</dt>
+<dt>1.4.  <a href="#intro-prereq">Prerequisites</a>
+</dt>
+</dl>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#roleresp">Roles and Responsibilities</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#roles">Roles</a>
+</dt>
+<dt>3.2.  <a href="#responsibilities">Responsibilities</a>
+</dt>
+</dl>
+<dt>4.  <a href="#proto">Protocol</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#proto-pres">Workgroup Presence</a>
+</dt>
+<dt>4.2.  <a href="#proto-states">User States</a>
+</dt>
+<dt>4.3.  <a href="#proto-user">User Packet Exchanges</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#proto-user-join">User Join Protocol</a>
+</dt>
+<dl>
+<dt>4.3.1.1.  <a href="#proto-user-join-errors">Error Conditions</a>
+</dt>
+<dt>4.3.1.2.  <a href="#proto-user-join-example">Example</a>
+</dt>
+</dl>
+<dt>4.3.2.  <a href="#proto-user-depart">User Depart Protocol</a>
+</dt>
+<dl>
+<dt>4.3.2.1.  <a href="#proto-user-depart-errors">Error Conditions</a>
+</dt>
+<dt>4.3.2.2.  <a href="#proto-user-depart-example">Example</a>
+</dt>
+</dl>
+<dt>4.3.3.  <a href="#proto-user-status">User Status Update Protocol</a>
+</dt>
+<dl>
+<dt>4.3.3.1.  <a href="#proto-user-status-updates">User Status Updates</a>
+</dt>
+<dt>4.3.3.2.  <a href="#proto-user-status-errors">Error Conditions</a>
+</dt>
+<dt>4.3.3.3.  <a href="#proto-user-status-example">Example</a>
+</dt>
+</dl>
+<dt>4.3.4.  <a href="#proto-user-invite">User Invite Protocol</a>
+</dt>
+<dl>
+<dt>4.3.4.1.  <a href="#proto-user-invite-errors">Error Conditions</a>
+</dt>
+<dt>4.3.4.2.  <a href="#proto-user-invite-example">Example</a>
+</dt>
+</dl>
+</dl>
+<dt>4.4.  <a href="#proto-agent-states">Agent States</a>
+</dt>
+<dt>4.5.  <a href="#proto-agent">Agent Packet Exchanges</a>
+</dt>
+<dl>
+<dt>4.5.1.  <a href="#proto-agent-presence">Agent Presence Protocol</a>
+</dt>
+<dl>
+<dt>4.5.1.1.  <a href="#proto-agent-presence-errors">Error Conditions</a>
+</dt>
+<dt>4.5.1.2.  <a href="#proto-agent-presence-example">Example</a>
+</dt>
+</dl>
+<dt>4.5.2.  <a href="#proto-agent-status">Agent Status Update Protocol</a>
+</dt>
+<dl>
+<dt>4.5.2.1.  <a href="#proto-agent-status-errors">Error Conditions</a>
+</dt>
+<dt>4.5.2.2.  <a href="#proto-agent-status-example">Example</a>
+</dt>
+</dl>
+<dt>4.5.3.  <a href="#proto-agent-offer">Agent Offer Protocol</a>
+</dt>
+<dl>
+<dt>4.5.3.1.  <a href="#proto-agent-offer-errors">Error Conditions</a>
+</dt>
+<dt>4.5.3.2.  <a href="#proto-agent-offer-example">Example</a>
+</dt>
+</dl>
+<dt>4.5.4.  <a href="#proto-agent-acceptreject">Agent Offer Accept/Reject Protocol</a>
+</dt>
+<dl>
+<dt>4.5.4.1.  <a href="#proto-agent-acceptreject-errors">Error Conditions</a>
+</dt>
+<dt>4.5.4.2.  <a href="#proto-agent-acceptreject-example">Example</a>
+</dt>
+</dl>
+<dt>4.5.5.  <a href="#proto-agent-revoke">Agent Offer Revoke Protocol</a>
+</dt>
+<dl>
+<dt>4.5.5.1.  <a href="#proto-agent-revoke-errors">Error Conditions</a>
+</dt>
+<dt>4.5.5.2.  <a href="#proto-agent-revoke-example">Example</a>
+</dt>
+</dl>
+<dt>4.5.6.  <a href="#proto-agent-invite">Agent Invite Protocol</a>
+</dt>
+<dl>
+<dt>4.5.6.1.  <a href="#proto-agent-invite-errors">Error Conditions</a>
+</dt>
+<dt>4.5.6.2.  <a href="#proto-agent-invite-example">Example</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>5.  <a href="#example">Complete Protocol Example</a>
+</dt>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <div class="indent">
+<h3>1.1 <a name="intro-over">Overview</a>
+</h3>
+    <p class="" style="">This JEP documents a protocol that provides a generic service allowing users to contact a representative of an organization or workgroup without knowing the address of a particular member of that organization or workgroup. This functionality is similar to an 'email alias' with the addition of queuing pending communication requests and quality of service negotiation to accommodate the real-time nature of IM/chat. Although this protocol is generic enough to handle many use cases, specific features have been added that make it particularly suitable for customer support environments.</p>
+  </div>
+  <div class="indent">
+<h3>1.2 <a name="intro-motive">Motivation</a>
+</h3>
+    <p class="" style="">This protocol addresses the need of starting a private XMPP conversation with a qualified member of a workgroup. In a standard XMPP exchange of messages, users either connect directly to another user for a one on one conversation, or connect to a chat room for a conversation between many people. The current protocols do not allow users to initiate a private conversation with any person playing a particular role in an organization or workgroup.</p>
+    <p class="" style="">For example, a customer has a question and needs to talk to a support representative. The conversation is private and therefore cannot be conducted in a well-known chat room. Using the workgroup protocol, the user requests a chat with support@company.com. The chat request is put into a queue and the server routes the chat request to individual support representatives in the support@company.com workgroup. The support representative can accept or reject the chat request. Once the request is accepted, the conversation takes place through standard XMPP messaging protocols.</p>
+  </div>
+  <div class="indent">
+<h3>1.3 <a name="intro-concepts">Concepts</a>
+</h3>
+    <p class="" style="">The namespace governing this protocol is &quot;http://jabber.org/protocol/workgroup&quot;. This namespace relies on the &lt;iq/&gt; element for execution, and uses the &lt;presence/&gt; element for announcing status updates.</p>
+    <p class="" style="">This protocol depends on Service Discovery for reporting and announcing available workgroup services. However, support for service discovery is entirely optional and workgroup services may be made known through other means (e.g. web pages, word of mouth, etc).</p>
+    <p class="" style="">The end result of a workgroup interaction is to negotiate and route a user and workgroup member (a.k.a. agent) to an appropriate chatroom for a chat conversation. Therefore, this JEP also relies on the groupchat and groupchat invitation protocols. However, groupchat essentially 'takes over' when the workgroup protocol successfully completes so there is no overlap between the two protocols. It is highly recommended that groupchat implementations support basic groupchat (a.k.a. Groupchat 1.0) for maximum client compatibility.</p>
+  </div>
+  <div class="indent">
+<h3>1.4 <a name="intro-prereq">Prerequisites</a>
+</h3>
+    <p class="" style="">There are no requirements for supporting the workgroup protocol beyond <span class="ref">XMPP Core</span>  [<a href="#nt-id2596124">1</a>] and <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596230">2</a>]. Support for <span class="ref">Data Forms</span>  [<a href="#nt-id2596242">3</a>] is optional if users need to submit additional data before joining (see User Join section of this document).</p>
+  </div>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in <span class="ref">RFC 2119</span>  [<a href="#nt-id2596293">4</a>].</p>
+<h2>3.
+       <a name="roleresp">Roles and Responsibilities</a>
+</h2>
+  <p class="" style="">This protocol has clearly defined roles and responsibilities for its participants.</p>
+  <div class="indent">
+<h3>3.1 <a name="roles">Roles</a>
+</h3>
+    <p class="" style="">The workgroup protocol involves three distinct participants that fill the following roles:</p>
+    <ul>
+      <li><p class="" style="">
+<span style="font-weight: bold">User</span> - The user participant requests a private conversation and drives the workgroup protocol. For examples throughout the rest of this JEP the user will be represented by the address user@server.com/home.</p></li>
+      <li><p class="" style="">
+<span style="font-weight: bold">Service</span> - The workgroup service receives and sends messages under the workgroup address. The workgroup address represents a general workgroup contact address where users can talk to members of a workgroup without the need to know any particular workgroup member's address. The workgroup service manages the interactions between users and agents. For examples throughout the rest of this JEP the service will be represented by the address support@company.com, representing a common scenario of a workgroup offering customer support for an organization.</p></li>
+      <li><p class="" style="">
+<span style="font-weight: bold">Agent</span> - The agent is a member of the workgroup and can carry out conversations with users on behalf of their workgroup organization or company. For examples throughout the rest of this JEP two agent addresses will be used: alice@company.com/work and bob@company.com/work.</p></li>
+    </ul>
+    <p class="" style="">Note: A service MAY contain several queues to help organize, route and handle incoming user chat requests. Implementations supporting multiple queues in a workgroup will respond differently to requests, and send different status information for each queue. Workgroup queues are identified by a unique resource name: e.g. support@company.com/platinum- plan or support@company.com/xmpp-products. Implementation should gracefully handle services with only one queue (using support@company.com) or multiple queues. Users should only be aware of one workgroup (users should never see workgroup queue resource names).</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="responsibilities">Responsibilities</a>
+</h3>
+    <p class="" style="">Each participant is responsible for certain behaviors in the workgroup protocol.</p>
+    <p class="" style="">Users should:</p>
+    <ul>
+      <li>Know the status of the workgroup queue before requesting a conversation.</li>
+      <li>This information allows users to see if the workgroup is available, and how</li>
+      <li>long a wait they may have before a chat is initiated.</li>
+      <li>Know the status of their request while in the request queue.</li>
+      <li>Are able to cancel a chat request at any time.</li>
+    </ul>
+    <p class="" style="">Workgroup agents should:</p>
+    <ul>
+      <li>Know the status of the workgroup queue(s).</li>
+      <li>Be able to accept or reject requests for conversation.</li>
+      <li>Indicate their availability for handling workgroup conversations.</li>
+    </ul>
+    <p class="" style="">The workgroup service:</p>
+    <ul>
+      <li>Controls the chat request queue(s).</li>
+      <li>Manages the updating of queue status information.</li>
+      <li>Determines how users are queued and how queue requests are routed to workgroup members. The queue routing algorithm is beyond the scope of this JEP and left to implementers (simple round-robin, priority based, rules based, etc).</li>
+      <li>Maintains its presence, indicating the availability of the workgroup service.</li>
+    </ul>
+  </div>
+<h2>4.
+       <a name="proto">Protocol</a>
+</h2>
+  <p class="" style="">The workgroup protocol consists of several XMPP packet exchanges that occur during the lifetime of the protocol. These packet exchanges change the state of the relationship between user, agent and service.</p>
+  <div class="indent">
+<h3>4.1 <a name="proto-pres">Workgroup Presence</a>
+</h3>
+    <p class="" style="">The workgroup is a normal XMPP messaging node and MUST maintain its own presence. We also recommend that the workgroup service be able to respond to arbitrary chat messages sent to it (preferably by responding with instructions on how to join the queue). Other users may subscribe to the workgroup services' presence using standard XMPP presence-subscribe and presence-unsubscribe protocols. The workgroup service's presence can be used to determine the workgroup's status without joining the workgroup as a user or agent. Workgroup presence updates SHOULD contain the queue summary and agent summary meta-data defined in the Agent Status Update Protocol detailed later in this JEP. For example, a website server-side component can subscribe to the workgroup presence and indicate on web pages whether a workgroup is available to offer live chat to website visitors.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="proto-states">User States</a>
+</h3>
+    <p class="" style="">Users join the workgroup queue to wait for a conversation with an agent.  Once they have joined the queue, they may receive zero or more status updates from the workgroup service informing them of their status in the queue. Users have the option to cancel their chat request at any time.</p>
+    <p class="" style="">When an agent is ready to chat with the user, the user will be sent a standard XMPP groupchat invitation to a chat room. Receipt of the invitation indicates that the user is no longer in the queue and that they should join the chat room using the standard XMPP groupchat protocol in order to converse with an agent. Groupchat is used because it offers several advantages in workgroup conversations including:</p>
+    <ul>
+      <li>Allowing more than one agent to join the conversation (useful for bringing in experts to join the conversation).</li>
+      <li>Allowing managers to monitor conversations for quality of service.</li>
+      <li>Creates a simple way of determining what is in a 'conversation' for logging and gathering other statistical information about the conversation.</li>
+      <li>Allows a convenient mechanism for bringing 'chatbot' services into the conversation (e.g. answering FAQ, etc).</li>
+    </ul>
+    <p class="" style="">The user's states and packet exchanges that cause state transitions are shown below:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+              +-------+
+              | Start |&lt;------+
+              +-------+       |
+                  |           |
+                  | Join      |
+                  v           |
+             +---------+      |
+      +-----&gt;| Queued  |      |
+      |      +---------+      |
+      | Status |  |  | Depart |
+      +--------+  |  +--------+
+                  |
+                  | Invite
+                  v
+            +-----------+
+            | Chat room |
+            +-----------+
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="proto-user">User Packet Exchanges</a>
+</h3>
+    <p class="" style="">Packets are exchanged between the user and service to trigger state changes in the user. These packet exchanges are described next.</p>
+    <div class="indent">
+<h3>4.3.1 <a name="proto-user-join">User Join Protocol</a>
+</h3>
+      <p class="" style="">This section describes the packet exchange allowing users to join a workgroup service queue. This protocol MUST be supported by compliant implementations.</p>
+      <p class="caption">Example 1. Transactions</p>
+<div class="indent"><pre>
+User                          Service
+  |        Join Request          |
+  |-----------------------------&gt;|
+  |                              |
+  |        Join Response         |
+  |&lt;-----------------------------|
+  |                              |
+      </pre></div>
+      <p class="" style="">The user sends a join request to the workgroup service in order to join the workgroup queue. The workgroup service may either accept or reject the request. A user session (e.g. user@server.com/home) may only join the workgroup service queue once. Subsequent, simultaneous joins will result in an error (see error section).</p>
+      <p class="" style="">Some workgroups require that the user submit certain information before the user is allowed to join. In these cases, the workgroup will reject the initial join request with a &lt;not-acceptable/&gt; error. The user should then use the Data Forms (JEP-0004) [4] protocol within iq-join-queue to obtain a form, and submit it. Once the server accepts the submitted data, the user join should be retried.</p>
+      <p class="caption">Example 2. Request Element</p>
+<div class="indent"><pre>
+U: &lt;iq to='service-jid' from='user-jid' id='id' type='set'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The request may contain meta-data to help the service determine queuing of the user or Data Forms data when submitting form information. There is one optional standard workgroup sub-element of &lt;join-queue&gt;:</p>
+      <ul>
+        <li>&lt;queue-notifications/&gt; - if present, indicates the user would like to receive user status updates about its state in the queue.</li>
+      </ul>
+      <p class="" style="">A successful join results in a success response:</p>
+      <p class="caption">Example 3. Response Element</p>
+<div class="indent"><pre>
+S: &lt;iq to='user-jid' from='service-jid' id='id' type='result'&gt;
+S:    &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:      &lt;queue-notifications/&gt;
+S:    &lt;/join-queue&gt;
+S: &lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">If the user indicated interest in their queue status information, the supported status updates that will be sent by the server is included in the response. Compliant implementations do not have to support any status update types. Status updates requested by the user and supported by the server will be pushed to the user by the service until the user departs or is invited to a chat room.</p>
+      <div class="indent">
+<h3>4.3.1.1 <a name="proto-user-join-errors">Error Conditions</a>
+</h3>
+        <p class="caption">Table 1: </p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+<th colspan="" rowspan="">Condition</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+<td align="" colspan="" rowspan="">The user is not authorized to join the queue. A determination of who has permission to join a queue is left to implementations.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;item-not-found/&gt;</td>
+<td align="" colspan="" rowspan="">The address the user requests a chat with does not exist or is not a workgroup. Compliant workgroup service implementations MUST NOT return this error if the requested address is a valid workgroup.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+<td align="" colspan="" rowspan="">The user must submit valid form data (using the Data Forms protocol [4]) before joining the queue. Note that this error is sent when user tries to join, or if the user submits form data that is not filled out correctly.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+<td align="" colspan="" rowspan="">The user has already joined the queue.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+<td align="" colspan="" rowspan="">The workgroup is valid but closed (not accepting new join-queue requests). </td>
+</tr>
+        </table>
+      </div>
+      <div class="indent">
+<h3>4.3.1.2 <a name="proto-user-join-example">Example</a>
+</h3>
+        <p class="" style="">The following protocol flows show an example of a user successfully joining a workgroup queue for support@company.com.</p>
+        <p class="caption">Example 4. Successful Join</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@company.com'
+U:       id='id1'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@company.com'
+S:       to='user@server.com/home'
+S:       id='id1'&gt;
+S:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;queue-notifications/&gt;
+S:   &lt;/join-queue&gt;
+S: &lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The following XML is another example where meta-data is sent by the user to assist the workgroup server in queuing and routing (naturally, the custom namespace that qualified the &lt;crm/&gt; element in this example would be defined outside the context of this specification). The service does not support the requested &lt;queue-notifications&gt; status updates and indicates this by not including it in the response.</p>
+        <p class="caption">Example 5. Join With Meta-Data</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@company.com'
+U:       id='id2'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;crm xmlns=&quot;http://www.company.com/xmpp/workgroup&quot;&gt;
+U:       &lt;customer-id&gt;the24th498onth&lt;/customer-id&gt;
+U:       &lt;referrer&gt;
+U:         http://www.company.com/portal/
+U:       &lt;/referrer&gt;
+U:       &lt;product&gt;Widget 1.0&lt;/product&gt;
+U:     &lt;/crm&gt;
+U:     &lt; queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@company.com'
+S:       to='user@server.com/home'
+S:       id='id2'/&gt;
+        </pre></div>
+        <p class="" style="">Finally an example of a required form submission before a user is allowed to the workgroup queue for support@company.com. The data form in this example is trivial; please see the Data Forms specification [4] for a complete data form example. The example begins as normal, but the workgroup returns a &lt;not-acceptable/&gt; error.</p>
+        <p class="caption">Example 6. Join With Form</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@company.com'
+U:       id='id1'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='error'
+S:     from='support@company.com'
+S:       to='user@server.com/home'
+S:       id='id1'&gt;
+S:   &lt;error code='406' type='modify'&gt;
+S:     &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+S:   &lt;/error&gt;
+S: &lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The &lt;not-acceptable/&gt; error indicates that a data form is required. The user requests the required data form from the workgroup.</p>
+        <p class="caption">Example 7. Join With Form (2)</p>
+<div class="indent"><pre>
+U: &lt;iq type='get'
+U:     from='user@server.com/home'
+U:       to='support@company.com'
+U:       id='id2'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@company.com'
+S:       to='user@server.com/home'
+S:       id='id2'&gt;
+S:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;x xmlns='jabber:iq:data' type='form'&gt;
+S:       &lt;title&gt;Support.com Chat Customer Information&lt;/title&gt;
+S:       &lt;instructions&gt;Welcome to support.com! Please provide us with
+S:         some information about yourself so we can serve you better.
+S:       &lt;/instructions&gt;
+S:       &lt;field type='text-single' label='First Name' var='first' /&gt;
+S:       &lt;field type='text-single' label='Last Name' var='last' /&gt;
+S:       &lt;field type='list-single' label='Contract Type'
+var='contract_type'&gt;
+S:         &lt;value&gt;0&lt;/value&gt;
+S:         &lt;option label='None'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/option&gt;
+S:         &lt;option label='Bronze'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/option&gt;
+S:         &lt;option label='Silver'&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+S:         &lt;option label='Gold'&gt;&lt;value&gt;3&lt;/value&gt;&lt;/option&gt;
+S:       &lt;/field&gt;
+S:     &lt;/x&gt;
+S:   &lt;/join-queue&gt;
+S: &lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">After presenting the form to the user and gathering the form data, the user submits the form data to the workgroup and the workgroup accepts it.</p>
+        <p class="caption">Example 8. Join With Form (3)</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@company.com'
+U:       id='id3'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;x xmlns='jabber:iq:data' type='submit'&gt;
+U:       &lt;field var='first'&gt;&lt;value&gt;John&lt;/value&gt;&lt;/field&gt;
+U:       &lt;field var='last'&gt;&lt;value&gt;Doe&lt;/value&gt;&lt;/field&gt;
+U:       &lt;field var='contract_type'&gt;&lt;value&gt;2&lt;/value&gt;&lt;/field&gt;
+U:     &lt;/x&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@company.com'
+S:       to='user@server.com/home'
+S:       id='id3' /&gt;
+        </pre></div>
+        <p class="" style="">A standard user join is attempted again. The workgroup now has the required form data so it allows the user to join.</p>
+        <p class="caption">Example 9. Join With Form (4)</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@company.com'
+U:       id='id4'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@company.com'
+S:       to='user@server.com/home'
+S:       id='id4'&gt;
+S:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;queue-notifications/&gt;
+S:   &lt;/join-queue&gt;
+S: &lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="proto-user-depart">User Depart Protocol</a>
+</h3>
+      <p class="" style="">Describes the packet exchange allowing users to depart a workgroup service queue, or for a workgroup service to remove a user from the workgroup queue. This protocol MUST be supported by compliant implementations.</p>
+      <p class="" style="">The user no longer wishes to be in the queue and issues a depart queue command.</p>
+      <p class="caption">Example 10. Transactions</p>
+<div class="indent"><pre>
+Requester                     Service
+  |        Depart Request        |
+  |-----------------------------&gt;|
+  |        Depart Response       |
+  |&lt;-----------------------------|
+  |                              |
+      </pre></div>
+      <p class="" style="">The service notifies the user that they have been removed from the workgroup queue.</p>
+      <p class="caption">Example 11. Transactions (2)</p>
+<div class="indent"><pre>
+User                          Service
+  |        Depart Message        |
+  |&lt;-----------------------------|
+  |                              |
+      </pre></div>
+      <p class="caption">Example 12. Depart Request</p>
+<div class="indent"><pre>
+U: &lt;iq from='user-jid' to='service-jid' id='id' type='set'&gt;
+U:   &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">In the typical case, the sender is the user departing the queue. However, it is possible for other users (system administrators for example) to request that another user be removed from the queue. In this case, the jid of the user who is departing is included in the depart request:</p>
+      <p class="caption">Example 13. Depart Request With JID</p>
+<div class="indent"><pre>
+U: &lt;iq from='admin-jid' to='service-jid' id='id' type='set'&gt;
+U:   &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;jid&gt;user-jid&lt;/jid&gt;
+U:   &lt;/depart-queue&gt;
+U: &lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">It is expected that implementations will determine who is allowed to remove other users from the queue based on an implementation specific permissions model. These administrator depart requests may result in &lt;not-authorized/&gt; errors (see error section). A user removing their own queue entry MUST NOT receive unauthorized errors (the workgroup service may not refuse to allow a user to depart the queue).</p>
+      <p class="" style="">The sender of the depart request receives a successful result packet:</p>
+      <p class="caption">Example 14. Depart Request</p>
+<div class="indent"><pre>
+S: &lt;iq from='service-jid' to=user-jid' id='id' type='result'/&gt;
+      </pre></div>
+      <p class="" style="">And the user who is departing receives a depart message (the user may not have been the sender of the request):</p>
+      <p class="caption">Example 15. Depart Message</p>
+<div class="indent"><pre>
+S: &lt;message from='service-jid' to='user-jid'&gt;
+S:    &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+S: &lt;/message&gt;
+      </pre></div>
+      <p class="" style="">The user will not be in the queue after a response is received unless the error response code is &lt;not-authorized/&gt;.</p>
+      <div class="indent">
+<h3>4.3.2.1 <a name="proto-user-depart-errors">Error Conditions</a>
+</h3>
+        <p class="caption">Table 2: </p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+<th colspan="" rowspan="">Condition</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+<td align="" colspan="" rowspan="">The sender did not have permission to remove the user from the queue. This error code MUST NOT be used when a user is removing their queue entry.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;item-not-found/&gt;</td>
+<td align="" colspan="" rowspan="">The user was not in the queue.</td>
+</tr>
+        </table>
+      </div>
+      <div class="indent">
+<h3>4.3.2.2 <a name="proto-user-depart-example">Example</a>
+</h3>
+        <p class="" style="">A user leaves the workgroup queue support@company.com.</p>
+        <p class="caption">Example 16. User Departs</p>
+<div class="indent"><pre>
+U: &lt;iq from='user@server.com/home'
+U:       to='support@company.com'
+U:       id='id1'
+U:     type='set'&gt;
+U:   &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq from='support@company.com'
+S:     to='user@server.com/home'
+S:     id='id1'
+S:     type='result'/&gt;
+S: &lt;message from='support@company.com' to='user@server.com/home'&gt;
+S:    &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+S: &lt;/message&gt;
+        </pre></div>
+        <p class="" style="">An administrator removes a user from the workgroup queue support@company.com. Notice that the depart-queue message is sent to the user that has left the queue.</p>
+        <p class="caption">Example 17. Administrator Removes User</p>
+<div class="indent"><pre>
+U: &lt;iq from='admin@company.com/work'
+U:       to='support@company.com'
+U:       id='id1'
+U:     type='set'&gt;
+U:   &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;jid&gt;user@server.com/home&lt;/jid&gt;
+U:   &lt;/depart-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq from='support@company.com'
+S:     to='admin@company.com/work'
+S:     id='id1'
+S:     type='result'/&gt;
+S: &lt;message from='support@company.com' to='user@server.com/home'&gt;
+S:    &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+S: &lt;/message&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3.3 <a name="proto-user-status">User Status Update Protocol</a>
+</h3>
+      <p class="" style="">Describes the packet exchange for updating users on their queue status.  This protocol MAY be supported by compliant implementations.</p>
+      <p class="caption">Example 18. Transactions</p>
+<div class="indent"><pre>
+User                          Service
+  |      User Status Push        |
+  |&lt;-----------------------------|
+  |      User Status Ack         |
+  |-----------------------------&gt;|
+  |                              |
+  |     User Status Request      |
+  |-----------------------------&gt;|
+  |     User Status Response     |
+  |&lt;-----------------------------|
+  |                              |
+      </pre></div>
+      <p class="" style="">The workgroup service pushes updates to the user as their queue status changes and the user may request their queue status at any time.</p>
+      <div class="indent">
+<h3>4.3.3.1 <a name="proto-user-status-updates">User Status Updates</a>
+</h3>
+        <p class="" style="">User status updates are contained in a &lt;queue-status/&gt; element that updates the user on their queue position and estimated time. The position contained in a &lt;position&gt; sub-element is a non-negative integer indicating the number of queue entries that must be routed to an agent before the user is routed to an agent. A position of 0 (zero) indicates the user is currently being routed. Clients may use this information to display the current queue position to the user.</p>
+        <p class="" style="">The queue time status is contained in a &lt;time/&gt; sub-element that updates the user with the estimated time until they will be routed to an agent. The time is a non-negative integer indicating the estimated number of seconds remaining before being routed. Services should send this update at regular intervals. We recommend every 15 seconds, but the best solution will depend on application dependent factors and the service may decide to send updates at any interval or never (relying on the client to request the information). User clients should assume the estimated time counts down at a rate of one second per second between status updates. Clients may use this information to display the running estimated time to the user.</p>
+        <p class="" style="">A server 'push' occurs asynchronously to client, and the client acknowledges the update:</p>
+        <p class="caption">Example 19. User Status Push</p>
+<div class="indent"><pre>
+S: &lt;iq to='user-jid' from='service-jid' id='id' type='set'&gt;
+S:   &lt;queue-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;position&gt;4&lt;/position&gt;
+S:     &lt;time&gt;60&lt;/time&gt;
+S:   &lt;/queue-status&gt;
+S: &lt;/iq&gt;
+U: &lt;iq to='service-jid' from='user-jid' id='id' type='result'/&gt;
+        </pre></div>
+        <p class="" style="">Alternately the client may poll their position:</p>
+        <p class="caption">Example 20. User Status Poll</p>
+<div class="indent"><pre>
+U: &lt;iq to='service-jid' from='user-jid' id='id' type='get'&gt;
+U:   &lt;queue-status xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq to='user-jid' from='service-jid' id='id' type='result'&gt;
+S:   &lt;queue-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;position&gt;4&lt;/position&gt;
+S:     &lt;time&gt;60&lt;/time&gt;
+S:   &lt;/queue-status&gt;
+S: &lt;/iq&gt;
+        </pre></div>
+      </div>
+      <div class="indent">
+<h3>4.3.3.2 <a name="proto-user-status-errors">Error Conditions</a>
+</h3>
+        <p class="caption">Table 3: </p>
+<table border="1" cellpadding="3" cellspacing="0">
+          <tr class="body">
+<th colspan="" rowspan="">Condition</th>
+<th colspan="" rowspan="">Description</th>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+<td align="" colspan="" rowspan="">Sent by the server to the user in response to a status query only if the user is not a member of the queue.</td>
+</tr>
+          <tr class="body">
+<td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+<td align="" colspan="" rowspan="">Sent only if status updates are not implemented in either the client or server.</td>
+</tr>
+        </table>
+      </div>
+      <div class="indent">
+<h3>4.3.3.3 <a name="proto-user-status-example">Example</a>
+</h3>
+        <p class="" style="">A user receives a position update from the workgroup queue support@company.com.</p>
+        <p class="caption">Example 21. Position Update</p>
+<div class="indent"><pre>
+S: &lt;iq from='support@company.com'
+S:       to='user@server.com/home'
+S:       id='id1'
+S:     type='set'&gt;
+S:   &lt;queue-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;position&gt;4&lt;/position&gt;
+S:     &lt;time&gt;60&lt;/time&gt;
+S:   &lt;/queue-status&gt;
+S: &lt;/iq&gt;
+U: &lt;iq from='user@server.com/home'
+U:       to='support@company.com'
+U:       id='id1'
+U:     type='result'/&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.3.4 <a name="proto-user-invite">User Invite Protocol</a>
+</h3>
+      <p class="" style="">This section describes the packet exchange for inviting a queued user to a chat room for conversation with an agent. This protocol MUST be supported by compliant implementations.</p>
+      <p class="caption">Example 22. Transactions</p>
+<div class="indent"><pre>
+User                          Service
+  |          User Invite         |
+  |&lt;-----------------------------|
+  |                              |
+      </pre></div>
+      <p class="" style="">The server sends a standard JEP-0045 groupchat invitation to the user to begin their conversation with an agent.</p>
+      <p class="" style="">User invitations use JEP-0045 standard multi-user chat invitations. The invitation indicates that the user is no longer in the workgroup queue. The user MUST NOT receive any more user queue status updates once they receive an invitation.</p>
+      <p class="" style="">In order to match invitations to offers, all invitations should carry meta data in the workgroup namespace in the 'workgroup' element with a 'user' and 'agent' attribute set to the address of each party in the invite. The typical meta-data fragment would appear as:</p>
+      <p class="caption">Example 23. Invitation Meta-Data</p>
+<div class="indent"><pre>
+&lt;workgroup user='user-jid' agent='agent-jid'/&gt;
+      </pre></div>
+      <div class="indent">
+<h3>4.3.4.1 <a name="proto-user-invite-errors">Error Conditions</a>
+</h3>
+        <p class="" style="">There are no valid error conditions for user invitations.</p>
+      </div>
+      <div class="indent">
+<h3>4.3.4.2 <a name="proto-user-invite-example">Example</a>
+</h3>
+        <p class="" style="">An invitation from the support@server.com workgroup:</p>
+        <p class="caption">Example 24. An Invitation</p>
+<div class="indent"><pre>
+&lt;message from='support@company.com' to='user@server.com/home&gt;
+  &lt;body&gt;You have been invited to chat with a support@company.com
+agent.&lt;/body&gt;
+  &lt;x jid='roomname@chatserver.company.com' xmlns='jabber:x:conference'/&gt;
+  &lt;workgroup xmlns='http://jabber.org/protocol/workgroup'
+             user='user@server.com/home'
+             agent='agent-alice@company.com/work'/&gt;
+&lt;/message&gt;
+        </pre></div>
+      </div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="proto-agent-states">Agent States</a>
+</h3>
+    <p class="" style="">Agents join a workgroup to indicate they are capable of handling conversations with users. Agent membership in the workgroup is expected to be a long term, persistent relationship similar to roster membership. For example, a customer support agent may join the support@company.com workgroup when they begin working at company.com and will only depart when they leave that position.  The wide variety of relationships, processes and permissions associated with joining and leaving workgroups lies outside the scope of this JEP.</p>
+    <p class="" style="">Once an agent has joined a workgroup they will receive workgroup status updates to inform them of the status of other members of the workgroup.  Agents are responsible for updating the workgroup service with their presence so the service can intelligently route chat requests to the 'best' agent. Workgroup agent presence uses standard XMPP presence packets with optional meta-data to help routing of chat requests to agents. Some meta- data will be standard and defined later in this JEP. It is expected that other deployment specific meta-data will also be needed to make routing decisions.</p>
+    <p class="" style="">The general agent workgroup state diagram is shown below:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+            +-----------+
+      +----&gt;| Workgroup |&lt;-----+
+      |     +-----------+      |
+      |        |     |Agent    |
+      | Status |     |Presence |
+      +--------+     +---------+
+    </pre></div>
+    <p class="" style="">Once an agent has joined a workgroup and is available, the agent will receive offers to chat with users by the workgroup service. Chat offers will be made to the agent and the agent has the opportunity to accept or reject each offer. The workgroup service may also revoke an offer. For example, a service may revoke chat offers if the offer is not responded to within a certain period of time to ensure fast responses to user chat requests.</p>
+    <p class="" style="">Once an offer has been accepted, the agent must wait for a standard groupchat invitation from the workgroup service. The workgroup service may revoke the offer at this stage of the protocol as well. This enables workgroup services to send offers to several agents in parallel, and choose the 'best' agent that accepts. A diagram showing the agent workgroup sub- states and transitions is shown below:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+              +-------+
+              | Start |&lt;---------+
+              +-------+          |
+                  |              |
+                  | Offer        |
+                  v              |
+            +---------------+    |
+            | Offer Pending |    |
+            +---------------+    |
+                 |  |  | Revoke  |
+                 |  |  +--------&gt;|
+                 |  | Reject     |
+          Accept |  +-----------&gt;|
+                 v               |
+            +--------------+     |
+            | Chat Pending |     |
+            +--------------+     |
+                 |   | Revoke    |
+          Invite |   +-----------+
+                 V
+              +-----------+
+              | Chat room |
+              +-----------+
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="proto-agent">Agent Packet Exchanges</a>
+</h3>
+    <p class="" style="">Packets are exchanged between the agent and service to trigger state changes in the agent client. These packet exchanges are described next.</p>
+    <div class="indent">
+<h3>4.5.1 <a name="proto-agent-presence">Agent Presence Protocol</a>
+</h3>
+      <p class="" style="">Describes the packet exchange allowing agents to update a workgroup with their current presence. This protocol MUST be supported by compliant implementations.</p>
+      <p class="caption">Example 25. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |       Presence Update        |
+  |-----------------------------&gt;|
+  |                              |
+      </pre></div>
+      <p class="" style="">The agent must inform the workgroup of its presence by sending it a presence update packet. Agent presence updates use standard XMPP presence with optional meta-data. However, there must always be an agent-status workgroup sub-element in the presence packet to indicate that the presence update relates to agent workgroup presence. Agent workgroup presence is designed to allow a separation between the agent's normal XMPP presence (server-managed via rosters) and their presence with the workgroup.</p>
+      <p class="caption">Example 26. Presence Update</p>
+<div class="indent"><pre>
+U: &lt;presence from='agent-jid' to='service-jid' id='id'&gt;
+U:   &lt;agent-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;max-chats&gt;count&lt;/max-chats&gt;
+U:     &lt;current-chats&gt;count&lt;/current-chats&gt;
+U:   &lt;/agent-status&gt;
+U: &lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">Agent presence updates use standard XMPP presence packets and should contain the normal sub elements as needed (e.g. &lt;show/&gt;, &lt;status/&gt;, etc) and can be of type='unavailable' to indicate the agent is not available for workgroup routing or for receiving workgroup agent updates. The standard XMPP show states have specific meaning within the context of the workgroup protocol:</p>
+      <ul>
+        <li>chat - Indicates the agent is available to chat (is idle and ready to handle more conversations).</li>
+        <li>away - The agent is busy (possibly with other chats). The agent may still be able to handle other chats but an offer rejection is likely.</li>
+        <li>xa - The agent is physically away from their terminal and should not have a chat routed to them.</li>
+        <li>dnd - The agent is busy and should not be disturbed. However, special case, or extreme urgency chats may still be offered to the agent although offer rejection or offer timeouts are highly likely.</li>
+      </ul>
+      <p class="" style="">Agents may also wish to embed meta-data to help the workgroup service route chat requests. The two optional standard presence updates in the workgroup namespace are:</p>
+      <ul>
+        <li><p class="" style="">&lt;max-chats&gt; - The maximum number of chats the agent can handle. If a presence is sent to the workgroup that does not contain the max-chats value, the &quot;default setting&quot; will be assumed. The value of the default setting for an agent is up to an implementation.   [<a href="#nt-id2603775">5</a>]</p></li>
+        <li><p class="" style="">&lt;current-chats&gt; - The number of chats the agent is currently handling. The number of chats the agent is handling may include chats outside of the workgroup (e.g. the agent is working in more than one workgroup), normal IM/chat conversations, and includes possible 'team' chats where multiple agents are chatting with a single user. Since it is impossible for the server to track all these interactions reliably, the agent must properly report the number of current chats the agent is engaged in. If a presence is sent to the workgroup that does not contain the current-chats value, the current chat value is assumed to be zero.  [<a href="#nt-id2603824">6</a>]</p></li>
+      </ul>
+      <div class="indent">
+<h3>4.5.1.1 <a name="proto-agent-presence-errors">Error Conditions</a>
+</h3>
+        <p class="" style="">There are no valid error conditions for presence updates.</p>
+      </div>
+      <div class="indent">
+<h3>4.5.1.2 <a name="proto-agent-presence-example">Example</a>
+</h3>
+        <p class="" style="">An agent becomes available to the workgroup support@company.com.</p>
+        <p class="caption">Example 27. Agent Becomes Available</p>
+<div class="indent"><pre>
+U: &lt;presence from='agent-alice@company.com/work'
+U:             to='support@company.com'
+U:             id='id1'&gt;
+U:   &lt;show&gt;chat&lt;/show&gt;
+U:   &lt;agent-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;max-chats&gt;3&lt;/max-chats&gt;
+U:     &lt;current-chats&gt;0&lt;/current-chats&gt;
+U:   &lt;/agent-status&gt;
+U: &lt;/presence&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.5.2 <a name="proto-agent-status">Agent Status Update Protocol</a>
+</h3>
+      <p class="" style="">This section describes the packet exchange used to update agents on the status of the workgroup. This protocol MAY be supported by compliant implementations.</p>
+      <p class="caption">Example 28. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |         Agent Status         |
+  |&lt;-----------------------------|
+  |                              |
+      </pre></div>
+      <p class="" style="">The workgroup service pushes updates to the agent as the workgroup and queue status changes.</p>
+      <p class="" style="">There are four standard status types currently defined. The first is , which updates the agent on the detailed status of other agents in the workgroup. All fields except for the embedded &lt;presence&gt; are optional:</p>
+      <p class="caption">Example 29. Agent Status Type</p>
+<div class="indent"><pre>
+S: &lt;presence to='agent-jid' from='service-jid' id='id'&gt;
+S:   &lt;agent-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;agent jid='agent-jid'&gt;
+S:       &lt;presence&gt;standard XMPP presence attributes&lt;/presence&gt;
+S:       &lt;current-chats&gt;count&lt;/current-chats&gt;
+S:       &lt;max-chats&gt;max&lt;/max-chats&gt;
+S:     &lt;/agent&gt;
+S:   &lt;/agent-status&gt;
+S: &lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">An update may contain one or more agent entries detailing the current status of other agents in the workgroup. The defined sub-elements of &lt;agent&gt; are:</p>
+      <ul>
+        <li><p class="" style="">&lt;presence&gt; - Required. Standard XMPP presence packet indicating the current presence of the agent reported to the workgroup.</p></li>
+        <li><p class="" style="">&lt;current-chats&gt; - The number of conversations currently being handled by the agent.</p></li>
+        <li><p class="" style="">&lt;max-chats&gt; - The maximum number of simultaneous conversations the agent can handle.</p></li>
+      </ul>
+      <p class="" style="">The second defined agent status type is , which updates the agent with a summary of the status of agents in the workgroup. All fields are optional:</p>
+      <p class="caption">Example 30. Notify-Agent Status Type</p>
+<div class="indent"><pre>
+S: &lt;presence to='agent-jid' from='service-jid' id='id'&gt;
+S:   &lt;notify-agents xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;available&gt;count&lt;/available&gt;
+S:     &lt;current-chats&gt;count&lt;/current-chats&gt;
+S:     &lt;max-chats&gt;max&lt;/max-chats&gt;
+S:   &lt;/notify-agents&gt;
+S: &lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">The defined sub-elements of &lt;notify-agents&gt; are:</p>
+      <ul>
+        <li><p class="" style="">&lt;available&gt; - The total number of agents available in the workgroup.</p></li>
+        <li><p class="" style="">&lt;current-chats&gt; - The current total number of chats being handled by agents in the workgroup.</p></li>
+        <li><p class="" style="">&lt;max-chats&gt; - The maximum number of simultaneous conversations that can be handled by agents in the workgroup.</p></li>
+      </ul>
+      <p class="" style="">The third defined agent status type is , which updates the agent with details on the status of the workgroup queue. All fields are optional:</p>
+      <p class="caption">Example 31. Notify-Queue-Details Status Type</p>
+<div class="indent"><pre>
+S: &lt;presence to='agent-jid' from='service-jid' id='id'&gt;
+S:   &lt;notify-queue-details xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;user jid='user-jid'&gt;
+S:       &lt;position&gt;pos&lt;/position&gt;
+S:       &lt;time&gt;estimated-time&lt;/time&gt;
+S:       &lt;join-time&gt;YYYYMMDDTHH:mm:SS&lt;/join-time&gt;
+S:     &lt;/user&gt;
+S:   &lt;/notify-queue-details&gt;
+S: &lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">An update may contain one or more &lt;user&gt; entries (one per user in the queue whose status has changed). The defined sub-elements of &lt;user&gt; are:</p>
+      <ul>
+        <li><p class="" style="">&lt;position&gt; - The user's position in the queue.</p></li>
+        <li><p class="" style="">&lt;time&gt; - Estimated time in seconds remaining before the user is routed to an agent.</p></li>
+        <li><p class="" style="">&lt;join-time&gt; - The date and time the user joined the queue in UTC.</p></li>
+      </ul>
+      <p class="" style="">The fourth defined user status type is , which updates the agent with a summary of the status of the workgroup queue. All fields are optional:</p>
+      <p class="caption">Example 32. Notify-Queue Status Type</p>
+<div class="indent"><pre>
+S: &lt;presence to='agent-jid' from='service-jid' id='id'&gt;
+S:   &lt;notify-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;count&gt;count&lt;/count&gt;
+S:     &lt;oldest&gt;YYYYMMDDTHH:mm:ss&lt;/oldest&gt;
+S:     &lt;time&gt;average-time-to-chat&lt;/time&gt;
+S:     &lt;status&gt;open&lt;/status&gt;
+S:   &lt;/notify-queue&gt;
+S: &lt;/presence&gt;
+      </pre></div>
+      <p class="" style="">The defined sub-elements of &lt;lnotify-queue&gt; are:</p>
+      <ul>
+        <li><p class="" style="">&lt;count&gt; - The total number of users in the workgroup queue.</p></li>
+        <li><p class="" style="">&lt;oldest&gt; - The date and time in UTC the oldest member of the queue joined.</p></li>
+        <li><p class="" style="">&lt;time&gt; - The average time in seconds that a user is in the queue before they are routed to an agent for handling.</p></li>
+        <li>
+          <p class="" style="">&lt;status&gt; - The status of the queue. Queues may be active (requests are being routed and handled by agents) but not accepting new requests for handling. Typical reasons for this state include the queue is shutting down but finishing processing users in the queue, or because the queue has too many requests and should not accept more request until the existing requests are handled. The status field MUST contain one of the following values:</p>
+          <ul>
+            <li>open - the queue is active and accepting new chat requests</li>
+            <li>active - the queue is active but NOT accepting new chat requests</li>
+            <li>closed - the queue is NOT active and NOT accepting new chat requests</li>
+          </ul>
+        </li>
+      </ul>
+      <div class="indent">
+<h3>4.5.2.1 <a name="proto-agent-status-errors">Error Conditions</a>
+</h3>
+        <p class="" style="">There are no valid error conditions for agent status updates.</p>
+      </div>
+      <div class="indent">
+<h3>4.5.2.2 <a name="proto-agent-status-example">Example</a>
+</h3>
+        <p class="" style="">An agent receives an update from workgroup support@company.com.</p>
+        <p class="caption">Example 33. Agent Receives Update</p>
+<div class="indent"><pre>
+S: &lt;presence from='support@company.com'
+S:             to='agent-alice@company.com/work'
+S:             id='id1'&gt;
+S:   &lt;agent-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:       &lt;available&gt;7&lt;/available&gt;
+S:       &lt;current-chats&gt;12&lt;/current-chats&gt;
+S:       &lt;max-chats&gt;21&lt;/max-chats&gt;
+S:   &lt;/agent-status&gt;
+S: &lt;/presence&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.5.3 <a name="proto-agent-offer">Agent Offer Protocol</a>
+</h3>
+      <p class="" style="">This section describes the packet exchange involved in a service offering a chat to an agent. This protocol MUST be supported by compliant implementations.</p>
+      <p class="caption">Example 34. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |         Offer Request        |
+  |&lt;-----------------------------|
+  |         Offer Response       |
+  |-----------------------------&gt;|
+  |                              |
+      </pre></div>
+      <p class="" style="">The agent is offered a chat with a user. A successful offer results in the agent owning the offer, but does not mean it has accepted the chat.  Accepting an offer is handled by the Agent Accept protocol. The separation between offer and acceptance is made so that agents may receive offers while engaged in other activities (busy with other chats) and accept them at a later time.</p>
+      <p class="caption">Example 35. Offer Request</p>
+<div class="indent"><pre>
+S: &lt;iq from='service-jid' to='agent-jid' id='id' type='set'&gt;
+S:   &lt;offer xmlns='http://jabber.org/protocol/workgroup' jid='user-jid'&gt;
+S:       &lt;timeout&gt;seconds&lt;/timeout&gt;
+S:   &lt;/offer&gt;
+S: &lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">Application specific meta-data will normally be added as a sub-element of &lt;offer&gt; to help agents decide whether to accept or not. An optional &lt;timeout&gt; sub-element may be included indicating the amount of time the offer stands before the service will revoke it.</p>
+      <p class="caption">Example 36. Offer Response</p>
+<div class="indent"><pre>
+A: &lt;iq from='agent-jid' to='service-jid' id='id' type='result'/&gt;
+      </pre></div>
+      <p class="" style="">The agent may respond only with a successful result.</p>
+      <div class="indent">
+<h3>4.5.3.1 <a name="proto-agent-offer-errors">Error Conditions</a>
+</h3>
+        <p class="" style="">There are no valid error results for an offer response.</p>
+      </div>
+      <div class="indent">
+<h3>4.5.3.2 <a name="proto-agent-offer-example">Example</a>
+</h3>
+        <p class="" style="">An agent is offered a chat with a user. The offer will be revoked in 30 seconds.</p>
+        <p class="caption">Example 37. Agent is Offered a Chat</p>
+<div class="indent"><pre>
+S: &lt;iq to='agent-alice@company.com/work'
+S:     from='support@company.com'
+S:     id='id1'
+S:     type='set'&gt;
+S:     &lt;offer xmlns='http://jabber.org/protocol/workgroup' jid='user@server.com/home'&gt;
+S:       &lt;timeout&gt;30&lt;/timeout&gt;
+S:     &lt;/offer&gt;
+S: &lt;/iq&gt;
+A: &lt;iq to='support@company.com'
+A:     from='agent-alice@company.com/work'
+A:     id='id1'
+A:     type='result'/&gt;
+        </pre></div>
+        <p class="" style="">The following is a more typical offer containing meta-data about the user.  The offer will be revoked in 30 seconds.</p>
+        <p class="caption">Example 38. Offer Including Meta-Data</p>
+<div class="indent"><pre>
+S: &lt;iq to='agent-alice@company.com/work'
+S:     from='support@company.com'
+S:     id='id1'
+S:     type='set'&gt;
+S:     &lt;offer xmlns='http://jabber.org/protocol/workgroup' jid='user@server.com/home'&gt;
+S:       &lt;timeout&gt;30&lt;/timeout&gt;
+S:       &lt;crm xmlns=&quot;http://www.company.com/xmpp/workgroup'&gt;
+S:         &lt;user-id&gt;423498ae84f&lt;/user-id&gt;
+S:         &lt;product&gt;Widget 1.0&lt;/product&gt;
+S:       &lt;/crm&gt;
+S:     &lt;/offer&gt;
+S: &lt;/iq&gt;
+A: &lt;iq to='support@company.com'
+A:     from='agent-alice@company.com/work'
+A:     id='id1'
+A:     type='result'/&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.5.4 <a name="proto-agent-acceptreject">Agent Offer Accept/Reject Protocol</a>
+</h3>
+      <p class="" style="">This section describes the packet exchange involved in an agent rejecting an offering a chat to a user. This protocol MUST be supported by compliant implementations.</p>
+      <p class="caption">Example 39. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |  Offer Accept/Reject Request |
+  |-----------------------------&gt;|
+  | Offer Accept/Reject Response |
+  |&lt;-----------------------------|
+  |                              |
+      </pre></div>
+      <p class="" style="">The agent accepts or rejects an offer to chat with a user.</p>
+      <p class="caption">Example 40. Offer Accept Request</p>
+<div class="indent"><pre>
+A: &lt;iq to='service-jid' from='agent-jid' id='id' type='set'&gt;
+A:   &lt;offer-accept jid='user-jid' xmlns='http://jabber.org/protocol/workgroup' /&gt;
+A: &lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 41. Offer Reject Request</p>
+<div class="indent"><pre>
+A: &lt;iq to='service-jid' from='agent-jid' id='id' type='set'&gt;
+A:   &lt;offer-reject jid='user-jid' xmlns='http://jabber.org/protocol/workgroup'/&gt;
+A: &lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 42. Offer Response</p>
+<div class="indent"><pre>
+S: &lt;iq to='agent-jid' from='service-jid' id='id' type='result'/&gt;
+      </pre></div>
+      <p class="" style="">The service may respond only with a successful result.</p>
+      <div class="indent">
+<h3>4.5.4.1 <a name="proto-agent-acceptreject-errors">Error Conditions</a>
+</h3>
+        <p class="" style="">There are no valid error results for an accept/reject offer response.</p>
+      </div>
+      <div class="indent">
+<h3>4.5.4.2 <a name="proto-agent-acceptreject-example">Example</a>
+</h3>
+        <p class="caption">Example 43. Agent Accepts Chat</p>
+<div class="indent"><pre>
+A: &lt;iq from='agent-alice@company.com/work'
+A:       to='support@company.com'
+A:       id='id1'
+A:     type='set'&gt;
+A:   &lt;offer-accept jid='user@server.com/home' xmlns='http://jabber.org/protocol/workgroup'/&gt;
+A: &lt;/iq&gt;
+S: &lt;iq from='support@company.com'
+S:     to='agent-alice@company.com/work'
+S:     id='id1'
+S:     type='result'/&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.5.5 <a name="proto-agent-revoke">Agent Offer Revoke Protocol</a>
+</h3>
+      <p class="" style="">This section describes the packet exchange involved in a service revoking an offer to an agent to chat to a user. This protocol MUST be supported by compliant implementations.</p>
+      <p class="caption">Example 44. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |     Offer Revoke Request     |
+  |&lt;-----------------------------|
+  |    Offer Revoke Response     |
+  |-----------------------------&gt;|
+  |                              |
+      </pre></div>
+      <p class="" style="">The service revokes an earlier offer to chat to a user. Offer revocations typically occur when the original offer times out, or a better agent was found to handle the chat. Note that offer revocations may occur anytime after an offer has been made, and before an invitation is sent (see agent state diagram). In other words, even though an agent has accepted an offer to chat, the agent may still receive an offer revocation (e.g. a better agent was found to handle the chat).</p>
+      <p class="caption">Example 45. Offer Revoke Request</p>
+<div class="indent"><pre>
+S: &lt;iq from='service-jid' to='agent-jid' id='id' type='set'&gt;
+S:     &lt;offer-revoke jid='user-jid' xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:       &lt;reason&gt;
+S:         [reason]
+S:       &lt;/reason&gt;
+S:     &lt;/offer-revoke&gt;
+S: &lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The reason element may optionally contain free form text explaining the reason the offer was revoked.</p>
+      <p class="caption">Example 46. Offer Response</p>
+<div class="indent"><pre>
+A: &lt;iq from='agent-jid' to='service-jid' id='id' type='result'/&gt;
+      </pre></div>
+      <p class="" style="">The agent may respond only with a successful result.</p>
+      <div class="indent">
+<h3>4.5.5.1 <a name="proto-agent-revoke-errors">Error Conditions</a>
+</h3>
+        <p class="" style="">There are no valid error results for an offer response.</p>
+      </div>
+      <div class="indent">
+<h3>4.5.5.2 <a name="proto-agent-revoke-example">Example</a>
+</h3>
+        <p class="caption">Example 47. Offer Revoked Due to Timeout</p>
+<div class="indent"><pre>
+S: &lt;iq   to='agent-alice@company.com/work'
+S:     from='support@company.com'
+S:       id='id1'
+S:     type='set'&gt;
+S:     &lt;offer-revoke xmlns='http://jabber.org/protocol/workgroup' jid='user@server.com/home'&gt;
+S:         &lt;reason&gt;
+S:           Offer timed out
+S:         &lt;/reason&gt;
+S:     &lt;/offer-revoke&gt;
+S: &lt;/iq&gt;
+A: &lt;iq   to='support@company.com'
+A:     from='agent-alice@company.com/work'
+A:       id='id1'
+A:     type='result'/&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>4.5.6 <a name="proto-agent-invite">Agent Invite Protocol</a>
+</h3>
+      <p class="" style="">This section describes the packet exchange inviting an agent to a chat room for conversation with a user. This protocol MUST be supported by compliant implementations.</p>
+      <p class="caption">Example 48. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |         Agent Invite         |
+  |&lt;-----------------------------|
+  |                              |
+      </pre></div>
+      <p class="" style="">The server sends a standard JEP-0045 groupchat invitation to the agent to begin their conversation with a user. The invitation follows the same format as shown in the User Invite Protocol.</p>
+      <p class="" style="">Agent invitations use JEP-0045 standard multi-user chat invitations. The agent will continue to receive agent status updates from the workgroup.</p>
+      <div class="indent">
+<h3>4.5.6.1 <a name="proto-agent-invite-errors">Error Conditions</a>
+</h3>
+        <p class="" style="">There are no valid error conditions for agent invitations.</p>
+      </div>
+      <div class="indent">
+<h3>4.5.6.2 <a name="proto-agent-invite-example">Example</a>
+</h3>
+        <p class="" style="">See <span style="font-weight: bold">JEP-0045: Multi-User Chat</span> for examples.</p>
+      </div>
+    </div>
+  </div>
+<h2>5.
+       <a name="example">Complete Protocol Example</a>
+</h2>
+  <p class="" style="">The following is a complete example showing the typical process flow and protocol packet exchanges between user, service, and agent.</p>
+  <p class="" style="">To follow.</p>
+<h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">If workgroup goes offline, all queued users SHOULD be notified of workgroup cancellation.</p>
+  <p class="" style="">An implementation MAY support for anonymous login by users, which makes it easier to deploy such a system on a website.</p>
+  <p class="" style="">A user MAY pass in arbitrary meta-data during the initial chat request, which allows for more complex routing and queue processing decisions by the server. Such meta-data SHOULD be included as xxx.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2605153">7</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <h2>1.
+       <a name="registrar-ns">Protocol Namespaces</a>
+</h2>
+    <p class="" style="">Upon advancement of this JEP to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2605100">8</a>] shall add 'http://jabber.org/protocol/workgroup' to its registry of protocol namespaces.</p>
+  
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596124">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596230">2</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596242">3</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596293">4</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603775">5</a>. The max-chats value sent from agent to workgroup service is a 'hint' or recommended value. The workgroup service is not obliged to accept this value. The actual max-chats value for the agent will be sent to the agent via the next Agent Status Update. This allows administrators to constrain agent behavior in order to enforce company policy, quality assurance, etc.</p>
+<p>
+<a name="nt-id2603824">6</a>. Presence values are not &quot;sticky&quot;. For example, if a presence show value is 'dnd' and another presence is sent without a show value, the entity's presence show is the default show, and NOT 'dnd'. The same non- sticky behavior applies to workgroup presence values such as max-chats and current-chats.</p>
+<p>
+<a name="nt-id2605153">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2605100">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-09-03)</h4>
+<div class="indent">Initial version. (is/mt)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0142-0.2.html
+++ b/content/xep-0142-0.2.html
@@ -1,0 +1,1643 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0142: Workgroups</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Workgroups">
+<meta name="DC.Creator" content="Matt Tucker">
+<meta name="DC.Creator" content="Iain Shigeoka">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension that enables a user to communicate
+            with a representative of an organization, department, or workgroup
+            (e.g., the support group).">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-02-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0142">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0142: Workgroups</h1>
+<p>This JEP defines an XMPP protocol extension that enables a user to communicate
+            with a representative of an organization, department, or workgroup
+            (e.g., the support group).</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0142<br>
+            Version: 0.2<br>
+            Last Updated: 2005-02-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: Not yet assigned<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Workgroups%20(JEP-0142)">http://wiki.jabber.org/index.php/Workgroups (JEP-0142)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Matt Tucker</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:matt@jivesoftware.com">matt@jivesoftware.com</a><br>
+        JID: 
+        <a href="xmpp:jivematt@jabber.org">jivematt@jabber.org</a></p>
+<h3>Iain Shigeoka</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:iain.shigeoka@messaginglogic.com">iain.shigeoka@messaginglogic.com</a><br>
+        JID: 
+        <a href="xmpp:smirk@jabber.org">smirk@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dl>
+<dt>1.1.  <a href="#intro-over">Overview</a>
+</dt>
+<dt>1.2.  <a href="#intro-motive">Motivation</a>
+</dt>
+<dt>1.3.  <a href="#intro-concepts">Concepts</a>
+</dt>
+<dt>1.4.  <a href="#intro-prereq">Prerequisites</a>
+</dt>
+</dl>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#roleresp">Roles and Responsibilities</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#roles">Roles</a>
+</dt>
+<dt>3.2.  <a href="#responsibilities">Responsibilities</a>
+</dt>
+</dl>
+<dt>4.  <a href="#user">User Protocol</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#proto-states">User States</a>
+</dt>
+<dt>4.2.  <a href="#proto-user">User Packet Exchanges</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#proto-user-join">User Join Protocol</a>
+</dt>
+<dl>
+<dt>4.2.1.1.  <a href="#proto-user-join-errors">Error Conditions</a>
+</dt>
+<dt>4.2.1.2.  <a href="#proto-user-join-example">Example</a>
+</dt>
+</dl>
+<dt>4.2.2.  <a href="#proto-user-depart">User Depart Protocol</a>
+</dt>
+<dl>
+<dt>4.2.2.1.  <a href="#proto-user-depart-errors">Error Conditions</a>
+</dt>
+<dt>4.2.2.2.  <a href="#proto-user-depart-example">Example</a>
+</dt>
+</dl>
+<dt>4.2.3.  <a href="#proto-user-status">User Status Update Protocol</a>
+</dt>
+<dl>
+<dt>4.2.3.1.  <a href="#proto-user-status-updates">User Status Updates</a>
+</dt>
+<dt>4.2.3.2.  <a href="#proto-user-status-errors">Error Conditions</a>
+</dt>
+</dl>
+<dt>4.2.4.  <a href="#proto-user-invite">User Invite Protocol</a>
+</dt>
+<dl>
+<dt>4.2.4.1.  <a href="#proto-user-invite-errors">Error Conditions</a>
+</dt>
+<dt>4.2.4.2.  <a href="#proto-user-invite-example">Example</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>5.  <a href="#agent">Agent Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#proto-agent-states">Agent States</a>
+</dt>
+<dt>5.2.  <a href="#proto-agent">Agent Packet Exchanges</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#proto-agent-presence">Agent Presence Protocol</a>
+</dt>
+<dl>
+<dt>5.2.1.1.  <a href="#proto-agent-presence-errors">Error Conditions</a>
+</dt>
+<dt>5.2.1.2.  <a href="#proto-agent-presence-example">Example</a>
+</dt>
+</dl>
+<dt>5.2.2.  <a href="#proto-workgroup-status">Workgroup Status Update Protocol</a>
+</dt>
+<dl>
+<dt>5.2.2.1.  <a href="#proto-workgroup-status-errors">Error Conditions</a>
+</dt>
+<dt>5.2.2.2.  <a href="#proto-workgroup-status-example">Example</a>
+</dt>
+</dl>
+<dt>5.2.3.  <a href="#proto-queue-status">Queue Status Update Protocol</a>
+</dt>
+<dl>
+<dt>5.2.3.1.  <a href="#proto-queue-status-errors">Error Conditions</a>
+</dt>
+<dt>5.2.3.2.  <a href="#proto-queue-status-example">Example</a>
+</dt>
+</dl>
+<dt>5.2.4.  <a href="#proto-agent-status">Agent Status Update Protocol</a>
+</dt>
+<dl><dt>5.2.4.1.  <a href="#proto-agent-status-errors">Error Conditions</a>
+</dt></dl>
+<dt>5.2.5.  <a href="#proto-agent-offer">Agent Offer Protocol</a>
+</dt>
+<dl>
+<dt>5.2.5.1.  <a href="#proto-agent-offer-errors">Error Conditions</a>
+</dt>
+<dt>5.2.5.2.  <a href="#proto-agent-offer-example">Example</a>
+</dt>
+</dl>
+<dt>5.2.6.  <a href="#proto-agent-acceptreject">Agent Offer Accept/Reject Protocol</a>
+</dt>
+<dl>
+<dt>5.2.6.1.  <a href="#proto-agent-acceptreject-errors">Error Conditions</a>
+</dt>
+<dt>5.2.6.2.  <a href="#proto-agent-acceptreject-example">Example</a>
+</dt>
+</dl>
+<dt>5.2.7.  <a href="#proto-agent-revoke">Agent Offer Revoke Protocol</a>
+</dt>
+<dl>
+<dt>5.2.7.1.  <a href="#proto-agent-revoke-errors">Error Conditions</a>
+</dt>
+<dt>5.2.7.2.  <a href="#proto-agent-revoke-example">Example</a>
+</dt>
+</dl>
+<dt>5.2.8.  <a href="#proto-agent-invite">Agent Invite Protocol</a>
+</dt>
+<dl>
+<dt>5.2.8.1.  <a href="#proto-user-invite-errors">Error Conditions</a>
+</dt>
+<dt>5.2.8.2.  <a href="#proto-user-invite-example">Example</a>
+</dt>
+</dl>
+</dl>
+</dl>
+<dt>6.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-discotype">Service Discovery Category/Type</a>
+</dt>
+<dt>9.3.  <a href="#registrar-discofeatures">Service Discovery Features</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>11.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+        <div class="indent">
+<h3>1.1 <a name="intro-over">Overview</a>
+</h3>
+            <p class="" style="">This JEP documents a protocol that provides a service allowing users to contact a
+            representative of an organization or workgroup without knowing the address of a particular
+            member of that organization or workgroup. This functionality is similar to an 'email alias'
+            with the addition of queuing pending communication requests and quality of service negotiation
+            to accommodate the real-time nature of IM/chat. Although this protocol is generic enough to
+            handle many use cases, specific features have been added that make it particularly suitable
+            for customer support environments.</p>
+        </div>
+        <div class="indent">
+<h3>1.2 <a name="intro-motive">Motivation</a>
+</h3>
+            <p class="" style="">This protocol addresses the need of starting a private XMPP conversation with a qualified
+            member of a workgroup. In a standard XMPP exchange of messages, users either connect directly
+            to another user for a one on one conversation, or connect to a chat room for a conversation
+            between many people. The current protocols do not allow users to initiate a private conversation
+            with any person playing a particular role in an organization or workgroup.</p>
+            <p class="" style="">For example, a customer has a question and needs to talk to a support representative.
+            The conversation is private and therefore cannot be conducted in a well-known chat room.
+            Using the workgroup protocol, the user requests a chat with support@workgroup.company.com.
+            The chat request is put into a queue and the server routes the chat request to individual
+            support representatives in the support@workgroup.company.com workgroup. The support
+            representative can accept or reject the chat request. Once the request is accepted, the
+            conversation takes place through standard XMPP messaging protocols.</p>
+        </div>
+        <div class="indent">
+<h3>1.3 <a name="intro-concepts">Concepts</a>
+</h3>
+            <p class="" style="">The namespace governing this protocol is "http://jabber.org/protocol/workgroup". This
+            namespace relies on the &lt;iq/&gt; element for execution, and uses the &lt;presence/&gt; element for
+            announcing status updates.</p>
+            <p class="" style="">This protocol depends on Service Discovery for reporting and announcing available
+            workgroup services. However, support for service discovery is entirely optional and
+            workgroup services may be made known through other means (e.g. web pages, word of mouth,
+            etc).</p>
+            <p class="" style="">The end result of a workgroup interaction is to negotiate and route a user and
+            workgroup member (a.k.a. agent) to an appropriate chat room for a chat conversation
+            using the multi-user chat (MUC) protocol. However, multi-user chat essentially 'takes
+            over' when the workgroup protocol successfully completes so there is no overlap between the
+            two protocols. It is recommended that groupchat implementations support basic groupchat
+            (a.k.a. Groupchat 1.0) for maximum client compatibility.</p>
+        </div>
+        <div class="indent">
+<h3>1.4 <a name="intro-prereq">Prerequisites</a>
+</h3>
+            <p class="" style="">There are no requirements for supporting the workgroup protocol beyond <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250969">1</a>]
+            and <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250869">2</a>]. Support for <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250891">3</a>] is optional if users need to submit additional
+            data before joining (see User Join section of this document).</p>
+        </div>
+    <h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+        <p class="" style="">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD",
+        "RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in
+         <span class="ref" style="">RFC 2119</span>  [<a href="#nt-id2251054">4</a>].</p>
+    <h2>3.
+       <a name="roleresp">Roles and Responsibilities</a>
+</h2>
+        <p class="" style="">This protocol has clearly defined roles and responsibilities for its participants.</p>
+        <div class="indent">
+<h3>3.1 <a name="roles">Roles</a>
+</h3>
+            <p class="" style="">The workgroup protocol involves three distinct participants that fill the following roles:</p>
+            <ul>
+                <li>
+                    <span style="font-weight: bold">User</span> - The user requests a private conversation with a member of a workgroup.
+                    For examples throughout the rest of this JEP the user will be represented by the address user@server.com/home.
+                </li>
+                <li>
+                    <span style="font-weight: bold">Service</span> - The workgroup service receives and sends messages using the
+                    workgroup address. The workgroup address represents a general contact address which allows users
+                    to find workgroup members to talk to without the need to know any particular workgroup member's
+                    individual address. The workgroup service manages the interactions between users and agents. For
+                    examples throughout the rest of this JEP the service will be represented by the address
+                    support@workgroup.company.com, representing a common scenario of a workgroup
+                    offering customer support for an organization.
+                </li>
+                <li>
+                    <span style="font-weight: bold">Agent</span> - The agent is a member of the workgroup and can carry out conversations
+                    with users on behalf of their workgroup organization or company. For examples throughout the rest
+                    of this JEP two agent addresses will be used: alice@company.com/work and bob@company.com/work.
+                </li>
+            </ul>
+            <p class="" style="">Note: A service MAY contain several queues to help organize, route and handle
+            incoming user chat requests. Implementations supporting multiple queues in a workgroup
+            will respond differently to requests, and send different status information for each
+            queue. Workgroup queues are identified by a unique resource name: e.g.
+            support@workgroup.company.com/platinum-plan or support@workgroup.company.com/xmpp-products.
+            Implementation should gracefully handle services with only one queue (using
+            support@workgroup.company.com) or multiple queues. Users should only be aware of one workgroup
+            (users should never see workgroup queue resource names).</p>
+        </div>
+        <div class="indent">
+<h3>3.2 <a name="responsibilities">Responsibilities</a>
+</h3>
+            <p class="" style="">Each participant is responsible for certain behaviors in the workgroup protocol.</p>
+            <p class="" style="">Users should:</p>
+            <ul>
+                <li>Know the status of the workgroup queue before requesting a conversation.
+                This information allows users to see if the workgroup is available, and how long a
+                wait they may have before a chat is initiated.</li>
+                <li>Know the status of their request while in the request queue.</li>
+                <li>Are able to cancel a chat request at any time.</li>
+            </ul>
+            <p class="" style="">Workgroup agents should:</p>
+            <ul>
+                <li>Know the status of the workgroup queue(s).</li>
+                <li>Be able to accept or reject chat requests.</li>
+                <li>Indicate their availability for handling workgroup chats.</li>
+            </ul>
+            <p class="" style="">The workgroup service:</p>
+            <ul>
+                <li>Controls the workgroup request queue(s).</li>
+                <li>Manages the updating of queue status information.</li>
+                <li>Determines how users are queued and how queue requests are routed to workgroup
+                members. The queue routing algorithm is beyond the scope of this JEP and left to
+                implementers (simple round-robin, priority based, rules based, etc).</li>
+                <li>Maintains its presence, indicating the availability of the workgroup service.</li>
+            </ul>
+        </div>
+    <h2>4.
+       <a name="user">User Protocol</a>
+</h2>
+        <p class="" style="">The workgroup protocol consists of several XMPP packet exchanges that occur during the
+        lifetime of the protocol. These packet exchanges change the state of the relationship
+        between user, agent and service.</p>
+
+        <div class="indent">
+<h3>4.1 <a name="proto-states">User States</a>
+</h3>
+            <p class="" style="">Users join the workgroup queue to wait for a chat with an agent. Once they have
+            joined the queue, they may receive zero or more status updates from the workgroup
+            service informing them of their status in the queue. Users have the option to cancel
+            their chat request at any time.</p>
+            <p class="" style="">When an agent is ready to chat with the user, the user will be sent a standard
+            XMPP groupchat invitation to a chat room. Receipt of the invitation indicates that
+            the user is no longer in the queue and that they should join the chat room using the
+            standard XMPP groupchat protocol in order to converse with an agent. Groupchat is
+            used because it offers several advantages in workgroup conversations
+            including:</p>
+            <ul>
+                <li>Allowing more than one agent to join the conversation (useful for bringing
+                in experts to join the conversation).</li>
+                <li>Allowing managers to monitor conversations for quality of service.</li>
+                <li>Creates a simple way of determining what is in a 'conversation' for logging
+                and gathering other statistical information about the conversation.</li>
+                <li>Allows a convenient mechanism for bringing 'chatbot' services into the
+                conversation (e.g. answering FAQ, etc).</li>
+            </ul>
+            <p class="" style="">The user's states and packet exchanges that cause state transitions are shown below:</p>
+            <p class="caption"></p>
+<div class="indent"><pre>
+              +-------+
+              | Start |&lt;------+
+              +-------+       |
+                  |           |
+                  | Join      |
+                  v           |
+             +---------+      |
+      +-----&gt;| Queued  |      |
+      |      +---------+      |
+      | Status |  |  | Depart |
+      +--------+  |  +--------+
+                  |
+                  | Invite
+                  v
+            +-----------+
+            | Chat room |
+            +-----------+
+            </pre></div>
+        </div>
+        <div class="indent">
+<h3>4.2 <a name="proto-user">User Packet Exchanges</a>
+</h3>
+            <p class="" style="">Packets are exchanged between the user and service to trigger state changes in the
+            user. These packet exchanges are described next.</p>
+            <div class="indent">
+<h3>4.2.1 <a name="proto-user-join">User Join Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange allowing users to join a workgroup
+                service queue. This protocol MUST be supported by compliant implementations.</p>
+                <p class="caption">Example 1. Transactions</p>
+<div class="indent"><pre>
+User                          Service
+  |        Join Request          |
+  |-----------------------------&gt;|
+  |                              |
+  |        Join Response         |
+  |&lt;-----------------------------|
+  |                              |
+                </pre></div>
+                <p class="" style="">The user sends a join request to the workgroup service in order to join the workgroup queue.
+                The workgroup service may either accept or reject the request. A user session (e.g. user@server.com/home)
+                may only have one active join request. Subsequent, simultaneous joins will result in an error
+                (see error section).</p>
+
+                <p class="" style="">Some workgroups require that the user submit certain information before the user is allowed to join.
+                In these cases, the workgroup will reject the initial join request with a &lt;not-acceptable/&gt; error. The user should then
+                use the Data Forms (JEP-0004) [4] protocol within iq-join-queue to obtain a form, and submit it to join
+                the queue.</p>
+                <p class="caption">Example 2. Request Element</p>
+<div class="indent"><pre>
+U: &lt;iq to='service-jid' from='user-jid' id='id1' type='set'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+                </pre></div>
+                <p class="" style="">The request may contain meta-data to help the service determine queuing of the user or
+                Data Forms data when submitting form information. There is one optional standard workgroup
+                sub-element of &lt;join-queue&gt;:</p>
+                
+                    <p class="" style="">&lt;queue-notifications/&gt; - if present, indicates the user would like to
+                    receive user status updates about their state in the queue.</p>
+                
+                <p class="" style="">A successful join results in a success response:</p>
+                <p class="caption">Example 3. Response Element</p>
+<div class="indent"><pre>
+S: &lt;iq to='user-jid' from='service-jid' id='id1' type='result'&gt;
+S: &lt;/iq&gt;
+                </pre></div>
+                <p class="" style="">If the user indicated interest in their queue status information, the supported status updates
+                will be sent by the server. Compliant implementations do not have to support any status update
+                types. Status updates requested by the user and supported by the server will be pushed to the user
+                by the service until the user departs or is invited to a chat room.</p>
+                <div class="indent">
+<h3>4.2.1.1 <a name="proto-user-join-errors">Error Conditions</a>
+</h3>
+                    <p class="caption">Table 1: </p>
+<table border="1" cellpadding="3" cellspacing="0">
+                        <tr class="body">
+                            <th colspan="" rowspan="">Condition</th>
+                            <th colspan="" rowspan="">Description</th>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+                            <td align="" colspan="" rowspan="">The user is not authorized to join the queue. A determination of who has
+                                permission to join a queue is left to implementations.
+                            </td>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;item-not-found/&gt;</td>
+                            <td align="" colspan="" rowspan="">The address the user requests a chat with does not exist or is not a workgroup.
+                                Compliant workgroup service implementations MUST NOT return this error if the
+                                requested address is a valid workgroup.
+                            </td>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+                            <td align="" colspan="" rowspan="">The user must submit valid form data (using the Data Forms protocol [4]) before
+                                joining the queue. Note that this error is sent when user tries to join, or if the
+                                user submits form data that is not filled out correctly.
+                            </td>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;conflict/&gt;</td>
+                            <td align="" colspan="" rowspan="">The user has already joined the queue.</td>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+                            <td align="" colspan="" rowspan="">The workgroup is valid but not accepting new join-queue requests.</td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="indent">
+<h3>4.2.1.2 <a name="proto-user-join-example">Example</a>
+</h3>
+                    <p class="" style="">The following protocol flows show an example of a user successfully joining a
+                    workgroup queue for support@workgroup.company.com.</p>
+                    <p class="caption">Example 4. Successful Join</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@workgruop.company.com'
+U:       id='id1'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@workgroup.company.com'
+S:     to='user@server.com/home'
+S:     id='id1'&gt;
+S: &lt;/iq&gt;
+                    </pre></div>
+                    <p class="" style="">The following XML is another example where meta-data is sent by the user to assist the workgroup
+                    server in queuing and routing (naturally, the custom namespace that qualified the &lt;crm/&gt; element in
+                    this example would be defined outside the context of this specification).</p>
+                    <p class="caption">Example 5. Join With Meta-Data</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@workgroup.company.com'
+U:       id='id2'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;crm xmlns="http://www.company.com/xmpp/workgroup"&gt;
+U:       &lt;customer-id&gt;the24th498onth&lt;/customer-id&gt;
+U:       &lt;referrer&gt;
+U:         http://www.company.com/portal/
+U:       &lt;/referrer&gt;
+U:       &lt;product&gt;Widget 1.0&lt;/product&gt;
+U:     &lt;/crm&gt;
+U:     &lt; queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@workgroup.company.com'
+S:       to='user@server.com/home'
+S:       id='id2'/&gt;
+                    </pre></div>
+                    <p class="" style="">Finally an example of a required form submission before a user is allowed to the
+                    workgroup queue for support@workgroup.company.com. The data form in this example is trivial; please
+                    see the Data Forms specification [4] for a complete data form example. The example begins as
+                    normal, but the workgroup returns a &lt;not-acceptable/&gt; error.</p>
+                    <p class="caption">Example 6. Join With Form</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@workgroup.company.com'
+U:       id='id1'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;queue-notifications/&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='error'
+S:     from='support@workgroup.company.com'
+S:       to='user@server.com/home'
+S:       id='id1'&gt;
+S:   &lt;error code='406' type='modify'&gt;
+S:     &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+S:   &lt;/error&gt;
+S: &lt;/iq&gt;
+                    </pre></div>
+                    <p class="" style="">The &lt;not-acceptable/&gt; error indicates that a data form is required. The user requests the
+                    required data form from the workgroup.</p>
+                    <p class="caption">Example 7. Join With Form (2)</p>
+<div class="indent"><pre>
+U: &lt;iq type='get'
+U:     from='user@server.com/home'
+U:       to='support@workgroup.company.com'
+U:       id='id2'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@workgroup.company.com'
+S:       to='user@server.com/home'
+S:       id='id2'&gt;
+S:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;x xmlns='jabber:iq:data' type='form'&gt;
+S:       &lt;title&gt;Support.com Chat Customer Information&lt;/title&gt;
+S:       &lt;instructions&gt;Welcome to support.com! Please provide us with
+S:         some information about yourself so we can serve you better.
+S:       &lt;/instructions&gt;
+S:       &lt;field type='text-single' label='First Name' var='first' /&gt;
+S:       &lt;field type='text-single' label='Last Name' var='last' /&gt;
+S:       &lt;field type='list-single' label='Contract Type'
+var='contract_type'&gt;
+S:         &lt;value&gt;0&lt;/value&gt;
+S:         &lt;option label='None'&gt;&lt;value&gt;0&lt;/value&gt;&lt;/option&gt;
+S:         &lt;option label='Bronze'&gt;&lt;value&gt;1&lt;/value&gt;&lt;/option&gt;
+S:         &lt;option label='Silver'&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+S:         &lt;option label='Gold'&gt;&lt;value&gt;3&lt;/value&gt;&lt;/option&gt;
+S:       &lt;/field&gt;
+S:     &lt;/x&gt;
+S:   &lt;/join-queue&gt;
+S: &lt;/iq&gt;
+                    </pre></div>
+                    <p class="" style="">After presenting the form to the user and gathering the form data, the user
+                    submits the form data to the workgroup and the workgroup accepts it. The
+                    user is now in the queue.</p>
+                    <p class="caption">Example 8. Join With Form (3)</p>
+<div class="indent"><pre>
+U: &lt;iq type='set'
+U:     from='user@server.com/home'
+U:       to='support@workgroup.company.com'
+U:       id='id3'&gt;
+U:   &lt;join-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;queue-notifications/&gt;
+U:     &lt;x xmlns='jabber:iq:data' type='submit'&gt;
+U:       &lt;field var='first'&gt;&lt;value&gt;John&lt;/value&gt;&lt;/field&gt;
+U:       &lt;field var='last'&gt;&lt;value&gt;Doe&lt;/value&gt;&lt;/field&gt;
+U:       &lt;field var='contract_type'&gt;&lt;value&gt;2&lt;/value&gt;&lt;/field&gt;
+U:     &lt;/x&gt;
+U:   &lt;/join-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq type='result'
+S:     from='support@workgroup.company.com'
+S:       to='user@server.com/home'
+S:       id='id3' /&gt;
+                    </pre></div>
+                </div>
+            </div>
+            <div class="indent">
+<h3>4.2.2 <a name="proto-user-depart">User Depart Protocol</a>
+</h3>
+                <p class="" style="">Describes the packet exchange allowing users to depart a workgroup service queue,
+                or for a workgroup service to remove a user from the workgroup queue. This protocol
+                MUST be supported by compliant implementations.</p>
+                <p class="" style="">The user no longer wishes to be in the queue and issues a depart queue command.</p>
+                <p class="caption">Example 9. Transactions</p>
+<div class="indent"><pre>
+Requester                     Service
+  |        Depart Request        |
+  |-----------------------------&gt;|
+  |        Depart Response       |
+  |&lt;-----------------------------|
+  |                              |
+                </pre></div>
+                <p class="" style="">The service notifies the user that they have been removed from the workgroup queue.</p>
+                <p class="caption">Example 10. Transactions (2)</p>
+<div class="indent"><pre>
+User                          Service
+  |        Depart Message        |
+  |&lt;-----------------------------|
+  |                              |
+                </pre></div>
+                <p class="caption">Example 11. Depart Request</p>
+<div class="indent"><pre>
+U: &lt;iq from='user-jid' to='service-jid' id='id1' type='set'&gt;
+U:   &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+                </pre></div>
+                <p class="" style="">In the typical case, the sender is the user departing the queue. However, it is
+                possible for other users (system administrators for example) to request that another
+                user be removed from the queue. In this case, the jid of the user who is departing
+                is included in the depart request:</p>
+                <p class="caption">Example 12. Depart Request With JID</p>
+<div class="indent"><pre>
+U: &lt;iq from='admin-jid' to='service-jid' id='id1' type='set'&gt;
+U:   &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;jid&gt;user-jid&lt;/jid&gt;
+U:   &lt;/depart-queue&gt;
+U: &lt;/iq&gt;
+                </pre></div>
+                <p class="" style="">It is expected that implementations will determine who is allowed to remove
+                other users from the queue based on an implementation specific permissions model.
+                These administrator depart requests may result in &lt;not-authorized/&gt; errors (see error
+                section). A user removing their own queue entry MUST NOT receive unauthorized
+                errors (the workgroup service may not refuse to allow a user to depart the queue).</p>
+                <p class="" style="">The sender of the depart request receives a successful result packet:</p>
+                <p class="caption">Example 13. Depart Request</p>
+<div class="indent"><pre>
+S: &lt;iq from='service-jid' to=user-jid' id='id1' type='result'/&gt;
+                </pre></div>
+                <p class="" style="">And the user who is departing receives a depart message (the user may not have
+                been the sender of the request):</p>
+                <p class="caption">Example 14. Depart Message</p>
+<div class="indent"><pre>
+S: &lt;message from='service-jid' to='user-jid'&gt;
+S:    &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+S: &lt;/message&gt;
+                </pre></div>
+                <p class="" style="">The user will not be in the queue after a response is received unless the error
+                response code is &lt;not-authorized/&gt;.</p>
+                <div class="indent">
+<h3>4.2.2.1 <a name="proto-user-depart-errors">Error Conditions</a>
+</h3>
+                    <p class="caption">Table 2: </p>
+<table border="1" cellpadding="3" cellspacing="0">
+                        <tr class="body">
+                            <th colspan="" rowspan="">Condition</th>
+                            <th colspan="" rowspan="">Description</th>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+                            <td align="" colspan="" rowspan="">The sender did not have permission to remove the user from the queue.
+                            This error code MUST NOT be used when a user is removing their queue entry.</td>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;item-not-found/&gt;</td>
+                            <td align="" colspan="" rowspan="">The user was not in the queue.</td>
+                        </tr>
+                    </table>
+                </div>
+                <div class="indent">
+<h3>4.2.2.2 <a name="proto-user-depart-example">Example</a>
+</h3>
+                    <p class="" style="">A user leaves the workgroup queue support@workgroup.company.com.</p>
+                    <p class="caption">Example 15. User Departs</p>
+<div class="indent"><pre>
+U: &lt;iq from='user@server.com/home'
+U:       to='support@workgroup.company.com'
+U:       id='id1'
+U:     type='set'&gt;
+U:   &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq from='support@workgoup.company.com'
+S:     to='user@server.com/home'
+S:     id='id1'
+S:     type='result'/&gt;
+S: &lt;message from='support@workgroup.company.com' to='user@server.com/home'&gt;
+S:    &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+S: &lt;/message&gt;
+                    </pre></div>
+                    <p class="" style="">An administrator removes a user from the workgroup queue support@workgroup.company.com.
+                    Notice that the depart-queue message is sent to the user that has left the queue.</p>
+                    <p class="caption">Example 16. Administrator Removes User</p>
+<div class="indent"><pre>
+U: &lt;iq from='admin@company.com/work'
+U:       to='support@workgroup.company.com'
+U:       id='id1'
+U:     type='set'&gt;
+U:   &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;jid&gt;user@server.com/home&lt;/jid&gt;
+U:   &lt;/depart-queue&gt;
+U: &lt;/iq&gt;
+S: &lt;iq from='support@workgroup.company.com'
+S:     to='admin@company.com/work'
+S:     id='id1'
+S:     type='result'/&gt;
+S: &lt;message from='support@workgroupcompany.com' to='user@server.com/home'&gt;
+S:    &lt;depart-queue xmlns='http://jabber.org/protocol/workgroup'/&gt;
+S: &lt;/message&gt;
+                    </pre></div>
+                </div>
+            </div>
+            <div class="indent">
+<h3>4.2.3 <a name="proto-user-status">User Status Update Protocol</a>
+</h3>
+                <p class="" style="">Describes the packet exchange for updating users on their queue status.  This protocol MAY
+                be supported by compliant implementations.</p>
+                <p class="caption">Example 17. Transactions</p>
+<div class="indent"><pre>
+User                          Service
+  |      User Status Push        |
+  |&lt;-----------------------------|
+  |                              |
+  |     User Status Request      |
+  |-----------------------------&gt;|
+  |     User Status Response     |
+  |&lt;-----------------------------|
+  |                              |
+                </pre></div>
+                <p class="" style="">The workgroup service pushes updates to the user as their queue status changes and the user
+                may request their queue status at any time.</p>
+                <div class="indent">
+<h3>4.2.3.1 <a name="proto-user-status-updates">User Status Updates</a>
+</h3>
+                    <p class="" style="">User status updates are contained in a &lt;queue-status/&gt; element that updates the user on
+                    their queue position and estimated time. The position contained in a &lt;position&gt; sub-element
+                    is a non-negative integer indicating the number of queue entries that must be routed to an agent
+                    before the user is routed to an agent. A position of 0 (zero) indicates the user is currently being
+                    routed. Clients may use this information to display the current queue position to the user.</p>
+                    <p class="" style="">The queue time status is contained in a &lt;time/&gt; sub-element that updates the user with the
+                    estimated time until they will be routed to an agent. The time is a non-negative integer indicating
+                    the estimated number of seconds remaining before being routed. Services should send this update at
+                    regular intervals. We recommend every 15 seconds, but the best solution will depend on application dependent
+                    factors and the service may decide to send updates at any interval or never (relying on the client to request
+                    the information). User clients should assume the estimated time counts down at a rate of one second per second
+                    between status updates. Clients may use this information to display the running estimated time to the user.</p>
+                    <p class="" style="">A server 'push' occurs asynchronously to client:</p>
+                    <p class="caption">Example 18. User Status Push</p>
+<div class="indent"><pre>
+S: &lt;message to='user-jid' from='service-jid'&gt;
+S:   &lt;queue-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;position&gt;4&lt;/position&gt;
+S:     &lt;time&gt;60&lt;/time&gt;
+S:   &lt;/queue-status&gt;
+S: &lt;/message&gt;
+                    </pre></div>
+                    <p class="" style="">Alternately the client may poll their position:</p>
+                    <p class="caption">Example 19. User Status Poll</p>
+<div class="indent"><pre>
+U: &lt;iq to='service-jid' from='user-jid' id='id1' type='get'&gt;
+U:   &lt;queue-status xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq to='user-jid' from='service-jid' id='id1' type='result'&gt;
+S:   &lt;queue-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;position&gt;4&lt;/position&gt;
+S:     &lt;time&gt;60&lt;/time&gt;
+S:   &lt;/queue-status&gt;
+S: &lt;/iq&gt;
+                    </pre></div>
+                </div>
+                <div class="indent">
+<h3>4.2.3.2 <a name="proto-user-status-errors">Error Conditions</a>
+</h3>
+                    <p class="caption">Table 3: </p>
+<table border="1" cellpadding="3" cellspacing="0">
+                        <tr class="body">
+                            <th colspan="" rowspan="">Condition</th>
+                            <th colspan="" rowspan="">Description</th>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;not-authorized/&gt;</td>
+                            <td align="" colspan="" rowspan="">Sent by the server to the user in response to a status query only if
+                            the user is not a member of the queue.</td>
+                        </tr>
+                        <tr class="body">
+                            <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+                            <td align="" colspan="" rowspan="">Sent only if status updates are not implemented in either the client or server.</td>
+                        </tr>
+                    </table>
+                </div>
+            </div>
+            <div class="indent">
+<h3>4.2.4 <a name="proto-user-invite">User Invite Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange for inviting a queued user to a chat
+                room for conversation with an agent. This protocol MUST be supported by compliant
+                implementations.</p>
+                <p class="caption">Example 20. Transactions</p>
+<div class="indent"><pre>
+User                          Service
+  |          User Invite         |
+  |&lt;-----------------------------|
+  |                              |
+                </pre></div>
+                <p class="" style="">The server sends a standard JEP-0045 groupchat invitation to the user to begin
+                their conversation with an agent.</p>
+                <p class="" style="">User invitations use JEP-0045 standard multi-user chat invitations. The
+                invitation indicates that the user is no longer in the workgroup queue. The user
+                MUST NOT receive any more user queue status updates once they receive an invitation.</p>
+                <p class="" style="">In order to match invitations to join requests, all invitations should carry meta
+                data in the workgroup namespace in the 'workgroup' element with the JID of the
+                workgroup as an attribute. The typical meta-data fragment would appear as:</p>
+                <p class="caption">Example 21. Invitation Meta-Data</p>
+<div class="indent"><pre>
+&lt;workgroup xmlns='http://jabber.org/protocol/workgroup' jid='support@workgroup.company.com'/&gt;
+                </pre></div>
+                <div class="indent">
+<h3>4.2.4.1 <a name="proto-user-invite-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error conditions for user invitations.</p>
+                </div>
+                <div class="indent">
+<h3>4.2.4.2 <a name="proto-user-invite-example">Example</a>
+</h3>
+                    <p class="" style="">An invitation from the server on behalf of the support@server.com workgroup:</p>
+                    <p class="caption">Example 22. An Invitation</p>
+<div class="indent"><pre>
+S: &lt;message
+S:     from='roomname@chatserver.company.com'
+S:     to='user@server.com/home'&gt;
+S:   &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+S:     &lt;invite from='support@workgroup.company.com'&gt;
+S:       &lt;reason&gt;
+S:        You have been invited to chat with a support@workgroup.company.com agent.
+S:       &lt;/reason&gt;
+S:     &lt;/invite&gt;
+S:   &lt;/x&gt;
+S:   &lt;x jid='roomname@chatserver.company.com' xmlns='jabber:x:conference'/&gt;
+S:   &lt;workgroup xmlns='http://jabber.org/protocol/workgroup'
+S:       jid='support@workgroup.company.com'/&gt;
+S: &lt;/message&gt;
+                    </pre></div>
+                </div>
+            </div>
+        </div>
+    <h2>5.
+       <a name="agent">Agent Protocol</a>
+</h2>
+        <div class="indent">
+<h3>5.1 <a name="proto-agent-states">Agent States</a>
+</h3>
+            <p class="" style="">Agents join a workgroup to indicate they are capable of handling conversations with users.
+            Agent membership in the workgroup is expected to be a long term, persistent relationship similar
+            to roster membership. For example, a customer support agent may join the support@workgroup.company.com
+            workgroup when they begin working at company.com and will only depart when they leave that position.
+            The wide variety of relationships, processes and permissions associated with joining and leaving workgroups
+            lies outside the scope of this JEP.</p>
+            <p class="" style="">Once an agent has joined a workgroup they will receive workgroup status updates to inform them of
+            the status of other members of the workgroup.  Agents are responsible for updating the workgroup
+            service with their presence so the service can intelligently route chat requests to the 'best' agent.
+            Workgroup agent presence uses standard XMPP presence packets with optional meta-data to help routing of
+            chat requests to agents. Some meta-data will be standard and defined later in this JEP. It is expected that
+            other deployment specific meta-data will also be needed to make routing decisions.</p>
+            <p class="" style="">The general agent workgroup state diagram is shown below:</p>
+            <p class="caption"></p>
+<div class="indent"><pre>
+            +-----------+
+      +----&gt;| Workgroup |&lt;-----+
+      |     +-----------+      |
+      |        |     |Agent    |
+      | Status |     |Presence |
+      +--------+     +---------+
+            </pre></div>
+            <p class="" style="">Once an agent has joined a workgroup and is available, the agent will receive offers to chat with
+            users by the workgroup service. Chat offers will be made to the agent and the agent has the opportunity to
+            accept or reject each offer. The workgroup service may also revoke an offer. For example, a service may revoke
+            chat offers if the offer is not responded to within a certain period of time to ensure fast responses to user chat
+            requests.</p>
+            <p class="" style="">Once an offer has been accepted, the agent must wait for a standard groupchat invitation from the workgroup
+            service. The workgroup service may revoke the offer at this stage of the protocol as well. This enables workgroup
+            services to send offers to several agents in parallel, and choose the 'best' agent that accepts. A diagram showing
+            the agent workgroup sub-states and transitions is shown below:</p>
+            <p class="caption"></p>
+<div class="indent"><pre>
+              +-------+
+              | Start |&lt;---------+
+              +-------+          |
+                  |              |
+                  | Offer        |
+                  v              |
+            +---------------+    |
+            | Offer Pending |    |
+            +---------------+    |
+                 |  |  | Revoke  |
+                 |  |  +--------&gt;|
+                 |  | Reject     |
+          Accept |  +-----------&gt;|
+                 v               |
+            +--------------+     |
+            | Chat Pending |     |
+            +--------------+     |
+                 |   | Revoke    |
+          Invite |   +-----------+
+                 V
+              +-----------+
+              | Chat room |
+              +-----------+
+            </pre></div>
+        </div>
+        <div class="indent">
+<h3>5.2 <a name="proto-agent">Agent Packet Exchanges</a>
+</h3>
+            <p class="" style="">Packets are exchanged between the agent and service to trigger state changes in the agent client.
+            These packet exchanges are described next.</p>
+            <div class="indent">
+<h3>5.2.1 <a name="proto-agent-presence">Agent Presence Protocol</a>
+</h3>
+                <p class="" style="">Describes the packet exchange allowing agents to update a workgroup with their current
+                presence. This protocol MUST be supported by compliant implementations.</p>
+                <p class="caption">Example 23. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |       Presence Update        |
+  |-----------------------------&gt;|
+  |                              |
+                </pre></div>
+                <p class="" style="">The agent must inform the workgroup of its presence by sending it a presence update packet.
+                Agent presence updates use standard XMPP presence with optional meta-data. However, there must
+                always be an agent-status workgroup sub-element in the presence packet to indicate that the presence
+                update relates to agent workgroup presence. Agent workgroup presence is designed to allow a separation
+                between the agent's normal XMPP presence (server-managed via rosters) and their presence with the
+                workgroup.</p>
+                <p class="caption">Example 24. Presence Update</p>
+<div class="indent"><pre>
+U: &lt;presence from='agent-jid' to='service-jid'&gt;
+U:   &lt;agent-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;max-chats&gt;count&lt;/max-chats&gt;
+U:   &lt;/agent-status&gt;
+U: &lt;/presence&gt;
+                </pre></div>
+                <p class="" style="">Agent presence updates use standard XMPP presence packets and should contain the normal
+                sub elements as needed (e.g. &lt;show/&gt;, &lt;status/&gt;, etc) and can be of type='unavailable' to indicate
+                the agent is not available for workgroup routing or for receiving workgroup agent updates. The
+                standard XMPP show states have specific meaning within the context of the workgroup protocol:</p>
+                <ul>
+                    <li>chat - Indicates the agent is available to chat (is idle and ready to handle more conversations).</li>
+                    <li>away - The agent is busy (possibly with other chats). The agent may still be able to handle
+                    other chats but an offer rejection is likely.</li>
+                    <li>xa - The agent is physically away from their terminal and should not have a chat routed to them.</li>
+                    <li>dnd - The agent is busy and should not be disturbed. However, special case, or extreme urgency
+                    chats may still be offered to the agent although offer rejection or offer timeouts are highly likely.</li>
+                </ul>
+                <p class="" style="">Agents may also wish to embed meta-data to help the workgroup service route chat requests. The optional
+                meta-data value in the workgroup namespace is:</p>
+                <ul>
+                    <li>
+                        &lt;max-chats&gt; - The maximum number of chats the agent can handle. If a presence is sent to
+                        the workgroup that does not contain the max-chats value, the "default setting" will be assumed.
+                        The value of the default setting for an agent is up to an implementation.
+                             [<a href="#nt-id2250426">5</a>]
+                    </li>
+                </ul>
+                <div class="indent">
+<h3>5.2.1.1 <a name="proto-agent-presence-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error conditions for presence updates.</p>
+                </div>
+                <div class="indent">
+<h3>5.2.1.2 <a name="proto-agent-presence-example">Example</a>
+</h3>
+                    <p class="" style="">An agent (alice) becomes available to the workgroup support@workgroup.company.com.</p>
+                    <p class="caption">Example 25. Agent Becomes Available</p>
+<div class="indent"><pre>
+U: &lt;presence from='alice@company.com/work'
+U:             to='support@workgroup.company.com'&gt;
+U:   &lt;show&gt;chat&lt;/show&gt;
+U:   &lt;agent-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+U:     &lt;max-chats&gt;3&lt;/max-chats&gt;
+U:   &lt;/agent-status&gt;
+U: &lt;/presence&gt;
+                    </pre></div>
+                </div>
+            </div>
+            <div class="indent">
+<h3>5.2.2 <a name="proto-workgroup-status">Workgroup Status Update Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange used to update agents on the status of
+                the workgroup. This protocol MAY be supported by compliant implementations.</p>
+                <p class="" style="">After an agent announces their presence to the workgroup, they will begin receiving
+                presence updates from the workgroup. All fields are optional:
+                </p>
+                <p class="caption">Example 26. Notify-Agent Status Type</p>
+<div class="indent"><pre>
+S: &lt;presence to='agent-jid' from='service-jid'&gt;
+S:   &lt;notify-agents xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;available&gt;count&lt;/available&gt;
+S:     &lt;current-chats&gt;count&lt;/current-chats&gt;
+S:     &lt;max-chats&gt;count&lt;/max-chats&gt;
+S:   &lt;/notify-agents&gt;
+S: &lt;/presence&gt;
+                </pre></div>
+
+                <p class="" style="">The defined sub-elements of &lt;notify-agents&gt; are:</p>
+                <ul>
+                    <li>&lt;available&gt; - The total number of agents available in the workgroup.</li>
+                    <li>&lt;current-chats&gt; - The current total number of chats being handled by
+                    agents in the workgroup.</li>
+                    <li>&lt;max-chats&gt; - The maximum number of simultaneous conversations that
+                    can be handled by agents in the workgroup.</li>
+                </ul>
+                <div class="indent">
+<h3>5.2.2.1 <a name="proto-workgroup-status-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error conditions for notify workgroup updates.</p>
+                </div>
+                <div class="indent">
+<h3>5.2.2.2 <a name="proto-workgroup-status-example">Example</a>
+</h3>
+                    <p class="" style="">An agent (alice) receives an update from workgroup support@workgroup.company.com.</p>
+                    <p class="caption">Example 27. Agent Recives Update</p>
+<div class="indent"><pre>
+S: &lt;presence to='alice@company.com/work' from='support@wokgroup.company.com'&gt;
+S:   &lt;notify-agents xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;available&gt;2&lt;/available&gt;
+S:     &lt;current-chats&gt;2&lt;/current-chats&gt;
+S:     &lt;max-chats&gt;7&lt;/max-chats&gt;
+S:   &lt;/notify-agents&gt;
+S: &lt;/presence&gt;
+                  </pre></div>
+                </div>
+            </div>
+            <div class="indent">
+<h3>5.2.3 <a name="proto-queue-status">Queue Status Update Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange used to update agents on the status of
+                the workgroup queue. This protocol MAY be supported by compliant implementations.</p>
+                <p class="" style="">After an agent announces their presence to the workgroup, they will begin receiving
+                presence updates from the workgroup with an overview and details on the queue status.</p>
+
+                <p class="" style="">The &lt;notify-queue/&gt; element updates the agent with a summary of the status
+                of the workgroup queue. All fields are optional:</p>
+                <p class="caption">Example 28. Notify-Queue Status Type</p>
+<div class="indent"><pre>
+S: &lt;presence to='agent-jid' from='service-jid'&gt;
+S:   &lt;notify-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;count&gt;count&lt;/count&gt;
+S:     &lt;oldest&gt;YYYYMMDDTHH:mm:ss&lt;/oldest&gt;
+S:     &lt;time&gt;average-time-to-chat&lt;/time&gt;
+S:     &lt;status&gt;open&lt;/status&gt;
+S:   &lt;/notify-queue&gt;
+S: &lt;/presence&gt;
+                </pre></div>
+                <p class="" style="">The defined sub-elements of &lt;notify-queue&gt; are:</p>
+                <ul>
+                    <li>&lt;count&gt; - The total number of users in the workgroup queue.</li>
+                    <li>&lt;oldest&gt; - The date and time in UTC the oldest member of the queue joined.</li>
+                    <li>&lt;time&gt; - The average time in seconds that a user is in the queue before
+                        they are routed to an agent for handling.</li>
+                    <li>&lt;status&gt; - The status of the queue. Queues may be active (requests are being
+                        routed and handled by agents) but not accepting new requests for handling. Typical reasons
+                        for this state include the queue is shutting down but finishing processing users in the queue,
+                        or because the queue has too many requests and should not accept more request until the existing
+                        requests are handled. The status field MUST contain one of the following values:
+                        <ul>
+                            <li>open - the queue is active and accepting new chat requests</li>
+                            <li>active - the queue is active but NOT accepting new chat requests</li>
+                            <li>closed - the queue is NOT active and NOT accepting new chat requests</li>
+                        </ul>
+                    </li>
+                </ul>
+
+                <p class="" style="">The &lt;notify-queue-details/&gt; element updates the agent with details of
+                the workgroup queue. All fields are optional:</p>
+                <p class="caption">Example 29. Notify-Queue-Details Status Type</p>
+<div class="indent"><pre>
+S: &lt;presence to='agent-jid' from='service-jid'&gt;
+S:   &lt;notify-queue-details xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;user jid='user-jid'&gt;
+S:       &lt;position&gt;pos&lt;/position&gt;
+S:       &lt;time&gt;estimated-time&lt;/time&gt;
+S:       &lt;join-time&gt;YYYYMMDDTHH:mm:SS&lt;/join-time&gt;
+S:     &lt;/user&gt;
+S:   &lt;/notify-queue-details&gt;
+S: &lt;/presence&gt;
+                </pre></div>
+                <p class="" style="">An update may contain one or more &lt;user&gt; entries (one per user in the queue).
+                The defined sub-elements of &lt;user&gt; are:</p>
+                <ul>
+                    <li>&lt;position&gt; - The user's zero-based position in the queue.</li>
+                    <li>&lt;time&gt; - Estimated time in seconds remaining before the user is routed to an agent.</li>
+                    <li>&lt;join-time&gt; - The date and time the user joined the queue in UTC.</li>
+                </ul>
+                <div class="indent">
+<h3>5.2.3.1 <a name="proto-queue-status-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error conditions for workgroup queue status updates.</p>
+                </div>
+                <div class="indent">
+<h3>5.2.3.2 <a name="proto-queue-status-example">Example</a>
+</h3>
+                    <p class="" style="">An agent receives an update from workgroup support@workgroup.company.com.</p>
+                    <p class="caption">Example 30. Agent Receives Updates</p>
+<div class="indent"><pre>
+S: &lt;presence to='alice@company.com/work' from='support@workgroup.company.com'&gt;
+S:   &lt;notify-queue xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;count&gt;1&lt;/count&gt;
+S:     &lt;oldest&gt;20050208T10:00:00&lt;/oldest&gt;
+S:     &lt;time&gt;30&lt;/time&gt;
+S:     &lt;status&gt;open&lt;/status&gt;
+S:   &lt;/notify-queue&gt;
+S: &lt;/presence&gt;
+S: &lt;presence to='alice@company.com/work' from='support@workgroup.company.com'&gt;
+S:   &lt;notify-queue-details xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;user jid='user@server.com/home'&gt;
+S:       &lt;position&gt;1&lt;/position&gt;
+S:       &lt;time&gt;5&lt;/time&gt;
+S:       &lt;join-time&gt;20050208T10:00:00&lt;/join-time&gt;
+S:     &lt;/user&gt;
+S:   &lt;/notify-queue-details&gt;
+S: &lt;/presence&gt;
+                    </pre></div>
+                </div>
+            </div>
+            <div class="indent">
+<h3>5.2.4 <a name="proto-agent-status">Agent Status Update Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange used to update agents on the status
+                of other agents in the workgroup. This protocol MAY be supported by compliant implementations.</p>
+                <p class="caption">Example 31. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |    Request Agent Status      |
+  |-----------------------------&gt;|
+  |         Agent List           |
+  |&lt;-----------------------------|
+  |                              |
+  |     Agent Presence Pushes    |
+  |&lt;-----------------------------|
+                </pre></div>
+                <p class="" style="">The workgroup service pushes presence updates to the agent as the presence
+                of other agents changes. This will only occur after an agent has requested to receive
+                other agents' information. The server will continue to send presence updates until
+                the agent sends an unavailable presence to the server. This protocol is
+                similar to the standard XMPP roster workflow.</p>
+                <p class="" style="">To receive presence updates for other agents in the workgroup, the agent sends
+                an agent info request to the workgroup:</p>
+                <p class="caption">Example 32. Request Element</p>
+<div class="indent"><pre>
+U: &lt;iq to='support@workgroup.company.com' from='alice@company.com/work' id='id1' type='get'&gt;
+U:   &lt;agent-status-request xmlns='http://jabber.org/protocol/workgroup'/&gt;
+U: &lt;/iq&gt;
+               </pre></div>
+                <p class="" style="">
+                The workgroup will then reply with a list of all agents in the workgroup (excluding
+                the agent making the request):
+                </p>
+                <p class="caption">Example 33. Response Element</p>
+<div class="indent"><pre>
+S: &lt;iq to='alice@company.com/work' from='support@workgroup.company.com' id='id1' type='result'&gt;
+S:   &lt;agent-status-request xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:     &lt;agent jid="bob@company.com" /&gt;
+S:   &lt;/agent-status-request&gt;
+S: &lt;/iq&gt;
+              </pre></div>
+                <p class="" style="">
+                The server will then push presence packets for other agents as their presence
+                changes. All fields in the &lt;agent-status&gt; child stanza are optional, but an
+                    &lt;agent-status&gt; child stanza must be present:
+                </p>
+                <p class="caption">Example 34. Agent Status Update</p>
+<div class="indent"><pre>
+S: &lt;presence to='alice@company.com/work' from='bob@company.com/work'&gt;
+S:   &lt;agent-status xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:       &lt;current-chats&gt;2&lt;/current-chats&gt;
+S:       &lt;max-chats&gt;4&lt;/max-chats&gt;
+S:   &lt;/agent-status&gt;
+S: &lt;/presence&gt;
+                </pre></div>
+                <p class="" style="">The defined sub-elements of &lt;agent-status&gt; are:</p>
+                <ul>
+                    <li>&lt;current-chats&gt; - The number of conversations currently being handled by the agent.</li>
+                    <li>&lt;max-chats&gt; - The maximum number of simultaneous conversations the agent can handle.</li>
+                </ul>
+                <div class="indent">
+<h3>5.2.4.1 <a name="proto-agent-status-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error conditions for agent status updates.</p>
+                </div>
+            </div>
+            <div class="indent">
+<h3>5.2.5 <a name="proto-agent-offer">Agent Offer Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange involved in a service offering a chat to an agent.
+                This protocol MUST be supported by compliant implementations.</p>
+                <p class="caption">Example 35. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |         Offer Request        |
+  |&lt;-----------------------------|
+  |         Offer Response       |
+  |-----------------------------&gt;|
+  |                              |
+                </pre></div>
+                <p class="" style="">The agent is offered a chat with a user. A successful offer results in the agent owning the
+                offer, but does not mean it has accepted the chat.  Accepting an offer is handled by the Agent Accept
+                protocol. The separation between offer and acceptance is made so that agents may receive offers while
+                engaged in other activities (busy with other chats) and accept them at a later time.</p>
+                <p class="caption">Example 36. Offer Request</p>
+<div class="indent"><pre>
+S: &lt;iq from='service-jid' to='agent-jid' id='id1' type='set'&gt;
+S:   &lt;offer xmlns='http://jabber.org/protocol/workgroup' jid='user-jid'&gt;
+S:       &lt;timeout&gt;seconds&lt;/timeout&gt;
+S:   &lt;/offer&gt;
+S: &lt;/iq&gt;
+                </pre></div>
+                <p class="" style="">Application specific meta-data will normally be added as a sub-element of &lt;offer&gt;
+                to help agents decide whether to accept or not. An optional &lt;timeout&gt; sub-element may be
+                included indicating the amount of time the offer stands before the service will revoke it.</p>
+                <p class="caption">Example 37. Offer Response</p>
+<div class="indent"><pre>
+A: &lt;iq from='agent-jid' to='service-jid' id='id1' type='result'/&gt;
+                </pre></div>
+                <p class="" style="">The agent may respond only with a successful result.</p>
+                <div class="indent">
+<h3>5.2.5.1 <a name="proto-agent-offer-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error results for an offer response.</p>
+                </div>
+                <div class="indent">
+<h3>5.2.5.2 <a name="proto-agent-offer-example">Example</a>
+</h3>
+                    <p class="" style="">An agent is offered a chat with a user. The offer will be revoked in 30 seconds.</p>
+                    <p class="caption">Example 38. Agent is Offered a Chat</p>
+<div class="indent"><pre>
+S: &lt;iq to='alice@company.com/work'
+S:     from='support@workgroup.company.com'
+S:     id='id1'
+S:     type='set'&gt;
+S:     &lt;offer xmlns='http://jabber.org/protocol/workgroup' jid='user@server.com/home'&gt;
+S:       &lt;timeout&gt;30&lt;/timeout&gt;
+S:     &lt;/offer&gt;
+S: &lt;/iq&gt;
+A: &lt;iq to='support@workgroup.company.com'
+A:     from='alice@company.com/work'
+A:     id='id1'
+A:     type='result'/&gt;
+                    </pre></div>
+                    <p class="" style="">The following is a more typical offer containing meta-data about the user.
+                    The offer will be revoked in 30 seconds.</p>
+                    <p class="caption">Example 39. Offer Including Meta-Data</p>
+<div class="indent"><pre>
+S: &lt;iq to='alice@company.com/work'
+S:     from='support@workgroup.company.com'
+S:     id='id2'
+S:     type='set'&gt;
+S:     &lt;offer xmlns='http://jabber.org/protocol/workgroup' jid='user@server.com/home'&gt;
+S:       &lt;timeout&gt;30&lt;/timeout&gt;
+S:       &lt;crm xmlns="http://www.company.com/xmpp/workgroup'&gt;
+S:         &lt;user-id&gt;423498ae84f&lt;/user-id&gt;
+S:         &lt;product&gt;Widget 1.0&lt;/product&gt;
+S:       &lt;/crm&gt;
+S:     &lt;/offer&gt;
+S: &lt;/iq&gt;
+A: &lt;iq to='support@workgroup.company.com'
+A:     from='alice@company.com/work'
+A:     id='id2'
+A:     type='result'/&gt;
+                    </pre></div>
+                </div>
+            </div>
+            <div class="indent">
+<h3>5.2.6 <a name="proto-agent-acceptreject">Agent Offer Accept/Reject Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange involved in an agent rejecting an offering a
+                chat to a user. This protocol MUST be supported by compliant implementations.</p>
+                <p class="caption">Example 40. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |  Offer Accept/Reject Request |
+  |-----------------------------&gt;|
+  | Offer Accept/Reject Response |
+  |&lt;-----------------------------|
+  |                              |
+                </pre></div>
+                <p class="" style="">The agent accepts or rejects an offer to chat with a user.</p>
+                <p class="caption">Example 41. Offer Accept Request</p>
+<div class="indent"><pre>
+A: &lt;iq to='service-jid' from='agent-jid' id='id1' type='set'&gt;
+A:   &lt;offer-accept jid='user-jid' xmlns='http://jabber.org/protocol/workgroup' /&gt;
+A: &lt;/iq&gt;
+                </pre></div>
+                <p class="caption">Example 42. Offer Reject Request</p>
+<div class="indent"><pre>
+A: &lt;iq to='service-jid' from='agent-jid' id='id1' type='set'&gt;
+A:   &lt;offer-reject jid='user-jid' xmlns='http://jabber.org/protocol/workgroup'/&gt;
+A: &lt;/iq&gt;
+                </pre></div>
+                <p class="caption">Example 43. Offer Response</p>
+<div class="indent"><pre>
+S: &lt;iq to='agent-jid' from='service-jid' id='id1' type='result'/&gt;
+                </pre></div>
+                <p class="" style="">The service may respond only with a successful result.</p>
+                <div class="indent">
+<h3>5.2.6.1 <a name="proto-agent-acceptreject-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error results for an accept/reject offer response.</p>
+                </div>
+                <div class="indent">
+<h3>5.2.6.2 <a name="proto-agent-acceptreject-example">Example</a>
+</h3>
+                    <p class="caption">Example 44. Agent Accepts Chat</p>
+<div class="indent"><pre>
+A: &lt;iq from='alice@company.com/work'
+A:       to='support@workgroup.company.com'
+A:       id='id3'
+A:     type='set'&gt;
+A:   &lt;offer-accept jid='user@server.com/home' xmlns='http://jabber.org/protocol/workgroup'/&gt;
+A: &lt;/iq&gt;
+S: &lt;iq from='support@workgroup.company.com'
+S:     to='alice@company.com/work'
+S:     id='id3'
+S:     type='result'/&gt;
+                    </pre></div>
+                </div>
+            </div>
+            <div class="indent">
+<h3>5.2.7 <a name="proto-agent-revoke">Agent Offer Revoke Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange involved in a service revoking an offer
+                to an agent to chat to a user. This protocol MUST be supported by compliant implementations.</p>
+                <p class="caption">Example 45. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |     Offer Revoke Request     |
+  |&lt;-----------------------------|
+  |    Offer Revoke Response     |
+  |-----------------------------&gt;|
+  |                              |
+                </pre></div>
+                <p class="" style="">The service revokes an earlier offer to chat to a user. Offer revocations typically occur
+                when the original offer times out, or a better agent was found to handle the chat. Note that offer
+                revocations may occur anytime after an offer has been made, and before an invitation is sent
+                (see agent state diagram). In other words, even though an agent has accepted an offer to chat, the agent
+                may still receive an offer revocation (e.g. a better agent was found to handle the chat).</p>
+                <p class="caption">Example 46. Offer Revoke Request</p>
+<div class="indent"><pre>
+S: &lt;iq from='service-jid' to='agent-jid' id='id1' type='set'&gt;
+S:     &lt;offer-revoke jid='user-jid' xmlns='http://jabber.org/protocol/workgroup'&gt;
+S:       &lt;reason&gt;
+S:         [reason]
+S:       &lt;/reason&gt;
+S:     &lt;/offer-revoke&gt;
+S: &lt;/iq&gt;
+                </pre></div>
+                <p class="" style="">The reason element may optionally contain free form text explaining the reason the offer was revoked.</p>
+                <p class="caption">Example 47. Offer Response</p>
+<div class="indent"><pre>
+A: &lt;iq from='agent-jid' to='service-jid' id='id1' type='result'/&gt;
+                </pre></div>
+                <p class="" style="">The agent may respond only with a successful result.</p>
+                <div class="indent">
+<h3>5.2.7.1 <a name="proto-agent-revoke-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error results for an offer response.</p>
+                </div>
+                <div class="indent">
+<h3>5.2.7.2 <a name="proto-agent-revoke-example">Example</a>
+</h3>
+                    <p class="caption">Example 48. Offer Revoked Due to Timeout</p>
+<div class="indent"><pre>
+S: &lt;iq to='alice@company.com/work'
+S:     from='support@workgroup.company.com'
+S:       id='id4'
+S:     type='set'&gt;
+S:     &lt;offer-revoke xmlns='http://jabber.org/protocol/workgroup' jid='user@server.com/home'&gt;
+S:         &lt;reason&gt;
+S:           Offer timed out
+S:         &lt;/reason&gt;
+S:     &lt;/offer-revoke&gt;
+S: &lt;/iq&gt;
+A: &lt;iq to='support@workgroup.company.com'
+A:     from='alice@company.com/work'
+A:       id='id4'
+A:     type='result'/&gt;
+                    </pre></div>
+                </div>
+            </div>
+            <div class="indent">
+<h3>5.2.8 <a name="proto-agent-invite">Agent Invite Protocol</a>
+</h3>
+                <p class="" style="">This section describes the packet exchange inviting an agent to a chat room for
+                conversation with a user. This protocol MUST be supported by compliant implementations.</p>
+                <p class="caption">Example 49. Transactions</p>
+<div class="indent"><pre>
+Agent                         Service
+  |         Agent Invite         |
+  |&lt;-----------------------------|
+  |                              |
+                </pre></div>
+                <p class="" style="">The server sends a standard JEP-0045 groupchat invitation to the agent to begin their
+                conversation with a user. The invitation follows the same format as shown in the User Invite
+                Protocol.</p>
+                <p class="" style="">In order to match invitations to offers, all invitations should carry meta-data
+                in the workgroup namespace in the 'offer' element with the JID of the user as an
+                attribute. The typical meta-data fragment would appear as:</p>
+                <p class="caption">Example 50. Invitation Meta-Data</p>
+<div class="indent"><pre>
+&lt;offer xmlns='http://jabber.org/protocol/workgroup' jid='user-jid'&gt;
+                </pre></div>
+                <div class="indent">
+<h3>5.2.8.1 <a name="proto-user-invite-errors">Error Conditions</a>
+</h3>
+                    <p class="" style="">There are no valid error conditions for agent invitations.</p>
+                </div>
+                <div class="indent">
+<h3>5.2.8.2 <a name="proto-user-invite-example">Example</a>
+</h3>
+                    <p class="" style="">An invitation from the server on behalf of the support@server.com workgroup:</p>
+                    <p class="caption">Example 51. An Invitation</p>
+<div class="indent"><pre>
+S: &lt;message
+S:     from='roomname@chatserver.company.com'
+S:     to='alice@company.com/work'&gt;
+S:   &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+S:     &lt;invite from='support@workgroup.company.com'&gt;
+S:       &lt;reason&gt;
+S:       Please join the chat room to start your chat with user@server.com.
+S:       &lt;/reason&gt;
+S:     &lt;/invite&gt;
+S:   &lt;/x&gt;
+S:   &lt;x jid='roomname@chatserver.company.com' xmlns='jabber:x:conference'/&gt;
+S:   &lt;offer xmlns='http://jabber.org/protocol/workgroup' jid='user@server.com/home'/&gt;
+S: &lt;/message&gt;
+                    </pre></div>
+                </div>
+            </div>
+        </div>
+    <h2>6.
+       <a name="impl">Implementation Notes</a>
+</h2>
+        <ul>
+            <li>A workgroup is a normal XMPP messaging node and MUST maintain its own presence.
+                It is recommended that a workgroup be able to respond to arbitrary chat messages
+                sent to it (preferably by responding with instructions on how to join the queue).
+                Other users may subscribe to the workgroup services' presence using standard XMPP
+                presence-subscribe and presence-unsubscribe protocols. The workgroup service's
+                presence can be used to determine the workgroup's status without joining the
+                workgroup as a user or agent. For example, a website server-side component can
+                subscribe to the workgroup presence and indicate on web pages whether a workgroup
+                is available to offer live chat to website visitors.</li>
+            <li>If workgroup goes offline, all queued users SHOULD be notified using the
+                appropriate workgroup presence, status, and depart protocols.</li>
+            <li>An implementation MAY support for anonymous login by users, which makes it easier
+                to deploy such a system on a website.</li>
+            <li>Generally, client authors only need to implement the "user" portion of this JEP so
+                that clients can contact workgroups. Implementing the "agent" portion of the JEP is
+                generally left to specialized clients for agents.</li>
+            <li>Coordination of groupchat and workgroup services is beyond the scope of this JEP.
+                It is recommended that implementations use or create standard mechanisms to allow
+                workgroups and groupchat services to interact.</li>
+        </ul>
+    <h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+        <p class="" style="">Implementations may wish to restrict who is allowed to join workgroups as users
+        and agents. Details concerning the implementation of this feature is outside the scope of
+        this JEP.</p>
+    <h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+        <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259840">6</a>].</p>
+    <h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+        <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+        <p class="" style="">Upon advancement of this JEP to a status of Draft, the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259892">7</a>] shall add
+        'http://jabber.org/protocol/workgroup' to its registry of protocol namespaces.</p>
+        </div>
+        <div class="indent">
+<h3>9.2 <a name="registrar-discotype">Service Discovery Category/Type</a>
+</h3>
+            <p class="" style="">Service Discovery support is optional for Workgroup compliant implementations.
+            Workgroup services that do support Service Discovery MUST:</p>
+            <ul>
+                <li>Use the &lt;identity&gt; category="collaboration".</li>
+                <li>Use the &lt;identity&gt; type="workgroup".</li>
+                <li>Use the &lt;feature&gt; var="http://jabber.org/protocol/workgroup".</li>
+            </ul>
+            <p class="" style="">An example of discovery browsing is included. Notice how probing starts at
+            the server (company.com) revealing the workgroup service by it's JID
+            (workgroup.company.com) and a simple, human friendly name ("Company.com Live Assistant").
+            It is only during the discovery probing of the service that it is identified as a
+            workgroup using the &lt;identity&gt; and &lt;feature&gt; tags. Finally individual workgroups
+            (support and sales) can be discovered on the Workgroup service. When individual
+            workgroups are probed, the &lt;identity&gt; and &lt;feature&gt; tags are again
+            presented to identify them as workgroups along with (optional) associated meta-data.</p>
+            <p class="caption">Example 52. Workgroup Service Discovery</p>
+<div class="indent"><pre>
+U: &lt;iq to="company.com" from="user@server.com/home" id="id1" type="get"&gt;
+U:     &lt;query xmlns="http://jabber.org/protocol/disco#items"/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq from="company.com" to="user@server.com/home" id="id1" type="result"&gt;
+S:    &lt;query xmlns="http://jabber.org/protocol/disco#items"&gt;
+S:        &lt;item jid="workgroup.company.com" name="Company.com Live Assistant"/&gt;
+S:    &lt;/query&gt;
+S: &lt;/iq&gt;
+
+U: &lt;iq to="workgroup.company.com" from="user@server.com/home" id="id2" type="get"&gt;
+U:    &lt;query xmlns="http://jabber.org/protocol/disco#info"/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq from="workgroup.company.com" to="user@server.com/home" id="i2" type="result"&gt;
+S:    &lt;query xmlns="http://jabber.org/protocol/disco#info"&gt;
+S:        &lt;identity category="collaboration" name="Live Assistant" type="workgroup"/&gt;
+S:        &lt;feature var="http://jabber.org/protocol/workgroup"/&gt;
+S:        &lt;feature var="http://jabber.org/protocol/disco#info"/&gt;
+S:    &lt;/query&gt;
+S: &lt;/iq&gt;
+
+U: &lt;iq to="workgroup.company.com"from="user@server.com/home" id="id3" type="get"&gt;
+U:     &lt;query xmlns="http://jabber.org/protocol/disco#items"/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq from="workgroup.company.com" to="user@server.com/home" id="id3" type="result"&gt;
+S:     &lt;query xmlns="http://jabber.org/protocol/disco#items"&gt;
+S:         &lt;item jid="support@workgroup.company.com" name="Company.com Support Live Assistant"/&gt;
+S:         &lt;item jid="sales@workgroup.company.com" name="Company.com Sales Live Assistant"/&gt;
+S:     &lt;/query&gt;
+S: &lt;/iq&gt;
+
+U: &lt;iq to="support@workgroup.company.com"from="user@server.com/home" id="id4" type="get"&gt;
+U:     &lt;query xmlns="http://jabber.org/protocol/disco#info"/&gt;
+U: &lt;/iq&gt;
+S: &lt;iq from="support@workgroup.company.com" to="user@server.com/home" id="id4" type="result"&gt;
+S:     &lt;query xmlns="http://jabber.org/protocol/disco#info"&gt;
+S:         &lt;identity category="collaboration" name="demo" type="workgroup"/&gt;
+S:         &lt;feature var="http://jabber.org/protocol/disco#info"/&gt;
+S:         &lt;x xmlns="jabber:x:data" type="result"&gt;
+S:             &lt;field var="FORM_TYPE" type="hidden"&gt;
+S:                 &lt;value&gt;http://jabber.org/protocol/workgroup#workgroupinfo&lt;/value&gt;
+S:             &lt;/field&gt;
+S:             &lt;field var="workgroup#description" label="Description"&gt;
+S:                 &lt;value&gt;Company.com Support Workgroup&lt;/value&gt;
+S:             &lt;/field&gt;
+S:             &lt;field var="workgroup#online" label="Status"&gt;
+S:                 &lt;value&gt;ready&lt;/value&gt;
+S:             &lt;/field&gt;
+S:         &lt;/x&gt;
+S:     &lt;/query&gt;
+S: &lt;/iq&gt;
+            </pre></div>
+        </div>
+        <div class="indent">
+<h3>9.3 <a name="registrar-discofeatures">Service Discovery Features</a>
+</h3>
+            <p class="" style="">Discovery of support for this JEP can be done using the 'http://jabber.org/protocol/workgroup'
+        namespace. Individual workgroups SHOULD provide information when queried about the status of
+        the room, such as expected wait time.</p>
+
+            <p class="caption">Example 53. Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/workgroup&lt;/name&gt;
+  &lt;desc&gt;Workgroup namespace&lt;/desc&gt;
+  &lt;doc&gt;JEP-0142&lt;/doc&gt;
+&lt;/var&gt;
+            </pre></div>
+        </div>
+    <h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+        <p class="" style="">To follow.</p>
+    <h2>11.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+    The authors would like to thank Derek DeMoro and Gaston Dombiak for their help with this JEP.
+    <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250969">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250869">2</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2250891">3</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2251054">4</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p><a name="nt-id2250426">5</a>. The max-chats value sent from agent to workgroup service is a 'hint' or recommended value.
+                            The workgroup service is not obliged to accept this value. The actual max-chats value for the agent
+                            will be sent to the agent via the next Agent Status Update. This allows administrators to constrain
+                            agent behavior in order to enforce company policy, quality assurance, etc.</p>
+<p><a name="nt-id2259840">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259892">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-02-28)</h4>
+<div class="indent">General re-organization, refined agent status protocol, removed
+                queue-notification element from join request replies, user status pushes
+                now use a message instead of IQ. (mt/is)
+    </div>
+<h4>Version 0.1 (2004-08-10)</h4>
+<div class="indent">Initial version. (mt/is)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0143-0.2.html
+++ b/content/xep-0143-0.2.html
@@ -1,0 +1,401 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0143: Guidelines for JEP Authors</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Guidelines for JEP Authors">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides information intended to assist authors of Jabber Enhancement Proposals.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0143">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0143: Guidelines for JEP Authors</h1>
+<p>This JEP provides information intended to assist authors of Jabber Enhancement Proposals.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This Procedural JEP proposes that the process or activity defined herein shall be followed by the Jabber Software Foundation (JSF). However, this process or activity has not yet been approved by the Jabber Council and/or the JSF Board of Directors and is therefore not currently in force.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Procedural<br>
+            Number: 0143<br>
+            Version: 0.2<br>
+            Last Updated: 2004-09-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: JEP-0001<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#prep">Preparation</a>
+</dt>
+<dt>3.  <a href="#submit">Submission Process</a>
+</dt>
+<dt>4.  <a href="#format">JEP XML Format</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#format-work">Working With JEP Files</a>
+</dt>
+<dt>4.2.  <a href="#format-metadata">File Metadata</a>
+</dt>
+<dt>4.3.  <a href="#format-contents">File Contents</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sections">The Sections of a JEP</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sections-intro">Introduction</a>
+</dt>
+<dt>5.2.  <a href="#sections-glossary">Glossary</a>
+</dt>
+<dt>5.3.  <a href="#sections-reqs">Requirements</a>
+</dt>
+<dt>5.4.  <a href="#sections-usecases">Use Cases</a>
+</dt>
+<dt>5.5.  <a href="#sections-errors">Error Codes</a>
+</dt>
+<dt>5.6.  <a href="#sections-bizrules">Business Rules</a>
+</dt>
+<dt>5.7.  <a href="#sections-impl">Implementation Notes</a>
+</dt>
+<dt>5.8.  <a href="#sections-i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.9.  <a href="#sections-security">Security Considerations</a>
+</dt>
+<dt>5.10.  <a href="#sections-iana">IANA Considerations</a>
+</dt>
+<dt>5.11.  <a href="#sections-registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>5.12.  <a href="#sections-schema">XML Schema</a>
+</dt>
+<dt>5.13.  <a href="#sections-ack">Acknowledgements</a>
+</dt>
+</dl>
+<dt>6.  <a href="#styleguide">JEP Styleguide</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#style-attr">Attributes</a>
+</dt>
+<dt>6.2.  <a href="#style-ex">Code Examples</a>
+</dt>
+<dt>6.3.  <a href="#style-conf">Conformance Terms</a>
+</dt>
+<dt>6.4.  <a href="#style-elem">Elements</a>
+</dt>
+<dt>6.5.  <a href="#style-err">Errors</a>
+</dt>
+<dt>6.6.  <a href="#style-ns">Namespaces</a>
+</dt>
+<dt>6.7.  <a href="#style-quot">Quotes</a>
+</dt>
+</dl>
+<dt>7.  <a href="#conclusion">Conclusion</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2595954">1</a>] receives a significant number of proposals for extending the core Jabber protocols. However, it is not always clear to authors how to best structure a proposal in order for it to be accepted as a Jabber Enhancement Proposal and advance through the JSF's standards process. Therefore, this JEP provides guidelines that are intended to help authors write better JEPs.</p>
+  <p class="" style="">These guidelines assume that the reader is familiar with the JEP series of documents and the processes for handling them within the JSF, as defined in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596006">2</a>].</p>
+<h2>2.
+       <a name="prep">Preparation</a>
+</h2>
+  <p class="" style="">Before submitting a proposal for consideration as a JEP, the prospective author is strongly encouraged to complete some research in order to determine:</p>
+  <ul>
+    <li>if the proposed protocol extension is truly needed in order to fill a gap in existing Jabber technologies and protocols</li>
+    <li>if similar extensions have been proposed in the past and either rejected or deferred</li>
+    <li>if existing protocols might be more appropriate (e.g., protocols developed in the JSF or in other standards development organizations, such as the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2596168">3</a>] and <span class="ref">World Wide Web Consortium (W3C)</span>  [<a href="#nt-id2596194">4</a>])</li>
+  </ul>
+  <p class="" style="">After completing this research, the prospective author may conclude that a new protocol extension is needed. If so, the author is advised to review the <span class="ref">Protocol Design Guidelines</span>  [<a href="#nt-id2596293">5</a>], to understand the <a href="#submit">Submission Process</a>, to become familiar with both the <a href="#format">JEP XML Format</a> and the <a href="#styleguide">JEP Styleguide</a>, and to write the content required in order to complete the various <a href="#sections">Sections of a JEP</a>.</p>
+<h2>3.
+       <a name="submit">Submission Process</a>
+</h2>
+  <p class="" style="">The process for submitting a JEP is straightforward:</p>
+  <ol start="" type="">
+    <li>Contact the <span class="ref">JEP Editor</span>  [<a href="#nt-id2596153">6</a>] so that he knows to expect your submission.</li>
+    <li>Write your proposal following the guidelines described herein.</li>
+    <li>Make sure you read, understand, and agree to the <span class="ref">JSF IPR Policy</span>  [<a href="#nt-id2596233">7</a>] before you submit your proposal.</li>
+    <li>Send your XML file (or a URL for the file) to the JEP Editor.</li>
+  </ol>
+<h2>4.
+       <a name="format">JEP XML Format</a>
+</h2>
+  <p class="" style="">The JEP XML format is substantially similar to a reduced set of XHTML. This is intentional: it makes authoring JEPs easier. In fact, if you use the JEP template file with its associated XSLT stylesheet, you should be able to view your proposal in most modern web browsers (see below). The following subsections explain how to get started with JEP authoring and describe the XML format used for JEPs.</p>
+  <div class="indent">
+<h3>4.1 <a name="format-work">Working With JEP Files</a>
+</h3>
+    <p class="" style="">The best way to start working on your proposal is to retrieve all of the existing JEPs and associated stylesheets from source control. These files are stored using the CVS system, in a CVS module labelled 'jeps' at the jabberstudio.org CVS repository. Instructions for accessing these files is provided at &lt;<a href="http://www.jabberstudio.org/cvs.php">http://www.jabberstudio.org/cvs.php</a>&gt;. The document structure is formally defined by both a DTD and an XML schema, but you do not need to understand these in order to author a JEP. In addition, a handy template file is included under the &quot;templates/&quot; directory in the &quot;jeps&quot; module, providing an easy starting point for JEP authoring.</p>
+    <p class="" style="">To create your proposal, do a CVS checkout of the 'jeps' module, create a new directory (e.g., 'tmp/') for your JEP within the existing 'jeps/' directory, and copy one of the template files from the 'template/' directory to your new directory. You should be able to view your JEP in most modern web browsers as an XML file as long as you have jep.xsl and jep.dtd in the 'jeps/' directory (i.e., the parent of the directory for your specific JEP). Because of inconsistencies in browser XSLT implementations, certain formatting (e.g., table layouts and the numbering of tables, examples, and footnotes) may not be perfect. Don't panic; it will look fine in HTML.</p>
+    <p class="" style="">If your XML file doesn't render at all (i.e., it's just one big text blob), you are using the wrong browser. If you see only the bare outline generated by jep.xsl but none of your text, you have an error in your XML. You can check your XML syntax at xml.com  [<a href="#nt-id2601848">8</a>].</p>
+    <p class="" style="">To programatically convert your XML file into HTML, we recommend using Daniel Veillard's <a href="http://xmlsoft.org/XSLT/">xsltproc</a> program, which will give you helpful error messages regarding XML syntax problems. However, the JEP Editor will do the final rendering of XML into HTML as well as posting of your HTML file to the website, so you do not need to generate HTML files for submission to the JEP Editor (in fact, the JEP Editor requires that you submit your proposal in the JEP XML format, not HTML).</p>
+    <p class="" style="">Finally, the jep.ent file contains helpful &quot;external entities&quot; that provide shortcuts for including references to JEPs, RFCs, and other common strings. Unfortunately, most browsers do not correctly process external entities, so you cannot include entities from jep.ent if you need to view your XML source file in a browser. However, the JEP Editor reserves the right to convert your markup to external entities, since it makes his life easier. Also, please do not add items to the jep.ent file; instead, ask the JEP Editor to add them for you.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="format-metadata">File Metadata</a>
+</h3>
+    <p class="" style="">This section describes the metadata elements contained in the &lt;header/&gt; element of a JEP file (see below for the file contents).</p>
+    <p class="" style="">The XML character data of the &lt;title/&gt; element is the title of your JEP. Choose a descriptive title that is less than five words long. The JEP Editor may change this in consultation with the author.</p>
+    <p class="" style="">The XML character data of the &lt;abstract/&gt; element should be one sentence that captures the essence of your proposal (usually beginning &quot;This JEP defines a protocol that...&quot;). The JEP Editor has been known to modify the abstract so that it accurately describes the proposal.</p>
+    <p class="" style="">The XML character data of the &lt;legal/&gt; element must be as follows:</p>
+    <p class="indent" style="">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy (http://jabber.org/jsf/ipr-policy.php). This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at http://www.opencontent.org/openpub/).</p>
+    <p class="" style="">Your JEP number will be assigned by the JEP Editor; thus you can just make the XML character data of the &lt;number/&gt; element &quot;xxxx&quot;.</p>
+    <p class="" style="">The XML character data of the &lt;status/&gt; element should be &quot;Experimental&quot; since all JEPs start out as Experimental.</p>
+    <p class="" style="">The XML character data of the &lt;type/&gt; element should be either &quot;Standards Track&quot; or &quot;Informational&quot; (there are also Historical and Procedural JEPs, but these are uncommon and usually written by the JEP Editor). A Standards Track JEP is basically any JEP that defines a protocol to be used in the Jabber community. An Informational JEP defines best practices or a usage profile related to an existing protocol (e.g., <span class="ref">Invisibility</span>  [<a href="#nt-id2602070">9</a>]).</p>
+    <p class="" style="">The XML character data of the &lt;approver/&gt; element should be &quot;Council&quot;.</p>
+    <p class="" style="">The &lt;dependencies/&gt; element is used to specify JEPs, RFCs, and other specifications on which your proposal depends in a normative fashion (i.e., specifications that must or should be implemented in order to implement your proposed protocol). Each specification must be identified by a distinct &lt;spec/&gt; child element (see existing JEPs for clues regarding document identifiersk, or consult with the JEP Editor).</p>
+    <p class="" style="">The &lt;supersedes/&gt;, &lt;supersededby/&gt;, &lt;shortname/&gt;, and &lt;schemaloc/&gt; elements are for use by the JEP Editor; however, if your JEP supersedes an existing JEP, feel free to include a &lt;spec/&gt; child element specifying the document identifier (e.g., JEP-0093) for the protocol that is being superseded.</p>
+    <p class="" style="">Include one &lt;author/&gt; element for each co-author. Note well that the &lt;firstname/&gt;, &lt;surname/&gt;, &lt;email/&gt;, and &lt;jid/&gt; elements are all mandatory per JEP-0001.</p>
+    <p class="" style="">Include one &lt;revision/&gt; element for each revision of your JEP. The XML character data of the &lt;version/&gt; element must be &quot;0.1&quot; for your initial submission to the JEP Editor, and the &lt;remark/&gt; should be &quot;Initial version.&quot;; for each revision, you will include another &lt;revision/&gt; element (place it before the existing &lt;revision/&gt; elements) and iterate the &lt;version/&gt; element (e.g., &quot;0.2&quot; after &quot;0.1&quot;). The format for the &lt;date/&gt; element is yyyy-mm-dd. Please do not include the characters ' or &quot; in your revision remarks.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="format-contents">File Contents</a>
+</h3>
+    <p class="" style="">Aside from the metadata in the JEP &lt;header/&gt; element (see above), a JEP file is a series of sections, arranged in a hierarchy (&lt;section1/&gt; is a top-level section, within which you can nest &lt;section2/&gt; sections, and so on down to &lt;section4/&gt;). The title of a section is captured in the 'topic' attribute. You may also include an 'anchor' element so that you can link to page fragments from within your JEP. The allowable elements within a section element probably look familiar: &lt;p/&gt; for paragraphs, &lt;ol/&gt; and &lt;ul/&gt; for ordered and unordered lists, and so on.</p>
+    <p class="" style="">The &lt;example/&gt; and &lt;code/&gt; elements are used to show protocol snippets; the &lt;example/&gt; element includes a 'caption' attribute so that you can provide a description of the example, whereas the &lt;code/&gt; element does not. Define an XML CDATA section within both of these elements so that you do not need to escape the '&lt;' and '&gt;' characters in your sample XML stanzas, since this makes life much easier for author and editor alike.</p>
+    <p class="" style="">The &lt;p/&gt; and &lt;li/&gt; elements can also contain more markup that is familiar from HTML, such as the &lt;img/&gt; element. Note that hyperlinks are of the form &lt;link url='foo'&gt;bar&lt;/link&gt; rather than &lt;a href='foo'&gt;bar&lt;/a&gt;; the reasons for this are lost in the mists of time and it is too late to change it now, so you'll just have to adjust. If needed, you can also use inline structural and presentational markup such as &lt;em/&gt;, &lt;strong/&gt;, &lt;tt/&gt;, &lt;cite/&gt;, and &lt;span/&gt; within the &lt;p/&gt; and &lt;li/&gt; elements. </p>
+    <p class="" style="">You can also include tables (these are helpful for listing error codes and such). The &lt;table/&gt; element also can possess a 'caption' attribute so that you can provide a description of the table's contents. Standard HTML table structure applies (&lt;tr/&gt; defines a row, which contains &lt;th/&gt; elements for header rows and &lt;td/&gt; elements for data rows), and the 'colspan' and 'rowspan' attributes are also available if you need them. Table presentation (such as cellpadding and cellspacing) is handled by the XSLT and CSS stylesheets.</p>
+    <p class="" style="">In fact, the jep.xsl file performs all sorts of magic in converting your XML file into HTML, including creation of the front matter, table of contents, section numbering, notes, and revision history. Feel free to submit patches for this file, but do not commit your modified version to CVS.</p>
+  </div>
+<h2>5.
+       <a name="sections">The Sections of a JEP</a>
+</h2>
+  <p class="" style="">Most JEPs will have most of the following sections, usually in something like the order shown. Other sections may be appropriate (e.g., <span class="ref">XHTML-IM</span>  [<a href="#nt-id2602563">10</a>] has a section for W3C Considerations). Use your best judgement regarding the sections you need to make your argument, or consult with the JEP Editor regarding your needs.</p>
+  <div class="indent">
+<h3>5.1 <a name="sections-intro">Introduction</a>
+</h3>
+    <p class="" style="">The introduction to a JEP is quite important since it provides the rationale for considering the proposal. In particular, the introduction should include information such as the following:</p>
+    <ol start="" type="">
+      <li>Tasks that users currently cannot complete because we are lacking the protocol you propose. (Note: users are not just IM users, but any person, system, or application that could gain value from interacting with other entities over Jabber/XMPP networks.)</li>
+      <li>Other projects or protocols and how Jabber technologies could interface with them because of your proposed protocol (e.g., XML-RPC, SOAP, DotGNU).</li>
+      <li>A comparison between Jabber technologies and &quot;the competition&quot; (e.g., other IM systems or messaging protocols) that describes holes in the Jabber protocols that need to be filled in order to offer similar functionality.</li>
+      <li>The relevant history of thinking within the Jabber community.</li>
+      <li>Real-world examples of problems the protocol can solve.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sections-glossary">Glossary</a>
+</h3>
+    <p class="" style="">If your JEP uses terms that may not be familiar to the reader, please define them in a glossary.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="sections-reqs">Requirements</a>
+</h3>
+    <p class="" style="">Every JEP should include a section describing the requirements being addressed by the JEP. This information is critically important, because it clearly defines the scope of the proposal as well as any relevant constraints on the protocol design.</p>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="sections-usecases">Use Cases</a>
+</h3>
+    <p class="" style="">It is recommended that JEP authors structure their proposals according to the use cases that the proposal will address  [<a href="#nt-id2602616">11</a>]. We have found that use cases force JEP authors to focus on functionality rather than &quot;protocol for the sake of protocol&quot;. It is also helpful to sort use cases by actor, as is done in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602733">12</a>], for example. Include one subsection for each use case.</p>
+    <p class="" style="">When writing use cases and the associated protocols, make sure to:</p>
+    <ul>
+      <li>Clearly define the successful scenarios as well as alternate flows.</li>
+      <li>Include lots of protocol examples.</li>
+      <li>Describe the expected behavior of Jabber clients, servers, and components when using this protocol.</li>
+    </ul>
+    <p class="" style="">We just said so, but we will repeat ourselves: include lots of protocol examples. The help not only implementors but also those who will review your proposal. You get extra credit with the JEP Editor if you follow Jabber tradition by using characters and situations from the plays of Shakespeare:</p>
+    <p class="caption">Example 1. An Example from Shakespeare</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/garden'
+    type='chat'&gt;
+  &lt;body&gt;Wherefore art thou, Romeo?&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="sections-errors">Error Codes</a>
+</h3>
+    <p class="" style="">If your proposal defines a number of error and status codes (as is done in JEP-0045), it is a good idea to include a table of all the codes defined in your document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="sections-bizrules">Business Rules</a>
+</h3>
+    <p class="" style="">As with implementation notes, you may want to include a section describing various business rules (essentially, a variety of MUSTs, SHOULDs, and MAYs regarding application behavior). This is not required but can be helpful to implementors.</p>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="sections-impl">Implementation Notes</a>
+</h3>
+    <p class="" style="">You may want to include a section devoted to implementation notes. Again, this is not required but can be helpful to implementors.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="sections-i18n">Internationalization Considerations</a>
+</h3>
+    <p class="" style="">If there are any internationalization or localization issues related to your proposal, define them in this optional section.</p>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="sections-security">Security Considerations</a>
+</h3>
+    <p class="" style="">Your proposal MUST include a section entitled &quot;Security Considerations&quot;. Even if there are no security features or concerns related to your proposal, you must note that fact. For helpful guidelines, refer to <span class="ref">RFC 3552</span>  [<a href="#nt-id2602922">13</a>].</p>
+  </div>
+  <div class="indent">
+<h3>5.10 <a name="sections-iana">IANA Considerations</a>
+</h3>
+    <p class="" style="">This section is REQUIRED. The IANA is the Internet Assigned Numbers Authority, the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. Most proposals do not require interaction with the IANA, in which case the text of this section should read &quot;This JEP requires no interaction with the Internet Assigned Numbers Authority (IANA).&quot; If your proposal requires interaction with the IANA, discuss the matter with the JEP Editor. Do not contact the IANA on your own!</p>
+  </div>
+  <div class="indent">
+<h3>5.11 <a name="sections-registrar">Jabber Registrar Considerations</a>
+</h3>
+    <p class="" style="">This section is REQUIRED. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. If your proposal does not require interaction with the Jabber Registrar, the text of this section should read &quot;No namespaces or parameters need to be registered with the Jabber Registrar as a result of this JEP.&quot; Refer to Draft or Final JEPs for appropriate text in other cases, or consult with the JEP Editor.</p>
+  </div>
+  <div class="indent">
+<h3>5.12 <a name="sections-schema">XML Schema</a>
+</h3>
+    <p class="" style="">An XML Schema is required in order for a JEP to be approved by the Jabber Council. The JEP Editor can assist you in defining an XML Schema for the protocol you are proposing.</p>
+  </div>
+  <div class="indent">
+<h3>5.13 <a name="sections-ack">Acknowledgements</a>
+</h3>
+    <p class="" style="">Some JEPs end with a section thanking non-authors who have made strong contributions to the specification; if that is true of your JEP, feel free to include this section.</p>
+  </div>
+<h2>6.
+       <a name="styleguide">JEP Styleguide</a>
+</h2>
+  <p class="" style="">JEPs are written in English. It is not expected that you will be a fine prose writer, but try to write in a clear, easily-understood fashion. The JEP Editor will correct any errors of grammar, spelling  [<a href="#nt-id2602969">14</a>], punctuation, and usage he may find in your proposal, but may not do so until your proposal is farther along in the JEP process; in addition, the JEP Editor reserves the right to improve phrases that are unclear or infelicitous, move sections around, modify examples to use Shakespearean characters, and otherwise improve the argument and logical flow of your proposal (naturally, without changing the meaning of your proposal).</p>
+  <p class="" style="">The following styleguide is provided to supplement the standard English styleguides, such as <span style="font-weight: bold">The Elements of Style</span> and the <span style="font-weight: bold">Chicago Manual of Style</span>; please refer to those resources for information about basic English usage and to this styleguide for JEP-specific guidelines.</p>
+  <div class="indent">
+<h3>6.1 <a name="style-attr">Attributes</a>
+</h3>
+    <p class="" style="">When talking about an attribute by name, refer to it in single quotes. Example: the 'to' attribute.</p>
+    <p class="" style="">When talking about an attribute value, refer to it in double quotes. Example: the value of the 'subscription' attribute is &quot;both&quot;.</p>
+    <p class="" style="">Elements <span style="font-style: italic">possess</span> attributes and <span style="font-style: italic">contain</span> character data and/or child elements; do not confuse these terms.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="style-ex">Code Examples</a>
+</h3>
+    <p class="" style="">In examples, use single quotes rather than double quotes; they are more readable.</p>
+    <p class="" style="">To show the hierarchy of XML elements, indent two spaces for every level.</p>
+    <p class="" style="">If an element possesses a large number of attributes, include a line break before each attribute and indent them by four spaces or so that the attributes are vertically aligned for readability.</p>
+    <p class="" style="">If the XML character data of an element is long, include line breaks and indent by two spaces.</p>
+    <p class="" style="">Examples are the major source of right-scrolling in our HTML output files. Right-scrolling is evil. Adjust your example layouts accordingly (line widths should be no more than 110 characters or so).</p>
+    <p class="" style="">Example:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit' 
+    id='config1' 
+    to='crone1@shakespeare.lit/desktop' 
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+        Please coomplete this form to make changes to the configuration 
+        of your room; to add room owners and administrators, use the 
+        appropriate room commands rather than this form.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="style-conf">Conformance Terms</a>
+</h3>
+    <p class="" style="">Conformance terms (e.g,, &quot;MUST&quot; and &quot;SHOULD&quot;) are specified in RFC 2119. Use them.</p>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="style-elem">Elements</a>
+</h3>
+    <p class="" style="">When talking about an element by name, refer to it as an empty XML element. Example: the &lt;query/&gt; element.</p>
+    <p class="" style="">The top-level &lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt; elements are actually XML stanzas (see <span class="ref">XMPP Core</span>  [<a href="#nt-id2603223">15</a>]); refer to them as such.</p>
+    <p class="" style="">Elements <span style="font-style: italic">possess</span> attributes and <span style="font-style: italic">contain</span> character data and/or child elements; do not confuse these terms.</p>
+    <p class="" style="">Do not use the term &quot;tag&quot; when you mean &quot;element&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="style-err">Errors</a>
+</h3>
+    <p class="" style="">When talking about an error condition, use the XML element names defined in XMPP Core rather than the old HTTP-style code numbers. Example: the &lt;feature-not-implemented/&gt; error.</p>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="style-ns">Namespaces</a>
+</h3>
+    <p class="" style="">When talking about a namespace by name, refer to it in single quotes. Example: the 'jabber:iq:roster' namespace.</p>
+    <p class="" style="">An element or attribute is <span style="font-style: italic">qualified by</span> (rather than &quot;scoped by&quot; or &quot;in&quot;) a particular namespace.</p>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="style-quot">Quotes</a>
+</h3>
+    <p class="" style="">For precision, the JSF follows IETF usage by placing all punctuation outside the quotation marks unless one is quoting a text that includes the punctuation. Example: the port used for Jabber client communications is &quot;5222&quot;.</p>
+  </div>
+<h2>7.
+       <a name="conclusion">Conclusion</a>
+</h2>
+  <p class="" style="">For further information about the JEP process, please familiarize yourself with JEP-0001. For examples of formatting, refer to existing JEPs. For an understanding of current issues of interest to the Jabber community and to follow discussions about Jabber protocols, subscribe to the mailing list of the <span class="ref">Standards JIG</span>  [<a href="#nt-id2603470">16</a>].</p>
+  <p class="" style="">If you have any questions or have difficulties writing your JEP, feel free to contact the JEP Editor via email at editor@jabber.org, or via Jabber for a faster response.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2595954">1</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596006">2</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596168">3</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596194">4</a>. The World Wide Web Consortium defines data formats and markup languages (such as HTML and XML) for use over the Internet. For further information, see &lt;<a href="http://www.w3.org/">http://www.w3.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596293">5</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596153">6</a>. The JEP Editor is the individual appointed by the JSF Board of Directors to handle protocol submissions and provide day-to-day management of the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/jeps/editor.php">http://www.jabber.org/jeps/editor.php</a>&gt;.</p>
+<p>
+<a name="nt-id2596233">7</a>. The JSF IPR Policy defines the Jabber Software Foundation's official policy regarding intellectual property rights (IPR) as they pertain to Jabber Enhancement Proposals (JEPs). For further information, see &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;.</p>
+<p>
+<a name="nt-id2601848">8</a>. &lt;<a href="http://www.xml.com/pub/a/tools/ruwf/check.html">http://www.xml.com/pub/a/tools/ruwf/check.html</a>&gt;</p>
+<p>
+<a name="nt-id2602070">9</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602563">10</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602616">11</a>. A good introduction to use cases may be found at &lt;<a href="http://www.pols.co.uk/usecasezone/">http://www.pols.co.uk/usecasezone/</a>&gt;.</p>
+<p>
+<a name="nt-id2602733">12</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602922">13</a>. RFC 3552: Guidelines for Writing RFC Text on Security Considerations &lt;<a href="http://www.ietf.org/rfc/rfc3552.txt">http://www.ietf.org/rfc/rfc3552.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602969">14</a>. With all due respect to authors in other parts of the world, JEPs follow American spelling conventions; thus &quot;authorise&quot; will be changed to &quot;authorize&quot; and such.</p>
+<p>
+<a name="nt-id2603223">15</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603470">16</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-09-16)</h4>
+<div class="indent">Described JEP metadata elements. (psa)
+    </div>
+<h4>Version 0.1 (2004-09-15)</h4>
+<div class="indent">Initial version (adapted from JEP template). (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0143-0.3.html
+++ b/content/xep-0143-0.3.html
@@ -1,0 +1,413 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0143: Guidelines for JEP Authors</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Guidelines for JEP Authors">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides information intended to assist authors of Jabber Enhancement Proposals.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0143">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0143: Guidelines for JEP Authors</h1>
+<p>This JEP provides information intended to assist authors of Jabber Enhancement Proposals.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This Procedural JEP proposes that the process or activity defined herein shall be followed by the Jabber Software Foundation (JSF). However, this process or activity has not yet been approved by the Jabber Council and/or the JSF Board of Directors and is therefore not currently in force.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Procedural<br>
+            Number: 0143<br>
+            Version: 0.3<br>
+            Last Updated: 2004-10-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: JEP-0001<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#prep">Preparation</a>
+</dt>
+<dt>3.  <a href="#submit">Submission Process</a>
+</dt>
+<dt>4.  <a href="#format">JEP XML Format</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#format-work">Working With JEP Files</a>
+</dt>
+<dt>4.2.  <a href="#format-metadata">File Metadata</a>
+</dt>
+<dt>4.3.  <a href="#format-contents">File Contents</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sections">The Sections of a JEP</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sections-intro">Introduction</a>
+</dt>
+<dt>5.2.  <a href="#sections-glossary">Glossary</a>
+</dt>
+<dt>5.3.  <a href="#sections-reqs">Requirements</a>
+</dt>
+<dt>5.4.  <a href="#sections-usecases">Use Cases</a>
+</dt>
+<dt>5.5.  <a href="#sections-errors">Error Codes</a>
+</dt>
+<dt>5.6.  <a href="#sections-bizrules">Business Rules</a>
+</dt>
+<dt>5.7.  <a href="#sections-impl">Implementation Notes</a>
+</dt>
+<dt>5.8.  <a href="#sections-i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.9.  <a href="#sections-security">Security Considerations</a>
+</dt>
+<dt>5.10.  <a href="#sections-iana">IANA Considerations</a>
+</dt>
+<dt>5.11.  <a href="#sections-registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>5.12.  <a href="#sections-schema">XML Schema</a>
+</dt>
+<dt>5.13.  <a href="#sections-ack">Acknowledgements</a>
+</dt>
+</dl>
+<dt>6.  <a href="#styleguide">JEP Styleguide</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#style-attr">Attributes</a>
+</dt>
+<dt>6.2.  <a href="#style-ex">Code Examples</a>
+</dt>
+<dt>6.3.  <a href="#style-conf">Conformance Terms</a>
+</dt>
+<dt>6.4.  <a href="#style-elem">Elements</a>
+</dt>
+<dt>6.5.  <a href="#style-err">Errors</a>
+</dt>
+<dt>6.6.  <a href="#style-ns">Namespaces</a>
+</dt>
+<dt>6.7.  <a href="#style-quot">Quotes</a>
+</dt>
+</dl>
+<dt>7.  <a href="#conclusion">Conclusion</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596160">1</a>] receives a significant number of proposals for extending the core Jabber/XMPP protocols. However, it is not always clear to authors how to best structure a proposal in order for it to be accepted as a Jabber Enhancement Proposal and advance through the JSF's standards process. Therefore, this JEP provides guidelines that are intended to help authors write better JEPs.</p>
+  <p class="" style="">These guidelines assume that the reader is familiar with the JEP series of documents and the processes for handling them within the JSF, as defined in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596098">2</a>].</p>
+<h2>2.
+       <a name="prep">Preparation</a>
+</h2>
+  <p class="" style="">Before submitting a proposal for consideration as a JEP, the prospective author is strongly encouraged to complete some research in order to determine:</p>
+  <ul>
+    <li>if the proposed protocol extension is truly needed in order to fill a gap in existing Jabber technologies and protocols</li>
+    <li>if similar extensions have been proposed in the past and either rejected or deferred</li>
+    <li>if existing protocols might be more appropriate (e.g., protocols developed in the JSF or in other standards development organizations, such as the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2596271">3</a>] and <span class="ref">World Wide Web Consortium (W3C)</span>  [<a href="#nt-id2596297">4</a>])</li>
+  </ul>
+  <p class="" style="">After completing this research, the prospective author may conclude that a new protocol extension is needed. If so, the author is strongly advised to do the following:</p>
+  <ol start="" type="">
+    <li>Review the <span class="ref">Protocol Design Guidelines</span>  [<a href="#nt-id2596203">5</a>].</li>
+    <li>Understand the <a href="#submit">Submission Process</a>.</li>
+    <li>Become familiar with the <a href="#format">JEP XML Format</a>.</li>
+    <li>Read the <a href="#styleguide">JEP Styleguide</a>.</li>
+    <li>Then and only then write the content required in order to complete the various <a href="#sections">Sections of a JEP</a>.</li>
+  </ol>
+<h2>3.
+       <a name="submit">Submission Process</a>
+</h2>
+  <p class="" style="">The process for submitting a JEP is straightforward:</p>
+  <ol start="" type="">
+    <li>Contact the <span class="ref">JEP Editor</span>  [<a href="#nt-id2596361">6</a>] so that he knows to expect your submission.</li>
+    <li>Write your proposal following the guidelines described herein.</li>
+    <li>Make sure you read, understand, and agree to the <span class="ref">JSF IPR Policy</span>  [<a href="#nt-id2601948">7</a>] before you submit your proposal.</li>
+    <li>Send your XML file (or a URL for the file) to the JEP Editor.</li>
+  </ol>
+<h2>4.
+       <a name="format">JEP XML Format</a>
+</h2>
+  <p class="" style="">The JEP XML format is substantially similar to a reduced set of XHTML. This is intentional: it makes authoring JEPs easier. In fact, if you use the JEP template file with its associated XSLT stylesheet, you should be able to view your proposal in most modern web browsers (see below). The following subsections explain how to get started with JEP authoring and describe the XML format used for JEPs (see the jep.xsd or jep.dtd file for a formal description).</p>
+  <div class="indent">
+<h3>4.1 <a name="format-work">Working With JEP Files</a>
+</h3>
+    <p class="" style="">The best way to start working on your proposal is to retrieve all of the existing JEPs and associated stylesheets from source control. These files are stored using the CVS system, in a CVS module labelled 'jeps' at the jabberstudio.org CVS repository. Instructions for accessing these files are provided at &lt;<a href="http://www.jabberstudio.org/cvs.php">http://www.jabberstudio.org/cvs.php</a>&gt;. The document structure is formally defined by both a DTD and an XML schema, but you do not need to understand these in order to author a JEP. In addition, a handy template file is included under the &quot;templates/&quot; directory in the &quot;jeps&quot; module, providing an easy starting point for JEP authoring.</p>
+    <p class="" style="">To create your proposal, do a CVS checkout of the 'jeps' module, create a new directory (e.g., 'tmp/') for your JEP within the existing 'jeps/' directory, copy the template file from the 'template/' directory to your new directory, and start editing the file using either a basic text editor or a specialized XML editing application such as XML Spy or XMLmind.</p>
+    <p class="" style="">Even if you use a basic text editor, you should be able to view your JEP in most modern web browsers as an XML file as long as you have jep.xsl and jep.dtd in the 'jeps/' directory (i.e., the parent of the directory for your specific JEP). Because of inconsistencies in browser XSLT implementations, certain formatting (e.g., table layouts and the numbering of tables, examples, and footnotes) may not be perfect. Don't panic; it will look fine in HTML. If your XML file doesn't render at all (i.e., it's just one big text blob), you are using the wrong browser. If you see only the bare outline generated by jep.xsl but none of your text, you have an error in your XML. You can check your XML syntax at xml.com  [<a href="#nt-id2602006">8</a>].</p>
+    <p class="" style="">To programatically convert your XML file into HTML, we recommend using Daniel Veillard's <a href="http://xmlsoft.org/XSLT/">xsltproc</a> program, which will give you helpful error messages regarding XML syntax problems. However, the JEP Editor will do the final rendering of XML into HTML as well as posting of your HTML file to the JSF website, so you do not need to generate HTML files for submission to the JEP Editor (in fact, the JEP Editor requires that you submit your proposal in the JEP XML format, not HTML).</p>
+    <p class="" style="">Finally, the jep.ent file contains helpful &quot;external entities&quot; that provide shortcuts for including references to JEPs, RFCs, and other common strings. Unfortunately, most browsers do not correctly process external entities, so you cannot include entities from jep.ent if you need to view your XML source file in a browser. However, the JEP Editor reserves the right to convert your markup to external entities, since it makes his life easier. Also, please do not add items to the jep.ent file; instead, ask the JEP Editor to add them for you.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="format-metadata">File Metadata</a>
+</h3>
+    <p class="" style="">This section describes the metadata elements contained in the &lt;header/&gt; element of a JEP file (see below for the file contents).</p>
+    <p class="" style="">The XML character data of the &lt;title/&gt; element is the title of your JEP. Choose a descriptive title that is less than five words long. The JEP Editor may change this in consultation with the author.</p>
+    <p class="" style="">The XML character data of the &lt;abstract/&gt; element SHOULD be one sentence that captures the essence of your proposal (usually beginning &quot;This JEP defines a protocol that...&quot;). The JEP Editor has been known to modify the abstract so that it accurately describes the proposal.</p>
+    <p class="" style="">The XML character data of the &lt;legal/&gt; element MUST be as follows:</p>
+    <p class="indent" style="">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy (http://jabber.org/jsf/ipr-policy.php). This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at http://www.opencontent.org/openpub/).</p>
+    <p class="" style="">Your JEP number will be assigned by the JEP Editor; thus you can just make the XML character data of the &lt;number/&gt; element &quot;xxxx&quot;.</p>
+    <p class="" style="">The XML character data of the &lt;status/&gt; element SHOULD be &quot;Experimental&quot; since all JEPs start out as Experimental.</p>
+    <p class="" style="">The XML character data of the &lt;type/&gt; element SHOULD be either &quot;Standards Track&quot; or &quot;Informational&quot; (there are also Historical and Procedural JEPs, but these are uncommon and usually written by the JEP Editor). A Standards Track JEP is basically any JEP that defines a protocol to be used in the Jabber community. An Informational JEP defines best practices or a usage profile related to an existing protocol (e.g., <span class="ref">Invisibility</span>  [<a href="#nt-id2602313">9</a>]).</p>
+    <p class="" style="">The XML character data of the &lt;approver/&gt; element SHOULD be &quot;Council&quot;.</p>
+    <p class="" style="">The &lt;dependencies/&gt; element is used to specify JEPs, RFCs, and other specifications on which your proposal depends in a normative fashion (i.e., specifications that MUST or SHOULD be implemented in order to implement your proposed protocol). Each specification MUST be identified by a distinct &lt;spec/&gt; child element (see existing JEPs for clues regarding document identifiers, or consult with the JEP Editor).</p>
+    <p class="" style="">The &lt;supersedes/&gt;, &lt;supersededby/&gt;, &lt;shortname/&gt;, and &lt;schemaloc/&gt; elements are for use by the JEP Editor; however, if your JEP supersedes an existing JEP, feel free to include a &lt;spec/&gt; child element specifying the document identifier (e.g., JEP-0093) for the protocol that is being superseded.</p>
+    <p class="" style="">Include one &lt;author/&gt; element for each co-author. Note well that the &lt;firstname/&gt;, &lt;surname/&gt;, &lt;email/&gt;, and &lt;jid/&gt; elements are all mandatory per JEP-0001.</p>
+    <p class="" style="">Include one &lt;revision/&gt; element for each revision of your JEP. The XML character data of the &lt;version/&gt; element SHOULD be &quot;0.0.1&quot; for your initial submission to the JEP Editor, and the &lt;remark/&gt; SHOULD be &quot;Initial version.&quot;; for each revision, you will include another &lt;revision/&gt; element (place it before the existing &lt;revision/&gt; elements) and iterate the &lt;version/&gt; element (e.g., &quot;0.2&quot; after &quot;0.1&quot;). The format for the &lt;date/&gt; element is yyyy-mm-dd. Please do not include the characters ' or &quot; in your revision remarks.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="format-contents">File Contents</a>
+</h3>
+    <p class="" style="">Aside from the metadata in the JEP &lt;header/&gt; element (see above), a JEP file is a series of sections, arranged in a hierarchy (&lt;section1/&gt; is a top-level section, within which you can nest &lt;section2/&gt; sections, and so on down to &lt;section4/&gt;). The title of a section is captured in the 'topic' attribute. You may also include an 'anchor' element so that you can link to page fragments from within your JEP. The allowable elements within a section element probably look familiar: &lt;p/&gt; for paragraphs, &lt;ol/&gt; and &lt;ul/&gt; for ordered and unordered lists, and so on.</p>
+    <p class="" style="">The &lt;example/&gt; and &lt;code/&gt; elements are used to show protocol snippets; the &lt;example/&gt; element includes a 'caption' attribute so that you can provide a description of the example, whereas the &lt;code/&gt; element does not. Define an XML CDATA section within both of these elements so that you do not need to escape the '&lt;' and '&gt;' characters in your sample XML stanzas, since this makes life much easier for author and editor alike.</p>
+    <p class="" style="">The &lt;p/&gt; and &lt;li/&gt; elements can also contain more markup that is familiar from HTML, such as the &lt;img/&gt; element. Note that hyperlinks are of the form &lt;link url='foo'&gt;bar&lt;/link&gt; rather than &lt;a href='foo'&gt;bar&lt;/a&gt;; the reasons for this are lost in the mists of time and it is too late to change it now, so you'll just have to adjust. If needed, you can also use inline structural and presentational markup such as &lt;em/&gt;, &lt;strong/&gt;, &lt;tt/&gt;, &lt;cite/&gt;, and &lt;span/&gt; within the &lt;p/&gt; and &lt;li/&gt; elements. </p>
+    <p class="" style="">You can also include tables (these are helpful for listing error codes and such). The &lt;table/&gt; element also can possess a 'caption' attribute so that you can provide a description of the table's contents. Standard HTML table structure applies (&lt;tr/&gt; defines a row, which contains &lt;th/&gt; elements for header rows and &lt;td/&gt; elements for data rows), and the 'colspan' and 'rowspan' attributes are also available if you need them. Table presentation (such as cellpadding and cellspacing) is handled by the XSLT and CSS stylesheets.</p>
+    <p class="" style="">In fact, the jep.xsl file performs all sorts of magic in converting your XML file into HTML, including creation of the front matter, table of contents, section numbering, notes, and revision history. Feel free to submit patches for this file, but do not commit your modified version to CVS.</p>
+  </div>
+<h2>5.
+       <a name="sections">The Sections of a JEP</a>
+</h2>
+  <p class="" style="">Most JEPs will have most of the following sections, usually in something like the order shown. Other sections may be appropriate (e.g., <span class="ref">XHTML-IM</span>  [<a href="#nt-id2602567">10</a>] has a section for W3C Considerations). Use your best judgment regarding the sections you need in order to make your argument, or consult with the JEP Editor regarding your needs.</p>
+  <div class="indent">
+<h3>5.1 <a name="sections-intro">Introduction</a>
+</h3>
+    <p class="" style="">The introduction to a JEP is quite important since it provides the rationale for considering the proposal. In particular, the introduction SHOULD include information such as the following:</p>
+    <ol start="" type="">
+      <li>Tasks that users currently cannot complete because we are lacking the protocol you propose. (Note: users are not just IM users, but any person, system, or application that could gain value from interacting with other entities over Jabber/XMPP networks.)</li>
+      <li>Other projects or protocols and how Jabber technologies could interface with them because of your proposed protocol (e.g., XML-RPC, SOAP).</li>
+      <li>A comparison between Jabber technologies and &quot;the competition&quot; (e.g., other IM systems or messaging protocols) that describes holes in the Jabber protocols that need to be filled in order to offer similar functionality.</li>
+      <li>The relevant history of thinking within the Jabber community.</li>
+      <li>Real-world examples of problems the protocol can solve.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sections-glossary">Glossary</a>
+</h3>
+    <p class="" style="">If your JEP uses terms that may not be familiar to the reader, please define them in a glossary.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="sections-reqs">Requirements</a>
+</h3>
+    <p class="" style="">Every JEP SHOULD include a section describing the requirements being addressed by the JEP. This information is critically important, because it clearly defines the scope of the proposal as well as any relevant constraints on the protocol design.</p>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="sections-usecases">Use Cases</a>
+</h3>
+    <p class="" style="">It is recommended that JEP authors structure their proposals according to the use cases that the proposal will address.  [<a href="#nt-id2602620">11</a>] We have found that use cases force JEP authors to focus on functionality rather than &quot;protocol for the sake of protocol&quot;. It is also helpful to sort use cases by actor, as is done in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602738">12</a>], for example. Include one subsection for each use case.</p>
+    <p class="" style="">When writing use cases and the associated protocols, make sure to:</p>
+    <ul>
+      <li>Clearly define the successful scenarios as well as alternate flows.</li>
+      <li>Include lots of protocol examples.</li>
+      <li>Describe the expected behavior of Jabber clients, servers, and components when using this protocol.</li>
+    </ul>
+    <p class="" style="">We just said so, but we will repeat ourselves: include lots of protocol examples. Examples help not only implementors but also those who will review your proposal in the <span class="ref">Standards JIG</span>  [<a href="#nt-id2602704">13</a>] and <span class="ref">Jabber Council</span>  [<a href="#nt-id2602837">14</a>]. You get extra credit with the JEP Editor if you follow Jabber tradition by using characters and situations from the plays of Shakespeare:</p>
+    <p class="caption">Example 1. An Example from Shakespeare</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/garden'
+    type='chat'&gt;
+  &lt;body&gt;Wherefore art thou, Romeo?&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="sections-errors">Error Codes</a>
+</h3>
+    <p class="" style="">If your proposal defines a number of error and status codes (as is done in JEP-0045), it is a good idea to include a table of all the codes defined in your document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="sections-bizrules">Business Rules</a>
+</h3>
+    <p class="" style="">As with implementation notes, you may want to include a section describing various business rules (essentially, a variety of MUSTs, SHOULDs, and MAYs regarding application behavior). This is not required but can be helpful to implementors.</p>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="sections-impl">Implementation Notes</a>
+</h3>
+    <p class="" style="">You may want to include a section devoted to implementation notes. Again, this is not required but can be helpful to implementors.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="sections-i18n">Internationalization Considerations</a>
+</h3>
+    <p class="" style="">If there are any internationalization or localization issues related to your proposal, define them in this optional section.</p>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="sections-security">Security Considerations</a>
+</h3>
+    <p class="" style="">Your proposal MUST include a section entitled &quot;Security Considerations&quot;. Even if there are no security features or concerns related to your proposal, you MUST note that fact. For helpful guidelines, refer to <span class="ref">RFC 3552</span>  [<a href="#nt-id2602987">15</a>].</p>
+  </div>
+  <div class="indent">
+<h3>5.10 <a name="sections-iana">IANA Considerations</a>
+</h3>
+    <p class="" style="">This section is REQUIRED. The IANA is the Internet Assigned Numbers Authority, the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. Most proposals do not require interaction with the IANA, in which case the text of this section SHOULD read &quot;This JEP requires no interaction with the Internet Assigned Numbers Authority (IANA).&quot; If your proposal requires interaction with the IANA, discuss the matter with the JEP Editor. Do not contact the IANA on your own!</p>
+  </div>
+  <div class="indent">
+<h3>5.11 <a name="sections-registrar">Jabber Registrar Considerations</a>
+</h3>
+    <p class="" style="">This section is REQUIRED. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. If your proposal does not require interaction with the Jabber Registrar, the text of this section SHOULD read &quot;No namespaces or parameters need to be registered with the Jabber Registrar as a result of this JEP.&quot; Refer to Draft or Final JEPs for appropriate text in other cases, or consult with the JEP Editor.</p>
+  </div>
+  <div class="indent">
+<h3>5.12 <a name="sections-schema">XML Schema</a>
+</h3>
+    <p class="" style="">An XML Schema is required in order for a JEP to be approved by the Jabber Council. The JEP Editor can assist you in defining an XML Schema for the protocol you are proposing.</p>
+  </div>
+  <div class="indent">
+<h3>5.13 <a name="sections-ack">Acknowledgements</a>
+</h3>
+    <p class="" style="">Some JEPs end with a section thanking non-authors who have made strong contributions to the specification; if that is true of your JEP, feel free to include this section.</p>
+  </div>
+<h2>6.
+       <a name="styleguide">JEP Styleguide</a>
+</h2>
+  <p class="" style="">JEPs are written in English. It is not expected that you will be a fine prose writer, but try to write in a clear, easily-understood fashion. The JEP Editor will correct any errors of grammar, spelling  [<a href="#nt-id2603034">16</a>], punctuation, and usage he may find in your proposal, but may not do so until your proposal is farther along in the JEP process. In addition, the JEP Editor reserves the right to improve phrases that are unclear or infelicitous, move sections around, modify examples to use Shakespearean characters, and otherwise improve the argument and logical flow of your proposal (naturally, without changing the meaning).</p>
+  <p class="" style="">The following styleguide is provided to supplement the standard English styleguides, such as <span style="font-weight: bold">The Elements of Style</span> and the <span style="font-weight: bold">Chicago Manual of Style</span>; please refer to those resources for information about basic English usage and to this styleguide for JEP-specific guidelines.</p>
+  <div class="indent">
+<h3>6.1 <a name="style-attr">Attributes</a>
+</h3>
+    <p class="" style="">When talking about an attribute by name, refer to it in single quotes. Example: the 'to' attribute.</p>
+    <p class="" style="">When talking about an attribute value, refer to it in double quotes. Example: the value of the 'subscription' attribute is &quot;both&quot;.</p>
+    <p class="" style="">Elements <span style="font-style: italic">possess</span> attributes and <span style="font-style: italic">contain</span> character data and/or child elements; do not confuse these terms.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="style-ex">Code Examples</a>
+</h3>
+    <p class="" style="">In examples, use single quotes rather than double quotes; they are more readable.</p>
+    <p class="" style="">To show the hierarchy of XML elements, indent two spaces for every level.</p>
+    <p class="" style="">If an element possesses a large number of attributes, include a line break before each attribute and indent them by four spaces or so that the attributes are vertically aligned for readability.</p>
+    <p class="" style="">If the XML character data of an element is long, include line breaks and indent by two spaces.</p>
+    <p class="" style="">Examples are the major source of right-scrolling in our HTML output files. Right-scrolling is evil. Adjust your example layouts accordingly (line widths should be no more than 110 characters or so).</p>
+    <p class="" style="">Example:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit' 
+    id='config1' 
+    to='crone1@shakespeare.lit/desktop' 
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+        Please coomplete this form to make changes to the configuration 
+        of your room; to add room owners and administrators, use the 
+        appropriate room commands rather than this form.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="style-conf">Conformance Terms</a>
+</h3>
+    <p class="" style="">Conformance terms (e.g,, &quot;MUST&quot; and &quot;SHOULD&quot;) are specified in RFC 2119. Use them. When such terms are not in ALL CAPS, the special conformance sense does not apply (this should be obvious but may not be).</p>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="style-elem">Elements</a>
+</h3>
+    <p class="" style="">When talking about an element by name, refer to it as an empty XML element. Example: the &lt;query/&gt; element. There are shortcuts for some common element names in the jep.ent file.</p>
+    <p class="" style="">The top-level &lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt; elements are actually XML stanzas (see <span class="ref">XMPP Core</span>  [<a href="#nt-id2603291">17</a>]); refer to them as such. There are shortcuts for stanza names in the jep.ent file.</p>
+    <p class="" style="">Elements <span style="font-style: italic">possess</span> attributes and <span style="font-style: italic">contain</span> character data and/or child elements; do not confuse these terms.</p>
+    <p class="" style="">Do not use the term &quot;tag&quot; when you mean &quot;element&quot;.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="style-err">Errors</a>
+</h3>
+    <p class="" style="">When talking about an error condition, use the XML element names defined in XMPP Core rather than the old HTTP-style code numbers. Example: the &lt;feature-not-implemented/&gt; error. There are shortcuts for the stanza errors in the jep.ent file.</p>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="style-ns">Namespaces</a>
+</h3>
+    <p class="" style="">When talking about a namespace by name, refer to it in single quotes. Example: the 'jabber:iq:roster' namespace.</p>
+    <p class="" style="">An element or attribute is <span style="font-style: italic">qualified by</span> (rather than &quot;scoped by&quot; or &quot;in&quot;) a particular namespace.</p>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="style-quot">Quotes</a>
+</h3>
+    <p class="" style="">For precision, the JSF follows IETF usage by placing all punctuation outside the quotation marks unless one is quoting text that includes the punctuation. Example: the port used for Jabber client communications is &quot;5222&quot;.</p>
+  </div>
+<h2>7.
+       <a name="conclusion">Conclusion</a>
+</h2>
+  <p class="" style="">For further information about the JEP process, please familiarize yourself with JEP-0001. For examples of formatting, refer to existing JEPs. For an understanding of current issues of interest to the Jabber community and to follow discussions about Jabber protocols, subscribe to the &lt;standards-jig@jabber.org&gt; mailing list.</p>
+  <p class="" style="">If you have any questions or have difficulties writing your JEP, feel free to contact the JEP Editor via email at editor@jabber.org, or via Jabber for a faster response.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596160">1</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596098">2</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596271">3</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596297">4</a>. The World Wide Web Consortium defines data formats and markup languages (such as HTML and XML) for use over the Internet. For further information, see &lt;<a href="http://www.w3.org/">http://www.w3.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596203">5</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596361">6</a>. The JEP Editor is the individual appointed by the JSF Board of Directors to handle protocol submissions and provide day-to-day management of the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/jeps/editor.php">http://www.jabber.org/jeps/editor.php</a>&gt;.</p>
+<p>
+<a name="nt-id2601948">7</a>. The JSF IPR Policy defines the Jabber Software Foundation's official policy regarding intellectual property rights (IPR) as they pertain to Jabber Enhancement Proposals (JEPs). For further information, see &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;.</p>
+<p>
+<a name="nt-id2602006">8</a>. &lt;<a href="http://www.xml.com/pub/a/tools/ruwf/check.html">http://www.xml.com/pub/a/tools/ruwf/check.html</a>&gt;</p>
+<p>
+<a name="nt-id2602313">9</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602567">10</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602620">11</a>. A good introduction to use cases may be found at &lt;<a href="http://www.pols.co.uk/usecasezone/">http://www.pols.co.uk/usecasezone/</a>&gt;.</p>
+<p>
+<a name="nt-id2602738">12</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602704">13</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p>
+<a name="nt-id2602837">14</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p>
+<a name="nt-id2602987">15</a>. RFC 3552: Guidelines for Writing RFC Text on Security Considerations &lt;<a href="http://www.ietf.org/rfc/rfc3552.txt">http://www.ietf.org/rfc/rfc3552.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603034">16</a>. With all due respect to authors in other parts of the world, JEPs follow American spelling conventions; thus &quot;authorise&quot; will be changed to &quot;authorize&quot; and such.</p>
+<p>
+<a name="nt-id2603291">17</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2004-10-12)</h4>
+<div class="indent">Minor clarifications throughout. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-16)</h4>
+<div class="indent">Described JEP metadata elements. (psa)
+    </div>
+<h4>Version 0.1 (2004-09-15)</h4>
+<div class="indent">Initial version (adapted from JEP template). (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0143-0.4.html
+++ b/content/xep-0143-0.4.html
@@ -1,0 +1,413 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0143: Guidelines for JEP Authors</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Guidelines for JEP Authors">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides information intended to assist authors of Jabber Enhancement Proposals.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0143">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0143: Guidelines for JEP Authors</h1>
+<p>This JEP provides information intended to assist authors of Jabber Enhancement Proposals.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.php">http://www.jabber.org/council/queue.php</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Procedural<br>
+            Number: 0143<br>
+            Version: 0.4<br>
+            Last Updated: 2004-10-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: JEP-0001<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#prep">Preparation</a>
+</dt>
+<dt>3.  <a href="#submit">Submission Process</a>
+</dt>
+<dt>4.  <a href="#format">JEP XML Format</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#format-work">Working With JEP Files</a>
+</dt>
+<dt>4.2.  <a href="#format-metadata">File Metadata</a>
+</dt>
+<dt>4.3.  <a href="#format-contents">File Contents</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sections">The Sections of a JEP</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sections-intro">Introduction</a>
+</dt>
+<dt>5.2.  <a href="#sections-reqs">Requirements</a>
+</dt>
+<dt>5.3.  <a href="#sections-terms">Terminology</a>
+</dt>
+<dt>5.4.  <a href="#sections-usecases">Use Cases</a>
+</dt>
+<dt>5.5.  <a href="#sections-errors">Error Codes</a>
+</dt>
+<dt>5.6.  <a href="#sections-bizrules">Business Rules</a>
+</dt>
+<dt>5.7.  <a href="#sections-impl">Implementation Notes</a>
+</dt>
+<dt>5.8.  <a href="#sections-i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.9.  <a href="#sections-security">Security Considerations</a>
+</dt>
+<dt>5.10.  <a href="#sections-iana">IANA Considerations</a>
+</dt>
+<dt>5.11.  <a href="#sections-registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>5.12.  <a href="#sections-schema">XML Schema</a>
+</dt>
+<dt>5.13.  <a href="#sections-ack">Acknowledgements</a>
+</dt>
+</dl>
+<dt>6.  <a href="#styleguide">JEP Styleguide</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#style-attr">Attributes</a>
+</dt>
+<dt>6.2.  <a href="#style-ex">Code Examples</a>
+</dt>
+<dt>6.3.  <a href="#style-conf">Conformance Terms</a>
+</dt>
+<dt>6.4.  <a href="#style-elem">Elements</a>
+</dt>
+<dt>6.5.  <a href="#style-err">Errors</a>
+</dt>
+<dt>6.6.  <a href="#style-ns">Namespaces</a>
+</dt>
+<dt>6.7.  <a href="#style-quot">Quotes</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The <span class="ref">Jabber Software Foundation (JSF)</span>  [<a href="#nt-id2596192">1</a>] receives a significant number of proposals for defining extensions to the core XMPP protocols specified in <span class="ref">XMPP Core</span>  [<a href="#nt-id2596194">2</a>]. However, it is not always clear to authors how to best structure a proposal in order for it to be accepted as a Jabber Enhancement Proposal and then advance through the JSF's standards process. Therefore, this JEP provides guidelines that are intended to help authors write better JEPs.</p>
+  <p class="" style="">These guidelines assume that the reader is familiar with the JEP series of documents and the processes for handling them within the JSF, as defined in <span class="ref">Jabber Enhancement Proposals</span>  [<a href="#nt-id2596127">3</a>].</p>
+<h2>2.
+       <a name="prep">Preparation</a>
+</h2>
+  <p class="" style="">The prospective author is strongly encouraged to complete some research before submitting a proposal for consideration as a JEP. In particular, the author should do the following:</p>
+  <ul>
+    <li>Review the XMPP RFCs and existing JSF JEPs to determine if the proposed protocol extension is truly needed in order to fill a gap in existing Jabber technologies and protocols.</li>
+    <li>Review rejected and deferred JEPs to determine if similar extensions have been proposed in the past but not approved by the <span class="ref">Jabber Council</span>  [<a href="#nt-id2596322">4</a>].</li>
+    <li>Review protocols developed within other standards development organizations, such as the <span class="ref">Internet Engineering Task Force (IETF)</span>  [<a href="#nt-id2596356">5</a>] and <span class="ref">World Wide Web Consortium (W3C)</span>  [<a href="#nt-id2596382">6</a>], to determine if they might be more appropriate than a new XMPP extension.</li>
+    <li>Review discussions within the <span class="ref">Standards JIG</span>  [<a href="#nt-id2601918">7</a>] to determine if similar functionality has been discussed in the past or is currently under discussion.</li>
+  </ul>
+  <p class="" style="">After completing this research, the prospective author may conclude that a new protocol extension is needed. If so, the author is strongly advised to do the following:</p>
+  <ol start="" type="">
+    <li>Review JEP-0001 and the <span class="ref">Protocol Design Guidelines</span>  [<a href="#nt-id2596272">8</a>].</li>
+    <li>Understand the <a href="#submit">Submission Process</a>.</li>
+    <li>Become familiar with the <a href="#format">JEP XML Format</a>.</li>
+    <li>Then and only then write a proposal that includes all of the appropriate <a href="#sections">Sections of a JEP</a>.</li>
+    <li>Review the content to ensure that it conforms to the <a href="#styleguide">JEP Styleguide</a>.</li>
+  </ol>
+<h2>3.
+       <a name="submit">Submission Process</a>
+</h2>
+  <p class="" style="">The process for submitting a JEP is straightforward:</p>
+  <ol start="" type="">
+    <li>Contact the <span class="ref">JEP Editor</span>  [<a href="#nt-id2602079">9</a>] so that he knows to expect your submission.</li>
+    <li>Write your proposal following the guidelines described herein.</li>
+    <li>Make sure you read, understand, and agree to the <span class="ref">JSF IPR Policy</span>  [<a href="#nt-id2602011">10</a>] before you submit your proposal.</li>
+    <li>Send your XML file (or a URL for the file) to the JEP Editor.</li>
+  </ol>
+<h2>4.
+       <a name="format">JEP XML Format</a>
+</h2>
+  <p class="" style="">The JEP XML format is substantially similar to a reduced set of XHTML. This is intentional: it makes authoring JEPs easier. In fact, if you use the JEP template file with its associated XSLT stylesheet, you should be able to view your proposal in most modern web browsers (see below). The following subsections explain how to get started with JEP authoring and describe the XML format used for JEPs (see the jep.xsd or jep.dtd file for a formal description).</p>
+  <div class="indent">
+<h3>4.1 <a name="format-work">Working With JEP Files</a>
+</h3>
+    <p class="" style="">The best way to start working on your proposal is to retrieve all of the existing JEPs and associated stylesheets from source control. These files are stored using the CVS system, in a CVS module labelled 'jeps' at the jabberstudio.org CVS repository. Instructions for accessing these files are provided at &lt;<a href="http://www.jabberstudio.org/cvs.php">http://www.jabberstudio.org/cvs.php</a>&gt;. The document structure is formally defined by both a DTD and an XML schema, but you do not need to understand the formal descriptions in order to author a JEP. In addition, a handy template file is included under the 'templates/' directory in the 'jeps' module, providing a quick starting point for JEP authoring.</p>
+    <p class="" style="">To create your proposal, do a CVS checkout of the 'jeps' module, create a new directory (e.g., 'tmp/') for your JEP within the existing 'jeps/' directory, copy the template file from the 'template/' directory to your new directory, and start editing the file using either a basic text editor or a specialized XML editing application such as XML Spy or XMLmind.</p>
+    <p class="" style="">Even if you use a basic text editor, you should be able to view your JEP in most modern web browsers as an XML file as long as you have jep.xsl and jep.dtd in the 'jeps/' directory (i.e., the parent of the directory for your specific JEP). Because of inconsistencies in browser XSLT implementations, certain formatting (e.g., table layouts and the numbering of tables, examples, and footnotes) may not be perfect. Don't panic; it will look fine in the HTML output produced by the JEP Editor. If your XML file doesn't render at all (i.e., it's just one big text blob), you are using the wrong browser. If you see only the bare outline generated by jep.xsl but none of your text, you have an error in your XML. You can check your XML syntax at xml.com  [<a href="#nt-id2602165">11</a>].</p>
+    <p class="" style="">To programatically convert your XML file into HTML, we recommend using Daniel Veillard's <a href="http://xmlsoft.org/XSLT/">xsltproc</a> program, which will give you helpful error messages regarding XML syntax problems. However, the JEP Editor will do the final rendering of XML into HTML as well as posting of your HTML file to the JSF website, so you do not need to generate HTML files for submission to the JEP Editor (in fact, the JEP Editor requires that you submit your proposal in the JEP XML format, not HTML).</p>
+    <p class="" style="">Finally, the jep.ent file contains convenient &quot;external entities&quot; that provide shortcuts for including references to JEPs, RFCs, and other common strings. Unfortunately, most browsers do not correctly process external entities, so you cannot include entities from jep.ent if you need to view your XML source file in a browser. However, the JEP Editor reserves the right to convert your markup to external entities, since it makes his life easier. Also, please do not add items to the jep.ent file; instead, ask the JEP Editor to add them for you.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="format-metadata">File Metadata</a>
+</h3>
+    <p class="" style="">This section describes the metadata elements contained in the &lt;header/&gt; element of a JEP file (see below for the file contents).</p>
+    <p class="" style="">The XML character data of the &lt;title/&gt; element is the title of your JEP. Choose a descriptive title that is less than five words long. The JEP Editor may change this in consultation with the author.</p>
+    <p class="" style="">The XML character data of the &lt;abstract/&gt; element SHOULD be one sentence that captures the essence of your proposal (usually beginning &quot;This JEP defines a protocol that...&quot;). The JEP Editor has been known to modify the abstract so that it accurately describes the proposal.</p>
+    <p class="" style="">The XML character data of the &lt;legal/&gt; element MUST be as follows:</p>
+    <p class="indent" style="">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy (http://jabber.org/jsf/ipr-policy.php). This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at http://www.opencontent.org/openpub/).</p>
+    <p class="" style="">Your JEP number will be assigned by the JEP Editor; thus you can just make the XML character data of the &lt;number/&gt; element &quot;xxxx&quot;.</p>
+    <p class="" style="">The XML character data of the &lt;status/&gt; element SHOULD be &quot;Experimental&quot; since all JEPs start out as Experimental.</p>
+    <p class="" style="">The XML character data of the &lt;type/&gt; element SHOULD be either &quot;Standards Track&quot; or &quot;Informational&quot; (there are also Historical and Procedural JEPs, but these are uncommon and usually written by the JEP Editor). A Standards Track JEP is basically any JEP that defines a protocol to be used in the Jabber community. An Informational JEP defines best practices or a usage profile related to an existing protocol (e.g., <span class="ref">Invisibility</span>  [<a href="#nt-id2602473">12</a>]).</p>
+    <p class="" style="">The XML character data of the &lt;approver/&gt; element SHOULD be &quot;Council&quot;.</p>
+    <p class="" style="">The &lt;dependencies/&gt; element is used to specify JEPs, RFCs, and other specifications on which your proposal depends in a normative fashion (i.e., specifications that MUST or SHOULD be implemented in order to implement your proposed protocol). Each specification MUST be identified by a distinct &lt;spec/&gt; child element (see existing JEPs for clues regarding document identifiers, or consult with the JEP Editor).</p>
+    <p class="" style="">The &lt;supersedes/&gt;, &lt;supersededby/&gt;, &lt;shortname/&gt;, and &lt;schemaloc/&gt; elements are for use by the JEP Editor; however, if your JEP supersedes an existing JEP, feel free to include a &lt;spec/&gt; child element specifying the document identifier (e.g., JEP-0093) for the protocol that is being superseded.</p>
+    <p class="" style="">Include one &lt;author/&gt; element for each co-author. Note well that the &lt;firstname/&gt;, &lt;surname/&gt;, &lt;email/&gt;, and &lt;jid/&gt; elements are all REQUIRED per JEP-0001.</p>
+    <p class="" style="">Include one &lt;revision/&gt; element for each revision of your JEP. The XML character data of the &lt;version/&gt; element SHOULD be &quot;0.0.1&quot; for your initial submission to the JEP Editor, and the &lt;remark/&gt; SHOULD be &quot;Initial version.&quot;; for each revision, you will include another &lt;revision/&gt; element (place it before the existing &lt;revision/&gt; elements) and iterate the &lt;version/&gt; element (e.g., &quot;0.2&quot; after &quot;0.1&quot;). The format for the &lt;date/&gt; element is yyyy-mm-dd. Please do not include the characters ' or &quot; in your revision remarks.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="format-contents">File Contents</a>
+</h3>
+    <p class="" style="">Aside from the metadata in the JEP &lt;header/&gt; element (see above), a JEP file is a series of sections, arranged in a hierarchy (&lt;section1/&gt; is a top-level section, within which you can nest &lt;section2/&gt; sections, and so on down to &lt;section4/&gt;). The title of a section is captured in the 'topic' attribute. You should also include an 'anchor' element so that you can link to page fragments from within your JEP. The allowable elements within a section element probably look familiar: &lt;p/&gt; for paragraphs, &lt;ol/&gt; and &lt;ul/&gt; for ordered and unordered lists, and so on.</p>
+    <p class="" style="">The &lt;example/&gt; and &lt;code/&gt; elements are used to show protocol snippets; the &lt;example/&gt; element SHOULD possess a 'caption' attribute that describes the example, whereas the &lt;code/&gt; element does not. Define an XML CDATA section within both of these elements so that you do not need to escape the '&lt;' and '&gt;' characters in your sample XML stanzas, since this makes life much easier for author and editor alike (see the markup in existing JEPs).</p>
+    <p class="" style="">The &lt;p/&gt; and &lt;li/&gt; elements can also contain more markup that is familiar from HTML, such as the &lt;img/&gt; element. Note that hyperlinks are of the form &lt;link url='foo'&gt;bar&lt;/link&gt; rather than &lt;a href='foo'&gt;bar&lt;/a&gt;; the reasons for this are lost in the mists of time and it is too late to change it now, so you'll just have to adjust. If needed, you can also use inline structural and presentational markup such as &lt;em/&gt;, &lt;strong/&gt;, &lt;tt/&gt;, &lt;cite/&gt;, and &lt;span/&gt; within the &lt;p/&gt; and &lt;li/&gt; elements. </p>
+    <p class="" style="">You may also include tables (these are helpful for listing error codes and such). The &lt;table/&gt; element SHOULD possess a 'caption' attribute that describes the table's contents. Standard HTML table structure applies (&lt;tr/&gt; defines a row, which contains &lt;th/&gt; elements for header rows and &lt;td/&gt; elements for data rows), and the 'colspan' and 'rowspan' attributes are also available if you need them. Table presentation (such as cellpadding and cellspacing) is handled by the XSLT and CSS stylesheets.</p>
+    <p class="" style="">In fact, the jep.xsl file performs all sorts of magic in converting your XML file into HTML, including creation of the front matter, table of contents, section numbering, notes, and revision history. Feel free to submit patches for this file, but do not commit your modified version to CVS.</p>
+  </div>
+<h2>5.
+       <a name="sections">The Sections of a JEP</a>
+</h2>
+  <p class="" style="">Most JEPs will have most of the following sections, usually in something like the order shown. Other sections may be appropriate (e.g., <span class="ref">XHTML-IM</span>  [<a href="#nt-id2602726">13</a>] has a section for W3C Considerations). Use your best judgment regarding the sections you need in order to make your argument, or consult with the JEP Editor regarding your needs.</p>
+  <div class="indent">
+<h3>5.1 <a name="sections-intro">Introduction</a>
+</h3>
+    <p class="" style="">The introduction to a JEP is quite important since it provides the rationale for considering the proposal. In particular, the introduction SHOULD include information such as the following:</p>
+    <ol start="" type="">
+      <li>Tasks that users currently cannot complete because we are lacking the protocol you propose. (Note: Users are not just IM users, but any person, system, or application that could gain value from interacting with other entities over Jabber/XMPP networks.)</li>
+      <li>Other projects or protocols and how Jabber technologies could interface with them because of your proposed protocol (e.g., XML-RPC, SOAP).</li>
+      <li>A comparison between Jabber technologies and &quot;the competition&quot; (e.g., other IM systems or messaging protocols) that describes holes in the Jabber protocols that need to be filled in order to offer similar functionality.</li>
+      <li>The relevant history of thinking within the Jabber community.</li>
+      <li>Real-world examples of problems the protocol can solve.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sections-reqs">Requirements</a>
+</h3>
+    <p class="" style="">Every JEP SHOULD include a section describing the requirements being addressed by the JEP. This information is critically important, because it clearly defines the scope of the proposal as well as any relevant constraints on the protocol design.</p>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="sections-terms">Terminology</a>
+</h3>
+    <p class="" style="">If your JEP uses terms that may not be familiar to the reader, please define them in a terminology section.</p>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="sections-usecases">Use Cases</a>
+</h3>
+    <p class="" style="">It is recommended that JEP authors structure their proposals according to the use cases that the proposal will address.  [<a href="#nt-id2602779">14</a>] We have found that use cases force JEP authors to focus on functionality rather than &quot;protocol for the sake of protocol&quot;. It is also helpful to sort use cases by actor, as is done in <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2602897">15</a>], for example. Include one subsection for each use case.</p>
+    <p class="" style="">When writing use cases and the associated protocols, make sure to:</p>
+    <ul>
+      <li>Clearly define the success scenarios, alternate flows, and possible errors.</li>
+      <li>Describe the expected behavior of Jabber clients, servers, and components when using this protocol.</li>
+      <li>Include lots of protocol examples.</li>
+    </ul>
+    <p class="" style="">We just said so, but we will repeat ourselves: include lots of protocol examples. Examples help not only implementors but also those who will review your proposal in the Standards JIG and Jabber Council. You get extra credit with the JEP Editor if you follow Jabber tradition by using characters and situations from the plays of Shakespeare:</p>
+    <p class="caption">Example 1. An Example from Shakespeare</p>
+<div class="indent"><pre>
+&lt;message 
+    from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/garden'
+    type='chat'&gt;
+  &lt;body&gt;Wherefore art thou, Romeo?&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="sections-errors">Error Codes</a>
+</h3>
+    <p class="" style="">If your proposal defines a number of error and status codes (as is done in JEP-0045), it is a good idea to include a table of all the codes defined in your document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="sections-bizrules">Business Rules</a>
+</h3>
+    <p class="" style="">You may want to include a section describing various business rules (essentially, a variety of MUSTs, SHOULDs, and MAYs regarding application behavior). This is not required but can be helpful to implementors.</p>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="sections-impl">Implementation Notes</a>
+</h3>
+    <p class="" style="">You may want to include a section devoted to implementation notes. Again, this is not required but can be helpful to implementors.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="sections-i18n">Internationalization Considerations</a>
+</h3>
+    <p class="" style="">If there are any internationalization or localization issues related to your proposal (e.g., whether to include the 'xml:lang' attribute), define them in this optional section.</p>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="sections-security">Security Considerations</a>
+</h3>
+    <p class="" style="">Your proposal MUST include a section entitled &quot;Security Considerations&quot;. Even if there are no security features or concerns related to your proposal, you MUST note that fact. For helpful guidelines, refer to <span class="ref">RFC 3552</span>  [<a href="#nt-id2603087">16</a>].</p>
+  </div>
+  <div class="indent">
+<h3>5.10 <a name="sections-iana">IANA Considerations</a>
+</h3>
+    <p class="" style="">This section is REQUIRED. The IANA is the Internet Assigned Numbers Authority, the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. Most proposals do not require interaction with the IANA, in which case the text of this section SHOULD read &quot;This JEP requires no interaction with the Internet Assigned Numbers Authority (IANA).&quot; If your proposal requires interaction with the IANA, discuss the matter with the JEP Editor. Do not contact the IANA on your own!</p>
+  </div>
+  <div class="indent">
+<h3>5.11 <a name="sections-registrar">Jabber Registrar Considerations</a>
+</h3>
+    <p class="" style="">This section is REQUIRED. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. If your proposal does not require interaction with the Jabber Registrar, the text of this section SHOULD read &quot;No namespaces or parameters need to be registered with the Jabber Registrar as a result of this JEP.&quot; Refer to Draft or Final JEPs for appropriate text in other cases, or consult with the JEP Editor.</p>
+  </div>
+  <div class="indent">
+<h3>5.12 <a name="sections-schema">XML Schema</a>
+</h3>
+    <p class="" style="">An XML Schema is required in order for a protocol JEP to be approved by the Jabber Council. The JEP Editor can assist you in defining an XML Schema for the protocol you are proposing.</p>
+  </div>
+  <div class="indent">
+<h3>5.13 <a name="sections-ack">Acknowledgements</a>
+</h3>
+    <p class="" style="">Some JEPs end with a section thanking non-authors who have made significant contributions to the specification; if that is true of your JEP, feel free to include this section.</p>
+  </div>
+<h2>6.
+       <a name="styleguide">JEP Styleguide</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: JEP authors can consider this a kind of &quot;Implementation Guidelines&quot;. :-)</span></p>
+  <p class="" style="">JEPs are written in English. It is not expected that you will be a fine prose writer, but try to write in a clear, easily-understood fashion. The JEP Editor will correct any errors of grammar, spelling  [<a href="#nt-id2603157">17</a>], punctuation, and usage he may find in your proposal, but may not do so until your proposal is in the Jabber Council's queue for consideration. In addition, the JEP Editor reserves the right to improve phrases that are unclear or infelicitous, move sections around, modify examples to use Shakespearean characters, and otherwise improve the argument and logical flow of your proposal (naturally, without changing the meaning).</p>
+  <p class="" style="">The following styleguide is provided to supplement the standard English styleguides, such as <span style="font-weight: bold">The Elements of Style</span> and the <span style="font-weight: bold">Chicago Manual of Style</span>; please refer to those resources for information about basic English usage and to this styleguide for JEP-specific guidelines.</p>
+  <div class="indent">
+<h3>6.1 <a name="style-attr">Attributes</a>
+</h3>
+    <p class="" style="">When talking about an attribute by name, refer to it in single quotes. Example: the 'to' attribute.</p>
+    <p class="" style="">When talking about an attribute value, refer to it in double quotes. Example: the value of the 'subscription' attribute is &quot;both&quot;.</p>
+    <p class="" style="">Elements <span style="font-style: italic">possess</span> attributes and <span style="font-style: italic">contain</span> character data and/or child elements; do not confuse these terms.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="style-ex">Code Examples</a>
+</h3>
+    <p class="" style="">In examples, use single quotes rather than double quotes; they are more readable.</p>
+    <p class="" style="">To show the hierarchy of XML elements, indent two spaces for every level.</p>
+    <p class="" style="">If an element possesses a large number of attributes, include a line break before each attribute and indent them by four spaces or so that the attributes are vertically aligned for readability.</p>
+    <p class="" style="">If the XML character data of an element is long, include line breaks and indent by two spaces.</p>
+    <p class="" style="">Examples are the major source of right-scrolling in our HTML output files. Right-scrolling is evil. Adjust your example layouts accordingly (line widths should be no more than 110 characters or so).</p>
+    <p class="" style="">Example:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq from='darkcave@macbeth.shakespeare.lit' 
+    id='config1' 
+    to='crone1@shakespeare.lit/desktop' 
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/muc#owner'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Configuration for &quot;darkcave&quot; Room&lt;/title&gt;
+      &lt;instructions&gt;
+        Please coomplete this form to make changes to the configuration 
+        of your room; to add room owners and administrators, use the 
+        appropriate room commands rather than this form.
+      &lt;/instructions&gt;
+      &lt;field
+          type='hidden'
+          var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/muc#owner&lt;/value&gt;
+      &lt;/field&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="style-conf">Conformance Terms</a>
+</h3>
+    <p class="" style="">Conformance terms (e.g,, &quot;MUST&quot; and &quot;SHOULD&quot;) are specified in RFC 2119. Use them. When such terms are not in ALL CAPS, the special conformance sense does not apply (this should be obvious but may not be to all authors).</p>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="style-elem">Elements</a>
+</h3>
+    <p class="" style="">When talking about an element by name, refer to it as an empty XML element. Example: the &lt;query/&gt; element.</p>
+    <p class="" style="">The top-level &lt;message/&gt;, &lt;presence/&gt;, and &lt;iq/&gt; elements are actually XML stanzas (see <span style="font-weight: bold">XMPP Core</span>); refer to them as such.</p>
+    <p class="" style="">Elements <span style="font-style: italic">possess</span> attributes and <span style="font-style: italic">contain</span> character data and/or child elements; do not confuse these terms.</p>
+    <p class="" style="">Do not use the term &quot;tag&quot; when you mean &quot;element&quot;.</p>
+    <p class="" style="">Note: There are shortcuts for stanza names and some common element names in the jep.ent file.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="style-err">Errors</a>
+</h3>
+    <p class="" style="">When talking about an error condition, use the XML element names defined in XMPP Core rather than the old HTTP-style code numbers. Example: the &lt;feature-not-implemented/&gt; error.</p>
+    <p class="" style="">Note: There are shortcuts for the stanza errors in the jep.ent file.</p>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="style-ns">Namespaces</a>
+</h3>
+    <p class="" style="">When talking about a namespace by name, refer to it in single quotes. Example: the 'jabber:iq:roster' namespace.</p>
+    <p class="" style="">An element or attribute is <span style="font-style: italic">qualified by</span> (rather than &quot;scoped by&quot; or &quot;in&quot;) a particular namespace.</p>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="style-quot">Quotes</a>
+</h3>
+    <p class="" style="">For precision, the JSF follows IETF usage by placing all punctuation outside the quotation marks unless one is quoting text that includes the punctuation. Example: the port used for Jabber client communications is &quot;5222&quot;.</p>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596192">1</a>. The Jabber Software Foundation (JSF) is an independent, non-profit organization that develops open application protocols on top of the IETF's Extensible Messaging and Presence Protocol (XMPP). For further information, see &lt;<a href="http://www.jabber.org/jsf/">http://www.jabber.org/jsf/</a>&gt;.</p>
+<p>
+<a name="nt-id2596194">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596127">3</a>. JEP-0001: Jabber Enhancement Proposals &lt;<a href="http://www.jabber.org/jeps/jep-0001.html">http://www.jabber.org/jeps/jep-0001.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596322">4</a>. The Jabber Council is a technical steering committee, authorized by the JSF Board of Directors and elected by JSF members, that approves of new Jabber protocols and oversees the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/council/">http://www.jabber.org/council/</a>&gt;.</p>
+<p>
+<a name="nt-id2596356">5</a>. The Internet Engineering Task Force is the principal body engaged in the development of new Internet standard specifications, best known for its work on standards such as HTTP and SMTP. For further information, see &lt;<a href="http://www.ietf.org/">http://www.ietf.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2596382">6</a>. The World Wide Web Consortium defines data formats and markup languages (such as HTML and XML) for use over the Internet. For further information, see &lt;<a href="http://www.w3.org/">http://www.w3.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601918">7</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p>
+<a name="nt-id2596272">8</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602079">9</a>. The JEP Editor is the individual appointed by the JSF Board of Directors to handle protocol submissions and provide day-to-day management of the JSF's standards process. For further information, see &lt;<a href="http://www.jabber.org/jeps/editor.php">http://www.jabber.org/jeps/editor.php</a>&gt;.</p>
+<p>
+<a name="nt-id2602011">10</a>. The JSF IPR Policy defines the Jabber Software Foundation's official policy regarding intellectual property rights (IPR) as they pertain to Jabber Enhancement Proposals (JEPs). For further information, see &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;.</p>
+<p>
+<a name="nt-id2602165">11</a>. &lt;<a href="http://www.xml.com/pub/a/tools/ruwf/check.html">http://www.xml.com/pub/a/tools/ruwf/check.html</a>&gt;</p>
+<p>
+<a name="nt-id2602473">12</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602726">13</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602779">14</a>. A good introduction to use cases may be found at &lt;<a href="http://www.pols.co.uk/usecasezone/">http://www.pols.co.uk/usecasezone/</a>&gt;.</p>
+<p>
+<a name="nt-id2602897">15</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603087">16</a>. RFC 3552: Guidelines for Writing RFC Text on Security Considerations &lt;<a href="http://www.ietf.org/rfc/rfc3552.txt">http://www.ietf.org/rfc/rfc3552.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2603157">17</a>. With all due respect to authors in other parts of the world, JEPs follow American spelling conventions; thus &quot;authorise&quot; will be changed to &quot;authorize&quot; and such.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2004-10-22)</h4>
+<div class="indent">Further clarifications. (psa)
+    </div>
+<h4>Version 0.3 (2004-10-12)</h4>
+<div class="indent">Minor clarifications throughout. (psa)
+    </div>
+<h4>Version 0.2 (2004-09-16)</h4>
+<div class="indent">Described JEP metadata elements. (psa)
+    </div>
+<h4>Version 0.1 (2004-09-15)</h4>
+<div class="indent">Initial version (adapted from JEP template). (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0144-0.1.html
+++ b/content/xep-0144-0.1.html
@@ -1,0 +1,373 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0144: Roster Item Exchange</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Roster Item Exchange">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-09-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0144">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0144: Roster Item Exchange</h1>
+<p>This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0144<br>
+            Version: 0.1<br>
+            Last Updated: 2004-09-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0093<br>
+                Superseded By: None<br>
+            Short Name: rosterx<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#add">Suggesting Roster Item Addition</a>
+</dt>
+<dt>3.2.  <a href="#delete">Suggesting Roster Item Deletion</a>
+</dt>
+<dt>3.3.  <a href="#modify">Suggesting Roster Item Modification</a>
+</dt>
+</dl>
+<dt>4.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>5.  <a href="#stanza">Recommended Stanza Type</a>
+</dt>
+<dl><dt>5.1.  <a href="#stanza-iq">IQ Semantics</a>
+</dt></dl>
+<dt>6.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#security-trust">Trusted Entities</a>
+</dt>
+<dt>7.2.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>7.3.  <a href="#security-support">Advertising Support</a>
+</dt>
+</dl>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for sending roster items from one entity to another, making use of the 'jabber:x:roster' namespace. Because this protocol extension was not required by <span class="ref">RFC 2779</span>  [<a href="#nt-id2596083">1</a>], it was removed from <span class="ref">XMPP IM</span>  [<a href="#nt-id2596115">2</a>] and documented for historical purposes in <span class="ref">Roster Item Exchange</span>  [<a href="#nt-id2596135">3</a>]. However, since that time discussions in the <span class="ref">Standards JIG</span>  [<a href="#nt-id2596154">4</a>] have revealed that it would be helpful to use roster item exchange in the problem spaces of &quot;shared groups&quot; (e.g., predefined roster groups used within an organization) and roster synchronization (e.g., keeping a Jabber roster in sync with a contact list on a legacy IM service). These problem spaces require a slightly more sophisticated kind of roster item exchange than was documented in JEP-0093, specifically the ability to indicate whether a roster item is to be added, deleted, or modified. Therefore this JEP redefines roster item exchange to provide this functionality in a way that is backwards-compatible with existing implementations, but uses a modern namespace URI of 'http://jabber.org/protocol/rosterx' rather than the old 'jabber:x:roster' namespace name. Further JEPs will specify how to solve the problems of shared groups and roster synchronization using the protocol defined herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">JEP-0093 did not define the requirements for roster item exchange. This section remedies that oversight.</p>
+  <p class="" style="">Roster item exchange meets the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be added to the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be deleted from the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be modified in the recipient's roster.</li>
+  </ol>
+  <p class="" style="">This JEP deliberately speaks of rosters and roster items, not presence subscriptions. Although rosters and subscriptions are closely connected (as explained in <span style="font-weight: bold">XMPP IM</span>), they are not identical. The protocol defined herein enables an entity to suggest that another entity might want to add, delete, or modify roster items only, and does not dictate the suggested presence subscription state associated with those roster items. This is intentional.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="add">Suggesting Roster Item Addition</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should add one or more items to its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace (see <a href="#stanza">Recommended Stanza Type</a> regarding when to use &lt;message/&gt; and when to use &lt;iq/&gt;); the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which SHOULD possess an 'action' attribute whose value is &quot;add&quot;  [<a href="#nt-id2596312">5</a>], MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 1. Suggesting Addition</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='add'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='add'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;add&quot; (either explicitly or as the default value), the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item already exists in the roster and the item is in the specified group (or no group is specified), the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item does not already exist in the roster, the receiving application SHOULD prompt a human user for approval regarding that item and, if approval is granted, MUST add that item to the roster.</li>
+      <li>If the item already exists in the roster but not in the specified group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that will also belong to the specified group (in addition to the existing group, if any).</li>
+    </ol>
+    <p class="" style="">If the roster item addition stanza will result in adding the item to the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server containing the new item as described in <span style="font-weight: bold">XMPP IM</span>. After completing the roster set, the receiving application SHOULD also send a &lt;presence/&gt; stanza of type &quot;subscribe&quot; to the JID of the new item.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item addition stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="delete">Suggesting Roster Item Deletion</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should delete one or more items from its roster, the sending entity MUST send a &lt;message/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is &quot;delete&quot;, MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 2. Suggesting Deletion</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='delete'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='delete'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;delete&quot;, the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT delete that item to the roster.</li>
+      <li>If the item exists in the roster but not in the specified group, the receiving application MUST NOT prompt the user for approval and MUST NOT delete the existing item.</li>
+      <li>If the item exists in the roster and is in both the specified group and another group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that it no longer belongs to the specified group.</li>
+    </ol>
+    <p class="" style="">If a roster item deletion stanza will result in removal of the item from the roster (rather than editing of the item), the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with the 'subscription' attribute set to a value of &quot;remove&quot; as described in <span style="font-weight: bold">XMPP IM</span>, since this results in generation of the appropriate &lt;presence/&gt; stanzas by the user's server.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item deletion stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="modify">Suggesting Roster Item Modification</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should modify one or more items from its roster, the sending entity MUST send a &lt;message/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is &quot;modify&quot;, MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 3. Suggesting Modification</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='modify'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='modify'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;modify&quot;, the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item exists in the roster and the modification results in a change of group only, the receiving application MAY prompt the user for approval and SHOULD move the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results adding the item to a new group in addition to its existing group, the receiving application MAY prompt the user for approval and SHOULD add the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in a change of name only, the receiving application MAY prompt the user for approval and SHOULD modify the name to that specified in the modification suggestion.</li>
+    </ol>
+    <p class="" style="">If a roster item addition, deletion, or modification stanza will result in editing of an existing item in the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with no changes to the 'subscription' attribute but rather with appropriate changes to the value of 'name' attribute or the &lt;group/&gt; child element or elements, as described in <span style="font-weight: bold">XMPP IM</span>.</p>
+  </div>
+<h2>4.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to determine whether a receiving entity supports the protocol defined herein, the sending entity SHOULD use <span class="ref">Service Discovery</span>  [<a href="#nt-id2602128">6</a>] but MAY depend on the &quot;profile&quot; of Service Discovery defined in <span class="ref">Entity Capabilities</span>  [<a href="#nt-id2602149">7</a>]. If an entity supports roster item exchange, it MUST (subject to appropriate security considerations as described under <a href="#security-support">Advertising Support</a>) include &lt;feature var='http://jabber.org/protocol/rosterx'/&gt; in its responses to disco#info queries. Thus a sending entity can discover if a receiving entity supports the protocol defined herein by sending an IQ request of the following form:</p>
+  <p class="caption">Example 4. Sending Entity Queries for Support</p>
+<div class="indent"><pre>
+&lt;iq from='horatio@denmark.lit/castle'
+    to='hamlet@denmark.lit/throne'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 5. Receiving Entity Advertises Support</p>
+<div class="indent"><pre>
+&lt;iq from='hamlet@denmark.lit/throne'
+    to='horatio@denmark.lit/castle'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rosterx'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="stanza">Recommended Stanza Type</a>
+</h2>
+  <p class="" style="">If the sending entity has knowledge (e.g., via presence or an active chat conversation) that the receiving entity is online and available, it SHOULD:  [<a href="#nt-id2602093">8</a>]</p>
+  <ol start="" type="">
+    <li>Discover if the receiving entity supports the protocol defined herein (see the <a href="#disco">Service Discovery</a> section of this document).</li>
+    <li>If so, send its roster item exchange stanza to a particular resource (user@host/resource) of the receiving entity using an &lt;iq/&gt; stanza rather than a &lt;message/&gt; stanza.</li>
+  </ol>
+  <p class="" style="">If the sending entity does not know that the receiving entity is online and available, it MUST send a &lt;message/&gt; stanza to the receiving entity's &quot;bare JID&quot; (user@host) rather than an &lt;iq/&gt; stanza to a particular resource.</p>
+  <div class="indent">
+<h3>5.1 <a name="stanza-iq">IQ Semantics</a>
+</h3>
+    <p class="" style="">If the sending entity uses &lt;iq/&gt; stanzas to communicate its roster item exchange suggestions, the receiving entity MUST adhere to the IQ semantics defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2602306">9</a>]. Specifically:</p>
+    <ol start="" type="">
+      <li>If the receiving entity successfully processes the suggested action(s) (which may include ignoring certain suggestions), the receiving entity MUST return an empty IQ result to the sending entity.</li>
+      <li>If the receiving entity does not understand the roster item exchange namespace, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;service-unavailable/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the receiving entity is not registered with the sending entity, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;registration-required/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not in the receiving entity's roster, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;not-authorized/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not trusted (see <a href="#security-trust">Trusted Entities</a>), the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;forbidden/&gt;.</li>
+    </ol>
+    <p class="" style="">Naturally, other IQ errors may be more appropriate; however, if the receiving entity will not or cannot process the suggested action(s), it MUST return an error to the sending entity.</p>
+  </div>
+<h2>6.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <ol start="" type="">
+    <li><p class="" style="">The sending entity or sending application SHOULD NOT send additions, deletions, and modifications in the same &lt;x/&gt; element and &lt;message/&gt; stanza; instead, it SHOULD send separate stanzas for the additions, deletions, and modifications.</p></li>
+    <li><p class="" style="">If approval is required or recommended regarding more than one item suggested by the sending entity, the receiving entity SHOULD present all of the items for approval at the same time or in the same interface; however, the receiving application may want to split additions, deletions, and modifications into separate prompts so as not to confuse the user.</p></li>
+    <li><p class="" style="">If the sending entity is in some sense &quot;trusted&quot; (see <a href="#security-trust">Trusted Entities</a>), then the receiving application MAY skip the approval steps described above.</p></li>
+    <li><p class="" style="">The receiving application SHOULD NOT accept an unreasonable number of roster items from any one sending entity at one time. Unfortunately, it can be difficult to determine how many roster items are &quot;unreasonable&quot;. For example, when a user registers with a gateway, it is possible that the initial set of roster items may be quite large (however, note that most existing consumer IM services enforce a limit of 100 to 150 items in their contact lists). Users who have newly registered with or been newly created on a server (e.g., within an organization) may also receive a large set of initial roster items in order to sync up with shared groups established on the server. However, after such initialization, the subsequent roster item sets should be much smaller. In any case, sets of more than 150 or 200 roster items SHOULD be treated with suspicion, and entities that repeatedly send such sets SHOULD NOT be trusted.</p></li>
+  </ol>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="security-trust">Trusted Entities</a>
+</h3>
+    <p class="" style="">A principal (user) or receiving application MAY establish a list of trusted entities from which roster item exchanges are handled without approval by a human user. In order to avoid corruption of the roster, it is STRONGLY RECOMMENDED that such trusted entities meet at least one of the following criteria, in order of trustworthiness:</p> 
+    <ol start="" type="">
+      <li><p class="" style="">The sending entity is a component (e.g., &quot;groups.example.com&quot;) or authoritative representative (e.g., &quot;admin@example.com&quot; if that address is reserved) of the server with which the receiving entity is registered, or the sending entity is the server itself (e.g., &quot;example.com&quot;), such that the receiving application can trust the sending entity as much as it trusts the server.</p></li>
+      <li><p class="" style="">The sending entity has a <span style="font-weight: bold">Service Discovery</span> identity that typically involves responsibility for roster items (e.g., &quot;gateway/msn&quot;) and the receiving entity has previously and explicitly registered with the sending entity, including acknowledgement on the user's part that the sending entity will suggest roster items that may be automatically approved by the receiving application (e.g., a human user has registered with a gateway); such trust SHOULD be periodically verified with the human user (e.g., once per session in which the sending entity suggests roster additions, modifications, or deletions).</p></li>
+      <li><p class="" style="">The sending entity has otherwise been explicitly approved by a human user as the trusted source of roster items; such trust SHOULD extend to specified roster groups only (e.g., a sender of &quot;stpeter@jabber.org&quot; is trusted only for the &quot;JSF Members&quot; group), and SHOULD be periodically verified with the human user (e.g., once per session in which the sending entity suggests roster additions, modifications, or deletions).</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">A sending entity could effectively deny service to the receiving entity by rapidly and repeatedly sending (1) alternating add and delete suggestions or (2) modify suggestions, thus invoking throttling mechanisms enforced by the receiving entity's server. The receiving application SHOULD guard against this by monitoring roster item exchanges received from each sending entity and refusing or ignoring roster item exchanges from offending entities (e.g., by adding such entities to a list of distrusted entities).</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="security-support">Advertising Support</a>
+</h3>
+    <p class="" style="">A receiving application MAY refuse to advertise its support for the roster item exchange protocol (see the <a href="#disco">Service Discovery</a> section of this document) to entities that that are (1) not explicitly trusted or (2) explicitly distrusted.</p>
+  </div>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602694">10</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">Upon advancement of this JEP to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602632">11</a>] shall add 'http://jabber.org/protocol/rosterx' to its registry of protocol namespaces.</p>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rosterx'
+    xmlns='http://jabber.org/protocol/rosterx'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='group' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='optional'/&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName' default='add'&gt;
+            &lt;xs:enumeration value='add'/&gt;
+            &lt;xs:enumeration value='delete'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596083">1</a>. RFC 2779: Instant Messaging / Presence Protocol Requirements &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596115">2</a>. XMPP IM &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2596135">3</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596154">4</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p>
+<a name="nt-id2596312">5</a>. The default value of the 'action' attribute is &quot;add&quot;; therefore, if the 'action' attribute is not included or the receiving application does not understand the 'action' attribute, the receiving application MUST treat the item as if the value were &quot;add&quot;.</p>
+<p>
+<a name="nt-id2602128">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602149">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602093">8</a>. If the receiving entity has more than one available resource, the sending application SHOULD communicate with the &quot;most available&quot; resource according its best estimation (e.g., the resource with the highest priority).</p>
+<p>
+<a name="nt-id2602306">9</a>. XMPP Core &lt;<a href="http://www.jabber.org/ietf/">http://www.jabber.org/ietf/</a>&gt; (Proposed Standard, RFC number to follow).</p>
+<p>
+<a name="nt-id2602694">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602632">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-09-29)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2004-09-22)</h4>
+<div class="indent">To address Council feedback, added text about service discovery and choice of stanza type (message or IQ). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-09-16)</h4>
+<div class="indent">Forked JEP-0093 by adding the action attribute, defining requirements and use cases, specifying processing rules, and detailing security considerations. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0144-0.2.html
+++ b/content/xep-0144-0.2.html
@@ -1,0 +1,377 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0144: Roster Item Exchange</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Roster Item Exchange">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-04">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0144">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0144: Roster Item Exchange</h1>
+<p>This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0144<br>
+            Version: 0.2<br>
+            Last Updated: 2004-10-04<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0093<br>
+                Superseded By: None<br>
+            Short Name: rosterx<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#add">Suggesting Roster Item Addition</a>
+</dt>
+<dt>3.2.  <a href="#delete">Suggesting Roster Item Deletion</a>
+</dt>
+<dt>3.3.  <a href="#modify">Suggesting Roster Item Modification</a>
+</dt>
+</dl>
+<dt>4.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>5.  <a href="#stanza">Recommended Stanza Type</a>
+</dt>
+<dl><dt>5.1.  <a href="#stanza-iq">IQ Semantics</a>
+</dt></dl>
+<dt>6.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#security-trust">Trusted Entities</a>
+</dt>
+<dt>7.2.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>7.3.  <a href="#security-support">Advertising Support</a>
+</dt>
+</dl>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for sending roster items from one entity to another, making use of the 'jabber:x:roster' namespace. Because this protocol extension was not required by <span class="ref">RFC 2779</span>  [<a href="#nt-id2596105">1</a>], it was removed from <span class="ref">XMPP IM</span>  [<a href="#nt-id2596137">2</a>] and documented for historical purposes in <span class="ref">Roster Item Exchange</span>  [<a href="#nt-id2596159">3</a>]. However, since that time discussions in the <span class="ref">Standards JIG</span>  [<a href="#nt-id2596178">4</a>] have revealed that it would be helpful to use roster item exchange in the problem spaces of &quot;shared groups&quot; (e.g., predefined roster groups used within an organization) and roster synchronization (e.g., keeping a Jabber roster in sync with a contact list on a legacy IM service). These problem spaces require a slightly more sophisticated kind of roster item exchange than was documented in JEP-0093, specifically the ability to indicate whether a roster item is to be added, deleted, or modified. Therefore this JEP redefines roster item exchange to provide this functionality in a way that is backwards-compatible with existing implementations, albeit using a modern namespace URI of 'http://jabber.org/protocol/rosterx' rather than the old 'jabber:x:roster' namespace name. Further JEPs will specify how to solve the problems of shared groups and roster synchronization using the protocol defined herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">JEP-0093 did not define the requirements for roster item exchange. This section remedies that oversight.</p>
+  <p class="" style="">Roster item exchange meets the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be added to the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be deleted from the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be modified in the recipient's roster.</li>
+  </ol>
+  <p class="" style="">This JEP deliberately speaks of rosters and roster items, not presence subscriptions. Although rosters and subscriptions are closely connected (as explained in <span style="font-weight: bold">XMPP IM</span>), they are not identical. The protocol defined herein enables an entity to suggest that another entity might want to add, delete, or modify roster items only, and does not dictate the suggested presence subscription state associated with those roster items. This is intentional.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="add">Suggesting Roster Item Addition</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should add one or more items to its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace (see <a href="#stanza">Recommended Stanza Type</a> regarding when to use &lt;message/&gt; and when to use &lt;iq/&gt;); the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which SHOULD possess an 'action' attribute whose value is &quot;add&quot;  [<a href="#nt-id2596261">5</a>], MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 1. Suggesting Addition</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='add'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='add'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;add&quot; (either explicitly or as the default value), the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item already exists in the roster and the item is in the specified group (or no group is specified), the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item does not already exist in the roster, the receiving application SHOULD prompt a human user for approval regarding that item and, if approval is granted, MUST add that item to the roster.</li>
+      <li>If the item already exists in the roster but not in the specified group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that will also belong to the specified group (in addition to the existing group, if any).</li>
+    </ol>
+    <p class="" style="">If the roster item addition stanza will result in adding the item to the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server containing the new item as described in <span style="font-weight: bold">XMPP IM</span>. After completing the roster set, the receiving application SHOULD also send a &lt;presence/&gt; stanza of type &quot;subscribe&quot; to the JID of the new item.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item addition stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="delete">Suggesting Roster Item Deletion</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should delete one or more items from its roster, the sending entity MUST send a &lt;message/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is &quot;delete&quot;, MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 2. Suggesting Deletion</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='delete'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='delete'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;delete&quot;, the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT delete that item to the roster.</li>
+      <li>If the item exists in the roster but not in the specified group, the receiving application MUST NOT prompt the user for approval and MUST NOT delete the existing item.</li>
+      <li>If the item exists in the roster and is in both the specified group and another group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that it no longer belongs to the specified group.</li>
+    </ol>
+    <p class="" style="">If a roster item deletion stanza will result in removal of the item from the roster (rather than editing of the item), the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with the 'subscription' attribute set to a value of &quot;remove&quot; as described in <span style="font-weight: bold">XMPP IM</span>, since this results in generation of the appropriate &lt;presence/&gt; stanzas by the user's server.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item deletion stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="modify">Suggesting Roster Item Modification</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should modify one or more items from its roster, the sending entity MUST send a &lt;message/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is &quot;modify&quot;, MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 3. Suggesting Modification</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='modify'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='modify'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;modify&quot;, the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item exists in the roster and the modification results in a change of group only, the receiving application MAY prompt the user for approval and SHOULD move the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results adding the item to a new group in addition to its existing group, the receiving application MAY prompt the user for approval and SHOULD add the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in a change of name only, the receiving application MAY prompt the user for approval and SHOULD modify the name to that specified in the modification suggestion.</li>
+    </ol>
+    <p class="" style="">If a roster item addition, deletion, or modification stanza will result in editing of an existing item in the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with no changes to the 'subscription' attribute but rather with appropriate changes to the value of 'name' attribute or the &lt;group/&gt; child element or elements, as described in <span style="font-weight: bold">XMPP IM</span>.</p>
+  </div>
+<h2>4.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to determine whether a receiving entity supports the protocol defined herein, the sending entity SHOULD use <span class="ref">Service Discovery</span>  [<a href="#nt-id2595838">6</a>] but MAY depend on the &quot;profile&quot; of Service Discovery defined in <span class="ref">Entity Capabilities</span>  [<a href="#nt-id2595860">7</a>]. If an entity supports roster item exchange, it MUST (subject to appropriate security considerations as described under <a href="#security-support">Advertising Support</a>) include &lt;feature var='http://jabber.org/protocol/rosterx'/&gt; in its responses to disco#info queries. Thus a sending entity can discover if a receiving entity supports the protocol defined herein by sending an IQ request of the following form:</p>
+  <p class="caption">Example 4. Sending Entity Queries for Support</p>
+<div class="indent"><pre>
+&lt;iq from='horatio@denmark.lit/castle'
+    to='hamlet@denmark.lit/throne'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 5. Receiving Entity Advertises Support</p>
+<div class="indent"><pre>
+&lt;iq from='hamlet@denmark.lit/throne'
+    to='horatio@denmark.lit/castle'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rosterx'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="stanza">Recommended Stanza Type</a>
+</h2>
+  <p class="" style="">If the sending entity has knowledge (e.g., via presence or an active chat conversation) that the receiving entity is online and available, it SHOULD:  [<a href="#nt-id2595802">8</a>]</p>
+  <ol start="" type="">
+    <li>Discover if the receiving entity supports the protocol defined herein (see the <a href="#disco">Service Discovery</a> section of this document).</li>
+    <li>If so, send its roster item exchange stanza to a particular resource (user@host/resource) of the receiving entity using an &lt;iq/&gt; stanza rather than a &lt;message/&gt; stanza.</li>
+  </ol>
+  <p class="" style="">If the sending entity does not know that the receiving entity is online and available, it MUST send a &lt;message/&gt; stanza to the receiving entity's &quot;bare JID&quot; (user@host) rather than an &lt;iq/&gt; stanza to a particular resource.</p>
+  <div class="indent">
+<h3>5.1 <a name="stanza-iq">IQ Semantics</a>
+</h3>
+    <p class="" style="">If the sending entity uses &lt;iq/&gt; stanzas to communicate its roster item exchange suggestions, the receiving entity MUST adhere to the IQ semantics defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2602552">9</a>]. Specifically:</p>
+    <ol start="" type="">
+      <li>If the receiving entity successfully processes the suggested action(s) (which may include ignoring certain suggestions), the receiving entity MUST return an empty IQ result to the sending entity.</li>
+      <li>If the receiving entity does not understand the roster item exchange namespace, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;service-unavailable/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the receiving entity is not registered with the sending entity, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;registration-required/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not in the receiving entity's roster, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;not-authorized/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not trusted (see <a href="#security-trust">Trusted Entities</a>), the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;forbidden/&gt;.</li>
+    </ol>
+    <p class="" style="">Naturally, other IQ errors may be more appropriate; however, if the receiving entity will not or cannot process the suggested action(s), it MUST return an error to the sending entity.</p>
+  </div>
+<h2>6.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <ol start="" type="">
+    <li><p class="" style="">The sending entity or sending application SHOULD NOT send additions, deletions, and modifications in the same &lt;x/&gt; element and &lt;message/&gt; stanza; instead, it SHOULD send separate stanzas for the additions, deletions, and modifications.</p></li>
+    <li><p class="" style="">If approval is required or recommended regarding more than one item suggested by the sending entity, the receiving entity SHOULD present all of the items for approval at the same time or in the same interface; however, the receiving application may want to split additions, deletions, and modifications into separate prompts so as not to confuse the user.</p></li>
+    <li><p class="" style="">If the sending entity is in some sense &quot;trusted&quot; (see <a href="#security-trust">Trusted Entities</a>), then the receiving application MAY skip the approval steps described above.</p></li>
+    <li><p class="" style="">The receiving application SHOULD NOT accept an unreasonable number of roster items from any one sending entity at one time. Unfortunately, it can be difficult to determine how many roster items are &quot;unreasonable&quot;. For example, when a user registers with a gateway, it is possible that the initial set of roster items may be quite large (however, note that most existing consumer IM services enforce a limit of 100 to 150 items in their contact lists). Users who have newly registered with or been newly created on a server (e.g., within an organization) may also receive a large set of initial roster items in order to sync up with shared groups established on the server. However, after such initialization, the subsequent roster item sets should be much smaller. In any case, sets of more than 150 or 200 roster items SHOULD be treated with suspicion, and entities that repeatedly send such sets SHOULD NOT be trusted.</p></li>
+  </ol>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="security-trust">Trusted Entities</a>
+</h3>
+    <p class="" style="">A principal (user) or receiving application MAY establish a list of trusted entities from which roster item exchanges are handled without approval by a human user. In order to avoid corruption of the roster, it is STRONGLY RECOMMENDED that such trusted entities meet at least one of the following criteria, in order of trustworthiness:</p> 
+    <ol start="" type="">
+      <li><p class="" style="">The sending entity is the server at which the receiving entity has its primary account (e.g., &quot;example.com&quot; if the user's JID is &quot;juliet@example.com&quot;).</p></li>
+      <li><p class="" style="">The sending entity is a component (e.g., &quot;groups.example.com&quot;) of the receiving entity's server, such that the receiving application can trust the sending entity as much as it trusts the server.</p></li>
+      <li><p class="" style="">The sending entity has a <span style="font-weight: bold">Service Discovery</span> identity that typically involves responsibility for roster items (e.g., &quot;gateway/msn&quot;) and the receiving entity has previously and explicitly registered with the sending entity, including acknowledgement on the user's part that the sending entity will suggest roster items that may be automatically approved by the receiving application (e.g., a human user has registered with a gateway); such trust SHOULD be periodically verified with the human user (e.g., once per session in which the sending entity suggests roster additions, modifications, or deletions).</p></li>
+      <li><p class="" style="">The sending entity has otherwise been explicitly approved by a human user as the trusted source of roster items; such trust SHOULD extend to particular roster groups only (e.g., a sender of &quot;stpeter@jabber.org&quot; is trusted only for the &quot;JSF Members&quot; group), and SHOULD be periodically verified with the human user (e.g., once per session in which the sending entity suggests roster additions, modifications, or deletions).</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">A sending entity could effectively deny service to the receiving entity by rapidly and repeatedly sending (1) alternating add and delete suggestions or (2) modify suggestions, thus invoking throttling mechanisms enforced by the receiving entity's server. The receiving application SHOULD guard against this by monitoring roster item exchanges received from each sending entity and refusing or ignoring roster item exchanges from offending entities (e.g., by adding such entities to a list of distrusted entities).</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="security-support">Advertising Support</a>
+</h3>
+    <p class="" style="">A receiving application MAY refuse to advertise its support for the roster item exchange protocol (see the <a href="#disco">Service Discovery</a> section of this document) to entities that that are (1) not explicitly trusted or (2) explicitly distrusted.</p>
+  </div>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602950">10</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">Upon advancement of this JEP to a status of Draft, the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602889">11</a>] shall add 'http://jabber.org/protocol/rosterx' to its registry of protocol namespaces.</p>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rosterx'
+    xmlns='http://jabber.org/protocol/rosterx'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='group' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='optional'/&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName' default='add'&gt;
+            &lt;xs:enumeration value='add'/&gt;
+            &lt;xs:enumeration value='delete'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596105">1</a>. RFC 2779: Instant Messaging / Presence Protocol Requirements &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596137">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596159">3</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596178">4</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p>
+<a name="nt-id2596261">5</a>. The default value of the 'action' attribute is &quot;add&quot;; therefore, if the 'action' attribute is not included or the receiving application does not understand the 'action' attribute, the receiving application MUST treat the item as if the value were &quot;add&quot;.</p>
+<p>
+<a name="nt-id2595838">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595860">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p>
+<a name="nt-id2595802">8</a>. If the receiving entity has more than one available resource, the sending application SHOULD communicate with the &quot;most available&quot; resource according its best estimation (e.g., the resource with the highest priority).</p>
+<p>
+<a name="nt-id2602552">9</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602950">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602889">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2004-10-04)</h4>
+<div class="indent">Added further granularity to the definition of trusted entities. (psa)
+    </div>
+<h4>Version 0.1 (2004-09-29)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2004-09-22)</h4>
+<div class="indent">To address Council feedback, added text about service discovery and choice of stanza type (message or IQ). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-09-16)</h4>
+<div class="indent">Forked JEP-0093 by adding the action attribute, defining requirements and use cases, specifying processing rules, and detailing security considerations. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0144-0.3.html
+++ b/content/xep-0144-0.3.html
@@ -1,0 +1,435 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0144: Roster Item Exchange</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Roster Item Exchange">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-10-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0144">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0144: Roster Item Exchange</h1>
+<p>This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0144<br>
+            Version: 0.3<br>
+            Last Updated: 2004-10-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0093<br>
+                Superseded By: None<br>
+            Short Name: rosterx<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core and XMPP IM specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#add">Suggesting Roster Item Addition</a>
+</dt>
+<dt>3.2.  <a href="#delete">Suggesting Roster Item Deletion</a>
+</dt>
+<dt>3.3.  <a href="#modify">Suggesting Roster Item Modification</a>
+</dt>
+</dl>
+<dt>4.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>5.  <a href="#stanza">Recommended Stanza Type</a>
+</dt>
+<dl><dt>5.1.  <a href="#stanza-iq">IQ Semantics</a>
+</dt></dl>
+<dt>6.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>7.  <a href="#entities">Types of Sending Entities</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#entities-user">Jabber Users</a>
+</dt>
+<dt>7.2.  <a href="#entities-gateway">Gateways</a>
+</dt>
+<dt>7.3.  <a href="#entities-groupservice">Group Services</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-trust">Trusted Entities</a>
+</dt>
+<dt>8.2.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.3.  <a href="#security-support">Advertising Support</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Identities</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for sending roster items from one entity to another, making use of the 'jabber:x:roster' namespace. Because this protocol extension was not required by <span class="ref">RFC 2779</span>  [<a href="#nt-id2596216">1</a>], it was removed from <span class="ref">XMPP IM</span>  [<a href="#nt-id2596247">2</a>] and documented for historical purposes in <span class="ref">Roster Item Exchange</span>  [<a href="#nt-id2596270">3</a>]. However, since that time discussions in the <span class="ref">Standards JIG</span>  [<a href="#nt-id2596289">4</a>] have revealed that it would be helpful to use roster item exchange in the problem spaces of &quot;shared groups&quot; (e.g., predefined roster groups used within an organization) and roster synchronization (e.g., keeping a Jabber roster in sync with a contact list on a legacy IM service). These problem spaces require a slightly more sophisticated kind of roster item exchange than was documented in JEP-0093, specifically the ability to indicate whether a roster item is to be added, deleted, or modified. Therefore this JEP redefines roster item exchange to provide this functionality in a way that is backwards-compatible with existing implementations, albeit using a modern namespace URI of 'http://jabber.org/protocol/rosterx' rather than the old 'jabber:x:roster' namespace name. Further JEPs will specify how to solve the problems of shared groups and roster synchronization using the protocol defined herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">JEP-0093 did not define the requirements for roster item exchange. This section remedies that oversight.</p>
+  <p class="" style="">Roster item exchange meets the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be added to the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be deleted from the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be modified in the recipient's roster.</li>
+  </ol>
+  <p class="" style="">This JEP deliberately speaks of rosters and roster items, not presence subscriptions. Although rosters and subscriptions are closely connected (as explained in <span style="font-weight: bold">XMPP IM</span>), they are not identical. The protocol defined herein enables an entity to suggest that another entity might want to add, delete, or modify roster items only, and does not dictate the suggested presence subscription state associated with those roster items. This is intentional.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="add">Suggesting Roster Item Addition</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should add one or more items to its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace (see <a href="#stanza">Recommended Stanza Type</a> regarding when to use &lt;message/&gt; and when to use &lt;iq/&gt;); the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which SHOULD possess an 'action' attribute whose value is &quot;add&quot;  [<a href="#nt-id2596371">5</a>], MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 1. Suggesting Addition</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='add'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='add'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;add&quot; (either explicitly or as the default value), the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item already exists in the roster and the item is in the specified group (or no group is specified), the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item does not already exist in the roster, the receiving application SHOULD prompt a human user for approval regarding that item and, if approval is granted, MUST add that item to the roster.</li>
+      <li>If the item already exists in the roster but not in the specified group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that will also belong to the specified group (in addition to the existing group, if any).</li>
+    </ol>
+    <p class="" style="">If the roster item addition stanza will result in adding the item to the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server containing the new item as described in <span style="font-weight: bold">XMPP IM</span>. After completing the roster set, the receiving application SHOULD also send a &lt;presence/&gt; stanza of type &quot;subscribe&quot; to the JID of the new item.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item addition stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="delete">Suggesting Roster Item Deletion</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should delete one or more items from its roster, the sending entity MUST send a &lt;message/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is &quot;delete&quot;, MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 2. Suggesting Deletion</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='delete'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='delete'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;delete&quot;, the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT delete that item to the roster.</li>
+      <li>If the item exists in the roster but not in the specified group, the receiving application MUST NOT prompt the user for approval and MUST NOT delete the existing item.</li>
+      <li>If the item exists in the roster and is in both the specified group and another group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that it no longer belongs to the specified group.</li>
+    </ol>
+    <p class="" style="">If a roster item deletion stanza will result in removal of the item from the roster (rather than editing of the item), the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with the 'subscription' attribute set to a value of &quot;remove&quot; as described in <span style="font-weight: bold">XMPP IM</span>, since this results in generation of the appropriate &lt;presence/&gt; stanzas by the user's server.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item deletion stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="modify">Suggesting Roster Item Modification</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should modify one or more items from its roster, the sending entity MUST send a &lt;message/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is &quot;modify&quot;, MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. The &lt;message/&gt; stanza SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 3. Suggesting Modification</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='modify'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='modify'
+          jid='guildenstern@denmark'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of &quot;modify&quot;, the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item exists in the roster and the modification results in a change of group only, the receiving application MAY prompt the user for approval and SHOULD move the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results adding the item to a new group in addition to its existing group, the receiving application MAY prompt the user for approval and SHOULD add the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in a change of name only, the receiving application MAY prompt the user for approval and SHOULD modify the name to that specified in the modification suggestion.</li>
+    </ol>
+    <p class="" style="">If a roster item addition, deletion, or modification stanza will result in editing of an existing item in the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with no changes to the 'subscription' attribute but rather with appropriate changes to the value of 'name' attribute or the &lt;group/&gt; child element or elements, as described in <span style="font-weight: bold">XMPP IM</span>.</p>
+  </div>
+<h2>4.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to determine whether a receiving entity supports the protocol defined herein, the sending entity SHOULD use <span class="ref">Service Discovery</span>  [<a href="#nt-id2602352">6</a>] but MAY depend on the &quot;profile&quot; of Service Discovery defined in <span class="ref">Entity Capabilities</span>  [<a href="#nt-id2602374">7</a>]. If an entity supports roster item exchange, it MUST (subject to appropriate security considerations as described under <a href="#security-support">Advertising Support</a>) include &lt;feature var='http://jabber.org/protocol/rosterx'/&gt; in its responses to disco#info queries. Thus a sending entity can discover if a receiving entity supports the protocol defined herein by sending an IQ request of the following form:</p>
+  <p class="caption">Example 4. Sending Entity Queries for Support</p>
+<div class="indent"><pre>
+&lt;iq from='horatio@denmark.lit/castle'
+    to='hamlet@denmark.lit/throne'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 5. Receiving Entity Advertises Support</p>
+<div class="indent"><pre>
+&lt;iq from='hamlet@denmark.lit/throne'
+    to='horatio@denmark.lit/castle'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rosterx'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="stanza">Recommended Stanza Type</a>
+</h2>
+  <p class="" style="">If the sending entity has knowledge (e.g., via presence or an active chat conversation) that the receiving entity is online and available, it SHOULD:  [<a href="#nt-id2602317">8</a>]</p>
+  <ol start="" type="">
+    <li>Discover if the receiving entity supports the protocol defined herein (see the <a href="#disco">Service Discovery</a> section of this document).</li>
+    <li>If so, send its roster item exchange stanza to a particular resource (user@host/resource) of the receiving entity using an &lt;iq/&gt; stanza rather than a &lt;message/&gt; stanza.</li>
+  </ol>
+  <p class="" style="">If the sending entity does not know that the receiving entity is online and available, it MUST send a &lt;message/&gt; stanza to the receiving entity's &quot;bare JID&quot; (user@host) rather than an &lt;iq/&gt; stanza to a particular resource.</p>
+  <div class="indent">
+<h3>5.1 <a name="stanza-iq">IQ Semantics</a>
+</h3>
+    <p class="" style="">If the sending entity uses &lt;iq/&gt; stanzas to communicate its roster item exchange suggestions, the receiving entity MUST adhere to the IQ semantics defined in <span class="ref">XMPP Core</span>  [<a href="#nt-id2602531">9</a>]. Specifically:</p>
+    <ol start="" type="">
+      <li>If the receiving entity successfully processes the suggested action(s) (which may include ignoring certain suggestions), the receiving entity MUST return an empty IQ result to the sending entity.</li>
+      <li>If the receiving entity does not understand the roster item exchange namespace, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;service-unavailable/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the receiving entity is not registered with the sending entity, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;registration-required/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not in the receiving entity's roster, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;not-authorized/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not trusted (see <a href="#security-trust">Trusted Entities</a>), the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;forbidden/&gt;.</li>
+    </ol>
+    <p class="" style="">Naturally, other IQ errors may be more appropriate; however, if the receiving entity will not or cannot process the suggested action(s), it MUST return an error to the sending entity.</p>
+  </div>
+<h2>6.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <ol start="" type="">
+    <li><p class="" style="">The sending entity or sending application SHOULD NOT send additions, deletions, and modifications in the same &lt;x/&gt; element and &lt;message/&gt; stanza; instead, it SHOULD send separate stanzas for the additions, deletions, and modifications.</p></li>
+    <li><p class="" style="">If approval is required or recommended regarding more than one item suggested by the sending entity, the receiving entity SHOULD present all of the items for approval at the same time or in the same interface; however, the receiving application may want to split additions, deletions, and modifications into separate prompts so as not to confuse the user.</p></li>
+    <li><p class="" style="">If the sending entity is in some sense &quot;trusted&quot; (see <a href="#security-trust">Trusted Entities</a>), then the receiving application MAY skip the approval steps described above.</p></li>
+    <li><p class="" style="">The receiving application SHOULD NOT accept an unreasonable number of roster items from any one sending entity at one time. Unfortunately, it can be difficult to determine how many roster items are &quot;unreasonable&quot;. For example, when a user registers with a gateway, it is possible that the initial set of roster items may be quite large (however, note that most existing consumer IM services enforce a limit of 100 to 150 items in their contact lists). Users who have newly registered with or been newly created on a server (e.g., within an organization) may also receive a large set of initial roster items in order to sync up with shared groups established on the server. However, after such initialization, the subsequent roster item sets should be much smaller. In any case, sets of more than 150 or 200 roster items SHOULD be treated with suspicion, and entities that repeatedly send such sets SHOULD NOT be trusted.</p></li>
+  </ol>
+<h2>7.
+       <a name="entities">Types of Sending Entities</a>
+</h2>
+  <p class="" style="">The foregoing protocol description speaks only of &quot;sending entities&quot; and does not differentiate between different types of sending entities. However, it is envisioned that roster items will be sent to receiving entities by three different kinds of senders:</p>
+  <ol start="" type="">
+    <li>Human users of Jabber clients.</li>
+    <li>Client proxy gateways.</li>
+    <li>Shared group services.</li>
+  </ol>
+  <p class="" style="">These are described more completely below.</p>
+  <div class="indent">
+<h3>7.1 <a name="entities-user">Jabber Users</a>
+</h3>
+    <p class="" style="">Roster item exchange as developed within the early Jabber community and documented in JEP-0093 was used to send a roster item from one user to another in a manner more structured than simply typing a third party's JID in a chat window. This usage is still encouraged. However, if the sender is a human user and/or the sending application has a primary <span style="font-weight: bold">Service Discovery</span> category of &quot;client&quot;, the sending application SHOULD NOT specify an 'action' attribute other than &quot;add&quot;, the receiving application MAY ignore values of the 'action' attribute other than &quot;add&quot;, and the receiving application MUST prompt a human user regarding whether to add the suggested item or items to the user's roster.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="entities-gateway">Gateways</a>
+</h3>
+    <p class="" style="">The nature of client proxy gateways (i.e., entities with a service discovery category of &quot;gateway&quot;) is specified more fully in <span class="ref">Gateway Interaction</span>  [<a href="#nt-id2602844">10</a>]. Herein we describe how such gateways should use roster item exchange, and how receiving applications should treat roster items received from such gateways.</p>
+    <p class="" style="">In order to make use of a gateway's protocol translation service, a user MUST first register with the gateway. If the gateway advertises support for a service discovery feature of 'http://jabber.org/protocol/rosterx', then the user's client SHOULD expect that it may receive roster item suggestions from the gateway. In order to maintain synchronization between the user's contact list on a legacy IM service and the user's Jabber roster, the gateway SHOULD send roster items with an 'action' attribute of &quot;add&quot;, &quot;delete&quot;, or &quot;modify&quot; as appropriate, and the receiving application SHOULD process such roster item suggestions. Such processing MAY occur automatically (i.e., without the user's approval of each roster item or batch of roster items) if and only if the receiving application has explicitly informed the user that it will automatically process roster items from the gateway. Furthermore, the receiving application SHOULD periodically verify automatic processing with the user (e.g., once per session in which the gateway sends roster item suggestions to the user).</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="entities-groupservice">Group Services</a>
+</h3>
+    <p class="" style="">There is a third category of entities that might initiate roster item exchanges, which we label a &quot;group service&quot; and identify by a <span style="font-weight: bold">Service Discovery</span> category of &quot;directory&quot; and type of &quot;group&quot;. A group service enables an administrator to centrally define and administer roster groups so that they can be shared among a user population in an organized fashion. Such a service could prove useful in enterprise environments
+       [<a href="#nt-id2602805">11</a>]
+    and other settings where it is beneficial to synchronize rosters across individuals (e.g., schools, social networking applications, consumer IM services, and anywhere else that it is important to build and manage small communities of users).</p>
+    <p class="" style="">In some contexts, an IM server could function as a group service (e.g., if there is a single server deployed on a small company intranet); in other contexts, it may make more sense to deploy a standalone group service (e.g., in a larger or more heterogeneous environment with users on multiple servers). In both cases, the group service MUST advertise a service discovery identity of &quot;directory/group&quot; and SHOULD use the protocol specified herein to communicate changes (&quot;add&quot;, &quot;delete&quot;, and &quot;modify&quot;) to the relevant shared groups; in addition, a user MUST first register with the service (either over Jabber via <span class="ref">In-Band Registration</span>  [<a href="#nt-id2602980">12</a>] or out of band, e.g., via the web) or be otherwise provisioned to use the service (e.g., by a system administrator) before accepting roster item suggestions from the service.</p> 
+    <p class="" style="">If the user has registered with a group service or been otherwise provisioned to use a group service, the receiving application SHOULD process roster item suggestions received from the service. Such processing MAY occur automatically (i.e., without the user's approval of each roster item or batch of roster items) if and only if the receiving application has explicitly informed the user that it will automatically process roster items from the service. Furthermore, the receiving application SHOULD periodically verify automatic processing with the user (e.g., once per session in which the service sends roster item suggestions to the user).</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="security-trust">Trusted Entities</a>
+</h3>
+    <p class="" style="">A principal (user) or receiving application MAY establish a list of trusted entities from which roster item exchanges are processed automatically, i.e., without explicit approval by a human user. In order to avoid corruption of the roster, it is STRONGLY RECOMMENDED that such trusted entities be limited to gateways and group services as defined above. In addition, the receiving application SHOULD periodically verify such automatic processing with the principal, e.g., once per session in which the trusted entity sends roster item suggestions to the user.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">A sending entity could effectively deny service to the receiving entity by rapidly and repeatedly sending (1) alternating add and delete suggestions or (2) modify suggestions, thus invoking throttling mechanisms enforced by the receiving entity's server. The receiving application SHOULD guard against this by monitoring roster item exchanges received from each sending entity and refusing or ignoring roster item exchanges from offending entities (e.g., by adding such entities to a list of distrusted entities).</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="security-support">Advertising Support</a>
+</h3>
+    <p class="" style="">A receiving application MAY refuse to advertise its support for the roster item exchange protocol (see the <a href="#disco">Service Discovery</a> section of this document) to entities that that are (1) not explicitly trusted or (2) explicitly distrusted.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2603147">13</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2603094">14</a>] shall include 'http://jabber.org/protocol/rosterx' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Identities</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include a <span style="font-weight: bold">Service Discovery</span> type of &quot;group&quot; under the &quot;directory&quot; category in its registry of service discovery identities.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rosterx'
+    xmlns='http://jabber.org/protocol/rosterx'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='group' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='optional'/&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName' default='add'&gt;
+            &lt;xs:enumeration value='add'/&gt;
+            &lt;xs:enumeration value='delete'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596216">1</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596247">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596270">3</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596289">4</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p>
+<a name="nt-id2596371">5</a>. The default value of the 'action' attribute is &quot;add&quot;; therefore, if the 'action' attribute is not included or the receiving application does not understand the 'action' attribute, the receiving application MUST treat the item as if the value were &quot;add&quot;.</p>
+<p>
+<a name="nt-id2602352">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602374">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602317">8</a>. If the receiving entity has more than one available resource, the sending application SHOULD communicate with the &quot;most available&quot; resource according its best estimation (e.g., the resource with the highest priority).</p>
+<p>
+<a name="nt-id2602531">9</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602844">10</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602805">11</a>. For example, when Alice is hired by the marketing department of Big Company Enterprises, it makes sense for her to automatically have the other members of the marketing department in her roster the first time she logs in, and for the rest of the marketing department to have Alice in their rosters as soon as her account has been set up. Similarly, when Bob in logistics gets fired, it makes sense for him to disappear from the rosters of everyone else in the logistics department.</p>
+<p>
+<a name="nt-id2602980">12</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2603147">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2603094">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2004-10-27)</h4>
+<div class="indent">Clarified the nature of sending entities (users, gateways, and group services); specified &quot;directory/group&quot; service discovery identity for shared group services. (psa)
+    </div>
+<h4>Version 0.2 (2004-10-04)</h4>
+<div class="indent">Further defined the nature of trusted entities. (psa)
+    </div>
+<h4>Version 0.1 (2004-09-29)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2004-09-22)</h4>
+<div class="indent">To address Council feedback, added text about service discovery and choice of stanza type (message or IQ). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-09-16)</h4>
+<div class="indent">Forked JEP-0093 by adding the action attribute, defining requirements and use cases, specifying processing rules, and detailing security considerations. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0144-0.4.html
+++ b/content/xep-0144-0.4.html
@@ -1,0 +1,418 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0144: Roster Item Exchange</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Roster Item Exchange">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0144">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0144: Roster Item Exchange</h1>
+<p>This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0144<br>
+            Version: 0.4<br>
+            Last Updated: 2005-07-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0093<br>
+                Superseded By: None<br>
+            Short Name: rosterx<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#add">Suggesting Roster Item Addition</a>
+</dt>
+<dt>3.2.  <a href="#delete">Suggesting Roster Item Deletion</a>
+</dt>
+<dt>3.3.  <a href="#modify">Suggesting Roster Item Modification</a>
+</dt>
+</dl>
+<dt>4.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>5.  <a href="#stanza">Recommended Stanza Type</a>
+</dt>
+<dl><dt>5.1.  <a href="#stanza-iq">IQ Semantics</a>
+</dt></dl>
+<dt>6.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>7.  <a href="#entities">Types of Sending Entities</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#entities-user">Jabber Users</a>
+</dt>
+<dt>7.2.  <a href="#entities-gateway">Gateways</a>
+</dt>
+<dt>7.3.  <a href="#entities-groupservice">Group Services</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-trust">Trusted Entities</a>
+</dt>
+<dt>8.2.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.3.  <a href="#security-support">Advertising Support</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Identities</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for sending roster items from one entity to another, making use of the 'jabber:x:roster' namespace. Because this protocol extension was not required by <span class="ref" style="">RFC 2779</span>  [<a href="#nt-id2250569">1</a>], it was removed from <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2251197">2</a>] and documented for historical purposes in <span class="ref" style="">Roster Item Exchange</span>  [<a href="#nt-id2251218">3</a>]. However, since that time discussions in the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2251240">4</a>] have revealed that it would be helpful to use roster item exchange in the problem spaces of "shared groups" (e.g., predefined roster groups used within an organization) and roster synchronization (e.g., keeping a Jabber roster in sync with a contact list on a legacy IM service). These problem spaces require a slightly more sophisticated kind of roster item exchange than was documented in JEP-0093, specifically the ability to indicate whether a roster item is to be added, deleted, or modified. Therefore this JEP redefines roster item exchange to provide this functionality in a way that is backwards-compatible with existing implementations, albeit using a modern namespace URI of 'http://jabber.org/protocol/rosterx' rather than the old 'jabber:x:roster' namespace name. Further JEPs will specify how to solve the problems of shared groups and roster synchronization using the protocol defined herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">JEP-0093 did not define the requirements for roster item exchange. This section remedies that oversight.</p>
+  <p class="" style="">Roster item exchange meets the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be added to the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be deleted from the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be modified in the recipient's roster.</li>
+  </ol>
+  <p class="" style="">This JEP deliberately speaks of rosters and roster items, not presence subscriptions. Although rosters and subscriptions are closely connected (as explained in <span style="font-weight: bold">RFC 3921</span>), they are not identical. The protocol defined herein enables an entity to suggest that another entity might want to add, delete, or modify roster items only, and does not dictate the suggested presence subscription state associated with those roster items. This is intentional.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="add">Suggesting Roster Item Addition</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should add one or more items to its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace (see <a href="#stanza">Recommended Stanza Type</a> regarding when to use &lt;message/&gt; and when to use &lt;iq/&gt;); the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which SHOULD possess an 'action' attribute whose value is "add"  [<a href="#nt-id2251356">5</a>], MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. If a &lt;message/&gt; stanza was sent, it SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 1. Suggesting Addition</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='add'
+          jid='rosencrantz@denmark.lit'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='add'
+          jid='guildenstern@denmark.lit'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "add" (either explicitly or as the default value), the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item already exists in the roster and the item is in the specified group (or no group is specified), the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item does not already exist in the roster, the receiving application SHOULD prompt a human user for approval regarding that item and, if approval is granted, MUST add that item to the roster.</li>
+      <li>If the item already exists in the roster but not in the specified group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that will also belong to the specified group (in addition to the existing group, if any).</li>
+    </ol>
+    <p class="" style="">If the roster item addition stanza will result in adding the item to the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server containing the new item as described in <span style="font-weight: bold">RFC 3921</span>. After completing the roster set, the receiving application SHOULD also send a &lt;presence/&gt; stanza of type "subscribe" to the JID of the new item.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item addition stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="delete">Suggesting Roster Item Deletion</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should delete one or more items from its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is "delete", MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups. If a &lt;message/&gt; stanza was sent, it SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 2. Suggesting Deletion</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='delete' jid='rosencrantz@denmark.lit'/&gt;
+    &lt;item action='delete' jid='guildenstern@denmark.lit'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "delete", the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT delete that item from the roster.</li>
+      <li>If the item exists in the roster, the receiving application SHOULD prompt the user for approval and SHOULD remove the item from the roster by sending a roster set to the user's server with the 'subscription' attribute set to a value of "remove" as described in <span style="font-weight: bold">RFC 3921</span>, since this results in generation of the appropriate &lt;presence/&gt; stanzas by the user's server.</li>
+    </ol>
+    <p class="" style="">The receiving application MAY use the 'name' and &lt;group/&gt; when prompting the user, but otherwise SHOULD ignore them.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="modify">Suggesting Roster Item Modification</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should modify one or more items from its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is "modify", MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. If a &lt;message/&gt; stanza was sent, it SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 3. Suggesting Modification</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='modify'
+          jid='rosencrantz@denmark.lit'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='modify'
+          jid='guildenstern@denmark.lit'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "modify", the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item exists in the roster and the modification results in a change of group only, the receiving application MAY prompt the user for approval and SHOULD move the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in adding the item to a new group in addition to its existing group, the receiving application MAY prompt the user for approval and SHOULD add the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in a change of name only, the receiving application MAY prompt the user for approval and SHOULD modify the name to that specified in the modification suggestion.</li>
+    </ol>
+    <p class="" style="">If a roster item addition or modification stanza will result in editing of an existing item in the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with no changes to the 'subscription' attribute but rather with appropriate changes to the value of 'name' attribute or the &lt;group/&gt; child element or elements, as described in <span style="font-weight: bold">RFC 3921</span>.</p>
+  </div>
+<h2>4.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to determine whether a receiving entity supports the protocol defined herein, the sending entity SHOULD use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255601">6</a>] but MAY depend on the "profile" of Service Discovery defined in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2255624">7</a>]. If an entity supports roster item exchange, it MUST (subject to appropriate security considerations as described under <a href="#security-support">Advertising Support</a>) include &lt;feature var='http://jabber.org/protocol/rosterx'/&gt; in its responses to disco#info queries. Thus a sending entity can discover if a receiving entity supports the protocol defined herein by sending an IQ request of the following form:</p>
+  <p class="caption">Example 4. Sending Entity Queries for Support</p>
+<div class="indent"><pre>
+&lt;iq from='horatio@denmark.lit/castle'
+    to='hamlet@denmark.lit/throne'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The receiving entity then indicates its support:</p>
+  <p class="caption">Example 5. Receiving Entity Advertises Support</p>
+<div class="indent"><pre>
+&lt;iq from='hamlet@denmark.lit/throne'
+    to='horatio@denmark.lit/castle'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rosterx'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="stanza">Recommended Stanza Type</a>
+</h2>
+  <p class="" style="">If the sending entity has knowledge (e.g., via presence or an active chat conversation) that the receiving entity is online and available, it SHOULD:  [<a href="#nt-id2255685">8</a>]</p>
+  <ol start="" type="">
+    <li>Discover if the receiving entity supports the protocol defined herein (see the <a href="#disco">Service Discovery</a> section of this document).</li>
+    <li>If so, send its roster item exchange stanza to a particular resource (user@host/resource) of the receiving entity using an &lt;iq/&gt; stanza rather than a &lt;message/&gt; stanza.</li>
+  </ol>
+  <p class="" style="">If the sending entity does not know that the receiving entity is online and available, it MUST send a &lt;message/&gt; stanza to the receiving entity's "bare JID" (user@host) rather than an &lt;iq/&gt; stanza to a particular resource.</p>
+  <div class="indent">
+<h3>5.1 <a name="stanza-iq">IQ Semantics</a>
+</h3>
+    <p class="" style="">If the sending entity uses &lt;iq/&gt; stanzas to communicate its roster item exchange suggestions, the receiving entity MUST adhere to the IQ semantics defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2255771">9</a>]. Specifically:</p>
+    <ol start="" type="">
+      <li>If the receiving entity successfully processes the suggested action(s) (which may include ignoring certain suggestions), the receiving entity MUST return an empty IQ result to the sending entity.</li>
+      <li>If the receiving entity does not understand the roster item exchange namespace, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;service-unavailable/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the receiving entity is not registered with the sending entity, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;registration-required/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not in the receiving entity's roster, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;not-authorized/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not trusted (see <a href="#security-trust">Trusted Entities</a>), the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;forbidden/&gt;.</li>
+    </ol>
+    <p class="" style="">Naturally, other IQ errors may be more appropriate; however, if the receiving entity will not or cannot process the suggested action(s), it MUST return an error to the sending entity.</p>
+  </div>
+<h2>6.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <ol start="" type="">
+    <li><p class="" style="">The sending entity or sending application SHOULD NOT send additions, deletions, and modifications in the same &lt;x/&gt; element and &lt;message/&gt; or &lt;iq/&gt; stanza; instead, it SHOULD send separate stanzas for the additions, deletions, and modifications.</p></li>
+    <li><p class="" style="">If approval is required or recommended regarding more than one item suggested by the sending entity, the receiving entity SHOULD present all of the items for approval at the same time or in the same interface; however, the receiving application may want to split additions, deletions, and modifications into separate prompts so as not to confuse the user.</p></li>
+    <li><p class="" style="">If the sending entity is in some sense "trusted" (see <a href="#security-trust">Trusted Entities</a>), then the receiving application MAY skip the approval steps described above.</p></li>
+    <li><p class="" style="">The receiving application SHOULD NOT accept an unreasonable number of roster items from any one sending entity at one time. Unfortunately, it can be difficult to determine how many roster items count as "unreasonable". For example, when a user registers with a gateway, it is possible that the initial set of roster items may be quite large (however, note that most existing consumer IM services enforce a limit of 100 to 150 items in their contact lists). Users who have newly registered with or been newly created on a server (e.g., within an organization) may also receive a large set of initial roster items in order to sync up with shared groups established on the server. However, after such initialization, the subsequent roster item sets should be much smaller. In any case, sets of more than 150 or 200 roster items SHOULD be treated with suspicion, and entities that repeatedly send such sets SHOULD NOT be trusted.</p></li>
+  </ol>
+<h2>7.
+       <a name="entities">Types of Sending Entities</a>
+</h2>
+  <p class="" style="">The foregoing protocol description speaks only of "sending entities" and does not differentiate between different types of sending entities. However, it is envisioned that roster items will be sent to receiving entities by three different kinds of senders:</p>
+  <ol start="" type="">
+    <li>Human users of Jabber clients.</li>
+    <li>Client proxy gateways.</li>
+    <li>Shared group services.</li>
+  </ol>
+  <p class="" style="">These are described more completely below.</p>
+  <div class="indent">
+<h3>7.1 <a name="entities-user">Jabber Users</a>
+</h3>
+    <p class="" style="">Roster item exchange as developed within the early Jabber community and documented in JEP-0093 was used to send a roster item from one user to another in a manner more structured than simply typing a third party's JID in a chat window. This usage is still encouraged. However, if the sender is a human user and/or the sending application has a primary <span style="font-weight: bold">Service Discovery</span> category of "client", the sending application SHOULD NOT specify an 'action' attribute other than "add", the receiving application MAY ignore values of the 'action' attribute other than "add", and the receiving application MUST prompt a human user regarding whether to add the suggested item or items to the user's roster.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="entities-gateway">Gateways</a>
+</h3>
+    <p class="" style="">The nature of client proxy gateways (i.e., entities with a service discovery category of "gateway") is specified more fully in <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2256033">10</a>]. Herein we describe how such gateways should use roster item exchange, and how receiving applications should treat roster items received from such gateways.</p>
+    <p class="" style="">In order to make use of a gateway's protocol translation service, a user MUST first register with the gateway. If the gateway advertises support for a service discovery feature of 'http://jabber.org/protocol/rosterx', then the user's client SHOULD expect that it may receive roster item suggestions from the gateway. In order to maintain synchronization between the user's contact list on a legacy IM service and the user's Jabber roster, the gateway SHOULD send roster items with an 'action' attribute of "add", "delete", or "modify" as appropriate, and the receiving application SHOULD process such roster item suggestions. Such processing MAY occur automatically (i.e., without the user's approval of each roster item or batch of roster items) if and only if the receiving application has explicitly informed the user that it will automatically process roster items from the gateway. Furthermore, the receiving application SHOULD periodically verify automatic processing with the user (e.g., once per session in which the gateway sends roster item suggestions to the user).</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="entities-groupservice">Group Services</a>
+</h3>
+    <p class="" style="">There is a third category of entities that might initiate roster item exchanges, which we label a "group service" and identify by a <span style="font-weight: bold">Service Discovery</span> category of "directory" and type of "group". A group service enables an administrator to centrally define and administer roster groups so that they can be shared among a user population in an organized fashion. Such a service could prove useful in enterprise environments
+       [<a href="#nt-id2256087">11</a>]
+    and other settings where it is beneficial to synchronize rosters across individuals (e.g., schools, social networking applications, consumer IM services, and anywhere else that it is important to build and manage small communities of users).</p>
+    <p class="" style="">In some contexts, an IM server could function as a group service (e.g., if there is a single server deployed on a small company intranet); in other contexts, it may make more sense to deploy a standalone group service (e.g., in a larger or more heterogeneous environment with users on multiple servers). In both cases, the group service MUST advertise a service discovery identity of "directory/group" and SHOULD use the protocol specified herein to communicate changes ("add", "delete", and "modify") to the relevant shared groups; in addition, a user MUST first register with the service (either over Jabber via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256180">12</a>] or out of band, e.g., via the web) or be otherwise provisioned to use the service (e.g., by a system administrator) before accepting roster item suggestions from the service.</p> 
+    <p class="" style="">If the user has registered with a group service or been otherwise provisioned to use a group service, the receiving application SHOULD process roster item suggestions received from the service. Such processing MAY occur automatically (i.e., without the user's approval of each roster item or batch of roster items) if and only if the receiving application has explicitly informed the user that it will automatically process roster items from the service. Furthermore, the receiving application SHOULD periodically verify automatic processing with the user (e.g., once per session in which the service sends roster item suggestions to the user).</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="security-trust">Trusted Entities</a>
+</h3>
+    <p class="" style="">A principal (user) or receiving application MAY establish a list of trusted entities from which roster item exchanges are processed automatically, i.e., without explicit approval by a human user. In order to avoid corruption of the roster, it is STRONGLY RECOMMENDED that such trusted entities be limited to gateways and group services as defined above. In addition, the receiving application SHOULD periodically verify such automatic processing with the principal, e.g., once per session in which the trusted entity sends roster item suggestions to the user.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">A sending entity could effectively deny service to the receiving entity by rapidly and repeatedly sending (1) alternating add and delete suggestions or (2) modify suggestions, thus invoking throttling mechanisms enforced by the receiving entity's server. The receiving application SHOULD guard against this by monitoring roster item exchanges received from each sending entity and refusing or ignoring roster item exchanges from offending entities (e.g., by adding such entities to a list of distrusted entities).</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="security-support">Advertising Support</a>
+</h3>
+    <p class="" style="">A receiving application MAY refuse to advertise its support for the roster item exchange protocol (see the <a href="#disco">Service Discovery</a> section of this document) to entities that that are (1) not explicitly trusted or (2) explicitly distrusted.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256284">13</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256335">14</a>] shall include 'http://jabber.org/protocol/rosterx' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Identities</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include a <span style="font-weight: bold">Service Discovery</span> type of "group" under the "directory" category in its registry of service discovery identities.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rosterx'
+    xmlns='http://jabber.org/protocol/rosterx'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='group' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='optional'/&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName' default='add'&gt;
+            &lt;xs:enumeration value='add'/&gt;
+            &lt;xs:enumeration value='delete'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250569">1</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p><a name="nt-id2251197">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251218">3</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p><a name="nt-id2251240">4</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2251356">5</a>. The default value of the 'action' attribute is "add"; therefore, if the 'action' attribute is not included or the receiving application does not understand the 'action' attribute, the receiving application MUST treat the item as if the value were "add".</p>
+<p><a name="nt-id2255601">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255624">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2255685">8</a>. If the receiving entity has more than one available resource, the sending application SHOULD communicate with the "most available" resource according its best estimation (e.g., the resource with the highest priority).</p>
+<p><a name="nt-id2255771">9</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256033">10</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2256087">11</a>. For example, when Alice is hired by the marketing department of Big Company Enterprises, it makes sense for her to automatically have the other members of the marketing department in her roster the first time she logs in, and for the rest of the marketing department to have Alice in their rosters as soon as her account has been set up. Similarly, when Bob in logistics gets fired, it makes sense for him to disappear from the rosters of everyone else in the logistics department.</p>
+<p><a name="nt-id2256180">12</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2256284">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256335">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2005-07-21)</h4>
+<div class="indent">Simplified processing of roster item deletions. (psa)
+    </div>
+<h4>Version 0.3 (2004-10-27)</h4>
+<div class="indent">Clarified the nature of sending entities (users, gateways, and group services); specified "directory/group" service discovery identity for shared group services. (psa)
+    </div>
+<h4>Version 0.2 (2004-10-04)</h4>
+<div class="indent">Further defined the nature of trusted entities. (psa)
+    </div>
+<h4>Version 0.1 (2004-09-29)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2004-09-22)</h4>
+<div class="indent">To address Council feedback, added text about service discovery and choice of stanza type (message or IQ). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-09-16)</h4>
+<div class="indent">Forked JEP-0093 by adding the action attribute, defining requirements and use cases, specifying processing rules, and detailing security considerations. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0144-0.5.html
+++ b/content/xep-0144-0.5.html
@@ -1,0 +1,430 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0144: Roster Item Exchange</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Roster Item Exchange">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-26">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0144">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0144: Roster Item Exchange</h1>
+<p>This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0144<br>
+            Version: 0.5<br>
+            Last Updated: 2005-07-26<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0093<br>
+                Superseded By: None<br>
+            Short Name: rosterx<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#add">Suggesting Roster Item Addition</a>
+</dt>
+<dt>3.2.  <a href="#delete">Suggesting Roster Item Deletion</a>
+</dt>
+<dt>3.3.  <a href="#modify">Suggesting Roster Item Modification</a>
+</dt>
+</dl>
+<dt>4.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>5.  <a href="#stanza">Recommended Stanza Type</a>
+</dt>
+<dl><dt>5.1.  <a href="#stanza-iq">IQ Semantics</a>
+</dt></dl>
+<dt>6.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>7.  <a href="#entities">Types of Sending Entities</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#entities-user">Jabber Users</a>
+</dt>
+<dt>7.2.  <a href="#entities-gateway">Gateways</a>
+</dt>
+<dt>7.3.  <a href="#entities-groupservice">Group Services</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-trust">Trusted Entities</a>
+</dt>
+<dt>8.2.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.3.  <a href="#security-support">Advertising Support</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Identities</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for sending roster items from one entity to another, making use of the 'jabber:x:roster' namespace. Because this protocol extension was not required by <span class="ref" style="">RFC 2779</span>  [<a href="#nt-id2251188">1</a>], it was removed from <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2251349">2</a>] and documented for historical purposes in <span class="ref" style="">Roster Item Exchange</span>  [<a href="#nt-id2251371">3</a>]. However, since that time discussions in the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2251392">4</a>] have revealed that it would be helpful to use roster item exchange in the problem spaces of "shared groups" (e.g., predefined roster groups used within an organization) and roster synchronization (e.g., keeping a Jabber roster in sync with a contact list on a legacy IM service). These problem spaces require a slightly more sophisticated kind of roster item exchange than was documented in JEP-0093, specifically the ability to indicate whether a roster item is to be added, deleted, or modified. Therefore this JEP redefines roster item exchange to provide this functionality in a way that is backwards-compatible with existing implementations, albeit using a modern namespace URI of 'http://jabber.org/protocol/rosterx' rather than the old 'jabber:x:roster' namespace name. Further JEPs will specify how to solve the problems of shared groups and roster synchronization using the protocol defined herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">JEP-0093 did not define the requirements for roster item exchange. This section remedies that oversight.</p>
+  <p class="" style="">Roster item exchange meets the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be added to the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be deleted from the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be modified in the recipient's roster.</li>
+  </ol>
+  <p class="" style="">This JEP deliberately speaks of rosters and roster items, not presence subscriptions. Although rosters and subscriptions are closely connected (as explained in <span style="font-weight: bold">RFC 3921</span>), they are not identical. The protocol defined herein enables an entity to suggest that another entity might want to add, delete, or modify roster items only, and does not dictate the suggested presence subscription state associated with those roster items. This is intentional.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="add">Suggesting Roster Item Addition</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should add one or more items to its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace (see <a href="#stanza">Recommended Stanza Type</a> regarding when to use &lt;message/&gt; and when to use &lt;iq/&gt;); the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which SHOULD possess an 'action' attribute whose value is "add"  [<a href="#nt-id2251268">5</a>], MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. If a &lt;message/&gt; stanza was sent, it SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 1. Suggesting Addition</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='add'
+          jid='rosencrantz@denmark.lit'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='add'
+          jid='guildenstern@denmark.lit'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "add" (either explicitly or as the default value), the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item already exists in the roster and the item is in the specified group (or no group is specified), the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item does not already exist in the roster, the receiving application SHOULD prompt a human user for approval regarding that item and, if approval is granted, MUST add that item to the roster.</li>
+      <li>If the item already exists in the roster but not in the specified group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that will also belong to the specified group (in addition to the existing group, if any).</li>
+    </ol>
+    <p class="" style="">If the roster item addition stanza will result in adding the item to the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server containing the new item as described in <span style="font-weight: bold">RFC 3921</span>. After completing the roster set, the receiving application SHOULD also send a &lt;presence/&gt; stanza of type "subscribe" to the JID of the new item.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item addition stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="delete">Suggesting Roster Item Deletion</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should delete one or more items from its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is "delete", MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups for the item. If a &lt;message/&gt; stanza was sent, it SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 2. Suggesting Deletion</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='delete'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;   
+       &lt;group&gt;Visitors&lt;/group&gt;   
+     &lt;/item&gt;     
+     &lt;item action='delete'       
+           jid='guildenstern@denmark'    
+           name='Guildenstern'&gt;          
+       &lt;group&gt;Visitors&lt;/group&gt;   
+     &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "delete", the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT delete that item from the roster.</li>
+      <li>If the item exists in the roster but not in the specified group, the receiving application MUST NOT prompt the user for approval and MUST NOT delete the existing item.</li>
+      <li>If the item exists in the roster and is in both the specified group and another group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that it no longer belongs to the specified group.</li>
+    </ol>
+    <p class="" style="">If the item is to be deleted, the receiving application SHOULD remove the item from the roster by sending a roster set to the user's server with the 'subscription' attribute set to a value of "remove" as described in <span style="font-weight: bold">RFC 3921</span>, since this results in generation of the appropriate &lt;presence/&gt; stanzas by the user's server.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="modify">Suggesting Roster Item Modification</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should modify one or more items from its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is "modify", MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. If a &lt;message/&gt; stanza was sent, it SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 3. Suggesting Modification</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='modify'
+          jid='rosencrantz@denmark.lit'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='modify'
+          jid='guildenstern@denmark.lit'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "modify", the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item exists in the roster and the modification results in a change of group only, the receiving application MAY prompt the user for approval and SHOULD move the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in adding the item to a new group in addition to its existing group, the receiving application MAY prompt the user for approval and SHOULD add the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in a change of name only, the receiving application MAY prompt the user for approval and SHOULD modify the name to that specified in the modification suggestion.</li>
+    </ol>
+    <p class="" style="">If a roster item addition, deletion, or modification stanza will result in editing of an existing item in the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with no changes to the 'subscription' attribute but rather with appropriate changes to the value of 'name' attribute or the &lt;group/&gt; child element or elements, as described in <span style="font-weight: bold">RFC 3921</span>.</p>
+  </div>
+<h2>4.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to determine whether a receiving entity supports the protocol defined herein, the sending entity SHOULD use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255794">6</a>] but MAY depend on the "profile" of Service Discovery defined in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2255818">7</a>]. If an entity supports roster item exchange, it MUST (subject to appropriate security considerations as described under <a href="#security-support">Advertising Support</a>) include &lt;feature var='http://jabber.org/protocol/rosterx'/&gt; in its responses to disco#info queries. Thus a sending entity can discover if a receiving entity supports the protocol defined herein by sending an IQ request of the following form:</p>
+  <p class="caption">Example 4. Sending Entity Queries for Support</p>
+<div class="indent"><pre>
+&lt;iq from='horatio@denmark.lit/castle'
+    to='hamlet@denmark.lit/throne'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The receiving entity then indicates its support:</p>
+  <p class="caption">Example 5. Receiving Entity Advertises Support</p>
+<div class="indent"><pre>
+&lt;iq from='hamlet@denmark.lit/throne'
+    to='horatio@denmark.lit/castle'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rosterx'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="stanza">Recommended Stanza Type</a>
+</h2>
+  <p class="" style="">If the sending entity has knowledge (e.g., via presence or an active chat conversation) that the receiving entity is online and available, it SHOULD:  [<a href="#nt-id2255878">8</a>]</p>
+  <ol start="" type="">
+    <li>Discover if the receiving entity supports the protocol defined herein (see the <a href="#disco">Service Discovery</a> section of this document).</li>
+    <li>If so, send its roster item exchange stanza to a particular resource (user@host/resource) of the receiving entity using an &lt;iq/&gt; stanza rather than a &lt;message/&gt; stanza.</li>
+  </ol>
+  <p class="" style="">If the sending entity does not know that the receiving entity is online and available, it MUST send a &lt;message/&gt; stanza to the receiving entity's "bare JID" (user@host) rather than an &lt;iq/&gt; stanza to a particular resource.</p>
+  <div class="indent">
+<h3>5.1 <a name="stanza-iq">IQ Semantics</a>
+</h3>
+    <p class="" style="">If the sending entity uses &lt;iq/&gt; stanzas to communicate its roster item exchange suggestions, the receiving entity MUST adhere to the IQ semantics defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2255964">9</a>]. Specifically:</p>
+    <ol start="" type="">
+      <li>If the receiving entity successfully processes the suggested action(s) (which may include ignoring certain suggestions), the receiving entity MUST return an empty IQ result to the sending entity.</li>
+      <li>If the receiving entity does not understand the roster item exchange namespace, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;service-unavailable/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the receiving entity is not registered with the sending entity, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;registration-required/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not in the receiving entity's roster, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;not-authorized/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not trusted (see <a href="#security-trust">Trusted Entities</a>), the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;forbidden/&gt;.</li>
+    </ol>
+    <p class="" style="">Naturally, other IQ errors may be more appropriate; however, if the receiving entity will not or cannot process the suggested action(s), it MUST return an error to the sending entity.</p>
+  </div>
+<h2>6.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <ol start="" type="">
+    <li><p class="" style="">The sending entity or sending application SHOULD NOT send additions, deletions, and modifications in the same &lt;x/&gt; element and &lt;message/&gt; or &lt;iq/&gt; stanza; instead, it SHOULD send separate stanzas for the additions, deletions, and modifications.</p></li>
+    <li><p class="" style="">If approval is required or recommended regarding more than one item suggested by the sending entity, the receiving entity SHOULD present all of the items for approval at the same time or in the same interface; however, the receiving application may want to split additions, deletions, and modifications into separate prompts so as not to confuse the user.</p></li>
+    <li><p class="" style="">If the sending entity is in some sense "trusted" (see <a href="#security-trust">Trusted Entities</a>), then the receiving application MAY skip the approval steps described above.</p></li>
+    <li><p class="" style="">The receiving application SHOULD NOT accept an unreasonable number of roster items from any one sending entity at one time. Unfortunately, it can be difficult to determine how many roster items count as "unreasonable". For example, when a user registers with a gateway, it is possible that the initial set of roster items may be quite large (however, note that most existing consumer IM services enforce a limit of 100 to 150 items in their contact lists). Users who have newly registered with or been newly created on a server (e.g., within an organization) may also receive a large set of initial roster items in order to sync up with shared groups established on the server. However, after such initialization, the subsequent roster item sets should be much smaller. In any case, sets of more than 150 or 200 roster items SHOULD be treated with suspicion, and entities that repeatedly send such sets SHOULD NOT be trusted.</p></li>
+  </ol>
+<h2>7.
+       <a name="entities">Types of Sending Entities</a>
+</h2>
+  <p class="" style="">The foregoing protocol description speaks only of "sending entities" and does not differentiate between different types of sending entities. However, it is envisioned that roster items will be sent to receiving entities by three different kinds of senders:</p>
+  <ol start="" type="">
+    <li>Human users of Jabber clients.</li>
+    <li>Client proxy gateways.</li>
+    <li>Shared group services.</li>
+  </ol>
+  <p class="" style="">These are described more completely below.</p>
+  <div class="indent">
+<h3>7.1 <a name="entities-user">Jabber Users</a>
+</h3>
+    <p class="" style="">Roster item exchange as developed within the early Jabber community and documented in JEP-0093 was used to send a roster item from one user to another in a manner more structured than simply typing a third party's JID in a chat window. This usage is still encouraged. However, if the sender is a human user and/or the sending application has a primary <span style="font-weight: bold">Service Discovery</span> category of "client", the sending application SHOULD NOT specify an 'action' attribute other than "add", the receiving application MAY ignore values of the 'action' attribute other than "add", and the receiving application MUST prompt a human user regarding whether to add the suggested item or items to the user's roster.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="entities-gateway">Gateways</a>
+</h3>
+    <p class="" style="">The nature of client proxy gateways (i.e., entities with a service discovery category of "gateway") is specified more fully in <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2256225">10</a>]. Herein we describe how such gateways should use roster item exchange, and how receiving applications should treat roster items received from such gateways.</p>
+    <p class="" style="">In order to make use of a gateway's protocol translation service, a user MUST first register with the gateway. If the gateway advertises support for a service discovery feature of 'http://jabber.org/protocol/rosterx', then the user's client SHOULD expect that it may receive roster item suggestions from the gateway. In order to maintain synchronization between the user's contact list on a legacy IM service and the user's Jabber roster, the gateway SHOULD send roster items with an 'action' attribute of "add", "delete", or "modify" as appropriate, and the receiving application SHOULD process such roster item suggestions. Such processing MAY occur automatically (i.e., without the user's approval of each roster item or batch of roster items) if and only if the receiving application has explicitly informed the user that it will automatically process roster items from the gateway. Furthermore, the receiving application SHOULD periodically verify automatic processing with the user (e.g., once per session in which the gateway sends roster item suggestions to the user).</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="entities-groupservice">Group Services</a>
+</h3>
+    <p class="" style="">There is a third category of entities that might initiate roster item exchanges, which we label a "group service" and identify by a <span style="font-weight: bold">Service Discovery</span> category of "directory" and type of "group". A group service enables an administrator to centrally define and administer roster groups so that they can be shared among a user population in an organized fashion. Such a service could prove useful in enterprise environments
+       [<a href="#nt-id2256278">11</a>]
+    and other settings where it is beneficial to synchronize rosters across individuals (e.g., schools, social networking applications, consumer IM services, and anywhere else that it is important to build and manage small communities of users).</p>
+    <p class="" style="">In some contexts, an IM server could function as a group service (e.g., if there is a single server deployed on a small company intranet); in other contexts, it may make more sense to deploy a standalone group service (e.g., in a larger or more heterogeneous environment with users on multiple servers). In both cases, the group service MUST advertise a service discovery identity of "directory/group" and SHOULD use the protocol specified herein to communicate changes ("add", "delete", and "modify") to the relevant shared groups; in addition, a user MUST first register with the service (either over Jabber via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256384">12</a>] or out of band, e.g., via the web) or be otherwise provisioned to use the service (e.g., by a system administrator) before accepting roster item suggestions from the service.</p> 
+    <p class="" style="">If the user has registered with a group service or been otherwise provisioned to use a group service, the receiving application SHOULD process roster item suggestions received from the service. Such processing MAY occur automatically (i.e., without the user's approval of each roster item or batch of roster items) if and only if the receiving application has explicitly informed the user that it will automatically process roster items from the service. Furthermore, the receiving application SHOULD periodically verify automatic processing with the user (e.g., once per session in which the service sends roster item suggestions to the user).</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="security-trust">Trusted Entities</a>
+</h3>
+    <p class="" style="">A principal (user) or receiving application MAY establish a list of trusted entities from which roster item exchanges are processed automatically, i.e., without explicit approval by a human user. In order to avoid corruption of the roster, it is STRONGLY RECOMMENDED that such trusted entities be limited to gateways and group services as defined above. In addition, the receiving application SHOULD periodically verify such automatic processing with the principal, e.g., once per session in which the trusted entity sends roster item suggestions to the user.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">A sending entity could effectively deny service to the receiving entity by rapidly and repeatedly sending (1) alternating add and delete suggestions or (2) modify suggestions, thus invoking throttling mechanisms enforced by the receiving entity's server. The receiving application SHOULD guard against this by monitoring roster item exchanges received from each sending entity and refusing or ignoring roster item exchanges from offending entities (e.g., by adding such entities to a list of distrusted entities).</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="security-support">Advertising Support</a>
+</h3>
+    <p class="" style="">A receiving application MAY refuse to advertise its support for the roster item exchange protocol (see the <a href="#disco">Service Discovery</a> section of this document) to entities that that are (1) not explicitly trusted or (2) explicitly distrusted.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256488">13</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256539">14</a>] shall include 'http://jabber.org/protocol/rosterx' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Identities</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include a <span style="font-weight: bold">Service Discovery</span> type of "group" under the "directory" category in its registry of service discovery identities.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rosterx'
+    xmlns='http://jabber.org/protocol/rosterx'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='group' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='optional'/&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName' default='add'&gt;
+            &lt;xs:enumeration value='add'/&gt;
+            &lt;xs:enumeration value='delete'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251188">1</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p><a name="nt-id2251349">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251371">3</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p><a name="nt-id2251392">4</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2251268">5</a>. The default value of the 'action' attribute is "add"; therefore, if the 'action' attribute is not included or the receiving application does not understand the 'action' attribute, the receiving application MUST treat the item as if the value were "add".</p>
+<p><a name="nt-id2255794">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255818">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2255878">8</a>. If the receiving entity has more than one available resource, the sending application SHOULD communicate with the "most available" resource according its best estimation (e.g., the resource with the highest priority).</p>
+<p><a name="nt-id2255964">9</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256225">10</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2256278">11</a>. For example, when Alice is hired by the marketing department of Big Company Enterprises, it makes sense for her to automatically have the other members of the marketing department in her roster the first time she logs in, and for the rest of the marketing department to have Alice in their rosters as soon as her account has been set up. Similarly, when Bob in logistics gets fired, it makes sense for him to disappear from the rosters of everyone else in the logistics department.</p>
+<p><a name="nt-id2256384">12</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2256488">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256539">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2005-07-26)</h4>
+<div class="indent">Reverted roster item deletion changes. (psa)
+    </div>
+<h4>Version 0.4 (2005-07-21)</h4>
+<div class="indent">Simplified processing of roster item deletions. (psa)
+    </div>
+<h4>Version 0.3 (2004-10-27)</h4>
+<div class="indent">Clarified the nature of sending entities (users, gateways, and group services); specified "directory/group" service discovery identity for shared group services. (psa)
+    </div>
+<h4>Version 0.2 (2004-10-04)</h4>
+<div class="indent">Further defined the nature of trusted entities. (psa)
+    </div>
+<h4>Version 0.1 (2004-09-29)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2004-09-22)</h4>
+<div class="indent">To address Council feedback, added text about service discovery and choice of stanza type (message or IQ). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-09-16)</h4>
+<div class="indent">Forked JEP-0093 by adding the action attribute, defining requirements and use cases, specifying processing rules, and detailing security considerations. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0144-0.6.html
+++ b/content/xep-0144-0.6.html
@@ -1,0 +1,435 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0144: Roster Item Exchange</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Roster Item Exchange">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0144">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0144: Roster Item Exchange</h1>
+<p>This JEP defines a protocol for exchanging roster items, including the ability to suggest whether the item is to be added, deleted, or modified.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0144<br>
+            Version: 0.6<br>
+            Last Updated: 2005-07-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>Supersedes: JEP-0093<br>
+                Superseded By: None<br>
+            Short Name: rosterx<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#add">Suggesting Roster Item Addition</a>
+</dt>
+<dt>3.2.  <a href="#delete">Suggesting Roster Item Deletion</a>
+</dt>
+<dt>3.3.  <a href="#modify">Suggesting Roster Item Modification</a>
+</dt>
+</dl>
+<dt>4.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>5.  <a href="#stanza">Recommended Stanza Type</a>
+</dt>
+<dl><dt>5.1.  <a href="#stanza-iq">IQ Semantics</a>
+</dt></dl>
+<dt>6.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>7.  <a href="#entities">Types of Sending Entities</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#entities-user">Jabber Users</a>
+</dt>
+<dt>7.2.  <a href="#entities-gateway">Gateways</a>
+</dt>
+<dt>7.3.  <a href="#entities-groupservice">Group Services</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-trust">Trusted Entities</a>
+</dt>
+<dt>8.2.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.3.  <a href="#security-support">Advertising Support</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Identities</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The Jabber protocols have long included a method for sending roster items from one entity to another, making use of the 'jabber:x:roster' namespace. Because this protocol extension was not required by <span class="ref" style="">RFC 2779</span>  [<a href="#nt-id2251206">1</a>], it was removed from <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2251230">2</a>] and documented for historical purposes in <span class="ref" style="">Roster Item Exchange</span>  [<a href="#nt-id2251390">3</a>]. However, since that time discussions in the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2251445">4</a>] have revealed that it would be helpful to use roster item exchange in the problem spaces of "shared groups" (e.g., predefined roster groups used within an organization) and roster synchronization (e.g., keeping a Jabber roster in sync with a contact list on a legacy IM service). These problem spaces require a slightly more sophisticated kind of roster item exchange than was documented in JEP-0093, specifically the ability to indicate whether a roster item is to be added, deleted, or modified. Therefore this JEP redefines roster item exchange to provide this functionality in a way that is backwards-compatible with existing implementations, albeit using a modern namespace URI of 'http://jabber.org/protocol/rosterx' rather than the old 'jabber:x:roster' namespace name. Further JEPs will specify how to solve the problems of shared groups and roster synchronization using the protocol defined herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">JEP-0093 did not define the requirements for roster item exchange. This section remedies that oversight.</p>
+  <p class="" style="">Roster item exchange meets the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be added to the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be deleted from the recipient's roster.</li>
+    <li>Enable an entity to send one or more roster items to another entity, with the suggestion that the roster item(s) be modified in the recipient's roster.</li>
+  </ol>
+  <p class="" style="">This JEP deliberately speaks of rosters and roster items, not presence subscriptions. Although rosters and subscriptions are closely connected (as explained in <span style="font-weight: bold">RFC 3921</span>), they are not identical. The protocol defined herein enables an entity to suggest that another entity might want to add, delete, or modify roster items only, and does not dictate the suggested presence subscription state associated with those roster items. This is intentional.</p>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="add">Suggesting Roster Item Addition</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should add one or more items to its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace (see <a href="#stanza">Recommended Stanza Type</a> regarding when to use &lt;message/&gt; and when to use &lt;iq/&gt;); the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which SHOULD possess an 'action' attribute whose value is "add"  [<a href="#nt-id2251322">5</a>], MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. If a &lt;message/&gt; stanza is sent, it MAY contain a &lt;body/&gt; element but SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 1. Suggesting Addition</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;body&gt;Some visitors, m'lord!&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='add'
+          jid='rosencrantz@denmark.lit'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='add'
+          jid='guildenstern@denmark.lit'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Visitors&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "add" (either explicitly or as the default value), the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item already exists in the roster and the item is in the specified group (or no group is specified), the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item does not already exist in the roster, the receiving application SHOULD prompt a human user for approval regarding that item and, if approval is granted, MUST add that item to the roster.</li>
+      <li>If the item already exists in the roster but not in the specified group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that will also belong to the specified group (in addition to the existing group, if any).</li>
+    </ol>
+    <p class="" style="">If the roster item addition stanza will result in adding the item to the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server containing the new item as described in <span style="font-weight: bold">RFC 3921</span>. After completing the roster set, the receiving application SHOULD also send a &lt;presence/&gt; stanza of type "subscribe" to the JID of the new item.</p>
+    <p class="" style="">For a description of the recommended application behavior when a roster item addition stanza actually results in editing of an existing roster item, refer to the <a href="#modify">Suggesting Roster Item Modification</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="delete">Suggesting Roster Item Deletion</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should delete one or more items from its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is "delete", MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups for the item. If a &lt;message/&gt; stanza is sent, it MAY contain a &lt;body/&gt; element but SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 2. Suggesting Deletion</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='delete'
+          jid='rosencrantz@denmark'
+          name='Rosencrantz'&gt;   
+       &lt;group&gt;Visitors&lt;/group&gt;   
+     &lt;/item&gt;     
+     &lt;item action='delete'       
+           jid='guildenstern@denmark'    
+           name='Guildenstern'&gt;          
+       &lt;group&gt;Visitors&lt;/group&gt;   
+     &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "delete", the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT delete that item from the roster.</li>
+      <li>If the item exists in the roster but not in the specified group, the receiving application MUST NOT prompt the user for approval and MUST NOT delete the existing item.</li>
+      <li>If the item exists in the roster and is in both the specified group and another group, the receiving application MAY prompt the user for approval and SHOULD edit the existing item so that it no longer belongs to the specified group.</li>
+    </ol>
+    <p class="" style="">If the item is to be deleted, the receiving application SHOULD remove the item from the roster by sending a roster set to the user's server with the 'subscription' attribute set to a value of "remove" as described in <span style="font-weight: bold">RFC 3921</span>, since this results in generation of the appropriate &lt;presence/&gt; stanzas by the user's server.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="modify">Suggesting Roster Item Modification</a>
+</h3>
+    <p class="" style="">In order to programatically suggest that the receiving entity should modify one or more items from its roster, the sending entity MUST send a &lt;message/&gt; or &lt;iq/&gt; stanza containing an &lt;x/&gt; element qualified by the 'http://jabber.org/protocol/rosterx' namespace; the &lt;x/&gt; element in turn MUST contain one or more &lt;item/&gt; child elements, each of which MUST possess an 'action' attribute whose value is "modify", MUST possess a 'jid' attribute that specifies the JabberID of the item to be added, MAY possess a 'name' attribute that specifies a natural-language name or nickname for the item, and MAY contain one or more &lt;group/&gt; elements specifying roster groups into which to place the item. If a &lt;message/&gt; stanza is sent, it MAY contain a &lt;body/&gt; element but SHOULD NOT contain any other child elements. Here is an example:</p>
+    <p class="caption">Example 3. Suggesting Modification</p>
+<div class="indent"><pre>
+&lt;message from='horatio@denmark.lit' to='hamlet@denmark.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt; 
+    &lt;item action='modify'
+          jid='rosencrantz@denmark.lit'
+          name='Rosencrantz'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item action='modify'
+          jid='guildenstern@denmark.lit'
+          name='Guildenstern'&gt;
+      &lt;group&gt;Retinue&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In determining how to handle any given roster item whose 'action' attribute has a value of "modify", the receiving application SHOULD proceed as follows:</p>
+    <ol start="" type="">
+      <li>If the item does not exist in the roster, the receiving application MUST NOT prompt a human user for approval regarding that item and MUST NOT add that item to the roster.</li>
+      <li>If the item exists in the roster and the modification results in a change of group only, the receiving application MAY prompt the user for approval and SHOULD move the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in adding the item to a new group in addition to its existing group, the receiving application MAY prompt the user for approval and SHOULD add the item to the specified group.</li>
+      <li>If the item exists in the roster and the modification results in a change of name only, the receiving application MAY prompt the user for approval and SHOULD modify the name to that specified in the modification suggestion.</li>
+    </ol>
+    <p class="" style="">If a roster item addition, deletion, or modification stanza will result in editing of an existing item in the roster, the receiving application MUST (either with approval by a human user or automatically subject to configuration) send a roster set to the user's server with no changes to the 'subscription' attribute but rather with appropriate changes to the value of 'name' attribute or the &lt;group/&gt; child element or elements, as described in <span style="font-weight: bold">RFC 3921</span>.</p>
+  </div>
+<h2>4.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to determine whether a receiving entity supports the protocol defined herein, the sending entity SHOULD use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2255834">6</a>] but MAY depend on the "profile" of Service Discovery defined in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2255858">7</a>]. If an entity supports roster item exchange, it MUST (subject to appropriate security considerations as described under <a href="#security-support">Advertising Support</a>) include &lt;feature var='http://jabber.org/protocol/rosterx'/&gt; in its responses to disco#info queries. Thus a sending entity can discover if a receiving entity supports the protocol defined herein by sending an IQ request of the following form:</p>
+  <p class="caption">Example 4. Sending Entity Queries for Support</p>
+<div class="indent"><pre>
+&lt;iq from='horatio@denmark.lit/castle'
+    to='hamlet@denmark.lit/throne'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The receiving entity then indicates its support:</p>
+  <p class="caption">Example 5. Receiving Entity Advertises Support</p>
+<div class="indent"><pre>
+&lt;iq from='hamlet@denmark.lit/throne'
+    to='horatio@denmark.lit/castle'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rosterx'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="stanza">Recommended Stanza Type</a>
+</h2>
+  <p class="" style="">If the sending entity has knowledge (e.g., via presence or an active chat conversation) that the receiving entity is online and available, it SHOULD:  [<a href="#nt-id2255915">8</a>]</p>
+  <ol start="" type="">
+    <li>Discover if the receiving entity supports the protocol defined herein (see the <a href="#disco">Service Discovery</a> section of this document).</li>
+    <li>If so, send its roster item exchange stanza to a particular resource (user@host/resource) of the receiving entity using an &lt;iq/&gt; stanza rather than a &lt;message/&gt; stanza.</li>
+  </ol>
+  <p class="" style="">If the sending entity does not know that the receiving entity is online and available, it MUST send a &lt;message/&gt; stanza to the receiving entity's "bare JID" (user@host) rather than an &lt;iq/&gt; stanza to a particular resource.</p>
+  <div class="indent">
+<h3>5.1 <a name="stanza-iq">IQ Semantics</a>
+</h3>
+    <p class="" style="">If the sending entity uses &lt;iq/&gt; stanzas to communicate its roster item exchange suggestions, the receiving entity MUST adhere to the IQ semantics defined in <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2256003">9</a>]. Specifically:</p>
+    <ol start="" type="">
+      <li>If the receiving entity successfully processes the suggested action(s) (which may include ignoring certain suggestions), the receiving entity MUST return an empty IQ result to the sending entity.</li>
+      <li>If the receiving entity does not understand the roster item exchange namespace, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;service-unavailable/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the receiving entity is not registered with the sending entity, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;registration-required/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not in the receiving entity's roster, the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;not-authorized/&gt;.</li>
+      <li>If the receiving entity will not process the suggested action(s) because the sending entity is not trusted (see <a href="#security-trust">Trusted Entities</a>), the receiving entity MUST return an error to the sending entity, which error SHOULD be &lt;forbidden/&gt;.</li>
+    </ol>
+    <p class="" style="">Naturally, other IQ errors may be more appropriate; however, if the receiving entity will not or cannot process the suggested action(s), it MUST return an error to the sending entity.</p>
+  </div>
+<h2>6.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <ol start="" type="">
+    <li><p class="" style="">The sending entity or sending application MUST NOT send additions, deletions, and modifications in the same &lt;x/&gt; element and &lt;message/&gt; or &lt;iq/&gt; stanza; instead, it SHOULD send separate stanzas for the additions, deletions, and modifications.</p></li>
+    <li><p class="" style="">If approval is required or recommended regarding more than one item suggested by the sending entity, the receiving entity SHOULD present all of the items for approval at the same time or in the same interface.</p></li>
+    <li><p class="" style="">If the sending entity is in some sense "trusted" (see <a href="#security-trust">Trusted Entities</a>), then the receiving application MAY skip the approval steps described above.</p></li>
+    <li><p class="" style="">The receiving application SHOULD NOT accept an unreasonable number of roster items from any one sending entity at one time. Unfortunately, it can be difficult to determine how many roster items count as "unreasonable". For example, when a user registers with a gateway, it is possible that the initial set of roster items may be quite large (however, note that most existing consumer IM services enforce a limit of 100 to 150 items in their contact lists). Users who have newly registered with or been newly created on a server (e.g., within an organization) may also receive a large set of initial roster items in order to sync up with shared groups established on the server. However, after such initialization, the subsequent roster item sets should be much smaller. In any case, sets of more than 150 or 200 roster items SHOULD be treated with suspicion, and entities that repeatedly send such sets SHOULD NOT be trusted.</p></li>
+  </ol>
+<h2>7.
+       <a name="entities">Types of Sending Entities</a>
+</h2>
+  <p class="" style="">The foregoing protocol description speaks only of "sending entities" and does not differentiate between different types of sending entities. However, it is envisioned that roster items will be sent to receiving entities by three different kinds of senders:</p>
+  <ol start="" type="">
+    <li>Users of Jabber clients.</li>
+    <li>Client proxy gateways.</li>
+    <li>Shared group services.</li>
+  </ol>
+  <p class="" style="">These are described more completely below.</p>
+  <div class="indent">
+<h3>7.1 <a name="entities-user">Jabber Users</a>
+</h3>
+    <p class="" style="">Roster item exchange as developed within the early Jabber community and documented in JEP-0093 was used to send a roster item from one user to another in a manner more structured than simply typing a third party's JID in a chat window. This usage is still encouraged. However, if the sender is a human user and/or the sending application has a primary <span style="font-weight: bold">Service Discovery</span> category of "client" (e.g., a bot)  [<a href="#nt-id2250135">10</a>], the sending application SHOULD NOT specify an 'action' attribute other than "add", the receiving application MAY ignore values of the 'action' attribute other than "add", and the receiving application MUST prompt a human user regarding whether to add the suggested item or items to the user's roster.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="entities-gateway">Gateways</a>
+</h3>
+    <p class="" style="">The nature of client proxy gateways (i.e., entities with a service discovery category of "gateway") is specified more fully in <span class="ref" style="">Gateway Interaction</span>  [<a href="#nt-id2250191">11</a>]. Herein we describe how such gateways should use roster item exchange, and how receiving applications should treat roster items received from such gateways.</p>
+    <p class="" style="">In order to make use of a gateway's protocol translation service, a user MUST first register with the gateway. If the gateway advertises support for a service discovery feature of 'http://jabber.org/protocol/rosterx', then the user's client SHOULD expect that it may receive roster item suggestions from the gateway. In order to maintain synchronization between the user's contact list on a legacy IM service and the user's Jabber roster, the gateway SHOULD send roster items with an 'action' attribute of "add", "delete", or "modify" as appropriate, and the receiving application SHOULD process such roster item suggestions. Such processing MAY occur automatically (i.e., without the user's approval of each roster item or batch of roster items) if and only if the receiving application has explicitly informed the user that it will automatically process roster items from the gateway. Furthermore, the receiving application SHOULD periodically verify automatic processing with the user (e.g., once per session in which the gateway sends roster item suggestions to the user).</p>
+  </div>
+  <div class="indent">
+<h3>7.3 <a name="entities-groupservice">Group Services</a>
+</h3>
+    <p class="" style="">There is a third category of entities that might initiate roster item exchanges, which we label a "group service" and identify by a <span style="font-weight: bold">Service Discovery</span> category of "directory" and type of "group". A group service enables an administrator to centrally define and administer roster groups so that they can be shared among a user population in an organized fashion. Such a service could prove useful in enterprise environments
+       [<a href="#nt-id2250246">12</a>]
+    and other settings where it is beneficial to synchronize rosters across individuals (e.g., schools, social networking applications, consumer IM services, and anywhere else that it is important to build and manage small communities of users).</p>
+    <p class="" style="">In some contexts, an IM server could function as a group service (e.g., if there is a single server deployed on a small company intranet); in other contexts, it may make more sense to deploy a standalone group service (e.g., in a larger or more heterogeneous environment with users on multiple servers). In both cases, the group service MUST advertise a service discovery identity of "directory/group" and SHOULD use the protocol specified herein to communicate changes ("add", "delete", and "modify") to the relevant shared groups; in addition, a user MUST first register with the service (either over Jabber via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256521">13</a>] or out of band, e.g., via the web) or be otherwise provisioned to use the service (e.g., by a system administrator) before accepting roster item suggestions from the service.</p> 
+    <p class="" style="">If the user has registered with a group service or been otherwise provisioned to use a group service, the receiving application SHOULD process roster item suggestions received from the service. Such processing MAY occur automatically (i.e., without the user's approval of each roster item or batch of roster items) if and only if the receiving application has explicitly informed the user that it will automatically process roster items from the service. Furthermore, the receiving application SHOULD periodically verify automatic processing with the user (e.g., once per session in which the service sends roster item suggestions to the user).</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="security-trust">Trusted Entities</a>
+</h3>
+    <p class="" style="">A principal (user) or receiving application MAY establish a list of trusted entities from which roster item exchanges are processed automatically, i.e., without explicit approval by a human user. In order to avoid corruption of the roster, it is STRONGLY RECOMMENDED that such trusted entities be limited to gateways and group services as defined above. In addition, the receiving application SHOULD periodically verify such automatic processing with the principal, e.g., once per session in which the trusted entity sends roster item suggestions to the user.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">A sending entity could effectively deny service to the receiving entity by rapidly and repeatedly sending (1) alternating add and delete suggestions or (2) modify suggestions, thus invoking throttling mechanisms enforced by the receiving entity's server. The receiving application SHOULD guard against this by monitoring roster item exchanges received from each sending entity and refusing or ignoring roster item exchanges from offending entities (e.g., by adding such entities to a list of distrusted entities).</p>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="security-support">Advertising Support</a>
+</h3>
+    <p class="" style="">A receiving application MAY refuse to advertise its support for the roster item exchange protocol (see the <a href="#disco">Service Discovery</a> section of this document) to entities that that are (1) not explicitly trusted or (2) explicitly distrusted.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256668">14</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256713">15</a>] shall include 'http://jabber.org/protocol/rosterx' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Identities</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include a <span style="font-weight: bold">Service Discovery</span> type of "group" under the "directory" category in its registry of service discovery identities.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rosterx'
+    xmlns='http://jabber.org/protocol/rosterx'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='group' type='xs:string' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='optional'/&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName' default='add'&gt;
+            &lt;xs:enumeration value='add'/&gt;
+            &lt;xs:enumeration value='delete'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251206">1</a>. RFC 2779: A Model for Presence and Instant Messaging &lt;<a href="http://www.ietf.org/rfc/rfc2779.txt">http://www.ietf.org/rfc/rfc2779.txt</a>&gt;.</p>
+<p><a name="nt-id2251230">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251390">3</a>. JEP-0093: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0093.html">http://www.jabber.org/jeps/jep-0093.html</a>&gt;.</p>
+<p><a name="nt-id2251445">4</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2251322">5</a>. The default value of the 'action' attribute is "add"; therefore, if the 'action' attribute is not included or the receiving application does not understand the 'action' attribute, the receiving application MUST treat the item as if the value were "add".</p>
+<p><a name="nt-id2255834">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255858">7</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2255915">8</a>. If the receiving entity has more than one available resource, the sending application SHOULD communicate with the "most available" resource according its best estimation (e.g., the resource with the highest priority).</p>
+<p><a name="nt-id2256003">9</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250135">10</a>. See &lt;<a href="http://www.jabber.org/registrar/disco-categories.html#client">http://www.jabber.org/registrar/disco-categories.html#client</a>&gt;.</p>
+<p><a name="nt-id2250191">11</a>. JEP-0100: Gateway Interaction &lt;<a href="http://www.jabber.org/jeps/jep-0100.html">http://www.jabber.org/jeps/jep-0100.html</a>&gt;.</p>
+<p><a name="nt-id2250246">12</a>. For example, when Alice is hired by the marketing department of Big Company Enterprises, it makes sense for her to automatically have the other members of the marketing department in her roster the first time she logs in, and for the rest of the marketing department to have Alice in their rosters as soon as her account has been set up. Similarly, when Bob in logistics gets fired, it makes sense for him to disappear from the rosters of everyone else in the logistics department.</p>
+<p><a name="nt-id2256521">13</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2256668">14</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256713">15</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-07-28)</h4>
+<div class="indent">Incorporated Council feedback: specified that a body MAY be included when sending a message stanza; changed prohibition on mixing of additions, deletions, and modifications from SHOULD NOT to MUST NOT; clarified status of bots as sending entities. (psa)
+    </div>
+<h4>Version 0.5 (2005-07-26)</h4>
+<div class="indent">Reverted roster item deletion changes. (psa)
+    </div>
+<h4>Version 0.4 (2005-07-21)</h4>
+<div class="indent">Simplified processing of roster item deletions. (psa)
+    </div>
+<h4>Version 0.3 (2004-10-27)</h4>
+<div class="indent">Clarified the nature of sending entities (users, gateways, and group services); specified "directory/group" service discovery identity for shared group services. (psa)
+    </div>
+<h4>Version 0.2 (2004-10-04)</h4>
+<div class="indent">Further defined the nature of trusted entities. (psa)
+    </div>
+<h4>Version 0.1 (2004-09-29)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2004-09-22)</h4>
+<div class="indent">To address Council feedback, added text about service discovery and choice of stanza type (message or IQ). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-09-16)</h4>
+<div class="indent">Forked JEP-0093 by adding the action attribute, defining requirements and use cases, specifying processing rules, and detailing security considerations. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0145-0.1.html
+++ b/content/xep-0145-0.1.html
@@ -1,0 +1,232 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0145: Annotations</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Annotations">
+<meta name="DC.Creator" content="Stefan Strigler">
+<meta name="DC.Description" content="This JEP defines a protocol for making annotations about roster items and other entities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0145">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0145: Annotations</h1>
+<p>This JEP defines a protocol for making annotations about roster items and other entities.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0145<br>
+            Version: 0.1<br>
+            Last Updated: 2004-11-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0001, JEP-0049<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: Not yet assigned<br>
+</p>
+<h2>Author Information</h2>
+<h3>Stefan Strigler</h3>
+<p class="indent">
+        Email: steve@zeank.in-berlin.de<br>
+        JID: zeank@jwchat.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#ns_storage_notes">The storage:notes Namespace</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+
+		<p class="" style="">Many modern IM clients offer functionality that enables users 
+		to make notes about items in their roster. This comes in handy
+		if users don't have meaningful information in their vCard or if
+		you need to remember additional things related with another
+		entitity.</p>
+
+		<p class="" style="">This specification defines a protocol for storing annotations
+		about a given set of entities. Its primary goal is to enable users to
+		store some personal piece of information with their roster
+		items. <span class="ref">Private XML Storage</span>  [<a href="#nt-id2596154">1</a>] provides us with a convenient method for storing
+		user data on the server using jabber:iq:private; all we need to do
+		is define a namespace and schema for storing this sort of
+		information. For this the 'storage' element introduced at
+		<span class="ref">Bookmark Storage</span>  [<a href="#nt-id2596074">2</a>] is being reused and a new namespace of 'storage:notes'
+		is added.</p>
+
+	<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+
+		<p class="" style="">A server MUST implement JEP-0049 so that clients can use the
+		functionality described in this document.</p>
+
+	<h2>3.
+       <a name="ns_storage_notes">The storage:notes Namespace</a>
+</h2>
+		
+		<p class="" style="">Annotations are stored in the jabber:iq:private namespace. A
+		storage element marked by the storage:notes namespace will contain
+		a collection of 'note' elements, each representing a 'note' about a
+		given entity.  For any given JID there MUST NOT be more than one
+		note.</p>
+
+		<p class="" style="">Attribute 'jid' of the 'note' element SHOULD be used without a
+		resource. Along with the annotation a client MAY choose to store
+		creation time ('cdate') and modification time ('mdate') as
+		attributes to the 'note' element containing the note.</p>
+
+		<p class="caption">Example 1. Storing Annotations</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' id='a1'&gt;
+  &lt;query xmlns='jabber:iq:private'&gt;
+    &lt;storage xmlns='storage:notes'&gt;
+      &lt;note jid='hamlet@shakespeare.lit'
+            cdate='20040924T15:23:21'
+            mdate='20040924T15:23:21'&gt;Seems to be a good writer&lt;/note&gt;
+      &lt;note jid='juliet@capulet.org'
+            cdate='20040927T17:23:14'
+            mdate='20040928T12:43:12'&gt;Oh my sweetest love ...&lt;/note&gt;
+    &lt;/storage&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+
+		<p class="" style="">Note: All notes are stored as a &quot;bundle&quot; within the same &lt;storage/&gt; element.</p>
+
+		<p class="" style="">Retrieving notes is pretty straight forward as how it is described in JEP-0049.</p>
+
+		<p class="caption">Example 2. Retrieving Annotations</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' id='a2'&gt;
+  &lt;query xmlns='jabber:iq:private'&gt;
+    &lt;storage xmlns='storage:notes' /&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+
+		<p class="caption">Example 3. Server response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a2' to='client' from='server'&gt;
+  &lt;query xmlns='jabber:iq:private'&gt;
+    &lt;storage xmlns='storage:notes'&gt;
+      &lt;note jid='hamlet@shakespeare.lit'
+            cdate='20040924T15:23:21'
+            mdate='20040924T15:23:21'&gt;Seems to be a good writer&lt;/note&gt;
+      &lt;note jid='juliet@capulet.org'
+            cdate='20040927T17:23:14'
+            mdate='20040928T12:43:12'&gt;Oh my sweetest love ...&lt;/note&gt;
+    &lt;/storage&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+
+		For error conditions please refer to JEP-0049.
+
+	<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+		<p class="" style="">Security considerations related to private XML storage are
+		described in JEP-0049.</p>
+	<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+		<p class="" style="">No interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2596366">3</a>] is required as a result of this
+		JEP.</p>
+	<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+		<p class="" style="">No namespaces or parameters need to be registered with the
+		<span class="ref">Jabber Registrar</span>  [<a href="#nt-id2601892">4</a>] as a result of this JEP.</p>
+	<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+		<p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='storage:notes'
+    xmlns='storage:notes'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='storage'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:element ref='note'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='note'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='cdate' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='mdate' type='xs:string' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+	<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596154">1</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596074">2</a>. JEP-0048: Bookmark Storage &lt;<a href="http://www.jabber.org/jeps/jep-0048.html">http://www.jabber.org/jeps/jep-0048.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596366">3</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2601892">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-11-05)</h4>
+<div class="indent">Initial version. (st)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0145-0.2.html
+++ b/content/xep-0145-0.2.html
@@ -1,0 +1,217 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0145: Annotations</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Annotations">
+<meta name="DC.Creator" content="Stefan Strigler">
+<meta name="DC.Description" content="This JEP defines a protocol for making annotations about roster items and other entities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0145">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0145: Annotations</h1>
+<p>This JEP defines a protocol for making annotations about roster items and other entities.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Historical<br>
+            Number: 0145<br>
+            Version: 0.2<br>
+            Last Updated: 2005-07-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0049<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rosternotes<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Annotations%20(JEP-0145)">http://wiki.jabber.org/index.php/Annotations (JEP-0145)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Stefan Strigler</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:steve@zeank.in-berlin.de">steve@zeank.in-berlin.de</a><br>
+        JID: 
+        <a href="xmpp:zeank@jwchat.org">zeank@jwchat.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#ns_storage_notes">The storage:rosternotes Namespace</a>
+</dt>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>5.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>6.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+
+    <p class="" style="">Many modern IM clients offer functionality that enables users to make notes about items in their roster. This comes in handy if users don't have meaningful information in their vCard or if you need to remember additional things related to a roster item.</p>
+
+    <p class="" style="">This specification defines a protocol for storing annotations about a given set of entities. Its primary goal is to enable users to store some personal piece of information with their roster items. <span class="ref" style="">Private XML Storage</span>  [<a href="#nt-id2250808">1</a>] provides with a convenient method for storing user data on the server using the 'jabber:iq:private' namespace; all we need to do is define a namespace and schema for storing this sort of information. For this the 'storage' element introduced in <span class="ref" style="">Bookmark Storage</span>  [<a href="#nt-id2250835">2</a>] is reused, and a new namespace of 'storage:rosternotes' is added.</p>
+
+  <h2>2.
+       <a name="ns_storage_notes">The storage:rosternotes Namespace</a>
+</h2>
+    
+    <p class="" style="">Annotations are stored using server-side private XML storage (the 'jabber:iq:private' namespace). A storage element marked by the storage:rosternotes namespace contains a collection of one or more &lt;note/&gt; elements, each representing a note about a given entity.  For any given JID there MUST NOT be more than one note.</p>
+
+    <p class="" style="">The 'jid' attribute of the &lt;note/&gt; element SHOULD be used without a resource. Along with the annotation a client MAY choose to store creation time ('cdate') and modification time ('mdate') as attributes to the &lt;note/&gt; element containing the note; these attributes MUST conform to the DateTime profile specified in <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2250890">3</a>] and the timezone SHOULD be UTC.</p>
+
+    <p class="caption">Example 1. Storing Annotations</p>
+<div class="indent"><pre>
+    
+&lt;iq type='set' id='a1'&gt;
+  &lt;query xmlns='jabber:iq:private'&gt;
+    &lt;storage xmlns='storage:rosternotes'&gt;
+      &lt;note jid='hamlet@shakespeare.lit'
+            cdate='2004-09-24T15:23:21Z'
+            mdate='2004-09-24T15:23:21Z'&gt;Seems to be a good writer&lt;/note&gt;
+      &lt;note jid='juliet@capulet.com'
+            cdate='2004-09-27T17:23:14Z'
+            mdate='2004-09-28T12:43:12Z'&gt;Oh my sweetest love ...&lt;/note&gt;
+    &lt;/storage&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+
+    <p class="" style="">Note: All notes are stored as a "bundle" within the same &lt;storage/&gt; element.</p>
+
+    <p class="" style="">Retrieving notes uses the protocol described in <span style="font-weight: bold">JEP-0049</span>.</p>
+
+    <p class="caption">Example 2. Retrieving Annotations</p>
+<div class="indent"><pre>
+    
+&lt;iq type='get' id='a2'&gt;
+  &lt;query xmlns='jabber:iq:private'&gt;
+    &lt;storage xmlns='storage:rosternotes'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+
+    <p class="caption">Example 3. Server response</p>
+<div class="indent"><pre>
+    
+&lt;iq type='result' id='a2'&gt;
+  &lt;query xmlns='jabber:iq:private'&gt;
+    &lt;storage xmlns='storage:rosternotes'&gt;
+      &lt;note jid='hamlet@shakespeare.lit'
+            cdate='2004-09-24T15:23:21Z'
+            mdate='2004-09-24T15:23:21Z'&gt;Seems to be a good writer&lt;/note&gt;
+      &lt;note jid='juliet@capulet.com'
+            cdate='2004-09-27T17:23:14Z'
+            mdate='2004-09-28T12:43:12Z'&gt;Oh my sweetest love ...&lt;/note&gt;
+    &lt;/storage&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+</pre></div>
+
+    <p class="" style="">For error conditions please refer to <span style="font-weight: bold">JEP-0049</span>.</p>
+
+  <h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+    <p class="" style="">Security considerations related to private XML storage are described in <span style="font-weight: bold">JEP-0049</span>.</p>
+  <h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+    <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2251031">4</a>] is required as a result of this
+    JEP.</p>
+  <h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <div class="indent">
+<h3>5.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+      <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2251083">5</a>] shall include 'storage:rosternotes' in its registry of protocol namespaces.</p>
+    </div>
+  <h2>6.
+       <a name="schema">XML Schema</a>
+</h2>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='storage:rosternotes'
+    xmlns='storage:rosternotes'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='storage'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='note' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='note'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='xs:string'&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='cdate' type='xs:dateTime' use='optional'/&gt;
+          &lt;xs:attribute name='mdate' type='xs:dateTime' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+  <p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250808">1</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p><a name="nt-id2250835">2</a>. JEP-0048: Bookmark Storage &lt;<a href="http://www.jabber.org/jeps/jep-0048.html">http://www.jabber.org/jeps/jep-0048.html</a>&gt;.</p>
+<p><a name="nt-id2250890">3</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2251031">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2251083">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-07-15)</h4>
+<div class="indent">JEP Editor revisions: changed type to Historical; changed namespace to storage:rosternotes; corrected schema; specified use of DateTime profile from JEP-0082; corrected some small textual errors. (psa)
+    </div>
+<h4>Version 0.1 (2004-11-05)</h4>
+<div class="indent">Initial version. (st)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0146-0.1.html
+++ b/content/xep-0146-0.1.html
@@ -1,0 +1,610 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0146: Remote Controlling Clients</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Remote Controlling Clients">
+<meta name="DC.Creator" content="Remko Troncon">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies recommended best practices for remote controlling clients using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0146">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0146: Remote Controlling Clients</h1>
+<p>This JEP specifies recommended best practices for remote controlling clients using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0146<br>
+            Version: 0.1<br>
+            Last Updated: 2004-11-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: <br>
+</p>
+<h2>Author Information</h2>
+<h3>Remko Troncon</h3>
+<p class="indent">
+        Email: remko.troncon@cs.kuleuven.ac.be<br>
+        JID: remko@fab4.be</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#disco">Discovery</a>
+</dt>
+<dt>5.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#set-status">Change Status</a>
+</dt>
+<dt>5.2.  <a href="#forward">Forward Unread Messages Residing at a Remote Client</a>
+</dt>
+<dt>5.3.  <a href="#sect-id2602052">Change Run-Time Options</a>
+</dt>
+<dt>5.4.  <a href="#sect-id2602087">Accept Pending File Transfer Requests</a>
+</dt>
+<dt>5.5.  <a href="#sect-id2602161">Leave Groupchats</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#implementation">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>11.  <a href="#sect-id2602756">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">
+    When one has multiple clients at different locations logged in 
+    simultaneously, it is often desirable to control these clients from 
+    the client you are currently using. There are a number of common tasks
+    one might want to perform remotely on clients: change the status of the
+    client, forward all received unread messages to this client, and so on.
+    Therefore, it makes sense to define a protocol for performing these tasks.
+    </p>
+    
+    <p class="" style="">
+    This JEP describes a protocol to perform a set of common tasks on a
+    remote client, by specifying a profile of <span class="ref">Ad-Hoc Commands</span>  [<a href="#nt-id2596058">1</a>].
+    </p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+    <p>The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in <span class="ref">RFC 2119</span>  [<a href="#nt-id2596132">2</a>].</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This JEP addresses the following requirements:</p>
+    <ul>
+        <li>Enable users to perform a set of common tasks on a remote 
+            client.</li>
+        <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+    </ul>
+<h2>4.
+       <a name="disco">Discovery</a>
+</h2>
+    <p class="" style="">A client MUST advertise any remote controlling commands it supports via 
+    <span class="ref">Service Discovery</span>  [<a href="#nt-id2596279">3</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>).
+    <span class="ref">Entity Capabilities</span>  [<a href="#nt-id2596300">4</a>] can be used to query capability of remote controlling commands
+    in a client.
+    </p>
+<h2>5.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>
+    that enables a user to perform the following tasks on a remote client:</p>
+    <ol start="" type="">
+        <li>Change status</li>
+        <li>Forward unread messages residing at the remote client to the
+        local client</li>
+        <li>Change run-time options</li>
+        <li>Accept pending file transfer requests</li>
+        <li>Leave groupchats</li>
+    </ol>
+	<p class="" style="">
+	Although this JEP aims to define common use cases for remote controlling clients,
+	an implementation or deployment MAY support any subset and MAY support additional
+	commands not defined herein.
+	</p>
+    <p class="" style="">
+<span style="font-style: italic">Note: The text that follows assumes that implementors have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span></span>.</p>
+
+
+    <div class="indent">
+<h3>5.1 <a name="set-status">Change Status</a>
+</h3>
+        <p class="" style="">It is common to forget changing the status of a resource when leaving the
+		client for a longer period. When realizing this while at another location, it 
+		might be desirable to change the status from there, to avoid contacts 
+		thinking that resource is attended and sending it messages.</p>
+        <p class="caption">Example 1. Local Client Requests to Set the Status of a Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-status-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#set-status'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Unless an error occurs (see the 
+        <a href="#errors">Error Handling</a> section below), the service 
+        SHOULD return the appropriate form.</p>
+        
+        <p class="caption">Example 2. Remote Client Replies with a Form to Set its Status</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-status-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#set-status'
+             sessionid='set-status:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Setting the status&lt;/title&gt;
+      &lt;instructions&gt;Choose the status and status message&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Status' 
+             type='list-single' 
+             var='status'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;online&lt;/value&gt;
+        &lt;option label='Chat'&gt; 
+            &lt;value&gt;chat&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Online'&gt; 
+            &lt;value&gt;online&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Away'&gt; 
+            &lt;value&gt;away&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Extended Away'&gt; 
+            &lt;value&gt;xa&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Do Not Disturb'&gt; 
+            &lt;value&gt;dnd&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Invisible'&gt; 
+            &lt;value&gt;invisible&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Offline'&gt; 
+            &lt;value&gt;offline&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Priority'
+             type='text-single'
+             var='status-priority'&gt;
+        &lt;value&gt;5&lt;/value&gt; 
+      &lt;/field&gt;
+      &lt;field label='Message' 
+             type='text-multi' 
+             var='status-message'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. Local Client Submits Set Status Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-status-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#set-status'
+           sessionid='set-status:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form' &gt;
+      &lt;field type='hidden' var='FORM_TYPE' &gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='status' &gt;
+        &lt;value&gt;xa&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='status-priority'&gt;
+        &lt;value&gt;-1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-multi' var='status-message' &gt;
+        &lt;value&gt;In my chamber.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the 'status-priority' variable is omitted, the client SHOULD NOT
+        change the priority of the client</p>
+        <p class="caption">Example 4. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-status-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#set-status'
+           sessionid='set-status:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Notification of completion MAY include the processed data in a data 
+        form of type &quot;result&quot;.</p>
+    </div>
+
+
+    <div class="indent">
+<h3>5.2 <a name="forward">Forward Unread Messages Residing at a Remote Client</a>
+</h3>
+        <p class="" style="">A user might want to forward all the unread messages residing at
+        the remote client to the local client (e.g. when the remote client was
+        accidentally left on-line, and has received messages in the meantime).</p>
+        
+        For example, suppose Romeo sends a message to Juliet, thinking she is
+        still on her balcony. The balcony client receives the message:
+        <p class="caption">Example 5. Remote Client Receives Message</p>
+<div class="indent"><pre>
+&lt;message from=&quot;romeo@example.com/orchard&quot; 
+         to=&quot;juliet@example.com/balcony&quot;&gt;
+  &lt;subject&gt;Just saying hi&lt;/subject&gt;
+  &lt;body&gt;Hello Juliet!&lt;/body&gt;
+&lt;/message&gt;
+        </pre></div>
+
+        However, Juliet is in her chamber, so she doesn't know about the message
+        (yet). Realizing she left her balcony client unattended, she sends a 
+        request to the remote client to forward all unread messages.
+
+        <p class="caption">Example 6. Local Client Requests to Forward Unread Messages Currently Residing at the Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='forward-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#forward'
+           sessionid='forward:20040727T0337Z'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        
+        The client forwards all unread messages to the local client, adding
+        information about the origin of the message (protocol for this to
+		follow). The chamber client receives both these messages and a
+        confirmation that the command was completed.
+        <p class="caption">Example 7. Remote Client Forwards All Unread Messages to Local Client</p>
+<div class="indent"><pre>
+&lt;message from=&quot;juliet@example.com/balcony&quot; 
+         to=&quot;juliet@example.com/chamber&quot; &gt;
+  &lt;subject&gt;Just saying hi&lt;/subject&gt;
+  &lt;body&gt;Hello Juliet!&lt;/body&gt;
+  &lt;x xmlns=&quot;jabber:x:forward&quot;&gt;
+    &lt;from jid=&quot;romeo@example.com/orchard&quot;/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+        </pre></div>
+
+        <p class="caption">Example 8. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='forward-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#forward'
+           sessionid='forward:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+
+		A client MAY provide a more fine-grained implementation, e.g. by
+		presenting the requester an extra form to select which messages
+		have to be forwarded.
+    </div>
+
+
+    <div class="indent">
+<h3>5.3 <a name="sect-id2602052">Change Run-Time Options</a>
+</h3>
+        <p class="" style="">It might be desirable to remotely set some run-time options of
+        a client. For example, when neighbours complain about the sounds your 
+        client makes while you're at another location, you could turn the 
+        sounds off at the remote client.
+        </p>
+        <p class="" style="">Protocol to follow.</p>
+    </div>
+
+
+	
+
+    <div class="indent">
+<h3>5.4 <a name="sect-id2602087">Accept Pending File Transfer Requests</a>
+</h3>
+        <p class="caption">Example 9. Local Client Requests to Accept Pending File Transfer Requests on the Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='accept-files-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#accept-files'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Unless an error occurs (see the 
+        <a href="#errors">Error Handling</a> section below), the service 
+        SHOULD return the appropriate form.</p>
+        
+        <p class="caption">Example 10. Remote Client Replies with a Form Containing Pending File Transfers</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='accept-files-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#accept-files'
+             sessionid='set-status:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Pending File Transfers&lt;/title&gt;
+      &lt;instructions&gt;Select the pending file transfers to accept&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Files' 
+             type='list-multi' 
+             var='files'&gt;
+        &lt;required/&gt;
+        &lt;option label='ballad.ogg (romeo@example.com)'&gt; 
+          &lt;value&gt;romeo@example.com/orchard:1&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='picture.jpg (romeo@example.com)'&gt; 
+          &lt;value&gt;romeo@example.com/orchard:2&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='challenge.txt (mercutio@example.com)'&gt; 
+          &lt;value&gt;mercutio@example.com/orchard:1&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 11. Local Client Submits Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='accept-files-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#accept-files'
+           sessionid='accept-files:20040727T0337Z'&gt;
+    &lt;x xmlns=&quot;jabber:x:data&quot; type=&quot;form&quot; &gt;
+      &lt;field type=&quot;hidden&quot; var=&quot;FORM_TYPE&quot; &gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type=&quot;list-multi&quot; var=&quot;files&quot; &gt;
+        &lt;value&gt;romeo@example.com/orchard:2&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+
+        The remote client accepts the selected file transfers, and informs
+        the local client of completion.
+        <p class="caption">Example 12. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='accept-files-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#accept-files'
+           sessionid='accept-files:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+    </div>
+
+
+
+    <div class="indent">
+<h3>5.5 <a name="sect-id2602161">Leave Groupchats</a>
+</h3>
+        <p class="" style="">Protocol to follow.</p>
+    </div>
+
+
+
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2> 
+    <p class="" style="">Several error conditions are possible when an entity sends a command
+    request to the service, as defined in the following table. If one of these
+    errors occurs, the service MUST return an error stanza to the requesting
+    entity.</p>
+
+    <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+            <th colspan="" rowspan="">Condition</th>
+            <th colspan="" rowspan="">Cause</th>
+        </tr>
+        
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+            <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc
+            commands protocol is)</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+            <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to 
+            perform the command</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+            <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported</td>
+        </tr>
+    </table>
+      
+    <p class="" style="">For the syntax of these errors, see <span class="ref">Error Condition Mappings</span>  [<a href="#nt-id2602616">5</a>]. Naturally, other errors
+    may be returned as well.</p>
+<h2>7.
+       <a name="implementation">Implementation Notes</a>
+</h2> 
+    <p class="" style="">Implementations of this protocol MAY add or remove fields to forms as
+    they see fit.  For example, when setting the status of a remote client that
+    supports multiple accounts, the client may choose to add a boolean field 
+    to allow the user to specify whether the status change should be applied
+    globally or only to the receiving account.</p>
+
+    <p class="" style=""> Implementations MAY also introduce extra forms for commands. For example,
+    when forwarding unread messages, a client could return a form containing a 
+    list 
+    of short descriptions of unread messages, allowing the user to select the
+    messages he wants to forward.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+      <p class="" style="">The ability to complete the tasks specified herein MUST NOT be granted
+      to users who lack privileges to control a client. A sensible 
+      access policy is to only allow remote controlling by other 
+      resources of the same account used by the client. If other accounts
+      are to be able to remote control the client, the client needs more 
+      complex access right management.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602726">6</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <p class="" style="">The <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2602665">7</a>] shall include the following information in its 
+    registries.</p>
+    
+    <div class="indent">
+<h3>10.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+        <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/rc' in its registry
+        of protocol namespaces.</p>
+    </div>
+
+    <div class="indent">
+<h3>10.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+        <p class="" style="">
+<span class="ref">Field Standardization for Data Forms</span>  [<a href="#nt-id2602838">8</a>] defines a process for standardizing the fields used within
+        Data Forms scoped by a particular namespace. The reserved fields for 
+        the 'http://jabber.org/protocol/rc' namespace are specified 
+        below.</p>
+        <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/rc&lt;/name&gt;
+  &lt;doc&gt;JEP-??&lt;/doc&gt;
+  &lt;desc&gt;Forms used for remote controlling clients&lt;/desc&gt;
+  &lt;field var='status'
+         type='list-single'
+         var='The list of statuses'/&gt;
+  &lt;field var='status-priority'
+         type='text-single'
+         var='The new priority for the client'/&gt;
+  &lt;field var='status-message'
+         type='text-multi'
+         label='The status message text'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="sect-id2602756">XML Schema</a>
+</h2>
+    <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: 
+    Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596058">1</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596132">2</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596279">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596300">4</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602616">5</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602726">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p>
+<a name="nt-id2602665">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2602838">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">Initial version. (rt)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0146-0.2.html
+++ b/content/xep-0146-0.2.html
@@ -1,0 +1,796 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0146: Remote Controlling Clients</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Remote Controlling Clients">
+<meta name="DC.Creator" content="Remko Troncon">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies recommended best practices for remote controlling clients using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-03-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0146">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0146: Remote Controlling Clients</h1>
+<p>This JEP specifies recommended best practices for remote controlling clients using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0146<br>
+            Version: 0.2<br>
+            Last Updated: 2005-03-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: <br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Remote%20Controlling%20Clients%20(JEP-0146)">http://wiki.jabber.org/index.php/Remote Controlling Clients (JEP-0146)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Remko Troncon</h3>
+<p class="indent">
+        Email: remko.troncon@cs.kuleuven.ac.be<br>
+        JID: remko@fab4.be</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#disco">Discovery</a>
+</dt>
+<dt>5.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#set-status">Change Status</a>
+</dt>
+<dt>5.2.  <a href="#forward">Forward Unread Messages Residing at a Remote Client</a>
+</dt>
+<dt>5.3.  <a href="#sect-id2256262">Change Run-Time Options</a>
+</dt>
+<dt>5.4.  <a href="#sect-id2250331">Accept Pending File Transfer Requests</a>
+</dt>
+<dt>5.5.  <a href="#sect-id2250380">Leave Groupchats</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#implementation">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>11.  <a href="#sect-id2257317">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">
+    When one has multiple clients at different locations logged in 
+    simultaneously, it is often desirable to control these clients from 
+    the client you are currently using. There are a number of common tasks
+    one might want to perform remotely on clients: change the status of the
+    client, forward all received unread messages to this client, and so on.
+    Therefore, it makes sense to define a protocol for performing these tasks.
+    </p>
+    
+    <p class="" style="">
+    This JEP describes a protocol to perform a set of common tasks on a
+    remote client, by specifying a profile of <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2251636">1</a>].
+    </p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+    <p class="" style="">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in <span class="ref" style="">RFC 2119</span>  [<a href="#nt-id2250810">2</a>].</p>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This JEP addresses the following requirements:</p>
+    <ul>
+        <li>Enable users to perform a set of common tasks on a remote 
+            client.</li>
+        <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+    </ul>
+<h2>4.
+       <a name="disco">Discovery</a>
+</h2>
+    <p class="" style="">A client MUST advertise any remote controlling commands it supports via 
+    <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250672">3</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>).
+    <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2250694">4</a>] can be used to query capability of remote controlling commands
+    in a client.
+    </p>
+<h2>5.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>
+    that enables a user to perform the following tasks on a remote client:</p>
+    <ol start="" type="">
+        <li>Change status</li>
+        <li>Forward unread messages residing at the remote client to the
+        local client</li>
+        <li>Change run-time options</li>
+        <li>Accept pending file transfer requests</li>
+        <li>Leave groupchats</li>
+    </ol>
+	<p class="" style="">
+	Although this JEP aims to define common use cases for remote controlling clients,
+	an implementation or deployment MAY support any subset and MAY support additional
+	commands not defined herein.
+	</p>
+    <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementors have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span></span>.</p>
+
+
+    <div class="indent">
+<h3>5.1 <a name="set-status">Change Status</a>
+</h3>
+        <p class="" style="">It is common to forget changing the status of a resource when leaving the
+		client for a longer period. When realizing this while at another location, it 
+		might be desirable to change the status from there, to avoid contacts 
+		thinking that resource is attended and sending it messages.</p>
+		<p class="caption">Example 1. Local Client Requests to Set the Status of a Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-status-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#set-status'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Unless an error occurs (see the 
+        <a href="#errors">Error Handling</a> section below), the service 
+        SHOULD return the appropriate form.</p>
+        
+        <p class="caption">Example 2. Remote Client Replies with a Form to Set its Status</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-status-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#set-status'
+             sessionid='set-status:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Change Status&lt;/title&gt;
+      &lt;instructions&gt;Choose the status and status message&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Status' 
+             type='list-single' 
+             var='status'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;online&lt;/value&gt;
+        &lt;option label='Chat'&gt; 
+            &lt;value&gt;chat&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Online'&gt; 
+            &lt;value&gt;online&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Away'&gt; 
+            &lt;value&gt;away&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Extended Away'&gt; 
+            &lt;value&gt;xa&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Do Not Disturb'&gt; 
+            &lt;value&gt;dnd&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Invisible'&gt; 
+            &lt;value&gt;invisible&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Offline'&gt; 
+            &lt;value&gt;offline&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Priority'
+             type='text-single'
+             var='status-priority'&gt;
+        &lt;value&gt;5&lt;/value&gt; 
+      &lt;/field&gt;
+      &lt;field label='Message' 
+             type='text-multi' 
+             var='status-message'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. Local Client Submits Set Status Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-status-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#set-status'
+           sessionid='set-status:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='status'&gt;
+        &lt;value&gt;xa&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='status-priority'&gt;
+        &lt;value&gt;-1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-multi' var='status-message'&gt;
+        &lt;value&gt;In my chamber.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the 'status-priority' variable is omitted, the client SHOULD NOT
+        change the priority of the client</p>
+        <p class="caption">Example 4. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-status-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#set-status'
+           sessionid='set-status:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Notification of completion MAY include the processed data in a data 
+        form of type 'result'.</p>
+    </div>
+
+
+    <div class="indent">
+<h3>5.2 <a name="forward">Forward Unread Messages Residing at a Remote Client</a>
+</h3>
+        <p class="" style="">A user might want to forward all the unread messages residing at
+        the remote client to the local client (e.g. when the remote client was
+        accidentally left on-line, and has received messages in the meantime).</p>
+        
+        For example, suppose Romeo sends a message to Juliet, thinking she is
+        still on her balcony. The balcony client receives the message:
+        <p class="caption">Example 5. Remote Client Receives Message</p>
+<div class="indent"><pre>
+&lt;message from='romeo@example.com/orchard' 
+         to='juliet@example.com/balcony'&gt;
+  &lt;subject&gt;Just saying hi&lt;/subject&gt;
+  &lt;body&gt;Hello Juliet!&lt;/body&gt;
+&lt;/message&gt;
+        </pre></div>
+
+        However, Juliet is in her chamber, so she doesn't know about the message
+        (yet). Realizing she left her balcony client unattended, she sends a 
+        request to the remote client to forward all unread messages.
+
+        <p class="caption">Example 6. Local Client Requests to Forward Unread Messages Currently Residing at the Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='forward-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#forward'
+           sessionid='forward:20040727T0337Z'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        
+        The client forwards all unread messages to the local client, adding
+        information about the origin of the message (protocol for this to
+		follow). The chamber client receives both these messages and a
+        confirmation that the command was completed.
+        <p class="caption">Example 7. Remote Client Forwards All Unread Messages to Local Client</p>
+<div class="indent"><pre>
+&lt;message from='juliet@example.com/balcony' 
+         to='juliet@example.com/chamber'&gt;
+  &lt;subject&gt;Just saying hi&lt;/subject&gt;
+  &lt;body&gt;Hello Juliet!&lt;/body&gt;
+  &lt;x xmlns='jabber:x:forward'&gt;
+    &lt;from jid='romeo@example.com/orchard'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+        </pre></div>
+
+        <p class="caption">Example 8. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='forward-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#forward'
+           sessionid='forward:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+
+		A client MAY provide a more fine-grained implementation, e.g. by
+		presenting the requester an extra form to select which messages
+		have to be forwarded.
+    </div>
+
+
+    <div class="indent">
+<h3>5.3 <a name="sect-id2256262">Change Run-Time Options</a>
+</h3>
+        <p class="" style="">It might be desirable to remotely set some run-time options of
+        a client. For example, when neighbours complain about the sounds your 
+        client makes while you're at another location, you could turn the 
+        sounds off at the remote client.
+        </p>
+		<p class="caption">Example 9. Local Client Requests to Change Options of a Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-options-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#set-options'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Unless an error occurs (see the 
+        <a href="#errors">Error Handling</a> section below), the service 
+        SHOULD return the appropriate form.</p>
+        
+		<p class="caption">Example 10. Remote Client Replies with a Form to Set its Options</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-options-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#set-options'
+             sessionid='set-options:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Set Options&lt;/title&gt;
+      &lt;instructions&gt;Set the desired options&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Play sounds' 
+             type='boolean' 
+             var='sounds'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Automatically Go Offline when Idle' 
+             type='boolean' 
+             var='auto-offline'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Automatically Open New Messages' 
+             type='boolean' 
+             var='auto-msg'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Automatically Authorize Contacts' 
+             type='boolean' 
+             var='auto-auth'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 11. Local Client Submits Set Options Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-options-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#set-options'
+           sessionid='set-options:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='sounds'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='auto-offline'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='auto-msg'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='auto-files'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='auto-auth'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The remote client sets the values of the options to their requested
+		value. If a variable is omitted, the client SHOULD NOT change the value of the 
+		corresponding option.</p>
+
+        <p class="caption">Example 12. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-options-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#set-options'
+           sessionid='set-options:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Notification of completion MAY include the processed data in a data 
+        form of type 'result'.</p>
+    </div>
+
+
+	
+
+    <div class="indent">
+<h3>5.4 <a name="sect-id2250331">Accept Pending File Transfer Requests</a>
+</h3>
+        <p class="caption">Example 13. Local Client Requests to Accept Pending File Transfer Requests on the Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='accept-files-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#accept-files'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Unless an error occurs (see the 
+        <a href="#errors">Error Handling</a> section below), the service 
+        SHOULD return the appropriate form.</p>
+        
+        <p class="caption">Example 14. Remote Client Replies with a Form Containing Pending File Transfers</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='accept-files-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#accept-files'
+             sessionid='set-status:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Pending File Transfers&lt;/title&gt;
+      &lt;instructions&gt;Select the pending file transfers to accept&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Files' 
+             type='list-multi' 
+             var='files'&gt;
+        &lt;required/&gt;
+        &lt;option label='ballad.ogg (romeo@example.com)'&gt; 
+          &lt;value&gt;romeo@example.com/orchard:1&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='picture.jpg (romeo@example.com)'&gt; 
+          &lt;value&gt;romeo@example.com/orchard:2&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='challenge.txt (mercutio@example.com)'&gt; 
+          &lt;value&gt;mercutio@example.com/orchard:1&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 15. Local Client Submits Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='accept-files-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#accept-files'
+           sessionid='accept-files:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='files'&gt;
+        &lt;value&gt;romeo@example.com/orchard:2&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+
+        The remote client accepts the selected file transfers, and informs
+        the local client of completion.
+        <p class="caption">Example 16. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='accept-files-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#accept-files'
+           sessionid='accept-files:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+    </div>
+
+
+
+    <div class="indent">
+<h3>5.5 <a name="sect-id2250380">Leave Groupchats</a>
+</h3>
+		<p class="caption">Example 17. Local Client Requests the Remote Client to Leave Groupchats</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='leave-groupchats-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#leave-groupchats'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 18. Remote Client Replies with a Form with a List of Groupchats it is currently in</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='leave-groupchats-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#leave-groupchats'
+             sessionid='leave-groupchats:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Leave Groupchats&lt;/title&gt;
+      &lt;instructions&gt;Choose the groupchats you want to leave&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Groupchats' 
+             type='list-multi' 
+             var='groupchats'&gt;
+        &lt;required/&gt;
+        &lt;option label='juliet on jdev@conference.jabber.org'&gt; 
+            &lt;value&gt;jdev@conference.jabber.org/juliet&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='juliette on jdev@conference.jabber.org'&gt; 
+            &lt;value&gt;jdev@conference.jabber.org/juliette&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='juliet on girlsonly@jabber.com'&gt; 
+            &lt;value&gt;girlsonly@jabber.com/juliet&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 19. Local Client Submits Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='leave-groupchats-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#leave-groupchats'
+           sessionid='leave-groupchats:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='groupchats'&gt;
+        &lt;value&gt;jdev@conference.jabber.org/juliet&lt;/value&gt;
+        &lt;value&gt;girlsonly@jabber.com/juliet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+		<p class="" style="">The remote client leaves the requested groupchats, and informs the
+		local client of completion.</p>
+        <p class="caption">Example 20. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='leave-groupchats-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#leave-groupchats'
+           sessionid='leave-groupchats:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+    </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2> 
+    <p class="" style="">Several error conditions are possible when an entity sends a command
+    request to the service, as defined in the following table. If one of these
+    errors occurs, the service MUST return an error stanza to the requesting
+    entity.</p>
+
+    <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+            <th colspan="" rowspan="">Condition</th>
+            <th colspan="" rowspan="">Cause</th>
+        </tr>
+        
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+            <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc
+            commands protocol is)</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+            <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to 
+            perform the command</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+            <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported</td>
+        </tr>
+    </table>
+      
+    <p class="" style="">For the syntax of these errors, see <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2256473">5</a>]. Naturally, other errors
+    may be returned as well.</p>
+<h2>7.
+       <a name="implementation">Implementation Notes</a>
+</h2> 
+    <p class="" style="">Implementations of this protocol MAY add or remove fields to forms as
+    they see fit.  For example, when setting the status of a remote client that
+    supports multiple accounts, the client may choose to add a boolean field 
+    to allow the user to specify whether the status change should be applied
+    globally or only to the receiving account.</p>
+
+    <p class="" style=""> Implementations MAY also introduce extra forms for commands. For example,
+    when forwarding unread messages, a client could return a form containing a 
+    list 
+    of short descriptions of unread messages, allowing the user to select the
+    messages he wants to forward.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+      <p class="" style="">The ability to complete the tasks specified herein MUST NOT be granted
+      to users who lack privileges to control a client. A sensible 
+      access policy is to only allow remote controlling by other 
+      resources of the same account used by the client. If other accounts
+      are to be able to remote control the client, the client needs more 
+      complex access right management.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256574">6</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257271">7</a>] shall include the following information in its 
+    registries.</p>
+    
+    <div class="indent">
+<h3>10.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+        <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/rc' in its registry
+        of protocol namespaces.</p>
+    </div>
+
+    <div class="indent">
+<h3>10.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+        <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2257326">8</a>] defines a process for standardizing the fields used within
+        Data Forms scoped by a particular namespace. The reserved fields for 
+        the 'http://jabber.org/protocol/rc' namespace are specified 
+        below.</p>
+        <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/rc&lt;/name&gt;
+  &lt;doc&gt;JEP-??&lt;/doc&gt;
+  &lt;desc&gt;Forms used for remote controlling clients&lt;/desc&gt;
+  &lt;field var='status'
+         type='list-single'
+         var='The list of statuses'/&gt;
+  &lt;field var='status-priority'
+         type='text-single'
+         var='The new priority for the client'/&gt;
+  &lt;field var='status-message'
+         type='text-multi'
+         label='The status message text'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="sect-id2257317">XML Schema</a>
+</h2>
+    <p class="" style="">Because the protocol defined here is a profile of <span style="font-weight: bold">JEP-0050: 
+    Ad-Hoc Commands</span>, no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251636">1</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2250810">2</a>. RFC 2119: Key words for use in RFCs to Indicate Requirement Levels &lt;<a href="http://www.ietf.org/rfc/rfc2119.txt">http://www.ietf.org/rfc/rfc2119.txt</a>&gt;.</p>
+<p><a name="nt-id2250672">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250694">4</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256473">5</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2256574">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257271">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2257326">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-03-16)</h4>
+<div class="indent">Minor modifications; completed Set Options use case; completed Leave Groupchats use case. (rt)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">Initial version. (rt)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0146-0.3.html
+++ b/content/xep-0146-0.3.html
@@ -1,0 +1,799 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0146: Remote Controlling Clients</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Remote Controlling Clients">
+<meta name="DC.Creator" content="Remko Tronçon">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies recommended best practices for remote controlling clients using Ad-Hoc Commands.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-25">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0146">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0146: Remote Controlling Clients</h1>
+<p>This JEP specifies recommended best practices for remote controlling clients using Ad-Hoc Commands.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0146<br>
+            Version: 0.3<br>
+            Last Updated: 2006-01-25<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0050<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Remote%20Controlling%20Clients%20(JEP-0146)">http://wiki.jabber.org/index.php/Remote Controlling Clients (JEP-0146)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Remko Tronçon</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:remko@el-tramo.be">remko@el-tramo.be</a><br>
+        JID: 
+        <a href="xmpp:remko@fab4.be">remko@fab4.be</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#disco">Discovery</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#set-status">Change Status</a>
+</dt>
+<dt>4.2.  <a href="#forward">Forward Unread Messages Residing at a Remote Client</a>
+</dt>
+<dt>4.3.  <a href="#sect-id2256622">Change Run-Time Options</a>
+</dt>
+<dt>4.4.  <a href="#sect-id2256759">Accept Pending File Transfer Requests</a>
+</dt>
+<dt>4.5.  <a href="#sect-id2250368">Leave Groupchats</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#implementation">Implementation Notes</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-protocol">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>10.  <a href="#sect-id2257432">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+    <p class="" style="">
+    When one has multiple clients at different locations logged in 
+    simultaneously, it is often desirable to control these clients from 
+    the client you are currently using. There are a number of common tasks
+    one might want to perform remotely on clients: change the status of the
+    client, forward all received unread messages to this client, and so on.
+    Therefore, it makes sense to define a protocol for performing these tasks.
+    </p>
+    
+    <p class="" style="">
+    This JEP describes a protocol to perform a set of common tasks on a
+    remote client, by specifying a profile of <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2250844">1</a>].
+    </p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+    <p class="" style="">This JEP addresses the following requirements:</p>
+    <ul>
+        <li>Enable users to perform a set of common tasks on a remote 
+            client.</li>
+        <li>Re-use existing XMPP and Jabber protocols wherever possible.</li>
+    </ul>
+<h2>3.
+       <a name="disco">Discovery</a>
+</h2>
+    <p class="" style="">A client MUST advertise any remote controlling commands it supports via 
+    <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250910">2</a>] (as described in <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>).
+    <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2251145">3</a>] can be used to query capability of remote controlling commands
+    in a client.
+    </p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+    <p class="" style="">This JEP defines a profile of <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>
+    that enables a user to perform the following tasks on a remote client:</p>
+    <ol start="" type="">
+        <li>Change status</li>
+        <li>Forward unread messages residing at the remote client to the
+        local client</li>
+        <li>Change run-time options</li>
+        <li>Accept pending file transfer requests</li>
+        <li>Leave groupchats</li>
+    </ol>
+	<p class="" style="">
+	Although this JEP aims to define common use cases for remote controlling clients,
+	an implementation or deployment MAY support any subset and MAY support additional
+	commands not defined herein.
+	</p>
+    <p class="" style=""><span style="font-style: italic">Note: The text that follows assumes that implementors have read and understood <span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span></span>.</p>
+
+
+    <div class="indent">
+<h3>4.1 <a name="set-status">Change Status</a>
+</h3>
+        <p class="" style="">It is common to forget changing the status of a resource when leaving the
+		client for a longer period. When realizing this while at another location, it 
+		might be desirable to change the status from there, to avoid contacts 
+		thinking that resource is attended and sending it messages.</p>
+		<p class="caption">Example 1. Local Client Requests to Set the Status of a Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-status-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#set-status'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Unless an error occurs (see the 
+        <a href="#errors">Error Handling</a> section below), the service 
+        SHOULD return the appropriate form.</p>
+        
+        <p class="caption">Example 2. Remote Client Replies with a Form to Set its Status</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-status-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#set-status'
+             sessionid='set-status:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Change Status&lt;/title&gt;
+      &lt;instructions&gt;Choose the status and status message&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Status' 
+             type='list-single' 
+             var='status'&gt;
+        &lt;required/&gt;
+        &lt;value&gt;online&lt;/value&gt;
+        &lt;option label='Chat'&gt; 
+            &lt;value&gt;chat&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Online'&gt; 
+            &lt;value&gt;online&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Away'&gt; 
+            &lt;value&gt;away&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Extended Away'&gt; 
+            &lt;value&gt;xa&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Do Not Disturb'&gt; 
+            &lt;value&gt;dnd&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Invisible'&gt; 
+            &lt;value&gt;invisible&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='Offline'&gt; 
+            &lt;value&gt;offline&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+      &lt;field label='Priority'
+             type='text-single'
+             var='status-priority'&gt;
+        &lt;value&gt;5&lt;/value&gt; 
+      &lt;/field&gt;
+      &lt;field label='Message' 
+             type='text-multi' 
+             var='status-message'/&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 3. Local Client Submits Set Status Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-status-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#set-status'
+           sessionid='set-status:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-single' var='status'&gt;
+        &lt;value&gt;xa&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='status-priority'&gt;
+        &lt;value&gt;-1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='text-multi' var='status-message'&gt;
+        &lt;value&gt;In my chamber.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">If the 'status-priority' variable is omitted, the client SHOULD NOT
+        change the priority of the client</p>
+        <p class="caption">Example 4. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-status-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#set-status'
+           sessionid='set-status:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Notification of completion MAY include the processed data in a data 
+        form of type 'result'.</p>
+    </div>
+
+
+    <div class="indent">
+<h3>4.2 <a name="forward">Forward Unread Messages Residing at a Remote Client</a>
+</h3>
+        <p class="" style="">A user might want to forward all the unread messages residing at
+        the remote client to the local client (e.g. when the remote client was
+        accidentally left on-line, and has received messages in the meantime).</p>
+        
+        For example, suppose Romeo sends a message to Juliet, thinking she is
+        still on her balcony. The balcony client receives the message:
+        <p class="caption">Example 5. Remote Client Receives Message</p>
+<div class="indent"><pre>
+&lt;message from='romeo@example.com/orchard' 
+         to='juliet@example.com/balcony'&gt;
+  &lt;subject&gt;Just saying hi&lt;/subject&gt;
+  &lt;body&gt;Hello Juliet!&lt;/body&gt;
+&lt;/message&gt;
+        </pre></div>
+
+        However, Juliet is in her chamber, so she doesn't know about the message
+        (yet). Realizing she left her balcony client unattended, she sends a 
+        request to the remote client to forward all unread messages.
+
+        <p class="caption">Example 6. Local Client Requests to Forward Unread Messages Currently Residing at the Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='forward-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#forward'
+           sessionid='forward:20040727T0337Z'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        
+        The client forwards all unread messages to the local client, adding
+        information about the origin of the message (using the 'ofrom' 
+		<span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2256602">4</a>] address). 
+		The chamber client receives both these messages and a
+        confirmation that the command was completed.
+        <p class="caption">Example 7. Remote Client Forwards All Unread Messages to Local Client</p>
+<div class="indent"><pre>
+&lt;message from='juliet@example.com/balcony' 
+         to='juliet@example.com/chamber'&gt;
+  &lt;subject&gt;Just saying hi&lt;/subject&gt;
+  &lt;body&gt;Hello Juliet!&lt;/body&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='ofrom' jid='romeo@example.com/orchard'/&gt;
+  &lt;/addresses&gt;  
+&lt;/message&gt;
+        </pre></div>
+
+        <p class="caption">Example 8. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='forward-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#forward'
+           sessionid='forward:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+
+		A client MAY provide a more fine-grained implementation, e.g. by
+		presenting the requester an extra form to select which messages
+		have to be forwarded.
+    </div>
+
+
+    <div class="indent">
+<h3>4.3 <a name="sect-id2256622">Change Run-Time Options</a>
+</h3>
+        <p class="" style="">It might be desirable to remotely set some run-time options of
+        a client. For example, when neighbours complain about the sounds your 
+        client makes while you're at another location, you could turn the 
+        sounds off at the remote client.
+        </p>
+		<p class="caption">Example 9. Local Client Requests to Change Options of a Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-options-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#set-options'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Unless an error occurs (see the 
+        <a href="#errors">Error Handling</a> section below), the service 
+        SHOULD return the appropriate form.</p>
+        
+		<p class="caption">Example 10. Remote Client Replies with a Form to Set its Options</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-options-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#set-options'
+             sessionid='set-options:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Set Options&lt;/title&gt;
+      &lt;instructions&gt;Set the desired options&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Play sounds' 
+             type='boolean' 
+             var='sounds'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Automatically Go Offline when Idle' 
+             type='boolean' 
+             var='auto-offline'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Automatically Open New Messages' 
+             type='boolean' 
+             var='auto-msg'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Automatically Authorize Contacts' 
+             type='boolean' 
+             var='auto-auth'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 11. Local Client Submits Set Options Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='set-options-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#set-options'
+           sessionid='set-options:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='sounds'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='auto-offline'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='auto-msg'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='auto-files'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='auto-auth'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">The remote client sets the values of the options to their requested
+		value. If a variable is omitted, the client SHOULD NOT change the value of the 
+		corresponding option.</p>
+
+        <p class="caption">Example 12. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='set-options-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#set-options'
+           sessionid='set-options:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Notification of completion MAY include the processed data in a data 
+        form of type 'result'.</p>
+    </div>
+
+
+	
+
+    <div class="indent">
+<h3>4.4 <a name="sect-id2256759">Accept Pending File Transfer Requests</a>
+</h3>
+        <p class="caption">Example 13. Local Client Requests to Accept Pending File Transfer Requests on the Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='accept-files-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#accept-files'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="" style="">Unless an error occurs (see the 
+        <a href="#errors">Error Handling</a> section below), the service 
+        SHOULD return the appropriate form.</p>
+        
+        <p class="caption">Example 14. Remote Client Replies with a Form Containing Pending File Transfers</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='accept-files-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#accept-files'
+             sessionid='set-status:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Pending File Transfers&lt;/title&gt;
+      &lt;instructions&gt;Select the pending file transfers to accept&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Files' 
+             type='list-multi' 
+             var='files'&gt;
+        &lt;required/&gt;
+        &lt;option label='ballad.ogg (romeo@example.com)'&gt; 
+          &lt;value&gt;romeo@example.com/orchard:1&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='picture.jpg (romeo@example.com)'&gt; 
+          &lt;value&gt;romeo@example.com/orchard:2&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='challenge.txt (mercutio@example.com)'&gt; 
+          &lt;value&gt;mercutio@example.com/orchard:1&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 15. Local Client Submits Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='accept-files-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#accept-files'
+           sessionid='accept-files:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='files'&gt;
+        &lt;value&gt;romeo@example.com/orchard:2&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+
+        The remote client accepts the selected file transfers, and informs
+        the local client of completion.
+        <p class="caption">Example 16. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='accept-files-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#accept-files'
+           sessionid='accept-files:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+    </div>
+
+
+
+    <div class="indent">
+<h3>4.5 <a name="sect-id2250368">Leave Groupchats</a>
+</h3>
+		<p class="caption">Example 17. Local Client Requests the Remote Client to Leave Groupchats</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='leave-groupchats-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           action='execute'
+           node='http://jabber.org/protocol/rc#leave-groupchats'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 18. Remote Client Replies with a Form with a List of Groupchats it is currently in</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='leave-groupchats-1'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+             node='http://jabber.org/protocol/rc#leave-groupchats'
+             sessionid='leave-groupchats:20040727T0337Z'
+             status='executing'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;title&gt;Leave Groupchats&lt;/title&gt;
+      &lt;instructions&gt;Choose the groupchats you want to leave&lt;/instructions&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Groupchats' 
+             type='list-multi' 
+             var='groupchats'&gt;
+        &lt;required/&gt;
+        &lt;option label='juliet on jdev@conference.jabber.org'&gt; 
+            &lt;value&gt;jdev@conference.jabber.org/juliet&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='juliette on jdev@conference.jabber.org'&gt; 
+            &lt;value&gt;jdev@conference.jabber.org/juliette&lt;/value&gt;
+        &lt;/option&gt;
+        &lt;option label='juliet on girlsonly@jabber.com'&gt; 
+            &lt;value&gt;girlsonly@jabber.com/juliet&lt;/value&gt;
+        &lt;/option&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+        <p class="caption">Example 19. Local Client Submits Form to Remote Client</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/chamber'
+    to='juliet@example.com/balcony'
+    type='set'
+    id='leave-groupchats-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' 
+           node='http://jabber.org/protocol/rc#leave-groupchats'
+           sessionid='leave-groupchats:20040727T0337Z'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/rc&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='list-multi' var='groupchats'&gt;
+        &lt;value&gt;jdev@conference.jabber.org/juliet&lt;/value&gt;
+        &lt;value&gt;girlsonly@jabber.com/juliet&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/command&gt;
+&lt;/iq&gt;
+        </pre></div>
+		<p class="" style="">The remote client leaves the requested groupchats, and informs the
+		local client of completion.</p>
+        <p class="caption">Example 20. Remote Client Informs Local Client of Completion</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@example.com/balcony' 
+    to='juliet@example.com/chamber' 
+    type='result' 
+    id='leave-groupchats-2'
+    xml:lang='en'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands'
+           node='http://jabber.org/protocol/rc#leave-groupchats'
+           sessionid='leave-groupchats:20040727T0337Z'
+           status='completed'/&gt;
+&lt;/iq&gt;
+        </pre></div>
+    </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2> 
+    <p class="" style="">Several error conditions are possible when an entity sends a command
+    request to the service, as defined in the following table. If one of these
+    errors occurs, the service MUST return an error stanza to the requesting
+    entity.</p>
+
+    <p class="caption">Table 1: Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+        <tr class="body">
+            <th colspan="" rowspan="">Condition</th>
+            <th colspan="" rowspan="">Cause</th>
+        </tr>
+        
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+            <td align="" colspan="" rowspan="">The specific command is not supported (even though the ad-hoc
+            commands protocol is)</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;forbidden/&gt;</td>
+            <td align="" colspan="" rowspan="">The requesting entity does not have sufficient privileges to 
+            perform the command</td>
+        </tr>
+        <tr class="body">
+            <td align="" colspan="" rowspan="">&lt;service-unavailable/&gt;</td>
+            <td align="" colspan="" rowspan="">The ad-hoc commands protocol is not supported</td>
+        </tr>
+    </table>
+      
+    <p class="" style="">For the syntax of these errors, see <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2257216">5</a>]. Naturally, other errors
+    may be returned as well.</p>
+<h2>6.
+       <a name="implementation">Implementation Notes</a>
+</h2> 
+    <p class="" style="">Implementations of this protocol MAY add or remove fields to forms as
+    they see fit.  For example, when setting the status of a remote client that
+    supports multiple accounts, the client may choose to add a boolean field 
+    to allow the user to specify whether the status change should be applied
+    globally or only to the receiving account.</p>
+
+    <p class="" style=""> Implementations MAY also introduce extra forms for commands. For example,
+    when forwarding unread messages, a client could return a form containing a 
+    list 
+    of short descriptions of unread messages, allowing the user to select the
+    messages he wants to forward.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+      <p class="" style="">The ability to complete the tasks specified herein MUST NOT be granted
+      to users who lack privileges to control a client. A sensible 
+      access policy is to only allow remote controlling by other 
+      resources of the same account used by the client. If other accounts
+      are to be able to remote control the client, the client needs more 
+      complex access right management.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257319">6</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257357">7</a>] shall include the following information in its 
+    registries.</p>
+    
+    <div class="indent">
+<h3>9.1 <a name="registrar-protocol">Protocol Namespaces</a>
+</h3>
+        <p class="" style="">The Jabber Registrar shall include 'http://jabber.org/protocol/rc' in its registry
+        of protocol namespaces.</p>
+    </div>
+
+    <div class="indent">
+<h3>9.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+        <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2257414">8</a>] defines a process for standardizing the fields used within
+        Data Forms scoped by a particular namespace. The reserved fields for 
+        the 'http://jabber.org/protocol/rc' namespace are specified 
+        below.</p>
+        <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/rc&lt;/name&gt;
+  &lt;doc&gt;JEP-0144&lt;/doc&gt;
+  &lt;desc&gt;Forms used for remote controlling clients&lt;/desc&gt;
+  &lt;field var='status'
+         type='list-single'
+         var='The list of statuses'/&gt;
+  &lt;field var='status-priority'
+         type='text-single'
+         var='The new priority for the client'/&gt;
+  &lt;field var='status-message'
+         type='text-multi'
+         label='The status message text'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="sect-id2257432">XML Schema</a>
+</h2>
+    <p class="" style="">Because the protocol defined here is a profile of 
+	<span style="font-weight: bold">JEP-0050: Ad-Hoc Commands</span>,
+	no schema definition is needed.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250844">1</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2250910">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251145">3</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256602">4</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2257216">5</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2257319">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257357">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2257414">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-01-25)</h4>
+<div class="indent">Using JEP-0033 (Extended Stanza Addressing) for Forwarding 
+		use case. (rt)
+    </div>
+<h4>Version 0.2 (2005-03-16)</h4>
+<div class="indent">Minor modifications; completed Set Options use case; completed Leave Groupchats use case. (rt)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">Initial version. (rt)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0147-0.1.html
+++ b/content/xep-0147-0.1.html
@@ -1,0 +1,578 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0147: XMPP URI Query Components</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP URI Query Components">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a registry of XMPP URI query components and also specifies an initial submission of values to that registry.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2004-11-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0147">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2004 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.php&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0147: XMPP URI Query Components</h1>
+<p>This JEP defines a registry of XMPP URI query components and also specifies an initial submission of values to that registry.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0147<br>
+            Version: 0.1<br>
+            Last Updated: 2004-11-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP URI, JEP-0053<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2004 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.php">http://www.jabber.org/jsf/ipr-policy.php</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#actions">Query Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#actions-message">Message Action</a>
+</dt>
+<dt>3.2.  <a href="#actions-roster">Roster-Related Actions</a>
+</dt>
+<dt>3.3.  <a href="#actions-subscribe">Subscription-Related Actions</a>
+</dt>
+<dt>3.4.  <a href="#actions-probe">Presence Probe Action</a>
+</dt>
+<dt>3.5.  <a href="#actions-groupchat">Groupchat-Related Actions</a>
+</dt>
+<dt>3.6.  <a href="#actions-register">Registration-Related Actions</a>
+</dt>
+<dt>3.7.  <a href="#actions-pubsub">Pubsub-Related Actions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-querytype">XMPP URI Querytype Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-querytype-process">Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-querytype-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">XMPP URI</span>  [<a href="#nt-id2596033">1</a>] defines the xmpp: URI scheme for interaction with XMPP entities (see <span class="ref">XMPP Core</span>  [<a href="#nt-id2596059">2</a>]) by non-native applications, but intentionally leaves the potential values of the query component somewhat open-ended. In particular, that document does not provide a list of common &quot;actions&quot; for queries (e.g., send message or join chatroom), nor does it specify recommended &quot;key-value&quot; pairs to be used in the context of such actions. This JEP calls for a registry of such actions and key-value pairs, to be maintained by <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2596108">3</a>].</p>
+  <p class="" style="">Note: The format for XMPP URIs, including the format of the query component, is fully specified  and formally defined in <span style="font-weight: bold">XMPP URI</span>; this document does not modify the xmpp: URI scheme in any way and assumes that the reader is familiar with all aspects of that specification.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This document inherits terminology from <span style="font-weight: bold">XMPP URI</span> and from <span class="ref">URI Syntax</span>  [<a href="#nt-id2596261">4</a>].</p>
+<h2>3.
+       <a name="actions">Query Actions</a>
+</h2>
+  <p class="" style="">The range of actions that might be triggered by interaction with an XMPP entity by means of an XMPP URI is potentially as wide as the range of extensions to XMPP. This JEP does not seek to exhaustively defined all such potential actions. However, the following actions might be of general interest, and therefore are described below:</p>
+  <ol start="" type=""> 
+    <li>Sending a message.</li>
+    <li>Adding or removing a roster item.</li>
+    <li>Managing subscriptions to presence information.</li>
+    <li>Probing for current presence information.</li>
+    <li>Joining a groupchat room (see <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596238">5</a>]).</li>
+    <li>Registering with another entity via <span class="ref">In-Band Registration</span>  [<a href="#nt-id2596365">6</a>].</li>
+    <li>Subscribing to or unsubscribing from a <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596388">7</a>] node.</li>
+  </ol> 
+  <p class="" style="">For each such action, this JEP specifies a recommended &quot;querytype&quot; (this can be thought of as an action name; see <span style="font-weight: bold">XMPP URI</span> for syntax and semantics) as well as a list of keys to be used in key-value pairs if appropriate.</p>
+  <div class="indent">
+<h3>3.1 <a name="actions-message">Message Action</a>
+</h3>
+    <p class="" style="">It may desirable for an XMPP URI to trigger a specialized interface for sending an XMPP message stanza (as opposed to completing some other action). The RECOMMENDED querytype for this action is &quot;message&quot;. If no key-value pair is provided, interacting with an XMPP URI that contains a querytype of &quot;message&quot; SHOULD trigger an interface that enables the user to input the text of an XMPP message and other relevant parameters (e.g., a message subject or <span class="ref">XHTML-IM</span>  [<a href="#nt-id2596323">8</a>] markup).</p>
+    <p class="caption">Example 1. Basic Message Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message
+    </pre></div>
+    <p class="" style="">A query component whose querytype is &quot;message&quot; MAY specify various key-value pairs. The following three keys are associated with the child elements of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace:</p>
+    <ol start="" type="">
+      <li>subject</li>
+      <li>body</li>
+      <li>thread</li>
+    </ol>
+    <p class="" style="">In addition, the following three keys are associated with the attributes of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace (the 'to' attribute is unnecessary, since it is provided by the XMPP address included in the URI):</p>
+    <ol start="" type="">
+      <li>from</li>
+      <li>id</li>
+      <li>type</li>
+    </ol>
+    <p class="" style="">Other keys MAY be registered with the Jabber Registrar but are not specified herein.</p>
+    <p class="caption">Example 2. Message Action with Keys</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message&amp;subject=Test%20Message&amp;body=Here%27s%20a%20test%20message
+    </pre></div>
+    <p class="caption">Example 3. Message Action with Keys: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montage.net'&gt;
+  &lt;subject&gt;Test Message&lt;/subject&gt;
+  &lt;body&gt;Here&amp;apos;s a test message.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-roster">Roster-Related Actions</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:roster' namespace provides a mechanism for managing an XMPP roster (also called a &quot;contact list&quot;). This namespace is defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2602101">9</a>]. The registered querytype for adding items to the roster or editing items in the roster is &quot;roster&quot; (effectively there is no difference between adding and editing). An XMPP URI containing a &quot;roster&quot; querytype MAY also include at most one &quot;name&quot; key whose value maps to the 'name' attribute of the &lt;item/&gt; element within the 'jabber:iq:roster' namespace, and MAY contain one &quot;group&quot; key whose value maps to the character data of the &lt;group/&gt; child element of &lt;item/&gt;.</p>
+    <p class="caption">Example 4. Roster Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster
+    </pre></div>
+    <p class="caption">Example 5. Roster Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Roster Action With Name</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster&amp;name=Romeo%20Montague
+    </pre></div>
+    <p class="caption">Example 7. Roster Action With Name: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' name='Romeo Montague'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Roster Edit Action With Name and Group</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster&amp;action=edit&amp;name=Romeo%20Montague&amp;group=Friends
+    </pre></div>
+    <p class="caption">Example 9. Roster Edit Action With Name and Group: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' name='Romeo Montague'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Methods for including more than one group are yet to be determined.</p>
+    <p class="" style="">In order to remove an item from the roster, the registered querytype to use is &quot;remove&quot;.</p>
+    <p class="caption">Example 10. Roster Remove Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?remove
+    </pre></div>
+    <p class="caption">Example 11. Roster Remove Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' subscription='remove'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="actions-subscribe">Subscription-Related Actions</a>
+</h3>
+    <p class="" style="">Closely coupled with roster management is presence subscription management. In XMPP, subscription management is handled via special values of the &lt;presence/&gt; stanza, as described in <span style="font-weight: bold">XMPP IM</span>. Support for the subscribe and unsubscribe actions is RECOMMENDED, whereas support for the subscribed and unsubscribed actions is OPTIONAL.</p>
+    <p class="caption">Example 12. Subscribe Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?subscribe
+    </pre></div>
+    <p class="caption">Example 13. Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='subscribe'/&gt;
+    </pre></div>
+    <p class="caption">Example 14. Unsubscribe Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?unsubscribe
+    </pre></div>
+    <p class="caption">Example 15. Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='unsubscribe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-probe">Presence Probe Action</a>
+</h3>
+    <p class="" style="">Once an entity is subscribed to the presence of a contact, it is allowed to probe for the contact's current presence if necessary. Although normally this is done by the server on the user's behalf, the client may initiate a probe as well. The action and resulting protocol are shown below.</p>
+    <p class="caption">Example 16. Probe Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?probe
+    </pre></div>
+    <p class="caption">Example 17. Probe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='probe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="actions-groupchat">Groupchat-Related Actions</a>
+</h3>
+    <p class="" style="">The Jabber network has long included groupchat rooms (similar to IRC channels); this functionality is defined fully in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>. Two querytype values are registered to enable interaction with groupchat rooms: &quot;join&quot; and &quot;leave&quot;.</p>
+    <p class="caption">Example 18. Join Action</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join
+    </pre></div>
+    <p class="" style="">The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences.</p> 
+    <p class="caption">Example 19. Join Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 20. Leave Action</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?leave
+    </pre></div>
+    <p class="" style="">The application SHOULD populate the room nickname based on the value provided when joining.</p>
+    <p class="caption">Example 21. Leave Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'
+          type='unavailable'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="actions-register">Registration-Related Actions</a>
+</h3>
+    <p class="" style="">Sometimes it is necessary to register with an entity (e.g., a groupchat room or gateway to a non-Jabber IM system) before interacting with it further; the protocol for doing so is defined in <span style="font-weight: bold">JEP-0077: In-Band Registration</span>. Two querytype values are included in the querytype registry to enable registration management: &quot;register&quot; and &quot;unregister&quot;.</p>
+    <p class="caption">Example 22. Register Action</p>
+<div class="indent"><pre>
+xmpp:marlowe.shakespeare.lit?register
+    </pre></div>
+    <p class="" style="">Because registration is a two-step process (see JEP-0077), the application MUST then send an IQ-get to the entity in order to retrieve the required registration fields:</p>
+    <p class="caption">Example 23. Retrieving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 24. Receiving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq from='marlowe.shakespeare.lit' type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The application MUST then present an appropriate interface that enables the user to complete the registration form. Once the user provides the information, the application MUST send an IQ-set to the entity.</p>
+    <p class="caption">Example 25. Sending Registration Information</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Once registered, a user may also want to unregister.</p>
+    <p class="caption">Example 26. Unregister Action</p>
+<div class="indent"><pre>
+xmpp:marlowe.shakespeare.lit?unregister
+    </pre></div>
+    <p class="caption">Example 27. Unregister Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;remove/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="actions-pubsub">Pubsub-Related Actions</a>
+</h3>
+    <p class="" style="">
+<span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> defines a generic protocol for subscribing and publishing to &quot;feeds&quot; or &quot;channels&quot; of information. The &quot;pubsub&quot; quertype is defined herein for interaction with pubsub services, with an &quot;action&quot; key for pubsub-related actions, whose defined values are &quot;subscribe&quot;, &quot;unsubscribe&quot;, and &quot;publish&quot;.</p>
+    <p class="caption">Example 28. Pubsub Subscribe Action</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub&amp;action=subscribe#globe/performances
+    </pre></div>
+    <p class="" style="">Note the inclusion of a fragment identifier component; this is to be mapped to the pubsub NodeID.</p>
+    <p class="caption">Example 29. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 30. Pubsub Unsubscribe Action</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub&amp;action=unsubscribe#globe/performances
+    </pre></div>
+    <p class="caption">Example 31. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Internationalization considerations for XMPP URIs are specified in <span style="font-weight: bold">XMPP URI</span>; the reader is referred to that document for a complete discussion of the relevant issues.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP URIs are specified in <span style="font-weight: bold">XMPP URI</span>.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602684">10</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-querytype">XMPP URI Querytype Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of querytype values.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-querytype-process">Process</a>
+</h3>
+      <p>In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;the name of the querytype (e.g., &quot;pubsub&quot;)&lt;/name&gt;
+  &lt;proto&gt;
+    the namespace of associated protocol output 
+    (e.g., &quot;http://jabber.org/protocol/pubsub&quot;)
+  &lt;/proto&gt;
+  &lt;desc&gt;a natural-language description of the querytype&lt;/desc&gt;
+  &lt;doc&gt;the document in which the querytype is specified&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;the name of the key (e.g., &quot;action&quot;)&lt;/name&gt;
+      &lt;desc&gt;a natural-language description of the key&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;the name of a value (e.g., &quot;subscribe&quot;)&lt;/name&gt;
+          &lt;desc&gt;a natural-language description of the value&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+      <p class="" style="">Note: Within the &lt;querytype/&gt; element, the &lt;keys/&gt; child element is OPTIONAL; within any given &lt;key/&gt; element, the &lt;values/&gt; child element is also OPTIONAL.</p>
+      <p class="" style="">The registrant may register more than one querytype at a time, each contained in a separate &lt;querytype/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-querytype-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;join&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables joining a groupchat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;leave&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables leaving a groupchat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;message&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending of an XMPP message stanza&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;subject&lt;/name&gt;
+      &lt;desc&gt;a subject for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;body&lt;/name&gt;
+      &lt;desc&gt;a body for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;thread&lt;/name&gt;
+      &lt;desc&gt;a Thread ID for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;from&lt;/name&gt;
+      &lt;desc&gt;a from address for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;id&lt;/name&gt;
+      &lt;desc&gt;an ID for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the message type per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;chat&lt;/name&gt;
+          &lt;desc&gt;a message of type &quot;chat&quot;&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;groupchat&lt;/name&gt;
+          &lt;desc&gt;a message of type &quot;groupchat&quot;&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;headline&lt;/name&gt;
+          &lt;desc&gt;a message of type &quot;headline&quot;&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;normal&lt;/name&gt;
+          &lt;desc&gt;a message of type &quot;normal&quot;&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;probe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables probing for a contact's current presence information&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;register&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:register&lt;/proto&gt;
+  &lt;desc&gt;enables registering with a server or service&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;remove&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables removing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;roster&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables adding or editing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;subscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending a presence subscription request&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;unregister&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:register&lt;/proto&gt;
+  &lt;desc&gt;enables unregistering with a server or service&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;unsubscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables unsubscribing from a contact's presence&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/querytype&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596033">1</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-06.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-06.txt</a>&gt; (work in progress).</p>
+<p>
+<a name="nt-id2596059">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596108">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2596261">4</a>. Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/internet-drafts/draft-fielding-uri-rfc2396bis-07.txt">http://www.ietf.org/internet-drafts/draft-fielding-uri-rfc2396bis-07.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596238">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596365">6</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596388">7</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596323">8</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602101">9</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602684">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0147-0.2.html
+++ b/content/xep-0147-0.2.html
@@ -1,0 +1,608 @@
+<html>
+<head>
+<meta content="text/html; charset=UTF-8" http-equiv="Content-Type">
+<title>JEP-0147: XMPP URI Query Components</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP URI Query Components">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a registry of XMPP URI query components and also specifies an initial submission of values to that registry.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-02-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0147">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0147: XMPP URI Query Components</h1>
+<p>This JEP defines a registry of XMPP URI query components and also specifies an initial submission of values to that registry.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0147<br>
+            Version: 0.3<br>
+            Last Updated: 2005-02-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP URI, JEP-0053<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+</p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords &quot;MUST&quot;, &quot;MUST NOT&quot;, &quot;REQUIRED&quot;, &quot;SHALL&quot;, &quot;SHALL NOT&quot;, &quot;SHOULD&quot;, &quot;SHOULD NOT&quot;, &quot;RECOMMENDED&quot;, &quot;NOT RECOMMENDED&quot;, &quot;MAY&quot;, and &quot;OPTIONAL&quot; in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#actions">Query Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#actions-message">Message Action</a>
+</dt>
+<dt>3.2.  <a href="#actions-roster">Roster-Related Actions</a>
+</dt>
+<dt>3.3.  <a href="#actions-subscribe">Subscription-Related Actions</a>
+</dt>
+<dt>3.4.  <a href="#actions-probe">Presence Probe Action</a>
+</dt>
+<dt>3.5.  <a href="#actions-groupchat">Groupchat-Related Actions</a>
+</dt>
+<dt>3.6.  <a href="#actions-register">Registration-Related Actions</a>
+</dt>
+<dt>3.7.  <a href="#actions-pubsub">Pubsub-Related Actions</a>
+</dt>
+<dt>3.8.  <a href="#actions-disco">Disco-Related Actions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-querytype">XMPP URI Querytype Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-querytype-process">Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-querytype-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">
+<span class="ref">XMPP URI</span>  [<a href="#nt-id2596214">1</a>] defines the xmpp: URI scheme for interaction with XMPP entities (see <span class="ref">XMPP Core</span>  [<a href="#nt-id2596241">2</a>]) by non-native applications, but intentionally leaves the potential values of the query component somewhat open-ended. In particular, that document does not provide a list of common &quot;actions&quot; for queries (e.g., send message or join chatroom), nor does it specify recommended &quot;key-value&quot; pairs to be used in the context of such actions. This JEP calls for a registry of such actions and key-value pairs, to be maintained by the <span class="ref">Jabber Registrar</span>  [<a href="#nt-id2596144">3</a>].</p>
+  <p class="" style="">Note: The format for XMPP URIs, including the format of the query component, is fully specified  and formally defined in <span style="font-weight: bold">XMPP URI</span>; this document does not modify the xmpp: URI scheme in any way and assumes that the reader is familiar with all aspects of that specification.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This document inherits terminology from <span style="font-weight: bold">XMPP URI</span> and from <span class="ref">RFC 3986</span>  [<a href="#nt-id2596341">4</a>].</p>
+<h2>3.
+       <a name="actions">Query Actions</a>
+</h2>
+  <p class="" style="">The range of actions that might be triggered by interaction with an XMPP entity by means of an XMPP URI is potentially as wide as the range of extensions to XMPP. This JEP does not seek to exhaustively defined all such potential actions. However, the following actions might be of general interest, and therefore are described below:</p>
+  <ol start="" type=""> 
+    <li>Sending a message.</li>
+    <li>Adding or removing a roster item.</li>
+    <li>Subscribing to an entity's presence information.</li>
+    <li>Probing for current presence information.</li>
+    <li>Joining a groupchat room (see <span class="ref">Multi-User Chat</span>  [<a href="#nt-id2596312">5</a>]).</li>
+    <li>Registering with another entity via <span class="ref">In-Band Registration</span>  [<a href="#nt-id2601983">6</a>].</li>
+    <li>Subscribing to or unsubscribing from a <span class="ref">Publish-Subscribe</span>  [<a href="#nt-id2596369">7</a>] node.</li>
+    <li>Determining <span class="ref">Service Discovery</span>  [<a href="#nt-id2596393">8</a>] information about an entity.</li>
+  </ol> 
+  <p class="" style="">For each such action, this JEP specifies a recommended &quot;querytype&quot; (this can be thought of as an action name; see <span style="font-weight: bold">XMPP URI</span> for syntax and semantics) as well as a list of keys to be used in key-value pairs if appropriate.</p>
+  <div class="indent">
+<h3>3.1 <a name="actions-message">Message Action</a>
+</h3>
+    <p class="" style="">It may desirable for an XMPP URI to trigger a specialized interface for sending an XMPP message stanza (as opposed to completing some other action). The RECOMMENDED querytype for this action is &quot;message&quot;. If no key-value pair is provided, interacting with an XMPP URI that contains a querytype of &quot;message&quot; SHOULD trigger an interface that enables the user to input the text of an XMPP message and other relevant parameters (e.g., a message subject or <span class="ref">XHTML-IM</span>  [<a href="#nt-id2602096">9</a>] markup).</p>
+    <p class="caption">Example 1. Basic Message Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message
+    </pre></div>
+    <p class="" style="">A query component whose querytype is &quot;message&quot; MAY specify various key-value pairs. The following three keys are associated with the child elements of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace as defined in <span class="ref">XMPP IM</span>  [<a href="#nt-id2602042">10</a>]:</p>
+    <ol start="" type="">
+      <li>subject</li>
+      <li>body</li>
+      <li>thread</li>
+    </ol>
+    <p class="" style="">In addition, the following three keys are associated with the attributes of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace (the 'to' attribute is unnecessary, since it is provided by the XMPP address included in the URI):</p>
+    <ol start="" type="">
+      <li>from</li>
+      <li>id</li>
+      <li>type</li>
+    </ol>
+    <p class="" style="">Other keys MAY be registered with the Jabber Registrar but are not specified herein.</p>
+    <p class="caption">Example 2. Message Action with Keys: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message&amp;subject=Test%20Message&amp;body=Here%27s%20a%20test%20message
+    </pre></div>
+    <p class="caption">Example 3. Message Action with Keys: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montage.net'&gt;
+  &lt;subject&gt;Test Message&lt;/subject&gt;
+  &lt;body&gt;Here&amp;apos;s a test message.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-roster">Roster-Related Actions</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:roster' namespace provides a mechanism for managing an XMPP roster (also called a &quot;contact list&quot;). This namespace is defined in <span style="font-weight: bold">RFC 3921</span>. The registered querytype for adding items to the roster or editing items in the roster is &quot;roster&quot; (effectively there is no difference between adding and editing). An XMPP URI containing a &quot;roster&quot; querytype MAY also include at most one &quot;name&quot; key whose value maps to the 'name' attribute of the &lt;item/&gt; element within the 'jabber:iq:roster' namespace, and MAY contain one &quot;group&quot; key whose value maps to the character data of the &lt;group/&gt; child element of &lt;item/&gt;.</p>
+    <p class="caption">Example 4. Roster Action: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster
+    </pre></div>
+    <p class="caption">Example 5. Roster Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Roster Action With Name: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster&amp;name=Romeo%20Montague
+    </pre></div>
+    <p class="caption">Example 7. Roster Action With Name: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' name='Romeo Montague'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Roster Action With Name and Group: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster&amp;name=Romeo%20Montague&amp;group=Friends
+    </pre></div>
+    <p class="caption">Example 9. Roster Action With Name and Group: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' name='Romeo Montague'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Methods for including more than one group are yet to be determined.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="actions-subscribe">Subscription-Related Actions</a>
+</h3>
+    <p class="" style="">Closely coupled with roster management is presence subscription management. In XMPP, subscription management is handled via special values of the &lt;presence/&gt; stanza, as described in <span style="font-weight: bold">RFC 3921</span>. When an entity subscribes to another entity's presence by means of an XMPP URI, the invoked XMPP application SHOULD first send a roster add stanza as shown below (this is consistent with the recommendations in <span style="font-weight: bold">RFC 3921</span>.</p>
+    <p class="caption">Example 10. Subscribe Action: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?subscribe
+    </pre></div>
+    <p class="caption">Example 11. Subscribe Action: Resulting Stanzas</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;presence to='romeo@montague.net' type='subscribe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-probe">Presence Probe Action</a>
+</h3>
+    <p class="" style="">Once an entity is subscribed to the presence of a contact, it is allowed to probe for the contact's current presence if necessary. Although normally this is done by the server on the user's behalf, the client may initiate a probe as well. The action and resulting protocol are shown below.</p>
+    <p class="caption">Example 12. Probe Action: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?probe
+    </pre></div>
+    <p class="caption">Example 13. Probe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='probe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="actions-groupchat">Groupchat-Related Actions</a>
+</h3>
+    <p class="" style="">The Jabber network has long included groupchat rooms (similar to IRC channels); this functionality is defined fully in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>. Two querytype values are registered to enable interaction with groupchat rooms: &quot;join&quot; and &quot;invite&quot;.</p>
+    <p class="caption">Example 14. Join Action: URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join
+    </pre></div>
+    <p class="" style="">The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences.</p> 
+    <p class="caption">Example 15. Join Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The application SHOULD populate the room nickname based on the value provided when joining.</p>
+    <p class="" style="">It may be desirable to simultaneously join a room and invite one or more specified other individuals to join the room. The &quot;invite&quot; querytype is used to complete such an action.</p>
+    <p class="caption">Example 16. Invite Action: URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?invite&amp;jid=hecate@shakespeare.lit
+    </pre></div>
+    <p class="" style="">If the joining user is not yet in the room, the application MUST send two stanzas: the first to join the room and the second to invite the other individual. If the joining user is in the room already, the application shall send only the invitation stanza.</p>
+    <p class="caption">Example 17. Invite Action: Resulting Stanza(s)</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;message to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="actions-register">Registration-Related Actions</a>
+</h3>
+    <p class="" style="">Sometimes it is necessary to register with an entity (e.g., a groupchat room or gateway to a non-Jabber IM system) before interacting with it further; the protocol for doing so is defined in <span style="font-weight: bold">JEP-0077: In-Band Registration</span>. One querytype value is included in the querytype registry to enable registration management: &quot;register&quot;.</p>
+    <p class="caption">Example 18. Register Action: URI</p>
+<div class="indent"><pre>
+xmpp:marlowe.shakespeare.lit?register
+    </pre></div>
+    <p class="" style="">Because registration is a two-step process (see JEP-0077), the application MUST then send an IQ-get to the entity in order to retrieve the required registration fields:</p>
+    <p class="caption">Example 19. Retrieving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Receiving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq from='marlowe.shakespeare.lit' type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The application MUST then present an appropriate interface that enables the user to complete the registration form. Once the user provides the information, the application MUST send an IQ-set to the entity.</p>
+    <p class="caption">Example 21. Sending Registration Information</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="actions-pubsub">Pubsub-Related Actions</a>
+</h3>
+    <p class="" style="">
+<span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> defines a generic protocol for subscribing and publishing to &quot;feeds&quot; or &quot;channels&quot; of information. The &quot;pubsub&quot; querytype is defined herein for interaction with pubsub services, with two keys: (1) &quot;node&quot; (to specify pubsub nodes) and (2) &quot;action&quot;, whose defined values are &quot;subscribe&quot;, &quot;unsubscribe&quot;, and &quot;publish&quot;.</p>
+    <p class="caption">Example 22. Pubsub Subscribe Action: URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub&amp;action=subscribe&amp;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 23. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 24. Pubsub Unsubscribe Action: URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub&amp;action=unsubscribe&amp;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 25. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.8 <a name="actions-disco">Disco-Related Actions</a>
+</h3>
+    <p class="" style="">
+<span style="font-weight: bold">JEP-0030: Service Discovery</span> defines a protocol for for discovering information about Jabber entities as well as the items associated with such entities. The &quot;disco&quot; querytype is defined herein for interaction for the purpose of service discovery, with two keys: (1) &quot;node&quot; (to specify service discovery nodes) and (2) &quot;request&quot;, whose defined values are &quot;info&quot; and &quot;items&quot;.</p>
+    <p class="caption">Example 26. Service Discovery Information Request: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco&amp;type=get&amp;request=info
+    </pre></div>
+    <p class="caption">Example 27. Service Discovery Information Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Discovery Items Request: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco&amp;type=get&amp;request=items&amp;node=http://jabber.org/protocol/extended-presence
+    </pre></div>
+    <p class="caption">Example 29. Service Discovery Items Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/extended-presence'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Internationalization considerations for XMPP URIs are specified in <span style="font-weight: bold">XMPP URI</span>; the reader is referred to that document for a complete discussion of the relevant issues.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP URIs are specified in <span style="font-weight: bold">XMPP URI</span>.</p>
+  <p class="" style="">Furthermore, completion of some of the actions defined herein will cause changes to an entity's account, subscriptions to information, registration with services, communication with other entities, and the like. Naturally, such changes, information, services, and communications are potentially undesirable (e.g., joining a chatroom whose discussion topic is not of interest to, or even patently offensive to, the joining user). The invoked application SHOULD appropriately warn a human user regarding the consequences of the action about to be completed.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2602890">11</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-querytype">XMPP URI Querytype Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of querytype values.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-querytype-process">Process</a>
+</h3>
+      <p>In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;the name of the querytype (e.g., &quot;pubsub&quot;)&lt;/name&gt;
+  &lt;proto&gt;
+    the namespace of associated protocol output 
+    (e.g., &quot;http://jabber.org/protocol/pubsub&quot;)
+  &lt;/proto&gt;
+  &lt;desc&gt;a natural-language description of the querytype&lt;/desc&gt;
+  &lt;doc&gt;the document in which the querytype is specified&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;the name of the key (e.g., &quot;action&quot;)&lt;/name&gt;
+      &lt;desc&gt;a natural-language description of the key&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;the name of a value (e.g., &quot;subscribe&quot;)&lt;/name&gt;
+          &lt;desc&gt;a natural-language description of the value&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+      <p class="" style="">Note: Within the &lt;querytype/&gt; element, the &lt;keys/&gt; child element is OPTIONAL; within any given &lt;key/&gt; element, the &lt;values/&gt; child element is also OPTIONAL.</p>
+      <p class="" style="">The registrant may register more than one querytype at a time, each contained in a separate &lt;querytype/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-querytype-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+&lt;querytype&gt;
+  &lt;name&gt;disco&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/disco&lt;/proto&gt;
+  &lt;desc&gt;enables interaction for the purpose of service discovery&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;request&lt;/name&gt;
+      &lt;desc&gt;the service discovery request type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;info&lt;/name&gt;
+          &lt;desc&gt;a service discovery information (disco#info) request&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;items&lt;/name&gt;
+          &lt;desc&gt;a service discovery items (disco#items) request&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the service discovery node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;invite&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables simultaneously joining a groupchat room and inviting others&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;join&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables joining a groupchat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;message&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending of an XMPP message stanza&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;subject&lt;/name&gt;
+      &lt;desc&gt;a subject for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;body&lt;/name&gt;
+      &lt;desc&gt;a body for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;thread&lt;/name&gt;
+      &lt;desc&gt;a Thread ID for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;from&lt;/name&gt;
+      &lt;desc&gt;a from address for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;id&lt;/name&gt;
+      &lt;desc&gt;an ID for the message per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the message type per the &quot;jabber:client&quot; schema&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;chat&lt;/name&gt;
+          &lt;desc&gt;a message of type &quot;chat&quot;&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;groupchat&lt;/name&gt;
+          &lt;desc&gt;a message of type &quot;groupchat&quot;&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;headline&lt;/name&gt;
+          &lt;desc&gt;a message of type &quot;headline&quot;&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;normal&lt;/name&gt;
+          &lt;desc&gt;a message of type &quot;normal&quot;&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;probe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables probing for a contact's current presence information&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the pubsub node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;register&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:register&lt;/proto&gt;
+  &lt;desc&gt;enables registering with a server or service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;roster&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables adding or editing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;subscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending a presence subscription request&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p>
+<a name="nt-id2596214">1</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt</a>&gt; (work in progress).</p>
+<p>
+<a name="nt-id2596241">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596144">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p>
+<a name="nt-id2596341">4</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2596312">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p>
+<a name="nt-id2601983">6</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596369">7</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p>
+<a name="nt-id2596393">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602096">9</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p>
+<a name="nt-id2602042">10</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p>
+<a name="nt-id2602890">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-02-09)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-uri-08; removed use cases for editing roster items, removing roster items, leaving chatrooms, unsubscribing, and unregistering (these make more sense from within a dedicated client); added use case for simultaneously joining a room and inviting other participants; further specified security considerations. (psa)
+    </div>
+<h4>Version 0.2 (2004-11-17)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-uri-07; specified Service Discovery usage. (psa)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0147-0.3.html
+++ b/content/xep-0147-0.3.html
@@ -1,0 +1,593 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0147: XMPP URI Query Components</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP URI Query Components">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a registry of XMPP URI query components and also specifies an initial submission of values to that registry.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-02-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0147">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body bgcolor="#FFFFFF">
+<h1>JEP-0147: XMPP URI Query Components</h1>
+<p>This JEP defines a registry of XMPP URI query components and also specifies an initial submission of values to that registry.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0147<br>
+            Version: 0.3<br>
+            Last Updated: 2005-02-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP URI, JEP-0053<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br></p>
+<h2>Author Information</h2>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocols defined in this JEP have been developed outside the Internet Standards Process and are to be understood as extensions to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#actions">Query Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#actions-message">Message Action</a>
+</dt>
+<dt>3.2.  <a href="#actions-roster">Roster-Related Actions</a>
+</dt>
+<dt>3.3.  <a href="#actions-subscribe">Subscription-Related Actions</a>
+</dt>
+<dt>3.4.  <a href="#actions-probe">Presence Probe Action</a>
+</dt>
+<dt>3.5.  <a href="#actions-groupchat">Groupchat-Related Actions</a>
+</dt>
+<dt>3.6.  <a href="#actions-register">Registration-Related Actions</a>
+</dt>
+<dt>3.7.  <a href="#actions-pubsub">Pubsub-Related Actions</a>
+</dt>
+<dt>3.8.  <a href="#actions-disco">Disco-Related Actions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-querytype">XMPP URI Querytype Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-querytype-process">Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-querytype-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP URI</span>  [<a href="#nt-id2250451">1</a>] defines the xmpp: URI scheme for interaction with XMPP entities (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250477">2</a>]) by non-native applications, but intentionally leaves the potential values of the query component somewhat open-ended. In particular, that document does not provide a list of common "actions" for queries (e.g., send message or join chatroom), nor does it specify recommended "key-value" pairs to be used in the context of such actions. This JEP calls for a registry of such actions and key-value pairs, to be maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250468">3</a>].</p>
+  <p class="" style="">Note: The format for XMPP URIs, including the format of the query component, is fully specified  and formally defined in <span style="font-weight: bold">XMPP URI</span>; this document does not modify the xmpp: URI scheme in any way and assumes that the reader is familiar with all aspects of that specification.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This document inherits terminology from <span style="font-weight: bold">XMPP URI</span> and from <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2251162">4</a>].</p>
+<h2>3.
+       <a name="actions">Query Actions</a>
+</h2>
+  <p class="" style="">The range of actions that might be triggered by interaction with an XMPP entity by means of an XMPP URI is potentially as wide as the range of extensions to XMPP. This JEP does not seek to exhaustively defined all such potential actions. However, the following actions might be of general interest, and therefore are described below:</p>
+  <ol start="" type=""> 
+    <li>Sending a message.</li>
+    <li>Adding or removing a roster item.</li>
+    <li>Subscribing to an entity's presence information.</li>
+    <li>Probing for current presence information.</li>
+    <li>Joining a groupchat room (see <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2251229">5</a>]).</li>
+    <li>Registering with another entity via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2251253">6</a>].</li>
+    <li>Subscribing to or unsubscribing from a <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2251276">7</a>] node.</li>
+    <li>Determining <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251304">8</a>] information about an entity.</li>
+  </ol> 
+  <p class="" style="">For each such action, this JEP specifies a recommended "querytype" (this can be thought of as an action name; see <span style="font-weight: bold">XMPP URI</span> for syntax and semantics) as well as a list of keys to be used in key-value pairs if appropriate.</p>
+  <div class="indent">
+<h3>3.1 <a name="actions-message">Message Action</a>
+</h3>
+    <p class="" style="">It may desirable for an XMPP URI to trigger a specialized interface for sending an XMPP message stanza (as opposed to completing some other action). The RECOMMENDED querytype for this action is "message". If no key-value pair is provided, interacting with an XMPP URI that contains a querytype of "message" SHOULD trigger an interface that enables the user to input the text of an XMPP message and other relevant parameters (e.g., a message subject or <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2251359">9</a>] markup).</p>
+    <p class="caption">Example 1. Basic Message Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message
+    </pre></div>
+    <p class="" style="">A query component whose querytype is "message" MAY specify various key-value pairs. The following three keys are associated with the child elements of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2254992">10</a>]:</p>
+    <ol start="" type="">
+      <li>subject</li>
+      <li>body</li>
+      <li>thread</li>
+    </ol>
+    <p class="" style="">In addition, the following three keys are associated with the attributes of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace (the 'to' attribute is unnecessary, since it is provided by the XMPP address included in the URI):</p>
+    <ol start="" type="">
+      <li>from</li>
+      <li>id</li>
+      <li>type</li>
+    </ol>
+    <p class="" style="">Other keys MAY be registered with the Jabber Registrar but are not specified herein.</p>
+    <p class="caption">Example 2. Message Action with Keys: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message;subject=Test%20Message;body=Here%27s%20a%20test%20message
+    </pre></div>
+    <p class="caption">Example 3. Message Action with Keys: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montage.net'&gt;
+  &lt;subject&gt;Test Message&lt;/subject&gt;
+  &lt;body&gt;Here&amp;apos;s a test message.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-roster">Roster-Related Actions</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:roster' namespace provides a mechanism for managing an XMPP roster (also called a "contact list"). This namespace is defined in <span style="font-weight: bold">RFC 3921</span>. The registered querytype for adding items to the roster or editing items in the roster is "roster" (effectively there is no difference between adding and editing). An XMPP URI containing a "roster" querytype MAY also include at most one "name" key whose value maps to the 'name' attribute of the &lt;item/&gt; element within the 'jabber:iq:roster' namespace, and MAY contain one "group" key whose value maps to the character data of the &lt;group/&gt; child element of &lt;item/&gt;.</p>
+    <p class="caption">Example 4. Roster Action: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster
+    </pre></div>
+    <p class="caption">Example 5. Roster Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Roster Action With Name: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague
+    </pre></div>
+    <p class="caption">Example 7. Roster Action With Name: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' name='Romeo Montague'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Roster Action With Name and Group: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague;group=Friends
+    </pre></div>
+    <p class="caption">Example 9. Roster Action With Name and Group: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' name='Romeo Montague'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Methods for including more than one group are yet to be determined.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="actions-subscribe">Subscription-Related Actions</a>
+</h3>
+    <p class="" style="">Closely coupled with roster management is presence subscription management. In XMPP, subscription management is handled via special values of the &lt;presence/&gt; stanza, as described in <span style="font-weight: bold">RFC 3921</span>. When an entity subscribes to another entity's presence by means of an XMPP URI, the invoked XMPP application SHOULD first send a roster add stanza as shown below (this is consistent with the recommendations in <span style="font-weight: bold">RFC 3921</span>.</p>
+    <p class="caption">Example 10. Subscribe Action: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?subscribe
+    </pre></div>
+    <p class="caption">Example 11. Subscribe Action: Resulting Stanzas</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;presence to='romeo@montague.net' type='subscribe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-probe">Presence Probe Action</a>
+</h3>
+    <p class="" style="">Once an entity is subscribed to the presence of a contact, it is allowed to probe for the contact's current presence if necessary. Although normally this is done by the server on the user's behalf, the client may initiate a probe as well. The action and resulting protocol are shown below.</p>
+    <p class="caption">Example 12. Probe Action: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?probe
+    </pre></div>
+    <p class="caption">Example 13. Probe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='probe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="actions-groupchat">Groupchat-Related Actions</a>
+</h3>
+    <p class="" style="">The Jabber network has long included groupchat rooms (similar to IRC channels); this functionality is defined fully in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>. Two querytype values are registered to enable interaction with groupchat rooms: "join" and "invite".</p>
+    <p class="caption">Example 14. Join Action: URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join
+    </pre></div>
+    <p class="" style="">The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences.</p> 
+    <p class="caption">Example 15. Join Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The application SHOULD populate the room nickname based on the value provided when joining.</p>
+    <p class="" style="">It may be desirable to simultaneously join a room and invite one or more specified other individuals to join the room. The "invite" querytype is used to complete such an action.</p>
+    <p class="caption">Example 16. Invite Action: URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?invite;jid=hecate@shakespeare.lit
+    </pre></div>
+    <p class="" style="">If the joining user is not yet in the room, the application MUST send two stanzas: the first to join the room and the second to invite the other individual. If the joining user is in the room already, the application shall send only the invitation stanza.</p>
+    <p class="caption">Example 17. Invite Action: Resulting Stanza(s)</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;message to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="actions-register">Registration-Related Actions</a>
+</h3>
+    <p class="" style="">Sometimes it is necessary to register with an entity (e.g., a groupchat room or gateway to a non-Jabber IM system) before interacting with it further; the protocol for doing so is defined in <span style="font-weight: bold">JEP-0077: In-Band Registration</span>. One querytype value is included in the querytype registry to enable registration management: "register".</p>
+    <p class="caption">Example 18. Register Action: URI</p>
+<div class="indent"><pre>
+xmpp:marlowe.shakespeare.lit?register
+    </pre></div>
+    <p class="" style="">Because registration is a two-step process (see JEP-0077), the application MUST then send an IQ-get to the entity in order to retrieve the required registration fields:</p>
+    <p class="caption">Example 19. Retrieving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Receiving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq from='marlowe.shakespeare.lit' type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The application MUST then present an appropriate interface that enables the user to complete the registration form. Once the user provides the information, the application MUST send an IQ-set to the entity.</p>
+    <p class="caption">Example 21. Sending Registration Information</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="actions-pubsub">Pubsub-Related Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> defines a generic protocol for subscribing and publishing to "feeds" or "channels" of information. The "pubsub" querytype is defined herein for interaction with pubsub services, with two keys: (1) "node" (to specify pubsub nodes) and (2) "action", whose defined values are "subscribe", "unsubscribe", and "publish".</p>
+    <p class="caption">Example 22. Pubsub Subscribe Action: URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=subscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 23. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 24. Pubsub Unsubscribe Action: URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=unsubscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 25. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.8 <a name="actions-disco">Disco-Related Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0030: Service Discovery</span> defines a protocol for for discovering information about Jabber entities as well as the items associated with such entities. The "disco" querytype is defined herein for interaction for the purpose of service discovery, with two keys: (1) "node" (to specify service discovery nodes) and (2) "request", whose defined values are "info" and "items".</p>
+    <p class="caption">Example 26. Service Discovery Information Request: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=info
+    </pre></div>
+    <p class="caption">Example 27. Service Discovery Information Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Discovery Items Request: URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=items;node=http://jabber.org/protocol/extended-presence
+    </pre></div>
+    <p class="caption">Example 29. Service Discovery Items Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/extended-presence'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Internationalization considerations for XMPP URIs are specified in <span style="font-weight: bold">XMPP URI</span>; the reader is referred to that document for a complete discussion of the relevant issues.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP URIs are specified in <span style="font-weight: bold">XMPP URI</span>.</p>
+  <p class="" style="">Furthermore, completion of some of the actions defined herein will cause changes to an entity's account, subscriptions to information, registration with services, communication with other entities, and the like. Naturally, such changes, information, services, and communications are potentially undesirable (e.g., joining a chatroom whose discussion topic is not of interest to, or even patently offensive to, the joining user). The invoked application SHOULD appropriately warn a human user regarding the consequences of the action about to be completed.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2255627">11</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-querytype">XMPP URI Querytype Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of querytype values.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-querytype-process">Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;the name of the querytype (e.g., "pubsub")&lt;/name&gt;
+  &lt;proto&gt;
+    the namespace of associated protocol output 
+    (e.g., "http://jabber.org/protocol/pubsub")
+  &lt;/proto&gt;
+  &lt;desc&gt;a natural-language description of the querytype&lt;/desc&gt;
+  &lt;doc&gt;the document in which the querytype is specified&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;the name of the key (e.g., "action")&lt;/name&gt;
+      &lt;desc&gt;a natural-language description of the key&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;the name of a value (e.g., "subscribe")&lt;/name&gt;
+          &lt;desc&gt;a natural-language description of the value&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+      <p class="" style="">Note: Within the &lt;querytype/&gt; element, the &lt;keys/&gt; child element is OPTIONAL; within any given &lt;key/&gt; element, the &lt;values/&gt; child element is also OPTIONAL.</p>
+      <p class="" style="">The registrant may register more than one querytype at a time, each contained in a separate &lt;querytype/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-querytype-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+&lt;querytype&gt;
+  &lt;name&gt;disco&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/disco&lt;/proto&gt;
+  &lt;desc&gt;enables interaction for the purpose of service discovery&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;request&lt;/name&gt;
+      &lt;desc&gt;the service discovery request type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;info&lt;/name&gt;
+          &lt;desc&gt;a service discovery information (disco#info) request&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;items&lt;/name&gt;
+          &lt;desc&gt;a service discovery items (disco#items) request&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the service discovery node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;invite&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables simultaneously joining a groupchat room and inviting others&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;join&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables joining a groupchat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;message&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending of an XMPP message stanza&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;subject&lt;/name&gt;
+      &lt;desc&gt;a subject for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;body&lt;/name&gt;
+      &lt;desc&gt;a body for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;thread&lt;/name&gt;
+      &lt;desc&gt;a Thread ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;from&lt;/name&gt;
+      &lt;desc&gt;a from address for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;id&lt;/name&gt;
+      &lt;desc&gt;an ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the message type per the "jabber:client" schema&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;chat&lt;/name&gt;
+          &lt;desc&gt;a message of type "chat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;groupchat&lt;/name&gt;
+          &lt;desc&gt;a message of type "groupchat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;headline&lt;/name&gt;
+          &lt;desc&gt;a message of type "headline"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;normal&lt;/name&gt;
+          &lt;desc&gt;a message of type "normal"&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;probe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables probing for a contact's current presence information&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the pubsub node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;register&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:register&lt;/proto&gt;
+  &lt;desc&gt;enables registering with a server or service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;roster&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables adding or editing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;subscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending a presence subscription request&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<p><a name="nt-id2250451">1</a>. A Uniform Resource Identifier (URI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-uri-08.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2250477">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250468">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2251162">4</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2251229">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2251253">6</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2251276">7</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251304">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251359">9</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2254992">10</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2255627">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-02-28)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-uri-08 and subsequent XMPP WG discussion; removed use cases for editing roster items, removing roster items, leaving chatrooms, unsubscribing, and unregistering (these make more sense from within a dedicated client); added use case for simultaneously joining a room and inviting other participants; further specified security considerations. (psa)
+    </div>
+<h4>Version 0.2 (2004-11-17)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-uri-07; specified Service Discovery usage. (psa)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0147-0.4.html
+++ b/content/xep-0147-0.4.html
@@ -1,0 +1,616 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0147: XMPP IRI Query Components</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP IRI Query Components">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a registry of query components to be used in the context of XMPP IRIs and also specifies an initial submission of values to that registry.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0147">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0147: XMPP IRI Query Components</h1>
+<p>This JEP defines a registry of query components to be used in the context of XMPP IRIs and also specifies an initial submission of values to that registry.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0147<br>
+            Version: 0.4<br>
+            Last Updated: 2005-06-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, draft-saintandre-xmpp-iri-00, JEP-0053<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#actions">Query Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#actions-message">Message Action</a>
+</dt>
+<dt>3.2.  <a href="#actions-roster">Roster-Related Actions</a>
+</dt>
+<dt>3.3.  <a href="#actions-subscribe">Subscription-Related Actions</a>
+</dt>
+<dt>3.4.  <a href="#actions-probe">Presence Probe Action</a>
+</dt>
+<dt>3.5.  <a href="#actions-groupchat">Groupchat-Related Actions</a>
+</dt>
+<dt>3.6.  <a href="#actions-register">Registration-Related Actions</a>
+</dt>
+<dt>3.7.  <a href="#actions-pubsub">Pubsub-Related Actions</a>
+</dt>
+<dt>3.8.  <a href="#actions-disco">Disco-Related Actions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-querytype">XMPP IRI Querytype Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-querytype-process">Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-querytype-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP IRI</span>  [<a href="#nt-id2250569">1</a>] defines an Internationalized Resource Identifier (IRI) scheme  [<a href="#nt-id2250555">2</a>] for interaction with XMPP entities (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250552">3</a>]) by non-native applications, but intentionally leaves the potential values of the query component open-ended. In particular, that document does not provide a list of common "actions" for queries (e.g., send message or join chatroom), nor does it specify recommended "key-value" pairs to be used in the context of such actions. This JEP calls for a registry of such actions and key-value pairs, to be maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2251203">4</a>].</p>
+  <p class="" style="">Note: The format for XMPP IRIs, including the format of the query component, is fully specified  and formally defined in <span style="font-weight: bold">draft-saintandre-xmpp-iri-00</span>; this document does not modify the xmpp: IRI scheme in any way and assumes that the reader is familiar with all aspects of that specification.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This document inherits terminology from <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2251428">5</a>], <span class="ref" style="">RFC 3987</span>  [<a href="#nt-id2251235">6</a>], and <span style="font-weight: bold">draft-saintandre-xmpp-iri-00</span>.</p>
+<h2>3.
+       <a name="actions">Query Actions</a>
+</h2>
+  <p class="" style="">The range of actions that might be triggered by interaction with an XMPP entity by means of an XMPP IRI is potentially as wide as the range of extensions to XMPP. This JEP does not seek to exhaustively defined all such potential actions. However, the following actions might be of general interest, and therefore are described below:</p>
+  <ol start="" type=""> 
+    <li>Sending a message.</li>
+    <li>Adding or removing a roster item.</li>
+    <li>Subscribing to an entity's presence information.</li>
+    <li>Probing for current presence information.</li>
+    <li>Joining a groupchat room (see <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2251304">7</a>]).</li>
+    <li>Registering with another entity via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2251333">8</a>].</li>
+    <li>Subscribing to or unsubscribing from a <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2251356">9</a>] node.</li>
+    <li>Determining <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251379">10</a>] information about an entity.</li>
+  </ol> 
+  <p class="" style="">For each such action, this JEP specifies a recommended "querytype" (this can be thought of as an action name; see <span style="font-weight: bold">draft-saintandre-xmpp-iri-00</span> for syntax and semantics) as well as a list of keys to be used in key-value pairs if appropriate.</p>
+  <div class="indent">
+<h3>3.1 <a name="actions-message">Message Action</a>
+</h3>
+    <p class="" style="">It may desirable for an XMPP IRI to trigger a specialized interface for sending an XMPP message stanza (as opposed to completing some other action). The RECOMMENDED querytype for this action is "message". If no key-value pair is provided, interacting with an XMPP IRI that contains a querytype of "message" SHOULD trigger an interface that enables the user to input the text of an XMPP message and other relevant parameters (e.g., a message subject or <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2255613">11</a>] markup).</p>
+    <p class="caption">Example 1. Basic Message Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message
+    </pre></div>
+    <p class="" style="">A query component whose querytype is "message" MAY specify various key-value pairs. The following three keys are associated with the child elements of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2255654">12</a>]:</p>
+    <ol start="" type="">
+      <li>subject</li>
+      <li>body</li>
+      <li>thread</li>
+    </ol>
+    <p class="" style="">In addition, the following three keys are associated with the attributes of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace (the 'to' attribute is unnecessary, since it is provided by the XMPP address included in the IRI):</p>
+    <ol start="" type="">
+      <li>from</li>
+      <li>id</li>
+      <li>type</li>
+    </ol>
+    <p class="" style="">Other keys MAY be registered with the Jabber Registrar but are not specified herein.</p>
+    <p class="caption">Example 2. Message Action with Keys: IRI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message;subject=Test%20Message;body=Here%27s%20a%20test%20message
+    </pre></div>
+    <p class="caption">Example 3. Message Action with Keys: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montage.net'&gt;
+  &lt;subject&gt;Test Message&lt;/subject&gt;
+  &lt;body&gt;Here&amp;apos;s a test message.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-roster">Roster-Related Actions</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:roster' namespace provides a mechanism for managing an XMPP roster (also called a "contact list"). This namespace is defined in <span style="font-weight: bold">RFC 3921</span>. The registered querytype for adding items to the roster or editing items in the roster is "roster" (effectively there is no difference between adding and editing). An XMPP IRI containing a "roster" querytype MAY also include at most one "name" key whose value maps to the 'name' attribute of the &lt;item/&gt; element within the 'jabber:iq:roster' namespace, and MAY contain one "group" key whose value maps to the character data of the &lt;group/&gt; child element of &lt;item/&gt;.</p>
+    <p class="caption">Example 4. Roster Action: IRI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster
+    </pre></div>
+    <p class="caption">Example 5. Roster Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Roster Action With Name: IRI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague
+    </pre></div>
+    <p class="caption">Example 7. Roster Action With Name: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' name='Romeo Montague'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Roster Action With Name and Group: IRI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague;group=Friends
+    </pre></div>
+    <p class="caption">Example 9. Roster Action With Name and Group: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net' name='Romeo Montague'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Methods for including more than one group are yet to be determined.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="actions-subscribe">Subscription-Related Actions</a>
+</h3>
+    <p class="" style="">Closely coupled with roster management is presence subscription management. In XMPP, subscription management is handled via special values of the &lt;presence/&gt; stanza, as described in <span style="font-weight: bold">RFC 3921</span>. When an entity subscribes to another entity's presence by means of an XMPP IRI, the invoked XMPP application SHOULD first send a roster add stanza as shown below (this is consistent with the recommendations in <span style="font-weight: bold">RFC 3921</span>.</p>
+    <p class="caption">Example 10. Subscribe Action: IRI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?subscribe
+    </pre></div>
+    <p class="caption">Example 11. Subscribe Action: Resulting Stanzas</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montage.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;presence to='romeo@montague.net' type='subscribe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-probe">Presence Probe Action</a>
+</h3>
+    <p class="" style="">Once an entity is subscribed to the presence of a contact, it is allowed to probe for the contact's current presence if necessary. Although normally this is done by the server on the user's behalf, the client may initiate a probe as well. The action and resulting protocol are shown below.</p>
+    <p class="caption">Example 12. Probe Action: IRI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?probe
+    </pre></div>
+    <p class="caption">Example 13. Probe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='probe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="actions-groupchat">Groupchat-Related Actions</a>
+</h3>
+    <p class="" style="">The Jabber network has long included groupchat rooms (similar to IRC channels); this functionality is defined fully in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>. Two querytype values are registered to enable interaction with groupchat rooms: "join" and "invite".</p>
+    <p class="caption">Example 14. Join Action: IRI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join
+    </pre></div>
+    <p class="" style="">The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences.</p> 
+    <p class="caption">Example 15. Join Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The application SHOULD populate the room nickname based on the value provided when joining.</p>
+    <p class="" style="">It may be desirable to simultaneously join a room and invite one or more specified other individuals to join the room. The "invite" querytype is used to complete such an action.</p>
+    <p class="caption">Example 16. Invite Action: IRI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?invite;jid=hecate@shakespeare.lit
+    </pre></div>
+    <p class="" style="">If the joining user is not yet in the room, the application MUST send two stanzas: the first to join the room and the second to invite the other individual. If the joining user is in the room already, the application shall send only the invitation stanza.</p>
+    <p class="caption">Example 17. Invite Action: Resulting Stanza(s)</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;message to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="actions-register">Registration-Related Actions</a>
+</h3>
+    <p class="" style="">Sometimes it is necessary to register with an entity (e.g., a groupchat room or gateway to a non-Jabber IM system) before interacting with it further; the protocol for doing so is defined in <span style="font-weight: bold">JEP-0077: In-Band Registration</span>. One querytype value is included in the querytype registry to enable registration management: "register".</p>
+    <p class="caption">Example 18. Register Action: IRI</p>
+<div class="indent"><pre>
+xmpp:marlowe.shakespeare.lit?register
+    </pre></div>
+    <p class="" style="">Because registration is a two-step process (see JEP-0077), the application MUST then send an IQ-get to the entity in order to retrieve the required registration fields:</p>
+    <p class="caption">Example 19. Retrieving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 20. Receiving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq from='marlowe.shakespeare.lit' type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The application MUST then present an appropriate interface that enables the user to complete the registration form. Once the user provides the information, the application MUST send an IQ-set to the entity.</p>
+    <p class="caption">Example 21. Sending Registration Information</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="actions-pubsub">Pubsub-Related Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> defines a generic protocol for subscribing and publishing to "feeds" or "channels" of information. The "pubsub" querytype is defined herein for interaction with pubsub services, with two keys: (1) "node" (to specify pubsub nodes) and (2) "action", whose defined values are "subscribe", "unsubscribe", and "publish".</p>
+    <p class="caption">Example 22. Pubsub Subscribe Action: IRI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=subscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 23. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 24. Pubsub Unsubscribe Action: IRI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=unsubscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 25. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.8 <a name="actions-disco">Disco-Related Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0030: Service Discovery</span> defines a protocol for for discovering information about Jabber entities as well as the items associated with such entities. The "disco" querytype is defined herein for interaction for the purpose of service discovery, with three keys: (1) an OPTIONAL "node" (to specify service discovery nodes), (2) "request", whose defined values are "info" and "items" (corresponding to the disco#info and disco#items namespaces specified in JEP-0030), and (3) "type", whose defined values are "get" and "set" (corresponding to the IQ "get" and "set" methods specified in RFC 3920).</p>
+    <p class="caption">Example 26. Service Discovery Information Request: IRI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=info
+    </pre></div>
+    <p class="caption">Example 27. Service Discovery Information Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 28. Service Discovery Items Request: IRI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=items;node=http://jabber.org/protocol/extended-presence
+    </pre></div>
+    <p class="caption">Example 29. Service Discovery Items Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/extended-presence'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Internationalization considerations for XMPP IRIs are specified in <span style="font-weight: bold">draft-saintandre-xmpp-iri-00</span>; the reader is referred to that document for a complete discussion of the relevant issues.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP IRIs are specified in <span style="font-weight: bold">draft-saintandre-xmpp-iri-00</span>.</p>
+  <p class="" style="">Furthermore, completion of some of the actions defined herein will cause changes to an entity's account, subscriptions to information, registration with services, communication with other entities, and the like. Naturally, such changes, information, services, and communications are potentially undesirable (e.g., joining a chatroom whose discussion topic is not of interest to, or even patently offensive to, the joining user). The invoked application SHOULD appropriately warn a human user regarding the consequences of the action about to be completed.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256282">13</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-querytype">XMPP IRI Querytype Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of querytype values.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-querytype-process">Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;the name of the querytype (e.g., "pubsub")&lt;/name&gt;
+  &lt;proto&gt;
+    the namespace of associated protocol output 
+    (e.g., "http://jabber.org/protocol/pubsub")
+  &lt;/proto&gt;
+  &lt;desc&gt;a natural-language description of the querytype&lt;/desc&gt;
+  &lt;doc&gt;the document in which the querytype is specified&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;the name of the key (e.g., "action")&lt;/name&gt;
+      &lt;desc&gt;a natural-language description of the key&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;the name of a value (e.g., "subscribe")&lt;/name&gt;
+          &lt;desc&gt;a natural-language description of the value&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+      <p class="" style="">Note: Within the &lt;querytype/&gt; element, the &lt;keys/&gt; child element is OPTIONAL; within any given &lt;key/&gt; element, the &lt;values/&gt; child element is also OPTIONAL.</p>
+      <p class="" style="">The registrant may register more than one querytype at a time, each contained in a separate &lt;querytype/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-querytype-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+&lt;querytype&gt;
+  &lt;name&gt;disco&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/disco&lt;/proto&gt;
+  &lt;desc&gt;enables interaction for the purpose of service discovery&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the (optional) service discovery node&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;request&lt;/name&gt;
+      &lt;desc&gt;the service discovery request type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;info&lt;/name&gt;
+          &lt;desc&gt;a service discovery information (disco#info) request&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;items&lt;/name&gt;
+          &lt;desc&gt;a service discovery items (disco#items) request&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the IQ type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;get&lt;/name&gt;
+          &lt;desc&gt;an IQ get&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;set&lt;/name&gt;
+          &lt;desc&gt;an IQ set (disco publish)&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;invite&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables simultaneously joining a groupchat room and inviting others&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;join&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables joining a groupchat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;message&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending of an XMPP message stanza&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;subject&lt;/name&gt;
+      &lt;desc&gt;a subject for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;body&lt;/name&gt;
+      &lt;desc&gt;a body for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;thread&lt;/name&gt;
+      &lt;desc&gt;a Thread ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;from&lt;/name&gt;
+      &lt;desc&gt;a from address for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;id&lt;/name&gt;
+      &lt;desc&gt;an ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the message type per the "jabber:client" schema&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;chat&lt;/name&gt;
+          &lt;desc&gt;a message of type "chat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;groupchat&lt;/name&gt;
+          &lt;desc&gt;a message of type "groupchat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;headline&lt;/name&gt;
+          &lt;desc&gt;a message of type "headline"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;normal&lt;/name&gt;
+          &lt;desc&gt;a message of type "normal"&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;probe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables probing for a contact's current presence information&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the pubsub node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;register&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:register&lt;/proto&gt;
+  &lt;desc&gt;enables registering with a server or service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;roster&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables adding or editing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;subscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending a presence subscription request&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250569">1</a>. An Internationalized Resource Identifier (IRI) Scheme for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-00.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-00.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2250555">2</a>. On the difference between IRIs and URIs, see <span style="font-weight: bold">RFC 3987</span>.</p>
+<p><a name="nt-id2250552">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251203">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2251428">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2251235">6</a>. RFC 3987: Internationalized Resource Identifiers (IRIs) &lt;<a href="http://www.ietf.org/rfc/rfc3987.txt">http://www.ietf.org/rfc/rfc3987.txt</a>&gt;.</p>
+<p><a name="nt-id2251304">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2251333">8</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2251356">9</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251379">10</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2255613">11</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2255654">12</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256282">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2005-06-06)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-iri-00. (psa)
+    </div>
+<h4>Version 0.3 (2005-02-28)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-uri-08 and subsequent XMPP WG discussion; removed use cases for editing roster items, removing roster items, leaving chatrooms, unsubscribing, and unregistering (these make more sense from within a dedicated client); added use case for simultaneously joining a room and inviting other participants; further specified security considerations. (psa)
+    </div>
+<h4>Version 0.2 (2004-11-17)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-uri-07; specified Service Discovery usage. (psa)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0147-0.6.html
+++ b/content/xep-0147-0.6.html
@@ -1,0 +1,693 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0147: XMPP URI Scheme Query Components</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP URI Scheme Query Components">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0147">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0147: XMPP URI Scheme Query Components</h1>
+<p>This JEP defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0147<br>
+            Version: 0.6<br>
+            Last Updated: 2005-12-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, draft-saintandre-xmpp-iri-03, JEP-0053<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/XMPP%20URI%20Scheme%20Query%20Components%20(JEP-0147)">http://wiki.jabber.org/index.php/XMPP URI Scheme Query Components (JEP-0147)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#actions">Query Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#actions-message">Message Action</a>
+</dt>
+<dt>3.2.  <a href="#actions-roster">Roster Management Actions</a>
+</dt>
+<dt>3.3.  <a href="#actions-subscribe">Subscription Management Actions</a>
+</dt>
+<dt>3.4.  <a href="#actions-probe">Presence Probe Action</a>
+</dt>
+<dt>3.5.  <a href="#actions-groupchat">Groupchat Actions</a>
+</dt>
+<dt>3.6.  <a href="#actions-ft">File Transfer Actions</a>
+</dt>
+<dt>3.7.  <a href="#actions-register">Registration Actions</a>
+</dt>
+<dt>3.8.  <a href="#actions-pubsub">Publish-Subscribe Actions</a>
+</dt>
+<dt>3.9.  <a href="#actions-disco">Service Discovery Actions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-querytype">XMPP IRI/URI Querytype Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-querytype-process">Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-querytype-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP URI Scheme</span>  [<a href="#nt-id2251597">1</a>] defines a Uniform Resource Identifier (URI) scheme for use in forming URIs and Internationalized Resource Identifiers (IRIs)  [<a href="#nt-id2251583">2</a>] from the addresses of entities that can communicate using XMPP (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250904">3</a>]). Such identifiers enable identification of and interaction with XMPP entities by non-native applications such as databases and web browsers. However, that document intentionally leaves the potential values of the query component open-ended, does not provide a list of common "actions" for queries (e.g., send message or join chatroom), and does not specify recommended "key-value" pairs to be used in the context of such actions. This JEP calls for a registry of such actions and key-value pairs (to be maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250640">4</a>]) and specifies a set of initial values for that registry.</p>
+  <p class="" style="">Note: The format of the XMPP URI scheme, including the format of the query component, is fully specified  and formally defined in <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>; this JEP does not modify the xmpp URI scheme in any way and assumes that the reader is familiar with all aspects of that specification.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This document inherits terminology from <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2250735">5</a>], <span class="ref" style="">RFC 3987</span>  [<a href="#nt-id2250681">6</a>], and <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>.</p>
+<h2>3.
+       <a name="actions">Query Actions</a>
+</h2>
+  <p class="" style="">The range of actions that might be triggered by interaction with an XMPP entity by means of an XMPP IRI/URI is potentially as wide as the range of extensions to XMPP. This JEP does not seek to exhaustively defined all such potential actions. However, the following actions might be of general interest, and therefore are described below:</p>
+  <ol start="" type=""> 
+    <li>Sending a message.</li>
+    <li>Adding or removing a roster item.</li>
+    <li>Subscribing to an entity's presence information.</li>
+    <li>Probing for current presence information.</li>
+    <li>Joining a groupchat room (see <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250789">7</a>]).</li>
+    <li>Initiating a file transfer with another entity (see <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2250818">8</a>]).</li>
+    <li>Registering with another entity via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2250840">9</a>].</li>
+    <li>Subscribing to or unsubscribing from a <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250864">10</a>] node.</li>
+    <li>Determining <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250886">11</a>] information about an entity.</li>
+  </ol> 
+  <p class="" style="">For each such action, this JEP specifies a recommended "querytype" (this can be thought of as an action name or "verb"; see <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span> for syntax and semantics) as well as a list of keys to be used in key-value pairs if appropriate.</p>
+  <div class="indent">
+<h3>3.1 <a name="actions-message">Message Action</a>
+</h3>
+    <p class="" style="">It may desirable for an XMPP IRI/URI to trigger a specialized interface for sending an XMPP message stanza. The RECOMMENDED querytype for this action is "message". If no key-value pair is provided, interacting with an XMPP IRI/URI that contains a querytype of "message" SHOULD trigger an interface that enables the user to input the text of an XMPP message and other relevant parameters (e.g., a message subject or <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2256840">12</a>] markup).</p>
+    <p class="caption">Example 1. Basic Message Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message
+    </pre></div>
+    <p class="" style="">A query component whose querytype is "message" MAY specify various key-value pairs. The following three keys are associated with the child elements of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2256881">13</a>]:</p>
+    <ol start="" type="">
+      <li>subject</li>
+      <li>body</li>
+      <li>thread</li>
+    </ol>
+    <p class="" style="">In addition, the following three keys are associated with the attributes of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace (the 'to' attribute is unnecessary, since it is provided by the XMPP address included in the IRI/URI):</p>
+    <ol start="" type="">
+      <li>from</li>
+      <li>id</li>
+      <li>type</li>
+    </ol>
+    <p class="" style="">Other keys MAY be registered with the Jabber Registrar but are not specified herein.</p>
+    <p class="caption">Example 2. Message Action with Keys: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message;subject=Test%20Message;body=Here%27s%20a%20test%20message
+    </pre></div>
+    <p class="caption">Example 3. Message Action with Keys: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net'&gt;
+  &lt;subject&gt;Test Message&lt;/subject&gt;
+  &lt;body&gt;Here&amp;apos;s a test message.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-roster">Roster Management Actions</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:roster' namespace provides a mechanism for managing an XMPP roster (also called a "contact list"). This namespace is defined in <span style="font-weight: bold">RFC 3921</span>. The registered querytype for adding items to the roster or editing items in the roster is "roster" (effectively there is no difference between adding and editing). An XMPP IRI/URI containing a "roster" querytype MAY also include at most one "name" key whose value maps to the 'name' attribute of the &lt;item/&gt; element within the 'jabber:iq:roster' namespace, and MAY contain one "group" key whose value maps to the character data of the &lt;group/&gt; child element of &lt;item/&gt;.</p>
+    <p class="caption">Example 4. Roster Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster
+    </pre></div>
+    <p class="caption">Example 5. Roster Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Roster Action With Name: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague
+    </pre></div>
+    <p class="caption">Example 7. Roster Action With Name: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo Montague'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Roster Action With Name and Group: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague;group=Friends
+    </pre></div>
+    <p class="caption">Example 9. Roster Action With Name and Group: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo Montague'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Methods (if any) for including more than one group are yet to be determined. Furthermore, roster item removal is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="actions-subscribe">Subscription Management Actions</a>
+</h3>
+    <p class="" style="">Closely coupled with roster management is presence subscription management. In XMPP, subscription management is handled via special values of the &lt;presence/&gt; stanza, as described in <span style="font-weight: bold">RFC 3921</span>. When an entity subscribes to another entity's presence by means of an XMPP IRI/URI, the invoked XMPP application SHOULD first send a roster add stanza as shown below (this is consistent with the recommendations in <span style="font-weight: bold">RFC 3921</span>).</p>
+    <p class="caption">Example 10. Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?subscribe
+    </pre></div>
+    <p class="caption">Example 11. Subscribe Action: Resulting Stanzas</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;presence to='romeo@montague.net' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Note: Unsubscribing is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-probe">Presence Probe Action</a>
+</h3>
+    <p class="" style="">Once an entity is subscribed to the presence of a contact, it is allowed to probe for the contact's current presence if necessary. Although normally this is done by the server on the user's behalf, the client may initiate a probe as well. The registered querytype for initiating a presence probe is "probe".</p>
+    <p class="" style="">An example of the action and resulting protocol is shown below.</p>
+    <p class="caption">Example 12. Probe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?probe
+    </pre></div>
+    <p class="caption">Example 13. Probe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='probe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="actions-groupchat">Groupchat Actions</a>
+</h3>
+    <p class="" style="">The Jabber/XMPP network has long included groupchat rooms (similar to IRC channels); this functionality is defined fully in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>. Two querytype values are registered to enable interaction with groupchat rooms: "join" and "invite".</p>
+    <p class="caption">Example 14. Join Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join
+    </pre></div>
+    <p class="" style="">The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences.</p> 
+    <p class="caption">Example 15. Join Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The application SHOULD populate the room nickname based on the value provided when joining.</p>
+    <p class="" style="">It may be desirable to simultaneously join a room and invite one or more specified other individuals to join the room. The "invite" querytype is used to complete such an action.</p>
+    <p class="caption">Example 16. Invite Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?invite;jid=hecate@shakespeare.lit
+    </pre></div>
+    <p class="" style="">If the joining user is not yet in the room, the application MUST send two stanzas: the first to join the room and the second to invite the other individual. If the joining user is in the room already, the application shall send only the invitation stanza.</p>
+    <p class="caption">Example 17. Invite Action: Resulting Stanza(s)</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;message to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="actions-ft">File Transfer Actions</a>
+</h3>
+    <p class="" style="">The Jabber/XMPP protocols include an extension that enables two entities to transfer a file between them, as defined in <span style="font-weight: bold">JEP-0096: File Transfer</span>. The entity that controls an XMPP IRI/URI may enable other entities to send files or receive files, the registered querytypes for which are "sendfile" and "recvfile". Note well that "sendfile" means a second entity will send a file to the XMPP entity that controls the IRI/URI and that "recvfile" means a second entity will receive a file from the XMPP entity that controls the IRI/URI.</p>
+    <p class="" style="">To enable a second entity to send a file, the IRI/URI is of the following form:</p>
+    <p class="caption">Example 18. Sending a File: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net/orchard?sendfile
+    </pre></div>
+    <p class="" style="">The application SHOULD then present an interface enabling the user to provide information about the file to be sent (e.g., by "browsing" the file system of the user's computer in order to choose a file). As a result, the application SHOULD then send a <span class="ref" style="">Publishing SI Requests</span>  [<a href="#nt-id2257313">14</a>] message to the XMPP address encapsulated in the IRI/URI:</p>
+    <p class="caption">Example 19. Sending a File: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony' to='romeo@montague.net'&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+      id='publish-0123'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='missive.txt'
+          size='1024'
+          date='2005-11-29T11:21Z'/&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">To enable a second entity to receive a file, the IRI/URI is of the following form:</p>
+    <p class="caption">Example 20. Receiving a File: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net/orchard?recvfile;sid=pub234;mime-type=text%2Fplain&amp;name=reply.txt&amp;size=2048
+    </pre></div>
+    <p class="" style="">That IRI/URI is equivalent to the following XML stanza:</p>
+    <p class="caption">Example 21. Receiving a File: Equivalent Stanza</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net' to='juliet@capulet.com/balcony'&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+      id='pub234'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='reply.txt'
+          size='2048'/&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In accordance with <span style="font-weight: bold">JEP-0137</span>, the application SHOULD then initiate a file transfer exchange with by sending a stanza of the following form:</p>
+    <p class="caption">Example 22. Receiving a File: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard'&gt;
+  &lt;start xmlns='http://jabber.org/protocol/si-pub' id='pub234'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note well that the request to begin the stream is send to the full JID (user@host/resource) of the XMPP entity identified by the XMPP IRI/URI. Therefore, the IRI/URI SHOULD include a full JID. If it does not, the receiver MUST discover a full JID via presence or service discovery. If the receiver cannot discover a full JID for the sender (e.g., in the last resort through sending a presence subscription request to the sender and receiving presence from the sender's resources), then it SHOULD abort the file transfer exchange.</p>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="actions-register">Registration Actions</a>
+</h3>
+    <p class="" style="">Sometimes it is desirable or necessary to register with an entity (e.g., a groupchat room or a gateway to a non-Jabber IM system) before interacting with it further; the protocol for doing so is defined in <span style="font-weight: bold">JEP-0077: In-Band Registration</span>. The registered querytype value for registration management is "register".</p>
+    <p class="caption">Example 23. Register Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:marlowe.shakespeare.lit?register
+    </pre></div>
+    <p class="" style="">Because registration is a two-step process (see <span style="font-weight: bold">JEP-0077</span>), the application MUST then send an IQ-get to the entity in order to retrieve the required registration fields:</p>
+    <p class="caption">Example 24. Retrieving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 25. Receiving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq from='marlowe.shakespeare.lit' type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The application MUST then present an appropriate interface that enables the user to complete the registration form. Once the user provides the information, the application MUST send an IQ-set to the entity.</p>
+    <p class="caption">Example 26. Sending Registration Information</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Cancelling an existing registration is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.8 <a name="actions-pubsub">Publish-Subscribe Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> defines a generic protocol for subscribing and publishing to "feeds" or "channels" of information. The "pubsub" querytype is defined herein for interaction with pubsub services, with two keys: (1) "node" (to specify pubsub nodes) and (2) "action", whose defined values are "subscribe", "unsubscribe", and "publish".</p>
+    <p class="caption">Example 27. Pubsub Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=subscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 28. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 29. Pubsub Unsubscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=unsubscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 30. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.9 <a name="actions-disco">Service Discovery Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0030: Service Discovery</span> defines a protocol for discovering information about Jabber entities as well as the items associated with such entities. The "disco" querytype is defined herein for interaction for the purpose of service discovery, with three keys: (1) an OPTIONAL "node" (to specify service discovery nodes), (2) "request", whose defined values are "info" and "items" (corresponding to the disco#info and disco#items namespaces specified in <span style="font-weight: bold">JEP-0030</span>), and (3) "type", whose defined values are "get" and "set" (corresponding to the IQ "get" and "set" methods specified in <span style="font-weight: bold">RFC 3920</span>).</p>
+    <p class="caption">Example 31. Service Discovery Information Request: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=info
+    </pre></div>
+    <p class="caption">Example 32. Service Discovery Information Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 33. Service Discovery Items Request: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=items;node=http://jabber.org/protocol/extended-presence
+    </pre></div>
+    <p class="caption">Example 34. Service Discovery Items Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/extended-presence'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Internationalization considerations for XMPP IRIs/URIs are specified in <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>; the reader is referred to that document for a complete discussion of the relevant issues.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP IRIs/URIs are specified in <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>.</p>
+  <p class="" style="">Furthermore, completion of some of the actions defined herein will cause changes to an entity's account, subscriptions to information, registration with services, communication with other entities, and the like. Naturally, such changes, information, services, and communications are potentially undesirable (e.g., joining a chatroom whose discussion topic is not of interest to, or even patently offensive to, the joining user). The invoked application SHOULD appropriately warn a human user regarding the consequences of the action about to be completed.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257854">15</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-querytype">XMPP IRI/URI Querytype Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of querytype values.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-querytype-process">Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;the name of the querytype (e.g., "pubsub")&lt;/name&gt;
+  &lt;proto&gt;
+    the namespace of associated protocol output 
+    (e.g., "http://jabber.org/protocol/pubsub")
+  &lt;/proto&gt;
+  &lt;desc&gt;a natural-language description of the querytype&lt;/desc&gt;
+  &lt;doc&gt;the document in which the querytype is specified&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;the name of the key (e.g., "action")&lt;/name&gt;
+      &lt;desc&gt;a natural-language description of the key&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;the name of a value (e.g., "subscribe")&lt;/name&gt;
+          &lt;desc&gt;a natural-language description of the value&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+      <p class="" style="">Note: Within the &lt;querytype/&gt; element, the &lt;keys/&gt; child element is OPTIONAL; within any given &lt;key/&gt; element, the &lt;values/&gt; child element is also OPTIONAL.</p>
+      <p class="" style="">The registrant may register more than one querytype at a time, each contained in a separate &lt;querytype/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-querytype-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+&lt;querytype&gt;
+  &lt;name&gt;disco&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/disco&lt;/proto&gt;
+  &lt;desc&gt;enables interaction for the purpose of service discovery&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the (optional) service discovery node&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;request&lt;/name&gt;
+      &lt;desc&gt;the service discovery request type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;info&lt;/name&gt;
+          &lt;desc&gt;a service discovery information (disco#info) request&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;items&lt;/name&gt;
+          &lt;desc&gt;a service discovery items (disco#items) request&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the IQ type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;get&lt;/name&gt;
+          &lt;desc&gt;an IQ get&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;set&lt;/name&gt;
+          &lt;desc&gt;an IQ set (disco publish)&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;file&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/si/profile/file-transfer&lt;/proto&gt;
+  &lt;desc&gt;enables initiation of a file transfer&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;invite&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables simultaneously joining a groupchat room and inviting others&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;join&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables joining a groupchat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;message&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending of an XMPP message stanza&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;subject&lt;/name&gt;
+      &lt;desc&gt;a subject for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;body&lt;/name&gt;
+      &lt;desc&gt;a body for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;thread&lt;/name&gt;
+      &lt;desc&gt;a Thread ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;from&lt;/name&gt;
+      &lt;desc&gt;a from address for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;id&lt;/name&gt;
+      &lt;desc&gt;an ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the message type per the "jabber:client" schema&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;chat&lt;/name&gt;
+          &lt;desc&gt;a message of type "chat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;groupchat&lt;/name&gt;
+          &lt;desc&gt;a message of type "groupchat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;headline&lt;/name&gt;
+          &lt;desc&gt;a message of type "headline"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;normal&lt;/name&gt;
+          &lt;desc&gt;a message of type "normal"&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;probe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables probing for a contact's current presence information&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the pubsub node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;register&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:register&lt;/proto&gt;
+  &lt;desc&gt;enables registering with a server or service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;roster&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables adding or editing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;subscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending a presence subscription request&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251597">1</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-03.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-03.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2251583">2</a>. On the difference between IRIs and URIs, see <span style="font-weight: bold">RFC 3987</span>.</p>
+<p><a name="nt-id2250904">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250640">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250735">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2250681">6</a>. RFC 3987: Internationalized Resource Identifiers (IRIs) &lt;<a href="http://www.ietf.org/rfc/rfc3987.txt">http://www.ietf.org/rfc/rfc3987.txt</a>&gt;.</p>
+<p><a name="nt-id2250789">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2250818">8</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2250840">9</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2250864">10</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250886">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256840">12</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2256881">13</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257313">14</a>. JEP-0137: Publishing SI Requests &lt;<a href="http://www.jabber.org/jeps/jep-0137.html">http://www.jabber.org/jeps/jep-0137.html</a>&gt;.</p>
+<p><a name="nt-id2257854">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2005-12-01)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-iri-03; modified file transfer query operations to handle both send and receive use cases. (psa)
+    </div>
+<h4>Version 0.5 (2005-09-05)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-iri-01; added file querytype for file transfer. (psa)
+    </div>
+<h4>Version 0.4 (2005-06-06)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-iri-00. (psa)
+    </div>
+<h4>Version 0.3 (2005-02-28)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-uri-08 and subsequent XMPP WG discussion; removed use cases for editing roster items, removing roster items, leaving chatrooms, unsubscribing, and unregistering (these make more sense from within a dedicated client); added use case for simultaneously joining a room and inviting other participants; further specified security considerations. (psa)
+    </div>
+<h4>Version 0.2 (2004-11-17)</h4>
+<div class="indent">Updated to reflect draft-saintandre-xmpp-uri-07; specified Service Discovery usage. (psa)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0147-0.7.html
+++ b/content/xep-0147-0.7.html
@@ -1,0 +1,809 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0147: XMPP URI Scheme Query Components</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP URI Scheme Query Components">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0147">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0147: XMPP URI Scheme Query Components</h1>
+<p>This document defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0147<br>
+            Version: 0.7<br>
+            Last Updated: 2006-03-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, draft-saintandre-xmpp-iri-03, JEP-0053<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/XMPP%20URI%20Scheme%20Query%20Components%20(JEP-0147)">http://wiki.jabber.org/index.php/XMPP URI Scheme Query Components (JEP-0147)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#actions">Query Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#actions-message">Message Action</a>
+</dt>
+<dt>3.2.  <a href="#actions-roster">Roster Management Actions</a>
+</dt>
+<dt>3.3.  <a href="#actions-subscribe">Subscription Management Actions</a>
+</dt>
+<dt>3.4.  <a href="#actions-probe">Presence Probe Action</a>
+</dt>
+<dt>3.5.  <a href="#actions-groupchat">Groupchat Actions</a>
+</dt>
+<dt>3.6.  <a href="#actions-ft">File Transfer Actions</a>
+</dt>
+<dt>3.7.  <a href="#actions-register">Registration Actions</a>
+</dt>
+<dt>3.8.  <a href="#actions-pubsub">Publish-Subscribe Actions</a>
+</dt>
+<dt>3.9.  <a href="#actions-disco">Service Discovery Actions</a>
+</dt>
+<dt>3.10.  <a href="#actions-vcard">vCard Retrieval Action</a>
+</dt>
+<dt>3.11.  <a href="#actions-commands">Ad-Hoc Command Actions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-querytype">XMPP IRI/URI Querytype Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-querytype-process">Registration Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-querytype-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP URI Scheme</span>  [<a href="#nt-id2250650">1</a>] defines a Uniform Resource Identifier (URI) scheme for use in forming URIs and Internationalized Resource Identifiers (IRIs)  [<a href="#nt-id2250636">2</a>] from the addresses of entities that can communicate using the Extensible Messaging and Presence Protocol (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250686">3</a>]). Such identifiers enable identification of and interaction with XMPP entities by non-native applications such as databases and web browsers.</p>
+  <p class="" style="">However, <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span> intentionally leaves the potential values of the query component open-ended, does not provide a list of common "actions" for queries (e.g., send message or join chatroom), and does not specify recommended "key-value" pairs to be used in the context of such actions. Therefore, this document defines a registry of such actions and key-value pairs (to be maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250905">4</a>]) and specifies a set of initial values for that registry.</p>
+  <p class="" style="">This document is organized as follows:</p>
+  <ul>
+    <li>The registry is defined in the <a href="#registrar-querytype">XMPP IRI/URI Querytype Registry</a> section.</li>
+    <li>An initial set of actions and key-value pairs is described in the <a href="#actions">Query Actions</a> section.</li>
+    <li>A corresponding initial submission to the registry is specified in the <a href="#registrar-querytype-init">Initial Registration</a> section.</li>
+    <li>The process for submitting additional values to the registry is specified in the <a href="#registrar-querytype-process">Registration Process</a> section.</li>
+  </ul>
+  <p class="" style="">Note: The format of the XMPP URI scheme, including the format of the query component, is fully specified  and formally defined in <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>; this document does not modify the xmpp URI scheme in any way and assumes that the reader is familiar with all aspects of <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This document inherits terminology from <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2250824">5</a>], <span class="ref" style="">RFC 3987</span>  [<a href="#nt-id2250850">6</a>], and <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>.</p>
+<h2>3.
+       <a name="actions">Query Actions</a>
+</h2>
+  <p class="" style="">The range of actions that might be triggered by interaction with an XMPP entity by means of an XMPP IRI/URI is potentially as wide as the range of extensions to XMPP. This document does not seek to exhaustively defined all such potential actions. However, the following actions might be of general interest, and therefore are described below and included in the initial submission of values to the registry:</p>
+  <ol start="" type=""> 
+    <li>Sending a message.</li>
+    <li>Adding or removing a roster item.</li>
+    <li>Subscribing to an entity's presence information.</li>
+    <li>Probing for current presence information.</li>
+    <li>Joining a groupchat room (see <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256816">7</a>]).</li>
+    <li>Initiating a file transfer with another entity (see <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2256838">8</a>]).</li>
+    <li>Registering with another entity via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256861">9</a>].</li>
+    <li>Subscribing to or unsubscribing from a <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2256885">10</a>] node.</li>
+    <li>Determining <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256914">11</a>] information about an entity.</li>
+    <li>Retrieving the <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2256937">12</a>] data associated with an entity.</li>
+    <li>Requesting initiation of <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2256960">13</a>] associated with an entity.</li>
+  </ol> 
+  <p class="" style="">For each such action, this document specifies a RECOMMENDED "querytype" (this can be thought of as an action name or "verb"; see <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span> for syntax and semantics) as well as an OPTIONAL list of keys to be used in key-value pairs if appropriate.</p>
+  <div class="indent">
+<h3>3.1 <a name="actions-message">Message Action</a>
+</h3>
+    <p class="" style="">It may desirable for an XMPP IRI/URI to trigger a specialized interface for sending an XMPP message stanza. The RECOMMENDED querytype for this action is "message". If no key-value pair is provided, interacting with an XMPP IRI/URI that contains a querytype of "message" SHOULD trigger an interface that enables the user to input the text of an XMPP message and other relevant parameters (e.g., a message subject or <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2257016">14</a>] markup).</p>
+    <p class="caption">Example 1. Basic Message Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message
+    </pre></div>
+    <p class="" style="">A query component whose querytype is "message" MAY specify various key-value pairs. The following three keys are associated with the child elements of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2257058">15</a>]:</p>
+    <ol start="" type="">
+      <li>subject</li>
+      <li>body</li>
+      <li>thread</li>
+    </ol>
+    <p class="" style="">In addition, the following three keys are associated with the attributes of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace (the 'to' attribute is unnecessary, since it is provided by the XMPP address included in the IRI/URI):</p>
+    <ol start="" type="">
+      <li>from</li>
+      <li>id</li>
+      <li>type</li>
+    </ol>
+    <p class="" style="">Other keys MAY be registered with the Jabber Registrar but are not specified herein.</p>
+    <p class="caption">Example 2. Message Action with Keys: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message;subject=Test%20Message;body=Here%27s%20a%20test%20message
+    </pre></div>
+    <p class="caption">Example 3. Message Action with Keys: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net'&gt;
+  &lt;subject&gt;Test Message&lt;/subject&gt;
+  &lt;body&gt;Here&amp;apos;s a test message.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-roster">Roster Management Actions</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:roster' namespace provides a mechanism for managing an XMPP roster (also called a "contact list"). This namespace is defined in <span style="font-weight: bold">RFC 3921</span>. The registered querytype for adding items to the roster or editing items in the roster is "roster" (effectively there is no difference between adding and editing). An XMPP IRI/URI containing a "roster" querytype MAY also include at most one "name" key whose value maps to the 'name' attribute of the &lt;item/&gt; element within the 'jabber:iq:roster' namespace, and MAY contain one "group" key whose value maps to the character data of the &lt;group/&gt; child element of &lt;item/&gt;.</p>
+    <p class="caption">Example 4. Roster Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster
+    </pre></div>
+    <p class="caption">Example 5. Roster Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Roster Action With Name: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague
+    </pre></div>
+    <p class="caption">Example 7. Roster Action With Name: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo Montague'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Roster Action With Name and Group: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague;group=Friends
+    </pre></div>
+    <p class="caption">Example 9. Roster Action With Name and Group: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo Montague'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Methods (if any) for including more than one group are yet to be determined. Furthermore, roster item removal is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="actions-subscribe">Subscription Management Actions</a>
+</h3>
+    <p class="" style="">Closely coupled with roster management is presence subscription management. In XMPP, subscription management is handled via special values of the &lt;presence/&gt; stanza, as described in <span style="font-weight: bold">RFC 3921</span>. When an entity subscribes to another entity's presence by means of an XMPP IRI/URI, the invoked XMPP application SHOULD first send a roster add stanza as shown below (this is consistent with the recommendations in <span style="font-weight: bold">RFC 3921</span>).</p>
+    <p class="caption">Example 10. Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?subscribe
+    </pre></div>
+    <p class="caption">Example 11. Subscribe Action: Resulting Stanzas</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;presence to='romeo@montague.net' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Note: Unsubscribing is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-probe">Presence Probe Action</a>
+</h3>
+    <p class="" style="">Once an entity is subscribed to the presence of a contact, it is allowed to probe for the contact's current presence if necessary. Although normally this is done by the server on the user's behalf, the client may initiate a probe as well. The registered querytype for initiating a presence probe is "probe".</p>
+    <p class="" style="">An example of the action and resulting protocol is shown below.</p>
+    <p class="caption">Example 12. Probe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?probe
+    </pre></div>
+    <p class="caption">Example 13. Probe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='probe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="actions-groupchat">Groupchat Actions</a>
+</h3>
+    <p class="" style="">The Jabber/XMPP network has long included groupchat rooms (similar to IRC channels); this functionality is defined fully in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>. Two querytype values are registered to enable interaction with groupchat rooms: "join" and "invite".</p>
+    <p class="caption">Example 14. Join Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join
+    </pre></div>
+    <p class="" style="">The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences.</p> 
+    <p class="caption">Example 15. Join Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The application SHOULD populate the room nickname based on the value provided when joining.</p>
+    <p class="" style="">It may be desirable to simultaneously join a room and invite one or more specified other individuals to join the room. The "invite" querytype is used to complete such an action.</p>
+    <p class="caption">Example 16. Invite Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?invite;jid=hecate@shakespeare.lit
+    </pre></div>
+    <p class="" style="">If the joining user is not yet in the room, the application MUST send two stanzas: the first to join the room and the second to invite the other individual. If the joining user is in the room already, the application shall send only the invitation stanza.</p>
+    <p class="caption">Example 17. Invite Action: Resulting Stanza(s)</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;message to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="actions-ft">File Transfer Actions</a>
+</h3>
+    <p class="" style="">The Jabber/XMPP protocols include an extension that enables two entities to transfer a file between them, as defined in <span style="font-weight: bold">JEP-0096: File Transfer</span>. The entity that controls an XMPP IRI/URI may enable other entities to send files or receive files, the registered querytypes for which are "sendfile" and "recvfile". Note well that "sendfile" means a second entity will send a file to the XMPP entity that controls the IRI/URI and that "recvfile" means a second entity will receive a file from the XMPP entity that controls the IRI/URI.</p>
+    <p class="" style="">To enable a second entity to send a file, the IRI/URI is of the following form:</p>
+    <p class="caption">Example 18. Sending a File: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net/orchard?sendfile
+    </pre></div>
+    <p class="" style="">The application SHOULD then present an interface enabling the user to provide information about the file to be sent (e.g., by "browsing" the file system of the user's computer in order to choose a file). As a result, the application SHOULD then send a <span class="ref" style="">Publishing SI Requests</span>  [<a href="#nt-id2257490">16</a>] message to the XMPP address encapsulated in the IRI/URI:</p>
+    <p class="caption">Example 19. Sending a File: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony' to='romeo@montague.net'&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+      id='publish-0123'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='missive.txt'
+          size='1024'
+          date='2005-11-29T11:21Z'/&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">To enable a second entity to receive a file, the IRI/URI is of the following form:</p>
+    <p class="caption">Example 20. Receiving a File: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net/orchard?recvfile;sid=pub234;mime-type=text%2Fplain&amp;name=reply.txt&amp;size=2048
+    </pre></div>
+    <p class="" style="">That IRI/URI is equivalent to the following XML stanza:</p>
+    <p class="caption">Example 21. Receiving a File: Equivalent Stanza</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net' to='juliet@capulet.com/balcony'&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+      id='pub234'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='reply.txt'
+          size='2048'/&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In accordance with <span style="font-weight: bold">JEP-0137</span>, the application SHOULD then initiate a file transfer exchange with by sending a stanza of the following form:</p>
+    <p class="caption">Example 22. Receiving a File: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard'&gt;
+  &lt;start xmlns='http://jabber.org/protocol/si-pub' id='pub234'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note well that the request to begin the stream is send to the full JID (user@host/resource) of the XMPP entity identified by the XMPP IRI/URI. Therefore, the IRI/URI SHOULD include a full JID. If it does not, the receiver MUST discover a full JID via presence or service discovery. If the receiver cannot discover a full JID for the sender (e.g., in the last resort through sending a presence subscription request to the sender and receiving presence from the sender's resources), then it SHOULD abort the file transfer exchange.</p>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="actions-register">Registration Actions</a>
+</h3>
+    <p class="" style="">Sometimes it is desirable or necessary to register with an entity (e.g., a groupchat room or a gateway to a non-Jabber IM system) before interacting with it further; the protocol for doing so is defined in <span style="font-weight: bold">JEP-0077: In-Band Registration</span>. The registered querytype value for registration management is "register".</p>
+    <p class="caption">Example 23. Register Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:marlowe.shakespeare.lit?register
+    </pre></div>
+    <p class="" style="">Because registration is a two-step process (see <span style="font-weight: bold">JEP-0077</span>), the application MUST then send an IQ-get to the entity in order to retrieve the required registration fields:</p>
+    <p class="caption">Example 24. Retrieving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 25. Receiving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq from='marlowe.shakespeare.lit' type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The application MUST then present an appropriate interface that enables the user to complete the registration form. Once the user provides the information, the application MUST send an IQ-set to the entity.</p>
+    <p class="caption">Example 26. Sending Registration Information</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Cancelling an existing registration is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.8 <a name="actions-pubsub">Publish-Subscribe Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> defines a generic protocol for subscribing and publishing to "feeds" or "channels" of information. The "pubsub" querytype is defined herein for interaction with pubsub services, with two keys: (1) "node" (to specify pubsub nodes) and (2) "action", whose defined values are "subscribe", "unsubscribe", and "publish".</p>
+    <p class="caption">Example 27. Pubsub Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=subscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 28. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 29. Pubsub Unsubscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=unsubscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 30. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.9 <a name="actions-disco">Service Discovery Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0030: Service Discovery</span> defines a protocol for discovering information about Jabber entities as well as the items associated with such entities. The "disco" querytype is defined herein for interaction for the purpose of service discovery, with three keys: (1) an OPTIONAL "node" (to specify service discovery nodes), (2) "request", whose defined values are "info" and "items" (corresponding to the disco#info and disco#items namespaces specified in <span style="font-weight: bold">JEP-0030</span>), and (3) "type", whose defined values are "get" and "set" (corresponding to the IQ "get" and "set" methods specified in <span style="font-weight: bold">RFC 3920</span>).</p>
+    <p class="caption">Example 31. Service Discovery Information Request: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=info
+    </pre></div>
+    <p class="caption">Example 32. Service Discovery Information Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 33. Service Discovery Items Request: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=items;node=http://jabber.org/protocol/extended-presence
+    </pre></div>
+    <p class="caption">Example 34. Service Discovery Items Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/extended-presence'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.10 <a name="actions-vcard">vCard Retrieval Action</a>
+</h3>
+    <p class="" style="">Many Jabber/XMPP systems have long included support for user (and even server) vCards, as specified in <span style="font-weight: bold">JEP-0054</span>. Although this functionality may be superseded by a more flexible and extensible protocol in the future, it remains valuable to be able to retrieve vCard data associated with an XMPP entity. The "vcard" querytype is defined for this purpose.</p>
+    <p class="caption">Example 35. vCard Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?vcard
+    </pre></div>
+    <p class="caption">Example 36. vCard Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;vCard xmlns='vcard-temp'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.11 <a name="actions-commands">Ad-Hoc Command Actions</a>
+</h3>
+    <p class="" style="">The ad-hoc commands protocol specified in <span style="font-weight: bold">JEP-0050</span> enables one entity to interact with another entity to complete application-specific functions such as configuration or statistics retrieval. The "command" querytype is defined for this purpose.</p>
+    <p class="caption">Example 37. Command Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:montague.net?command;node=stats
+    </pre></div>
+    <p class="caption">Example 38. Command Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='montague.net' type='get'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' node='stats'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Internationalization considerations for XMPP IRIs/URIs are specified in <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>; the reader is referred to that document for a complete discussion of the relevant issues.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP IRIs/URIs are specified in <span style="font-weight: bold">draft-saintandre-xmpp-iri-03</span>.</p>
+  <p class="" style="">Completion of some of the actions defined herein will cause changes to an entity's account, subscriptions to information, registration with services, communication with other entities, completion of ad-hoc commands, and the like. Naturally, such changes, information, services, and communications are potentially undesirable (e.g., joining a chatroom whose discussion topic is not of interest to, or even patently offensive to, the joining user). The invoked application SHOULD appropriately warn a human user regarding the potential consequences of the action about to be completed.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250400">17</a>]. If in the future the IANA should wish to maintain a registry of XMPP URI/IRI query components, the Jabber Registrar will cooperate with efforts to migrate the registry from the Jabber Registrar to the IANA.</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-querytype">XMPP IRI/URI Querytype Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of querytype values.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-querytype-process">Registration Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;the name of the querytype (e.g., "pubsub")&lt;/name&gt;
+  &lt;proto&gt;
+    the namespace of associated protocol output 
+    (e.g., "http://jabber.org/protocol/pubsub")
+  &lt;/proto&gt;
+  &lt;desc&gt;a natural-language description of the querytype&lt;/desc&gt;
+  &lt;doc&gt;the document in which the querytype is specified&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;the name of the key (e.g., "action")&lt;/name&gt;
+      &lt;desc&gt;a natural-language description of the key&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;the name of a value (e.g., "subscribe")&lt;/name&gt;
+          &lt;desc&gt;a natural-language description of the value&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+      <p class="" style="">Note: Within the &lt;querytype/&gt; element, the &lt;keys/&gt; child element is OPTIONAL; within any given &lt;key/&gt; element, the &lt;values/&gt; child element is also OPTIONAL.</p>
+      <p class="" style="">The registrant may register more than one querytype at a time, each contained in a separate &lt;querytype/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-querytype-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+&lt;querytype&gt;
+  &lt;name&gt;command&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/commands&lt;/proto&gt;
+  &lt;desc&gt;enables completion of ad-hoc commands&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the command node&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the ad-commands action type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;cancel&lt;/name&gt;
+          &lt;desc&gt;a request to cancel processing of the command&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;complete&lt;/name&gt;
+          &lt;desc&gt;a request to complete processing of the command&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;execute&lt;/name&gt;
+          &lt;desc&gt;a request to execute the command (the default implied action)&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;next&lt;/name&gt;
+          &lt;desc&gt;a request to move to the next command in a series&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;complete&lt;/name&gt;
+          &lt;desc&gt;a request to move to the previous command in a series&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the IQ type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;get&lt;/name&gt;
+          &lt;desc&gt;an IQ get&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;set&lt;/name&gt;
+          &lt;desc&gt;an IQ set (disco publish)&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;disco&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/disco&lt;/proto&gt;
+  &lt;desc&gt;enables interaction for the purpose of service discovery&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the (optional) service discovery node&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;request&lt;/name&gt;
+      &lt;desc&gt;the service discovery request type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;info&lt;/name&gt;
+          &lt;desc&gt;a service discovery information (disco#info) request&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;items&lt;/name&gt;
+          &lt;desc&gt;a service discovery items (disco#items) request&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the IQ type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;get&lt;/name&gt;
+          &lt;desc&gt;an IQ get&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;set&lt;/name&gt;
+          &lt;desc&gt;an IQ set (disco publish)&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;file&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/si/profile/file-transfer&lt;/proto&gt;
+  &lt;desc&gt;enables initiation of a file transfer&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;invite&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables simultaneously joining a groupchat room and inviting others&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;join&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables joining a groupchat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;message&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending of an XMPP message stanza&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;subject&lt;/name&gt;
+      &lt;desc&gt;a subject for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;body&lt;/name&gt;
+      &lt;desc&gt;a body for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;thread&lt;/name&gt;
+      &lt;desc&gt;a Thread ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;from&lt;/name&gt;
+      &lt;desc&gt;a from address for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;id&lt;/name&gt;
+      &lt;desc&gt;an ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the message type per the "jabber:client" schema&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;chat&lt;/name&gt;
+          &lt;desc&gt;a message of type "chat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;groupchat&lt;/name&gt;
+          &lt;desc&gt;a message of type "groupchat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;headline&lt;/name&gt;
+          &lt;desc&gt;a message of type "headline"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;normal&lt;/name&gt;
+          &lt;desc&gt;a message of type "normal"&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;probe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables probing for a contact's current presence information&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the pubsub node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;register&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:register&lt;/proto&gt;
+  &lt;desc&gt;enables registering with a server or service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;roster&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables adding or editing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;subscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending a presence subscription request&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;vcard&lt;/name&gt;
+  &lt;proto&gt;vcard-temp&lt;/proto&gt;
+  &lt;desc&gt;enables retrieval of an entity's vCard data&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250650">1</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-03.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-03.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2250636">2</a>. On the difference between IRIs and URIs, see <span style="font-weight: bold">RFC 3987</span>.</p>
+<p><a name="nt-id2250686">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250905">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250824">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2250850">6</a>. RFC 3987: Internationalized Resource Identifiers (IRIs) &lt;<a href="http://www.ietf.org/rfc/rfc3987.txt">http://www.ietf.org/rfc/rfc3987.txt</a>&gt;.</p>
+<p><a name="nt-id2256816">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256838">8</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2256861">9</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2256885">10</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256914">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256937">12</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2256960">13</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2257016">14</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2257058">15</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257490">16</a>. JEP-0137: Publishing SI Requests &lt;<a href="http://www.jabber.org/jeps/jep-0137.html">http://www.jabber.org/jeps/jep-0137.html</a>&gt;.</p>
+<p><a name="nt-id2250400">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Added actions for ad-hoc commands and vCard retrieval; clarified some explanatory text.</p> (psa)
+    </div>
+<h4>Version 0.6 (2005-12-01)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-iri-03; modified file transfer query operations to handle both send and receive use cases.</p> (psa)
+    </div>
+<h4>Version 0.5 (2005-09-05)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-iri-01; added file querytype for file transfer.</p> (psa)
+    </div>
+<h4>Version 0.4 (2005-06-06)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-iri-00.</p> (psa)
+    </div>
+<h4>Version 0.3 (2005-02-28)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-uri-08 and subsequent XMPP WG discussion; removed use cases for editing roster items, removing roster items, leaving chatrooms, unsubscribing, and unregistering (these make more sense from within a dedicated client); added use case for simultaneously joining a room and inviting other participants; further specified security considerations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2004-11-17)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-uri-07; specified Service Discovery usage.</p> (psa)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0147-1.0.html
+++ b/content/xep-0147-1.0.html
@@ -1,0 +1,824 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0147: XMPP URI Scheme Query Components</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP URI Scheme Query Components">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-23">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0147">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0147: XMPP URI Scheme Query Components</h1>
+<p>This document defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Informational JEP defines a best practice or protocol profile that has been approved by the Jabber Council and/or the JSF Board of Directors. Implementations are encouraged and the best practice or protocol profile is appropriate for deployment in production systems.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Active<br>
+            Type: Informational<br>
+            Number: 0147<br>
+            Version: 1.0<br>
+            Last Updated: 2006-03-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, draft-saintandre-xmpp-iri, JEP-0053<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: querytypes<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/querytypes.html">http://www.jabber.org/registrar/querytypes.html</a>&gt;
+              <br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/XMPP%20URI%20Scheme%20Query%20Components%20(JEP-0147)">http://wiki.jabber.org/index.php/XMPP URI Scheme Query Components (JEP-0147)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#actions">Query Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#actions-message">Message Action</a>
+</dt>
+<dt>3.2.  <a href="#actions-roster">Roster Management Actions</a>
+</dt>
+<dt>3.3.  <a href="#actions-subscribe">Subscription Management Actions</a>
+</dt>
+<dt>3.4.  <a href="#actions-probe">Presence Probe Action</a>
+</dt>
+<dt>3.5.  <a href="#actions-groupchat">Groupchat Actions</a>
+</dt>
+<dt>3.6.  <a href="#actions-ft">File Transfer Actions</a>
+</dt>
+<dt>3.7.  <a href="#actions-register">Registration Actions</a>
+</dt>
+<dt>3.8.  <a href="#actions-pubsub">Publish-Subscribe Actions</a>
+</dt>
+<dt>3.9.  <a href="#actions-disco">Service Discovery Actions</a>
+</dt>
+<dt>3.10.  <a href="#actions-vcard">vCard Retrieval Action</a>
+</dt>
+<dt>3.11.  <a href="#actions-commands">Ad-Hoc Command Actions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-querytype">XMPP IRI/URI Querytype Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-querytype-process">Registration Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-querytype-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP URI Scheme</span>  [<a href="#nt-id2250732">1</a>] defines a Uniform Resource Identifier (URI) scheme for use in forming URIs and Internationalized Resource Identifiers (IRIs)  [<a href="#nt-id2250719">2</a>] from the addresses of entities that can communicate using the Extensible Messaging and Presence Protocol (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250913">3</a>]). Such identifiers enable identification of and interaction with XMPP entities by non-native applications such as databases and web browsers.</p>
+  <p class="" style="">However, <span style="font-weight: bold">draft-saintandre-xmpp-iri</span> intentionally leaves the potential values of the query component open-ended, does not provide a list of common "actions" for queries (e.g., send message or join chatroom), and does not specify recommended "key-value" pairs to be used in the context of such actions. Therefore, this document defines a registry of such actions and key-value pairs (to be maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250952">4</a>]) and specifies a set of initial values for that registry.</p>
+  <p class="" style="">This document is organized as follows:</p>
+  <ul>
+    <li>The registry is defined in the <a href="#registrar-querytype">XMPP IRI/URI Querytype Registry</a> section.</li>
+    <li>An initial set of actions and key-value pairs is described in the <a href="#actions">Query Actions</a> section.</li>
+    <li>A corresponding initial submission to the registry is specified in the <a href="#registrar-querytype-init">Initial Registration</a> section.</li>
+    <li>The process for submitting additional values to the registry is specified in the <a href="#registrar-querytype-process">Registration Process</a> section.</li>
+  </ul>
+  <p class="" style="">Note: The format of the XMPP URI scheme, including the format of the query component, is fully specified  and formally defined in <span style="font-weight: bold">draft-saintandre-xmpp-iri</span>; this document does not modify the xmpp URI scheme in any way and assumes that the reader is familiar with all aspects of <span style="font-weight: bold">draft-saintandre-xmpp-iri</span>.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This document inherits terminology from <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2250888">5</a>], <span class="ref" style="">RFC 3987</span>  [<a href="#nt-id2250859">6</a>], and <span style="font-weight: bold">draft-saintandre-xmpp-iri</span>.</p>
+<h2>3.
+       <a name="actions">Query Actions</a>
+</h2>
+  <p class="" style="">The range of actions that might be triggered by interaction with an XMPP entity by means of an XMPP IRI/URI is potentially as wide as the range of extensions to XMPP. This document does not seek to exhaustively defined all such potential actions. However, the following actions might be of general interest, and therefore are described below and included in the initial submission of values to the registry:</p>
+  <ol start="" type=""> 
+    <li>Sending a message.</li>
+    <li>Adding or removing a roster item.</li>
+    <li>Subscribing to an entity's presence information.</li>
+    <li>Probing for current presence information.</li>
+    <li>Joining a groupchat room (see <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257186">7</a>]).</li>
+    <li>Initiating a file transfer with another entity (see <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2257209">8</a>]).</li>
+    <li>Registering with another entity via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2257232">9</a>].</li>
+    <li>Subscribing to or unsubscribing from a <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257256">10</a>] node.</li>
+    <li>Determining <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257284">11</a>] information about an entity.</li>
+    <li>Retrieving the <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257304">12</a>] data associated with an entity.</li>
+    <li>Requesting initiation of <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2257328">13</a>] associated with an entity.</li>
+  </ol> 
+  <p class="" style="">For each such action, this document specifies a RECOMMENDED "querytype" (this can be thought of as an action name or "verb"; see <span style="font-weight: bold">draft-saintandre-xmpp-iri</span> for syntax and semantics) as well as an OPTIONAL list of keys to be used in key-value pairs if appropriate.</p>
+  <div class="indent">
+<h3>3.1 <a name="actions-message">Message Action</a>
+</h3>
+    <p class="" style="">It may desirable for an XMPP IRI/URI to trigger a specialized interface for sending an XMPP message stanza. The RECOMMENDED querytype for this action is "message". If no key-value pair is provided, interacting with an XMPP IRI/URI that contains a querytype of "message" SHOULD trigger an interface that enables the user to input the text of an XMPP message and other relevant parameters (e.g., a message subject or <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2257382">14</a>] markup).</p>
+    <p class="caption">Example 1. Basic Message Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message
+    </pre></div>
+    <p class="" style="">A query component whose querytype is "message" MAY specify various key-value pairs. The following three keys are associated with the child elements of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2257422">15</a>]:</p>
+    <ol start="" type="">
+      <li>subject</li>
+      <li>body</li>
+      <li>thread</li>
+    </ol>
+    <p class="" style="">In addition, the following three keys are associated with the attributes of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace (the 'to' attribute is unnecessary, since it is provided by the XMPP address included in the IRI/URI):</p>
+    <ol start="" type="">
+      <li>from</li>
+      <li>id</li>
+      <li>type</li>
+    </ol>
+    <p class="" style="">Other keys MAY be registered with the Jabber Registrar but are not specified herein.</p>
+    <p class="caption">Example 2. Message Action with Keys: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message;subject=Test%20Message;body=Here%27s%20a%20test%20message
+    </pre></div>
+    <p class="caption">Example 3. Message Action with Keys: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net'&gt;
+  &lt;subject&gt;Test Message&lt;/subject&gt;
+  &lt;body&gt;Here&amp;apos;s a test message.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-roster">Roster Management Actions</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:roster' namespace provides a mechanism for managing an XMPP roster (also called a "contact list"). This namespace is defined in <span style="font-weight: bold">RFC 3921</span>. The registered querytype for adding items to the roster or editing items in the roster is "roster" (effectively there is no difference between adding and editing). An XMPP IRI/URI containing a "roster" querytype MAY also include at most one "name" key whose value maps to the 'name' attribute of the &lt;item/&gt; element within the 'jabber:iq:roster' namespace, and MAY contain one "group" key whose value maps to the character data of the &lt;group/&gt; child element of &lt;item/&gt;.</p>
+    <p class="caption">Example 4. Roster Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster
+    </pre></div>
+    <p class="caption">Example 5. Roster Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Roster Action With Name: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague
+    </pre></div>
+    <p class="caption">Example 7. Roster Action With Name: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo Montague'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Roster Action With Name and Group: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague;group=Friends
+    </pre></div>
+    <p class="caption">Example 9. Roster Action With Name and Group: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo Montague'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Methods (if any) for including more than one group are yet to be determined. Furthermore, roster item removal is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="actions-subscribe">Subscription Management Actions</a>
+</h3>
+    <p class="" style="">Closely coupled with roster management is presence subscription management. In XMPP, subscription management is handled via special values of the &lt;presence/&gt; stanza, as described in <span style="font-weight: bold">RFC 3921</span>. When an entity subscribes to another entity's presence by means of an XMPP IRI/URI, the invoked XMPP application SHOULD first send a roster add stanza as shown below (this is consistent with the recommendations in <span style="font-weight: bold">RFC 3921</span>).</p>
+    <p class="caption">Example 10. Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?subscribe
+    </pre></div>
+    <p class="caption">Example 11. Subscribe Action: Resulting Stanzas</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;presence to='romeo@montague.net' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Note: Unsubscribing is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-probe">Presence Probe Action</a>
+</h3>
+    <p class="" style="">Once an entity is subscribed to the presence of a contact, it is allowed to probe for the contact's current presence if necessary. Although normally this is done by the server on the user's behalf, the client may initiate a probe as well. The registered querytype for initiating a presence probe is "probe".</p>
+    <p class="" style="">An example of the action and resulting protocol is shown below.</p>
+    <p class="caption">Example 12. Probe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?probe
+    </pre></div>
+    <p class="caption">Example 13. Probe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='probe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="actions-groupchat">Groupchat Actions</a>
+</h3>
+    <p class="" style="">The Jabber/XMPP network has long included groupchat rooms (similar to IRC channels); this functionality is defined fully in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>. Two querytype values are registered to enable interaction with groupchat rooms: "join" and "invite".</p>
+    <p class="caption">Example 14. Join Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?join
+    </pre></div>
+    <p class="" style="">The application MUST either present an interface enabling the user to provide a room nickname or populate the room nickname based on configured preferences.</p> 
+    <p class="caption">Example 15. Join Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The application SHOULD populate the room nickname based on the value provided when joining.</p>
+    <p class="" style="">It may be desirable to simultaneously join a room and invite one or more specified other individuals to join the room. The "invite" querytype is used to complete such an action.</p>
+    <p class="caption">Example 16. Invite Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:darkcave@macbeth.shakespeare.lit?invite;jid=hecate@shakespeare.lit
+    </pre></div>
+    <p class="" style="">If the joining user is not yet in the room, the application MUST send two stanzas: the first to join the room and the second to invite the other individual. If the joining user is in the room already, the application shall send only the invitation stanza.</p>
+    <p class="caption">Example 17. Invite Action: Resulting Stanza(s)</p>
+<div class="indent"><pre>
+&lt;presence to='darkcave@macbeth.shakespeare.lit/thirdwitch'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc'/&gt;
+&lt;/presence&gt;
+
+&lt;message to='darkcave@macbeth.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='hecate@shakespeare.lit'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="actions-ft">File Transfer Actions</a>
+</h3>
+    <p class="" style="">The Jabber/XMPP protocols include an extension that enables two entities to transfer a file between them, as defined in <span style="font-weight: bold">JEP-0096: File Transfer</span>. The entity that controls an XMPP IRI/URI may enable other entities to send files or receive files, the registered querytypes for which are "sendfile" and "recvfile". Note well that "sendfile" means a second entity will send a file to the XMPP entity that controls the IRI/URI and that "recvfile" means a second entity will receive a file from the XMPP entity that controls the IRI/URI.</p>
+    <p class="" style="">To enable a second entity to send a file, the IRI/URI is of the following form:</p>
+    <p class="caption">Example 18. Sending a File: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net/orchard?sendfile
+    </pre></div>
+    <p class="" style="">The application SHOULD then present an interface enabling the user to provide information about the file to be sent (e.g., by "browsing" the file system of the user's computer in order to choose a file). As a result, the application SHOULD then send a <span class="ref" style="">Publishing SI Requests</span>  [<a href="#nt-id2257855">16</a>] message to the XMPP address encapsulated in the IRI/URI:</p>
+    <p class="caption">Example 19. Sending a File: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony' to='romeo@montague.net'&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+      id='publish-0123'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='missive.txt'
+          size='1024'
+          date='2005-11-29T11:21Z'/&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">To enable a second entity to receive a file, the IRI/URI is of the following form:</p>
+    <p class="caption">Example 20. Receiving a File: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net/orchard?recvfile;sid=pub234;mime-type=text%2Fplain&amp;name=reply.txt&amp;size=2048
+    </pre></div>
+    <p class="" style="">That IRI/URI is equivalent to the following XML stanza:</p>
+    <p class="caption">Example 21. Receiving a File: Equivalent Stanza</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net' to='juliet@capulet.com/balcony'&gt;
+  &lt;sipub xmlns='http://jabber.org/protocol/si-pub'
+      id='pub234'
+      mime-type='text/plain'
+      profile='http://jabber.org/protocol/si/profile/file-transfer'&gt;
+    &lt;file xmlns='http://jabber.org/protocol/si/profile/file-transfer'
+          name='reply.txt'
+          size='2048'/&gt;
+  &lt;/sipub&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In accordance with <span style="font-weight: bold">JEP-0137</span>, the application SHOULD then initiate a file transfer exchange with by sending a stanza of the following form:</p>
+    <p class="caption">Example 22. Receiving a File: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard'&gt;
+  &lt;start xmlns='http://jabber.org/protocol/si-pub' id='pub234'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note well that the request to begin the stream is send to the full JID (user@host/resource) of the XMPP entity identified by the XMPP IRI/URI. Therefore, the IRI/URI SHOULD include a full JID. If it does not, the receiver MUST discover a full JID via presence or service discovery. If the receiver cannot discover a full JID for the sender (e.g., in the last resort through sending a presence subscription request to the sender and receiving presence from the sender's resources), then it SHOULD abort the file transfer exchange.</p>
+  </div>
+  <div class="indent">
+<h3>3.7 <a name="actions-register">Registration Actions</a>
+</h3>
+    <p class="" style="">Sometimes it is desirable or necessary to register with an entity (e.g., a groupchat room or a gateway to a non-Jabber IM system) before interacting with it further; the protocol for doing so is defined in <span style="font-weight: bold">JEP-0077: In-Band Registration</span>. The registered querytype value for registration management is "register".</p>
+    <p class="caption">Example 23. Register Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:marlowe.shakespeare.lit?register
+    </pre></div>
+    <p class="" style="">Because registration is a two-step process (see <span style="font-weight: bold">JEP-0077</span>), the application MUST then send an IQ-get to the entity in order to retrieve the required registration fields:</p>
+    <p class="caption">Example 24. Retrieving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='get'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 25. Receiving Registration Fields</p>
+<div class="indent"><pre>
+&lt;iq from='marlowe.shakespeare.lit' type='result'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username/&gt;
+    &lt;password/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The application MUST then present an appropriate interface that enables the user to complete the registration form. Once the user provides the information, the application MUST send an IQ-set to the entity.</p>
+    <p class="caption">Example 26. Sending Registration Information</p>
+<div class="indent"><pre>
+&lt;iq to='marlowe.shakespeare.lit' type='set'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;username&gt;juliet&lt;/username&gt;
+    &lt;password&gt;R0m30&lt;/password&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Cancelling an existing registration is not supported.</p>
+  </div>
+  <div class="indent">
+<h3>3.8 <a name="actions-pubsub">Publish-Subscribe Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0060: Publish-Subscribe</span> defines a generic protocol for subscribing and publishing to "feeds" or "channels" of information. The "pubsub" querytype is defined herein for interaction with pubsub services, with two keys: (1) "node" (to specify pubsub nodes) and (2) "action", whose defined values are "subscribe", "unsubscribe", and "publish".</p>
+    <p class="caption">Example 27. Pubsub Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=subscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 28. Pubsub Subscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 29. Pubsub Unsubscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:pubsub.shakespeare.lit?pubsub;action=unsubscribe;node=globe/performances
+    </pre></div>
+    <p class="caption">Example 30. Pubsub Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='pubsub.shakespeare.lit' type='set'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;unsubscribe node='globe/performances'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.9 <a name="actions-disco">Service Discovery Actions</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0030: Service Discovery</span> defines a protocol for discovering information about Jabber entities as well as the items associated with such entities. The "disco" querytype is defined herein for interaction for the purpose of service discovery, with three keys: (1) an OPTIONAL "node" (to specify service discovery nodes), (2) "request", whose defined values are "info" and "items" (corresponding to the disco#info and disco#items namespaces specified in <span style="font-weight: bold">JEP-0030</span>), and (3) "type", whose defined values are "get" and "set" (corresponding to the IQ "get" and "set" methods specified in <span style="font-weight: bold">RFC 3920</span>).</p>
+    <p class="caption">Example 31. Service Discovery Information Request: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=info
+    </pre></div>
+    <p class="caption">Example 32. Service Discovery Information Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 33. Service Discovery Items Request: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?disco;type=get;request=items;node=http://jabber.org/protocol/extended-presence
+    </pre></div>
+    <p class="caption">Example 34. Service Discovery Items Request: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/extended-presence'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.10 <a name="actions-vcard">vCard Retrieval Action</a>
+</h3>
+    <p class="" style="">Many Jabber/XMPP systems have long included support for user (and even server) vCards, as specified in <span style="font-weight: bold">JEP-0054</span>. Although this functionality may be superseded by a more flexible and extensible protocol in the future, it remains valuable to be able to retrieve vCard data associated with an XMPP entity. The "vcard" querytype is defined for this purpose.</p>
+    <p class="caption">Example 35. vCard Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?vcard
+    </pre></div>
+    <p class="caption">Example 36. vCard Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='romeo@montague.net' type='get'&gt;
+  &lt;vCard xmlns='vcard-temp'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.11 <a name="actions-commands">Ad-Hoc Command Actions</a>
+</h3>
+    <p class="" style="">The ad-hoc commands protocol specified in <span style="font-weight: bold">JEP-0050</span> enables one entity to interact with another entity to complete application-specific functions such as configuration or statistics retrieval. The "command" querytype is defined for this purpose.</p>
+    <p class="caption">Example 37. Command Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:montague.net?command;node=stats
+    </pre></div>
+    <p class="caption">Example 38. Command Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq to='montague.net' type='get'&gt;
+  &lt;command xmlns='http://jabber.org/protocol/commands' node='stats'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Internationalization considerations for XMPP IRIs/URIs are specified in <span style="font-weight: bold">draft-saintandre-xmpp-iri</span>; the reader is referred to that document for a complete discussion of the relevant issues.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP IRIs/URIs are specified in <span style="font-weight: bold">draft-saintandre-xmpp-iri</span>.</p>
+  <p class="" style="">Completion of some of the actions defined herein will cause changes to an entity's account, subscriptions to information, registration with services, communication with other entities, completion of ad-hoc commands, and the like. Naturally, such changes, information, services, and communications are potentially undesirable (e.g., joining a chatroom whose discussion topic is not of interest to, or even patently offensive to, the joining user). The invoked application SHOULD appropriately warn a human user regarding the potential consequences of the action about to be completed.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258346">17</a>]. If in the future the IANA should wish to maintain a registry of XMPP URI/IRI query components, the Jabber Registrar will cooperate with efforts to migrate the registry from the Jabber Registrar to the IANA.</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-querytype">XMPP IRI/URI Querytype Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar maintains a registry of querytype values (see &lt;<a href="http://www.jabber.org/registrar/querytypes.html">http://www.jabber.org/registrar/querytypes.html</a>&gt;).</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-querytype-process">Registration Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;the name of the querytype (e.g., "pubsub")&lt;/name&gt;
+  &lt;proto&gt;
+    the namespace of associated protocol output 
+    (e.g., "http://jabber.org/protocol/pubsub")
+  &lt;/proto&gt;
+  &lt;desc&gt;a natural-language description of the querytype&lt;/desc&gt;
+  &lt;doc&gt;the document in which the querytype is specified&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;the name of the key (e.g., "action")&lt;/name&gt;
+      &lt;desc&gt;a natural-language description of the key&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;the name of a value (e.g., "subscribe")&lt;/name&gt;
+          &lt;desc&gt;a natural-language description of the value&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+      <p class="" style="">Note: Within the &lt;querytype/&gt; element, the &lt;keys/&gt; child element is OPTIONAL; within any given &lt;key/&gt; element, the &lt;values/&gt; child element is also OPTIONAL.</p>
+      <p class="" style="">The registrant may register more than one querytype at a time, each contained in a separate &lt;querytype/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-querytype-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+&lt;querytype&gt;
+  &lt;name&gt;command&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/commands&lt;/proto&gt;
+  &lt;desc&gt;enables completion of ad-hoc commands&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the command node&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the ad-hoc commands action type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;cancel&lt;/name&gt;
+          &lt;desc&gt;a request to cancel processing of the command&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;complete&lt;/name&gt;
+          &lt;desc&gt;a request to complete processing of the command&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;execute&lt;/name&gt;
+          &lt;desc&gt;a request to execute the command (the default implied action)&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;next&lt;/name&gt;
+          &lt;desc&gt;a request to move to the next command in a series&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;complete&lt;/name&gt;
+          &lt;desc&gt;a request to move to the previous command in a series&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the IQ type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;get&lt;/name&gt;
+          &lt;desc&gt;an IQ get&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;set&lt;/name&gt;
+          &lt;desc&gt;an IQ set (disco publish)&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;disco&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/disco&lt;/proto&gt;
+  &lt;desc&gt;enables interaction for the purpose of service discovery&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the (optional) service discovery node&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;request&lt;/name&gt;
+      &lt;desc&gt;the service discovery request type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;info&lt;/name&gt;
+          &lt;desc&gt;a service discovery information (disco#info) request&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;items&lt;/name&gt;
+          &lt;desc&gt;a service discovery items (disco#items) request&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the IQ type&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;get&lt;/name&gt;
+          &lt;desc&gt;an IQ get&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;set&lt;/name&gt;
+          &lt;desc&gt;an IQ set (disco publish)&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;invite&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables simultaneously joining a groupchat room and inviting others&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;join&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/muc&lt;/proto&gt;
+  &lt;desc&gt;enables joining a groupchat room&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;message&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending of an XMPP message stanza&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;subject&lt;/name&gt;
+      &lt;desc&gt;a subject for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;body&lt;/name&gt;
+      &lt;desc&gt;a body for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;thread&lt;/name&gt;
+      &lt;desc&gt;a Thread ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;from&lt;/name&gt;
+      &lt;desc&gt;a from address for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;id&lt;/name&gt;
+      &lt;desc&gt;an ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the message type per the "jabber:client" schema&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;chat&lt;/name&gt;
+          &lt;desc&gt;a message of type "chat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;groupchat&lt;/name&gt;
+          &lt;desc&gt;a message of type "groupchat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;headline&lt;/name&gt;
+          &lt;desc&gt;a message of type "headline"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;normal&lt;/name&gt;
+          &lt;desc&gt;a message of type "normal"&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;probe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables probing for a contact's current presence information&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/pubsub&lt;/proto&gt;
+  &lt;desc&gt;enables interaction with a publish-subscribe service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;action&lt;/name&gt;
+      &lt;desc&gt;the pubsub action&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;subscribe&lt;/name&gt;
+          &lt;desc&gt;enables subscribing to a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;unsubscribe&lt;/name&gt;
+          &lt;desc&gt;enables unsubscribing from a pubsub node&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;node&lt;/name&gt;
+      &lt;desc&gt;the pubsub node&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;recvfile&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/si/profile/file-transfer&lt;/proto&gt;
+  &lt;desc&gt;enables initiation of an outbound file transfer from XMPP entity&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;register&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:register&lt;/proto&gt;
+  &lt;desc&gt;enables registering with a server or service&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;roster&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables adding or editing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;sendfile&lt;/name&gt;
+  &lt;proto&gt;http://jabber.org/protocol/si/profile/file-transfer&lt;/proto&gt;
+  &lt;desc&gt;enables initiation of an inbound file transfer to XMPP entity&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;subscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending a presence subscription request&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;vcard&lt;/name&gt;
+  &lt;proto&gt;vcard-temp&lt;/proto&gt;
+  &lt;desc&gt;enables retrieval of an entity's vCard data&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250732">1</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-04.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-04.txt</a>&gt; (approved by the IESG on 2006-05-08, publication as an RFC is pending).</p>
+<p><a name="nt-id2250719">2</a>. On the difference between IRIs and URIs, see <span style="font-weight: bold">RFC 3987</span>.</p>
+<p><a name="nt-id2250913">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250952">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250888">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2250859">6</a>. RFC 3987: Internationalized Resource Identifiers (IRIs) &lt;<a href="http://www.ietf.org/rfc/rfc3987.txt">http://www.ietf.org/rfc/rfc3987.txt</a>&gt;.</p>
+<p><a name="nt-id2257186">7</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257209">8</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2257232">9</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2257256">10</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257284">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257304">12</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257328">13</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2257382">14</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2257422">15</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257855">16</a>. JEP-0137: Publishing SI Requests &lt;<a href="http://www.jabber.org/jeps/jep-0137.html">http://www.jabber.org/jeps/jep-0137.html</a>&gt;.</p>
+<p><a name="nt-id2258346">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.0 (2006-03-23)</h4>
+<div class="indent">
+<p class="" style="">Per a vote of the Jabber Council, advanced to Active.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Added actions for ad-hoc commands and vCard retrieval; clarified some explanatory text.</p> (psa)
+    </div>
+<h4>Version 0.6 (2005-12-01)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-iri-03; modified file transfer query operations to handle both send and receive use cases.</p> (psa)
+    </div>
+<h4>Version 0.5 (2005-09-05)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-iri-01; added file querytype for file transfer.</p> (psa)
+    </div>
+<h4>Version 0.4 (2005-06-06)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-iri-00.</p> (psa)
+    </div>
+<h4>Version 0.3 (2005-02-28)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-uri-08 and subsequent XMPP WG discussion; removed use cases for editing roster items, removing roster items, leaving chatrooms, unsubscribing, and unregistering (these make more sense from within a dedicated client); added use case for simultaneously joining a room and inviting other participants; further specified security considerations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2004-11-17)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-uri-07; specified Service Discovery usage.</p> (psa)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0147-1.1.html
+++ b/content/xep-0147-1.1.html
@@ -1,0 +1,493 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0147: XMPP URI Scheme Query Components</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="XMPP URI Scheme Query Components">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-06-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0147">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0147: XMPP URI Scheme Query Components</h1>
+<p>This document defines a registry of query components to be used in the context of XMPP IRIs/URIs and also specifies an initial submission of values to that registry.</p>
+<p><hr></p>
+<p style="color:green">NOTICE: This Informational JEP defines a best practice or protocol profile that has been approved by the Jabber Council and/or the JSF Board of Directors. Implementations are encouraged and the best practice or protocol profile is appropriate for deployment in production systems.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Active">Active</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Informational">Informational</a><br>
+            Number: 0147<br>
+            Version: 1.1<br>
+            Last Updated: 2006-06-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, RFC 4622, JEP-0053<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: querytypes<br>
+              Registry: 
+              
+              &lt;<a href="http://www.jabber.org/registrar/querytypes.html">http://www.jabber.org/registrar/querytypes.html</a>&gt;
+              <br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/XMPP%20URI%20Scheme%20Query%20Components%20(JEP-0147)">http://wiki.jabber.org/index.php/XMPP URI Scheme Query Components (JEP-0147)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#actions">Query Actions</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#actions-message">Message Action</a>
+</dt>
+<dt>3.2.  <a href="#actions-roster">Roster Management Actions</a>
+</dt>
+<dt>3.3.  <a href="#actions-subscribe">Subscription Management Actions</a>
+</dt>
+<dt>3.4.  <a href="#actions-probe">Presence Probe Action</a>
+</dt>
+</dl>
+<dt>4.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-querytype">XMPP IRI/URI Querytype Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-querytype-process">Registration Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-querytype-reg">Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">RFC 4622</span>  [<a href="#nt-id2250837">1</a>] defines a Uniform Resource Identifier (URI) scheme for use in forming URIs and Internationalized Resource Identifiers (IRIs)  [<a href="#nt-id2250823">2</a>] from the addresses of entities that can communicate using the Extensible Messaging and Presence Protocol (see <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251043">3</a>]). Such identifiers enable identification of and interaction with XMPP entities by non-native applications such as databases and web browsers.</p>
+  <p class="" style="">However, <span style="font-weight: bold">RFC 4622</span> intentionally leaves the potential values of the query component open-ended, does not provide a list of common "actions" for queries (e.g., send message or join chatroom), and does not specify recommended "key-value" pairs to be used in the context of such actions. Therefore, this document defines a registry of such actions and key-value pairs (to be maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250900">4</a>]) and specifies a set of initial values for that registry.</p>
+  <p class="" style="">This document is organized as follows:</p>
+  <ul>
+    <li>The registry is defined in the <a href="#registrar-querytype">XMPP IRI/URI Querytype Registry</a> section.</li>
+    <li>An initial set of actions and key-value pairs is described in the <a href="#actions">Query Actions</a> section.</li>
+    <li>A corresponding initial submission to the registry is specified in the <a href="#registrar-querytype-init">Initial Registration</a> section.</li>
+    <li>The process for submitting additional values to the registry is specified in the <a href="#registrar-querytype-process">Registration Process</a> section.</li>
+  </ul>
+  <p class="" style="">Note: The format of the XMPP URI scheme, including the format of the query component, is fully specified  and formally defined in <span style="font-weight: bold">RFC 4622</span>; this document does not modify the xmpp URI scheme in any way and assumes that the reader is familiar with all aspects of <span style="font-weight: bold">RFC 4622</span>.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This document inherits terminology from <span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2251019">5</a>], <span class="ref" style="">RFC 3987</span>  [<a href="#nt-id2259614">6</a>], and <span style="font-weight: bold">RFC 4622</span>.</p>
+<h2>3.
+       <a name="actions">Query Actions</a>
+</h2>
+  <p class="" style="">The range of actions that might be triggered by interaction with an XMPP entity by means of an XMPP IRI/URI is potentially as wide as the range of extensions to XMPP. This document does not seek to exhaustively define all such potential actions. However, the following actions might be of general interest:</p>
+  <ol start="" type=""> 
+    <li>Sending a message.</li>
+    <li>Adding or removing a roster item.</li>
+    <li>Subscribing to or unsubscribing from an entity's presence information.</li>
+    <li>Probing for current presence information.</li>
+    <li>Determining <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259677">7</a>] information about an entity.</li>
+    <li>Joining a groupchat room (see <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2259706">8</a>]).</li>
+    <li>Requesting initiation of <span class="ref" style="">Ad-Hoc Commands</span>  [<a href="#nt-id2259728">9</a>] associated with an entity.</li>
+    <li>Retrieving the <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2259751">10</a>] data associated with an entity.</li>
+    <li>Subscribing to or unsubscribing from a <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2259775">11</a>] node.</li>
+    <li>Registering with another entity via <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2259833">12</a>].</li>
+    <li>Initiating a file transfer with another entity (see <span class="ref" style="">File Transfer</span>  [<a href="#nt-id2259803">13</a>]).</li>
+  </ol> 
+  <p class="" style="">For each such action, the Jabber Registrar maintains a RECOMMENDED "querytype" (this can be thought of as an action name or "verb"; see <span style="font-weight: bold">RFC 4622</span> for syntax and semantics) as well as an OPTIONAL list of keys to be used in key-value pairs if appropriate.</p>
+  <p class="" style="">The querytypes and key-value pairs related to <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span> are defined herein; the querytypes and key-value pairs related to protocols defined in the JSF's JEP series are defined in the relevant JEPs.</p>
+  <div class="indent">
+<h3>3.1 <a name="actions-message">Message Action</a>
+</h3>
+    <p class="" style="">It may desirable for an XMPP IRI/URI to trigger a specialized interface for sending an XMPP message stanza. The RECOMMENDED querytype for this action is "message". If no key-value pair is provided, interacting with an XMPP IRI/URI that contains a querytype of "message" SHOULD trigger an interface that enables the user to input the text of an XMPP message and other relevant parameters (e.g., a message subject or <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2259896">14</a>] markup).</p>
+    <p class="caption">Example 1. Basic Message Action</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message
+    </pre></div>
+    <p class="" style="">A query component whose querytype is "message" MAY specify various key-value pairs. The following three keys are associated with the child elements of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace as defined in <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2259936">15</a>]:</p>
+    <ol start="" type="">
+      <li>subject</li>
+      <li>body</li>
+      <li>thread</li>
+    </ol>
+    <p class="" style="">In addition, the following three keys are associated with the attributes of the &lt;message/&gt; stanza specified in the XML schema for the 'jabber:client' namespace (the 'to' attribute is unnecessary, since it is provided by the XMPP address included in the IRI/URI):</p>
+    <ol start="" type="">
+      <li>from</li>
+      <li>id</li>
+      <li>type</li>
+    </ol>
+    <p class="" style="">Other keys MAY be registered with the Jabber Registrar but are not specified herein.</p>
+    <p class="caption">Example 2. Message Action with Keys: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?message;subject=Test%20Message;body=Here%27s%20a%20test%20message
+    </pre></div>
+    <p class="caption">Example 3. Message Action with Keys: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net'&gt;
+  &lt;subject&gt;Test Message&lt;/subject&gt;
+  &lt;body&gt;Here&amp;apos;s a test message.&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="actions-roster">Roster Management Actions</a>
+</h3>
+    <p class="" style="">The 'jabber:iq:roster' namespace provides a mechanism for managing an XMPP roster (also called a "contact list"). This namespace is defined in <span style="font-weight: bold">RFC 3921</span>. The registered querytype for adding items to the roster or editing items in the roster is "roster" (effectively there is no difference between adding and editing). An XMPP IRI/URI containing a "roster" querytype MAY also include at most one "name" key whose value maps to the 'name' attribute of the &lt;item/&gt; element within the 'jabber:iq:roster' namespace, and MAY contain one "group" key whose value maps to the character data of the &lt;group/&gt; child element of &lt;item/&gt;.</p>
+    <p class="caption">Example 4. Roster Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster
+    </pre></div>
+    <p class="caption">Example 5. Roster Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Roster Action With Name: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague
+    </pre></div>
+    <p class="caption">Example 7. Roster Action With Name: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo Montague'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Roster Action With Name and Group: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?roster;name=Romeo%20Montague;group=Friends
+    </pre></div>
+    <p class="caption">Example 9. Roster Action With Name and Group: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo Montague'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Methods (if any) for including more than one group are yet to be determined.</p>
+    <p class="" style="">The 'jabber:iq:roster' namespace includes a mechanism for removing an XMPP roster item. The registered querytype for removing an item from the roster is "remove".</p>
+    <p class="caption">Example 10. Roster Removal Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?remove
+    </pre></div>
+    <p class="caption">Example 11. Roster Removal Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' subscription='remove'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="actions-subscribe">Subscription Management Actions</a>
+</h3>
+    <p class="" style="">Closely coupled with roster management is presence subscription management. In XMPP, subscription management is handled via special values of the &lt;presence/&gt; stanza, as described in <span style="font-weight: bold">RFC 3921</span>. When an entity subscribes to another entity's presence by means of an XMPP IRI/URI, the invoked XMPP application SHOULD first send a roster add stanza as shown below (this is consistent with the recommendations in <span style="font-weight: bold">RFC 3921</span>).</p>
+    <p class="caption">Example 12. Subscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?subscribe
+    </pre></div>
+    <p class="caption">Example 13. Subscribe Action: Resulting Stanzas</p>
+<div class="indent"><pre>
+&lt;iq type='set'&gt;
+  &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+
+&lt;presence to='romeo@montague.net' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">XMPP includes a mechanism for unsubscribing from an entity. The registered querytype for doing so is "unsubscribe".</p>
+    <p class="caption">Example 14. Unsubscribe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?unsubscribe
+    </pre></div>
+    <p class="caption">Example 15. Unsubscribe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='unsubscribe'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="actions-probe">Presence Probe Action</a>
+</h3>
+    <p class="" style="">Once an entity is subscribed to the presence of a contact, it is allowed to probe for the contact's current presence if necessary. Although normally this is done by the server on the user's behalf, the client may initiate a probe as well (see <span style="font-weight: bold">RFC 3921</span>). The registered querytype for initiating a presence probe is "probe".</p>
+    <p class="" style="">An example of the action and resulting protocol is shown below.</p>
+    <p class="caption">Example 16. Probe Action: IRI/URI</p>
+<div class="indent"><pre>
+xmpp:romeo@montague.net?probe
+    </pre></div>
+    <p class="caption">Example 17. Probe Action: Resulting Stanza</p>
+<div class="indent"><pre>
+&lt;presence to='romeo@montague.net' type='probe'/&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">Internationalization considerations for XMPP IRIs/URIs are specified in <span style="font-weight: bold">RFC 4622</span>; the reader is referred to that document for a complete discussion of the relevant issues.</p>
+  <p class="" style="">Localization of application-specific data presented to a human user (e.g., as encapsulated in key-value pairs) is the responsibility of the using protocol.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Security considerations for XMPP IRIs/URIs are specified in <span style="font-weight: bold">RFC 4622</span>.</p>
+  <p class="" style="">Completion of some of the actions defined herein will cause changes to an entity's account, subscriptions to information, registration with services, communication with other entities, completion of ad-hoc commands, and the like. Naturally, such changes, information, services, and communications are potentially undesirable (e.g., joining a chatroom whose discussion topic is not of interest to, or even patently offensive to, the joining user). The invoked application SHOULD appropriately warn a human user regarding the potential consequences of the action about to be completed.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260348">16</a>]. If in the future the IANA should wish to maintain a registry of XMPP URI/IRI query components, the Jabber Registrar will cooperate with efforts to migrate the registry from the Jabber Registrar to the IANA.</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-querytype">XMPP IRI/URI Querytype Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar maintains a registry of querytype values (see &lt;<a href="http://www.jabber.org/registrar/querytypes.html">http://www.jabber.org/registrar/querytypes.html</a>&gt;).</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-querytype-process">Registration Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;querytype&gt;
+  &lt;name&gt;the name of the querytype (e.g., "pubsub")&lt;/name&gt;
+  &lt;proto&gt;
+    the namespace of associated protocol output 
+    (e.g., "http://jabber.org/protocol/pubsub")
+  &lt;/proto&gt;
+  &lt;desc&gt;a natural-language description of the querytype&lt;/desc&gt;
+  &lt;doc&gt;the document in which the querytype is specified&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;the name of the key (e.g., "action")&lt;/name&gt;
+      &lt;desc&gt;a natural-language description of the key&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;the name of a value (e.g., "subscribe")&lt;/name&gt;
+          &lt;desc&gt;a natural-language description of the value&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+      </pre></div>
+      <p class="" style="">Note: Within the &lt;querytype/&gt; element, the &lt;keys/&gt; child element is OPTIONAL; within any given &lt;key/&gt; element, the &lt;values/&gt; child element is also OPTIONAL.</p>
+      <p class="" style="">The registrant may register more than one querytype at a time, each contained in a separate &lt;querytype/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-querytype-reg">Registration</a>
+</h3>
+      <p class="" style="">The following submission registers parameters related to the XMPP RFCs. For submissions related to XMPP extensions, refer to the relevant JEPs.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+
+&lt;querytype&gt;
+  &lt;name&gt;message&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending of an XMPP message stanza&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;subject&lt;/name&gt;
+      &lt;desc&gt;a subject for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;body&lt;/name&gt;
+      &lt;desc&gt;a body for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;thread&lt;/name&gt;
+      &lt;desc&gt;a Thread ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;from&lt;/name&gt;
+      &lt;desc&gt;a from address for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;id&lt;/name&gt;
+      &lt;desc&gt;an ID for the message per the "jabber:client" schema&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;type&lt;/name&gt;
+      &lt;desc&gt;the message type per the "jabber:client" schema&lt;/desc&gt;
+      &lt;values&gt;
+        &lt;value&gt;
+	  &lt;name&gt;chat&lt;/name&gt;
+          &lt;desc&gt;a message of type "chat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;groupchat&lt;/name&gt;
+          &lt;desc&gt;a message of type "groupchat"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;headline&lt;/name&gt;
+          &lt;desc&gt;a message of type "headline"&lt;/desc&gt;
+        &lt;/value&gt;
+        &lt;value&gt;
+	  &lt;name&gt;normal&lt;/name&gt;
+          &lt;desc&gt;a message of type "normal"&lt;/desc&gt;
+        &lt;/value&gt;
+      &lt;/values&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;probe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables probing for a contact's current presence information&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;remove&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables removing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;roster&lt;/name&gt;
+  &lt;proto&gt;jabber:iq:roster&lt;/proto&gt;
+  &lt;desc&gt;enables adding or editing a roster item&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+  &lt;keys&gt;
+    &lt;key&gt;
+      &lt;name&gt;group&lt;/name&gt;
+      &lt;desc&gt;the user-assigned group for the roster item&lt;/desc&gt;
+    &lt;/key&gt;
+    &lt;key&gt;
+      &lt;name&gt;name&lt;/name&gt;
+      &lt;desc&gt;the user-assigned name for the roster item&lt;/desc&gt;
+    &lt;/key&gt;
+  &lt;/keys&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;subscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables sending a presence subscription request&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+&lt;querytype&gt;
+  &lt;name&gt;unsubscribe&lt;/name&gt;
+  &lt;proto&gt;jabber:client&lt;/proto&gt;
+  &lt;desc&gt;enables unsubscribing from an entity's presence&lt;/desc&gt;
+  &lt;doc&gt;JEP-0147&lt;/doc&gt;
+&lt;/querytype&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250837">1</a>. RFC 4622: Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc4622.txt">http://www.ietf.org/rfc/rfc4622.txt</a>&gt;.</p>
+<p><a name="nt-id2250823">2</a>. On the difference between IRIs and URIs, see <span style="font-weight: bold">RFC 3987</span>.</p>
+<p><a name="nt-id2251043">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250900">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2251019">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2259614">6</a>. RFC 3987: Internationalized Resource Identifiers (IRIs) &lt;<a href="http://www.ietf.org/rfc/rfc3987.txt">http://www.ietf.org/rfc/rfc3987.txt</a>&gt;.</p>
+<p><a name="nt-id2259677">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259706">8</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259728">9</a>. JEP-0050: Ad-Hoc Commands &lt;<a href="http://www.jabber.org/jeps/jep-0050.html">http://www.jabber.org/jeps/jep-0050.html</a>&gt;.</p>
+<p><a name="nt-id2259751">10</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2259775">11</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2259833">12</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2259803">13</a>. JEP-0096: File Transfer &lt;<a href="http://www.jabber.org/jeps/jep-0096.html">http://www.jabber.org/jeps/jep-0096.html</a>&gt;.</p>
+<p><a name="nt-id2259896">14</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2259936">15</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2260348">16</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 1.1 (2006-06-19)</h4>
+<div class="indent">
+<p class="" style="">Added actions for roster removal, presence unsubscription, and cancellation of registration; moved querytypes related to XMPP extensions from this document to the relevant JEPs.</p> (psa)
+    </div>
+<h4>Version 1.0 (2006-03-23)</h4>
+<div class="indent">
+<p class="" style="">Per a vote of the Jabber Council, advanced to Active.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Added actions for ad-hoc commands and vCard retrieval; clarified some explanatory text.</p> (psa)
+    </div>
+<h4>Version 0.6 (2005-12-01)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect RFC 4622-03; modified file transfer query operations to handle both send and receive use cases.</p> (psa)
+    </div>
+<h4>Version 0.5 (2005-09-05)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect RFC 4622-01; added file querytype for file transfer.</p> (psa)
+    </div>
+<h4>Version 0.4 (2005-06-06)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect RFC 4622-00.</p> (psa)
+    </div>
+<h4>Version 0.3 (2005-02-28)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-uri-08 and subsequent XMPP WG discussion; removed use cases for editing roster items, removing roster items, leaving chatrooms, unsubscribing, and unregistering (these make more sense from within a dedicated client); added use case for simultaneously joining a room and inviting other participants; further specified security considerations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2004-11-17)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect draft-saintandre-xmpp-uri-07; specified Service Discovery usage.</p> (psa)
+    </div>
+<h4>Version 0.1 (2004-11-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0149-0.1.html
+++ b/content/xep-0149-0.1.html
@@ -1,0 +1,255 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0149: Time Periods</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Time Periods">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines a method to specify time periods for states, events, and activities communicated in XMPP and XMPP extensions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-04-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0149">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0149: Time Periods</h1>
+<p>This JEP defines a method to specify time periods for states, events, and activities communicated in XMPP and XMPP extensions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0149<br>
+            Version: 0.1<br>
+            Last Updated: 2005-04-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Time%20Periods%20(JEP-0149)">http://wiki.jabber.org/index.php/Time Periods (JEP-0149)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#examples">Examples</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#presence">Basic Presence</a>
+</dt>
+<dt>4.2.  <a href="#activity">User Activity</a>
+</dt>
+<dt>4.3.  <a href="#mood">User Mood</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-shim">SHIM Headers</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Certain events and states may last for only a limited period of time. For example, when a person changes his availability to "dnd" and his status to "In a Meeting", the person (or his calendaring application) may know that the meeting is expected to last for 90 minutes; because those who subscribe to the person's presence may find it helpful to know how long the person will be in the meeting, it might be desirable to include that time period information in the presence stanza sent when the person's availability changes. Similar considerations apply to other states, events, and activities, such as "extended presence" (see <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2251641">1</a>]).</p>
+  <p class="" style="">This JEP defines a straightforward XMPP extension for encapsulating information about time periods, using new headers that adhere to the format specified in <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2251678">2</a>].</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Provide the ability to specify time periods for states, events, and activities communicated via XMPP and XMPP extensions.</li>
+    <li>Conform to <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2250531">3</a>].</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">In order to specify the time period for a state, event, or activity, the generating entity SHOULD include both "Start" and "Stop" SHIM headers that specify the dateTimes at which the time period starts and stops. The following rules apply:</p>
+  <ol start="" type="">
+    <li>All start and stop dates MUST conform to the dateTime profile specified in JEP-0082.</li>
+    <li>All dateTime information MUST be expressed in UTC (i.e., with no timezone offsets).</li>
+    <li>Start and stop times SHOULD be understood by the recipient as estimates or approximations.</li>
+    <li>If both a start time and a stop time are specified, the stop time MUST be later than the start time.</li>
+  </ol>
+  <p class="" style="">These SHIM headers MAY be included wherever appropriate; however, it is expected that they will be included mainly to further specify basic presence states (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250606">4</a>]) and various "extended presence" states, events, and activities (see, for example, <span class="ref" style="">User Mood</span>  [<a href="#nt-id2250804">5</a>] and <span class="ref" style="">User Activity</span>  [<a href="#nt-id2250637">6</a>]).</p>
+  <p class="" style="">There is no requirement that the start time needs to be the time when the stanza is generated; for example, the start time may be retroactive to a dateTime in the past or may be an estimated dateTime in the future.</p>
+<h2>4.
+       <a name="examples">Examples</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="presence">Basic Presence</a>
+</h3>
+    <p class="" style="">In order to specify that a basic presence state will last for a specific time period, the entity that generates the presence stanza SHOULD include the desired SHIM headers.</p>
+    <p class="caption">Example 1. Basic Presence With Time Period</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;show&gt;dnd&lt;/show&gt;
+  &lt;status&gt;In a Meeting&lt;/status&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Stop'&gt;2005-03-17T11:30:00Z&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="activity">User Activity</a>
+</h3>
+    <p class="" style="">An XMPP extension for user activity is specified in JEP-0108. It may be desirable to include time period information when publishing one's activity.</p>
+    <p class="caption">Example 2. User Activity With Time Period</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='juliet@capulet.com/balcony' 
+    to='pubsub.shakespeare.lit' 
+    id='activity1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/juliet-activity'&gt;
+      &lt;item id='current'&gt;
+        &lt;activity xmlns='http://jabber.org/protocol/activity'&gt;
+          &lt;relaxing&gt;
+            &lt;partying/&gt;
+          &lt;/relaxing&gt;
+          &lt;text xml:lang='en'&gt;My best friend&amp;apos;s birthday!&lt;/text&gt;
+        &lt;/activity&gt;
+        &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+          &lt;header name='Start'&gt;2005-03-17T19:00:00Z&lt;/header&gt;
+          &lt;header name='Stop'&gt;2005-03-17T23:00:00Z&lt;/header&gt;
+        &lt;/headers&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="mood">User Mood</a>
+</h3>
+    <p class="" style="">An XMPP extension for user mood is specified in JEP-0107. It may be desirable to include time period information when publishing one's mood.</p>
+    <p class="caption">Example 3. User Mood With Time Period</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='juliet@capulet.com/balcony' 
+    to='pubsub.shakespeare.lit' 
+    id='mood1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/juliet-mood'&gt;
+      &lt;item id='current'&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;annoyed/&gt;
+          &lt;text&gt;She has been bothering me *all day*!&lt;/text&gt;
+        &lt;/mood&gt;
+        &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+          &lt;header name='Start'&gt;2005-03-17T07:00:00Z&lt;/header&gt;
+        &lt;/headers&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note that the start time is (intended to be) retroactive.</p>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">For the sake of interoperability, it may be desirable for certain kinds of implementations (e.g., gateways) to transform XMPP start and stop times into the formats used by other protocols (e.g., the 'since' and 'until' attributes specified in <span class="ref" style="">draft-ietf-simple-rpid</span>  [<a href="#nt-id2256228">7</a>]).</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is possible that inclusion of time periods for particular states, events, or activities may reveal information that would enable a recipient to launch an attack while the sender is unavailable or away (e.g., if the sender specifies that he will be on vacation for the next three weeks, a recipient might therefore learn that this is a good time to break into the sender's house). Therefore, senders of time period information should balance the desire to share helpful information against the need for appropriate control over security-critical availability information.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256287">8</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-shim">SHIM Headers</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256335">9</a>] shall include the following entries in its registry of SHIM headers.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;Start&lt;/name&gt;
+  &lt;desc&gt;The dateTime at which a state, event, or activity starts&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Stop&lt;/name&gt;
+  &lt;desc&gt;The dateTime at which a state, event, or activity stops&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/header&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Not applicable.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251641">1</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2251678">2</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2250531">3</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2250606">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250804">5</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2250637">6</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p><a name="nt-id2256228">7</a>. draft-ietf-simple-rpid &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-simple-rpid-09.txt">http://www.ietf.org/internet-drafts/draft-ietf-simple-rpid-09.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256287">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256335">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-04-21)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-04-07)</h4>
+<div class="indent">Modified to use SHIM headers rather than a structured data format qualified by a dedicated namespace. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-03-17)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0149-0.2.html
+++ b/content/xep-0149-0.2.html
@@ -1,0 +1,252 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0149: Time Periods</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Time Periods">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a method to specify the valid time periods for states, events, and activities communicated via Jabber/XMPP protocols.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0149">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0149: Time Periods</h1>
+<p>This document defines a method to specify the valid time periods for states, events, and activities communicated via Jabber/XMPP protocols.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0149<br>
+            Version: 0.2<br>
+            Last Updated: 2005-12-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0082<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Time%20Periods%20(JEP-0149)">http://wiki.jabber.org/index.php/Time Periods (JEP-0149)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol</a>
+</dt>
+<dt>4.  <a href="#examples">Examples</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#presence">Basic Presence</a>
+</dt>
+<dt>4.2.  <a href="#activity">User Activity</a>
+</dt>
+<dt>4.3.  <a href="#mood">User Mood</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-shim">SHIM Headers</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Certain events and states may last for only a limited period of time. For example, when a person changes his availability to "dnd" and his status to "In a Meeting", the person (or his calendaring application) may know that the meeting is expected to last for 90 minutes; because those who subscribe to the person's presence may find it helpful to know how long the person will be in the meeting, it might be desirable to include that time period information in the presence stanza sent when the person's availability changes. Similar considerations apply to other states, events, and activities, such as various forms of "extended presence" (see <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2253991">1</a>]).</p>
+  <p class="" style="">This JEP defines a straightforward XMPP extension for encapsulating information about time periods, using new headers that adhere to the format specified in <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2253951">2</a>].</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Provide the ability to specify time periods for states, events, and activities communicated via Jabber/XMPP protocols.</li>
+    <li>Conform to <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2250564">3</a>].</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol</a>
+</h2>
+  <p class="" style="">In order to specify the time period for a state, event, or activity, the generating entity SHOULD include both "Start" and "Stop" SHIM headers that specify the dateTimes at which the time period starts and stops. The following rules apply:</p>
+  <ol start="" type="">
+    <li>All start and stop dates MUST conform to the dateTime profile specified in <span style="font-weight: bold">JEP-0082</span>.</li>
+    <li>All dateTime information MUST be expressed in UTC (i.e., with no timezone offsets).</li>
+    <li>Start and stop times SHOULD be understood by the recipient as estimates or approximations.</li>
+    <li>If both a start time and a stop time are specified, the stop time MUST be later than the start time.</li>
+  </ol>
+  <p class="" style="">These SHIM headers MAY be included wherever appropriate; however, it is expected that they will be included mainly to further specify basic presence states (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250822">4</a>]) and various "extended presence" states, events, and activities (see, for example, <span class="ref" style="">User Mood</span>  [<a href="#nt-id2250782">5</a>] and <span class="ref" style="">User Activity</span>  [<a href="#nt-id2250804">6</a>]).</p>
+  <p class="" style="">There is no requirement that the start time needs to be the time when the stanza is generated; for example, the start time may be retroactive to a dateTime in the past or may be an estimated dateTime in the future.</p>
+<h2>4.
+       <a name="examples">Examples</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="presence">Basic Presence</a>
+</h3>
+    <p class="" style="">In order to specify that a basic presence state will last for a specific time period, the entity that generates the presence stanza SHOULD include the desired SHIM headers.</p>
+    <p class="caption">Example 1. Basic Presence With Time Period</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;show&gt;dnd&lt;/show&gt;
+  &lt;status&gt;In a Meeting&lt;/status&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Stop'&gt;2005-03-17T11:30:00Z&lt;/header&gt;
+  &lt;/headers&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="activity">User Activity</a>
+</h3>
+    <p class="" style="">An XMPP extension for user activity is specified in <span style="font-weight: bold">JEP-0108</span>. It may be desirable to include time period information when publishing one's activity.</p>
+    <p class="caption">Example 2. User Activity With Time Period</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='juliet@capulet.com/balcony' 
+    to='pubsub.shakespeare.lit' 
+    id='activity1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/juliet-activity'&gt;
+      &lt;item id='current'&gt;
+        &lt;activity xmlns='http://jabber.org/protocol/activity'&gt;
+          &lt;relaxing&gt;
+            &lt;partying/&gt;
+          &lt;/relaxing&gt;
+          &lt;text xml:lang='en'&gt;My best friend&amp;apos;s birthday!&lt;/text&gt;
+        &lt;/activity&gt;
+        &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+          &lt;header name='Start'&gt;2005-03-17T19:00:00Z&lt;/header&gt;
+          &lt;header name='Stop'&gt;2005-03-17T23:00:00Z&lt;/header&gt;
+        &lt;/headers&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="mood">User Mood</a>
+</h3>
+    <p class="" style="">An XMPP extension for user mood is specified in <span style="font-weight: bold">JEP-0107</span>. It may be desirable to include time period information when publishing one's mood.</p>
+    <p class="caption">Example 3. User Mood With Time Period</p>
+<div class="indent"><pre>
+&lt;iq type='set' 
+    from='juliet@capulet.com/balcony' 
+    to='pubsub.shakespeare.lit' 
+    id='mood1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='generic/juliet-mood'&gt;
+      &lt;item id='current'&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;annoyed/&gt;
+          &lt;text&gt;She has been bothering me *all day*!&lt;/text&gt;
+        &lt;/mood&gt;
+        &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+          &lt;header name='Start'&gt;2005-03-17T07:00:00Z&lt;/header&gt;
+        &lt;/headers&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note that the start time is (intended to be) retroactive.</p>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">For the sake of interoperability, it may be desirable for certain kinds of implementations (e.g., gateways) to transform XMPP start and stop times into the formats used by other protocols (e.g., the 'from' and 'until' attributes specified in <span class="ref" style="">draft-ietf-simple-rpid</span>  [<a href="#nt-id2256462">7</a>]).</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is possible that inclusion of time periods for particular states, events, or activities may reveal information that would enable a recipient to launch an attack while the sender is unavailable or away (e.g., if the sender specifies that he will be on vacation for the next three weeks, a recipient might therefore learn that this is a good time to break into the sender's house). Therefore, senders of time period information should balance the desire to share helpful information against the need for appropriate control over security-critical availability information.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256525">8</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-shim">SHIM Headers</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256610">9</a>] shall include the following entries in its registry of SHIM headers.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;header&gt;
+  &lt;name&gt;Start&lt;/name&gt;
+  &lt;desc&gt;The dateTime at which a state, event, or activity starts&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/header&gt;
+
+&lt;header&gt;
+  &lt;name&gt;Stop&lt;/name&gt;
+  &lt;desc&gt;The dateTime at which a state, event, or activity stops&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/header&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2253991">1</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2253951">2</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2250564">3</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2250822">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250782">5</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2250804">6</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p><a name="nt-id2256462">7</a>. draft-ietf-simple-rpid &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-simple-rpid-10.txt">http://www.ietf.org/internet-drafts/draft-ietf-simple-rpid-10.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256525">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256610">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-12-21)</h4>
+<div class="indent">Updated to reflect draft-ietf-simple-rpid-10. (psa)
+    </div>
+<h4>Version 0.1 (2005-04-21)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-04-07)</h4>
+<div class="indent">Modified to use SHIM headers rather than a structured data format qualified by a dedicated namespace. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-03-17)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0150-0.1.html
+++ b/content/xep-0150-0.1.html
@@ -1,0 +1,459 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0150: Use of Entity Tags in XMPP Extensions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Use of Entity Tags in XMPP Extensions">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This JEP defines best practices for the use of Entity Tags in XMPP extensions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0150">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0150: Use of Entity Tags in XMPP Extensions</h1>
+<p>This JEP defines best practices for the use of Entity Tags in XMPP extensions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Informational<br>
+            Number: 0150<br>
+            Version: 0.1<br>
+            Last Updated: 2005-06-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 2616, JEP-0131<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Use%20of%20Entity%20Tags%20in%20XMPP%20Extensions%20(JEP-0150)">http://wiki.jabber.org/index.php/Use of Entity Tags in XMPP Extensions (JEP-0150)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#support">Discovering Support</a>
+</dt>
+<dt>4.2.  <a href="#roster">Caching and Retrieving Rosters</a>
+</dt>
+<dt>4.3.  <a href="#privacy">Caching and Retrieving Privacy Lists</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">When a Jabber instant messaging client connects to its server, it typically retrieves a great deal of information, such as a user's roster, privacy lists, and service discovery information. However, this information may not have changed since the client last retrieved the data. In order to improve client start-up time or conserve bandwidth in certain environments, it would be desirable if the client could cache the information and retrieve it only if it has changed.</p>
+  <p class="" style="">Such a mechanism exists as part of <span class="ref" style="">RFC 2616</span>  [<a href="#nt-id2250693">1</a>] in the form of the Entity Tags, which are included in the ETag and If-None-Match headers used for HTTP caching. Since <span class="ref" style="">Stanza Headers and Internet Metadata (SHIM)</span>  [<a href="#nt-id2250718">2</a>] enables an XMPP entity to communicate any HTTP header, it should be possible to re-use existing Entity Tag semantics for caching information sent over an XMPP network. This JEP defines best practices for such functionality, which could be used between any two XMPP entities that support SHIM headers (though it is envisioned to be most useful for clients that retrieve information from servers and services).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable caching of information sent over an XMPP network (i.e., retrieval of information only if it has changed since it was last retrieved).</li>
+    <li>Re-use existing HTTP Entity Tag semantics.</li>
+  </ol>
+<h2>3.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">In HTTP, an "entity" is the information transferred as the payload of a request or response, and an "Entity Tag" is an opaque string that uniquely identifies that payload. For example, when an HTTP server sends an entity in an HTTP response, it can include an ETag header that identifies the payload as cacheable, and the client can cache that entity; in future requests, the client can include the same value in an If-None-Match header and the server will either return an HTTP 304 ("Not Modified") error if the entity has not changed or return the entity in the HTTP response if it has changed. (Note: For information about the semantics of Entity Tags, the ETag header, and the If-None-Match header, refer to Sections 3.11, 14.19, and 14.26 respectively of <span style="font-weight: bold">RFC 2616</span>.)</p>
+  <p class="" style="">Similarly, the basic concept behind XMPP Entity Tag use is semantically equivalent to the use in HTTP; this is made possible by a straightforward application of SHIM headers as specified in <span style="font-weight: bold">JEP-0131</span>. In the context of an IQ request-response interaction, the responding entity will include an ETag SHIM header in its IQ response (indicating that the data can be cached), the requesting entity will include that identical value in an If-None-Match SHIM header when it queries the server for the same entity, and the responding entity will return either an IQ result with the changed entity or an IQ error indicating that the entity has not changed.</p>
+  <p class="" style="">Here is an example of such a request-response flow (the example is that of roster retrieval):</p>
+  <p class="caption">Example 1. Client Requests Roster</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='juliet@capulet.com/balcony'
+    id='roster1'&gt;
+ &lt;query xmlns='jabber:iq:roster'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 2. Server Returns Roster Including ETag Header</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    to='juliet@capulet.com/balcony'
+    id='roster1'&gt;
+ &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='nurse@capulet.com' name='Nurse'&gt;
+      &lt;group&gt;Servants&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='ETag'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+ &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 3. Client Requests Roster Including If-None-Match Header</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='juliet@capulet.com/balcony'
+    id='roster2'&gt;
+ &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='If-None-Match'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+ &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the responding entity does not understand the If-None-Match header or does not handle Entity Tags for the namespace in the request, it MUST ignore the header and return whatever information it would have returned if the header had not been present.</p>
+  <p class="" style="">If the responding entity determines that the requested information has not changed since it was last retrieved by the requesting entity, then it MUST return a &lt;not-modified/&gt; error corresponding to the HTTP 304 error returned by HTTP entities that support the ETag header:</p>
+  <p class="caption">Example 4. Responding Entity Returns Not Modified Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    to='juliet@capulet.com/balcony'
+    id='roster2'&gt;
+ &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='If-None-Match'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+ &lt;/query&gt;
+  &lt;error code='304' type='modify'&gt;
+    &lt;not-modified xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Note: The &lt;not-modified/&gt; error is not specified as a stanza error in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250862">3</a>] and an error code of 304 was not included in the older Jabber error codes (see <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2250886">4</a>]). The authors of this proposal will request that the relevant error condition be added to the successor to <span style="font-weight: bold">RFC 3920</span> during the process of revising the XMPP specifications within the Internet Standards Process.</p>
+  <p class="" style="">Note: In HTTP, an Entity Tag may be either "strong" or "weak" (see Section 13.3.3 of <span style="font-weight: bold">RFC 2616</span>); Entity Tags as used in XMPP extensions MUST be considered strong rather than weak.</p>
+  <p class="" style="">Note: The ETag and If-None-Match headers SHOULD be used only in &lt;iq/&gt; stanzas, although they MAY be used in &lt;message/&gt; stanza interactions if IQ request-response semantics are not appropriate, for example in <span class="ref" style="">SOAP over XMPP</span>  [<a href="#nt-id2250974">5</a>] and in certain applications that use <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250919">6</a>].</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="support">Discovering Support</a>
+</h3>
+    <p class="" style=""><span style="font-weight: bold">JEP-0131</span> specifies how support for a particular SHIM header can be determined using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257056">7</a>]. To review, the protocol flow between a client and a server would be as follows:</p>
+    <p class="caption">Example 5. Client Queries Server Regarding SHIM Header Support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='header1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 6. Server Communicates Supported SHIM Headers</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='header1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/shim#ETag'/&gt;
+    &lt;feature var='http://jabber.org/protocol/shim#If-None-Match'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client now knows that the server supports the ETag and If-None-Match SHIM headers and can proceed accordingly.</p>
+    <p class="" style="">Note: If an XMPP entity supports Entity Tags, it MUST at a minimum support both the ETag and If-None-Match SHIM headers.</p>
+    <p class="" style="">Note: Even if an entity supports the ETag and If-None-Match SHIM headers, it is not required to support Entity Tag functionality for all namespaces. For example, a server could support Entity Tags only for rosters and privacy lists but not for the 'jabber:iq:last' or 'jabber:iq:version' namespaces. Similarly, a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257127">8</a>] service could support Entity Tags only for room lists (retrieved via a "disco#items" request) but not for other requests. As noted, if an entity does not support Entity Tags for a given namespace or request, it SHOULD proceed as if the ETag or If-None-Match SHIM header had not been included in the request.</p>
+    <p class="" style="">Optionally, an entity MAY communicate the namespaces for which it supports Entity Tag functionality by listing those namespaces in its response to a "disco#info" request sent to a node of "http://jabber.org/protocol/shim#ETag":</p>
+    <p class="caption">Example 7. Client Queries Server Regarding Supported Entity Tag Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='header1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim#ETag'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Server Communicates Supported Entity Tag Namespaces</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='header1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/shim#ETag'&gt;
+    ...
+    &lt;feature var='jabber:iq:roster'/&gt;
+    &lt;feature var='jabber:iq:privacy'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, as shown above and as used in HTTP, the requesting entity MAY implicitly discover that Entity Tag functionality is supposed with regard to a given response entity type if the responding entity includes an ETag SHIM header in its response.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="roster">Caching and Retrieving Rosters</a>
+</h3>
+    <p class="" style="">As specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2257212">9</a>], an XMPP instant messaging client will typically store its "roster" (contact list) on the server so that any connecting client for that account can retrieve the roster at will. Since <span style="font-weight: bold">RFC 3921</span> defines no upper limit on the number of items allowed in the roster, it is possible for a roster to become quite large (e.g., there are known cases of rosters with more than 500 or even 1,000 items). Therefore a server may support Entity Tag functionality with regard to roster management. The process is as follows.</p>
+    <p class="" style="">First, the client requests its roster:</p>
+    <p class="caption">Example 9. Client Requests Roster</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='juliet@capulet.com/balcony'
+    id='roster1'&gt;
+ &lt;query xmlns='jabber:iq:roster'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server supports Entity Tag functionality for rosters, it SHOULD include an ETag SHIM header in its response (although it MAY decide not to include the header if the roster is deemed to be not worth caching because it is so small):</p>
+    <p class="caption">Example 10. Server Returns Roster Including ETag Header</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    to='juliet@capulet.com/balcony'
+    id='roster1'&gt;
+ &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='nurse@capulet.com' name='Nurse'&gt;
+      &lt;group&gt;Servants&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='ETag'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+ &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The client would then cache that roster and associate the included Entity Tag with that cached copy. In order to subsequently retrieve the roster, the client would include the last known Entity Tag value with the request in an If-None-Match SHIM header:</p>
+    <p class="caption">Example 11. Client Requests Roster, Including If-None-Match Header</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='juliet@capulet.com/balcony'
+    id='roster2'&gt;
+ &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='If-None-Match'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+ &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the roster did not change since the client last retrieved the roster and the server supports Entity Tags for the 'jabber:iq:roster' namespace, the server MUST return a &lt;not-modified/&gt; error:</p>
+    <p class="caption">Example 12. Server Returns Not Modified Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    to='juliet@capulet.com/balcony'
+    id='roster2'&gt;
+ &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='ETag'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+ &lt;/query&gt;
+  &lt;error code='304' type='modify'&gt;
+    &lt;not-modified xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the roster has changed, the provided Entity Tag value is not valid, or the server does not support Entity Tags, it MUST return the roster as if the If-None-Match header was not included:</p>
+    <p class="caption">Example 13. Server Returns Roster</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    to='juliet@capulet.com/balcony'
+    id='roster2'&gt;
+ &lt;query xmlns='jabber:iq:roster'&gt;
+    &lt;item jid='romeo@montague.net' name='Romeo'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;item jid='nurse@capulet.com' name='Nurse'&gt;
+      &lt;group&gt;Servants&lt;/group&gt;
+    &lt;/item&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='ETag'&gt;some-new-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+ &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="privacy">Caching and Retrieving Privacy Lists</a>
+</h3>
+    <p class="" style="">The payloads exchanged in the privacy list protocol (specified Section 10 of <span style="font-weight: bold">RFC 3921</span>) can also be quite large. Therefore a server might want to support Entity Tags in the context of privacy list management. The process is as follows.</p>
+    <p class="" style="">First, a client requests a privacy lists:</p>
+    <p class="caption">Example 14. Client Requests Privacy List</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='romeo@montague.net/orchard' 
+    id='getlist1'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='special'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server returns the list and includes an Entity Tag in an ETag SHIM header.</p>
+    <p class="caption">Example 15. Server Returns Privacy List Including ETag Header</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    to='romeo@example.net/orchard'
+    id='getlist1'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='special'&gt;
+      &lt;item type='jid'
+            value='juliet@example.com'
+            action='allow'
+            order='6'/&gt;
+      &lt;item type='jid'
+            value='benvolio@example.org'
+            action='allow'
+            order='7'/&gt;
+      &lt;item type='jid'
+            value='mercutio@example.org'
+            action='allow'
+            order='42'/&gt;
+      &lt;item action='deny' order='666'/&gt;
+    &lt;/list&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='ETag'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Later, the client requests the same privacy list again and includes the provided Entity Tag in an If-None-Match SHIM header:</p>
+    <p class="caption">Example 16. Client Requests Privacy List Including If-None-Match Header</p>
+<div class="indent"><pre>
+&lt;iq type='get' 
+    from='romeo@montague.net/orchard' 
+    id='getlist2'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='special'/&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='If-None-Match'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the privacy list did not change since the client last retrieved it and the server supports Entity Tags for the 'jabber:iq:privacy' namespace, the server MUST return a &lt;not-modified/&gt; error:</p>
+    <p class="caption">Example 17. Server Returns Not Modified Error</p>
+<div class="indent"><pre>
+&lt;iq type='error' 
+    to='romeo@example.net/orchard'
+    id='getlist2'&gt;
+ &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='special'/&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='ETag'&gt;some-long-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+ &lt;/query&gt;
+  &lt;error code='304' type='modify'&gt;
+    &lt;not-modified xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the privacy list has changed, the provided Entity Tag value is not valid, or the server does not support Entity Tags, it MUST return the privacy list as if the If-None-Match header was not included:</p>
+    <p class="caption">Example 18. Server Returns Privacy List</p>
+<div class="indent"><pre>
+&lt;iq type='result' 
+    to='romeo@example.net/orchard'
+    id='getlist2'&gt;
+  &lt;query xmlns='jabber:iq:privacy'&gt;
+    &lt;list name='special'&gt;
+      &lt;item type='jid'
+            value='juliet@example.com'
+            action='allow'
+            order='6'/&gt;
+      &lt;item type='jid'
+            value='benvolio@example.org'
+            action='allow'
+            order='7'/&gt;
+      &lt;item type='jid'
+            value='mercutio@example.org'
+            action='allow'
+            order='42'/&gt;
+      &lt;item action='deny' order='666'/&gt;
+    &lt;/list&gt;
+    &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+      &lt;header name='ETag'&gt;some-new-opaque-string&lt;/header&gt;
+    &lt;/headers&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This proposal requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257672">10</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This proposal requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257718">11</a>].</p>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This JEP describes best practices for use of JEP-0131 and therefore does not require a dedicated schema.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250693">1</a>. RFC 2616: Hypertext Transport Protocol -- HTTP/1.1 &lt;<a href="http://www.ietf.org/rfc/rfc2616.txt">http://www.ietf.org/rfc/rfc2616.txt</a>&gt;.</p>
+<p><a name="nt-id2250718">2</a>. JEP-0131: Stanza Headers and Internet Metadata (SHIM) &lt;<a href="http://www.jabber.org/jeps/jep-0131.html">http://www.jabber.org/jeps/jep-0131.html</a>&gt;.</p>
+<p><a name="nt-id2250862">3</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250886">4</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2250974">5</a>. JEP-0072: SOAP over XMPP &lt;<a href="http://www.jabber.org/jeps/jep-0072.html">http://www.jabber.org/jeps/jep-0072.html</a>&gt;.</p>
+<p><a name="nt-id2250919">6</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2257056">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257127">8</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257212">9</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257672">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257718">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-06-02)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-05-26)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0151-0.1.html
+++ b/content/xep-0151-0.1.html
@@ -1,0 +1,1101 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0151: Virtual Presence</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Virtual Presence">
+<meta name="DC.Creator" content="Klaus H. Wolf">
+<meta name="DC.Description" content="This JEP proposes extensions to the Jabber groupchat protocol for virtual presence on Web pages.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0151">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0151: Virtual Presence</h1>
+<p>This JEP proposes extensions to the Jabber groupchat protocol for virtual presence on Web pages.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0151<br>
+            Version: 0.1<br>
+            Last Updated: 2005-06-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0045<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: Not yet assigned<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Virtual%20Presence%20(JEP-0151)">http://wiki.jabber.org/index.php/Virtual Presence (JEP-0151)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Klaus H. Wolf</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:wolf@bluehands.de">wolf@bluehands.de</a><br>
+        JID: 
+        <a href="xmpp:wolfspelz@jabber.bluehands.de">wolfspelz@jabber.bluehands.de</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#sect-id2250743">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2250761">Requirements</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#sect-id2250944">Interaction on Virtual Locations</a>
+</dt>
+<dt>2.2.  <a href="#sect-id2250816">Discovering Virtual Locations</a>
+</dt>
+</dl>
+<dt>3.  <a href="#sect-id2257226">Example of a Virtual Meeting</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#sect-id2257257">Meeting on Virtual Locations</a>
+</dt>
+<dt>3.2.  <a href="#sect-id2257413">Getting more information</a>
+</dt>
+<dt>3.3.  <a href="#sect-id2257534">Avatars</a>
+</dt>
+<dt>3.4.  <a href="#sect-id2257992">Other Ways to get the Avatar</a>
+</dt>
+<dt>3.5.  <a href="#sect-id2258109">Avatar Movement</a>
+</dt>
+<dt>3.6.  <a href="#sect-id2258290">Bubble Chat</a>
+</dt>
+<dt>3.7.  <a href="#sect-id2258403">Video Icon</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2258509">Finding Virtual Locations</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#sect-id2258543">Mapping Rules</a>
+</dt>
+<dt>4.2.  <a href="#sect-id2258947">Web Server based Configuration</a>
+</dt>
+<dt>4.3.  <a href="#sect-id2259180">The Mapping Process</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#sect-id2259230">Retrieve the Configuration File</a>
+</dt>
+<dt>4.3.2.  <a href="#sect-id2259408">Find a Mapping Rule</a>
+</dt>
+<dt>4.3.3.  <a href="#sect-id2259474">Apply the Rule</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#sect-id2259555">Error Codes</a>
+</dt>
+<dt>6.  <a href="#sect-id2259570">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#sect-id2259600">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#sect-id2259663">Formal Definition</a>
+</dt>
+<dl><dt>8.1.  <a href="#sect-id2259670">Schema</a>
+</dt></dl>
+<dt>9.  <a href="#sect-id2259688">Conclusion</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="sect-id2250743">Introduction</a>
+</h2>
+  <p class="" style="">Virtual presence on Web pages (also sometimes known as co-browsing, while co-browsing can also mean something different) makes people aware of each other, who are at the same Web location at the same time. The basic purpose of a virtual presence system is to show names, icons, and/or avatars of people who are on a page or a set of pages and to let them communicate. This document proposes extensions to the Jabber protocol, which enable neat virtual presence on Web pages. The extensions are implemented as namespaces for the protocol elements &lt;iq/&gt;, &lt;presence/&gt;, &lt;message/&gt;, and for server storage. </p>
+  
+  <p class="" style="">This document also covers the mapping of URLs to Jabber chat rooms. It describes step by step how clients derive virtual locations from URLs of web pages. The process includes queries to the web server, queries to default configuration sources, delegation between configuration sets, ways for administrators of websites to opt out, and methods to shape the virtual space actively by clustering together or splitting off URL groups.</p>  
+  
+  <p class="" style="">This document describes an implementation that proved to be useful over one year. We propose the extensions, but we are open to comments and other proposals, if readers think that different approaches would better fit into the Jabber architecture. This also applies to namespaces, especially since the extensions where designed while the Jabber community was moving to URL-style namespaces. So did this implementation.</p>
+<h2>2.
+       <a name="sect-id2250761">Requirements</a>
+</h2>
+
+  <div class="indent">
+<h3>2.1 <a name="sect-id2250944">Interaction on Virtual Locations</a>
+</h3>
+
+  <p class="" style="">Meeting on virtual locations is very similar to meeting peers in a public chat room. But web pages can be regarded as 2 dimensional. They very often cover the entire screen. They use graphics elements for their content. Plainly speaking: representing users as figures or other images fits well to web pages. Once they are shown as individual figures, a line based chat and a chat window are not required any more (though a chat window can still be used). The figures can move around and talk in chat bubble style. Chat bubbles in turn enable incremental chat.</p>
+
+  <p class="" style="">This document describes protocol elements for 
+    <ul>
+      <li>the visualization of users on web pages (animated avatars) and</li>
+      <li>communication beyond line based group chat (incremental or instant bubble chat)</li>
+    </ul>
+  </p>
+
+  <p class="" style="">While users are browsing the web, they enter and leave many rooms. They meet many people and some of them multiple times. Minimum overall traffic and minimum traffic on the user connection are primary design goals. The user connection is limited by typical karma settings of jabber servers. Logging in to virtual locations (rooms) must be quick in terms of round trips and cheap in terms of traffic. Once logged in to a room, the traffic on the user connection should be independent of the number of peers already present. </p>
+
+  <p class="" style="">The extensions have been designed to be:
+    <ul>
+      <li>compatible to the existing Jabber infrastructure and protocols,</li>
+      <li>lightweight with respect to the number of new elements,</li>
+      <li>lightweight with respect to the traffic generated.</li>
+    </ul>
+  </p>
+
+  <p class="" style="">The traffic goals can be met by using only the initial &lt;presence/&gt; stanza, which carries all required information, so that no peer-to-peer messages are required on entering. VP clients which gather additional information about peers (e.g. avatar images) should cache the data so that it can be re-used. This is especially important since users browsing virtually connected locations (i.e. linked pages) may meet very often in a short time.</p>
+
+  <p class="" style="">The virtual presence extensions make use of Jabber group chat. Virtual locations are implemented as public Jabber chat channels. The proposed protocol works with <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250805">1</a>] rooms and GroupChat 1.0 compatible services. It core functionality described here uses only groupchat features.</p> 
+
+  <p class="" style="">The virtual presence extensions are supposed to be implemented by Jabber IM clients in addition to the IM functions or by pure virtual presence (Jabber VP) clients.</p>
+
+  </div>
+
+  <div class="indent">
+<h3>2.2 <a name="sect-id2250816">Discovering Virtual Locations</a>
+</h3>
+
+  <p class="" style="">The virtual presence network is a distributed network of Jabber conference components. Each component is hosting a part of the Web. Conference components may be specifically set up for virtual locations, or they may run chat rooms for virtual locations in addition to other rooms. A website may choose to run a conference component to host the presence on its web pages or it may use a publicly available service. Websites, which do not care, are covered by default servers, while others may opt out entirely in order to avoid virtual presence on their pages. </p>
+
+  <p class="" style="">Usually VP clients gather URLs from active web browsers. They convert these URLs to Jabber chat rooms IDs (JIDs) using web server specific and general rules for the mapping process. Then they enter the room as described in the section 'Example of a Virtual Meeting'. There are many different types of URLs. Many are based on file system paths, others are query style, or a mix of path and query. Sometimes users regard individual pages as locations, sometimes a 'location' consists of multiple pages. Large websites may even consist of multiple DNS names, so that users expect to be at the same location regardless of the actual server name.</p>
+
+  <p class="" style="">Usually website operators will not care about virtual presence on their pages. But once there is a significant amount of chat on their pages, they want to control what happens there. In other words: they need to be able to enforce domestic authority on their pages and even expel visitors from 'their' chat. They will install moderators (persons or software). Moderators authorized by the website might operate on public chat servers, but control is only guaranteed, if a website controls the assignment of moderators by running the chat server. Hence, website operators must be able to control the mapping process so that they can assign chat server addresses (and chat room names) to URLs. Many websites are hierarchical, with sub-folders being managed by different independent owners. The mapping process should allow for detailed mapping rules for sub-folders and general rules closer to the root of websites, so that the 'inner' config prevails. </p>
+
+  <p class="" style="">The mapping process is controlled by configuration files. The files will be downloaded from websites and/or from a default location. Most websites do not know about virtual presence and if they know, then they do not care. Therefore, the mapping process should be designed to allow for virtual presence without cooperation of the website. A default configuration with a simple standard mapping will be used if a website does not provide mapping rules. </p>
+
+  <p class="" style="">Configuration files for the mapping process will often be downloaded over the network. Since the data for multiple virtual locations might add up to large files, the configuration can be split up into individual documents. The splitting is managed by delegation to other config files for subsets of URLs. This is especially important for the default configuration, which may cover special rules for prominent websites.</p>
+
+  <p class="" style="">Global fallback servers are not able to carry all the enter/leave and chat traffic. The virtual presence of many users on many websites demands commercial services for virtual presence hosting. Much like web hosters provide disk space, traffic and processing power, there are commercial (or free) presence hosting services, which provide traffic and processing power. Website operators will either run their own presence servers or rely on commercial services. Commercial operators are limiting the ad-hoc creation of chat rooms for virtual presence or they allow static rooms only. Website operators encode the 'rented' room JID into their mapping configuration. They might even delegate the handling of configuration files entirely to the presence server operator by means of config file delegation.</p>
+
+  <p class="" style="">The mapping process should try to protect the privacy of the user. After all, virtual presence is a violation of privacy in general, because people know where other people are (virtually). This is critical, if compared to the totally un-observed Web without virtual presence. In the real world people are used to being seen in physical locations, but only by others who are physically present in the same location. The mapping process should emulate this restriction. The general idea is to include a one way function (message digest) during the mapping process to prohibit the discovery of 'interesting' chat room names. In other words: observers must do the forward mapping and enter a room to see who is there or discover random room names without being able to re-create the source URL. So, they may be able to find people in random rooms, but do not know the virtual location.</p>
+
+  <p class="" style="">This mapping process is designed to 
+    <ul>
+      <li>make the virtual presence service a distributed network of jabber servers, i.e. conference components,</li>
+      <li>allow for flexible mapping from URLs to JIDs, taking into account that
+        <ul>
+          <li>most URLs are path based,</li>
+          <li>URLs contain queries,</li>
+          <li>sometimes only the query part defines the virtual location,</li>
+          <li>groups of URLs map to a single JID,</li>
+          <li>a single virtual location may comprise multiple web servers,</li>
+          <li>groups of URLs may only cover a sub-folder of path based URLs,</li>
+          <li>not all URLs are known at config time,</li>
+        </ul>
+      </li>
+      <li>allow operators of websites to control the mapping for the URL-space they control,</li>
+      <li>let websites opt out of virtual presence,</li>
+      <li>allow for hierarchical configuration for file system path based URLs,</li>
+      <li>support delegation,</li>
+      <li>allow for virtual presence without the cooperation of the website,</li>
+      <li>allow for distribution of the load of the default configuration server,</li>
+      <li>support commercial virtual presence servers and rented rooms,</li>
+      <li>be extensible to other protocols as virtual presence transport,</li>
+      <li>be easily implemented by website operators,</li>
+      <li>at least limit the privacy issues associated with virtual presence.</li>
+    </ul>
+  </p>
+
+  </div>
+
+<h2>3.
+       <a name="sect-id2257226">Example of a Virtual Meeting</a>
+</h2>
+
+  <p class="" style="">Since it has been suggested that the use of Shakespeare characters might please the reader we will try to employ them without really knowing the works of Shakespeare. Two characters called Romeo and Juliet will appear. Both will be equipped with a Web browser and a virtual presence Jabber client which implements the protocol extensions described in this document (called VP client in the following). The communication is shown as seen by the conference component including 'from' attributes.</p> 
+
+  <div class="indent">
+<h3>3.1 <a name="sect-id2257257">Meeting on Virtual Locations</a>
+</h3>
+    <p class="" style="">This shows how the first meeting of Romeo and Juliet would have happened if they had known Cyberspace, i.e. the Web. Romeo browses the Web with his favorite web client. He reads the page http://www.shakespeare.com/market/ModernLibrary/page1.html. He is also running a VP client. There is no mention of a buddy list jabber client at this point. The VP client is properly logged in to the Jabber server using the JID romeo@montague.net. Through some magic, the VP client acquires the URL of the current web page. The VP client converts the URL into the JID of a public chat room (see section 'Virtual Locations'). The JID will usually be a SHA1 digest of the URL prefixed to a conference component (like f4eb29410ec339144633773dda1dc4a643513933@shakespeare.com). For the sake of readability we will refer to the chat room as room1@shakespeare.com. The VP client then enters the room using 'YoungHero' as the nickname.</p>
+    <p class="caption">Example 1. Entering a virtual location</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/garden' to='room1@shakespeare.com/YoungHero' /&gt;
+    </pre></div>
+
+    <p class="" style="">The room responds:</p>
+    <p class="caption">Example 2. Acknowledgement of the entry</p>
+<div class="indent"><pre>
+&lt;presence from='room1@shakespeare.com/YoungHero' to='romeo@montague.net/garden' /&gt;
+    </pre></div>
+
+  <p class="" style="">Upon reception the VP client visualizes the presence of Romeo at the location to Romeo, e.g. by displaying Romeo's icon and/or nickname on, at, or close to the web page. In other words: the VP client shows an avatar of Romeo on the page.</p> 
+
+  <p class="" style="">Dramatic increases when Juliet browses to the same web page. Her VP client also gathers the URL, performs the same mapping and enters the room. It sends a &lt;presence/&gt; stanza to the room using nickname 'WebGirl'. The room as expected returns the acknowledgement. In addition the room forwards both &lt;presence/&gt; stanzas to the VP clients in order to announce the mutual presence. </p> 
+
+    <p class="" style="">Romeo gets:</p>
+    <p class="caption">Example 3. Announcement of peer presence</p>
+<div class="indent"><pre>
+&lt;presence from='room1@shakespeare.com/WebGirl' to='romeo@montague.net/garden' /&gt;
+    </pre></div>
+
+  <p class="" style="">Juliet gets the equivalent. Romeo's VP client shows Juliet's presence by adding a second avatar to the page. They now engage in a vivid conversation. In deviation to the original text Juliet would not ask "Who art thou, Romeo?", because she only knows the nickname and on the other hand she actually knows where Romeo is: he is on the same web page. There is nothing new until now. Everything happened according to GroupChat 1.0 (JEP-0045) without MUC features. Of course, users can join the same room with any client that supports GroupChat, if they know the room's JID.</p> 
+
+  <p class="" style="">Extensions come into the play in order to make the virtual presence more attractive and more vivid.</p>
+  </div>
+
+  <div class="indent">
+<h3>3.2 <a name="sect-id2257413">Getting more information</a>
+</h3>
+  
+    <p class="" style="">For more information about 'YoungHero' beyond the nickname Juliet needs a JID (see below for anonymous variants of the avatar image). Non-anonymous rooms will supply the JIDs automatically. But we suggest that rooms, which make up the virtual presence network are configured to be anonymous so that users can choose if they want to disclose the JID. We propose an extension to the &lt;presence/&gt; stanza for users to supply their JID automatically to peers in anonymous rooms with minimum traffic even for many participants. </p>
+    
+    <p class="" style="">Note: even though Romeo sends a JID, the systems is still anonymous. Romeo could send any JID. He may send a (fake) JID that is just the base address of his storage, but not his communication address. In anonymous rooms Juliet will use any JID Romeo provides. If the room is not anonymous, then Romeo's client may use Juliet's actual JID. </p>
+    
+    <p class="" style="">Entering the room Juliet would add a JID-element to the initial &lt;presence/&gt; stanza.</p>
+
+    <p class="caption">Example 4. Disclosing the JID</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='room1@shakespeare.com/WebGirl' 
+  &lt;x xmlns='firebat:user:jid'&gt;juliet@capulet.com/balcony&lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+
+    <p class="" style="">(Note: 'firebat' was the developer name of the VP client. Jabber.org URIs could be used here)</p>
+
+    <p class="" style="">This tells the conference component to send the JID to all participants automatically. Romeo will receive the &lt;presence/&gt; stanza including the JID element. Romeo may now fetch Juliet's avatar or add Juliet to a buddy list. </p>
+
+    <p class="" style="">Note: disclosing the JID is usually not advisable in public rooms. We decided to offer the functionality as an option, for 2 reasons:
+      <ol start="" type="">
+        <li>to provide access to extended information from peers without cluttering the &lt;presence/&gt; stanza more than necessary,</li>
+        <li>to allow for caching of extended information.</li>
+      </ol>
+    Caching requires a persistent and unique id per user. While a message digest of the JID would be sufficient for caching extended information, it is not sufficient for retrieving extended information. 
+    </p>
+
+  </div>
+
+  <div class="indent">
+<h3>3.3 <a name="sect-id2257534">Avatars</a>
+</h3>
+
+    <p class="" style="">Romeo will be much more interested in Juliet if Juliet is depicted by a nice image rather than only a name. Users may choose avatars, publish those avatars, and change them on the fly. Changes to the avatar are tracked by comparing a stored digest of the avatar data to the received digest. The avatar digest will be received as part of the &lt;presence/&gt; stanza. Juliet also includes an avatar-digest element with a hex-coded SHA1-digest of the avatar data (i.e. the digest of the image file): </p>
+
+    <p class="caption">Example 5. Avatar Digest</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='room1@shakespeare.com/WebGirl' 
+  &lt;x xmlns='firebat:user:jid'&gt;juliet@capulet.com/balcony&lt;/x&gt;
+  &lt;x xmlns='firebat:avatar:digest'&gt;9b3635eb1440a1ee1c9f67767651194f34ecf130&lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+
+    <p class="" style="">Romeo receives the digest with the initial &lt;presence/&gt; stanza from Juliet. Since this is their first meeting Romeo does not have Juliet's avatar yet. He will fetch the avatar from Juliet's public XML server storage (for a public XML storage free variant see below):</p>
+
+    <p class="caption">Example 6. Avatar Request</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='storage:client:avatar' /&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="" style="">The server returns Juliet's avatar.  </p>
+
+    <p class="caption">Example 7. Avatar Response with Avatar URL</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/garden'&gt;
+  &lt;query xmlns='storage:client:avatar'&gt;
+    &lt;data src='http://www.capulet.com/juliet.png'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="" style="">The 'src' attribute points to the real data, which is to be fetched out of band via HTTP. Juliet supplied a reference to the data because she is a smart WebGirl concerned about bandwidth on the Jabber connection. But if the Capulets would not own a domain she could also choose to store the avatar data directly on the server using base-64 encoding. The avatar response would then be like:</p>
+
+    <p class="caption">Example 8. Avatar Response with Immediate Data</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/garden'&gt;
+  &lt;query xmlns='storage:client:avatar'&gt;
+    &lt;data mimetype='image/png' encoding='base64'
+      &gt;E00fcB79F822u192e7A2067E5229ec136892A296... &lt;/data&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+  <p class="" style="">Juliet can omit the 'mimetype' attribute if she supplies the avatar URL, because the HTTP server will return the MIME type. The 'mimetype' attribute must be included for immediate data. Avatars may be of any type and size. The maximum visible dimensions of avatars should be 64x96 pixels. Larger images will be scaled down to fit into this rectangle. They will not be scaled up. Images align at the bottom so that they can 'stand' on a page on the same base line. </p>
+
+  <p class="" style="">Implementation note: The client should check the image size (byte count) and advice the user if the size exceeds 20 kb. It should also check the image dimensions and warn the user if the image will be scaled down. Checking the size is especially important for immediate data, which will be uploaded over a Jabber connection which is subject to flow control. Typical karma settings only allow for few kb without stalling the connection.</p>
+
+  <p class="" style="">Implementation note: Avatars and associated digests should be stored permanently. They will always be up to date as soon as people meet and exchange digests. There is no cache timeout. The implementation should keep an eye on the avatar storage and delete old and rarely used ones.</p>
+
+  <p class="" style="">Avatars images can also be created of other data types. The following shows an avatar description in XML format, which is to be processed by an advanced avatar engine. The avatar engine will be chosen by the MIME type. For simple image based avatars, the MIME type selects the type of image decoder. Other MIME types may select from a dynamic list of installable avatar rendering plug-ins.</p>
+
+    <p class="caption">Example 9. Avatar Response for an Advanced Avatar</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/garden'&gt;
+  &lt;query xmlns='storage:client:avatar'&gt;
+    &lt;data mimetype='avatar/comic' encoding='plain'&gt;
+      &lt;config xmlns='http://schema.bluehands.de/character-config' version='1.0'&gt;
+        &lt;character name='lluna' version='1.0'
+         src='http://avatar.vp.bluehands.de/comic/lluna.xml'/&gt;
+        &lt;color rgb='#00FF00' name='head'/&gt;
+        &lt;color rgb='#999900' name='shadow'/&gt;
+        &lt;color rgb='#000000' name='border'/&gt;
+        &lt;color rgb='#FFFFFF' name='tooth'/&gt;
+        &lt;color rgb='#FFFFFF' name='eye'/&gt;
+        &lt;color rgb='#000000' name='pupil'/&gt;
+        &lt;color rgb='#000000' name='mouth'/&gt;
+        &lt;color rgb='#FF0000' name='tail1'/&gt;
+        &lt;color rgb='#FF0000' name='tail2'/&gt;
+        &lt;color rgb='#FF0000' name='tail3'/&gt;
+        &lt;scale ratio='0.8'/&gt;
+      &lt;/config&gt;
+    &lt;/data&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+  <p class="" style="">The example avatar data above will be interpreted by the avatar engine, which registered for the MIME type 'avatar/comic'. This is a sample implementation of an animated avatar. The data states that an animation file shall be loaded from <a href="http://avatar.vp.bluehands.de/comic/lluna.xml">http://avatar.vp.bluehands.de/comic/lluna.xml</a> and then the character config shall be applied modifying the colors of the character definition.</p>
+
+  <p class="" style="">The design is particular targeted at existing online games as avatar providers. It would be very easy to adapt the avatar rendering of an online role playing game (MMORPG) or any other community so that it provides avatar images for the VP client. In this case the avatar data would probably only consist of the online accout ID. This is up to the implementation. We imagine such avatar data to be like:</p>
+
+    <p class="caption">Example 10. Potential Role Play-Plugin Avatar Data</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='romeo@montague.net/garden'&gt;
+  &lt;query xmlns='storage:client:avatar'&gt;
+    &lt;data mimetype='rpg/my-favorite-mmorpg' encoding='plain'&gt;ACCOUNTID=6575438998&lt;/data&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+  <p class="" style="">... and the plug-in (which is part or the game distribution) connects to the game server, fetches the configuration, and renders Juliet as an nightelve mage level 30 with all insignia on the web page of Romeo. Romeo is very impressed, falls in love instantly and they both die in the course of a tragic story. Provided that Romeo happens to have the same gaming engine installed. Having not might save him in this time.</p>
+
+  <p class="" style="">Note: As a matter of fact, we propose a call level plug-in interface described at  [<a href="#nt-id2257963">2</a>] for advanced avatars.</p>
+
+  <p class="" style="">Note: To make things simple for the implementation users may have 2 avatars. The first avatar ('storage:client:avatar') is restricted to GIF and PNG images. The second avatar is fully featured, but optional. It is accessed through the namespace 'storage:client:avatar2' and tracked through digest 'firebat:avatar2:digest'. VP clients must implement 'storage:client:avatar' and 'firebat:avatar:digest' with at least PNG support. They may implement 'storage:client:avatar2' and 'firebat:avatar2:digest'. The scheme can be extended with higher numbers. </p>
+
+  </div>
+
+  <div class="indent">
+<h3>3.4 <a name="sect-id2257992">Other Ways to get the Avatar</a>
+</h3>
+
+  <p class="" style="">If Juliet wants to protect her real JID, then she can not use public XML server storage. She can still provide an avatar by including the avatar data into the &lt;presence/&gt; stanza. </p>
+    <p class="caption">Example 11. Explicit Avatar Presence Data</p>
+<div class="indent"><pre>
+&lt;x xmlns='firebat:avatar:data'&gt;&lt;data src='http://www.capulet.com/juliet.png'/&gt;&lt;/x&gt;
+
+as part of:
+&lt;presence from='juliet@capulet.com/balcony' to='room1@shakespeare.com/WebGirl' 
+  &lt;x xmlns='firebat:avatar:digest'&gt;9b3635eb1440a1ee1c9f67767651194f34ecf130&lt;/x&gt;
+  &lt;x xmlns='firebat:avatar:data'&gt;&lt;data src='http://www.capulet.com/juliet.png'/&gt;&lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+
+  <p class="" style="">Juliet must not send bulky immediate data, but a reference to the image. Immediate data is only allowed, if it is smaller than a simple &lt;presence/&gt; stanza (see above). </p>
+    <p class="caption">Example 12. Explicit and Immediate Avatar Presence Data</p>
+<div class="indent"><pre>
+&lt;x xmlns='firebat:avatar:data'&gt;
+  &lt;data mimetype='rpg/my-favorite-mmorpg' encoding='plain'&gt;ACCOUNTID=6575438998&lt;/data&gt;
+&lt;/x&gt;
+    </pre></div>
+
+  <p class="" style="">Note: There are other features which won't work without the real JID. Therefore it is recommended that clients include the JID in the &lt;presence/&gt; stanza. If Juliet wants to use all JID-based features then she would rather use a public Jabber server with an anonymous account, like she is used to do in case of email. This feature is supported because there are still Juliets who refrain from disclosing the JID and because the avatar is very important.</p>
+
+  <p class="" style="">If Juliet provides the JID, but public XML server storage is not supported on Juliet's server, then Romeo may try to discover the avatar using disco features. He will query Juliet's server avatar disco node</p>
+    <p class="caption">Example 13. Avatar Discovery Request</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com' type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info' node='http://jabber.org/protocol/avatar'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+  <p class="" style="">The result contains an item with the JID of the pubsub component where Juliet's avatar information is published and the specific node for that information:</p>
+    <p class="caption">Example 14. Avatar Discovery Response</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com' to='romeo@montague.net/orchard' &gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+    node='http://jabber.org/protocol/avatar'&gt;
+    &lt;item jid='pubsub.shakespeare.lit' node='avatar/info/juliet@capulet.com'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+  </div>
+
+  <div class="indent">
+<h3>3.5 <a name="sect-id2258109">Avatar Movement</a>
+</h3>
+    <p class="" style="">A web page can be regarded as a two dimensional space. Avatars can move around on the page. Users are not just at a page, they are at a certain coordinate of the page. Entering the room Juliet tells Romeo (and all other participants) her initial position by including a position element into the initial &lt;presence/&gt; stanza:</p>
+
+    <p class="caption">Example 15. Avatar Position</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='room1@shakespeare.com/WebGirl' 
+  &lt;x xmlns='firebat:user:jid'&gt;juliet@capulet.com/balcony&lt;/x&gt;
+  &lt;x xmlns='firebat:avatar:digest'&gt;9b3635eb1440a1ee1c9f67767651194f34ecf130&lt;/x&gt;
+  &lt;x xmlns='firebat:avatar:position'&gt;&lt;position x='180' w='853'/&gt;&lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+
+    <p class="" style="">The coordinates are in pixels from the bottom left corner of the browser window. In this case she only tells the horizontal position. She could add a 'y' attribute. She also voluntarily discloses the width of her browser window. The width ('w') and height ('h') attributes are optional. They enable relative positioning at the other end.</p>
+
+    <p class="" style="">As soon as Juliet enters and her avatar appears, Romeo moves his avatar up to Juliet's. Romeo's VP client sends a new &lt;presence/&gt; stanza with an altered position. The message is automatically broadcast by the room to all participants and stored for new participants. Romeo approaches Juliet:</p>
+
+    <p class="caption">Example 16. Move Avatar</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/garden' to='room1@shakespeare.com/YoungHero' 
+  &lt;x xmlns='firebat:user:jid'&gt;romeo@montague.net&lt;/x&gt;
+  &lt;x xmlns='firebat:avatar:digest'&gt;e5229ec136892e00fcb79f822c192e7a2067a296&lt;/x&gt;
+  &lt;x xmlns='firebat:avatar:position'&gt;&lt;position x='150'/&gt;&lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+
+    <p class="" style="">Note that this &lt;presence/&gt; stanza, which is sent in order to move the avatar is not different from the initial &lt;presence/&gt; stanza to the room. This is just a repetition with a different coordinate.</p>
+
+    <p class="" style="">Juliet's VP client forwards the movement to the avatar rendering engine. In case of an image based avatar the image is just moved to take up the new position. In case on an animated avatar, the avatar engine will generate a sequence of images which lets the figure 'walk' to the new position or whatever movement method is appropriate for the avatar.</p>
+
+    <p class="" style="">Now Romeo occupies exactly the part of the web page that Juliet is reading so she moves Romeo (locally) out of the way. This happens only on Juliet's screen. Once Juliet finished reading, she wants to restore Romeo's position. She sends a control message to Romeo to request the current position:</p>
+
+    <p class="caption">Example 17. Request Avatar Position</p>
+<div class="indent"><pre>
+&lt;iq from='room1@shakespeare.com/WebGirl' to='room1@shakespeare.com/YoungHero' type='get'&gt;
+  &lt;query xmlns='http://schema.bluehands.de/avatar#position'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="" style="">Romeo responds with a control message which indicates the avatar position:</p>
+
+    <p class="caption">Example 18. Send Avatar Position</p>
+<div class="indent"><pre>
+&lt;iq from='room1@shakespeare.com/YoungHero' to='room1@shakespeare.com/WebGirl' type='result'&gt;
+  &lt;query xmlns='http://schema.bluehands.de/avatar#position'&gt;
+    &lt;position x='123' w='800'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="" style="">Juliet' VP client restores Romeo's avatar position:</p>
+
+  </div>
+
+  <div class="indent">
+<h3>3.6 <a name="sect-id2258290">Bubble Chat</a>
+</h3>
+    
+    <p class="" style="">We remember: after seeing Juliet's avatar, Romeo has already falling in love. But Juliet is a more realistic type. She insists on talking before falling in love. The avatar-on-web-pages paradigm frees us from chat line based chat. Each avatar may show a separate chat bubble with the latest text or even a chat history. </p>
+
+    <p class="" style="">While Juliet is writing an opening, her VP client may send the current contents of the chat line to the room giving other participants snapshots of the text. We propose instant chat updates as an extension to groupchat. For backward compatibility these snapshots are transmitted as control messages without body text, so that other clients ignore them. Once Juliet hits the send button (or the enter-key) the VP client sends the chat message as body text of a &lt;message/&gt;. With a timely distance of fractions of seconds to few seconds Juliet sends the following messages:</p>
+
+    <p class="caption">Example 19. Instant Chat</p>
+<div class="indent"><pre>
+&lt;message from='room1@shakespeare.com/WebGirl' to='room1@shakespeare.com'&gt;
+  &lt;x xmlns='firebat:chat:state'&gt;Who&lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message from='room1@shakespeare.com/WebGirl' to='room1@shakespeare.com'&gt;
+  &lt;x xmlns='firebat:chat:state'&gt;Who art thou,&lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message from='room1@shakespeare.com/WebGirl' to='room1@shakespeare.com'&gt;
+  &lt;x xmlns='firebat:chat:state'&gt;Who art thou, YoungHer&lt;/x&gt;
+&lt;/message&gt;
+
+&lt;message from='room1@shakespeare.com/WebGirl' to='room1@shakespeare.com'&gt;
+  &lt;body&gt;Who art thou, YoungHero?&lt;/body&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    <p class="" style="">Note: we propose to send the full text with every message. Differential updates seem to be the proper way. But the addressing information sent with each message produces more traffic than the enclosed text. This is especially true for randomly chosen (read: long) room names. On the other hand differential text requires synchronization points for new participants, who lack the history. Such synchronization points would carry the full text every other second rendering differential updates almost useless.</p>
+
+    <p class="" style="">Implementation note: The traffic must stay below the karma-limitations of typical jabber servers. The minimum delay between instant chat messages should be 1 sec. The delay should be increased with the size of the text. We get a good balance between interactivity and traffic with the following algorithm (in msec): delay = max(5000, min(NumberOfChars x 25, 1000)). In words: from 1 second at 40 characters up to 5 seconds at 200 characters.</p>
+
+    <p class="" style="">Implementation note: There is no limitation on the size of the instant chat specified. But some users, especially the ones not used to chat channels write without ever pressing the enter-key. Implementations should limit the size to reasonable length (200-1000 characters) by telling the user, refusing to send more, or just stripping the beginning of a long text.</p>
+
+  </div>
+
+  <div class="indent">
+<h3>3.7 <a name="sect-id2258403">Video Icon</a>
+</h3>    
+    <p class="" style="">After some chatting, Juliet is still not convinced. She demands to see Romeo live (although not in person). Romeo switches on his webcam and sends the webcam URL as part of the &lt;presence/&gt; stanza.</p>
+
+    <p class="caption">Example 20. Iconic Video</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/garden' to='room1@shakespeare.com/YoungHero' 
+  &lt;x xmlns='firebat:user:jid'&gt;romeo@montague.net&lt;/x&gt;
+  &lt;x xmlns='firebat:avatar:digest'&gt;e5229ec136892e00fcb79f822c192e7a2067a296&lt;/x&gt;
+  &lt;x xmlns='firebat:avatar:position'&gt;&lt;position x='150'/&gt;&lt;/x&gt;
+  &lt;x xmlns='firebat:icon:video'&gt;http://romeo.montague.net/video/icon&lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+
+    <p class="" style="">Juliet's VP client HTTP-requests the video stream. The video is shown close to Romeo's avatar. Juliet falls in love.</p>
+
+    <p class="" style="">The video format is the common, widely used webcam format introduced by Netscape (JPEG server-pushed).</p>
+
+    <p class="" style="">In the real world there are many Romeos and Juliets even on the same page at the same time. Some of them with a webcam. Depending on the default settings of VP clients all users (say 8) will automatically request the videos of the subset of users equipped with a webcam (say 3). This automatically creates many video streams, 3 streams on the dialup line of all users and 7 streams on the line of webcam users. We therefore suggest the following optimizations and limitations:
+      <ul>
+        <li>video dimensions should be limited to 64x64 pixels, thus fitting into the 64x96 avatar rectangle,</li>
+        <li>the frame rate should not exceed 3 frames per second for simple web browsing (special applications, especially assymmetric ones, like virtual class rooms, presentations may differ),</li>
+        <li>for small sizes, quantization tables and Huffman tables make much more data than the encoded image. Therefore the DQT and DHT markers should be stripped from JPEG frames except for the first frame of a stream. Only the JPEG baseline algorithm is supported with static Huffman tables,</li>
+        <li>VP clients which support such a optimized JPEG server-push format should add a 'Accept: image/djpeg' header to the HTTP request. (djpeg for differential JPEG)</li>
+      </ul>
+
+    The purpose of these limitations is to allow for webcams which send optimized streams of small images (reducing the data volume by a factor of 3) while supporting usual webcams.
+    </p>
+
+  </div>
+
+<h2>4.
+       <a name="sect-id2258509">Finding Virtual Locations</a>
+</h2>
+
+  <p class="" style="">Finding a virtual location for a websites means mapping a URL to a JID. The VP client gets the URL from the browser by some platform dependent way of interprocess communication. The URL may have been entered by the user, or it may be the result of a URI resolver. Then the VP client searches for an applicable mapping rule. This may include fetching multiple configuration files over the network. Finally the rule is applied and the VP client can enter the room.</p>
+
+  <p class="" style="">Note: It is not possible to map general URIs to JIDs. Finding a mapping rule is only defined for HTTP and FTP schemes. Hence the mapping process is only defined for http: and ftp: URLs.</p>
+
+  <div class="indent">
+<h3>4.1 <a name="sect-id2258543">Mapping Rules</a>
+</h3>
+
+  <p class="" style="">The basic mechanism is very simple: a URL is mapped by means of a regular expression with replacement term. A hash function may follow after the regular expression and an optional prefix has been added for convenience. This is called a mapping rule. </p>
+
+  <p class="" style="">Romeo is on http://www.shakespeare.com/market/ModernLibrary/index.html. A single mapping rule might cover the entire URL space of http://www.shakespeare.com/. It might look like:</p>
+
+  <p class="caption">Example 21. Basic Mapping Rule</p>
+<div class="indent"><pre>
+&lt;rule&gt;
+  &lt;search&gt;^http://www\.shakespeare\.com/([^/]+)/.*$&lt;/search&gt; 
+  &lt;replace&gt;\1-room&lt;/replace&gt;
+  &lt;digest&gt;
+    &lt;prefix&gt;vp-generated-&lt;/prefix&gt;
+  &lt;/digest&gt;
+&lt;/rule&gt;
+  </pre></div>
+
+  <p class="" style="">This rule extracts the first level folder of the path section from the URL. It creates a room for each first level folder. The result ('market-room') is hashed by a message digest, if the &lt;digest/&gt; tag is present. A SHA1 digest is used by default. VP clients must support SHA1. The hashed result will be prefixed by 'vp-generated-'. This is for convenience, so that rooms generated for virtual presence can be sorted easily in room lists of conference components. Both &lt;digest/&gt; and &lt;prefix/&gt; are optional.</p>
+
+  <p class="" style="">Flexibility requires that there be a set of rules applied to a URL. At least one of the rules (actually the &lt;search/&gt;-expression of the rule) should match the URL. The first matching rule will be used for the mapping. Rules are applied in the order of appearance. The set is enclosed by a &lt;location/&gt;-tag. The &lt;location/&gt; has a match-attribute that selects the URL space, which is handled by the &lt;location/&gt;. In other words: the URL is compared to the match-attribute of all &lt;location/&gt;s in a config file. If a match-attribute is omitted, then the &lt;location/&gt; generates JIDs for all URLs <span style="font-style: italic">in the same folder as the original URL</span>. The first &lt;location/&gt; that matches will produce the JID. All &lt;rule/&gt;s will be &lt;search&gt;ed and the first matching &lt;rule/&gt; will be used for the mapping by doing the &lt;replace&gt;ment, &lt;digest/&gt; and &lt;prefix/&gt;.</p>
+  
+  <p class="" style="">The rule set produces a room-name. The address of the conference component will then be appended to the room-name. The result is a Jabber room JID. This is the Jabber view.</p>
+  
+  <p class="" style="">More generally speaking: The rules generate a virtual location ID. The location ID is then sent to the virtual presence service denoted in the &lt;service/&gt;-tag of the &lt;location/&gt;. The &lt;service/&gt;-tag contains a service URL, which consists of a scheme and address. In this case the 'jabber'-scheme means that the Jabber protocol will be used and that the VP client joins a Jabber chat room with a JID created according to the Jabber ID building rules, i.e. room-name@address. This mechanism is extensible to other protocols as virtual presence transport, e.g. IRC.</p>
+
+  <p class="" style="">A location configuration looks like: </p>
+
+  <p class="caption">Example 22. Location Config</p>
+<div class="indent"><pre>
+&lt;location match="^http://www\.shakespeare\.com($|/.*$)"&gt;
+  &lt;mapping&gt;
+    &lt;rule&gt;
+      &lt;search&gt;^http://www\.shakespeare\.com($|/$|/index\..+$)&lt;/search&gt; 
+      &lt;replace&gt;toplevel-room&lt;/replace&gt;
+      &lt;digest&gt;
+        &lt;prefix&gt;vp-generated-&lt;/prefix&gt;
+      &lt;/digest&gt;
+    &lt;/rule&gt;
+    &lt;rule&gt;
+      &lt;search&gt;^http://www\.shakespeare\.com/([^/]+)/.*$&lt;/search&gt; 
+      &lt;replace&gt;\1-room&lt;/replace&gt;
+      &lt;digest&gt;
+        &lt;prefix&gt;vp-generated-&lt;/prefix&gt;
+      &lt;/digest&gt;
+    &lt;/rule&gt;
+    &lt;rule&gt;
+      &lt;search&gt;.*&lt;/search&gt; 
+      &lt;replace&gt;fallback-room&lt;/replace&gt;
+      &lt;digest&gt;
+        &lt;prefix&gt;vp-generated-&lt;/prefix&gt;
+      &lt;/digest&gt;
+    &lt;/rule&gt;
+  &lt;/mapping&gt;
+  &lt;service&gt;jabber:conference.shakespeare.com&lt;/service&gt;
+&lt;/location&gt;
+  </pre></div>
+
+  <p class="" style="">Most web sites will use the same conference server for all rooms. Therefore the location has a default &lt;service/&gt; directive. In the above example the service-URL is <span style="font-style: italic">jabber:conference.shakespeare.com</span> (please note the scheme). But there might be configurations where a single &lt;location/&gt; section connects to different conference servers. For this reason the default &lt;service/&gt; directive can be overridden by a rule specific &lt;service/&gt; directive. The service-URL of the rule is computed by means of the same search expression, using the rule specific &lt;service/&gt; directive as replacement string.</p>
+
+  <p class="caption">Example 23. Service URL by rule</p>
+<div class="indent"><pre>
+&lt;location match="^http://www\.shakespeare\.com($|/.*$)"&gt;
+  &lt;mapping&gt;
+    &lt;rule&gt;
+      &lt;search&gt;^http://www\.shakespeare\.com/([^/]+)/(.*)$&lt;/search&gt; 
+      &lt;replace&gt;\2&lt;/replace&gt;
+      &lt;service&gt;jabber:\1.conference.shakespeare.com&lt;/service&gt;
+    &lt;/rule&gt;
+  &lt;/mapping&gt;
+&lt;/location&gt;
+  </pre></div>
+
+  <p class="" style="">In this example each sub-folder of the URL will connect to a different conference server. The \1 means that the name of the first sub-folder is used as part of the conference server name. The URL part behind the first sub-folder determines the room name (\2).</p>
+
+
+  <p class="" style="">Independent services may publish lists of virtual locations. An example is a 'topsites'-service, which publishes a list of most active locations as a list of URLs. These services usually require the cooperation of VP clients. VP clients publish their locations (and URLs), if configured to do so. In some cases website operators allow for virtual presence on their pages, but they do not want that the real URLs are published, or they do not want the URLs published at all. Therefore the location configuration offers optional tags to control how URLs are disclosed by VP clients. A &lt;hidden/&gt;-tag prohibits the publication of the URL. A &lt;destination/&gt;-tag modifies the URL. A &lt;hidden/&gt; location may look like:</p>
+
+  <p class="caption">Example 24. Hidden Location</p>
+<div class="indent"><pre>
+&lt;location match="^http://www\.shakespeare\.com($|/.*$)"&gt;
+  &lt;mapping&gt;
+    &lt;rule&gt;
+      &lt;search&gt;.*&lt;/search&gt; 
+      &lt;replace&gt;www.shakespeare.com&lt;/replace&gt;
+      &lt;hidden/&gt;
+    &lt;/rule&gt;
+  &lt;/mapping&gt;
+&lt;/location&gt;
+  </pre></div>
+
+  <p class="" style="">In this example all URLs of the website will be mapped to a single room. Users will be present there, but the room will not appear in public lists (if clients and publication services comply).</p>
+
+  <p class="" style="">A simplification of the above is the &lt;mapped/&gt;-tag, which does not employ regular expressions. All URLs of the website can be mapped to a single location (omitting the &lt;hidden/&gt; feature again):</p>
+
+  <p class="caption">Example 25. Direct Mapping</p>
+<div class="indent"><pre>
+&lt;location match="^http://www\.shakespeare\.com($|/.*$)"&gt;
+  &lt;mapping&gt;
+    &lt;mapped&gt;www.shakespeare.com&lt;/mapped&gt;
+  &lt;/mapping&gt;
+&lt;/location&gt;
+  </pre></div>
+
+  <p class="" style="">The &lt;destination/&gt;-tag modifies the URL so that website operators control which URLs are published. They might delete a web-session ID from URLs or alter the URL so that users who discover the location on a publication service are directed to a different URL. The biggest concern is that the exposed URL may contain security relevant session data. The &lt;destination/&gt;- (per &lt;rule/&gt;) allows to remove this data from URLs while preserving browseable URLs. The following example deletes the query part from URLs.</p>
+
+  <p class="caption">Example 26. Destination: Modifying Published URLs</p>
+<div class="indent"><pre>
+&lt;location match="^http://www\.shakespeare\.com($|/.*$)"&gt;
+  &lt;mapping&gt;
+    &lt;rule&gt;
+      &lt;search&gt;.*&lt;/search&gt; 
+      &lt;replace&gt;www.shakespeare.com&lt;/replace&gt;
+      &lt;destination&gt;
+        &lt;search&gt;(^http://www\.shakespeare\.com[^?]*)($|[?].*$)&lt;/search&gt;
+        &lt;replace&gt;\1&lt;/replace&gt;
+      &lt;/destination&gt;
+    &lt;/rule&gt;
+  &lt;/mapping&gt;
+&lt;/location&gt;
+  </pre></div>
+
+  <p class="" style="">Note: VP clients should not rely on a &lt;destination/&gt; only, when publishing URLs. A client should consult the user if, how, and where URLs are to be published. It is recommended to strip the query part by default until configured otherwise. </p>
+
+  <p class="" style="">The &lt;ignore/&gt;-tag prevents virtual presence clients from dealing with matching URLs. There will be no virtual presence associated with the URL.</p>
+
+  <p class="caption">Example 27. Ignore: Opt out</p>
+<div class="indent"><pre>
+&lt;location match="^http://www\.shakespeare\.com($|/.*$)"&gt;
+  &lt;ignore/&gt;
+&lt;/location&gt;
+  </pre></div>
+
+  <p class="" style="">Finally, all &lt;location/&gt;s are wrapped by the document element &lt;vpi/&gt; with an appropriate XML namespace. A VPI file looks like: 
+      <p class="caption">Example 28. VPI file format</p><div class="indent"><pre>
+&lt;?xml version='1.0' ?&gt;
+&lt;vpi xmlns='http://schema.bluehands.de/virtual-presence-info'&gt;
+  &lt;location match='...'&gt;...&lt;/location&gt;
+  &lt;location match='...'&gt;...&lt;/location&gt;
+  ...                        &lt;!--   more locations  --&gt;
+  &lt;location&gt;...&lt;/location&gt;   &lt;!--  default location --&gt;
+&lt;/vpi&gt;</pre></div>
+  
+  Examples are available at  [<a href="#nt-id2258931">3</a>]
+  </p>
+  
+  </div>
+
+  <div class="indent">
+<h3>4.2 <a name="sect-id2258947">Web Server based Configuration</a>
+</h3>
+
+  <p class="" style="">Location configuration data, such as the above is stored in configuration files called Virtual Presence Information (VPI) files. The files are fetched via HTTP or FTP, according to the scheme of the URL which is to be mapped. Websites can offer VPI files at each level in the path hierarchy. If they do not offer VPI files then the VP client reverts to default VPI. The VP client tries to find a VPI file in the same folder as the file of the URL. It strips the file and query parts of the URL and appends the file name _vpi.xml:</p>
+
+  <p class="caption">Example 29. Nearest VPI File</p>
+<div class="indent"><pre>
+http://www.shakespeare.com/market/ModernLibrary/_vpi.xml
+  </pre></div>
+
+  <p class="" style="">HTTP-servers have many different ways to respond if the file is not available, which is the most common case. They should respond with a 404 status code and an optional HTML message. But some web servers are configured to return a default document, some return a status code 200 and a 'Content-type: text/html' message with an error text, some even return  status code 200 and 'Content-type: text/xml' with an HTML message. It is therefore recommended that VP clients check the HTTP status code, the Content-type and the validity of the XML document. If there is no such file or if it is not a valid XML file or, in case of HTTP, if the Content-type is not text/xml, then the request fails. If the request fails then the client ascends the path until it hits the top level of the website trying to fetch:</p>
+
+  <p class="caption">Example 30. Web Site Toplevel VPI File</p>
+<div class="indent"><pre>
+http://www.shakespeare.com/_vpi.xml
+  </pre></div>
+
+  <p class="" style="">If the request fails, then the client reverts to a default VPI file if there is any. Our implementation uses http://vpi.vp.bluehands.de/lluna-2.3.10/root-vpi.xml. It will finally use http://vpi.vp.bluehands.de/root-vpi.xml or another global configuration file. http://vpi.jabber.org/root.xml would be an option.</p>
+
+  <p class="" style="">If there is no default VPI file then the VP client uses the following configuration data:</p>
+
+  <p class="caption">Default VPI</p>
+<div class="indent"><pre>
+&lt;location&gt;
+  &lt;service&gt;jabber:conference.jabber.bluehands.de&lt;/service&gt; 
+  &lt;mapping&gt;
+    &lt;rule&gt;
+      &lt;search&gt;^http://([^/]+)($|/.*$)&lt;/search&gt; 
+      &lt;replace&gt;\1&lt;/replace&gt; 
+      &lt;digest/&gt;
+    &lt;/rule&gt;
+  &lt;/mapping&gt;
+&lt;/location&gt;
+  </pre></div>
+
+  <p class="" style="">This configuration creates a virtual location for each web server address. The server name is obfuscated by a hash function (SHA1). The location configuration applies to all URLs, since the match attribute of the &lt;location/&gt; defaults to '.*'.</p>
+
+  <p class="" style="">VP clients must cache the result of VPI downloads including failed requests and invalid responses. They must keep a local copy for at least a few minutes to avoid traffic from multiple (ascending) VPI file downloads. </p>
+
+  <p class="" style="">Note: There are many websites, which consist of multiple web server addresses. This is especially true for large sites, which use DNS round-robin for load balancing. These websites need a special mapping to meet the expectation of the user, because users usually do not care if they are on www01.website.com or on www02.website.com. If users expect to see each other, then the virtual presence service should meet the expectations. There might also be website operators, who do not like virtual presence on their pages. These operators may even take legal action against the provider of the VP client software. So, these websites may require special configuration as well. And there may be other reasons for individual configuration of selected websites. Therefore it is recommended, that VP clients update their default configuration, i.e. by using an automatic update feature or by downloading the default VPI.</p>
+
+  <p class="" style="">A VPI file may delegate the handling of URL spaces to another VPI file. The &lt;delegate/&gt;-node replaces the &lt;mapping/&gt; and &lt;service/&gt; nodes of the &lt;location/&gt;. If the VP client discovers a &lt;delegate/&gt; tag inside a &lt;location/&gt;, which matches the URL to be mapped, then it stops processing the file and loads the VPI file denoted by the &lt;delegate/&gt;-tag. A request to http://www.shakespeare.com/market/ModernLibrary/_vpi.xml could return VPI like:</p>
+
+  <p class="caption">Example 31. Delegation</p>
+<div class="indent"><pre>
+&lt;location&gt;
+  &lt;delegate&gt;http://www.shakespeare.com/_vpi.xml&lt;/delegate&gt; 
+&lt;/location&gt;
+  </pre></div>
+
+  <p class="" style="">This means that the VP client skips http://www.shakespeare.com/market/_vpi.xml and continues with http://www.shakespeare.com/_vpi.xml. Delegation can be used to direct the VP client to the VPI file of a commercial virtual presence service. The commercial service would then be responsible to create rooms for customers and to provide the appropriate VPI. Delegation is also useful to split up the default VPI file. The default VPI file contains special configuration for some large websites. It has been split into individual files for different (DNS) top level domains. The global VPI file currently in use (http://vpi.vp.bluehands.de/lluna-2.3.10/root-vpi.xml) contains the following statement for the .com space:</p>
+
+  <p class="caption">Example 32. Delegation for Subspaces</p>
+<div class="indent"><pre>
+...
+&lt;location match="^http://.*\.com($|/.*)"&gt;
+  &lt;delegate&gt;http://vpi.vp.bluehands.de/lluna-2.3.10/dotcom-vpi.xml&lt;/delegate&gt; 
+&lt;/location&gt;
+...
+  </pre></div>
+
+  </div>
+
+  <div class="indent">
+<h3>4.3 <a name="sect-id2259180">The Mapping Process</a>
+</h3>
+
+  <p class="" style="">This section is intended as a guideline for the implementation of the mapping process.</p>
+
+  <p class="" style="">The mapping has 3 phases: 
+    <ol start="" type="">
+    <li>retrieving the config file, </li>
+    <li>finding the appropriate mapping rule, and</li>
+    <li>applying the rule</li>
+    </ol>
+  </p>
+
+  <div class="indent">
+<h3>4.3.1 <a name="sect-id2259230">Retrieve the Configuration File</a>
+</h3>
+
+  <p class="" style="">
+      We get a URL from the web browser, say
+        <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/market/ModernLibrary/index.html</pre></div>
+      We try to fetch the configuration file from 
+        <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/market/ModernLibrary/_vpi.xml</pre></div>
+      The request fails (the failure is noted in the cache), and we try
+        <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/market/_vpi.xml</pre></div>
+      The request fails again (the failure is noted in the cache). We try
+        <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/_vpi.xml</pre></div>
+      We do not find it (the failure is noted in the cache), and we revert to the 
+      global file (this depends on the client configuration)
+        <p class="caption"></p><div class="indent"><pre>http://vpi.vp.bluehands.de/lluna-2.3.10/root-vpi.xml</pre></div>
+      The request returns (and the data is stored in the cache): 
+      <p class="caption"></p><div class="indent"><pre>
+&lt;?xml version='1.0' ?&gt;
+&lt;vpi xmlns='http://schema.bluehands.de/virtual-presence-info'&gt;
+
+  &lt;!-- handle .com(s) by another file --&gt; 
+  &lt;location match='^http://.*\.com/.*'&gt;
+    &lt;delegate&gt;http://vpi.vp.bluehands.de/lluna-2.3.10/dotcom-vpi.xml&lt;/delegate&gt;
+  &lt;/location&gt;
+
+  &lt;!-- handle .de(s) by another file --&gt; 
+  &lt;location match='^http://.*\.de/.*'&gt;
+    &lt;delegate&gt;http://vpi.vp.bluehands.de/lluna-2.3.10/dotde-vpi.xml&lt;/delegate&gt;
+  &lt;/location&gt;
+
+  &lt;!-- all others go here --&gt;
+  &lt;location&gt;
+    &lt;service&gt;jabber:conference.jabber.bluehands.de&lt;/service&gt;
+    &lt;mapping&gt;
+      &lt;!-- one location per website  --&gt;
+      &lt;rule&gt;
+        &lt;search&gt;^http://([^/]+)($|/.*$)&lt;/search&gt;
+        &lt;replace&gt;\1&lt;/replace&gt;
+        &lt;digest/&gt;
+      &lt;/rule&gt;
+    &lt;/mapping&gt;
+  &lt;/location&gt;
+&lt;/vpi&gt;</pre></div>
+
+      We try to find a &lt;location/&gt; that matches our URL. We find:
+      <p class="caption"></p><div class="indent"><pre>
+&lt;location match='^http://.*\.com/.*'&gt;
+  &lt;delegate&gt;http://vpi.vp.bluehands.de/lluna-2.3.10/dotcom-vpi.xml&lt;/delegate&gt;
+&lt;/location&gt;</pre></div>
+
+      This means that all .com domains are forwarded to a separate VPI file. 
+      We fetch:
+      <p class="caption"></p><div class="indent"><pre>http://vpi.vp.bluehands.de/lluna-2.3.10/dotcom-vpi.xml</pre></div>
+
+      We store the result in the cache and search for a matching &lt;location/&gt;
+      again. We find the default section (rest of the file omitted):
+      <p class="caption"></p><div class="indent"><pre>
+...
+&lt;location&gt;
+  &lt;service&gt;jabber:conference.jabber.bluehands.de&lt;/service&gt;
+  &lt;mapping&gt;
+    &lt;rule&gt;
+      &lt;search&gt;^http://([^/]+)($|/.*$)&lt;/search&gt;
+      &lt;replace&gt;\1&lt;/replace&gt;
+      &lt;digest/&gt;
+    &lt;/rule&gt;
+  &lt;/mapping&gt;
+&lt;/location&gt;
+...</pre></div>
+
+      The default &lt;location/&gt; matches, so we get a virtual presence 
+      service address and a set of rules. 
+      The virtual presence service is 
+        <p class="caption"></p><div class="indent"><pre>conference.jabber.bluehands.de</pre></div>
+
+      The protocol to use is 
+        <p class="caption"></p><div class="indent"><pre>jabber</pre></div>
+
+      There is one mapping rule:
+      <p class="caption"></p><div class="indent"><pre>
+&lt;rule&gt;
+  &lt;search&gt;^http://([^/]+)($|/.*$)&lt;/search&gt; 
+  &lt;replace&gt;\1&lt;/replace&gt;
+  &lt;digest/&gt;
+&lt;/rule&gt;</pre></div>
+
+      The result of the first phase is a set of mapping rules (with 1 rule), which will be 
+      applied to all URLs <span style="font-style: italic">in the same folder</span> as the original URL. In regex-speech:
+      <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/market/ModernLibrary/.*</pre></div>
+
+      To apply the mask only to URLs in the same URL-path folder is a security 
+      requirement, so that 'inner' VPI files 
+      from websites can not configure the mapping of 'outer' folders or 'sibling' folders. 
+      VPI files from web sites can only configure the path from which they are 
+      loaded. So, there are actually 2 URL-masks which must be combined to get the real 
+      mask of a rule set. 
+  </p>
+  <p class="" style="">
+      The VPI file has been found at:
+      <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/market/ModernLibrary/_vpi.xml</pre></div>
+
+      So, the security mask is:
+      <p class="caption"></p><div class="indent"><pre>^http://www\.shakespeare\.com/market/ModernLibrary/.*</pre></div>
+
+      The &lt;location/&gt; has a match attribute. This is the user supplied mask 
+      of the rule set:
+      <p class="caption"></p><div class="indent"><pre>^http://www\.shakespeare\.com($|/.*$)</pre></div>
+
+      The simplest way to guarantee that both masks are matched is to check against 
+      both, rather than creating a combined mask. So, the rule above will be 
+      stored to the rule repository with 2 masks:
+      <p class="caption"></p><div class="indent"><pre>
+^http://www\.shakespeare\.com/market/ModernLibrary/.* (security-mask)
+^http://www\.shakespeare\.com($|/.*$)                 (user-mask)</pre></div>
+
+  </p>
+
+  </div>
+
+  <div class="indent">
+<h3>4.3.2 <a name="sect-id2259408">Find a Mapping Rule</a>
+</h3>
+
+  <p class="" style="">
+      We have a URL and a set of mapping rules. There are mapping rules left
+      over from earlier browser navigations and the new one just retrieved.
+
+      In deviation from the above (which featured delegation and the default VPI) now
+      imagine that there is a special configuration for the www.shakespeare.com
+      website. Imagine the VPI is
+      <p class="caption"></p><div class="indent"><pre>
+...
+&lt;location match="^http://www\.shakespeare\.com($|/.*$)"&gt;
+  &lt;service&gt;jabber:conference.jabber.bluehands.de&lt;/service&gt;
+  &lt;mapping&gt;
+    &lt;rule&gt;
+      &lt;search&gt;^http://www\.shakespeare\.com/([^/]+)/.*$&lt;/search&gt; 
+      &lt;replace&gt;\1-room&lt;/replace&gt;
+      &lt;digest&gt;
+        &lt;prefix&gt;vp-generated-&lt;/prefix&gt;
+      &lt;/digest&gt;
+    &lt;/rule&gt;
+  &lt;/mapping&gt;
+&lt;/location&gt;
+...</pre></div>
+
+      In this case we had the masks:
+      <p class="caption"></p><div class="indent"><pre>
+^http://www.shakespeare.com/market/ModernLibrary/.*
+^http://www\.shakespeare\.com($|/.*$)</pre></div>
+
+      With a single rule:
+      <p class="caption"></p><div class="indent"><pre>
+&lt;rule&gt;
+  &lt;search&gt;^http://www\.shakespeare\.com/([^/]+)/.*$&lt;/search&gt; 
+  &lt;replace&gt;\1-room&lt;/replace&gt;
+  &lt;digest&gt;
+    &lt;prefix&gt;vp-generated-&lt;/prefix&gt;
+  &lt;/digest&gt;
+&lt;/rule&gt;</pre></div>
+
+      We now scan all rule sets (including the new one) to find the rule set 
+      whose URL-mask(s) match our URL
+      <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/market/ModernLibrary/index.html</pre></div>
+
+      Surprise! We find the rule set, which has just been downloaded and 
+      added to the repository. We would do the same for any following URL 
+      and even for a slightly different URL like  
+      <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/market/ModernLibrary/page1.html</pre></div>
+
+      we would find the same mask. So we do not have to fetch a config file 
+      as long as we are in the same folder. If we leave the folder then we 
+      fetch a new config file. This will probably end up in the same 
+      global config file, which will already be available in the VPI cache.
+
+      But for now we have to map a URL and we already found the rule set. So...
+  </p>
+
+  </div>
+
+  <div class="indent">
+<h3>4.3.3 <a name="sect-id2259474">Apply the Rule</a>
+</h3>
+
+  <p class="" style="">
+      In the rule set applicable to there is one rule that matches the URL. 
+      <p class="caption"></p><div class="indent"><pre>
+&lt;rule&gt;
+  &lt;search&gt;^http://www\.shakespeare\.com/([^/]+)/.*$&lt;/search&gt; 
+  &lt;replace&gt;\1-room&lt;/replace&gt;
+  &lt;digest&gt;
+    &lt;prefix&gt;vp-generated-&lt;/prefix&gt;
+  &lt;/digest&gt;
+&lt;/rule&gt;</pre></div>
+
+      The rule is a regex expression with replacement. The expression
+      <p class="caption"></p><div class="indent"><pre>^http://www\.shakespeare\.com/([^/]+)/.*$</pre></div>
+
+      will be replaced by (see regex syntax)
+      <p class="caption"></p><div class="indent"><pre>\1-room</pre></div>
+
+      which means that it will extract the first level folder from the URL. The URL
+      <p class="caption"></p><div class="indent"><pre>http://www.shakespeare.com/market/ModernLibrary/index.html</pre></div>
+
+      is replaced by
+      <p class="caption"></p><div class="indent"><pre>market-room</pre></div>
+
+      The &lt;digest/&gt;-tag tells us to hash the regex replacement result with 
+      the default message digest SHA1. So we get:
+      <p class="caption"></p><div class="indent"><pre>87d0c3e8d08f344375f22014c7cafe6527acbae3</pre></div>
+
+      The &lt;prefix/&gt;-tag tells us to prefix with 
+      <p class="caption"></p><div class="indent"><pre>vp-generated-</pre></div>
+      
+      and finally the ID of the virtual location (the room name) is:
+      <p class="caption"></p><div class="indent"><pre>vp-generated-87d0c3e8d08f344375f22014c7cafe6527acbae3</pre></div>
+
+      From the &lt;service/&gt;
+      <p class="caption"></p><div class="indent"><pre>jabber:conference.jabber.bluehands.de</pre></div>
+
+      the client knows the transport protocol and the address. The Jabber protocol will 
+      be used as transport protocol and the Jabber conference room JID is
+      <p class="caption"></p><div class="indent"><pre>vp-generated-87d0c3e8d08f344375f22014c7cafe6527acbae3@conference.jabber.bluehands.de</pre></div>
+
+  </p>
+
+  </div>
+  
+  </div>
+
+<h2>5.
+       <a name="sect-id2259555">Error Codes</a>
+</h2>
+  <p class="" style="">This document does not introduce new error codes.</p>
+<h2>6.
+       <a name="sect-id2259570">Security Considerations</a>
+</h2>
+  <p class="" style="">The system has been designed to protect the privacy of the user as good as possible. If users decide to run the VP client, then other users may see their movement, but only if they enter the same locations. There is no way to track users, especially since the JIDs of virtual locations (Jabber chat rooms) are supposed to be SHA1 digests of URLs which are not predicable. So people trying to track Romeo have to guess the URL and enter the respective chat room to find Romeo. They cannot browse the room list of a conference component and deduce the URL from the room name.</p>
+  <p class="" style="">The fact that clients may disclose their JID in order to provide access to their avatar server storage and in order to enable caching is a weak point. A different but equally unique ID could be for caching purposes, provided that it is part of the &lt;presence/&gt; stanza. But traffic restrictions on the client connection prevent that additional data is exchanged between peers in a room. The data could be broadcast to the room, but this could end up in many people always broadcasting avatars while entering a room (web page). The chosen solution is to let peers download from public server storage. A better solution might be to let the conference component fetch from the server storage. In this case clients would need only the room-JID of the user, not the real JID.</p>
+<h2>7.
+       <a name="sect-id2259600">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">These namespaces need to be reviewed and/or registered with the Jabber Registrar as a result of this JEP. 
+      <ul>
+        <li>firebat:user:jid</li>
+        <li>firebat:avatar:position</li>
+        <li>firebat:avatar:getpos</li>
+        <li>firebat:chat:state</li>
+        <li>firebat:icon:video</li>
+        <li>firebat:avatar:digest</li>
+        <li>firebat:avatar2:digest</li>
+        <li>storage:client:avatar</li>
+        <li>storage:client:avatar2</li>
+      </ul>
+  </p>
+<h2>8.
+       <a name="sect-id2259663">Formal Definition</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="sect-id2259670">Schema</a>
+</h3>
+    <p class="" style="">No schema definitions yet. They will be added in the next version of this document, if it is considered for publication. </p>
+  </div>
+<h2>9.
+       <a name="sect-id2259688">Conclusion</a>
+</h2>
+  <p class="" style="">The virtual presence on Jabber has been designed to fit easily into the existing Jabber infrastructure including existing software components, clients, and protocols. It turns out that Jabber offers everything necessary for basic virtual presence. </p>
+
+  <p class="" style="">This document proposes a mapping process in order to create a space for virtual presence on top of the URL based Web infrastructure. It also proposes namespace extensions for the protocol, which make virtual presence on web pages more convenient. The core features are: 
+    <ul>
+      <li>URL mapping and service discovery,</li>
+      <li>avatars standing and walking on a web page,</li>
+      <li>bubble chat,</li>
+      <li>iconic video.</li>
+    </ul>
+    There are definitely more features possible. Suggestions are welcome</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250805">1</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257963">2</a>. <a href="http://www.lluna.de/docs/animated-avatars.html">http://www.lluna.de/docs/animated-avatars.html</a></p>
+<p><a name="nt-id2258931">3</a>. <a href="http://www.lluna.de/docs/vpi-file-syntax.html">http://www.lluna.de/docs/vpi-file-syntax.html</a></p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-06-02)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.8 (2005-05-20)</h4>
+<div class="indent">Added ignore-tag. (hw)
+    </div>
+<h4>Version 0.0.7 (2005-02-08)</h4>
+<div class="indent">Added comments on anonymity of presence element JID. 
+            Added additional avatar retrieval methods: 1. presence stanza avatar data element 2. via disco (hw)
+    </div>
+<h4>Version 0.0.6 (2005-01-26)</h4>
+<div class="indent">Replaced firebat:chat:key by firebat:chat:state (hw)
+    </div>
+<h4>Version 0.0.5 (2004-07-29)</h4>
+<div class="indent">Notes about future changes in the JID/storage related sections. (hw)
+    </div>
+<h4>Version 0.0.4 (2004-07-27)</h4>
+<div class="indent">Changed avatar position request frem message-x to iq-get, because MUC may block unknown message namespaces. (hw)
+    </div>
+<h4>Version 0.0.3 (2004-03-17)</h4>
+<div class="indent">Textual changes. Added service tag to rule to overwrite default service of the location. (hw)
+    </div>
+<h4>Version 0.0.2 (2003-11-19)</h4>
+<div class="indent">Refined introduction and requirements. Added location mapping. (hw)
+    </div>
+<h4>Version 0.0.1 (2003-11-11)</h4>
+<div class="indent">Initial version. (hw)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0152-0.1.html
+++ b/content/xep-0152-0.1.html
@@ -1,0 +1,349 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0152: Reachability Addresses</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Reachability Addresses">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP defines an XMPP protocol extension for communicating reachability information.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0152">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0152: Reachability Addresses</h1>
+<p>This JEP defines an XMPP protocol extension for communicating reachability information.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0152<br>
+            Version: 0.1<br>
+            Last Updated: 2005-06-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: reach<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Reachability%20Addresses%20(JEP-0152)">http://wiki.jabber.org/index.php/Reachability Addresses (JEP-0152)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#format">Data Format</a>
+</dt>
+<dt>4.  <a href="#transport">Data Transport</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#transport-presence">Presence Broadcast</a>
+</dt>
+<dt>4.2.  <a href="#transport-presence">Publish-Subscribe Transport</a>
+</dt>
+<dt>4.3.  <a href="#transport-iq">IQ Request</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Sometimes it is desirable or necessary to switch from instant messaging to another real-time communications medium, such as a telephone conversation conducted over the traditional public switched telephone network (PSTN) or more recent Voice over Internet Protocol (VoIP) applications. In order to facilitate switching from IM to telephony or some other media, a user needs to advertise the address(es) at which they can be reached. There are several possible ways to do this:</p>
+  <ul>
+    <li><p class="" style="">Publish the reachability address(es) in the user's vCard (see <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2250694">1</a>]); this is convenient, but is not very dynamic (e.g., reachability addresses might change when the user moves to a new conference room in an office building).</p></li>
+    <li><p class="" style="">Publish the user's reachability status (but not addresses) as a feature bundle within <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2250726">2</a>] information; this is somewhat dynamic (subscribers can be informed when reachability information is available) but requires every interested subscriber to perform service discovery in order to determine the reachability address(es).</p></li>
+    <li><p class="" style="">Send the reachability address(es) within a &lt;presence/&gt; stanza; this option is described in the <a href="#transport-presence">Presence Broadcast</a> section of this JEP and is consistent with Section 5.1.2 of <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2251002">3</a>] since reachability is one aspect of a user's availability for communication.</p></li>
+    <li><p class="" style="">Create a <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250742">4</a>] node for the user's reachability address(es); this option is described in the <a href="#transport-pubsub">Publish-Subscribe Transport</a> section of this JEP but may not be available to a full range of devices.</p></li>
+  </ul>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ul>
+    <li>Enable clients to dynamically publish reachability addresses.</li>
+    <li>Minimize network traffic if possible.</li>
+  </ul>
+<h2>3.
+       <a name="format">Data Format</a>
+</h2>
+  <p class="" style="">The following is an example of the data format for reachability addresses:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;reach xmlns='http://jabber.org/protocol/reach'&gt;
+  &lt;addr uri='tel:+1-303-555-1212'&gt;
+    &lt;desc xml:lang='en'&gt;New conference room number&lt;/desc&gt;
+  &lt;/addr&gt;
+  &lt;addr uri='sip:romeo@sipspeare.lit'/&gt;
+&lt;/reach&gt;
+  </pre></div>
+  <p class="" style="">When publishing reachability addresses, the &lt;reach/&gt; element MUST contain at least one &lt;addr/&gt; element. Each &lt;addr/&gt; element MUST possess a 'uri' attribute, whose value MUST be the Uniform Resource Identifier (<span class="ref" style="">RFC 3986</span>  [<a href="#nt-id2250842">5</a>]) or Internationalized Resource Identifier (<span class="ref" style="">RFC 3987</span>  [<a href="#nt-id2250864">6</a>]) of an alternate communications method for reaching the user. The &lt;addr/&gt; element MAY contain one or more &lt;desc/&gt; children whose XML character data is a natural-language description of the address; this element SHOULD possess an 'xml:lang' attribute whose value is a language tag that conforms to <span class="ref" style="">RFC 3066</span>  [<a href="#nt-id2250895">7</a>] (although the default language MAY be specified at the stanza level; see Section 9.1.5 of <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250917">8</a>]).</p>
+<h2>4.
+       <a name="transport">Data Transport</a>
+</h2>
+  <p class="" style="">As described below, this JEP specifies two methods of advertising reachability addresses:</p>
+  <ul>
+    <li>Presence broadcast</li>
+    <li>Publish-subscribe</li>
+  </ul>
+  <p class="" style="">This JEP does not recommend one transport method over the other.</p>
+  <p class="" style="">In addition, a contact MAY request a user's reachability addresses using an &lt;iq/&gt; request-response sequence.</p>
+  <div class="indent">
+<h3>4.1 <a name="transport-presence">Presence Broadcast</a>
+</h3>
+    <p class="" style="">In order to broadcast reachability addresses in presence information, a user's client includes the &lt;reach/&gt; element in the &lt;presence/&gt; stanza it sends to its server:</p>
+    <p class="caption">Example 1. User's Client Includes Reachability Addresses in Presence Broadcast</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net'&gt;
+  &lt;reach xmlns='http://jabber.org/protocol/reach'&gt;
+    &lt;addr uri='tel:+1-303-555-1212'&gt;
+      &lt;desc xml:lang='en'&gt;My mobile number&lt;/desc&gt;
+    &lt;/addr&gt;
+    &lt;addr uri='sip:romeo@sipspeare.lit'&gt;
+      &lt;desc xml:lang='en'&gt;My softphone&lt;/desc&gt;
+    &lt;/addr&gt;
+  &lt;/reach&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The user's server then broadcasts that presence stanza to all entities who are subscribed to the user's presence:</p>
+    <p class="caption">Example 2. User's Server Broadcasts Presence Information</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net' to='juliet@capulet.com'&gt;
+  &lt;reach xmlns='http://jabber.org/protocol/reach'&gt;
+    &lt;addr uri='tel:+1-303-555-1212'&gt;
+      &lt;desc xml:lang='en'&gt;My mobile number&lt;/desc&gt;
+    &lt;/addr&gt;
+    &lt;addr uri='sip:romeo@sipspeare.lit'&gt;
+      &lt;desc xml:lang='en'&gt;My softphone&lt;/desc&gt;
+    &lt;/addr&gt;
+  &lt;/reach&gt;
+&lt;/presence&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="transport-presence">Publish-Subscribe Transport</a>
+</h3>
+    <p class="" style="">In order to publish reachability via the publish-subscribe transport, an entity MUST first create the appropriate node as explained in <span style="font-weight: bold">JEP-0060</span>. Here we assume that the node already exists.</p>
+    <p class="caption">Example 3. Entity publishes reachability addresses</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net'
+    to='pubsub.shakespeare.lit'
+    id='publish1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;reach xmlns='http://jabber.org/protocol/reach'&gt;
+          &lt;addr uri='tel:+1-303-555-1212'&gt;
+            &lt;desc xml:lang='en'&gt;My mobile number&lt;/desc&gt;
+          &lt;/addr&gt;
+          &lt;addr uri='sip:romeo@sipspeare.lit'&gt;
+            &lt;desc xml:lang='en'&gt;My softphone&lt;/desc&gt;
+          &lt;/addr&gt;
+        &lt;/reach&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 4. Subscriber receives event with payload</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit'
+         to='juliet@capulet.com'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='n48ad4fj78zn38st734'&gt;
+      &lt;item id='a1s2d3f4g5h6bjeh936'&gt;
+        &lt;reach xmlns='http://jabber.org/protocol/reach'&gt;
+          &lt;addr uri='tel:+1-303-555-1212'&gt;
+            &lt;desc xml:lang='en'&gt;My mobile number&lt;/desc&gt;
+          &lt;/addr&gt;
+          &lt;addr uri='sip:romeo@sipspeare.lit'&gt;
+            &lt;desc xml:lang='en'&gt;My softphone&lt;/desc&gt;
+          &lt;/addr&gt;
+        &lt;/reach&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="transport-iq">IQ Request</a>
+</h3>
+    <p class="" style="">If a client supports the reachability addresses protocol described herein, it SHOULD include a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257156">9</a>] feature of 'http://jabber.org/protocol/reach' in its replies to disco#info requests:</p>
+    <p class="caption">Example 5. Service Discovery Interaction</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+
+&lt;iq to='romeo@montague.net/orchard' from='juliet@capulet.com/balcony' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/reach'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If desired, the contact then MAY query the user for any reachability addresses:</p>
+    <p class="caption">Example 6. Reachability Request-Response</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='reach1'&gt;
+  &lt;reach xmlns='http://jabber.org/protocol/reach'/&gt;
+&lt;/iq&gt;
+
+&lt;iq to='romeo@montague.net/orchard' from='juliet@capulet.com/balcony' id='reach1'&gt;
+  &lt;reach xmlns='http://jabber.org/protocol/reach'&gt;
+    &lt;addr uri='tel:+1-303-555-1212'&gt;
+      &lt;desc xml:lang='en'&gt;My mobile number&lt;/desc&gt;
+    &lt;/addr&gt;
+    &lt;addr uri='sip:romeo@sipspeare.lit'&gt;
+      &lt;desc xml:lang='en'&gt;My softphone&lt;/desc&gt;
+    &lt;/addr&gt;
+  &lt;/reach&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: IQ requests are NOT RECOMMENDED; instead, it is RECOMMENDED to use either presence broadcast or publish-subscribe transport as described above.</p>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">To preserve network bandwidth, the sender SHOULD NOT include the &lt;desc/&gt; element unless that information is deemed necessary to enable communication.</p>
+  <p class="" style="">A recipient SHOULD attempt communications with reachability addresses in the order that the &lt;addr/&gt; elements appear within the &lt;reach/&gt; element.</p>
+<h2>6.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">If included, the &lt;desc/&gt; element SHOULD possess an 'xml:lang' attribute specifying the language of the human-readable descriptive text for a particular address.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations above and beyond those described in RFC 3920, RFC 3921, and (for the pubsub transport) JEP-0060.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257317">10</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257360">11</a>] shall include 'http://jabber.org/protocol/reach' in its registry of protocol namespaces.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/reach'
+    xmlns='http://jabber.org/protocol/reach'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='reach'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='addr' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='address'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='desc' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='uri' use='required' type='xs:anyURI'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='desc' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250694">1</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2250726">2</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2251002">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250742">4</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250842">5</a>. RFC 3986: Uniform Resource Identifiers (URI): Generic Syntax &lt;<a href="http://www.ietf.org/rfc/rfc3986.txt">http://www.ietf.org/rfc/rfc3986.txt</a>&gt;.</p>
+<p><a name="nt-id2250864">6</a>. RFC 3987: Internationalized Resource Identifiers (IRIs) &lt;<a href="http://www.ietf.org/rfc/rfc3987.txt">http://www.ietf.org/rfc/rfc3987.txt</a>&gt;.</p>
+<p><a name="nt-id2250895">7</a>. RFC 3066: Tags for the Identification of Languages &lt;<a href="http://www.ietf.org/rfc/rfc3066.txt">http://www.ietf.org/rfc/rfc3066.txt</a>&gt;.</p>
+<p><a name="nt-id2250917">8</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2257156">9</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257317">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257360">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-06-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-06-07)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0153-0.1.html
+++ b/content/xep-0153-0.1.html
@@ -1,0 +1,347 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0153: vCard-Based Avatars</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="vCard-Based Avatars">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides historical documentation of a vCard-based protocol for exchanging user avatars.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0153">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0153: vCard-Based Avatars</h1>
+<p>This JEP provides historical documentation of a vCard-based protocol for exchanging user avatars.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This Historical JEP attempts to provide canonical documentation of a protocol that is in use within the Jabber/XMPP community. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; however, it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Historical<br>
+            Number: 0153<br>
+            Version: 0.1<br>
+            Last Updated: 2005-06-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0054<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: Not yet assigned<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#publish">User Publishes Avatar</a>
+</dt>
+<dt>3.2.  <a href="#retrieve">Contact Retrieves Avatar</a>
+</dt>
+</dl>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-presence">Inclusion of Update Data in Presence</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-vcard">Downloading and Uploading the vCard</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-resources">Multiple Resources</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-reset">Resetting the Image Hash</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-image">Image Restrictions</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exist several proposed protocols for communicating user avatar information over Jabber/XMPP (see <span class="ref" style="">IQ-Based Avatars</span>  [<a href="#nt-id2250570">1</a>] and <span class="ref" style="">User Avatar</span>  [<a href="#nt-id2250534">2</a>]). This JEP describes another such protocol that is in use today on the Jabber/XMPP network. This JEP is historical and does not purport to propose a standards-track protocol. However, a future protocol may improve on the approach documented herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol described herein seems to have been designed with the following requirements in mind:</p>
+  <ul>
+    <li>Enable a user to store an avatar image in his or her vCard.</li>
+    <li>Provide notice of avatar changes via the &lt;presence/&gt; stanza.</li>
+    <li>Enable a contact to retrieve a user's avatar image if the user is offline.</li>
+    <li>Enable a contact to retrieve a user's avatar image without requesting it of the user's particular client, thus preserving bandwidth.</li>
+  </ul>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="publish">User Publishes Avatar</a>
+</h3>
+    <p class="" style="">Before informing contacts of the user's avatar, the user's client first publishes the avatar data to the user's public vCard using the protocol defined in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2251550">3</a>]. The avatar image (more precisely, the Base64-encoded image data) SHOULD be provided as the XML character data of the &lt;BINVAL/&gt; child of the &lt;PHOTO/&gt; element (rather than pointing to a URI for the image file in the &lt;EXTVAL/&gt; child), and the image type SHOULD be communicated as the XML character data of the &lt;TYPE/&gt; child of the &lt;PHOTO/&gt; element.</p>
+    <p class="caption">Example 1. User's Client Publishes Avatar Data to vCard</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com' 
+    type='set'
+    id='vc1'&gt;
+  &lt;vCard xmlns='vcard-temp'&gt;
+    &lt;BDAY&gt;1476-06-09&lt;/BDAY&gt;
+    &lt;ADR&gt;
+      &lt;CTRY&gt;Italy&lt;/CTRY&gt;
+      &lt;LOCALITY&gt;Verona&lt;/LOCALITY&gt;
+      &lt;HOME/&gt;
+    &lt;/ADR&gt;
+    &lt;NICKNAME/&gt;
+    &lt;N&gt;&lt;GIVEN&gt;Juliet&lt;/GIVEN&gt;&lt;FAMILY&gt;Capulet&lt;/FAMILY&gt;&lt;/N&gt;
+    &lt;EMAIL&gt;jcapulet@shakespeare.lit&lt;/EMAIL&gt;
+    &lt;PHOTO&gt;
+      &lt;TYPE&gt;image/jpeg&lt;/TYPE&gt;
+      &lt;BINVAL&gt;
+        Base64-encoded-avatar-file-here!
+      &lt;/BINVAL&gt;
+    &lt;/PHOTO&gt;
+  &lt;/vCard&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. User's Server Acknowledges Publish</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com' type='result' id='vc1'/&gt;
+    </pre></div>
+    <p class="" style="">Next, the user's client computes the SHA1 hash of the avatar image in accordance with <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2251391">4</a>]. This hash is then included in the user's presence information as the XML character data of the &lt;photo/&gt; child of an &lt;x/&gt; element qualified by the 'vcard-temp:x:update' namespace, as shown in the following example:</p>
+    <p class="caption">Example 3. User's Client Includes Avatar Hash in Presence Broadcast</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony'&gt;
+  &lt;x xmlns='vcard-temp:x:update'&gt;&lt;photo&gt;sha1-hash-of-image&lt;/photo&gt;&lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The user's server then broadcasts that presence information to all contacts who are subscribed to the user's presence information.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="retrieve">Contact Retrieves Avatar</a>
+</h3>
+    <p class="" style="">When the recipient's client receives the hash of the avatar image, it SHOULD check the hash to determine if it already has a cached copy of that avatar image. If not, it retrieves the sender's full vCard in accordance with the protocol flow describerd in <span style="font-weight: bold">JEP-0054</span> (note that this request is sent to the user's bare JID, not full JID):</p>
+    <p class="caption">Example 4. Contact's Client Requests User's vCard</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com'
+    type='get' 
+    id='vc2'&gt;
+  &lt;vCard xmlns='vcard-temp'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Server Returns vCard on Behalf of User</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com' 
+    to='romeo@montague.net/orchard' 
+    type='result'
+    id='vc2'&gt;
+  &lt;vCard xmlns='vcard-temp'&gt;
+    &lt;BDAY&gt;1476-06-09&lt;/BDAY&gt;
+    &lt;ADR&gt;
+      &lt;CTRY&gt;Italy&lt;/CTRY&gt;
+      &lt;LOCALITY&gt;Verona&lt;/LOCALITY&gt;
+      &lt;HOME/&gt;
+    &lt;/ADR&gt;
+    &lt;NICKNAME/&gt;
+    &lt;N&gt;&lt;GIVEN&gt;Juliet&lt;/GIVEN&gt;&lt;FAMILY&gt;Capulet&lt;/FAMILY&gt;&lt;/N&gt;
+    &lt;EMAIL&gt;jcapulet@shakespeare.lit&lt;/EMAIL&gt;
+    &lt;PHOTO&gt;
+      &lt;TYPE&gt;image/jpeg&lt;/TYPE&gt;
+      &lt;BINVAL&gt;
+        Base64-encoded-avatar-file-here!
+      &lt;/BINVAL&gt;
+    &lt;/PHOTO&gt;
+  &lt;/vCard&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-presence">Inclusion of Update Data in Presence</a>
+</h3>
+    <p class="" style="">The following rules apply to inclusion of the update child element (&lt;x xmlns='vcard-temp:x:update'/&gt;) in presence broadcasts:</p>
+    <ol start="" type="">
+      <li><p class="" style="">If a client supports the protocol defined herein, it MUST include the update child element in every presence broadcast it sends.</p></li>
+      <li>
+        <p class="" style="">If a client is not yet ready to advertise an image, it MUST send an empty update child element, i.e.:</p>
+        <p class="caption">Example 6. User Is Not Ready to Advertise an Image</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='vcard-temp:x:update'/&gt;
+&lt;/presence&gt;
+        </pre></div>
+      </li>
+      <li>
+        <p class="" style="">If there is no avatar image to be advertised, the photo element MUST be empty, i.e.:</p>
+        <p class="caption">Example 7. No Image to be Advertised</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='vcard-temp:x:update'&gt;
+    &lt;photo/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+        </pre></div>
+        <p class="" style="">This enables recipients to distinguish between the absence of an image (empty photo element) and mere support for the protocol (empty update child).</p>
+      </li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-vcard">Downloading and Uploading the vCard</a>
+</h3>
+    <p class="" style="">The following rules apply to downloading and uploading the vCard:</p>
+    <ol start="" type="">
+      <li><p class="" style="">A client MUST NOT advertise an avatar image without first downloading the current vCard. Once it has done this, it MAY advertise an image. However, a client MUST advertise an image if it has just uploaded the vCard with a new avatar image. In this case, the client MAY choose not to redownload the vCard to verify its contents.</p></li>
+      <li><p class="" style="">Within a given session, a client MUST NOT attempt to upload a given avatar image more than once. The client MAY upload the avatar image to the vCard on login and after that MUST NOT upload the vCard again unless the user actively changes the avatar image.</p></li>
+      <li><p class="" style="">The client MUST NOT poll for new versions of the user's vCard in order to determine whether to update the avatar image hash.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-resources">Multiple Resources</a>
+</h3>
+    <p class="" style="">Jabber/XMPP allows multiple resources to authenticate for the same JID simultaneously. This introduces the potential of conflict between the resources regarding the user's avatar image. The following rules apply when a client receives a presence broadcast from another resource of its own JID:</p>
+    <ol start="" type="">
+      <li><p class="" style="">If the presence stanza received from the other resource does not contain the update child element, then the other resource does not support vCard-based avatars. That resource could modify the contents of the vCard (including the photo element); because polling for vCard updates is not allowed, the client MUST stop advertising the avatar image hash. However, the client MAY reset its hash if all instances of non-conforming resources have gone offline.</p></li>
+      <li>
+        <p class="" style="">If the presence stanza received from the other resource contains the update child element, then the other resource conforms to the protocol for vCard-based avatars. There are three possible scenarios:</p>
+        <ul>
+          <li><p class="" style="">If the update child element is empty, then the other resource supports the protocol but does not have its own avatar image. Therefore the client can ignore the other resource and continue to broadcast the existing image hash.</p></li>
+          <li><p class="" style="">If the update child element contains an empty photo element, then the other resource has updated the vCard with an empty BINVAL. Therefore the client MUST retrieve the vCard. If the retrieved vCard contains a photo element with an empty BINVAL, then the client MUST stop advertising the old image.</p></li>
+          <li><p class="" style="">If the update child element contains a non-empty photo element, then the client MUST compare the image hashes. If the hashes are identical, then the client can ignore the other resource and continue to broadcast the existing image hash. If the hashes are different, then the client MUST NOT attempt to resolve the conflict by uploading its avatar image again. Instead, it MUST defer to the content of the retrieved vCard by resetting its image hash (see below) and providing that hash in future presence broadcasts.</p></li>
+        </ul>
+      </li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-reset">Resetting the Image Hash</a>
+</h3>
+    <p class="" style="">Resetting the image hash consists of the following steps:</p>
+    <ol start="" type="">
+      <li><p class="" style="">Immediately send out a presence element with an empty update child element (containing no photo element).</p></li>
+      <li><p class="" style="">Download the vCard from the server.</p></li>
+      <li><p class="" style="">If the BINVAL is empty or missing, advertise an empty photo element in future presence broadcasts.</p></li>
+      <li><p class="" style="">If the BINVAL contains image data, calculate the hash of image and advertise that hash in future presence broadcasts.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-image">Image Restrictions</a>
+</h3>
+    <p class="" style="">The following rules apply to images:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The image MUST use less than eight kilobytes (8k) of data; this restriction is to be enforced by the publishing client.</p></li>
+      <li><p class="" style="">The image height and width SHOULD be between thirty-two (32) and ninety-six (96) pixels; the recommended size is sixty-four (64) pixels high and sixty-four (64) pixels wide.</p></li>
+      <li><p class="" style="">The image SHOULD be square.</p></li>
+      <li><p class="" style="">The image content type  [<a href="#nt-id2256148">5</a>] SHOULD be image/gif, image/jpeg, or image/png; support for the "image/png" content type is REQUIRED, support for the "image/gif" and "image/jpeg" content types is RECOMMENDED, and support for any other content type is OPTIONAL.</p></li>
+    </ol>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations above and beyond those described in RFC 3920 and RFC 3921.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256223">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256274">7</a>] shall include 'vcard-temp:x:update' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='vcard-temp:x:update'
+    xmlns='vcard-temp:x:update'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='photo' minOccurs='0' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The author wishes to thank the helpful developers who have implemented this protocol and provided feedback regarding its documentation.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250570">1</a>. JEP-0008: IQ-Based Avatars &lt;<a href="http://www.jabber.org/jeps/jep-0008.html">http://www.jabber.org/jeps/jep-0008.html</a>&gt;.</p>
+<p><a name="nt-id2250534">2</a>. JEP-0084: User Avatar &lt;<a href="http://www.jabber.org/jeps/jep-0084.html">http://www.jabber.org/jeps/jep-0084.html</a>&gt;.</p>
+<p><a name="nt-id2251550">3</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2251391">4</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2256148">5</a>. The IANA registry of content types is located at &lt;<a href="http://www.iana.org/assignments/media-types/">http://www.iana.org/assignments/media-types/</a>&gt;.</p>
+<p><a name="nt-id2256223">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256274">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-06-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-06-14)</h4>
+<div class="indent">Changed type from Informational to Historical, adjusted text accordingly. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-06-13)</h4>
+<div class="indent">Specified that the image data is actually Base64 encoded. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-06-09)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0153-0.2.html
+++ b/content/xep-0153-0.2.html
@@ -1,0 +1,358 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0153: vCard-Based Avatars</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="vCard-Based Avatars">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides historical documentation of a vCard-based protocol for exchanging user avatars.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0153">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0153: vCard-Based Avatars</h1>
+<p>This JEP provides historical documentation of a vCard-based protocol for exchanging user avatars.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This Historical JEP attempts to provide canonical documentation of a protocol that is in use within the Jabber/XMPP community. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. This JEP is not a standards-track specification within the Jabber Software Foundation's standards process; however, it may be converted to standards-track in the future or may be obsoleted by a more modern protocol.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Historical<br>
+            Number: 0153<br>
+            Version: 0.2<br>
+            Last Updated: 2005-10-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0054<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: Not yet assigned<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/vCard-Based%20Avatars%20(JEP-0153)">http://wiki.jabber.org/index.php/vCard-Based Avatars (JEP-0153)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#publish">User Publishes Avatar</a>
+</dt>
+<dt>3.2.  <a href="#retrieve">Contact Retrieves Avatar</a>
+</dt>
+</dl>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-presence">Inclusion of Update Data in Presence</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-vcard">Downloading and Uploading the vCard</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-resources">Multiple Resources</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-reset">Resetting the Image Hash</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-image">Image Restrictions</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exist several proposed protocols for communicating user avatar information over Jabber/XMPP (see <span class="ref" style="">IQ-Based Avatars</span>  [<a href="#nt-id2251712">1</a>] and <span class="ref" style="">User Avatar</span>  [<a href="#nt-id2251680">2</a>]). This JEP describes another such protocol that is in use today on the Jabber/XMPP network. This JEP is historical and does not purport to propose a standards-track protocol. However, a future protocol may improve on the approach documented herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol described herein seems to have been designed with the following requirements in mind:</p>
+  <ul>
+    <li>Enable a user to store an avatar image in his or her vCard.</li>
+    <li>Provide notice of avatar changes via the &lt;presence/&gt; stanza.</li>
+    <li>Enable a contact to retrieve a user's avatar image if the user is offline.</li>
+    <li>Enable a contact to retrieve a user's avatar image without requesting it of the user's particular client, thus preserving bandwidth.</li>
+  </ul>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="publish">User Publishes Avatar</a>
+</h3>
+    <p class="" style="">Before informing contacts of the user's avatar, the user's client first publishes the avatar data to the user's public vCard using the protocol defined in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2250565">3</a>]. The avatar image (more precisely, the Base64-encoded image data) SHOULD be provided as the XML character data of the &lt;BINVAL/&gt; child of the &lt;PHOTO/&gt; element (rather than pointing to a URI for the image file in the &lt;EXTVAL/&gt; child), and the image type SHOULD be communicated as the XML character data of the &lt;TYPE/&gt; child of the &lt;PHOTO/&gt; element.</p>
+    <p class="caption">Example 1. User's Client Publishes Avatar Data to vCard</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com' 
+    type='set'
+    id='vc1'&gt;
+  &lt;vCard xmlns='vcard-temp'&gt;
+    &lt;BDAY&gt;1476-06-09&lt;/BDAY&gt;
+    &lt;ADR&gt;
+      &lt;CTRY&gt;Italy&lt;/CTRY&gt;
+      &lt;LOCALITY&gt;Verona&lt;/LOCALITY&gt;
+      &lt;HOME/&gt;
+    &lt;/ADR&gt;
+    &lt;NICKNAME/&gt;
+    &lt;N&gt;&lt;GIVEN&gt;Juliet&lt;/GIVEN&gt;&lt;FAMILY&gt;Capulet&lt;/FAMILY&gt;&lt;/N&gt;
+    &lt;EMAIL&gt;jcapulet@shakespeare.lit&lt;/EMAIL&gt;
+    &lt;PHOTO&gt;
+      &lt;TYPE&gt;image/jpeg&lt;/TYPE&gt;
+      &lt;BINVAL&gt;
+        Base64-encoded-avatar-file-here!
+      &lt;/BINVAL&gt;
+    &lt;/PHOTO&gt;
+  &lt;/vCard&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. User's Server Acknowledges Publish</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com' type='result' id='vc1'/&gt;
+    </pre></div>
+    <p class="" style="">Next, the user's client computes the SHA1 hash of the avatar image in accordance with <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2250627">4</a>]. This hash is then included in the user's presence information as the XML character data of the &lt;photo/&gt; child of an &lt;x/&gt; element qualified by the 'vcard-temp:x:update' namespace, as shown in the following example:</p>
+    <p class="caption">Example 3. User's Client Includes Avatar Hash in Presence Broadcast</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony'&gt;
+  &lt;x xmlns='vcard-temp:x:update'&gt;
+    &lt;photo&gt;sha1-hash-of-image&lt;/photo&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The user's server then broadcasts that presence information to all contacts who are subscribed to the user's presence information.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="retrieve">Contact Retrieves Avatar</a>
+</h3>
+    <p class="" style="">When the recipient's client receives the hash of the avatar image, it SHOULD check the hash to determine if it already has a cached copy of that avatar image. If not, it retrieves the sender's full vCard in accordance with the protocol flow describerd in <span style="font-weight: bold">JEP-0054</span> (note that this request is sent to the user's bare JID, not full JID):</p>
+    <p class="caption">Example 4. Contact's Client Requests User's vCard</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com'
+    type='get' 
+    id='vc2'&gt;
+  &lt;vCard xmlns='vcard-temp'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Server Returns vCard on Behalf of User</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com' 
+    to='romeo@montague.net/orchard' 
+    type='result'
+    id='vc2'&gt;
+  &lt;vCard xmlns='vcard-temp'&gt;
+    &lt;BDAY&gt;1476-06-09&lt;/BDAY&gt;
+    &lt;ADR&gt;
+      &lt;CTRY&gt;Italy&lt;/CTRY&gt;
+      &lt;LOCALITY&gt;Verona&lt;/LOCALITY&gt;
+      &lt;HOME/&gt;
+    &lt;/ADR&gt;
+    &lt;NICKNAME/&gt;
+    &lt;N&gt;&lt;GIVEN&gt;Juliet&lt;/GIVEN&gt;&lt;FAMILY&gt;Capulet&lt;/FAMILY&gt;&lt;/N&gt;
+    &lt;EMAIL&gt;jcapulet@shakespeare.lit&lt;/EMAIL&gt;
+    &lt;PHOTO&gt;
+      &lt;TYPE&gt;image/jpeg&lt;/TYPE&gt;
+      &lt;BINVAL&gt;
+        Base64-encoded-avatar-file-here!
+      &lt;/BINVAL&gt;
+    &lt;/PHOTO&gt;
+  &lt;/vCard&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-presence">Inclusion of Update Data in Presence</a>
+</h3>
+    <p class="" style="">The following rules apply to inclusion of the update child element (&lt;x xmlns='vcard-temp:x:update'/&gt;) in presence broadcasts:</p>
+    <ol start="" type="">
+      <li><p class="" style="">If a client supports the protocol defined herein, it MUST include the update child element in every presence broadcast it sends and SHOULD also include the update child in directed presence stanzas (e.g., directed presence sent when joining <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250764">5</a>] rooms).</p></li>
+      <li>
+        <p class="" style="">If a client is not yet ready to advertise an image, it MUST send an empty update child element, i.e.:</p>
+        <p class="caption">Example 6. User Is Not Ready to Advertise an Image</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='vcard-temp:x:update'/&gt;
+&lt;/presence&gt;
+        </pre></div>
+      </li>
+      <li>
+        <p class="" style="">If there is no avatar image to be advertised, the photo element MUST be empty, i.e.:</p>
+        <p class="caption">Example 7. No Image to be Advertised</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='vcard-temp:x:update'&gt;
+    &lt;photo/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+        </pre></div>
+        <p class="" style="">If the client subsequently obtains an avatar image (e.g., by updating or retrieving the vCard), it SHOULD then publish a new &lt;presence/&gt; stanza with character data in the &lt;photo/&gt; element.</p>
+      </li>
+      <p class="" style="">Note: This enables recipients to distinguish between the absence of an image (empty photo element) and mere support for the protocol (empty update child).</p>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-vcard">Downloading and Uploading the vCard</a>
+</h3>
+    <p class="" style="">The following rules apply to downloading and uploading the vCard:</p>
+    <ol start="" type="">
+      <li><p class="" style="">A client MUST NOT advertise an avatar image without first downloading the current vCard. Once it has done this, it MAY advertise an image. However, a client MUST advertise an image if it has just uploaded the vCard with a new avatar image. In this case, the client MAY choose not to redownload the vCard to verify its contents.</p></li>
+      <li><p class="" style="">Within a given session, a client MUST NOT attempt to upload a given avatar image more than once. The client MAY upload the avatar image to the vCard on login and after that MUST NOT upload the vCard again unless the user actively changes the avatar image.</p></li>
+      <li><p class="" style="">The client MUST NOT poll for new versions of the user's vCard in order to determine whether to update the avatar image hash.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-resources">Multiple Resources</a>
+</h3>
+    <p class="" style="">Jabber/XMPP allows multiple resources to authenticate for the same JID simultaneously. This introduces the potential of conflict between the resources regarding the user's avatar image. The following rules apply when a client receives a presence broadcast from another resource of its own JID:</p>
+    <ol start="" type="">
+      <li><p class="" style="">If the presence stanza received from the other resource does not contain the update child element, then the other resource does not support vCard-based avatars. That resource could modify the contents of the vCard (including the photo element); because polling for vCard updates is not allowed, the client MUST stop advertising the avatar image hash. However, the client MAY reset its hash if all instances of non-conforming resources have gone offline.</p></li>
+      <li>
+        <p class="" style="">If the presence stanza received from the other resource contains the update child element, then the other resource conforms to the protocol for vCard-based avatars. There are three possible scenarios:</p>
+        <ul>
+          <li><p class="" style="">If the update child element is empty, then the other resource supports the protocol but does not have its own avatar image. Therefore the client can ignore the other resource and continue to broadcast the existing image hash.</p></li>
+          <li><p class="" style="">If the update child element contains an empty photo element, then the other resource has updated the vCard with an empty BINVAL. Therefore the client MUST retrieve the vCard. If the retrieved vCard contains a photo element with an empty BINVAL, then the client MUST stop advertising the old image.</p></li>
+          <li><p class="" style="">If the update child element contains a non-empty photo element, then the client MUST compare the image hashes. If the hashes are identical, then the client can ignore the other resource and continue to broadcast the existing image hash. If the hashes are different, then the client MUST NOT attempt to resolve the conflict by uploading its avatar image again. Instead, it MUST defer to the content of the retrieved vCard by resetting its image hash (see below) and providing that hash in future presence broadcasts.</p></li>
+        </ul>
+      </li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-reset">Resetting the Image Hash</a>
+</h3>
+    <p class="" style="">Resetting the image hash consists of the following steps:</p>
+    <ol start="" type="">
+      <li><p class="" style="">Immediately send out a presence element with an empty update child element (containing no photo element).</p></li>
+      <li><p class="" style="">Download the vCard from the server.</p></li>
+      <li><p class="" style="">If the BINVAL is empty or missing, advertise an empty photo element in future presence broadcasts.</p></li>
+      <li><p class="" style="">If the BINVAL contains image data, calculate the hash of image and advertise that hash in future presence broadcasts.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-image">Image Restrictions</a>
+</h3>
+    <p class="" style="">The following rules apply to images:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The image SHOULD use less than eight kilobytes (8k) of data; this restriction is to be enforced by the publishing client.</p></li>
+      <li><p class="" style="">The image height and width SHOULD be between thirty-two (32) and ninety-six (96) pixels; the recommended size is sixty-four (64) pixels high and sixty-four (64) pixels wide.</p></li>
+      <li><p class="" style="">The image SHOULD be square.</p></li>
+      <li><p class="" style="">The image content type  [<a href="#nt-id2256556">6</a>] SHOULD be image/gif, image/jpeg, or image/png; support for the "image/png" content type is REQUIRED, support for the "image/gif" and "image/jpeg" content types is RECOMMENDED, and support for any other content type is OPTIONAL.</p></li>
+      <li><p class="" style="">The image data MUST be encoded in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2256604">7</a>]. Any whitespace characters (e.g., '\r' and '\n') MUST be stripped before decoding of the image data.</p></li>
+    </ol>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations above and beyond those described in RFC 3920 and RFC 3921.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256667">8</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256752">9</a>] shall include 'vcard-temp:x:update' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='vcard-temp:x:update'
+    xmlns='vcard-temp:x:update'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='photo' minOccurs='0' type='xs:string'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The author wishes to thank the helpful developers who have implemented this protocol and provided feedback regarding its documentation.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251712">1</a>. JEP-0008: IQ-Based Avatars &lt;<a href="http://www.jabber.org/jeps/jep-0008.html">http://www.jabber.org/jeps/jep-0008.html</a>&gt;.</p>
+<p><a name="nt-id2251680">2</a>. JEP-0084: User Avatar &lt;<a href="http://www.jabber.org/jeps/jep-0084.html">http://www.jabber.org/jeps/jep-0084.html</a>&gt;.</p>
+<p><a name="nt-id2250565">3</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2250627">4</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2250764">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256556">6</a>. The IANA registry of content types is located at &lt;<a href="http://www.iana.org/assignments/media-types/">http://www.iana.org/assignments/media-types/</a>&gt;.</p>
+<p><a name="nt-id2256604">7</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2256667">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256752">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-10-18)</h4>
+<div class="indent">Changed 8k limit from MUST NOT to SHOULD NOT; specified that client should publish new presence stanza if it obtains an avatar image after sending an empty photo element; specified that the update child should be included in directed presence stanzas; more clearly specified Base64 rules. (psa)
+    </div>
+<h4>Version 0.1 (2005-06-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-06-14)</h4>
+<div class="indent">Changed type from Informational to Historical, adjusted text accordingly. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-06-13)</h4>
+<div class="indent">Specified that the image data is actually Base64 encoded. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-06-09)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0153-0.3.html
+++ b/content/xep-0153-0.3.html
@@ -1,0 +1,387 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0153: vCard-Based Avatars</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="vCard-Based Avatars">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP provides historical documentation of a vCard-based protocol for exchanging user avatars.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0153">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0153: vCard-Based Avatars</h1>
+<p>This JEP provides historical documentation of a vCard-based protocol for exchanging user avatars.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Historical">Historical</a><br>
+            Number: 0153<br>
+            Version: 0.3<br>
+            Last Updated: 2006-01-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0054<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: Not yet assigned<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/vCard-Based%20Avatars%20(JEP-0153)">http://wiki.jabber.org/index.php/vCard-Based Avatars (JEP-0153)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#publish">User Publishes Avatar</a>
+</dt>
+<dt>3.2.  <a href="#retrieve">Contact Retrieves Avatar</a>
+</dt>
+</dl>
+<dt>4.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#bizrules-presence">Inclusion of Update Data in Presence</a>
+</dt>
+<dt>4.2.  <a href="#bizrules-vcard">Downloading and Uploading the vCard</a>
+</dt>
+<dt>4.3.  <a href="#bizrules-resources">Multiple Resources</a>
+</dt>
+<dt>4.4.  <a href="#bizrules-reset">Resetting the Image Hash</a>
+</dt>
+<dt>4.5.  <a href="#bizrules-xml">XML Syntax</a>
+</dt>
+<dt>4.6.  <a href="#bizrules-image">Image Restrictions</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>10.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exist several proposed protocols for communicating user avatar information over Jabber/XMPP (see <span class="ref" style="">IQ-Based Avatars</span>  [<a href="#nt-id2251732">1</a>] and <span class="ref" style="">User Avatar</span>  [<a href="#nt-id2250749">2</a>]). This JEP describes another such protocol that is in use today on the Jabber/XMPP network. This JEP is historical and does not purport to propose a standards-track protocol. However, a future protocol may improve on the approach documented herein.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol described herein seems to have been designed with the following requirements in mind:</p>
+  <ul>
+    <li>Enable a user to store an avatar image in his or her vCard.</li>
+    <li>Provide notice of avatar changes via the &lt;presence/&gt; stanza.</li>
+    <li>Enable a contact to retrieve a user's avatar image if the user is offline.</li>
+    <li>Enable a contact to retrieve a user's avatar image without requesting it of the user's particular client, thus preserving bandwidth.</li>
+  </ul>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="publish">User Publishes Avatar</a>
+</h3>
+    <p class="" style="">Before informing contacts of the user's avatar, the user's client first publishes the avatar data to the user's public vCard using the protocol defined in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2250972">3</a>].</p>
+    <p class="caption">Example 1. User's Client Publishes Avatar Data to vCard</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com' 
+    type='set'
+    id='vc1'&gt;
+  &lt;vCard xmlns='vcard-temp'&gt;
+    &lt;BDAY&gt;1476-06-09&lt;/BDAY&gt;
+    &lt;ADR&gt;
+      &lt;CTRY&gt;Italy&lt;/CTRY&gt;
+      &lt;LOCALITY&gt;Verona&lt;/LOCALITY&gt;
+      &lt;HOME/&gt;
+    &lt;/ADR&gt;
+    &lt;NICKNAME/&gt;
+    &lt;N&gt;&lt;GIVEN&gt;Juliet&lt;/GIVEN&gt;&lt;FAMILY&gt;Capulet&lt;/FAMILY&gt;&lt;/N&gt;
+    &lt;EMAIL&gt;jcapulet@shakespeare.lit&lt;/EMAIL&gt;
+    &lt;PHOTO&gt;
+      &lt;TYPE&gt;image/jpeg&lt;/TYPE&gt;
+      &lt;BINVAL&gt;
+        Base64-encoded-avatar-file-here!
+      &lt;/BINVAL&gt;
+    &lt;/PHOTO&gt;
+  &lt;/vCard&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. User's Server Acknowledges Publish</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com' type='result' id='vc1'/&gt;
+    </pre></div>
+    <p class="" style="">Next, the user's client computes the SHA1 hash of the avatar image data itself (not the base64-encoded version) in accordance with <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2251027">4</a>]. This hash is then included in the user's presence information as the XML character data of the &lt;photo/&gt; child of an &lt;x/&gt; element qualified by the 'vcard-temp:x:update' namespace, as shown in the following example:</p>
+    <p class="caption">Example 3. User's Client Includes Avatar Hash in Presence Broadcast</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony'&gt;
+  &lt;x xmlns='vcard-temp:x:update'&gt;
+    &lt;photo&gt;sha1-hash-of-image&lt;/photo&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The user's server then broadcasts that presence information to all contacts who are subscribed to the user's presence information.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="retrieve">Contact Retrieves Avatar</a>
+</h3>
+    <p class="" style="">When the recipient's client receives the hash of the avatar image, it SHOULD check the hash to determine if it already has a cached copy of that avatar image. If not, it retrieves the sender's full vCard in accordance with the protocol flow describerd in <span style="font-weight: bold">JEP-0054</span> (note that this request is sent to the user's bare JID, not full JID):</p>
+    <p class="caption">Example 4. Contact's Client Requests User's vCard</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    to='juliet@capulet.com'
+    type='get' 
+    id='vc2'&gt;
+  &lt;vCard xmlns='vcard-temp'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 5. Server Returns vCard on Behalf of User</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com' 
+    to='romeo@montague.net/orchard' 
+    type='result'
+    id='vc2'&gt;
+  &lt;vCard xmlns='vcard-temp'&gt;
+    &lt;BDAY&gt;1476-06-09&lt;/BDAY&gt;
+    &lt;ADR&gt;
+      &lt;CTRY&gt;Italy&lt;/CTRY&gt;
+      &lt;LOCALITY&gt;Verona&lt;/LOCALITY&gt;
+      &lt;HOME/&gt;
+    &lt;/ADR&gt;
+    &lt;NICKNAME/&gt;
+    &lt;N&gt;&lt;GIVEN&gt;Juliet&lt;/GIVEN&gt;&lt;FAMILY&gt;Capulet&lt;/FAMILY&gt;&lt;/N&gt;
+    &lt;EMAIL&gt;jcapulet@shakespeare.lit&lt;/EMAIL&gt;
+    &lt;PHOTO&gt;
+      &lt;TYPE&gt;image/jpeg&lt;/TYPE&gt;
+      &lt;BINVAL&gt;
+        Base64-encoded-avatar-file-here!
+      &lt;/BINVAL&gt;
+    &lt;/PHOTO&gt;
+  &lt;/vCard&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>4.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="bizrules-presence">Inclusion of Update Data in Presence</a>
+</h3>
+    <p class="" style="">The following rules apply to inclusion of the update child element (&lt;x xmlns='vcard-temp:x:update'/&gt;) in presence broadcasts:</p>
+    <ol start="" type="">
+      <li><p class="" style="">If a client supports the protocol defined herein, it MUST include the update child element in every presence broadcast it sends and SHOULD also include the update child in directed presence stanzas (e.g., directed presence sent when joining <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250926">5</a>] rooms).</p></li>
+      <li>
+        <p class="" style="">If a client is not yet ready to advertise an image, it MUST send an empty update child element, i.e.:</p>
+        <p class="caption">Example 6. User Is Not Ready to Advertise an Image</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='vcard-temp:x:update'/&gt;
+&lt;/presence&gt;
+        </pre></div>
+      </li>
+      <li>
+        <p class="" style="">If there is no avatar image to be advertised, the photo element MUST be empty, i.e.:</p>
+        <p class="caption">Example 7. No Image to be Advertised</p>
+<div class="indent"><pre>
+&lt;presence&gt;
+  &lt;x xmlns='vcard-temp:x:update'&gt;
+    &lt;photo/&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+        </pre></div>
+        <p class="" style="">If the client subsequently obtains an avatar image (e.g., by updating or retrieving the vCard), it SHOULD then publish a new &lt;presence/&gt; stanza with character data in the &lt;photo/&gt; element.</p>
+      </li>
+      <p class="" style="">Note: This enables recipients to distinguish between the absence of an image (empty photo element) and mere support for the protocol (empty update child).</p>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="bizrules-vcard">Downloading and Uploading the vCard</a>
+</h3>
+    <p class="" style="">The following rules apply to downloading and uploading the vCard:</p>
+    <ol start="" type="">
+      <li><p class="" style="">A client MUST NOT advertise an avatar image without first downloading the current vCard. Once it has done this, it MAY advertise an image. However, a client MUST advertise an image if it has just uploaded the vCard with a new avatar image. In this case, the client MAY choose not to redownload the vCard to verify its contents.</p></li>
+      <li><p class="" style="">Within a given session, a client MUST NOT attempt to upload a given avatar image more than once. The client MAY upload the avatar image to the vCard on login and after that MUST NOT upload the vCard again unless the user actively changes the avatar image.</p></li>
+      <li><p class="" style="">The client MUST NOT poll for new versions of the user's vCard in order to determine whether to update the avatar image hash.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="bizrules-resources">Multiple Resources</a>
+</h3>
+    <p class="" style="">Jabber/XMPP allows multiple resources to authenticate for the same JID simultaneously. This introduces the potential of conflict between the resources regarding the user's avatar image. The following rules apply when a client receives a presence broadcast from another resource of its own JID:</p>
+    <ol start="" type="">
+      <li><p class="" style="">If the presence stanza received from the other resource does not contain the update child element, then the other resource does not support vCard-based avatars. That resource could modify the contents of the vCard (including the photo element); because polling for vCard updates is not allowed, the client MUST stop advertising the avatar image hash. However, the client MAY reset its hash if all instances of non-conforming resources have gone offline.</p></li>
+      <li>
+        <p class="" style="">If the presence stanza received from the other resource contains the update child element, then the other resource conforms to the protocol for vCard-based avatars. There are three possible scenarios:</p>
+        <ul>
+          <li><p class="" style="">If the update child element is empty, then the other resource supports the protocol but does not have its own avatar image. Therefore the client can ignore the other resource and continue to broadcast the existing image hash.</p></li>
+          <li><p class="" style="">If the update child element contains an empty photo element, then the other resource has updated the vCard with an empty BINVAL. Therefore the client MUST retrieve the vCard. If the retrieved vCard contains a photo element with an empty BINVAL, then the client MUST stop advertising the old image.</p></li>
+          <li><p class="" style="">If the update child element contains a non-empty photo element, then the client MUST compare the image hashes. If the hashes are identical, then the client can ignore the other resource and continue to broadcast the existing image hash. If the hashes are different, then the client MUST NOT attempt to resolve the conflict by uploading its avatar image again. Instead, it MUST defer to the content of the retrieved vCard by resetting its image hash (see below) and providing that hash in future presence broadcasts.</p></li>
+        </ul>
+      </li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="bizrules-reset">Resetting the Image Hash</a>
+</h3>
+    <p class="" style="">Resetting the image hash consists of the following steps:</p>
+    <ol start="" type="">
+      <li><p class="" style="">Immediately send out a presence element with an empty update child element (containing no photo element).</p></li>
+      <li><p class="" style="">Download the vCard from the server.</p></li>
+      <li><p class="" style="">If the BINVAL is empty or missing, advertise an empty photo element in future presence broadcasts.</p></li>
+      <li><p class="" style="">If the BINVAL contains image data, calculate the hash of image and advertise that hash in future presence broadcasts.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="bizrules-xml">XML Syntax</a>
+</h3>
+    <p class="" style="">The following rules apply to the XML syntax:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The &lt;PHOTO/&gt; element SHOULD contain a &lt;BINVAL/&gt; child whose XML character data is Base64-encoded data for the avatar image.</p></li>
+      <li><p class="" style="">The &lt;PHOTO/&gt; element SHOULD NOT contain an &lt;EXTVAL/&gt; that points to a URI for the image file.</p></li>
+      <li><p class="" style="">The &lt;PHOTO/&gt; element MUST NOT contain the avatar image itself.</p></li>
+      <li><p class="" style="">The &lt;PHOTO/&gt; element SHOULD contain a &lt;TYPE/&gt; child whose XML character data specifies the content-type of the image data. The XML character data SHOULD be "image/gif", "image/jpeg", or "image/png".</p></li>
+      <li><p class="" style="">The &lt;PHOTO/&gt; element MUST NOT possess a 'mime-type' attribute.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="bizrules-image">Image Restrictions</a>
+</h3>
+    <p class="" style="">The following rules apply to images:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The image SHOULD use less than eight kilobytes (8k) of data; this restriction is to be enforced by the publishing client.</p></li>
+      <li><p class="" style="">The image height and width SHOULD be between thirty-two (32) and ninety-six (96) pixels; the recommended size is sixty-four (64) pixels high and sixty-four (64) pixels wide.</p></li>
+      <li><p class="" style="">The image SHOULD be square.</p></li>
+      <li><p class="" style="">The image content type  [<a href="#nt-id2259968">6</a>] SHOULD be image/gif, image/jpeg, or image/png; support for the "image/png" content type is REQUIRED, support for the "image/gif" and "image/jpeg" content types is RECOMMENDED, and support for any other content type is OPTIONAL.</p></li>
+      <li><p class="" style="">The image data MUST conform to the base64Binary datatype  [<a href="#nt-id2259994">7</a>] and thus be encoded in accordance with Section 6.8 of <span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2260027">8</a>], which recommends that base64 data should have lines limited to at most 76 characters in length. However, any whitespace characters (e.g., '\r' and '\n') MUST be ignored.</p></li>
+    </ol>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">The XML character data of the &lt;TYPE/&gt; element is a hint. If the XML character data of the &lt;TYPE/&gt; specifies a content type that does not match the data provided in the &lt;BINVAL/&gt; element, the processing application MUST adhere to the content type of the actual image data and MUST ignore the &lt;TYPE/&gt;. If the &lt;TYPE/&gt; is something other than image/gif, image/jpeg, or image/png, it SHOULD be ignored.</p>
+  <p class="" style="">If the image data exceeds the 8 KB restriction, the processing application SHOULD process the data.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations above and beyond those described in RFC 3920 and RFC 3921.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260131">9</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260181">10</a>] shall include 'vcard-temp:x:update' in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='vcard-temp:x:update'
+    xmlns='vcard-temp:x:update'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='photo' minOccurs='0' type='xs:base64Binary'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>10.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The author wishes to thank the helpful developers who have implemented this protocol and provided feedback regarding its documentation.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251732">1</a>. JEP-0008: IQ-Based Avatars &lt;<a href="http://www.jabber.org/jeps/jep-0008.html">http://www.jabber.org/jeps/jep-0008.html</a>&gt;.</p>
+<p><a name="nt-id2250749">2</a>. JEP-0084: User Avatar &lt;<a href="http://www.jabber.org/jeps/jep-0084.html">http://www.jabber.org/jeps/jep-0084.html</a>&gt;.</p>
+<p><a name="nt-id2250972">3</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2251027">4</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2250926">5</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259968">6</a>. The IANA registry of content types is located at &lt;<a href="http://www.iana.org/assignments/media-types/">http://www.iana.org/assignments/media-types/</a>&gt;.</p>
+<p><a name="nt-id2259994">7</a>. See &lt;<a href="http://www.w3.org/TR/xmlschema-2/#base64Binary">http://www.w3.org/TR/xmlschema-2/#base64Binary</a>&gt;.</p>
+<p><a name="nt-id2260027">8</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2260131">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260181">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-01-12)</h4>
+<div class="indent">Collected all syntax rules into dedicated section; incorporated feedback from implementation experience; adjusted text regarding base64 encoding. (psa)
+    </div>
+<h4>Version 0.2 (2005-10-18)</h4>
+<div class="indent">Changed 8k limit from MUST NOT to SHOULD NOT; specified that client should publish new presence stanza if it obtains an avatar image after sending an empty photo element; specified that the update child should be included in directed presence stanzas; more clearly specified Base64 rules. (psa)
+    </div>
+<h4>Version 0.1 (2005-06-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-06-14)</h4>
+<div class="indent">Changed type from Informational to Historical, adjusted text accordingly. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-06-13)</h4>
+<div class="indent">Specified that the image data is actually Base64 encoded. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-06-09)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0154-0.1.html
+++ b/content/xep-0154-0.1.html
@@ -1,0 +1,1703 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0154: Profile Data Representation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Profile Data Representation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies how to represent data about IM users and other XMPP entities in terms of the Data Forms protocol.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-06-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0154">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0154: Profile Data Representation</h1>
+<p>This JEP specifies how to represent data about IM users and other XMPP entities in terms of the Data Forms protocol.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0154<br>
+            Version: 0.1<br>
+            Last Updated: 2005-06-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004, JEP-0060, JEP-0068<br>Supersedes: JEP-0054<br>
+                Superseded By: None<br>
+            Short Name: profiledata<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#design">Design Decisions</a>
+</dt>
+<dt>4.  <a href="#approach">Approach</a>
+</dt>
+<dt>5.  <a href="#common_fields">Common Data Fields</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#fields-name">Name Data Aspects</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#display_name">Display Name</a>
+</dt>
+<dt>5.1.2.  <a href="#family_name">Family Name</a>
+</dt>
+<dt>5.1.3.  <a href="#given_name">Given Name</a>
+</dt>
+<dt>5.1.4.  <a href="#middle_name">Middle Name</a>
+</dt>
+<dt>5.1.5.  <a href="#name_prefix">Name Prefix</a>
+</dt>
+<dt>5.1.6.  <a href="#name_suffix">Name Suffix</a>
+</dt>
+<dt>5.1.7.  <a href="#nickname">Nickname</a>
+</dt>
+<dt>5.1.8.  <a href="#patronymic">Patronymic</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#fields-physicaladdress">Physical Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#country">Country</a>
+</dt>
+<dt>5.2.2.  <a href="#region">Region</a>
+</dt>
+<dt>5.2.3.  <a href="#locality">Locality</a>
+</dt>
+<dt>5.2.4.  <a href="#area">Area</a>
+</dt>
+<dt>5.2.5.  <a href="#street">Street</a>
+</dt>
+<dt>5.2.6.  <a href="#building">Building</a>
+</dt>
+<dt>5.2.7.  <a href="#floor">Floor</a>
+</dt>
+<dt>5.2.8.  <a href="#room">Room</a>
+</dt>
+<dt>5.2.9.  <a href="#postalbox">Postal Box</a>
+</dt>
+<dt>5.2.10.  <a href="#postalcode">Postal Code</a>
+</dt>
+</dl>
+<dt>5.3.  <a href="#fields-geoloc">Geolocation Data Aspects</a>
+</dt>
+<dl>
+<dt>5.3.1.  <a href="#alt">Altitude</a>
+</dt>
+<dt>5.3.2.  <a href="#lat">Latitude</a>
+</dt>
+<dt>5.3.3.  <a href="#lat">Longitude</a>
+</dt>
+</dl>
+<dt>5.4.  <a href="#fields-tel">Telephony Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.4.1.  <a href="#fax">Fax Number</a>
+</dt>
+<dt>5.4.2.  <a href="#landline">Landline Telephone Number</a>
+</dt>
+<dt>5.4.3.  <a href="#mobile">Mobile Telephone Number</a>
+</dt>
+<dt>5.4.4.  <a href="#pager">Pager Number</a>
+</dt>
+<dt>5.4.5.  <a href="#sip_address">SIP Address</a>
+</dt>
+<dt>5.4.6.  <a href="#skype_address">Skype Address</a>
+</dt>
+</dl>
+<dt>5.5.  <a href="#fields-net">Electronic Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.5.1.  <a href="#aim_id">AIM Screen Name</a>
+</dt>
+<dt>5.5.2.  <a href="#email">Email Address</a>
+</dt>
+<dt>5.5.3.  <a href="#icq_id">ICQ Number</a>
+</dt>
+<dt>5.5.4.  <a href="#jid">Jabber ID</a>
+</dt>
+<dt>5.5.5.  <a href="#msn_id">MSN Address</a>
+</dt>
+<dt>5.5.6.  <a href="#yahoo_id">Yahoo ID</a>
+</dt>
+</dl>
+<dt>5.6.  <a href="#fields-www">World Wide Web Resource Aspects</a>
+</dt>
+<dl>
+<dt>5.6.1.  <a href="#avatar_url">Avatar URL</a>
+</dt>
+<dt>5.6.2.  <a href="#bio">Biographical URL</a>
+</dt>
+<dt>5.6.3.  <a href="#foaf_url">FOAF URL</a>
+</dt>
+<dt>5.6.4.  <a href="#homepage">Homepage URL</a>
+</dt>
+<dt>5.6.5.  <a href="#photo_url">Photo URL</a>
+</dt>
+<dt>5.6.6.  <a href="#publications">Publications URL</a>
+</dt>
+<dt>5.6.7.  <a href="#resume">Resume URL</a>
+</dt>
+<dt>5.6.8.  <a href="#status_url">Status URL</a>
+</dt>
+<dt>5.6.9.  <a href="#org_url">Organizational URL</a>
+</dt>
+<dt>5.6.10.  <a href="#weblog">Weblog URL</a>
+</dt>
+</dl>
+<dt>5.7.  <a href="#fields-org">Organizational Data Aspects</a>
+</dt>
+<dl>
+<dt>5.7.1.  <a href="#job_title">Job Title</a>
+</dt>
+<dt>5.7.2.  <a href="#org_name">Organizational Name</a>
+</dt>
+<dt>5.7.3.  <a href="#org_role">Organizational Role</a>
+</dt>
+<dt>5.7.4.  <a href="#org_unit">Organizational Unit</a>
+</dt>
+</dl>
+<dt>5.8.  <a href="#fields-basic">Basic Personal Data Aspects</a>
+</dt>
+<dl>
+<dt>5.8.1.  <a href="#birth_dayofmonth">Birth Day-of-Month</a>
+</dt>
+<dt>5.8.2.  <a href="#birth_month">Birth Month</a>
+</dt>
+<dt>5.8.3.  <a href="#birth_year">Birth Year</a>
+</dt>
+<dt>5.8.4.  <a href="#eye_color">Eye Color</a>
+</dt>
+<dt>5.8.5.  <a href="#gender">Gender</a>
+</dt>
+<dt>5.8.6.  <a href="#hair_color">Hair Color</a>
+</dt>
+<dt>5.8.7.  <a href="#height">Height</a>
+</dt>
+<dt>5.8.8.  <a href="#weight">Weight</a>
+</dt>
+</dl>
+<dt>5.9.  <a href="#fields-extended">Extended Personal Data Aspects</a>
+</dt>
+<dl>
+<dt>5.9.1.  <a href="#avatar_data">Avatar Data</a>
+</dt>
+<dt>5.9.2.  <a href="#hobby">Hobbies</a>
+</dt>
+<dt>5.9.3.  <a href="#interest">Interests</a>
+</dt>
+<dt>5.9.4.  <a href="#languages_lesswell">Languages Known Less Well</a>
+</dt>
+<dt>5.9.5.  <a href="#languages_well">Languages Known Well</a>
+</dt>
+<dt>5.9.6.  <a href="#mbti">Myers-Briggs Type Indicator</a>
+</dt>
+<dt>5.9.7.  <a href="#photo_data">Photo Data</a>
+</dt>
+<dt>5.9.8.  <a href="#profession">Profession</a>
+</dt>
+<dt>5.9.9.  <a href="#religion">Religious Affiliation</a>
+</dt>
+<dt>5.9.10.  <a href="#wishlist">Wishlist</a>
+</dt>
+<dt>5.9.11.  <a href="#zodiac">Zodiac Sign</a>
+</dt>
+</dl>
+<dt>5.10.  <a href="#fields-favorites">Personal Favorites</a>
+</dt>
+<dl>
+<dt>5.10.1.  <a href="#fav_authors">Favorite Authors</a>
+</dt>
+<dt>5.10.2.  <a href="#fav_athletes">Favorite Athletes</a>
+</dt>
+<dt>5.10.3.  <a href="#fav_charities">Favorite Charities</a>
+</dt>
+<dt>5.10.4.  <a href="#fav_foods">Favorite Foods</a>
+</dt>
+<dt>5.10.5.  <a href="#fav_games">Favorite Games</a>
+</dt>
+<dt>5.10.6.  <a href="#fav_movies">Favorite Movies</a>
+</dt>
+<dt>5.10.7.  <a href="#fav_music">Favorite Music</a>
+</dt>
+<dt>5.10.8.  <a href="#fav_quotes">Favorite Quotes</a>
+</dt>
+<dt>5.10.9.  <a href="#fav_teams">Favorite Sports Teams</a>
+</dt>
+<dt>5.10.10.  <a href="#fav_tv">Favorite TV Shows</a>
+</dt>
+</dl>
+<dt>5.11.  <a href="#fields-history">Personal History</a>
+</dt>
+<dl>
+<dt>5.11.1.  <a href="#places_lived">Places Lived</a>
+</dt>
+<dt>5.11.2.  <a href="#schools">Schools Attended</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-formtype">Field Standardization</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">It is widely acknowledged within the Jabber/XMPP community that the <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2251181">1</a>] specification (JEP-0054) has outlived its usefulness. There are several reasons for this conclusion:</p>
+  <ol start="" type="">
+    <li>JEP-0054 is not fully consistent with the Internet-Draft on which it was based.</li>
+    <li>The Internet-Draft on which it was based was never approved by the IETF.</li>
+    <li>Because of confusion over aspects of the vcard-temp specification, there exist incompatible implementations.</li>
+    <li>vCard (<span class="ref" style="">RFC 2426</span>  [<a href="#nt-id2251225">2</a>]) captures only a limited set of information.</li>
+    <li>vCard (even in its XML representation  [<a href="#nt-id2251214">3</a>]) is not easily extensible, leading those who develop profiles for specialized communities to "roll their own" protocols, to the detriment of interoperability.</li>
+    <li>vCard data tends to be monolithic (the basic unit of information is the full vCard, not parts thereof).</li>
+    <li>The publication model for JEP-0054 is to set the full vCard, rather than only the parts that need to be modified.</li>
+    <li>The retrieval model for JEP-0054 is to get the full vCard, rather than only the parts that have been modified.</li>
+  </ol>
+  <p class="" style="">Given the weaknesses of vCard, there is interest across the broader Internet community in replacing vCard with something more modern and extensible. Unfortunately, no other standards development organization has developed an alternative to vCard. Part of the challenge is that quite detailed ontologies have been developed that might replace parts of the vCard specification (e.g., the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2251271">4</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2251307">5</a>]) while less-formal ontologies are being used to represent other parts of the problem space (e.g., <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2250451">6</a>]). The relevant protocols are in flux and it is unclear when (or even if) stability will emerge.</p>
+  <p class="" style="">Because of the unsettled landspace and the strong desire within the Jabber/XMPP community to move beyond JEP-0054, this JEP specifies a consistent framework for the wire representation of profile data fields in terms of the <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250481">7</a>] protocol, further qualified using the standardization concepts specified in <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2250504">8</a>]. The rationale behind this design decision is provided below.</p>
+  <p class="" style="">Note: This JEP does not offer solutions to the problems of publishing, storing, and retrieving profile data. Those issues will be addressed in a separate proposal.</p> 
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Specify how to represent profile data in an XMPP-friendly manner for communication over the wire.</li>
+    <li>Ensure that the protocol is extensible (e.g., not limited to vCard fields).  
+         [<a href="#nt-id2250544">9</a>]
+    </li> 
+    <li>Where possible, map profile data fields to existing vCard fields and other common formats.</li>
+  </ol>
+  <p class="" style="">As noted, this JEP does not offer solutions to the problems of publishing, storing, and retrieving profile data. Those issues will be addressed in a separate proposal.</p> 
+<h2>3.
+       <a name="design">Design Decisions</a>
+</h2>
+  <p class="" style="">There are many possible approaches to representing profile data for communication over XMPP networks, including the following:</p>
+  <ul>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">Structured data formats, such as <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2255311">10</a>] and <span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2255334">11</a>].</span></p>
+      <p class="" style="">Such data formats have the advantage of being human-readable. However:</p>
+      <ol start="" type="">
+        <li>They are not easily extensible: developers of specialized community services would need to write their own structured data formats, even to add one new field.</li>
+        <li>They are not easy to map to backend data storage facilities (e.g., database administrators generally would prefer to have generic database schemas and re-usable code for parsing the XML wire protocol into the database fields).</li>
+        <li>They would require specialized interface handlers for each data structure, rather than a generic interface handler.</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of <span class="ref" style="">Resource Description Framework</span>  [<a href="#nt-id2255400">12</a>].</span></p>
+      <p class="" style="">An argument could be made that RDF is a reasonable approach for representing profile data for communication over the XMPP network; however, such an argument will not be made in the current proposal. The author has considered RDF and has concluded that there are several reasons why RDF is undesirable as an XMPP wire protocol:</p>
+      <ol start="" type="">
+        <li>RDF exists in an XML representation but the semantics of RDF impose a more complex conceptual structure (data triples) than does XML, which is sub-optimal since unnecessary complexity is to be avoided (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2255450">13</a>]).</li>
+        <li>RDF requires a specialized parser rather than the normal XML parser that comes standard with all XMPP implementations.</li>
+        <li>As long as it is possible to define a consistent mapping of profile data to RDF representations, it should be straightforward to convert the XMPP data formats into those RDF representations if desired (e.g., to output a FOAF file).</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of <span class="ref" style="">Infobits</span>  [<a href="#nt-id2255496">14</a>].</span></p>
+      <p class="" style="">The infobits approach to representing profile data was deprecated in early 2004 because it provides few advantages over an approach based on Data Forms.</p>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of Data Forms (JEP-0004).</span></p>
+      <p class="" style="">The Data Forms protocol defined in JEP-0004 has several advantages for use over XMPP:</p>
+      <ol start="" type="">
+        <li>It can be parsed using an off-the-shelf XML parser.</li>
+        <li>It is already widely deployed in existing Jabber/XMPP clients, servers, and components.</li>
+        <li>The data forms protocol is easily extensible.</li>
+        <li>The Jabber/XMPP community possesses consistent methods for profiling and scoping data forms (as specified in JEP-0068).</li>
+        <li>Data forms have a generic schema that is easy to map to common data storage mechanisms (usually databases).</li>
+        <li>Data forms provide a consistent abstraction layer for XMPP applications, thus shielding them from changes in the profile data formats being defined by other Internet projects and standards development organizations.</li>
+        <li>The use of data forms as the medium of representation for communication over the wire does not prevent applications from storing backend profile data in some other underlying format (e.g., RDF or a database).</li> 
+      </ol>
+    </li>
+  </ul>
+  <p class="" style="">For these reasons, this proposal specifies a way to represent profile data in terms of the Data Forms (jabber:x:data) protocol.</p>
+<h2>4.
+       <a name="approach">Approach</a>
+</h2>
+  <p class="" style="">This proposal specifies that profile data shall be scoped by a FORM_TYPE of 'http://jabber.org/protocol/profiledata', in accordance with the field standardization methods defined in JEP-0068. For the sake of interoperability, profile data fields that will be in common use SHOULD be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2255616">15</a>] (although they may or may not be defined in a Jabber Enhancement Proposal). Profile data fields that are intended to be used only within the context of a specialized application MAY remain unregistered, but unregistered fields MUST begin with the string "x-" in accordance with Section 3.4 of JEP-0068.  [<a href="#nt-id2255607">16</a>]</p>
+  <p class="" style="">The following is a simple and incomplete example of profile data represented via the Data Forms protocol, containing two registered data fields and one unregistered field:</p>
+  <p class="caption">Example 1. A Basic Example</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='submit'&gt;
+  &lt;field var='FORM_TYPE' type='hidden'&gt;
+    &lt;value&gt;http://jabber.org/protocol/profiledata&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='display_name'&gt;
+    &lt;value&gt;Peter Saint-Andre&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='nickname'&gt;
+    &lt;value&gt;stpeter&lt;/value&gt;
+    &lt;value&gt;psa&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='x-favorite_painters'&gt;
+    &lt;value&gt;Joaquin Sorolla&lt;/value&gt;
+    &lt;value&gt;Jan Vermeer&lt;/value&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">By specifying that all fields are scoped by a FORM_TYPE of 'http://jabber.org/protocol/profiledata', this proposal does not mean to imply that all profile data will or should be gathered in one data form. In reality, most such data will probably be gathered at the time of registration either at a website or via a "wizard" interface that breaks the process into smaller bundles (such as "Basic Personal Data", "Physical Location", "Internet Addresses", "Hobbies and Interests", and "Favorite Things"). The use of one FORM_TYPE is simply meant to scope the data fields so that each field is unique within the context of profile data. Any form that uses these fields along with a FORM_TYPE of 'http://jabber.org/protocol/profiledata' is of the "profile type" (i.e., is a specific instance of that type), which does not limit the number of forms that can be of that type.</p>
+    <p class="" style="">However, scoping all data fields with a single FORM_TYPE implies it is necessary to define separate data fields for similar kinds of information. For example, the vCard specification (<span style="font-weight: bold">RFC 2426</span>) defines "types" for certains kinds of data, such as email addresses, telephone numbers, and physical addresses, making it possible to specify that a telephone number corresponds to a fax machine or mobile phone or that a physical address corresponds to one's home or work location. In the Data Forms representation, any desired piece of information (e.g., work phone) must be represented with a separate data field.</p>
+    <p class="" style="">In order to address most (if not all) of the pieces of information described in existing profile specifications, this JEP defines a great number of data fields. Even so, the data fields specified herein are not exhaustive, and it is expected that additional fields will be registered in the future through the mechanisms specified in the <a href="#registrar">Jabber Registrar Considerations</a> section of this JEP.</p>
+<h2>5.
+       <a name="common_fields">Common Data Fields</a>
+</h2>
+  <p class="" style="">The following subsections specify common fields for defining various aspects of a person, which shall form the initial submission to the Jabber Registrar; many of these fields map to elements specified in vCard, xNAL, FOAF, and other existing specifications.</p>
+  <div class="indent">
+<h3>5.1 <a name="fields-name">Name Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard, xNAL, and FOAF.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="display_name">Display Name</a>
+</h3>
+      <p class="" style="">A display name is a version of a person's name intended for display in a user interface. Sometimes also called a "full name" or "formatted name".</p>
+      <p class="" style="">The Data Forms field that represents a display name is "display_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard FN</li>
+        <li>FOAF name</li>
+      </ul>
+      <p class="caption">Example 2. Display Name</p>
+<div class="indent"><pre>
+&lt;field var='display_name'&gt;
+  &lt;value&gt;Peter Saint-Andre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="family_name">Family Name</a>
+</h3>
+      <p class="" style="">A family name is that part of a person's name which signifies the person's primary family association. Sometimes also called a "last name" or "surname".</p>
+      <p class="" style="">The Data Forms field that represents a family name is "family_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard FAMILY</li>
+        <li>xNAL LastName</li>
+        <li>FOAF family_name</li>
+        <li>FOAF surname</li>
+      </ul>
+      <p class="caption">Example 3. Family Name</p>
+<div class="indent"><pre>
+&lt;field var='family_name'&gt;
+  &lt;value&gt;Saint-Andre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.3 <a name="given_name">Given Name</a>
+</h3>
+      <p class="" style="">A given name is that part of a person's name which signifies the person's primary individual identity. Sometimes also called a "first name" or (in some countries) a "Christian name".</p>
+      <p class="" style="">The Data Forms field that represents a given name is "given_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard GIVEN</li>
+        <li>xNAL FirstName</li>
+        <li>FOAF first_name</li>
+        <li>FOAF givenname</li>
+      </ul>
+      <p class="caption">Example 4. Given Name</p>
+<div class="indent"><pre>
+&lt;field var='given_name'&gt;
+  &lt;value&gt;John&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.4 <a name="middle_name">Middle Name</a>
+</h3>
+      <p class="" style="">A middle name is that part of a person's name which signifies the person's secondary individual identity. Sometimes also called a "middle initial".</p>
+      <p class="" style="">The Data Forms field that represents a middle name is "middle_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard MIDDLE</li>
+        <li>xNAL MiddleName</li>
+      </ul>
+      <p class="caption">Example 5. Middle Name</p>
+<div class="indent"><pre>
+&lt;field var='middle_name'&gt;
+  &lt;value&gt;Peter&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.5 <a name="name_prefix">Name Prefix</a>
+</h3>
+      <p class="" style="">A name prefix is that part of a person's name which prepends the person's full name (e.g., Mr or Dr). Sometimes also called an "honorific" or "title".</p>
+      <p class="" style="">The Data Forms field that represents a name prefix is "name_prefix".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PREFIX</li>
+        <li>xNAL Title</li>
+        <li>FOAF title</li>
+      </ul>
+      <p class="caption">Example 6. Name Prefix</p>
+<div class="indent"><pre>
+&lt;field var='name_prefix'&gt;
+  &lt;value&gt;Mr&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.6 <a name="name_suffix">Name Suffix</a>
+</h3>
+      <p class="" style="">A name suffix is that part of a person's name which is appended to the person's full name (e.g., Jr or Esq).</p>
+      <p class="" style="">The Data Forms field that represents a name suffix is "name_suffix".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard SUFFIX</li>
+        <li>xNAL GeneralSuffix</li>
+      </ul>
+      <p class="caption">Example 7. Name Suffix</p>
+<div class="indent"><pre>
+&lt;field var='name_suffix'&gt;
+  &lt;value&gt;Esq&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.7 <a name="nickname">Nickname</a>
+</h3>
+      <p class="" style="">A nickname is a familiar name that may be used in informal contexts. Sometimes also called an "alias".</p>
+      <p class="" style="">The Data Forms field that represents a nickname is "nickname".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard NICKNAME</li>
+        <li>xNAL Alias</li>
+        <li>FOAF nick</li>
+      </ul>
+      <p class="caption">Example 8. Nickname</p>
+<div class="indent"><pre>
+&lt;field var='nickname'&gt;
+  &lt;value&gt;stpeter&lt;/value&gt;
+  &lt;value&gt;psa&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.8 <a name="patronymic">Patronymic</a>
+</h3>
+      <p class="" style="">In some cultures, one's name includes a part that is derived from the given name of one's father; this part of one's name is called a "patronymic".</p>
+      <p class="" style="">The Data Forms field that represents a patronymic is "patronymic".</p>
+      <p class="caption">Example 9. A Patronymic</p>
+<div class="indent"><pre>
+&lt;field var='patronymic'&gt;
+  &lt;value&gt;Ivanovich&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="fields-physicaladdress">Physical Address Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard, xNAL, and JEP-0112 (<span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2256218">17</a>]).</p>
+    <div class="indent">
+<h3>5.2.1 <a name="country">Country</a>
+</h3>
+      <p class="" style="">A country is the sovereign nation in which a person is located. Sometimes also called a "nation".</p>
+      <p class="" style="">The Data Forms fields that represent a country are "country", "home_country", and "work_country" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard COUNTRY (or JEP-0054 CTRY), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL CountryName</li>
+        <li>JEP-0112 country</li>
+      </ul>
+      <p class="caption">Example 10. Country</p>
+<div class="indent"><pre>
+&lt;field var='country'&gt;
+  &lt;value&gt;USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="region">Region</a>
+</h3>
+      <p class="" style="">A region is a second-level administrative unit within the nation in which a person is located. Sometimes also called a "province", "state", or "administrative area".</p>
+      <p class="" style="">The Data Forms field that represents a region is "region".</p>
+      <p class="" style="">The Data Forms fields that represent a region are "home_region" and "work_region" for home addresses and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard REGION, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL AdministrativeAreaName</li>
+        <li>JEP-0112 region</li>
+      </ul>
+      <p class="caption">Example 11. Region</p>
+<div class="indent"><pre>
+&lt;field var='region'&gt;
+  &lt;value&gt;New York&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.3 <a name="locality">Locality</a>
+</h3>
+      <p class="" style="">A locality is a defined place within the region in which a person is located. Sometimes also called a "city", "town", or "village".</p>
+      <p class="" style="">The Data Forms fields that represent a locality are "locality", "home_locality", and "work_locality" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LOCALITY, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL LocalityName</li>
+        <li>JEP-0112 locality</li>
+      </ul>
+      <p class="caption">Example 12. Locality</p>
+<div class="indent"><pre>
+&lt;field var='locality'&gt;
+  &lt;value&gt;New York City&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.4 <a name="area">Area</a>
+</h3>
+      <p class="" style="">An area is a sub-division within the locality in which a person is located. Sometimes also called a "neighborhood", "suburb", "district", or "section".</p>
+      <p class="" style="">The Data Forms fields that represent a area are "area", "home_area", and "work_area" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>xNAL DependentLocalityName</li>
+        <li>JEP-0112 area</li>
+      </ul>
+      <p class="caption">Example 13. Area</p>
+<div class="indent"><pre>
+&lt;field var='area'&gt;
+  &lt;value&gt;Manhattan&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.5 <a name="street">Street</a>
+</h3>
+      <p class="" style="">A street is the street address (number plus street name, or two street names at an intersection) at which a person is located, or a postal box number for physical mail delivery. Sometimes also called a "street address".</p>
+      <p class="" style="">The Data Forms fields that represent a street are "street", "home_street", and "work_street" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard STREET, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL ThoroughfareNumber + ThoroughfareName</li>
+        <li>JEP-0112 street</li>
+      </ul>
+      <p class="caption">Example 14. Street</p>
+<div class="indent"><pre>
+&lt;field var='street'&gt;
+  &lt;value&gt;Fifth Avenue and 34th Street&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.6 <a name="building">Building</a>
+</h3>
+      <p class="" style="">A building is the name for a specific structure on a street or within an area.</p>
+      <p class="" style="">The Data Forms fields that represent a building are "building", "home_building", and "work_building" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL BuildingName</li>
+        <li>JEP-0112 building</li>
+      </ul>
+      <p class="caption">Example 15. Building</p>
+<div class="indent"><pre>
+&lt;field var='building'&gt;
+  &lt;value&gt;Empire State Building&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.7 <a name="floor">Floor</a>
+</h3>
+      <p class="" style="">A floor is a named or numbered floor or level within a building. Sometimes also called a "level", "block", or "suite".</p>
+      <p class="" style="">The Data Forms fields that represent a floor are "floor", "home_floor", and "work_floor" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL SubPremiseNumber</li>
+        <li>JEP-0112 floor</li>
+      </ul>
+      <p class="caption">Example 16. Floor</p>
+<div class="indent"><pre>
+&lt;field var='floor'&gt;
+  &lt;value&gt;102&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.8 <a name="room">Room</a>
+</h3>
+      <p class="" style="">A room is a named or numbered subdivision of a floor. Sometimes also called a "unit" or "apartment".</p>
+      <p class="" style="">The Data Forms fields that represent a room are "room", "home_room", and "work_room" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL SubPremiseNumber</li>
+        <li>JEP-0112 room</li>
+      </ul>
+      <p class="caption">Example 17. Room</p>
+<div class="indent"><pre>
+&lt;field var='room'&gt;
+  &lt;value&gt;Observatory&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.9 <a name="postalbox">Postal Box</a>
+</h3>
+      <p class="" style="">A postal box is a set of numeric or alphanumeric characters used to identify a mailbox at a postal delivery center.</p>
+      <p class="" style="">The Data Forms fields that represent a postal box are "postalbox", "home_postalbox", and "work_postalbox" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard POBOX, optionally supplemented with the "HOME" or "WORK" type</li>
+      </ul>
+      <p class="caption">Example 18. Postal Box</p>
+<div class="indent"><pre>
+&lt;field var='postalbox'&gt;
+  &lt;value&gt;1641&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.10 <a name="postalcode">Postal Code</a>
+</h3>
+      <p class="" style="">A postal code is a set of numeric or alphanumeric characters used to identify an area for postal delivery. Sometimes also called a "ZIP code" (in the U.S.).</p>
+      <p class="" style="">The Data Forms fields that represent a postal code are "postalcode", "home_postalcode", and "work_postalcode" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PCODE, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL PostalCodeNumber</li>
+        <li>JEP-0112 postalcode</li>
+      </ul>
+      <p class="caption">Example 19. Postal Code</p>
+<div class="indent"><pre>
+&lt;field var='postalcode'&gt;
+  &lt;value&gt;10002&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="fields-geoloc">Geolocation Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard and JEP-0080 (<span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2256836">18</a>]).</p>
+    <div class="indent">
+<h3>5.3.1 <a name="alt">Altitude</a>
+</h3>
+      <p class="" style="">Altitude is a person's height or depth in relationship to sea level, where positive altitude is meters above sea level and negative altitude is meters below sea level.</p>
+      <p class="" style="">The Data Forms field that represents altitude is "alt".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>JEP-0080 alt</li>
+      </ul>
+      <p class="caption">Example 20. Altitude</p>
+<div class="indent"><pre>
+&lt;field var='alt'&gt;
+  &lt;value&gt;1609&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.3.2 <a name="lat">Latitude</a>
+</h3>
+      <p class="" style="">Latitude is a person's latitude in relation to the equator, where positive latitude is north of the equator and negative latitude is south of the equator.</p>
+      <p class="" style="">The Data Forms field that represents latitude is "lat".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LAT</li>
+        <li>JEP-0080 lat</li>
+      </ul>
+      <p class="caption">Example 21. Latitude</p>
+<div class="indent"><pre>
+&lt;field var='lat'&gt;
+  &lt;value&gt;39.75477&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.3.3 <a name="lat">Longitude</a>
+</h3>
+      <p class="" style="">Longitude is a person's longitude in relation to the equator, where positive longitude is east of the meridian and negative longitude is west of the equator.</p>
+      <p class="" style="">The Data Forms field that represents longitude is "lon".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LON</li>
+        <li>JEP-0080 lon</li>
+      </ul>
+      <p class="caption">Example 22. Latitude</p>
+<div class="indent"><pre>
+&lt;field var='lon'&gt;
+  &lt;value&gt;-104.99768&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="fields-tel">Telephony Address Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.4.1 <a name="fax">Fax Number</a>
+</h3>
+      <p class="" style="">A fax number is a number for a machine that handles fascimile transmissions.</p>
+      <p class="" style="">The Data Forms fields that represent a fax number are "fax", "home_fax", and "work_fax" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "FAX" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+      </ul>
+      <p class="caption">Example 23. Fax Number</p>
+<div class="indent"><pre>
+&lt;field var='fax'&gt;
+  &lt;value&gt;303-308-3215&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.2 <a name="landline">Landline Telephone Number</a>
+</h3>
+      <p class="" style="">A landline telephone number is a number for a traditional "PSTN" or "POTS" telephone.</p>
+      <p class="" style="">The Data Forms fields that represent a landline telephone number are "landline", "home_landline", and "work_landline" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>FOAF phone</li>
+      </ul>
+      <p class="caption">Example 24. Landline Telephone Number</p>
+<div class="indent"><pre>
+&lt;field var='landline_phone'&gt;
+  &lt;value&gt;303-308-3282&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.3 <a name="mobile">Mobile Telephone Number</a>
+</h3>
+      <p class="" style="">A mobile telephone number is a number for a mobile phone or cell phone on a wireless network.</p>
+      <p class="" style="">The Data Forms fields that represent a mobile telephone number are "mobile", "home_mobile", and "work_mobile" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "CELL" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>FOAF phone</li>
+      </ul>
+      <p class="caption">Example 25. Mobile Telephone Number</p>
+<div class="indent"><pre>
+&lt;field var='mobile_phone'&gt;
+  &lt;value&gt;303-555-1212&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.4 <a name="pager">Pager Number</a>
+</h3>
+      <p class="" style="">A pager number is a number for a dedicated alphanumeric paging device.</p>
+      <p class="" style="">The Data Forms fields that represent a pager number are "pager", "home_pager", and "work_pager" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "PAGER" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+      </ul>
+      <p class="caption">Example 26. Pager Number</p>
+<div class="indent"><pre>
+&lt;field var='pager'&gt;
+  &lt;value&gt;303-555-1212&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.5 <a name="sip_address">SIP Address</a>
+</h3>
+      <p class="" style="">A SIP address is a sip: or sips: URI at which a person can be contacted for Voice over Internet Protocol (VoIP) communications.</p>
+      <p class="" style="">The Data Forms field that represents a SIP address is "sip_address".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 27. SIP Address</p>
+<div class="indent"><pre>
+&lt;field var='sip_address'&gt;
+  &lt;value&gt;sip:stpeter@sipspeare.lit&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.6 <a name="skype_address">Skype Address</a>
+</h3>
+      <p class="" style="">A Skype address is an address on the popular Skype system for Voice over Internet Protocol (VoIP) communications.</p>
+      <p class="" style="">The Data Forms field that represents a SIP address is "skype_address".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 28. Skype Address</p>
+<div class="indent"><pre>
+&lt;field var='sip_address'&gt;
+  &lt;value&gt;SomeSkypeUser&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="fields-net">Electronic Address Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.5.1 <a name="aim_id">AIM Screen Name</a>
+</h3>
+      <p class="" style="">An AIM screen name is an address at which a person or other entity can be contacted on the AOL Instant Messenger service.</p>
+      <p class="" style="">The Data Forms field that represents an AIM screen name is "aim_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF aimChatID</li>
+      </ul>
+      <p class="caption">Example 29. AIM Screen Name</p>
+<div class="indent"><pre>
+&lt;field var='aim_id'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.2 <a name="email">Email Address</a>
+</h3>
+      <p class="" style="">An email address is the value of a mailto: URI at which a person or other entity can be contacted using standard electronic mail protocols.</p>
+      <p class="" style="">The Data Forms field that represents longitude is "email".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EMAIL</li>
+      </ul>
+      <p class="caption">Example 30. Email address</p>
+<div class="indent"><pre>
+&lt;field var='email'&gt;
+  &lt;value&gt;stpeter@jabber.org&lt;/value&gt;
+  &lt;value&gt;stpeter@gmail.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.3 <a name="icq_id">ICQ Number</a>
+</h3>
+      <p class="" style="">An ICQ number is an address at which a person or other entity can be contacted on the ICQ instant messaging service.</p>
+      <p class="" style="">The Data Forms field that represents an ICQ number is "icq_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF icqChatID</li>
+      </ul>
+      <p class="caption">Example 31. ICQ number</p>
+<div class="indent"><pre>
+&lt;field var='icq_id'&gt;
+  &lt;value&gt;70902454&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.4 <a name="jid">Jabber ID</a>
+</h3>
+      <p class="" style="">A Jabber ID is the value of an xmpp: URI at which a person or other entity can be contacted over a Jabber/XMPP network.</p>
+      <p class="" style="">The Data Forms field that represents a Jabber ID is "jid".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF jabberID</li>
+      </ul>
+      <p class="caption">Example 32. Jabber ID</p>
+<div class="indent"><pre>
+&lt;field var='jid'&gt;
+  &lt;value&gt;stpeter@jabber.org&lt;/value&gt;
+  &lt;value&gt;peter@saint-andre.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.5 <a name="msn_id">MSN Address</a>
+</h3>
+      <p class="" style="">An MSN address is address at which a person or other entity can be contacted on the MSN instant messaging service.</p>
+      <p class="" style="">The Data Forms field that represents an MSN address is "msn_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF msnChatID</li>
+      </ul>
+      <p class="caption">Example 33. MSN Address</p>
+<div class="indent"><pre>
+&lt;field var='msn_id'&gt;
+  &lt;value&gt;petersaintandre@hotmail.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.6 <a name="yahoo_id">Yahoo ID</a>
+</h3>
+      <p class="" style="">A Yahoo ID is address at which a person or other entity can be contacted on the Yahoo! Instant Messenger service.</p>
+      <p class="" style="">The Data Forms field that represents a Yahoo ID is "yahoo_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF yahooChatID</li>
+      </ul>
+      <p class="caption">Example 34. Yahoo ID</p>
+<div class="indent"><pre>
+&lt;field var='yahoo_id'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="fields-www">World Wide Web Resource Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.6.1 <a name="avatar_url">Avatar URL</a>
+</h3>
+      <p class="" style="">An avatar is an often fanciful representation of a user's desired self-image or persona (e.g., in the context of a game). An avatar is usually not intended to be an accurate picture of the user's actual physical appearance (that is handled by the photo_url and photo_data fields).</p>
+      <p class="" style="">An avatar can come in two forms: the avatar data itself, or a URL for a avatar.</p>
+      <p class="" style="">The Data Forms field that represents the URL for an avatar is "avatar_url".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 35. Avatar URL</p>
+<div class="indent"><pre>
+&lt;field var='avatar_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_small.jpg&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.2 <a name="bio">Biographical URL</a>
+</h3>
+      <p class="" style="">A biographical URL is the value of an http: URI at which can be found biographical information about a person.</p>
+      <p class="" style="">The Data Forms field that represents a biographical URL is "bio".</p>
+      <p class="caption">Example 36. Biographical URL</p>
+<div class="indent"><pre>
+&lt;field var='bio'&gt;
+  &lt;value&gt;http://www.jabber.org/people/stpeter.shtml&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/me/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.3 <a name="foaf_url">FOAF URL</a>
+</h3>
+      <p class="" style="">A FOAF URL is the value of an http: URI at which can be found a "friend of a friend" (FOAF) file about a person or entity.</p>
+      <p class="" style="">The Data Forms field that represents a FOAF URL is "foaf_url".</p>
+      <p class="caption">Example 37. FOAF URL</p>
+<div class="indent"><pre>
+&lt;field var='foaf_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/me/foaf.rdf&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.4 <a name="homepage">Homepage URL</a>
+</h3>
+      <p class="" style="">A homepage URL is the value of an http: URI that is the default resource on the World Wide Web for a person or other entity.</p>
+      <p class="" style="">The Data Forms field that represents a homepage URL is "homepage".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF homepage</li>
+      </ul>
+      <p class="caption">Example 38. Homepage URL</p>
+<div class="indent"><pre>
+&lt;field var='homepage'&gt;
+  &lt;value&gt;http://www.saint-andre.com/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.5 <a name="photo_url">Photo URL</a>
+</h3>
+      <p class="" style="">A photograph provides a pictorial representation of a person. Sometimes also called a "mugshot".</p>
+      <p class="" style="">A photograph can come in two forms: the photo data itself (see below) or a URL for a photograph (e.g., the vCard PHOTO element can represent either, while the FOAF depiction and FOAF img can represent only a URL). The Data Forms field specified here identifies a URL for a photograph, not the data itself.</p>
+      <p class="" style="">The Data Forms field that represents the URL for a photograph is "photo_url".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PHOTO</li>
+        <li>FOAF depiction</li>
+        <li>FOAF img</li>
+      </ul>
+      <p class="caption">Example 39. Photo URL</p>
+<div class="indent"><pre>
+&lt;field var='photo_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter.jpg&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_hell.jpg&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_oscon.jpg&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.6 <a name="publications">Publications URL</a>
+</h3>
+      <p class="" style="">A publications URL is the value of an http: URI at which can be found the list of a person's published writings.</p>
+      <p class="" style="">The Data Forms field that represents a publications URL is "publications".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF publications</li>
+      </ul>
+      <p class="caption">Example 40. Publications URL</p>
+<div class="indent"><pre>
+&lt;field var='publications'&gt;
+  &lt;value&gt;http://www.saint-andre.com/thoughts/publications.html&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.7 <a name="resume">Resume URL</a>
+</h3>
+      <p class="" style="">A resume URL is the value of an http: URI at which can be found a person's resume or curriculum vitae.</p>
+      <p class="" style="">The Data Forms field that represents a resume URL is "resume".</p>
+      <p class="caption">Example 41. Resume URL</p>
+<div class="indent"><pre>
+&lt;field var='resume'&gt;
+  &lt;value&gt;http://www.saint-andre.com/work/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.8 <a name="status_url">Status URL</a>
+</h3>
+      <p class="" style="">A status URL is the value of an http: URI that specifies the current status of a person or other entity (e.g., a person's online presence or a server's uptime).</p>
+      <p class="" style="">The Data Forms field that represents a homepage URL is "status_url".</p>
+      <p class="caption">Example 42. Status URL</p>
+<div class="indent"><pre>
+&lt;field var='status_url'&gt;
+  &lt;value&gt;http://status.jabber.org/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.9 <a name="org_url">Organizational URL</a>
+</h3>
+      <p class="" style="">An organizational URL is the value of an http: URI that specifies the homepage for an organization or employer.</p>
+      <p class="" style="">The Data Forms field that represents an organizational URL is "org_url".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF workplaceHomepage</li>
+      </ul>
+      <p class="caption">Example 43. Organizational URL</p>
+<div class="indent"><pre>
+&lt;field var='org_url'&gt;
+  &lt;value&gt;http://www.jabber.org/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.10 <a name="weblog">Weblog URL</a>
+</h3>
+      <p class="" style="">A weblog URL is the value of an http: URI at which a person or other entity maintains a weblog.</p>
+      <p class="" style="">The Data Forms field that represents a weblog URL is "weblog".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF weblog</li>
+      </ul>
+      <p class="caption">Example 44. Weblog URL</p>
+<div class="indent"><pre>
+&lt;field var='weblog'&gt;
+  &lt;value&gt;http://www.saint-andre.com/blog/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="fields-org">Organizational Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.7.1 <a name="job_title">Job Title</a>
+</h3>
+      <p class="" style="">A job title is the official name of a person's position within an organization.</p>
+      <p class="" style="">The Data Forms field that represents a job title is "job_title".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TITLE</li>
+        <li>FOAF title</li>
+      </ul>
+      <p class="caption">Example 45. Job Title</p>
+<div class="indent"><pre>
+&lt;field var='job_title'&gt;
+  &lt;value&gt;Executive Director&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.2 <a name="org_name">Organizational Name</a>
+</h3>
+      <p class="" style="">An organizational name is the official name of an organization (company, school, etc.) within which a person works.</p>
+      <p class="" style="">The Data Forms field that represents the name of an organization is "org_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ORGNAME</li>
+      </ul>
+      <p class="caption">Example 46. Organizational Name</p>
+<div class="indent"><pre>
+&lt;field var='org_name'&gt;
+  &lt;value&gt;Jabber Software Foundation&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.3 <a name="org_role">Organizational Role</a>
+</h3>
+      <p class="" style="">An organizational role describes a person's profession or how a person contributes within an organization.</p>
+      <p class="" style="">The Data Forms field that represents an organizational role is "org_role".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ROLE</li>
+      </ul>
+      <p class="caption">Example 47. Organizational Role</p>
+<div class="indent"><pre>
+&lt;field var='org_role'&gt;
+  &lt;value&gt;Patron Saint&lt;/value&gt;
+  &lt;value&gt;Chief Evangelist&lt;/value&gt;
+  &lt;value&gt;Glorified Tech Writer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.4 <a name="org_unit">Organizational Unit</a>
+</h3>
+      <p class="" style="">An organizational unit is the name of part (subsidiary, department, etc.) of an organization.</p>
+      <p class="" style="">The Data Forms field that represents an organizational unit is "org_unit".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ORGUNIT</li>
+      </ul>
+      <p class="caption">Example 48. Organizational Unit</p>
+<div class="indent"><pre>
+&lt;field var='org_unit'&gt;
+  &lt;value&gt;Jabber Council&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="fields-basic">Basic Personal Data Aspects</a>
+</h3>
+    <p class="" style="">These data fields are not necessarily permanent, but do not tend to change very often if at all.</p>
+    <div class="indent">
+<h3>5.8.1 <a name="birth_dayofmonth">Birth Day-of-Month</a>
+</h3>
+      <p class="" style="">A birth day-of-month is the day of the month in which a person was born. (Note: This data field is <span style="font-style: italic">not</span> what in English is usually referred to as a person's "birthday", i.e. the year+month+day on which the person was born; the "birthday" is split into three data fields in order to protect personal privacy, since a given individual might want to disclose his or her birth year, birth month, birth day-of-month, or some combination thereof but not all three.)</p>
+      <p class="" style="">The Data Forms field that represents a birth day-of-month is "birth_dayofmonth".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 49. Birth Day-of-Month</p>
+<div class="indent"><pre>
+&lt;field var='birth_dayofmonth'&gt;
+  &lt;value&gt;06&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.2 <a name="birth_month">Birth Month</a>
+</h3>
+      <p class="" style="">A birth month is the month of the year in which a person was born.</p>
+      <p class="" style="">The Data Forms field that represents a birth month is "birth_month".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 50. Birth Month</p>
+<div class="indent"><pre>
+&lt;field var='birth_month'&gt;
+  &lt;value&gt;08&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.3 <a name="birth_year">Birth Year</a>
+</h3>
+      <p class="" style="">A birth year is the year in which a person was born.</p>
+      <p class="" style="">The Data Forms field that represents a birth year is "birth_year".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 51. Birth Year</p>
+<div class="indent"><pre>
+&lt;field var='birth_year'&gt;
+  &lt;value&gt;1966&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.4 <a name="eye_color">Eye Color</a>
+</h3>
+      <p class="" style="">Some people may want to know the color of a person's eyes. The allowable or recommeended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's eye color is "eye_color".</p>
+      <p class="caption">Example 52. Eye Color</p>
+<div class="indent"><pre>
+&lt;field var='eye_color'&gt;
+  &lt;value&gt;blue&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.5 <a name="gender">Gender</a>
+</h3>
+      <p class="" style="">Gender is the self-defined gender of a person (this is not limited to "male" and "female", although those are the expected values in most instances). Sometimes also called "sex" or "gender identification".</p>
+      <p class="" style="">The Data Forms field that represents a person's gender is "gender".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF gender</li>
+      </ul>
+      <p class="caption">Example 53. Gender</p>
+<div class="indent"><pre>
+&lt;field var='gender'&gt;
+  &lt;value&gt;male&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.6 <a name="hair_color">Hair Color</a>
+</h3>
+      <p class="" style="">Some people may want to know the color of a person's hair (if any). The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's hair color is "hair_color".</p>
+      <p class="caption">Example 54. Hair Color</p>
+<div class="indent"><pre>
+&lt;field var='hair_color'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.7 <a name="height">Height</a>
+</h3>
+      <p class="" style="">Some people may want to know a person's height. This SHOULD be expressed in centimeters (which can be transformed into other units if necessary by a client).</p>
+      <p class="" style="">The Data Forms field that represents a person's height is "height".</p>
+      <p class="caption">Example 55. Height</p>
+<div class="indent"><pre>
+&lt;field var='height'&gt;
+  &lt;value&gt;178&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.8 <a name="weight">Weight</a>
+</h3>
+      <p class="" style="">Yes, it is a sensitive topic, but some people may want to know a person's weight. This SHOULD be expressed in kilograms (which can be transformed into other units if necessary by a client).</p>
+      <p class="" style="">The Data Forms field that represents a person's weight is "weight".</p>
+      <p class="caption">Example 56. Weight</p>
+<div class="indent"><pre>
+&lt;field var='weight'&gt;
+  &lt;value&gt;75&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="fields-extended">Extended Personal Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.9.1 <a name="avatar_data">Avatar Data</a>
+</h3>
+      <p class="" style="">An avatar is an often fanciful representation of a user's desired self-image or persona (e.g., in the context of a game). An avatar is usually not intended to be an accurate picture of the user's actual physical appearance (that is handled by the photo_url and photo_data fields).</p>
+      <p class="" style="">An avatar can come in two forms: the avatar data itself, or a URL for a avatar.</p>
+      <p class="" style="">The Data Forms field that represents avatar data is "avatar_data".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 57. Avatar Data</p>
+<div class="indent"><pre>
+&lt;field var='avatar_data'&gt;
+  &lt;value&gt;base64-encoded-image-data&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.2 <a name="hobby">Hobbies</a>
+</h3>
+      <p class="" style="">A hobby is a non-work activity that a person enjoys pursuing. Also called an "avocation".</p>
+      <p class="" style="">The Data Forms field that represents a hobby is "hobby".</p>
+      <p class="caption">Example 58. Some Hobbies</p>
+<div class="indent"><pre>
+&lt;field var='hobby'&gt;
+  &lt;value&gt;guitar&lt;/value&gt;
+  &lt;value&gt;songwriting&lt;/value&gt;
+  &lt;value&gt;blogging&lt;/value&gt;
+  &lt;value&gt;reading&lt;/value&gt;
+  &lt;value&gt;hiking&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.3 <a name="interest">Interests</a>
+</h3>
+      <p class="" style="">An interest a thing that a person cares about or is curious about. It is, generally, less active than a hobby.</p>
+      <p class="" style="">The Data Forms field that represents an interest is "interest".</p>
+      <p class="caption">Example 59. Some Interests</p>
+<div class="indent"><pre>
+&lt;field var='interest'&gt;
+  &lt;value&gt;history&lt;/value&gt;
+  &lt;value&gt;baseball&lt;/value&gt;
+  &lt;value&gt;economics&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.4 <a name="languages_lesswell">Languages Known Less Well</a>
+</h3>
+      <p class="" style="">Some people know more than one language, but less than well (e.g., the person may not be able to speak fluently). The definition of "less well" is left to the user.</p>
+      <p class="" style="">The value of this field MUST be an abbreviation for a language as specified in <span class="ref" style="">RFC 3066</span>  [<a href="#nt-id2258812">19</a>].</p>
+      <p class="" style="">The Data Forms field that represents a language known less that well is "languages_lesswell".</p>
+      <p class="caption">Example 60. Languages Known Less than Well</p>
+<div class="indent"><pre>
+&lt;field var='languages_lesswell'&gt;
+  &lt;value&gt;cz&lt;/value&gt;
+  &lt;value&gt;de&lt;/value&gt;
+  &lt;value&gt;nl&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.5 <a name="languages_well">Languages Known Well</a>
+</h3>
+      <p class="" style="">Everyone knows at least one language well (e.g., they are able to speak or write the language with a fair degree of fluency). Determination of whether someone knows a language "well" or "fluently" is left to the user.</p>
+      <p class="" style="">The value of this field MUST be an abbreviation for a language as specified in <span style="font-weight: bold">RFC 3066</span>.</p>
+      <p class="" style="">The Data Forms field that represents a language known well is "languages_well".</p>
+      <p class="caption">Example 61. Languages Known Well</p>
+<div class="indent"><pre>
+&lt;field var='languages_well'&gt;
+  &lt;value&gt;en&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.6 <a name="mbti">Myers-Briggs Type Indicator</a>
+</h3>
+      <p class="" style="">A Myers-Briggs type indicator is four-letter acronym that is a popular way to characterize different personality types.</p>
+      <p class="" style="">The Data Forms field that represents a Myers-Briggs type indicator is "mbti".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF myersBriggs</li>
+      </ul>
+      <p class="caption">Example 62. Myers-Briggs Type Indicator</p>
+<div class="indent"><pre>
+&lt;field var='mbti'&gt;
+  &lt;value&gt;INTP&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.7 <a name="photo_data">Photo Data</a>
+</h3>
+      <p class="" style="">A photo provides a pictorial representation of a person. Sometimes also called a "mugshot".</p>
+      <p class="" style="">A photo can come in two forms: the photo data itself, or a URL for a photo (e.g., the vCard PHOTO element can represent either, while the FOAF depiction and FOAF img can represent only a URL).</p>
+      <p class="" style="">The Data Forms field that represents photo data is "photo_data".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PHOTO</li>
+      </ul>
+      <p class="caption">Example 63. Photo Data</p>
+<div class="indent"><pre>
+&lt;field var='photo_data'&gt;
+  &lt;value&gt;base64-encoded-image-data&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.8 <a name="profession">Profession</a>
+</h3>
+      <p class="" style="">A profession is what a person does for his or her primary employment. Also known as a "vocation". The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a profession is "profession".</p>
+      <p class="caption">Example 64. A Profession</p>
+<div class="indent"><pre>
+&lt;field var='profession'&gt;
+  &lt;value&gt;software engineer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.9 <a name="religion">Religious Affiliation</a>
+</h3>
+      <p class="" style="">Many people feel affiliated with a religious belief system.</p> 
+      <p class="" style="">The Data Forms field that represents a religious affiliation is "religion".</p>
+      <p class="caption">Example 65. Religious Affiliation</p>
+<div class="indent"><pre>
+&lt;field var='religion'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.10 <a name="wishlist">Wishlist</a>
+</h3>
+      <p class="" style="">A wishlist is a list of items that a person would like to receive as gifts.</p>
+      <p class="" style="">The Data Forms field that represents a wishlist is "wishlist".</p>
+      <p class="caption">Example 66. Wishlist</p>
+<div class="indent"><pre>
+&lt;field var='wishlist'&gt;
+  &lt;value&gt;A Mini Cooper&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.11 <a name="zodiac">Zodiac Sign</a>
+</h3>
+      <p class="" style="">A zodiac sign is that part of the astrological belt under which a person was born; each sign is named after one of the constellations. (Note: we don't have to believe in astrology to support this field.)</p>
+      <p class="" style="">The Data Forms field that represents a zodiac sign is "zodiac".</p>
+      <p class="caption">Example 67. Zodiac Sign</p>
+<div class="indent"><pre>
+&lt;field var='zodiac'&gt;
+  &lt;value&gt;Leo&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.10 <a name="fields-favorites">Personal Favorites</a>
+</h3>
+    <p class="" style="">Most people have favorite movies, authors, TV shows, musical artists, foods, games, etc.</p>
+    <div class="indent">
+<h3>5.10.1 <a name="fav_authors">Favorite Authors</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite authors is "fav_authors".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 68. Favorite Authors</p>
+<div class="indent"><pre>
+&lt;field var='fav_authors'&gt;
+  &lt;value&gt;Jacob Bronowski&lt;/value&gt;
+  &lt;value&gt;Friedrich Nietzsche&lt;/value&gt;
+  &lt;value&gt;Carroll Quigley&lt;/value&gt;
+  &lt;value&gt;Yevgeny Zamyatin&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.2 <a name="fav_athletes">Favorite Athletes</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite athletes is "fav_athletes".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 69. Favorite Athletes</p>
+<div class="indent"><pre>
+&lt;field var='fav_athletes'&gt;
+  &lt;value&gt;Lance Armstrong&lt;/value&gt;
+  &lt;value&gt;Andre Agassiz&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.3 <a name="fav_charities">Favorite Charities</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite charities is "fav_charities".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 70. Favorite Charities</p>
+<div class="indent"><pre>
+&lt;field var='fav_charities'&gt;
+  &lt;value&gt;Amnesty International&lt;/value&gt;
+  &lt;value&gt;Institute for Justice&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.4 <a name="fav_foods">Favorite Foods</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite foods is "fav_foods".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 71. Favorite Foods</p>
+<div class="indent"><pre>
+&lt;field var='fav_foods'&gt;
+  &lt;value&gt;Thai&lt;/value&gt;
+  &lt;value&gt;Mexican&lt;/value&gt;
+  &lt;value&gt;Italian&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.5 <a name="fav_games">Favorite Games</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite games is "fav_games".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 72. Favorite Games</p>
+<div class="indent"><pre>
+&lt;field var='fav_games'&gt;
+  &lt;value&gt;chess&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.6 <a name="fav_movies">Favorite Movies</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite movies is "fav_movies".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 73. Favorite Movies</p>
+<div class="indent"><pre>
+&lt;field var='fav_movies'&gt;
+  &lt;value&gt;In Search of Bobby Fischer&lt;/value&gt;
+  &lt;value&gt;Strictly Ballroom&lt;/value&gt;
+  &lt;value&gt;The Truth About Cats and Dogs&lt;/value&gt;
+  &lt;value&gt;Ray&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.7 <a name="fav_music">Favorite Music</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite music is "fav_music".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 74. Favorite Music</p>
+<div class="indent"><pre>
+&lt;field var='fav_music'&gt;
+  &lt;value&gt;J.S. Bach&lt;/value&gt;
+  &lt;value&gt;Duke Ellington&lt;/value&gt;
+  &lt;value&gt;Mellow Candle&lt;/value&gt;
+  &lt;value&gt;Yes&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.8 <a name="fav_quotes">Favorite Quotes</a>
+</h3>
+      <p class="" style="">A quote is a phrase or saying that a person identifies with in some way. According to the 2004 Pew Internet survey on instant messaging, quotes represent the most popular item to include in online profiles on major consumer-oriented instant messaging services.</p>
+      <p class="" style="">The Data Forms field that represents favorite quotes is "fav_quotes".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 75. Favorite Quotes</p>
+<div class="indent"><pre>
+&lt;field var='fav_quotes'&gt;
+  &lt;value&gt;I am large, I contain multitudes.&lt;/value&gt;
+  &lt;value&gt;&amp;quot;Think like a man of action, act like a man of thought.&amp;quot; --Henri Bergson&lt;/value&gt;
+  &lt;value&gt;One crowded hour of glorious life is worth an age without a name.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.9 <a name="fav_teams">Favorite Sports Teams</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite sports teams is "fav_teams".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 76. Favorite Sports Teams</p>
+<div class="indent"><pre>
+&lt;field var='fav_teams'&gt;
+  &lt;value&gt;New York Yankees&lt;/value&gt;
+  &lt;value&gt;Colorado Rockies&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.10 <a name="fav_tv">Favorite TV Shows</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite TV shows is "fav_tv".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 77. Favorite TV Shows</p>
+<div class="indent"><pre>
+&lt;field var='fav_tv'&gt;
+  &lt;value&gt;Antiques Road Show&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.11 <a name="fields-history">Personal History</a>
+</h3>
+    <div class="indent">
+<h3>5.11.1 <a name="places_lived">Places Lived</a>
+</h3>
+      <p class="" style="">Some people move around a lot.</p>
+      <p class="" style="">The Data Forms field that represents places lived is "places_lived".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 78. Places Lived</p>
+<div class="indent"><pre>
+&lt;field var='places_lived'&gt;
+  &lt;value&gt;Denver, Colorado, USA&lt;/value&gt;
+  &lt;value&gt;New Hope, Pennsylvania, USA&lt;/value&gt;
+  &lt;value&gt;Maplewood, New Jersey, USA&lt;/value&gt;
+  &lt;value&gt;Atlanta, Georgia, USA&lt;/value&gt;
+  &lt;value&gt;Fairfax, Virginia, USA&lt;/value&gt;
+  &lt;value&gt;Ceske Budejovice, Czech Republic&lt;/value&gt;
+  &lt;value&gt;New York City&lt;/value&gt;
+  &lt;value&gt;Readfield, Maine, USA&lt;/value&gt;
+  &lt;value&gt;Sea Cliff, NY, USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.2 <a name="schools">Schools Attended</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents schools attended is "schools".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 79. Schools Attended</p>
+<div class="indent"><pre>
+&lt;field var='schools'&gt;
+  &lt;value&gt;Columbia University&lt;/value&gt;
+  &lt;value&gt;American Renaissance School&lt;/value&gt;
+  &lt;value&gt;Maranacook Community School&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Profile data can be personally significant and even security critical. Due care should be taken in determining who shall have access to such information. However, this proposal merely defines the data formats for profile data; mechanisms for controlling access to such data will be defined in a separate proposal.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259647">20</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">To follow.</p>
+    
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251181">1</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2251225">2</a>. RFC 2426: vCard MIME Directory Profile &lt;<a href="http://www.ietf.org/rfc/rfc2426.txt">http://www.ietf.org/rfc/rfc2426.txt</a>&gt;.</p>
+<p><a name="nt-id2251214">3</a>. For links to the experimental XML representation of vCard, see <span style="font-weight: bold">JEP-0054</span>.</p>
+<p><a name="nt-id2251271">4</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2251307">5</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2250451">6</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2250481">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2250504">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2250544">9</a>. The extensibility requirement is critically important, because it would be best if the protocol specified herein could be used to represent data used within specialized communities. Examples of such communities include dating services, multiplayer gaming networks, IM services provided by portals and ISPs, and expert-location systems within large corporations. While such communities might use part or all of some common set of data fields (such as fields that map to familiar vCard elements), each community might also want to represent quite disparate kinds of information (dating criteria, favorite games, contact preferences, areas of expertise, and the like). Furthermore, data might be used to profile network actors that are not persons (e.g., bots, services, and other software agents). Therefore, the ideal proposal will provide an extensible framework for representing profile data and will not limit itself to representing the relatively small set of data fields covered by the vCard format.</p>
+<p><a name="nt-id2255311">10</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2255334">11</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2255400">12</a>. Resource Description Framework (RDF) &lt;<a href="http://www.w3.org/RDF/">http://www.w3.org/RDF/</a>&gt;.</p>
+<p><a name="nt-id2255450">13</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2255496">14</a>. JEP-0120: Infobits &lt;<a href="http://www.jabber.org/jeps/jep-0120.html">http://www.jabber.org/jeps/jep-0120.html</a>&gt;.</p>
+<p><a name="nt-id2255616">15</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2255607">16</a>. Alternatively, specialized applications MAY define separate FORM_TYPEs for their particular data elements.</p>
+<p><a name="nt-id2256218">17</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2256836">18</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2258812">19</a>. RFC 3066: Tags for the Identification of Languages &lt;<a href="http://www.ietf.org/rfc/rfc3066.txt">http://www.ietf.org/rfc/rfc3066.txt</a>&gt;.</p>
+<p><a name="nt-id2259647">20</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-06-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.5 (2005-06-13)</h4>
+<div class="indent">Defined how to handle vCard types such as home vs. work addresses. (psa)
+    </div>
+<h4>Version 0.0.4 (2005-04-07)</h4>
+<div class="indent">Reworked field standardization; added support for telephony addresses, electronic addresses, and organizational data. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-03-11)</h4>
+<div class="indent">Added open issues. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-01-06)</h4>
+<div class="indent">Explained requirements and design decisions in more detail, especially with regard to extensibility; split photo into two elements (data and URL). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-11-10)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0154-0.2.html
+++ b/content/xep-0154-0.2.html
@@ -1,0 +1,1952 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0154: Profile Data Representation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Profile Data Representation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies how to represent data about IM users and other XMPP entities in terms of the Data Forms protocol.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-25">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0154">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0154: Profile Data Representation</h1>
+<p>This JEP specifies how to represent data about IM users and other XMPP entities in terms of the Data Forms protocol.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0154<br>
+            Version: 0.2<br>
+            Last Updated: 2005-07-25<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004, JEP-0060, JEP-0068<br>Supersedes: JEP-0054<br>
+                Superseded By: None<br>
+            Short Name: profiledata<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Profile%20Data%20Representation%20(JEP-0154)">http://wiki.jabber.org/index.php/Profile Data Representation (JEP-0154)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#design">Design Decisions</a>
+</dt>
+<dt>4.  <a href="#approach">Approach</a>
+</dt>
+<dt>5.  <a href="#common_fields">Common Data Fields</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#fields-name">Name Data Aspects</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#display_name">Display Name</a>
+</dt>
+<dt>5.1.2.  <a href="#family_name">Family Name</a>
+</dt>
+<dt>5.1.3.  <a href="#familiar_name">Familiar Name</a>
+</dt>
+<dt>5.1.4.  <a href="#given_name">Given Name</a>
+</dt>
+<dt>5.1.5.  <a href="#middle_name">Middle Name</a>
+</dt>
+<dt>5.1.6.  <a href="#name_prefix">Name Prefix</a>
+</dt>
+<dt>5.1.7.  <a href="#name_suffix">Name Suffix</a>
+</dt>
+<dt>5.1.8.  <a href="#nickname">Nickname</a>
+</dt>
+<dt>5.1.9.  <a href="#patronymic">Patronymic</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#fields-physicaladdress">Physical Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#country">Country</a>
+</dt>
+<dt>5.2.2.  <a href="#region">Region</a>
+</dt>
+<dt>5.2.3.  <a href="#locality">Locality</a>
+</dt>
+<dt>5.2.4.  <a href="#area">Area</a>
+</dt>
+<dt>5.2.5.  <a href="#street">Street</a>
+</dt>
+<dt>5.2.6.  <a href="#building">Building</a>
+</dt>
+<dt>5.2.7.  <a href="#floor">Floor</a>
+</dt>
+<dt>5.2.8.  <a href="#room">Room</a>
+</dt>
+<dt>5.2.9.  <a href="#postalbox">Postal Box</a>
+</dt>
+<dt>5.2.10.  <a href="#postalcode">Postal Code</a>
+</dt>
+</dl>
+<dt>5.3.  <a href="#fields-geoloc">Geolocation Data Aspects</a>
+</dt>
+<dl>
+<dt>5.3.1.  <a href="#alt">Altitude</a>
+</dt>
+<dt>5.3.2.  <a href="#lat">Latitude</a>
+</dt>
+<dt>5.3.3.  <a href="#lat">Longitude</a>
+</dt>
+</dl>
+<dt>5.4.  <a href="#fields-tel">Telephony Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.4.1.  <a href="#fax">Fax Number</a>
+</dt>
+<dt>5.4.2.  <a href="#landline">Landline Telephone Number</a>
+</dt>
+<dt>5.4.3.  <a href="#mobile">Mobile Telephone Number</a>
+</dt>
+<dt>5.4.4.  <a href="#pager">Pager Number</a>
+</dt>
+<dt>5.4.5.  <a href="#sip_address">SIP Address</a>
+</dt>
+<dt>5.4.6.  <a href="#skype_address">Skype Address</a>
+</dt>
+<dt>5.4.7.  <a href="#video_phone">Videophone Address</a>
+</dt>
+</dl>
+<dt>5.5.  <a href="#fields-net">Electronic Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.5.1.  <a href="#aim_id">AIM Screen Name</a>
+</dt>
+<dt>5.5.2.  <a href="#email">Email Address</a>
+</dt>
+<dt>5.5.3.  <a href="#icq_id">ICQ Number</a>
+</dt>
+<dt>5.5.4.  <a href="#jid">Jabber ID</a>
+</dt>
+<dt>5.5.5.  <a href="#msn_id">MSN Address</a>
+</dt>
+<dt>5.5.6.  <a href="#yahoo_id">Yahoo ID</a>
+</dt>
+</dl>
+<dt>5.6.  <a href="#fields-www">World Wide Web Resource Aspects</a>
+</dt>
+<dl>
+<dt>5.6.1.  <a href="#avatar_url">Avatar URL</a>
+</dt>
+<dt>5.6.2.  <a href="#bio">Biographical URL</a>
+</dt>
+<dt>5.6.3.  <a href="#foaf_url">FOAF URL</a>
+</dt>
+<dt>5.6.4.  <a href="#homepage">Homepage URL</a>
+</dt>
+<dt>5.6.5.  <a href="#photo_url">Photo URL</a>
+</dt>
+<dt>5.6.6.  <a href="#publications">Publications URL</a>
+</dt>
+<dt>5.6.7.  <a href="#resume">Resume URL</a>
+</dt>
+<dt>5.6.8.  <a href="#status_url">Status URL</a>
+</dt>
+<dt>5.6.9.  <a href="#org_url">Organizational URL</a>
+</dt>
+<dt>5.6.10.  <a href="#weblog">Weblog URL</a>
+</dt>
+</dl>
+<dt>5.7.  <a href="#fields-org">Organizational Data Aspects</a>
+</dt>
+<dl>
+<dt>5.7.1.  <a href="#manager">Assistant</a>
+</dt>
+<dt>5.7.2.  <a href="#job_title">Job Title</a>
+</dt>
+<dt>5.7.3.  <a href="#manager">Manager</a>
+</dt>
+<dt>5.7.4.  <a href="#org_name">Organizational Name</a>
+</dt>
+<dt>5.7.5.  <a href="#org_role">Organizational Role</a>
+</dt>
+<dt>5.7.6.  <a href="#org_unit">Organizational Unit</a>
+</dt>
+<dt>5.7.7.  <a href="#system_username">System Username</a>
+</dt>
+<dt>5.7.8.  <a href="#workstation">Workstation Address</a>
+</dt>
+</dl>
+<dt>5.8.  <a href="#fields-basic">Basic Personal Data Aspects</a>
+</dt>
+<dl>
+<dt>5.8.1.  <a href="#birth_dayofmonth">Birth Day-of-Month</a>
+</dt>
+<dt>5.8.2.  <a href="#birth_month">Birth Month</a>
+</dt>
+<dt>5.8.3.  <a href="#birth_year">Birth Year</a>
+</dt>
+<dt>5.8.4.  <a href="#description">Description</a>
+</dt>
+<dt>5.8.5.  <a href="#eye_color">Eye Color</a>
+</dt>
+<dt>5.8.6.  <a href="#gender">Gender</a>
+</dt>
+<dt>5.8.7.  <a href="#hair_color">Hair Color</a>
+</dt>
+<dt>5.8.8.  <a href="#height">Height</a>
+</dt>
+<dt>5.8.9.  <a href="#weight">Weight</a>
+</dt>
+</dl>
+<dt>5.9.  <a href="#fields-extended">Extended Personal Data Aspects</a>
+</dt>
+<dl>
+<dt>5.9.1.  <a href="#expertise">Areas of Expertise</a>
+</dt>
+<dt>5.9.2.  <a href="#avatar_data">Avatar Data</a>
+</dt>
+<dt>5.9.3.  <a href="#dietary_preferences">Dietary Preferences</a>
+</dt>
+<dt>5.9.4.  <a href="#hobby">Hobbies</a>
+</dt>
+<dt>5.9.5.  <a href="#interest">Interests</a>
+</dt>
+<dt>5.9.6.  <a href="#languages_lesswell">Languages Known Less Well</a>
+</dt>
+<dt>5.9.7.  <a href="#languages_well">Languages Known Well</a>
+</dt>
+<dt>5.9.8.  <a href="#marital_status">Marital Status</a>
+</dt>
+<dt>5.9.9.  <a href="#mbti">Myers-Briggs Type Indicator</a>
+</dt>
+<dt>5.9.10.  <a href="#photo_data">Photo Data</a>
+</dt>
+<dt>5.9.11.  <a href="#profession">Profession</a>
+</dt>
+<dt>5.9.12.  <a href="#religion">Religious Affiliation</a>
+</dt>
+<dt>5.9.13.  <a href="#sexual_orientation">Sexual Orientation</a>
+</dt>
+<dt>5.9.14.  <a href="#smoker">Smoker</a>
+</dt>
+<dt>5.9.15.  <a href="#wishlist">Wishlist</a>
+</dt>
+<dt>5.9.16.  <a href="#zodiac_chinese">Zodiac Sign (Chinese)</a>
+</dt>
+<dt>5.9.17.  <a href="#zodiac_western">Zodiac Sign (Western)</a>
+</dt>
+</dl>
+<dt>5.10.  <a href="#fields-favorites">Personal Favorites</a>
+</dt>
+<dl>
+<dt>5.10.1.  <a href="#fav_authors">Favorite Authors</a>
+</dt>
+<dt>5.10.2.  <a href="#fav_athletes">Favorite Athletes</a>
+</dt>
+<dt>5.10.3.  <a href="#fav_charities">Favorite Charities</a>
+</dt>
+<dt>5.10.4.  <a href="#fav_drinks">Favorite Drinks</a>
+</dt>
+<dt>5.10.5.  <a href="#fav_foods">Favorite Foods</a>
+</dt>
+<dt>5.10.6.  <a href="#fav_games">Favorite Games</a>
+</dt>
+<dt>5.10.7.  <a href="#fav_movies">Favorite Movies</a>
+</dt>
+<dt>5.10.8.  <a href="#fav_music">Favorite Music</a>
+</dt>
+<dt>5.10.9.  <a href="#fav_quotes">Favorite Quotes</a>
+</dt>
+<dt>5.10.10.  <a href="#fav_teams">Favorite Sports Teams</a>
+</dt>
+<dt>5.10.11.  <a href="#fav_tv">Favorite TV Shows</a>
+</dt>
+</dl>
+<dt>5.11.  <a href="#fields-history">Personal History</a>
+</dt>
+<dl>
+<dt>5.11.1.  <a href="#places_lived">Places Lived</a>
+</dt>
+<dt>5.11.2.  <a href="#schools">Schools Attended</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-formtype">Field Standardization</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">It is widely acknowledged within the Jabber/XMPP community that the <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2250520">1</a>] specification (JEP-0054) has outlived its usefulness. There are several reasons for this conclusion:</p>
+  <ol start="" type="">
+    <li>JEP-0054 is not fully consistent with the Internet-Draft on which it was based.</li>
+    <li>The Internet-Draft on which it was based was never approved by the IETF.</li>
+    <li>Because of confusion over aspects of the vcard-temp specification, there exist incompatible implementations.</li>
+    <li>vCard (<span class="ref" style="">RFC 2426</span>  [<a href="#nt-id2250564">2</a>]) captures only a limited set of information.</li>
+    <li>vCard (even in its XML representation  [<a href="#nt-id2250553">3</a>]) is not easily extensible, leading those who develop profiles for specialized communities to "roll their own" protocols, to the detriment of interoperability.</li>
+    <li>vCard data tends to be monolithic (the basic unit of information is the full vCard, not parts thereof).</li>
+    <li>The publication model for JEP-0054 is to set the full vCard, rather than only the parts that need to be modified.</li>
+    <li>The retrieval model for JEP-0054 is to get the full vCard, rather than only the parts that have been modified.</li>
+  </ol>
+  <p class="" style="">Given the weaknesses of vCard, there is interest across the broader Internet community in replacing vCard with something more modern and extensible. Unfortunately, no other standards development organization has developed an alternative to vCard. Part of the challenge is that quite detailed ontologies have been developed that might replace parts of the vCard specification (e.g., the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2250749">4</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2250771">5</a>]) while less-formal ontologies are being used to represent other parts of the problem space (e.g., <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2250802">6</a>]). The relevant protocols are in flux and it is unclear when (or even if) stability will emerge.</p>
+  <p class="" style="">Because of the unsettled landspace and the strong desire within the Jabber/XMPP community to move beyond JEP-0054, this JEP specifies a consistent framework for the wire representation of profile data fields in terms of the <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250613">7</a>] protocol, further qualified using the standardization concepts specified in <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2250636">8</a>]. The rationale behind this design decision is provided below.</p>
+  <p class="" style="">Note: This JEP does not offer solutions to the problems of publishing, storing, and retrieving profile data. Those issues will be addressed in a separate proposal.</p> 
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Specify how to represent profile data in an XMPP-friendly manner for communication over the wire.</li>
+    <li>Ensure that the protocol is extensible (e.g., not limited to vCard fields).  
+         [<a href="#nt-id2250675">9</a>]
+    </li> 
+    <li>Where possible, map profile data fields to existing vCard fields and other common formats.</li>
+  </ol>
+  <p class="" style="">As noted, this JEP does not offer solutions to the problems of publishing, storing, and retrieving profile data. Those issues will be addressed in a separate proposal.</p> 
+<h2>3.
+       <a name="design">Design Decisions</a>
+</h2>
+  <p class="" style="">There are many possible approaches to representing profile data for communication over XMPP networks, including the following:</p>
+  <ul>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">Structured data formats, such as <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2256263">10</a>] and <span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2256287">11</a>].</span></p>
+      <p class="" style="">Such data formats have the advantage of being human-readable. However:</p>
+      <ol start="" type="">
+        <li>They are not easily extensible: developers of specialized community services would need to write their own structured data formats, even to add one new field.</li>
+        <li>They are not easy to map to backend data storage facilities (e.g., database administrators generally would prefer to have generic database schemas and re-usable code for parsing the XML wire protocol into the database fields).</li>
+        <li>They would require specialized interface handlers for each data structure, rather than a generic interface handler.</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of <span class="ref" style="">Resource Description Framework</span>  [<a href="#nt-id2256352">12</a>].</span></p>
+      <p class="" style="">An argument could be made that RDF is a reasonable approach for representing profile data for communication over the XMPP network; however, such an argument will not be made in the current proposal. The author has considered RDF and has concluded that there are several reasons why RDF is undesirable as an XMPP wire protocol:</p>
+      <ol start="" type="">
+        <li>RDF exists in an XML representation but the semantics of RDF impose a more complex conceptual structure (data triples) than does XML, which is sub-optimal since unnecessary complexity is to be avoided (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2256398">13</a>]).</li>
+        <li>RDF requires a specialized parser rather than the normal XML parser that comes standard with all XMPP implementations.</li>
+        <li>As long as it is possible to define a consistent mapping of profile data to RDF representations, it should be straightforward to convert the XMPP data formats into those RDF representations if desired (e.g., to output a FOAF file).</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of <span class="ref" style="">Infobits</span>  [<a href="#nt-id2256446">14</a>].</span></p>
+      <p class="" style="">The infobits approach to representing profile data was deprecated in early 2004 because it provides few advantages over an approach based on Data Forms.</p>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of Data Forms (JEP-0004).</span></p>
+      <p class="" style="">The Data Forms protocol defined in JEP-0004 has several advantages for use over XMPP:</p>
+      <ol start="" type="">
+        <li>It can be parsed using an off-the-shelf XML parser.</li>
+        <li>It is already widely deployed in existing Jabber/XMPP clients, servers, and components.</li>
+        <li>The data forms protocol is easily extensible.</li>
+        <li>The Jabber/XMPP community possesses consistent methods for profiling and scoping data forms (as specified in JEP-0068).</li>
+        <li>Data forms have a generic schema that is easy to map to common data storage mechanisms (usually databases).</li>
+        <li>Data forms provide a consistent abstraction layer for XMPP applications, thus shielding them from changes in the profile data formats being defined by other Internet projects and standards development organizations.</li>
+        <li>The use of data forms as the medium of representation for communication over the wire does not prevent applications from storing backend profile data in some other underlying format (e.g., RDF or a database).</li> 
+      </ol>
+    </li>
+  </ul>
+  <p class="" style="">For these reasons, this proposal specifies a way to represent profile data in terms of the Data Forms (jabber:x:data) protocol.</p>
+<h2>4.
+       <a name="approach">Approach</a>
+</h2>
+  <p class="" style="">This proposal specifies that profile data shall be scoped by a FORM_TYPE of 'http://jabber.org/protocol/profiledata', in accordance with the field standardization methods defined in JEP-0068. For the sake of interoperability, profile data fields that will be in common use SHOULD be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256572">15</a>] (although they may or may not be defined in a Jabber Enhancement Proposal). Profile data fields that are intended to be used only within the context of a specialized application MAY remain unregistered, but unregistered fields MUST begin with the string "x-" in accordance with Section 3.4 of JEP-0068.  [<a href="#nt-id2256559">16</a>]</p>
+  <p class="" style="">The following is a simple and incomplete example of profile data represented via the Data Forms protocol, containing two registered data fields and one unregistered field:</p>
+  <p class="caption">Example 1. A Basic Example</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='submit'&gt;
+  &lt;field var='FORM_TYPE' type='hidden'&gt;
+    &lt;value&gt;http://jabber.org/protocol/profiledata&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='common_name'&gt;
+    &lt;value&gt;Peter Saint-Andre&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='nickname'&gt;
+    &lt;value&gt;stpeter&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='x-favorite_painters'&gt;
+    &lt;value&gt;Joaquin Sorolla&lt;/value&gt;
+    &lt;value&gt;Jan Vermeer&lt;/value&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">By specifying that all fields are scoped by a FORM_TYPE of 'http://jabber.org/protocol/profiledata', this proposal does not mean to imply that all profile data will or should be gathered in one data form. In reality, most such data will probably be gathered at the time of registration either at a website or via a "wizard" interface that breaks the process into smaller bundles (such as "Basic Personal Data", "Physical Location", "Internet Addresses", "Hobbies and Interests", and "Favorite Things"). The use of one FORM_TYPE is simply meant to scope the data fields so that each field is unique within the context of profile data. Any form that uses these fields along with a FORM_TYPE of 'http://jabber.org/protocol/profiledata' is of the "profile type" (i.e., is a specific instance of that type), which does not limit the number of forms that can be of that type.</p>
+    <p class="" style="">However, scoping all data fields with a single FORM_TYPE implies it is necessary to define separate data fields for similar kinds of information. For example, the vCard specification (<span style="font-weight: bold">RFC 2426</span>) defines "types" for certains kinds of data, such as email addresses, telephone numbers, and physical addresses, making it possible to specify that a telephone number corresponds to a fax machine or mobile phone or that a physical address corresponds to one's home or work location. In the Data Forms representation, any desired piece of information (e.g., work phone) must be represented with a separate data field.</p>
+    <p class="" style="">In order to address most (if not all) of the pieces of information described in existing profile specifications, this JEP defines a great number of data fields. Even so, the data fields specified herein are not exhaustive, and it is expected that additional fields will be registered in the future through the mechanisms specified in the <a href="#registrar">Jabber Registrar Considerations</a> section of this JEP.</p>
+<h2>5.
+       <a name="common_fields">Common Data Fields</a>
+</h2>
+  <p class="" style="">The following subsections specify common fields for defining various aspects of a person, which shall form the initial submission to the Jabber Registrar; many of these fields map to elements specified in vCard, LDAP (see <span class="ref" style="">RFC 2252</span>  [<a href="#nt-id2256732">17</a>], <span class="ref" style="">RFC 2256</span>  [<a href="#nt-id2256758">18</a>], and <span class="ref" style="">RFC 2798</span>  [<a href="#nt-id2256777">19</a>]), xNAL, FOAF, and other existing specifications.</p>
+  <div class="indent">
+<h3>5.1 <a name="fields-name">Name Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard, xNAL, and FOAF.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="display_name">Display Name</a>
+</h3>
+      <p class="" style="">A display name is a version of a person's name intended for display in a user interface. Sometimes also called a "full name" or "formatted name".</p>
+      <p class="" style="">The Data Forms field that represents a display name is "display_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard FN</li>
+        <li>LDAP displayName</li>
+        <li>FOAF name</li>
+      </ul>
+      <p class="caption">Example 2. Display Name</p>
+<div class="indent"><pre>
+&lt;field var='display_name'&gt;
+  &lt;value&gt;Peter Saint-Andre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="family_name">Family Name</a>
+</h3>
+      <p class="" style="">A family name is that part of a person's name which signifies the person's primary family association. Sometimes also called a "last name" or "surname".</p>
+      <p class="" style="">The Data Forms field that represents a family name is "family_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard FAMILY</li>
+        <li>LDAP sn</li>
+        <li>xNAL LastName</li>
+        <li>FOAF family_name</li>
+        <li>FOAF surname</li>
+      </ul>
+      <p class="caption">Example 3. Family Name</p>
+<div class="indent"><pre>
+&lt;field var='family_name'&gt;
+  &lt;value&gt;Saint-Andre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.3 <a name="familiar_name">Familiar Name</a>
+</h3>
+      <p class="" style="">A familiar name is a shortened or modified form of someone's given name that may be used in somewhat informal contexts or that is preferred by the person (e.g., "Chuck" instead of "Charles").</p>
+      <p class="" style="">The Data Forms field that represents a familiar name is "familiar_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP nickname</li>
+      </ul>
+      <p class="caption">Example 4. Familiar Name</p>
+<div class="indent"><pre>
+&lt;field var='familiar_name'&gt;
+  &lt;value&gt;Pete&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.4 <a name="given_name">Given Name</a>
+</h3>
+      <p class="" style="">A given name is that part of a person's name which signifies the person's primary individual identity. Sometimes also called a "first name" or (in some countries) a "Christian name".</p>
+      <p class="" style="">The Data Forms field that represents a given name is "given_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard GIVEN</li>
+        <li>LDAP givenName</li>
+        <li>xNAL FirstName</li>
+        <li>FOAF first_name</li>
+        <li>FOAF givenname</li>
+      </ul>
+      <p class="caption">Example 5. Given Name</p>
+<div class="indent"><pre>
+&lt;field var='given_name'&gt;
+  &lt;value&gt;J.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.5 <a name="middle_name">Middle Name</a>
+</h3>
+      <p class="" style="">A middle name is that part of a person's name which signifies the person's secondary individual identity. Sometimes also called a "middle initial".</p>
+      <p class="" style="">The Data Forms field that represents a middle name is "middle_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard MIDDLE</li>
+        <li>xNAL MiddleName</li>
+      </ul>
+      <p class="caption">Example 6. Middle Name</p>
+<div class="indent"><pre>
+&lt;field var='middle_name'&gt;
+  &lt;value&gt;Peter&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.6 <a name="name_prefix">Name Prefix</a>
+</h3>
+      <p class="" style="">A name prefix is that part of a person's name which prepends the person's full name (e.g., Mr or Dr). Sometimes also called an "honorific" or "title".</p>
+      <p class="" style="">The Data Forms field that represents a name prefix is "name_prefix".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PREFIX</li>
+        <li>xNAL Title</li>
+        <li>FOAF title</li>
+      </ul>
+      <p class="caption">Example 7. Name Prefix</p>
+<div class="indent"><pre>
+&lt;field var='name_prefix'&gt;
+  &lt;value&gt;Mr&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.7 <a name="name_suffix">Name Suffix</a>
+</h3>
+      <p class="" style="">A name suffix is that part of a person's name which is appended to the person's full name (e.g., Jr or Esq).</p>
+      <p class="" style="">The Data Forms field that represents a name suffix is "name_suffix".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard SUFFIX</li>
+        <li>xNAL GeneralSuffix</li>
+      </ul>
+      <p class="caption">Example 8. Name Suffix</p>
+<div class="indent"><pre>
+&lt;field var='name_suffix'&gt;
+  &lt;value&gt;Esq&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.8 <a name="nickname">Nickname</a>
+</h3>
+      <p class="" style="">A nickname is a global, memorable (but not unique) friendly or informal name chosen by the owner of a JID. The purpose of a nickname is to associate a distinctive mapping between the person's unique JID and non-unique nickname. A nickname is normally used in informal contexts (e.g., in chatrooms). Sometimes also called an "alias". A person SHOULD specify only one nickname (i.e., not more than one).</p>
+      <p class="" style="">The Data Forms field that represents a nickname is "nickname".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard NICKNAME</li>
+        <li>xNAL Alias</li>
+        <li>FOAF nick</li>
+      </ul>
+      <p class="caption">Example 9. Nickname</p>
+<div class="indent"><pre>
+&lt;field var='nickname'&gt;
+  &lt;value&gt;stpeter&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.9 <a name="patronymic">Patronymic</a>
+</h3>
+      <p class="" style="">In some cultures, one's name includes a part that is derived from the given name of one's father; this part of one's name is called a "patronymic".</p>
+      <p class="" style="">The Data Forms field that represents a patronymic is "patronymic".</p>
+      <p class="caption">Example 10. A Patronymic</p>
+<div class="indent"><pre>
+&lt;field var='patronymic'&gt;
+  &lt;value&gt;Ivanovich&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="fields-physicaladdress">Physical Address Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard, xNAL, and JEP-0112 (<span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2257299">20</a>]).</p>
+    <div class="indent">
+<h3>5.2.1 <a name="country">Country</a>
+</h3>
+      <p class="" style="">A country is the sovereign nation in which a person is located. Sometimes also called a "nation".</p>
+      <p class="" style="">The Data Forms fields that represent a country are "country", "home_country", and "work_country" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard COUNTRY (or JEP-0054 CTRY), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP c</li>
+        <li>xNAL CountryName</li>
+        <li>JEP-0112 country</li>
+      </ul>
+      <p class="caption">Example 11. Country</p>
+<div class="indent"><pre>
+&lt;field var='country'&gt;
+  &lt;value&gt;USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="region">Region</a>
+</h3>
+      <p class="" style="">A region is a second-level administrative unit within the nation in which a person is located. Sometimes also called a "province", "state", or "administrative area".</p>
+      <p class="" style="">The Data Forms field that represents a region is "region".</p>
+      <p class="" style="">The Data Forms fields that represent a region are "home_region" and "work_region" for home addresses and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard REGION, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP st</li>
+        <li>xNAL AdministrativeAreaName</li>
+        <li>JEP-0112 region</li>
+      </ul>
+      <p class="caption">Example 12. Region</p>
+<div class="indent"><pre>
+&lt;field var='region'&gt;
+  &lt;value&gt;New York&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.3 <a name="locality">Locality</a>
+</h3>
+      <p class="" style="">A locality is a defined place within the region in which a person is located. Sometimes also called a "city", "town", or "village".</p>
+      <p class="" style="">The Data Forms fields that represent a locality are "locality", "home_locality", and "work_locality" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LOCALITY, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP l</li>
+        <li>xNAL LocalityName</li>
+        <li>JEP-0112 locality</li>
+      </ul>
+      <p class="caption">Example 13. Locality</p>
+<div class="indent"><pre>
+&lt;field var='locality'&gt;
+  &lt;value&gt;New York City&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.4 <a name="area">Area</a>
+</h3>
+      <p class="" style="">An area is a sub-division within the locality in which a person is located. Sometimes also called a "neighborhood", "suburb", "district", or "section".</p>
+      <p class="" style="">The Data Forms fields that represent a area are "area", "home_area", and "work_area" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>xNAL DependentLocalityName</li>
+        <li>JEP-0112 area</li>
+      </ul>
+      <p class="caption">Example 14. Area</p>
+<div class="indent"><pre>
+&lt;field var='area'&gt;
+  &lt;value&gt;Manhattan&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.5 <a name="street">Street</a>
+</h3>
+      <p class="" style="">A street is the street address (number plus street name, or two street names at an intersection) at which a person is located, or a postal box number for physical mail delivery. Sometimes also called a "street address".</p>
+      <p class="" style="">The Data Forms fields that represent a street are "street", "home_street", and "work_street" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard STREET, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP street</li>
+        <li>xNAL ThoroughfareNumber + ThoroughfareName</li>
+        <li>JEP-0112 street</li>
+      </ul>
+      <p class="caption">Example 15. Street</p>
+<div class="indent"><pre>
+&lt;field var='street'&gt;
+  &lt;value&gt;Fifth Avenue and 34th Street&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.6 <a name="building">Building</a>
+</h3>
+      <p class="" style="">A building is the name for a specific structure on a street or within an area.</p>
+      <p class="" style="">The Data Forms fields that represent a building are "building", "home_building", and "work_building" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL BuildingName</li>
+        <li>JEP-0112 building</li>
+      </ul>
+      <p class="caption">Example 16. Building</p>
+<div class="indent"><pre>
+&lt;field var='building'&gt;
+  &lt;value&gt;Empire State Building&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.7 <a name="floor">Floor</a>
+</h3>
+      <p class="" style="">A floor is a named or numbered floor or level within a building. Sometimes also called a "level", "block", or "suite".</p>
+      <p class="" style="">The Data Forms fields that represent a floor are "floor", "home_floor", and "work_floor" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL SubPremiseNumber</li>
+        <li>JEP-0112 floor</li>
+      </ul>
+      <p class="caption">Example 17. Floor</p>
+<div class="indent"><pre>
+&lt;field var='floor'&gt;
+  &lt;value&gt;102&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.8 <a name="room">Room</a>
+</h3>
+      <p class="" style="">A room is a named or numbered subdivision of a floor. Sometimes also called a "unit" or "apartment".</p>
+      <p class="" style="">The Data Forms fields that represent a room are "room", "home_room", and "work_room" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP roomNumber</li>
+        <li>xNAL SubPremiseNumber</li>
+        <li>JEP-0112 room</li>
+      </ul>
+      <p class="caption">Example 18. Room</p>
+<div class="indent"><pre>
+&lt;field var='room'&gt;
+  &lt;value&gt;Observatory&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.9 <a name="postalbox">Postal Box</a>
+</h3>
+      <p class="" style="">A postal box is a set of numeric or alphanumeric characters used to identify a mailbox at a postal delivery center.</p>
+      <p class="" style="">The Data Forms fields that represent a postal box are "postalbox", "home_postalbox", and "work_postalbox" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard POBOX, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP postOfficeBox</li>
+      </ul>
+      <p class="caption">Example 19. Postal Box</p>
+<div class="indent"><pre>
+&lt;field var='postalbox'&gt;
+  &lt;value&gt;1641&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.10 <a name="postalcode">Postal Code</a>
+</h3>
+      <p class="" style="">A postal code is a set of numeric or alphanumeric characters used to identify an area for postal delivery. Sometimes also called a "ZIP code" (in the U.S.).</p>
+      <p class="" style="">The Data Forms fields that represent a postal code are "postalcode", "home_postalcode", and "work_postalcode" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PCODE, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP postalCode</li>
+        <li>xNAL PostalCodeNumber</li>
+        <li>JEP-0112 postalcode</li>
+      </ul>
+      <p class="caption">Example 20. Postal Code</p>
+<div class="indent"><pre>
+&lt;field var='postalcode'&gt;
+  &lt;value&gt;10002&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="fields-geoloc">Geolocation Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard and JEP-0080 (<span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2257939">21</a>]).</p>
+    <div class="indent">
+<h3>5.3.1 <a name="alt">Altitude</a>
+</h3>
+      <p class="" style="">Altitude is a person's height or depth in relationship to sea level, where positive altitude is meters above sea level and negative altitude is meters below sea level.</p>
+      <p class="" style="">The Data Forms field that represents altitude is "alt".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>JEP-0080 alt</li>
+      </ul>
+      <p class="caption">Example 21. Altitude</p>
+<div class="indent"><pre>
+&lt;field var='alt'&gt;
+  &lt;value&gt;1609&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.3.2 <a name="lat">Latitude</a>
+</h3>
+      <p class="" style="">Latitude is a person's latitude in relation to the equator, where positive latitude is north of the equator and negative latitude is south of the equator.</p>
+      <p class="" style="">The Data Forms field that represents latitude is "lat".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LAT</li>
+        <li>JEP-0080 lat</li>
+      </ul>
+      <p class="caption">Example 22. Latitude</p>
+<div class="indent"><pre>
+&lt;field var='lat'&gt;
+  &lt;value&gt;39.75477&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.3.3 <a name="lat">Longitude</a>
+</h3>
+      <p class="" style="">Longitude is a person's longitude in relation to the equator, where positive longitude is east of the meridian and negative longitude is west of the equator.</p>
+      <p class="" style="">The Data Forms field that represents longitude is "lon".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LON</li>
+        <li>JEP-0080 lon</li>
+      </ul>
+      <p class="caption">Example 23. Latitude</p>
+<div class="indent"><pre>
+&lt;field var='lon'&gt;
+  &lt;value&gt;-104.99768&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="fields-tel">Telephony Address Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.4.1 <a name="fax">Fax Number</a>
+</h3>
+      <p class="" style="">A fax number is a number for a machine that handles fascimile transmissions.</p>
+      <p class="" style="">The Data Forms fields that represent a fax number are "fax", "home_fax", and "work_fax" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "FAX" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP facsimileTelephoneNumber</li>
+      </ul>
+      <p class="caption">Example 24. Fax Number</p>
+<div class="indent"><pre>
+&lt;field var='fax'&gt;
+  &lt;value&gt;303-308-3215&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.2 <a name="landline">Landline Telephone Number</a>
+</h3>
+      <p class="" style="">A landline telephone number is a number for a traditional "PSTN" or "POTS" telephone.</p>
+      <p class="" style="">The Data Forms fields that represent a landline telephone number are "landline", "home_landline", and "work_landline" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP telephoneNumber</li>
+        <li>FOAF phone</li>
+      </ul>
+      <p class="caption">Example 25. Landline Telephone Number</p>
+<div class="indent"><pre>
+&lt;field var='landline_phone'&gt;
+  &lt;value&gt;303-308-3282&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.3 <a name="mobile">Mobile Telephone Number</a>
+</h3>
+      <p class="" style="">A mobile telephone number is a number for a mobile phone or cell phone on a wireless network.</p>
+      <p class="" style="">The Data Forms fields that represent a mobile telephone number are "mobile", "home_mobile", and "work_mobile" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "CELL" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP mobile</li>
+        <li>FOAF phone</li>
+      </ul>
+      <p class="caption">Example 26. Mobile Telephone Number</p>
+<div class="indent"><pre>
+&lt;field var='mobile_phone'&gt;
+  &lt;value&gt;303-555-1212&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.4 <a name="pager">Pager Number</a>
+</h3>
+      <p class="" style="">A pager number is a number for a dedicated alphanumeric paging device.</p>
+      <p class="" style="">The Data Forms fields that represent a pager number are "pager", "home_pager", and "work_pager" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "PAGER" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP pager</li>
+      </ul>
+      <p class="caption">Example 27. Pager Number</p>
+<div class="indent"><pre>
+&lt;field var='pager'&gt;
+  &lt;value&gt;303-555-1212&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.5 <a name="sip_address">SIP Address</a>
+</h3>
+      <p class="" style="">A SIP address is a sip: or sips: URI at which a person can be contacted for Voice over Internet Protocol (VoIP) communications.</p>
+      <p class="" style="">The Data Forms field that represents a SIP address is "sip_address".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 28. SIP Address</p>
+<div class="indent"><pre>
+&lt;field var='sip_address'&gt;
+  &lt;value&gt;sip:stpeter@sipspeare.lit&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.6 <a name="skype_address">Skype Address</a>
+</h3>
+      <p class="" style="">A Skype address is an address on the popular Skype system for Voice over Internet Protocol (VoIP) communications.</p>
+      <p class="" style="">The Data Forms field that represents a Skype address is "skype_address".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 29. Skype Address</p>
+<div class="indent"><pre>
+&lt;field var='skype_address'&gt;
+  &lt;value&gt;SomeSkypeUser&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.7 <a name="video_phone">Videophone Address</a>
+</h3>
+      <p class="" style="">A videophone address is an address used for for H.323 video conferencing systems.</p>
+      <p class="" style="">The Data Forms field that represents a videophone address is "video_phone".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 30. Videophone Address</p>
+<div class="indent"><pre>
+&lt;field var='video_phone'&gt;
+  &lt;value&gt;foo&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="fields-net">Electronic Address Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.5.1 <a name="aim_id">AIM Screen Name</a>
+</h3>
+      <p class="" style="">An AIM screen name is an address at which a person or other entity can be contacted on the AOL Instant Messenger service.</p>
+      <p class="" style="">The Data Forms field that represents an AIM screen name is "aim_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF aimChatID</li>
+      </ul>
+      <p class="caption">Example 31. AIM Screen Name</p>
+<div class="indent"><pre>
+&lt;field var='aim_id'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.2 <a name="email">Email Address</a>
+</h3>
+      <p class="" style="">An email address is the value of a mailto: URI at which a person or other entity can be contacted using standard electronic mail protocols.</p>
+      <p class="" style="">The Data Forms field that represents longitude is "email".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EMAIL</li>
+        <li>LDAP mail</li>
+      </ul>
+      <p class="caption">Example 32. Email address</p>
+<div class="indent"><pre>
+&lt;field var='email'&gt;
+  &lt;value&gt;stpeter@jabber.org&lt;/value&gt;
+  &lt;value&gt;stpeter@gmail.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.3 <a name="icq_id">ICQ Number</a>
+</h3>
+      <p class="" style="">An ICQ number is an address at which a person or other entity can be contacted on the ICQ instant messaging service.</p>
+      <p class="" style="">The Data Forms field that represents an ICQ number is "icq_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF icqChatID</li>
+      </ul>
+      <p class="caption">Example 33. ICQ number</p>
+<div class="indent"><pre>
+&lt;field var='icq_id'&gt;
+  &lt;value&gt;70902454&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.4 <a name="jid">Jabber ID</a>
+</h3>
+      <p class="" style="">A Jabber ID is the value of an xmpp: URI at which a person or other entity can be contacted over a Jabber/XMPP network.</p>
+      <p class="" style="">The Data Forms field that represents a Jabber ID is "jid".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF jabberID</li>
+      </ul>
+      <p class="caption">Example 34. Jabber ID</p>
+<div class="indent"><pre>
+&lt;field var='jid'&gt;
+  &lt;value&gt;stpeter@jabber.org&lt;/value&gt;
+  &lt;value&gt;peter@saint-andre.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.5 <a name="msn_id">MSN Address</a>
+</h3>
+      <p class="" style="">An MSN address is address at which a person or other entity can be contacted on the MSN instant messaging service.</p>
+      <p class="" style="">The Data Forms field that represents an MSN address is "msn_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF msnChatID</li>
+      </ul>
+      <p class="caption">Example 35. MSN Address</p>
+<div class="indent"><pre>
+&lt;field var='msn_id'&gt;
+  &lt;value&gt;petersaintandre@hotmail.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.6 <a name="yahoo_id">Yahoo ID</a>
+</h3>
+      <p class="" style="">A Yahoo ID is address at which a person or other entity can be contacted on the Yahoo! Instant Messenger service.</p>
+      <p class="" style="">The Data Forms field that represents a Yahoo ID is "yahoo_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF yahooChatID</li>
+      </ul>
+      <p class="caption">Example 36. Yahoo ID</p>
+<div class="indent"><pre>
+&lt;field var='yahoo_id'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="fields-www">World Wide Web Resource Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.6.1 <a name="avatar_url">Avatar URL</a>
+</h3>
+      <p class="" style="">An avatar is an often fanciful representation of a user's desired self-image or persona (e.g., in the context of a game). An avatar is usually not intended to be an accurate picture of the user's actual physical appearance (that is handled by the photo_url and photo_data fields).</p>
+      <p class="" style="">An avatar can come in two forms: the avatar data itself, or a URL for a avatar.</p>
+      <p class="" style="">The Data Forms field that represents the URL for an avatar is "avatar_url".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 37. Avatar URL</p>
+<div class="indent"><pre>
+&lt;field var='avatar_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_small.jpg&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.2 <a name="bio">Biographical URL</a>
+</h3>
+      <p class="" style="">A biographical URL is the value of an http: URI at which can be found biographical information about a person.</p>
+      <p class="" style="">The Data Forms field that represents a biographical URL is "bio".</p>
+      <p class="caption">Example 38. Biographical URL</p>
+<div class="indent"><pre>
+&lt;field var='bio'&gt;
+  &lt;value&gt;http://www.jabber.org/people/stpeter.shtml&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/me/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.3 <a name="foaf_url">FOAF URL</a>
+</h3>
+      <p class="" style="">A FOAF URL is the value of an http: URI at which can be found a "friend of a friend" (FOAF) file about a person or entity.</p>
+      <p class="" style="">The Data Forms field that represents a FOAF URL is "foaf_url".</p>
+      <p class="caption">Example 39. FOAF URL</p>
+<div class="indent"><pre>
+&lt;field var='foaf_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/me/foaf.rdf&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.4 <a name="homepage">Homepage URL</a>
+</h3>
+      <p class="" style="">A homepage URL is the value of an http: URI that is the default resource on the World Wide Web for a person or other entity.</p>
+      <p class="" style="">The Data Forms field that represents a homepage URL is "homepage".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP labelledURI</li>
+        <li>FOAF homepage</li>
+      </ul>
+      <p class="caption">Example 40. Homepage URL</p>
+<div class="indent"><pre>
+&lt;field var='homepage'&gt;
+  &lt;value&gt;http://www.saint-andre.com/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.5 <a name="photo_url">Photo URL</a>
+</h3>
+      <p class="" style="">A photograph provides a pictorial representation of a person. Sometimes also called a "mugshot".</p>
+      <p class="" style="">A photograph can come in two forms: the photo data itself (see below) or a URL for a photograph (e.g., the vCard PHOTO element can represent either, while the FOAF depiction and FOAF img can represent only a URL). The Data Forms field specified here identifies a URL for a photograph, not the data itself.</p>
+      <p class="" style="">The Data Forms field that represents the URL for a photograph is "photo_url".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PHOTO</li>
+        <li>FOAF depiction</li>
+        <li>FOAF img</li>
+      </ul>
+      <p class="caption">Example 41. Photo URL</p>
+<div class="indent"><pre>
+&lt;field var='photo_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter.jpg&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_hell.jpg&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_oscon.jpg&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.6 <a name="publications">Publications URL</a>
+</h3>
+      <p class="" style="">A publications URL is the value of an http: URI at which can be found the list of a person's published writings.</p>
+      <p class="" style="">The Data Forms field that represents a publications URL is "publications".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF publications</li>
+      </ul>
+      <p class="caption">Example 42. Publications URL</p>
+<div class="indent"><pre>
+&lt;field var='publications'&gt;
+  &lt;value&gt;http://www.saint-andre.com/thoughts/publications.html&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.7 <a name="resume">Resume URL</a>
+</h3>
+      <p class="" style="">A resume URL is the value of an http: URI at which can be found a person's resume or curriculum vitae.</p>
+      <p class="" style="">The Data Forms field that represents a resume URL is "resume".</p>
+      <p class="caption">Example 43. Resume URL</p>
+<div class="indent"><pre>
+&lt;field var='resume'&gt;
+  &lt;value&gt;http://www.saint-andre.com/work/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.8 <a name="status_url">Status URL</a>
+</h3>
+      <p class="" style="">A status URL is the value of an http: URI that specifies the current status of a person or other entity (e.g., a person's online presence or a server's uptime).</p>
+      <p class="" style="">The Data Forms field that represents a homepage URL is "status_url".</p>
+      <p class="caption">Example 44. Status URL</p>
+<div class="indent"><pre>
+&lt;field var='status_url'&gt;
+  &lt;value&gt;http://status.jabber.org/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.9 <a name="org_url">Organizational URL</a>
+</h3>
+      <p class="" style="">An organizational URL is the value of an http: URI that specifies the homepage for an organization or employer.</p>
+      <p class="" style="">The Data Forms field that represents an organizational URL is "org_url".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF workplaceHomepage</li>
+      </ul>
+      <p class="caption">Example 45. Organizational URL</p>
+<div class="indent"><pre>
+&lt;field var='org_url'&gt;
+  &lt;value&gt;http://www.jabber.org/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.10 <a name="weblog">Weblog URL</a>
+</h3>
+      <p class="" style="">A weblog URL is the value of an http: URI at which a person or other entity maintains a weblog.</p>
+      <p class="" style="">The Data Forms field that represents a weblog URL is "weblog".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF weblog</li>
+      </ul>
+      <p class="caption">Example 46. Weblog URL</p>
+<div class="indent"><pre>
+&lt;field var='weblog'&gt;
+  &lt;value&gt;http://www.saint-andre.com/blog/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="fields-org">Organizational Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.7.1 <a name="manager">Assistant</a>
+</h3>
+      <p class="" style="">In some organizations, a person may be assisted by another individual.</p>
+      <p class="" style="">The Data Forms field that represents an assistant is "assistant".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP secretary</li>
+      </ul>
+      <p class="caption">Example 47. Assistant</p>
+<div class="indent"><pre>
+&lt;field var='assistant'&gt;
+  &lt;value&gt;Peter Pan&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.2 <a name="job_title">Job Title</a>
+</h3>
+      <p class="" style="">A job title is the official name of a person's position within an organization.</p>
+      <p class="" style="">The Data Forms field that represents a job title is "job_title".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TITLE</li>
+        <li>LDAP title</li>
+        <li>FOAF title</li>
+      </ul>
+      <p class="caption">Example 48. Job Title</p>
+<div class="indent"><pre>
+&lt;field var='job_title'&gt;
+  &lt;value&gt;Executive Director&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.3 <a name="manager">Manager</a>
+</h3>
+      <p class="" style="">In most organizations, a person is managed by or reports to another individual (often not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents a manager is "manager".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP manager</li>
+      </ul>
+      <p class="caption">Example 49. Manager</p>
+<div class="indent"><pre>
+&lt;field var='manager'&gt;
+  &lt;value&gt;William Shakespeare&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.4 <a name="org_name">Organizational Name</a>
+</h3>
+      <p class="" style="">An organizational name is the official name of an organization (company, school, etc.) within which a person works.</p>
+      <p class="" style="">The Data Forms field that represents the name of an organization is "org_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ORGNAME</li>
+        <li>LDAP o</li>
+      </ul>
+      <p class="caption">Example 50. Organizational Name</p>
+<div class="indent"><pre>
+&lt;field var='org_name'&gt;
+  &lt;value&gt;Jabber Software Foundation&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.5 <a name="org_role">Organizational Role</a>
+</h3>
+      <p class="" style="">An organizational role describes a person's profession or how a person contributes within an organization.</p>
+      <p class="" style="">The Data Forms field that represents an organizational role is "org_role".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ROLE</li>
+      </ul>
+      <p class="caption">Example 51. Organizational Role</p>
+<div class="indent"><pre>
+&lt;field var='org_role'&gt;
+  &lt;value&gt;Patron Saint&lt;/value&gt;
+  &lt;value&gt;Chief Evangelist&lt;/value&gt;
+  &lt;value&gt;Glorified Tech Writer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.6 <a name="org_unit">Organizational Unit</a>
+</h3>
+      <p class="" style="">An organizational unit is the name of part (subsidiary, department, etc.) of an organization.</p>
+      <p class="" style="">The Data Forms field that represents an organizational unit is "org_unit".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ORGUNIT</li>
+        <li>LDAP ou</li>
+      </ul>
+      <p class="caption">Example 52. Organizational Unit</p>
+<div class="indent"><pre>
+&lt;field var='org_unit'&gt;
+  &lt;value&gt;Jabber Council&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.7 <a name="system_username">System Username</a>
+</h3>
+      <p class="" style="">Usually a person has a system or network username within an organization (usually not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents such a username is "system_username".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP uid</li>
+        <li>LDAP userid</li>
+      </ul>
+      <p class="caption">Example 53. System Username</p>
+<div class="indent"><pre>
+&lt;field var='system_username'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.8 <a name="workstation">Workstation Address</a>
+</h3>
+      <p class="" style="">Often a person has a dedicated workstation address or name within an organization (usually not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents such a username is "workstation".</p>
+      <p class="caption">Example 54. Workstation Address</p>
+<div class="indent"><pre>
+&lt;field var='workstation'&gt;
+  &lt;value&gt;squire&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="fields-basic">Basic Personal Data Aspects</a>
+</h3>
+    <p class="" style="">These data fields are not necessarily permanent, but do not tend to change very often if at all.</p>
+    <div class="indent">
+<h3>5.8.1 <a name="birth_dayofmonth">Birth Day-of-Month</a>
+</h3>
+      <p class="" style="">A birth day-of-month is the day of the month in which a person was born. (Note: This data field is <span style="font-style: italic">not</span> what in English is usually referred to as a person's "birthday", i.e. the year+month+day on which the person was born; the "birthday" is split into three data fields in order to protect personal privacy, since a given individual might want to disclose his or her birth year, birth month, birth day-of-month, or some combination thereof but not all three.)</p>
+      <p class="" style="">The Data Forms field that represents a birth day-of-month is "birth_dayofmonth".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 55. Birth Day-of-Month</p>
+<div class="indent"><pre>
+&lt;field var='birth_dayofmonth'&gt;
+  &lt;value&gt;06&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.2 <a name="birth_month">Birth Month</a>
+</h3>
+      <p class="" style="">A birth month is the month of the year in which a person was born.</p>
+      <p class="" style="">The Data Forms field that represents a birth month is "birth_month".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 56. Birth Month</p>
+<div class="indent"><pre>
+&lt;field var='birth_month'&gt;
+  &lt;value&gt;08&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.3 <a name="birth_year">Birth Year</a>
+</h3>
+      <p class="" style="">A birth year is the year in which a person was born.</p>
+      <p class="" style="">The Data Forms field that represents a birth year is "birth_year".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 57. Birth Year</p>
+<div class="indent"><pre>
+&lt;field var='birth_year'&gt;
+  &lt;value&gt;1966&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.4 <a name="description">Description</a>
+</h3>
+      <p class="" style="">It can be helpful to provide a natural-language description of a person.</p>
+      <p class="" style="">The Data Forms field that represents a description of a person is "description".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP description</li>
+      </ul>
+      <p class="caption">Example 58. Description</p>
+<div class="indent"><pre>
+&lt;field var='description'&gt;
+  &lt;value&gt;I'm a Jabber fanatic.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.5 <a name="eye_color">Eye Color</a>
+</h3>
+      <p class="" style="">Some people may want to know the color of a person's eyes. The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's eye color is "eye_color".</p>
+      <p class="caption">Example 59. Eye Color</p>
+<div class="indent"><pre>
+&lt;field var='eye_color'&gt;
+  &lt;value&gt;blue&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.6 <a name="gender">Gender</a>
+</h3>
+      <p class="" style="">Gender is the self-defined gender of a person (this is not limited to "male" and "female", although those are the expected values in most instances). Sometimes also called "sex" or "gender identification".</p>
+      <p class="" style="">The Data Forms field that represents a person's gender is "gender".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF gender</li>
+      </ul>
+      <p class="caption">Example 60. Gender</p>
+<div class="indent"><pre>
+&lt;field var='gender'&gt;
+  &lt;value&gt;male&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.7 <a name="hair_color">Hair Color</a>
+</h3>
+      <p class="" style="">Some people may want to know the color of a person's hair (if any). The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's hair color is "hair_color".</p>
+      <p class="caption">Example 61. Hair Color</p>
+<div class="indent"><pre>
+&lt;field var='hair_color'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.8 <a name="height">Height</a>
+</h3>
+      <p class="" style="">Some people may want to know a person's height. This SHOULD be expressed in centimeters (which can be transformed into other units if necessary by a client).</p>
+      <p class="" style="">The Data Forms field that represents a person's height is "height".</p>
+      <p class="caption">Example 62. Height</p>
+<div class="indent"><pre>
+&lt;field var='height'&gt;
+  &lt;value&gt;178&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.9 <a name="weight">Weight</a>
+</h3>
+      <p class="" style="">Yes, it is a sensitive topic, but some people may want to know a person's weight. This SHOULD be expressed in kilograms (which can be transformed into other units if necessary by a client).</p>
+      <p class="" style="">The Data Forms field that represents a person's weight is "weight".</p>
+      <p class="caption">Example 63. Weight</p>
+<div class="indent"><pre>
+&lt;field var='weight'&gt;
+  &lt;value&gt;75&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="fields-extended">Extended Personal Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.9.1 <a name="expertise">Areas of Expertise</a>
+</h3>
+      <p class="" style="">An area of expertise is a subject in which a person has a great deal of knowledge.</p>
+      <p class="" style="">The Data Forms field that represents an area of expertise is "expertise".</p>
+      <p class="caption">Example 64. Areas of Expertise</p>
+<div class="indent"><pre>
+&lt;field var='expertise'&gt;
+  &lt;value&gt;Jabber&lt;/value&gt;
+  &lt;value&gt;XMPP&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.2 <a name="avatar_data">Avatar Data</a>
+</h3>
+      <p class="" style="">An avatar is an often fanciful representation of a user's desired self-image or persona (e.g., in the context of a game). An avatar is usually not intended to be an accurate picture of the user's actual physical appearance (that is handled by the photo_url and photo_data fields).</p>
+      <p class="" style="">An avatar can come in two forms: the avatar data itself, or a URL for a avatar.</p>
+      <p class="" style="">The Data Forms field that represents avatar data is "avatar_data".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 65. Avatar Data</p>
+<div class="indent"><pre>
+&lt;field var='avatar_data'&gt;
+  &lt;value&gt;base64-encoded-image-data&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.3 <a name="dietary_preferences">Dietary Preferences</a>
+</h3>
+      <p class="" style="">Some people have dietary preferences (vegan, vegetarian, kosher, peanut allergy, no shellfish, etc.).</p>
+      <p class="" style="">The Data Forms field that represents dietary preferences is "dietary_preferences".</p>
+      <p class="caption">Example 66. Dietary Preferences</p>
+<div class="indent"><pre>
+&lt;field var='dietary_preferences'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.4 <a name="hobby">Hobbies</a>
+</h3>
+      <p class="" style="">A hobby is a non-work activity that a person enjoys pursuing. Also called an "avocation".</p>
+      <p class="" style="">The Data Forms field that represents a hobby is "hobby".</p>
+      <p class="caption">Example 67. Some Hobbies</p>
+<div class="indent"><pre>
+&lt;field var='hobby'&gt;
+  &lt;value&gt;guitar&lt;/value&gt;
+  &lt;value&gt;songwriting&lt;/value&gt;
+  &lt;value&gt;blogging&lt;/value&gt;
+  &lt;value&gt;reading&lt;/value&gt;
+  &lt;value&gt;hiking&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.5 <a name="interest">Interests</a>
+</h3>
+      <p class="" style="">An interest a thing that a person cares about or is curious about. It is, generally, less active than a hobby.</p>
+      <p class="" style="">The Data Forms field that represents an interest is "interest".</p>
+      <p class="caption">Example 68. Some Interests</p>
+<div class="indent"><pre>
+&lt;field var='interest'&gt;
+  &lt;value&gt;history&lt;/value&gt;
+  &lt;value&gt;baseball&lt;/value&gt;
+  &lt;value&gt;economics&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.6 <a name="languages_lesswell">Languages Known Less Well</a>
+</h3>
+      <p class="" style="">Some people know more than one language, but less than well (e.g., the person may not be able to speak fluently). The definition of "less well" is left to the user.</p>
+      <p class="" style="">The value of this field MUST be an abbreviation for a language as specified in <span class="ref" style="">RFC 3066</span>  [<a href="#nt-id2260286">22</a>].</p>
+      <p class="" style="">The Data Forms field that represents a language known less that well is "languages_lesswell".</p>
+      <p class="caption">Example 69. Languages Known Less than Well</p>
+<div class="indent"><pre>
+&lt;field var='languages_lesswell'&gt;
+  &lt;value&gt;cz&lt;/value&gt;
+  &lt;value&gt;de&lt;/value&gt;
+  &lt;value&gt;nl&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.7 <a name="languages_well">Languages Known Well</a>
+</h3>
+      <p class="" style="">Everyone knows at least one language well (e.g., they are able to speak or write the language with a fair degree of fluency). Determination of whether someone knows a language "well" or "fluently" is left to the user.</p>
+      <p class="" style="">The value of this field MUST be an abbreviation for a language as specified in <span style="font-weight: bold">RFC 3066</span>.</p>
+      <p class="" style="">The Data Forms field that represents a language known well is "languages_well".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP preferredLanguage</li>
+      </ul>
+      <p class="caption">Example 70. Languages Known Well</p>
+<div class="indent"><pre>
+&lt;field var='languages_well'&gt;
+  &lt;value&gt;en&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.8 <a name="marital_status">Marital Status</a>
+</h3>
+      <p class="" style="">Human beings often get married, sometimes get divorced, become widowed, etc.</p>
+      <p class="" style="">The Data Forms field that represents whether a person's marital status is "marital_status".</p>
+      <p class="caption">Example 71. Marital Status</p>
+<div class="indent"><pre>
+&lt;field var='marital_status'&gt;
+  &lt;value&gt;married&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.9 <a name="mbti">Myers-Briggs Type Indicator</a>
+</h3>
+      <p class="" style="">A Myers-Briggs type indicator is four-letter acronym that is a popular way to characterize different personality types.</p>
+      <p class="" style="">The Data Forms field that represents a Myers-Briggs type indicator is "mbti".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF myersBriggs</li>
+      </ul>
+      <p class="caption">Example 72. Myers-Briggs Type Indicator</p>
+<div class="indent"><pre>
+&lt;field var='mbti'&gt;
+  &lt;value&gt;INTP&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.10 <a name="photo_data">Photo Data</a>
+</h3>
+      <p class="" style="">A photo provides a pictorial representation of a person. Sometimes also called a "mugshot".</p>
+      <p class="" style="">A photo can come in two forms: the photo data itself, or a URL for a photo (e.g., the vCard PHOTO element can represent either, while the FOAF depiction and FOAF img can represent only a URL).</p>
+      <p class="" style="">The Data Forms field that represents photo data is "photo_data".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PHOTO</li>
+        <li>LDAP jpegPhoto</li>
+      </ul>
+      <p class="caption">Example 73. Photo Data</p>
+<div class="indent"><pre>
+&lt;field var='photo_data'&gt;
+  &lt;value&gt;base64-encoded-image-data&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.11 <a name="profession">Profession</a>
+</h3>
+      <p class="" style="">A profession is what a person does for his or her primary employment. Also known as a "vocation". The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a profession is "profession".</p>
+      <p class="caption">Example 74. A Profession</p>
+<div class="indent"><pre>
+&lt;field var='profession'&gt;
+  &lt;value&gt;software engineer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.12 <a name="religion">Religious Affiliation</a>
+</h3>
+      <p class="" style="">Many people feel affiliated with a religious belief system.</p> 
+      <p class="" style="">The Data Forms field that represents a religious affiliation is "religion".</p>
+      <p class="caption">Example 75. Religious Affiliation</p>
+<div class="indent"><pre>
+&lt;field var='religion'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.13 <a name="sexual_orientation">Sexual Orientation</a>
+</h3>
+      <p class="" style="">The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's sexual orientation is "sexual_orientation".</p>
+      <p class="caption">Example 76. Sexual Orientation</p>
+<div class="indent"><pre>
+&lt;field var='sexual_orientation'&gt;
+  &lt;value&gt;straight&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.14 <a name="smoker">Smoker</a>
+</h3>
+      <p class="" style="">Some people smoke tobacco in various forms (cigarettes, cigars, pipes, etc.).</p> 
+      <p class="" style="">The Data Forms field that represents whether a person smokes is "smoker".</p>
+      <p class="caption">Example 77. Smoker</p>
+<div class="indent"><pre>
+&lt;field var='smoker'&gt;
+  &lt;value&gt;no&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.15 <a name="wishlist">Wishlist</a>
+</h3>
+      <p class="" style="">A wishlist is a list of items that a person would like to receive as gifts.</p>
+      <p class="" style="">The Data Forms field that represents a wishlist is "wishlist".</p>
+      <p class="caption">Example 78. Wishlist</p>
+<div class="indent"><pre>
+&lt;field var='wishlist'&gt;
+  &lt;value&gt;A Mini Cooper&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.16 <a name="zodiac_chinese">Zodiac Sign (Chinese)</a>
+</h3>
+      <p class="" style="">A Chinese zodiac sign denotes the type of year in which a person was born according to the Chinese calendar (e.g., the year of the dragon).</p>
+      <p class="" style="">The Data Forms field that represents a Chinese zodiac sign is "zodiac_chinese".</p>
+      <p class="caption">Example 79. Zodiac Sign (Chinese)</p>
+<div class="indent"><pre>
+&lt;field var='zodiac_chinese'&gt;
+  &lt;value&gt;horse&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.17 <a name="zodiac_western">Zodiac Sign (Western)</a>
+</h3>
+      <p class="" style="">A Western zodiac sign is that part of the astrological belt under which a person was born; each sign is named after one of the constellations.</p>
+      <p class="" style="">The Data Forms field that represents a Western zodiac sign is "zodiac_western".</p>
+      <p class="caption">Example 80. Zodiac Sign (Western)</p>
+<div class="indent"><pre>
+&lt;field var='zodiac_western'&gt;
+  &lt;value&gt;Leo&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.10 <a name="fields-favorites">Personal Favorites</a>
+</h3>
+    <p class="" style="">Most people have favorite movies, authors, TV shows, musical artists, foods, games, etc.</p>
+    <div class="indent">
+<h3>5.10.1 <a name="fav_authors">Favorite Authors</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite authors is "fav_authors".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 81. Favorite Authors</p>
+<div class="indent"><pre>
+&lt;field var='fav_authors'&gt;
+  &lt;value&gt;Jacob Bronowski&lt;/value&gt;
+  &lt;value&gt;Friedrich Nietzsche&lt;/value&gt;
+  &lt;value&gt;Carroll Quigley&lt;/value&gt;
+  &lt;value&gt;Yevgeny Zamyatin&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.2 <a name="fav_athletes">Favorite Athletes</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite athletes is "fav_athletes".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 82. Favorite Athletes</p>
+<div class="indent"><pre>
+&lt;field var='fav_athletes'&gt;
+  &lt;value&gt;Lance Armstrong&lt;/value&gt;
+  &lt;value&gt;Andre Agassiz&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.3 <a name="fav_charities">Favorite Charities</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite charities is "fav_charities".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 83. Favorite Charities</p>
+<div class="indent"><pre>
+&lt;field var='fav_charities'&gt;
+  &lt;value&gt;Amnesty International&lt;/value&gt;
+  &lt;value&gt;Institute for Justice&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.4 <a name="fav_drinks">Favorite Drinks</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite drinks is "fav_drinks".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 84. Favorite Drinks</p>
+<div class="indent"><pre>
+&lt;field var='fav_drinks'&gt;
+  &lt;value&gt;Guinness&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.5 <a name="fav_foods">Favorite Foods</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite foods is "fav_foods".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 85. Favorite Foods</p>
+<div class="indent"><pre>
+&lt;field var='fav_foods'&gt;
+  &lt;value&gt;Thai&lt;/value&gt;
+  &lt;value&gt;Mexican&lt;/value&gt;
+  &lt;value&gt;Italian&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.6 <a name="fav_games">Favorite Games</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite games is "fav_games".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 86. Favorite Games</p>
+<div class="indent"><pre>
+&lt;field var='fav_games'&gt;
+  &lt;value&gt;chess&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.7 <a name="fav_movies">Favorite Movies</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite movies is "fav_movies".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 87. Favorite Movies</p>
+<div class="indent"><pre>
+&lt;field var='fav_movies'&gt;
+  &lt;value&gt;In Search of Bobby Fischer&lt;/value&gt;
+  &lt;value&gt;Strictly Ballroom&lt;/value&gt;
+  &lt;value&gt;The Truth About Cats and Dogs&lt;/value&gt;
+  &lt;value&gt;Ray&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.8 <a name="fav_music">Favorite Music</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite music is "fav_music".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 88. Favorite Music</p>
+<div class="indent"><pre>
+&lt;field var='fav_music'&gt;
+  &lt;value&gt;J.S. Bach&lt;/value&gt;
+  &lt;value&gt;Duke Ellington&lt;/value&gt;
+  &lt;value&gt;Mellow Candle&lt;/value&gt;
+  &lt;value&gt;Yes&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.9 <a name="fav_quotes">Favorite Quotes</a>
+</h3>
+      <p class="" style="">A quote is a phrase or saying that a person identifies with in some way. According to the 2004 Pew Internet survey on instant messaging, quotes represent the most popular item to include in online profiles on major consumer-oriented instant messaging services.</p>
+      <p class="" style="">The Data Forms field that represents favorite quotes is "fav_quotes".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 89. Favorite Quotes</p>
+<div class="indent"><pre>
+&lt;field var='fav_quotes'&gt;
+  &lt;value&gt;I am large, I contain multitudes.&lt;/value&gt;
+  &lt;value&gt;&amp;quot;Think like a man of action, act like a man of thought.&amp;quot; --Henri Bergson&lt;/value&gt;
+  &lt;value&gt;One crowded hour of glorious life is worth an age without a name.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.10 <a name="fav_teams">Favorite Sports Teams</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite sports teams is "fav_teams".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 90. Favorite Sports Teams</p>
+<div class="indent"><pre>
+&lt;field var='fav_teams'&gt;
+  &lt;value&gt;New York Yankees&lt;/value&gt;
+  &lt;value&gt;Colorado Rockies&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.11 <a name="fav_tv">Favorite TV Shows</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite TV shows is "fav_tv".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 91. Favorite TV Shows</p>
+<div class="indent"><pre>
+&lt;field var='fav_tv'&gt;
+  &lt;value&gt;Antiques Road Show&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.11 <a name="fields-history">Personal History</a>
+</h3>
+    <div class="indent">
+<h3>5.11.1 <a name="places_lived">Places Lived</a>
+</h3>
+      <p class="" style="">Some people move around a lot.</p>
+      <p class="" style="">The Data Forms field that represents places lived is "places_lived".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 92. Places Lived</p>
+<div class="indent"><pre>
+&lt;field var='places_lived'&gt;
+  &lt;value&gt;Denver, Colorado, USA&lt;/value&gt;
+  &lt;value&gt;New Hope, Pennsylvania, USA&lt;/value&gt;
+  &lt;value&gt;Maplewood, New Jersey, USA&lt;/value&gt;
+  &lt;value&gt;Atlanta, Georgia, USA&lt;/value&gt;
+  &lt;value&gt;Fairfax, Virginia, USA&lt;/value&gt;
+  &lt;value&gt;Ceske Budejovice, Czech Republic&lt;/value&gt;
+  &lt;value&gt;New York City&lt;/value&gt;
+  &lt;value&gt;Readfield, Maine, USA&lt;/value&gt;
+  &lt;value&gt;Sea Cliff, NY, USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.2 <a name="schools">Schools Attended</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents schools attended is "schools".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 93. Schools Attended</p>
+<div class="indent"><pre>
+&lt;field var='schools'&gt;
+  &lt;value&gt;Columbia University&lt;/value&gt;
+  &lt;value&gt;American Renaissance School&lt;/value&gt;
+  &lt;value&gt;Maranacook Community School&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Profile data can be personally significant and even security critical. Due care should be taken in determining who shall have access to such information. However, this proposal merely defines the data formats for profile data; mechanisms for controlling access to such data will be defined in a separate proposal.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261307">23</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">To follow.</p>
+    
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250520">1</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2250564">2</a>. RFC 2426: vCard MIME Directory Profile &lt;<a href="http://www.ietf.org/rfc/rfc2426.txt">http://www.ietf.org/rfc/rfc2426.txt</a>&gt;.</p>
+<p><a name="nt-id2250553">3</a>. For links to the experimental XML representation of vCard, see <span style="font-weight: bold">JEP-0054</span>.</p>
+<p><a name="nt-id2250749">4</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2250771">5</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2250802">6</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2250613">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2250636">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2250675">9</a>. The extensibility requirement is critically important, because it would be best if the protocol specified herein could be used to represent data used within specialized communities. Examples of such communities include dating services, multiplayer gaming networks, IM services provided by portals and ISPs, and expert-location systems within large corporations. While such communities might use part or all of some common set of data fields (such as fields that map to familiar vCard elements), each community might also want to represent quite disparate kinds of information (dating criteria, favorite games, contact preferences, areas of expertise, and the like). Furthermore, data might be used to profile network actors that are not persons (e.g., bots, services, and other software agents). Therefore, the ideal proposal will provide an extensible framework for representing profile data and will not limit itself to representing the relatively small set of data fields covered by the vCard format.</p>
+<p><a name="nt-id2256263">10</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2256287">11</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2256352">12</a>. Resource Description Framework (RDF) &lt;<a href="http://www.w3.org/RDF/">http://www.w3.org/RDF/</a>&gt;.</p>
+<p><a name="nt-id2256398">13</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2256446">14</a>. JEP-0120: Infobits &lt;<a href="http://www.jabber.org/jeps/jep-0120.html">http://www.jabber.org/jeps/jep-0120.html</a>&gt;.</p>
+<p><a name="nt-id2256572">15</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256559">16</a>. Alternatively, specialized applications MAY define separate FORM_TYPEs for their particular data elements.</p>
+<p><a name="nt-id2256732">17</a>. RFC 2252: Lightweight Directory Access Protocol (v3): Attribute Syntax Definitions &lt;<a href="http://www.ietf.org/rfc/rfc2252.txt">http://www.ietf.org/rfc/rfc2252.txt</a>&gt;.</p>
+<p><a name="nt-id2256758">18</a>. RFC 2256: A Summary of the X.500(96) User Schema for use with LDAPv3 &lt;<a href="http://www.ietf.org/rfc/rfc2256.txt">http://www.ietf.org/rfc/rfc2256.txt</a>&gt;.</p>
+<p><a name="nt-id2256777">19</a>. RFC 2798: Definition of the inetOrgPerson LDAP Object Class &lt;<a href="http://www.ietf.org/rfc/rfc2798.txt">http://www.ietf.org/rfc/rfc2798.txt</a>&gt;.</p>
+<p><a name="nt-id2257299">20</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2257939">21</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2260286">22</a>. RFC 3066: Tags for the Identification of Languages &lt;<a href="http://www.ietf.org/rfc/rfc3066.txt">http://www.ietf.org/rfc/rfc3066.txt</a>&gt;.</p>
+<p><a name="nt-id2261307">23</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-07-25)</h4>
+<div class="indent">Added mappings to common LDAP schemas. (psa)
+    </div>
+<h4>Version 0.1 (2005-06-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.5 (2005-06-13)</h4>
+<div class="indent">Defined how to handle vCard types such as home vs. work addresses. (psa)
+    </div>
+<h4>Version 0.0.4 (2005-04-07)</h4>
+<div class="indent">Reworked field standardization; added support for telephony addresses, electronic addresses, and organizational data. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-03-11)</h4>
+<div class="indent">Added open issues. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-01-06)</h4>
+<div class="indent">Explained requirements and design decisions in more detail, especially with regard to extensibility; split photo into two elements (data and URL). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-11-10)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0154-0.3.html
+++ b/content/xep-0154-0.3.html
@@ -1,0 +1,2133 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0154: Profile Data Representation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Profile Data Representation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies how to represent data about IM users and other XMPP entities in terms of the Data Forms protocol.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0154">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0154: Profile Data Representation</h1>
+<p>This JEP specifies how to represent data about IM users and other XMPP entities in terms of the Data Forms protocol.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0154<br>
+            Version: 0.3<br>
+            Last Updated: 2005-11-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004, JEP-0060, JEP-0068<br>Supersedes: JEP-0054<br>
+                Superseded By: None<br>
+            Short Name: profiledata<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Profile%20Data%20Representation%20(JEP-0154)">http://wiki.jabber.org/index.php/Profile Data Representation (JEP-0154)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#design">Design Decisions</a>
+</dt>
+<dt>4.  <a href="#approach">Approach</a>
+</dt>
+<dt>5.  <a href="#common_fields">Common Data Fields</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#fields-name">Name Data Aspects</a>
+</dt>
+<dl>
+<dt>5.1.1.  <a href="#display_name">Display Name</a>
+</dt>
+<dt>5.1.2.  <a href="#familiar_name">Familiar Name</a>
+</dt>
+<dt>5.1.3.  <a href="#family_name">Family Name</a>
+</dt>
+<dt>5.1.4.  <a href="#given_name">Given Name</a>
+</dt>
+<dt>5.1.5.  <a href="#middle_name">Middle Name</a>
+</dt>
+<dt>5.1.6.  <a href="#name_prefix">Name Prefix</a>
+</dt>
+<dt>5.1.7.  <a href="#name_suffix">Name Suffix</a>
+</dt>
+<dt>5.1.8.  <a href="#nickname">Nickname</a>
+</dt>
+<dt>5.1.9.  <a href="#patronymic">Patronymic</a>
+</dt>
+</dl>
+<dt>5.2.  <a href="#fields-physicaladdress">Physical Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.2.1.  <a href="#country">Country</a>
+</dt>
+<dt>5.2.2.  <a href="#region">Region</a>
+</dt>
+<dt>5.2.3.  <a href="#locality">Locality</a>
+</dt>
+<dt>5.2.4.  <a href="#area">Area</a>
+</dt>
+<dt>5.2.5.  <a href="#street">Street</a>
+</dt>
+<dt>5.2.6.  <a href="#building">Building</a>
+</dt>
+<dt>5.2.7.  <a href="#floor">Floor</a>
+</dt>
+<dt>5.2.8.  <a href="#room">Room</a>
+</dt>
+<dt>5.2.9.  <a href="#postalbox">Postal Box</a>
+</dt>
+<dt>5.2.10.  <a href="#postalcode">Postal Code</a>
+</dt>
+<dt>5.2.11.  <a href="#postaladdress">Postal Address</a>
+</dt>
+</dl>
+<dt>5.3.  <a href="#fields-geoloc">Geolocation Data Aspects</a>
+</dt>
+<dl>
+<dt>5.3.1.  <a href="#alt">Altitude</a>
+</dt>
+<dt>5.3.2.  <a href="#lat">Latitude</a>
+</dt>
+<dt>5.3.3.  <a href="#lat">Longitude</a>
+</dt>
+</dl>
+<dt>5.4.  <a href="#fields-tel">Telephony Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.4.1.  <a href="#fax">Fax Number</a>
+</dt>
+<dt>5.4.2.  <a href="#landline">Landline Telephone Number</a>
+</dt>
+<dt>5.4.3.  <a href="#mobile">Mobile Telephone Number</a>
+</dt>
+<dt>5.4.4.  <a href="#pager">Pager Number</a>
+</dt>
+<dt>5.4.5.  <a href="#sip_address">SIP Address</a>
+</dt>
+<dt>5.4.6.  <a href="#skype_address">Skype Address</a>
+</dt>
+<dt>5.4.7.  <a href="#video_phone">Videophone Address</a>
+</dt>
+</dl>
+<dt>5.5.  <a href="#fields-net">Electronic Address Data Aspects</a>
+</dt>
+<dl>
+<dt>5.5.1.  <a href="#aim_id">AIM Screen Name</a>
+</dt>
+<dt>5.5.2.  <a href="#email">Email Address</a>
+</dt>
+<dt>5.5.3.  <a href="#icq_id">ICQ Number</a>
+</dt>
+<dt>5.5.4.  <a href="#jid">Jabber ID</a>
+</dt>
+<dt>5.5.5.  <a href="#msn_id">MSN Address</a>
+</dt>
+<dt>5.5.6.  <a href="#yahoo_id">Yahoo ID</a>
+</dt>
+</dl>
+<dt>5.6.  <a href="#fields-www">World Wide Web Resource Aspects</a>
+</dt>
+<dl>
+<dt>5.6.1.  <a href="#avatar_url">Avatar URL</a>
+</dt>
+<dt>5.6.2.  <a href="#bio">Biographical URL</a>
+</dt>
+<dt>5.6.3.  <a href="#foaf_url">FOAF URL</a>
+</dt>
+<dt>5.6.4.  <a href="#homepage">Homepage URL</a>
+</dt>
+<dt>5.6.5.  <a href="#photo_url">Photo URL</a>
+</dt>
+<dt>5.6.6.  <a href="#publications">Publications URL</a>
+</dt>
+<dt>5.6.7.  <a href="#resume">Resume URL</a>
+</dt>
+<dt>5.6.8.  <a href="#status_url">Status URL</a>
+</dt>
+<dt>5.6.9.  <a href="#org_url">Organizational URL</a>
+</dt>
+<dt>5.6.10.  <a href="#weblog">Weblog URL</a>
+</dt>
+</dl>
+<dt>5.7.  <a href="#fields-org">Organizational Data Aspects</a>
+</dt>
+<dl>
+<dt>5.7.1.  <a href="#alt_contact">Alternative Contact</a>
+</dt>
+<dt>5.7.2.  <a href="#assistant">Assistant</a>
+</dt>
+<dt>5.7.3.  <a href="#job_title">Job Title</a>
+</dt>
+<dt>5.7.4.  <a href="#manager">Manager</a>
+</dt>
+<dt>5.7.5.  <a href="#org_name">Organizational Name</a>
+</dt>
+<dt>5.7.6.  <a href="#org_role">Organizational Role</a>
+</dt>
+<dt>5.7.7.  <a href="#org_unit">Organizational Unit</a>
+</dt>
+<dt>5.7.8.  <a href="#system_username">System Username</a>
+</dt>
+<dt>5.7.9.  <a href="#teams">Teams</a>
+</dt>
+<dt>5.7.10.  <a href="#workstation">Workstation Address</a>
+</dt>
+</dl>
+<dt>5.8.  <a href="#fields-basic">Basic Personal Data Aspects</a>
+</dt>
+<dl>
+<dt>5.8.1.  <a href="#birth_dayofmonth">Birth Day-of-Month</a>
+</dt>
+<dt>5.8.2.  <a href="#birth_month">Birth Month</a>
+</dt>
+<dt>5.8.3.  <a href="#birth_year">Birth Year</a>
+</dt>
+<dt>5.8.4.  <a href="#description">Description</a>
+</dt>
+<dt>5.8.5.  <a href="#eye_color">Eye Color</a>
+</dt>
+<dt>5.8.6.  <a href="#gender">Gender</a>
+</dt>
+<dt>5.8.7.  <a href="#hair_color">Hair Color</a>
+</dt>
+<dt>5.8.8.  <a href="#height">Height</a>
+</dt>
+<dt>5.8.9.  <a href="#weight">Weight</a>
+</dt>
+</dl>
+<dt>5.9.  <a href="#fields-extended">Extended Personal Data Aspects</a>
+</dt>
+<dl>
+<dt>5.9.1.  <a href="#expertise">Areas of Expertise</a>
+</dt>
+<dt>5.9.2.  <a href="#avatar_data">Avatar Data</a>
+</dt>
+<dt>5.9.3.  <a href="#dietary_preferences">Dietary Preferences</a>
+</dt>
+<dt>5.9.4.  <a href="#hobby">Hobbies</a>
+</dt>
+<dt>5.9.5.  <a href="#interest">Interests</a>
+</dt>
+<dt>5.9.6.  <a href="#languages_lesswell">Languages Known Less Well</a>
+</dt>
+<dt>5.9.7.  <a href="#languages_well">Languages Known Well</a>
+</dt>
+<dt>5.9.8.  <a href="#marital_status">Marital Status</a>
+</dt>
+<dt>5.9.9.  <a href="#mbti">Myers-Briggs Type Indicator</a>
+</dt>
+<dt>5.9.10.  <a href="#photo_data">Photo Data</a>
+</dt>
+<dt>5.9.11.  <a href="#profession">Profession</a>
+</dt>
+<dt>5.9.12.  <a href="#religion">Religious Affiliation</a>
+</dt>
+<dt>5.9.13.  <a href="#sexual_orientation">Sexual Orientation</a>
+</dt>
+<dt>5.9.14.  <a href="#smoker">Smoker</a>
+</dt>
+<dt>5.9.15.  <a href="#wishlist">Wishlist</a>
+</dt>
+<dt>5.9.16.  <a href="#zodiac_chinese">Zodiac Sign (Chinese)</a>
+</dt>
+<dt>5.9.17.  <a href="#zodiac_western">Zodiac Sign (Western)</a>
+</dt>
+</dl>
+<dt>5.10.  <a href="#fields-security">Security Data Aspects</a>
+</dt>
+<dl>
+<dt>5.10.1.  <a href="#pgpkey">PGP Key</a>
+</dt>
+<dt>5.10.2.  <a href="#pgp_fingerprint">PGP Key Fingerprint</a>
+</dt>
+<dt>5.10.3.  <a href="#pgpkey_id">PGP Key ID</a>
+</dt>
+<dt>5.10.4.  <a href="#x509_fingerprint_md5">X.509 Fingerprint (MD5)</a>
+</dt>
+<dt>5.10.5.  <a href="#x509_fingerprint_sha1">X.509 Fingerprint (SHA-1)</a>
+</dt>
+</dl>
+<dt>5.11.  <a href="#fields-favorites">Personal Favorites</a>
+</dt>
+<dl>
+<dt>5.11.1.  <a href="#fav_authors">Favorite Authors</a>
+</dt>
+<dt>5.11.2.  <a href="#fav_athletes">Favorite Athletes</a>
+</dt>
+<dt>5.11.3.  <a href="#fav_charities">Favorite Charities</a>
+</dt>
+<dt>5.11.4.  <a href="#fav_chatrooms">Favorite Chatrooms</a>
+</dt>
+<dt>5.11.5.  <a href="#fav_drinks">Favorite Drinks</a>
+</dt>
+<dt>5.11.6.  <a href="#fav_foods">Favorite Foods</a>
+</dt>
+<dt>5.11.7.  <a href="#fav_games">Favorite Games</a>
+</dt>
+<dt>5.11.8.  <a href="#fav_movies">Favorite Movies</a>
+</dt>
+<dt>5.11.9.  <a href="#fav_music">Favorite Music</a>
+</dt>
+<dt>5.11.10.  <a href="#fav_quotes">Favorite Quotes</a>
+</dt>
+<dt>5.11.11.  <a href="#fav_teams">Favorite Sports Teams</a>
+</dt>
+<dt>5.11.12.  <a href="#fav_tv">Favorite TV Shows</a>
+</dt>
+</dl>
+<dt>5.12.  <a href="#fields-history">Personal History</a>
+</dt>
+<dl>
+<dt>5.12.1.  <a href="#places_lived">Places Lived</a>
+</dt>
+<dt>5.12.2.  <a href="#schools">Schools Attended</a>
+</dt>
+</dl>
+</dl>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-formtype">Field Standardization</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">It is widely acknowledged within the Jabber/XMPP community that the <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2250699">1</a>] specification (JEP-0054) has outlived its usefulness. There are several reasons for this conclusion:</p>
+  <ol start="" type="">
+    <li>JEP-0054 is not fully consistent with the Internet-Draft on which it was based.</li>
+    <li>The Internet-Draft on which it was based was never approved by the IETF.</li>
+    <li>Because of confusion over aspects of the vcard-temp specification, there exist incompatible implementations.</li>
+    <li>vCard (<span class="ref" style="">RFC 2426</span>  [<a href="#nt-id2250881">2</a>]) captures only a limited set of information.</li>
+    <li>vCard (even in its XML representation  [<a href="#nt-id2250862">3</a>]) is not easily extensible, leading those who develop profiles for specialized communities to "roll their own" protocols, to the detriment of interoperability.</li>
+    <li>vCard data tends to be monolithic (the basic unit of information is the full vCard, not parts thereof).</li>
+    <li>The publication model for JEP-0054 is to set the full vCard, rather than only the parts that need to be modified.</li>
+    <li>The retrieval model for JEP-0054 is to get the full vCard, rather than only the parts that have been modified.</li>
+  </ol>
+  <p class="" style="">Given the weaknesses of vCard, there is interest across the broader Internet community in replacing vCard with something more modern and extensible. Unfortunately, no other standards development organization has developed an alternative to vCard. Part of the challenge is that quite detailed ontologies have been developed that might replace parts of the vCard specification (e.g., the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2250938">4</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2250971">5</a>]) while less-formal ontologies are being used to represent other parts of the problem space (e.g., <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2250740">6</a>]). The relevant protocols are in flux and it is unclear when (or even if) stability will emerge.</p>
+  <p class="" style="">Because of the unsettled landspace and the strong desire within the Jabber/XMPP community to move beyond JEP-0054, this JEP specifies a consistent framework for the wire representation of profile data fields in terms of the <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250770">7</a>] protocol, further qualified using the standardization concepts specified in <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2250793">8</a>]. The rationale behind this design decision is provided below.</p>
+  <p class="" style="">Note: This JEP does not offer solutions to the problems of publishing, storing, and retrieving profile data. Those issues will be addressed in a separate proposal.</p> 
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Specify how to represent profile data in an XMPP-friendly manner for communication over the wire.</li>
+    <li>Ensure that the protocol is extensible (e.g., not limited to vCard fields).  
+         [<a href="#nt-id2250833">9</a>]
+    </li> 
+    <li>Where possible, map profile data fields to existing vCard fields and other common formats.</li>
+  </ol>
+  <p class="" style="">As noted, this JEP does not offer solutions to the problems of publishing, storing, and retrieving profile data. Those issues will be addressed in a separate proposal.</p> 
+<h2>3.
+       <a name="design">Design Decisions</a>
+</h2>
+  <p class="" style="">There are many possible approaches to representing profile data for communication over XMPP networks, including the following:</p>
+  <ul>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">Structured data formats, such as <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2256362">10</a>] and <span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2256385">11</a>].</span></p>
+      <p class="" style="">Such data formats have the advantage of being human-readable. However:</p>
+      <ol start="" type="">
+        <li>They are not easily extensible: developers of specialized community services would need to write their own structured data formats, even to add one new field.</li>
+        <li>They are not easy to map to backend data storage facilities (e.g., database administrators generally would prefer to have generic database schemas and re-usable code for parsing the XML wire protocol into the database fields).</li>
+        <li>They would require specialized interface handlers for each data structure, rather than a generic interface handler.</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of <span class="ref" style="">Resource Description Framework</span>  [<a href="#nt-id2256451">12</a>].</span></p>
+      <p class="" style="">An argument could be made that RDF is a reasonable approach for representing profile data for communication over the XMPP network; however, such an argument will not be made in the current proposal. The author has considered RDF and has concluded that there are several reasons why RDF is undesirable as an XMPP wire protocol:</p>
+      <ol start="" type="">
+        <li>RDF exists in an XML representation but the semantics of RDF impose a more complex conceptual structure (data triples) than does XML, which is sub-optimal since unnecessary complexity is to be avoided (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2256501">13</a>]).</li>
+        <li>RDF requires a specialized parser rather than the normal XML parser that comes standard with all XMPP implementations.</li>
+        <li>As long as it is possible to define a consistent mapping of profile data to RDF representations, it should be straightforward to convert the XMPP data formats into those RDF representations if desired (e.g., to output a FOAF file).</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of <span class="ref" style="">Infobits</span>  [<a href="#nt-id2256548">14</a>].</span></p>
+      <p class="" style="">The infobits approach to representing profile data was deprecated in early 2004 because it provides few advantages over an approach based on Data Forms.</p>
+    </li>
+    <li>
+      <p class="" style=""><span style="font-weight: bold">A format represented by means of Data Forms (JEP-0004).</span></p>
+      <p class="" style="">The Data Forms protocol defined in JEP-0004 has several advantages for use over XMPP:</p>
+      <ol start="" type="">
+        <li>It can be parsed using an off-the-shelf XML parser.</li>
+        <li>It is already widely deployed in existing Jabber/XMPP clients, servers, and components.</li>
+        <li>The data forms protocol is easily extensible.</li>
+        <li>The Jabber/XMPP community possesses consistent methods for profiling and scoping data forms (as specified in JEP-0068).</li>
+        <li>Data forms have a generic schema that is easy to map to common data storage mechanisms (usually databases).</li>
+        <li>Data forms provide a consistent abstraction layer for XMPP applications, thus shielding them from changes in the profile data formats being defined by other Internet projects and standards development organizations.</li>
+        <li>The use of data forms as the medium of representation for communication over the wire does not prevent applications from storing backend profile data in some other underlying format (e.g., RDF or a database).</li> 
+      </ol>
+    </li>
+  </ul>
+  <p class="" style="">For these reasons, this proposal specifies a way to represent profile data in terms of the Data Forms (jabber:x:data) protocol.</p>
+<h2>4.
+       <a name="approach">Approach</a>
+</h2>
+  <p class="" style="">This proposal specifies that profile data shall be scoped by a FORM_TYPE of 'http://jabber.org/protocol/profiledata', in accordance with the field standardization methods defined in JEP-0068. For the sake of interoperability, profile data fields that will be in common use SHOULD be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256668">15</a>] (although they may or may not be defined in a Jabber Enhancement Proposal). Profile data fields that are intended to be used only within the context of a specialized application MAY remain unregistered, but unregistered fields MUST begin with the string "x-" in accordance with Section 3.4 of JEP-0068.  [<a href="#nt-id2256660">16</a>]</p>
+  <p class="" style="">The following is a simple and incomplete example of profile data represented via the Data Forms protocol, containing two registered data fields and one unregistered field:</p>
+  <p class="caption">Example 1. A Basic Example</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='result'&gt;
+  &lt;field var='FORM_TYPE' type='hidden'&gt;
+    &lt;value&gt;http://jabber.org/protocol/profiledata&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='common_name'&gt;
+    &lt;value&gt;Peter Saint-Andre&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='nickname'&gt;
+    &lt;value&gt;stpeter&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='x-favorite_painters'&gt;
+    &lt;value&gt;Joaquin Sorolla&lt;/value&gt;
+    &lt;value&gt;Jan Vermeer&lt;/value&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+    </pre></div>
+    <p class="" style="">By specifying that all fields are scoped by a FORM_TYPE of 'http://jabber.org/protocol/profiledata', this proposal does not mean to imply that all profile data will or should be gathered in one data form. In reality, most such data will probably be gathered at the time of registration either at a website or via a "wizard" interface that breaks the process into smaller bundles (such as "Basic Personal Data", "Physical Location", "Internet Addresses", "Hobbies and Interests", and "Favorite Things"). The use of one FORM_TYPE is simply meant to scope the data fields so that each field is unique within the context of profile data. Any form that uses these fields along with a FORM_TYPE of 'http://jabber.org/protocol/profiledata' is of the "profile type" (i.e., is a specific instance of that type), which does not limit the number of forms that can be of that type.</p>
+    <p class="" style="">However, scoping all data fields with a single FORM_TYPE implies it is necessary to define separate data fields for similar kinds of information. For example, the vCard specification (<span style="font-weight: bold">RFC 2426</span>) defines "types" for certains kinds of data, such as email addresses, telephone numbers, and physical addresses, making it possible to specify that a telephone number corresponds to a fax machine or mobile phone or that a physical address corresponds to one's home or work location. In the Data Forms representation, any desired piece of information (e.g., work phone) must be represented with a separate data field.</p>
+    <p class="" style="">In order to address most (if not all) of the pieces of information described in existing profile specifications, this JEP defines a great number of data fields. Even so, the data fields specified herein are not exhaustive, and it is expected that additional fields will be registered in the future through the mechanisms specified in the <a href="#registrar">Jabber Registrar Considerations</a> section of this JEP.</p>
+<h2>5.
+       <a name="common_fields">Common Data Fields</a>
+</h2>
+  <p class="" style="">The following subsections specify common fields for defining various aspects of a person, which shall form the initial submission to the Jabber Registrar; many of these fields map to elements specified in vCard, LDAP (see <span class="ref" style="">RFC 2252</span>  [<a href="#nt-id2250416">17</a>], <span class="ref" style="">RFC 2256</span>  [<a href="#nt-id2250386">18</a>], and <span class="ref" style="">RFC 2798</span>  [<a href="#nt-id2256997">19</a>]), xNAL, FOAF, and other existing specifications.</p>
+  <div class="indent">
+<h3>5.1 <a name="fields-name">Name Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard, xNAL, and FOAF.</p>
+    <div class="indent">
+<h3>5.1.1 <a name="display_name">Display Name</a>
+</h3>
+      <p class="" style="">A display name is a version of a person's name intended for display in a user interface. Sometimes also called a "full name" or "formatted name".</p>
+      <p class="" style="">The Data Forms field that represents a display name is "display_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard FN</li>
+        <li>LDAP displayName</li>
+        <li>FOAF name</li>
+      </ul>
+      <p class="caption">Example 2. Display Name</p>
+<div class="indent"><pre>
+&lt;field var='display_name'&gt;
+  &lt;value&gt;Peter Saint-Andre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.2 <a name="familiar_name">Familiar Name</a>
+</h3>
+      <p class="" style="">A familiar name is a shortened or modified form of someone's given name that may be used in somewhat informal contexts or that is preferred by the person (e.g., "Chuck" instead of "Charles").</p>
+      <p class="" style="">The Data Forms field that represents a familiar name is "familiar_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP nickname</li>
+      </ul>
+      <p class="caption">Example 3. Familiar Name</p>
+<div class="indent"><pre>
+&lt;field var='familiar_name'&gt;
+  &lt;value&gt;Pete&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.3 <a name="family_name">Family Name</a>
+</h3>
+      <p class="" style="">A family name is that part of a person's name which signifies the person's primary family association. Sometimes also called a "last name" or "surname".</p>
+      <p class="" style="">The Data Forms field that represents a family name is "family_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard FAMILY</li>
+        <li>LDAP sn</li>
+        <li>xNAL LastName</li>
+        <li>FOAF family_name</li>
+        <li>FOAF surname</li>
+      </ul>
+      <p class="caption">Example 4. Family Name</p>
+<div class="indent"><pre>
+&lt;field var='family_name'&gt;
+  &lt;value&gt;Saint-Andre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.4 <a name="given_name">Given Name</a>
+</h3>
+      <p class="" style="">A given name is that part of a person's name which signifies the person's primary individual identity. Sometimes also called a "first name" or (in some countries) a "Christian name".</p>
+      <p class="" style="">The Data Forms field that represents a given name is "given_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard GIVEN</li>
+        <li>LDAP givenName</li>
+        <li>xNAL FirstName</li>
+        <li>FOAF first_name</li>
+        <li>FOAF givenname</li>
+      </ul>
+      <p class="caption">Example 5. Given Name</p>
+<div class="indent"><pre>
+&lt;field var='given_name'&gt;
+  &lt;value&gt;J.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.5 <a name="middle_name">Middle Name</a>
+</h3>
+      <p class="" style="">A middle name is that part of a person's name which signifies the person's secondary individual identity. Sometimes also called a "middle initial".</p>
+      <p class="" style="">The Data Forms field that represents a middle name is "middle_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard MIDDLE</li>
+        <li>xNAL MiddleName</li>
+      </ul>
+      <p class="caption">Example 6. Middle Name</p>
+<div class="indent"><pre>
+&lt;field var='middle_name'&gt;
+  &lt;value&gt;Peter&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.6 <a name="name_prefix">Name Prefix</a>
+</h3>
+      <p class="" style="">A name prefix is that part of a person's name which prepends the person's full name (e.g., Mr or Dr). Sometimes also called an "honorific" or "title".</p>
+      <p class="" style="">The Data Forms field that represents a name prefix is "name_prefix".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PREFIX</li>
+        <li>xNAL Title</li>
+        <li>FOAF title</li>
+      </ul>
+      <p class="caption">Example 7. Name Prefix</p>
+<div class="indent"><pre>
+&lt;field var='name_prefix'&gt;
+  &lt;value&gt;Mr&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.7 <a name="name_suffix">Name Suffix</a>
+</h3>
+      <p class="" style="">A name suffix is that part of a person's name which is appended to the person's full name (e.g., Jr or Esq).</p>
+      <p class="" style="">The Data Forms field that represents a name suffix is "name_suffix".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard SUFFIX</li>
+        <li>xNAL GeneralSuffix</li>
+      </ul>
+      <p class="caption">Example 8. Name Suffix</p>
+<div class="indent"><pre>
+&lt;field var='name_suffix'&gt;
+  &lt;value&gt;Esq&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.8 <a name="nickname">Nickname</a>
+</h3>
+      <p class="" style="">A nickname is a global, memorable (but not unique) friendly or informal name chosen by the owner of a JID. The purpose of a nickname is to associate a distinctive mapping between the person's unique JID and non-unique nickname. A nickname is normally used in informal contexts (e.g., in chatrooms). Sometimes also called an "alias". A person SHOULD specify only one nickname (i.e., not more than one).</p>
+      <p class="" style="">The Data Forms field that represents a nickname is "nickname".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard NICKNAME</li>
+        <li>xNAL Alias</li>
+        <li>FOAF nick</li>
+      </ul>
+      <p class="caption">Example 9. Nickname</p>
+<div class="indent"><pre>
+&lt;field var='nickname'&gt;
+  &lt;value&gt;stpeter&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.1.9 <a name="patronymic">Patronymic</a>
+</h3>
+      <p class="" style="">In some cultures, one's name includes a part that is derived from the given name of one's father; this part of one's name is called a "patronymic".</p>
+      <p class="" style="">The Data Forms field that represents a patronymic is "patronymic".</p>
+      <p class="caption">Example 10. A Patronymic</p>
+<div class="indent"><pre>
+&lt;field var='patronymic'&gt;
+  &lt;value&gt;Ivanovich&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="fields-physicaladdress">Physical Address Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard, xNAL, and JEP-0112 (<span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2257522">20</a>]).</p>
+    <div class="indent">
+<h3>5.2.1 <a name="country">Country</a>
+</h3>
+      <p class="" style="">A country is the sovereign nation in which a person is located. Sometimes also called a "nation".</p>
+      <p class="" style="">The Data Forms fields that represent a country are "country", "home_country", and "work_country" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard COUNTRY (or JEP-0054 CTRY), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP c</li>
+        <li>xNAL CountryName</li>
+        <li>JEP-0112 country</li>
+      </ul>
+      <p class="caption">Example 11. Country</p>
+<div class="indent"><pre>
+&lt;field var='country'&gt;
+  &lt;value&gt;USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.2 <a name="region">Region</a>
+</h3>
+      <p class="" style="">A region is a second-level administrative unit within the nation in which a person is located. Sometimes also called a "province", "state", or "administrative area".</p>
+      <p class="" style="">The Data Forms field that represents a region is "region".</p>
+      <p class="" style="">The Data Forms fields that represent a region are "home_region" and "work_region" for home addresses and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard REGION, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP st</li>
+        <li>xNAL AdministrativeAreaName</li>
+        <li>JEP-0112 region</li>
+      </ul>
+      <p class="caption">Example 12. Region</p>
+<div class="indent"><pre>
+&lt;field var='region'&gt;
+  &lt;value&gt;New York&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.3 <a name="locality">Locality</a>
+</h3>
+      <p class="" style="">A locality is a defined place within the region in which a person is located. Sometimes also called a "city", "town", or "village".</p>
+      <p class="" style="">The Data Forms fields that represent a locality are "locality", "home_locality", and "work_locality" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LOCALITY, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP l</li>
+        <li>xNAL LocalityName</li>
+        <li>JEP-0112 locality</li>
+      </ul>
+      <p class="caption">Example 13. Locality</p>
+<div class="indent"><pre>
+&lt;field var='locality'&gt;
+  &lt;value&gt;New York City&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.4 <a name="area">Area</a>
+</h3>
+      <p class="" style="">An area is a sub-division within the locality in which a person is located. Sometimes also called a "neighborhood", "suburb", "district", or "section".</p>
+      <p class="" style="">The Data Forms fields that represent a area are "area", "home_area", and "work_area" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>xNAL DependentLocalityName</li>
+        <li>JEP-0112 area</li>
+      </ul>
+      <p class="caption">Example 14. Area</p>
+<div class="indent"><pre>
+&lt;field var='area'&gt;
+  &lt;value&gt;Manhattan&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.5 <a name="street">Street</a>
+</h3>
+      <p class="" style="">A street is the street address (number plus street name, or two street names at an intersection) at which a person is located, or a postal box number for physical mail delivery. Sometimes also called a "street address".</p>
+      <p class="" style="">The Data Forms fields that represent a street are "street", "home_street", and "work_street" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard STREET, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP street</li>
+        <li>xNAL ThoroughfareNumber + ThoroughfareName</li>
+        <li>JEP-0112 street</li>
+      </ul>
+      <p class="caption">Example 15. Street</p>
+<div class="indent"><pre>
+&lt;field var='street'&gt;
+  &lt;value&gt;Fifth Avenue and 34th Street&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.6 <a name="building">Building</a>
+</h3>
+      <p class="" style="">A building is the name for a specific structure on a street or within an area.</p>
+      <p class="" style="">The Data Forms fields that represent a building are "building", "home_building", and "work_building" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL BuildingName</li>
+        <li>JEP-0112 building</li>
+      </ul>
+      <p class="caption">Example 16. Building</p>
+<div class="indent"><pre>
+&lt;field var='building'&gt;
+  &lt;value&gt;Empire State Building&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.7 <a name="floor">Floor</a>
+</h3>
+      <p class="" style="">A floor is a named or numbered floor or level within a building. Sometimes also called a "level", "block", or "suite".</p>
+      <p class="" style="">The Data Forms fields that represent a floor are "floor", "home_floor", and "work_floor" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL SubPremiseNumber</li>
+        <li>JEP-0112 floor</li>
+      </ul>
+      <p class="caption">Example 17. Floor</p>
+<div class="indent"><pre>
+&lt;field var='floor'&gt;
+  &lt;value&gt;102&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.8 <a name="room">Room</a>
+</h3>
+      <p class="" style="">A room is a named or numbered subdivision of a floor. Sometimes also called a "unit" or "apartment".</p>
+      <p class="" style="">The Data Forms fields that represent a room are "room", "home_room", and "work_room" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP roomNumber</li>
+        <li>xNAL SubPremiseNumber</li>
+        <li>JEP-0112 room</li>
+      </ul>
+      <p class="caption">Example 18. Room</p>
+<div class="indent"><pre>
+&lt;field var='room'&gt;
+  &lt;value&gt;Observatory&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.9 <a name="postalbox">Postal Box</a>
+</h3>
+      <p class="" style="">A postal box is a set of numeric or alphanumeric characters used to identify a mailbox at a postal delivery center.</p>
+      <p class="" style="">The Data Forms fields that represent a postal box are "postalbox", "home_postalbox", and "work_postalbox" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard POBOX, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP postOfficeBox</li>
+      </ul>
+      <p class="caption">Example 19. Postal Box</p>
+<div class="indent"><pre>
+&lt;field var='postalbox'&gt;
+  &lt;value&gt;1641&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.10 <a name="postalcode">Postal Code</a>
+</h3>
+      <p class="" style="">A postal code is a set of numeric or alphanumeric characters used to identify an area for postal delivery. Sometimes also called a "ZIP code" (in the U.S.).</p>
+      <p class="" style="">The Data Forms fields that represent a postal code are "postalcode", "home_postalcode", and "work_postalcode" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PCODE, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP postalCode</li>
+        <li>xNAL PostalCodeNumber</li>
+        <li>JEP-0112 postalcode</li>
+      </ul>
+      <p class="caption">Example 20. Postal Code</p>
+<div class="indent"><pre>
+&lt;field var='postalcode'&gt;
+  &lt;value&gt;10002&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.2.11 <a name="postaladdress">Postal Address</a>
+</h3>
+      <p class="" style="">A postal address is a free-form mailing address, which may be easier to enter (or, in some cultural contexts, more appropriate) than the atomic address parts such as street, floor, etc.</p>
+      <p class="" style="">The Data Forms fields that represent a postal address are "postaladdress", "home_postaladdress", and "work_postaladdress" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP postalAddress, homePostalAddress</li>
+      </ul>
+      <p class="caption">Example 21. Postal Address</p>
+<div class="indent"><pre>
+&lt;field var='work_postaladdress'&gt;
+  &lt;value&gt;1899 Wynkoop Street&lt;/value&gt;
+  &lt;value&gt;Suite 600&lt;/value&gt;
+  &lt;value&gt;Denver, CO 80202&lt;/value&gt;
+  &lt;value&gt;USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="fields-geoloc">Geolocation Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard and JEP-0080 (<span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2258214">21</a>]).</p>
+    <div class="indent">
+<h3>5.3.1 <a name="alt">Altitude</a>
+</h3>
+      <p class="" style="">Altitude is a person's height or depth in relationship to sea level, where positive altitude is meters above sea level and negative altitude is meters below sea level.</p>
+      <p class="" style="">The Data Forms field that represents altitude is "alt".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>JEP-0080 alt</li>
+      </ul>
+      <p class="caption">Example 22. Altitude</p>
+<div class="indent"><pre>
+&lt;field var='alt'&gt;
+  &lt;value&gt;1609&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.3.2 <a name="lat">Latitude</a>
+</h3>
+      <p class="" style="">Latitude is a person's latitude in relation to the equator, where positive latitude is north of the equator and negative latitude is south of the equator.</p>
+      <p class="" style="">The Data Forms field that represents latitude is "lat".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LAT</li>
+        <li>JEP-0080 lat</li>
+      </ul>
+      <p class="caption">Example 23. Latitude</p>
+<div class="indent"><pre>
+&lt;field var='lat'&gt;
+  &lt;value&gt;39.75477&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.3.3 <a name="lat">Longitude</a>
+</h3>
+      <p class="" style="">Longitude is a person's longitude in relation to the equator, where positive longitude is east of the meridian and negative longitude is west of the equator.</p>
+      <p class="" style="">The Data Forms field that represents longitude is "lon".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LON</li>
+        <li>JEP-0080 lon</li>
+      </ul>
+      <p class="caption">Example 24. Latitude</p>
+<div class="indent"><pre>
+&lt;field var='lon'&gt;
+  &lt;value&gt;-104.99768&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="fields-tel">Telephony Address Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.4.1 <a name="fax">Fax Number</a>
+</h3>
+      <p class="" style="">A fax number is a number for a machine that handles fascimile transmissions.</p>
+      <p class="" style="">The Data Forms fields that represent a fax number are "fax", "home_fax", and "work_fax" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "FAX" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP facsimileTelephoneNumber</li>
+      </ul>
+      <p class="caption">Example 25. Fax Number</p>
+<div class="indent"><pre>
+&lt;field var='fax'&gt;
+  &lt;value&gt;303-308-3215&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.2 <a name="landline">Landline Telephone Number</a>
+</h3>
+      <p class="" style="">A landline telephone number is a number for a traditional "PSTN" or "POTS" telephone.</p>
+      <p class="" style="">The Data Forms fields that represent a landline telephone number are "landline", "home_landline", and "work_landline" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP telephoneNumber</li>
+        <li>FOAF phone</li>
+      </ul>
+      <p class="caption">Example 26. Landline Telephone Number</p>
+<div class="indent"><pre>
+&lt;field var='landline_phone'&gt;
+  &lt;value&gt;303-308-3282&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.3 <a name="mobile">Mobile Telephone Number</a>
+</h3>
+      <p class="" style="">A mobile telephone number is a number for a mobile phone or cell phone on a wireless network.</p>
+      <p class="" style="">The Data Forms fields that represent a mobile telephone number are "mobile", "home_mobile", and "work_mobile" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "CELL" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP mobile</li>
+        <li>FOAF phone</li>
+      </ul>
+      <p class="caption">Example 27. Mobile Telephone Number</p>
+<div class="indent"><pre>
+&lt;field var='mobile_phone'&gt;
+  &lt;value&gt;303-555-1212&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.4 <a name="pager">Pager Number</a>
+</h3>
+      <p class="" style="">A pager number is a number for a dedicated alphanumeric paging device.</p>
+      <p class="" style="">The Data Forms fields that represent a pager number are "pager", "home_pager", and "work_pager" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "PAGER" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP pager</li>
+      </ul>
+      <p class="caption">Example 28. Pager Number</p>
+<div class="indent"><pre>
+&lt;field var='pager'&gt;
+  &lt;value&gt;303-555-1212&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.5 <a name="sip_address">SIP Address</a>
+</h3>
+      <p class="" style="">A SIP address is a sip: or sips: URI at which a person can be contacted for Voice over Internet Protocol (VoIP) communications.</p>
+      <p class="" style="">The Data Forms field that represents a SIP address is "sip_address".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 29. SIP Address</p>
+<div class="indent"><pre>
+&lt;field var='sip_address'&gt;
+  &lt;value&gt;sip:stpeter@sipspeare.lit&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.6 <a name="skype_address">Skype Address</a>
+</h3>
+      <p class="" style="">A Skype address is an address on the popular Skype system for Voice over Internet Protocol (VoIP) communications.</p>
+      <p class="" style="">The Data Forms field that represents a Skype address is "skype_address".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 30. Skype Address</p>
+<div class="indent"><pre>
+&lt;field var='skype_address'&gt;
+  &lt;value&gt;SomeSkypeUser&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.4.7 <a name="video_phone">Videophone Address</a>
+</h3>
+      <p class="" style="">A videophone address is an address used for for H.323 video conferencing systems.</p>
+      <p class="" style="">The Data Forms field that represents a videophone address is "video_phone".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 31. Videophone Address</p>
+<div class="indent"><pre>
+&lt;field var='video_phone'&gt;
+  &lt;value&gt;foo&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="fields-net">Electronic Address Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.5.1 <a name="aim_id">AIM Screen Name</a>
+</h3>
+      <p class="" style="">An AIM screen name is an address at which a person or other entity can be contacted on the AOL Instant Messenger service.</p>
+      <p class="" style="">The Data Forms field that represents an AIM screen name is "aim_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF aimChatID</li>
+      </ul>
+      <p class="caption">Example 32. AIM Screen Name</p>
+<div class="indent"><pre>
+&lt;field var='aim_id'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.2 <a name="email">Email Address</a>
+</h3>
+      <p class="" style="">An email address is the value of a mailto: URI at which a person or other entity can be contacted using standard electronic mail protocols.</p>
+      <p class="" style="">The Data Forms field that represents longitude is "email".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EMAIL</li>
+        <li>LDAP mail</li>
+      </ul>
+      <p class="caption">Example 33. Email address</p>
+<div class="indent"><pre>
+&lt;field var='email'&gt;
+  &lt;value&gt;stpeter@jabber.org&lt;/value&gt;
+  &lt;value&gt;stpeter@gmail.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.3 <a name="icq_id">ICQ Number</a>
+</h3>
+      <p class="" style="">An ICQ number is an address at which a person or other entity can be contacted on the ICQ instant messaging service.</p>
+      <p class="" style="">The Data Forms field that represents an ICQ number is "icq_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF icqChatID</li>
+      </ul>
+      <p class="caption">Example 34. ICQ number</p>
+<div class="indent"><pre>
+&lt;field var='icq_id'&gt;
+  &lt;value&gt;70902454&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.4 <a name="jid">Jabber ID</a>
+</h3>
+      <p class="" style="">A Jabber ID is the value of an xmpp: URI at which a person or other entity can be contacted over a Jabber/XMPP network.</p>
+      <p class="" style="">The Data Forms field that represents a Jabber ID is "jid".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF jabberID</li>
+      </ul>
+      <p class="caption">Example 35. Jabber ID</p>
+<div class="indent"><pre>
+&lt;field var='jid'&gt;
+  &lt;value&gt;stpeter@jabber.org&lt;/value&gt;
+  &lt;value&gt;peter@saint-andre.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.5 <a name="msn_id">MSN Address</a>
+</h3>
+      <p class="" style="">An MSN address is address at which a person or other entity can be contacted on the MSN instant messaging service.</p>
+      <p class="" style="">The Data Forms field that represents an MSN address is "msn_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF msnChatID</li>
+      </ul>
+      <p class="caption">Example 36. MSN Address</p>
+<div class="indent"><pre>
+&lt;field var='msn_id'&gt;
+  &lt;value&gt;petersaintandre@hotmail.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.5.6 <a name="yahoo_id">Yahoo ID</a>
+</h3>
+      <p class="" style="">A Yahoo ID is address at which a person or other entity can be contacted on the Yahoo! Instant Messenger service.</p>
+      <p class="" style="">The Data Forms field that represents a Yahoo ID is "yahoo_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF yahooChatID</li>
+      </ul>
+      <p class="caption">Example 37. Yahoo ID</p>
+<div class="indent"><pre>
+&lt;field var='yahoo_id'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="fields-www">World Wide Web Resource Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.6.1 <a name="avatar_url">Avatar URL</a>
+</h3>
+      <p class="" style="">An avatar is an often fanciful representation of a user's desired self-image or persona (e.g., in the context of a game). An avatar is usually not intended to be an accurate picture of the user's actual physical appearance (that is handled by the photo_url and photo_data fields).</p>
+      <p class="" style="">An avatar can come in two forms: the avatar data itself, or a URL for a avatar.</p>
+      <p class="" style="">The Data Forms field that represents the URL for an avatar is "avatar_url".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 38. Avatar URL</p>
+<div class="indent"><pre>
+&lt;field var='avatar_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_small.jpg&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.2 <a name="bio">Biographical URL</a>
+</h3>
+      <p class="" style="">A biographical URL is the value of an http: URI at which can be found biographical information about a person.</p>
+      <p class="" style="">The Data Forms field that represents a biographical URL is "bio".</p>
+      <p class="caption">Example 39. Biographical URL</p>
+<div class="indent"><pre>
+&lt;field var='bio'&gt;
+  &lt;value&gt;http://www.jabber.org/people/stpeter.shtml&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/me/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.3 <a name="foaf_url">FOAF URL</a>
+</h3>
+      <p class="" style="">A FOAF URL is the value of an http: URI at which can be found a "friend of a friend" (FOAF) file about a person or entity.</p>
+      <p class="" style="">The Data Forms field that represents a FOAF URL is "foaf_url".</p>
+      <p class="caption">Example 40. FOAF URL</p>
+<div class="indent"><pre>
+&lt;field var='foaf_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/me/foaf.rdf&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.4 <a name="homepage">Homepage URL</a>
+</h3>
+      <p class="" style="">A homepage URL is the value of an http: URI that is the default resource on the World Wide Web for a person or other entity.</p>
+      <p class="" style="">The Data Forms field that represents a homepage URL is "homepage".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP labelledURI</li>
+        <li>FOAF homepage</li>
+      </ul>
+      <p class="caption">Example 41. Homepage URL</p>
+<div class="indent"><pre>
+&lt;field var='homepage'&gt;
+  &lt;value&gt;http://www.saint-andre.com/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.5 <a name="photo_url">Photo URL</a>
+</h3>
+      <p class="" style="">A photograph provides a pictorial representation of a person. Sometimes also called a "mugshot".</p>
+      <p class="" style="">A photograph can come in two forms: the photo data itself (see below) or a URL for a photograph (e.g., the vCard PHOTO element can represent either, while the FOAF depiction and FOAF img can represent only a URL). The Data Forms field specified here identifies a URL for a photograph, not the data itself.</p>
+      <p class="" style="">The Data Forms field that represents the URL for a photograph is "photo_url".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PHOTO</li>
+        <li>FOAF depiction</li>
+        <li>FOAF img</li>
+      </ul>
+      <p class="caption">Example 42. Photo URL</p>
+<div class="indent"><pre>
+&lt;field var='photo_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter.jpg&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_hell.jpg&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_oscon.jpg&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.6 <a name="publications">Publications URL</a>
+</h3>
+      <p class="" style="">A publications URL is the value of an http: URI at which can be found the list of a person's published writings.</p>
+      <p class="" style="">The Data Forms field that represents a publications URL is "publications".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF publications</li>
+      </ul>
+      <p class="caption">Example 43. Publications URL</p>
+<div class="indent"><pre>
+&lt;field var='publications'&gt;
+  &lt;value&gt;http://www.saint-andre.com/thoughts/publications.html&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.7 <a name="resume">Resume URL</a>
+</h3>
+      <p class="" style="">A resume URL is the value of an http: URI at which can be found a person's resume or curriculum vitae.</p>
+      <p class="" style="">The Data Forms field that represents a resume URL is "resume".</p>
+      <p class="caption">Example 44. Resume URL</p>
+<div class="indent"><pre>
+&lt;field var='resume'&gt;
+  &lt;value&gt;http://www.saint-andre.com/work/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.8 <a name="status_url">Status URL</a>
+</h3>
+      <p class="" style="">A status URL is the value of an http: URI that specifies the current status of a person or other entity (e.g., a person's online presence or a server's uptime).</p>
+      <p class="" style="">The Data Forms field that represents a homepage URL is "status_url".</p>
+      <p class="caption">Example 45. Status URL</p>
+<div class="indent"><pre>
+&lt;field var='status_url'&gt;
+  &lt;value&gt;http://status.jabber.org/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.9 <a name="org_url">Organizational URL</a>
+</h3>
+      <p class="" style="">An organizational URL is the value of an http: URI that specifies the homepage for an organization or employer.</p>
+      <p class="" style="">The Data Forms field that represents an organizational URL is "org_url".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF workplaceHomepage</li>
+      </ul>
+      <p class="caption">Example 46. Organizational URL</p>
+<div class="indent"><pre>
+&lt;field var='org_url'&gt;
+  &lt;value&gt;http://www.jabber.org/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.6.10 <a name="weblog">Weblog URL</a>
+</h3>
+      <p class="" style="">A weblog URL is the value of an http: URI at which a person or other entity maintains a weblog.</p>
+      <p class="" style="">The Data Forms field that represents a weblog URL is "weblog".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF weblog</li>
+      </ul>
+      <p class="caption">Example 47. Weblog URL</p>
+<div class="indent"><pre>
+&lt;field var='weblog'&gt;
+  &lt;value&gt;http://www.saint-andre.com/blog/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="fields-org">Organizational Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.7.1 <a name="alt_contact">Alternative Contact</a>
+</h3>
+      <p class="" style="">It may be appropriate to list others who can be contacted if the individual is not available.</p>
+      <p class="caption">Example 48. Alternative Contact</p>
+<div class="indent"><pre>
+&lt;field var='alt_contact'&gt;
+  &lt;value&gt;xmpp:peter@jabber.org&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.2 <a name="assistant">Assistant</a>
+</h3>
+      <p class="" style="">In some organizations, a person may be assisted by another individual.</p>
+      <p class="" style="">The Data Forms field that represents an assistant is "assistant".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP secretary</li>
+      </ul>
+      <p class="caption">Example 49. Assistant</p>
+<div class="indent"><pre>
+&lt;field var='assistant'&gt;
+  &lt;value&gt;Peter Pan&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.3 <a name="job_title">Job Title</a>
+</h3>
+      <p class="" style="">A job title is the official name of a person's position within an organization.</p>
+      <p class="" style="">The Data Forms field that represents a job title is "job_title".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TITLE</li>
+        <li>LDAP title</li>
+        <li>FOAF title</li>
+      </ul>
+      <p class="caption">Example 50. Job Title</p>
+<div class="indent"><pre>
+&lt;field var='job_title'&gt;
+  &lt;value&gt;Executive Director&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.4 <a name="manager">Manager</a>
+</h3>
+      <p class="" style="">In most organizations, a person is managed by or reports to another individual (often not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents a manager is "manager".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP manager</li>
+      </ul>
+      <p class="caption">Example 51. Manager</p>
+<div class="indent"><pre>
+&lt;field var='manager'&gt;
+  &lt;value&gt;William Shakespeare&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.5 <a name="org_name">Organizational Name</a>
+</h3>
+      <p class="" style="">An organizational name is the official name of an organization (company, school, etc.) within which a person works.</p>
+      <p class="" style="">The Data Forms field that represents the name of an organization is "org_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ORGNAME</li>
+        <li>LDAP o</li>
+      </ul>
+      <p class="caption">Example 52. Organizational Name</p>
+<div class="indent"><pre>
+&lt;field var='org_name'&gt;
+  &lt;value&gt;Jabber Software Foundation&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.6 <a name="org_role">Organizational Role</a>
+</h3>
+      <p class="" style="">An organizational role describes a person's profession or how a person contributes within an organization.</p>
+      <p class="" style="">The Data Forms field that represents an organizational role is "org_role".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ROLE</li>
+      </ul>
+      <p class="caption">Example 53. Organizational Role</p>
+<div class="indent"><pre>
+&lt;field var='org_role'&gt;
+  &lt;value&gt;Patron Saint&lt;/value&gt;
+  &lt;value&gt;Chief Evangelist&lt;/value&gt;
+  &lt;value&gt;Glorified Tech Writer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.7 <a name="org_unit">Organizational Unit</a>
+</h3>
+      <p class="" style="">An organizational unit is the name of part (subsidiary, department, etc.) of an organization.</p>
+      <p class="" style="">The Data Forms field that represents an organizational unit is "org_unit".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ORGUNIT</li>
+        <li>LDAP ou</li>
+      </ul>
+      <p class="caption">Example 54. Organizational Unit</p>
+<div class="indent"><pre>
+&lt;field var='org_unit'&gt;
+  &lt;value&gt;Jabber Council&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.8 <a name="system_username">System Username</a>
+</h3>
+      <p class="" style="">Usually a person has a system or network username within an organization (usually not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents such a username is "system_username".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP uid</li>
+        <li>LDAP userid</li>
+      </ul>
+      <p class="caption">Example 55. System Username</p>
+<div class="indent"><pre>
+&lt;field var='system_username'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.9 <a name="teams">Teams</a>
+</h3>
+      <p class="" style="">People often work in teams. Sometimes it can be helpful to list those teams.</p>
+      <p class="" style="">The Data Forms field that represents a work team is "teams".</p>
+      <p class="caption">Example 56. Teams</p>
+<div class="indent"><pre>
+&lt;field var='teams'&gt;
+  &lt;value&gt;Infrastructure Team&lt;/value&gt;
+  &lt;value&gt;Jabber Council&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.7.10 <a name="workstation">Workstation Address</a>
+</h3>
+      <p class="" style="">Often a person has a dedicated workstation address or name within an organization (usually not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents such a username is "workstation".</p>
+      <p class="caption">Example 57. Workstation Address</p>
+<div class="indent"><pre>
+&lt;field var='workstation'&gt;
+  &lt;value&gt;squire&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="fields-basic">Basic Personal Data Aspects</a>
+</h3>
+    <p class="" style="">These data fields are not necessarily permanent, but do not tend to change very often if at all.</p>
+    <div class="indent">
+<h3>5.8.1 <a name="birth_dayofmonth">Birth Day-of-Month</a>
+</h3>
+      <p class="" style="">A birth day-of-month is the day of the month in which a person was born. (Note: This data field is <span style="font-style: italic">not</span> what in English is usually referred to as a person's "birthday", i.e. the year+month+day on which the person was born; the "birthday" is split into three data fields in order to protect personal privacy, since a given individual might want to disclose his or her birth year, birth month, birth day-of-month, or some combination thereof but not all three.)</p>
+      <p class="" style="">The Data Forms field that represents a birth day-of-month is "birth_dayofmonth".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 58. Birth Day-of-Month</p>
+<div class="indent"><pre>
+&lt;field var='birth_dayofmonth'&gt;
+  &lt;value&gt;06&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.2 <a name="birth_month">Birth Month</a>
+</h3>
+      <p class="" style="">A birth month is the month of the year in which a person was born.</p>
+      <p class="" style="">The Data Forms field that represents a birth month is "birth_month".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 59. Birth Month</p>
+<div class="indent"><pre>
+&lt;field var='birth_month'&gt;
+  &lt;value&gt;08&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.3 <a name="birth_year">Birth Year</a>
+</h3>
+      <p class="" style="">A birth year is the year in which a person was born.</p>
+      <p class="" style="">The Data Forms field that represents a birth year is "birth_year".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 60. Birth Year</p>
+<div class="indent"><pre>
+&lt;field var='birth_year'&gt;
+  &lt;value&gt;1966&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.4 <a name="description">Description</a>
+</h3>
+      <p class="" style="">It can be helpful to provide a natural-language description of a person.</p>
+      <p class="" style="">The Data Forms field that represents a description of a person is "description".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP description</li>
+      </ul>
+      <p class="caption">Example 61. Description</p>
+<div class="indent"><pre>
+&lt;field var='description'&gt;
+  &lt;value&gt;I'm a Jabber fanatic.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.5 <a name="eye_color">Eye Color</a>
+</h3>
+      <p class="" style="">Some people may want to know the color of a person's eyes. The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's eye color is "eye_color".</p>
+      <p class="caption">Example 62. Eye Color</p>
+<div class="indent"><pre>
+&lt;field var='eye_color'&gt;
+  &lt;value&gt;blue&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.6 <a name="gender">Gender</a>
+</h3>
+      <p class="" style="">Gender is the self-defined gender of a person (this is not limited to "male" and "female", although those are the expected values in most instances). Sometimes also called "sex" or "gender identification".</p>
+      <p class="" style="">The Data Forms field that represents a person's gender is "gender".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF gender</li>
+      </ul>
+      <p class="caption">Example 63. Gender</p>
+<div class="indent"><pre>
+&lt;field var='gender'&gt;
+  &lt;value&gt;male&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.7 <a name="hair_color">Hair Color</a>
+</h3>
+      <p class="" style="">Some people may want to know the color of a person's hair (if any). The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's hair color is "hair_color".</p>
+      <p class="caption">Example 64. Hair Color</p>
+<div class="indent"><pre>
+&lt;field var='hair_color'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.8 <a name="height">Height</a>
+</h3>
+      <p class="" style="">Some people may want to know a person's height. This SHOULD be expressed in centimeters (which can be transformed into other units if necessary by a client).</p>
+      <p class="" style="">The Data Forms field that represents a person's height is "height".</p>
+      <p class="caption">Example 65. Height</p>
+<div class="indent"><pre>
+&lt;field var='height'&gt;
+  &lt;value&gt;178&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.8.9 <a name="weight">Weight</a>
+</h3>
+      <p class="" style="">Yes, it is a sensitive topic, but some people may want to know a person's weight. This SHOULD be expressed in kilograms (which can be transformed into other units if necessary by a client).</p>
+      <p class="" style="">The Data Forms field that represents a person's weight is "weight".</p>
+      <p class="caption">Example 66. Weight</p>
+<div class="indent"><pre>
+&lt;field var='weight'&gt;
+  &lt;value&gt;75&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="fields-extended">Extended Personal Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>5.9.1 <a name="expertise">Areas of Expertise</a>
+</h3>
+      <p class="" style="">An area of expertise is a subject in which a person has a great deal of knowledge.</p>
+      <p class="" style="">The Data Forms field that represents an area of expertise is "expertise".</p>
+      <p class="caption">Example 67. Areas of Expertise</p>
+<div class="indent"><pre>
+&lt;field var='expertise'&gt;
+  &lt;value&gt;Jabber&lt;/value&gt;
+  &lt;value&gt;XMPP&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.2 <a name="avatar_data">Avatar Data</a>
+</h3>
+      <p class="" style="">An avatar is an often fanciful representation of a user's desired self-image or persona (e.g., in the context of a game). An avatar is usually not intended to be an accurate picture of the user's actual physical appearance (that is handled by the photo_url and photo_data fields).</p>
+      <p class="" style="">An avatar can come in two forms: the avatar data itself, or a URL for a avatar.</p>
+      <p class="" style="">The Data Forms field that represents avatar data is "avatar_data".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 68. Avatar Data</p>
+<div class="indent"><pre>
+&lt;field var='avatar_data'&gt;
+  &lt;value&gt;base64-encoded-image-data&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.3 <a name="dietary_preferences">Dietary Preferences</a>
+</h3>
+      <p class="" style="">Some people have dietary preferences (vegan, vegetarian, kosher, peanut allergy, no shellfish, etc.).</p>
+      <p class="" style="">The Data Forms field that represents dietary preferences is "dietary_preferences".</p>
+      <p class="caption">Example 69. Dietary Preferences</p>
+<div class="indent"><pre>
+&lt;field var='dietary_preferences'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.4 <a name="hobby">Hobbies</a>
+</h3>
+      <p class="" style="">A hobby is a non-work activity that a person enjoys pursuing. Also called an "avocation".</p>
+      <p class="" style="">The Data Forms field that represents a hobby is "hobby".</p>
+      <p class="caption">Example 70. Some Hobbies</p>
+<div class="indent"><pre>
+&lt;field var='hobby'&gt;
+  &lt;value&gt;guitar&lt;/value&gt;
+  &lt;value&gt;songwriting&lt;/value&gt;
+  &lt;value&gt;blogging&lt;/value&gt;
+  &lt;value&gt;reading&lt;/value&gt;
+  &lt;value&gt;hiking&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.5 <a name="interest">Interests</a>
+</h3>
+      <p class="" style="">An interest a thing that a person cares about or is curious about. It is, generally, less active than a hobby.</p>
+      <p class="" style="">The Data Forms field that represents an interest is "interest".</p>
+      <p class="caption">Example 71. Some Interests</p>
+<div class="indent"><pre>
+&lt;field var='interest'&gt;
+  &lt;value&gt;history&lt;/value&gt;
+  &lt;value&gt;baseball&lt;/value&gt;
+  &lt;value&gt;economics&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.6 <a name="languages_lesswell">Languages Known Less Well</a>
+</h3>
+      <p class="" style="">Some people know more than one language, but less than well (e.g., the person may not be able to speak fluently). The definition of "less well" is left to the user.</p>
+      <p class="" style="">The value of this field MUST be an abbreviation for a language as specified in <span class="ref" style="">RFC 3066</span>  [<a href="#nt-id2260620">22</a>].</p>
+      <p class="" style="">The Data Forms field that represents a language known less that well is "languages_lesswell".</p>
+      <p class="caption">Example 72. Languages Known Less than Well</p>
+<div class="indent"><pre>
+&lt;field var='languages_lesswell'&gt;
+  &lt;value&gt;cz&lt;/value&gt;
+  &lt;value&gt;de&lt;/value&gt;
+  &lt;value&gt;nl&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.7 <a name="languages_well">Languages Known Well</a>
+</h3>
+      <p class="" style="">Everyone knows at least one language well (e.g., they are able to speak or write the language with a fair degree of fluency). Determination of whether someone knows a language "well" or "fluently" is left to the user.</p>
+      <p class="" style="">The value of this field MUST be an abbreviation for a language as specified in <span style="font-weight: bold">RFC 3066</span>.</p>
+      <p class="" style="">The Data Forms field that represents a language known well is "languages_well".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP preferredLanguage</li>
+      </ul>
+      <p class="caption">Example 73. Languages Known Well</p>
+<div class="indent"><pre>
+&lt;field var='languages_well'&gt;
+  &lt;value&gt;en&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.8 <a name="marital_status">Marital Status</a>
+</h3>
+      <p class="" style="">Human beings often get married, sometimes get divorced, become widowed, etc.</p>
+      <p class="" style="">The Data Forms field that represents whether a person's marital status is "marital_status".</p>
+      <p class="caption">Example 74. Marital Status</p>
+<div class="indent"><pre>
+&lt;field var='marital_status'&gt;
+  &lt;value&gt;married&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.9 <a name="mbti">Myers-Briggs Type Indicator</a>
+</h3>
+      <p class="" style="">A Myers-Briggs type indicator is four-letter acronym that is a popular way to characterize different personality types.</p>
+      <p class="" style="">The Data Forms field that represents a Myers-Briggs type indicator is "mbti".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF myersBriggs</li>
+      </ul>
+      <p class="caption">Example 75. Myers-Briggs Type Indicator</p>
+<div class="indent"><pre>
+&lt;field var='mbti'&gt;
+  &lt;value&gt;INTP&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.10 <a name="photo_data">Photo Data</a>
+</h3>
+      <p class="" style="">A photo provides a pictorial representation of a person. Sometimes also called a "mugshot".</p>
+      <p class="" style="">A photo can come in two forms: the photo data itself, or a URL for a photo (e.g., the vCard PHOTO element can represent either, while the FOAF depiction and FOAF img can represent only a URL).</p>
+      <p class="" style="">The Data Forms field that represents photo data is "photo_data".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PHOTO</li>
+        <li>LDAP jpegPhoto</li>
+      </ul>
+      <p class="caption">Example 76. Photo Data</p>
+<div class="indent"><pre>
+&lt;field var='photo_data'&gt;
+  &lt;value&gt;base64-encoded-image-data&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.11 <a name="profession">Profession</a>
+</h3>
+      <p class="" style="">A profession is what a person does for his or her primary employment. Also known as a "vocation". The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a profession is "profession".</p>
+      <p class="caption">Example 77. A Profession</p>
+<div class="indent"><pre>
+&lt;field var='profession'&gt;
+  &lt;value&gt;software engineer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.12 <a name="religion">Religious Affiliation</a>
+</h3>
+      <p class="" style="">Many people feel affiliated with a religious belief system.</p> 
+      <p class="" style="">The Data Forms field that represents a religious affiliation is "religion".</p>
+      <p class="caption">Example 78. Religious Affiliation</p>
+<div class="indent"><pre>
+&lt;field var='religion'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.13 <a name="sexual_orientation">Sexual Orientation</a>
+</h3>
+      <p class="" style="">The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's sexual orientation is "sexual_orientation".</p>
+      <p class="caption">Example 79. Sexual Orientation</p>
+<div class="indent"><pre>
+&lt;field var='sexual_orientation'&gt;
+  &lt;value&gt;straight&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.14 <a name="smoker">Smoker</a>
+</h3>
+      <p class="" style="">Some people smoke tobacco in various forms (cigarettes, cigars, pipes, etc.).</p> 
+      <p class="" style="">The Data Forms field that represents whether a person smokes is "smoker".</p>
+      <p class="caption">Example 80. Smoker</p>
+<div class="indent"><pre>
+&lt;field var='smoker'&gt;
+  &lt;value&gt;no&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.15 <a name="wishlist">Wishlist</a>
+</h3>
+      <p class="" style="">A wishlist is a list of items that a person would like to receive as gifts.</p>
+      <p class="" style="">The Data Forms field that represents a wishlist is "wishlist".</p>
+      <p class="caption">Example 81. Wishlist</p>
+<div class="indent"><pre>
+&lt;field var='wishlist'&gt;
+  &lt;value&gt;A Mini Cooper&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.16 <a name="zodiac_chinese">Zodiac Sign (Chinese)</a>
+</h3>
+      <p class="" style="">A Chinese zodiac sign denotes the type of year in which a person was born according to the Chinese calendar (e.g., the year of the dragon).</p>
+      <p class="" style="">The Data Forms field that represents a Chinese zodiac sign is "zodiac_chinese".</p>
+      <p class="caption">Example 82. Zodiac Sign (Chinese)</p>
+<div class="indent"><pre>
+&lt;field var='zodiac_chinese'&gt;
+  &lt;value&gt;horse&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.9.17 <a name="zodiac_western">Zodiac Sign (Western)</a>
+</h3>
+      <p class="" style="">A Western zodiac sign is that part of the astrological belt under which a person was born; each sign is named after one of the constellations.</p>
+      <p class="" style="">The Data Forms field that represents a Western zodiac sign is "zodiac_western".</p>
+      <p class="caption">Example 83. Zodiac Sign (Western)</p>
+<div class="indent"><pre>
+&lt;field var='zodiac_western'&gt;
+  &lt;value&gt;Leo&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.10 <a name="fields-security">Security Data Aspects</a>
+</h3>
+    <p class="" style="">Some people have PGP keys, X.509 certificates, and the like.</p>
+    <div class="indent">
+<h3>5.10.1 <a name="pgpkey">PGP Key</a>
+</h3>
+      <p class="" style="">The ASCII armored output of a PGP key.</p>
+      <p class="" style="">The Data Forms field that represents a PGP key is "pgpkey".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard KEY with TYPE of PGP</li>
+      </ul>
+      <p class="caption">Example 84. PGP Key</p>
+<div class="indent"><pre>
+&lt;field var='pgpkey'&gt;
+  &lt;value&gt;
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1.2.4 (Darwin)
+
+mQGiBEGSeUQRBADTT8NqGpxDQ1GjmAJBDNET0blyb1LF6exYLxydX+hzcooE5WxP
+Zdo5Xx0RrLYlKmmcKv0Z8cG/kei2pkS05h/oqluphGmzMBIeC/ox22z87PKpVDfj
+OEYQOZqhqdFI+KRIa4M89CQOO1N5V2KlX9GaNjxRearKvLgsoeTzpPtybwCgl91i
+SqQnry1YV+PFOjRcDT7cX+UD/2JxXU5d1Z1WZf7ttM3QjSaPc9CA4fS+axinRkn/
+IbRJ/Lj8Tz+Vb4kBbBhmFG8JCoRtj2J8bsDdaFCh7nHqT2u4oXy0NJSCKrDRBcuL
+bEQfasT/cuBXIM2A7nB1UtlUCYXnINxakYLIsW9BvvFN935FhZ81EJvLW34W2Mf7
+Y+9ZA/0adScaI05UUE5RRcZSiXs8/p+R6SeaW2gjS5beL5Wv6ExRlDe92rGqrjtN
+PmBRiDiVBSoYlqOepBZk+wM+/B4WMsmUFVeXsXWjWMlghyyni2rI1Z2v1UH8KBKm
+259k7SlU/BbnEAHIzuHPSQHJNUX+YqWArz1v5tDcQn7L1Wo7PbRAUGV0ZXIgU2Fp
+bnQtQW5kcmUgKHhtcHA6c3RwZXRlckBqYWJiZXIub3JnKSA8c3RwZXRlckBqYWJi
+ZXIub3JnPoheBBMRAgAeBQJBknlEAhsDBgsJCAcDAgMVAgMDFgIBAh4BAheAAAoJ
+EFmFiWTXBRKsfeQAoJdO0PvP1Mi/kJ9U1zVpa4GPpXYCAJ9oFjonfr+Z3ZTefjSb
+tZpE2mny57kCDQRBknlzEAgAisWlkK6daVjrxouZK9KvX8tt3CKVse4CY52Lq7xi
+dtEAhDcXX9SgTnlxgrcCnBipj/OMi/B2M0U88qv3TcsZ0dWZt7H4FnHJvU4xloK8
+qRkJ7xa6gCEoPAc7ESdr//6J/eEvWMqixstOUyfRg2AQp/eSHX0Cl/TQImRVZbh6
+HYCehrqpErAnz0VY8nvun3709LgvIMUvKrnV7lF9wOuuhWCK9IYdpmgoD4d/Gr4t
+ZVuE1jYN4tBLyQXtJDAR/UvKHEiXUAhsfXOtfCUQV5MaxM6YQce63BGl05kS7oLH
+Sx+KYOX1vEi3k1OFfH5CpqYaxmfhSzdyz7Hhdsl+IbkhzwAECwf/YQfpx4z9dnJn
+3ePrZhz5SI4KjdbOCmqhLFd8aVoQ9BCriePH3kPjjoE9Qz+0NlFqzuG4/tkZkAok
+BA0GqYE4XXgvpwGpK95mlUvxDOowu0fLVQA8NfpU3U7YItZkfAPZ2M+PnmayRILi
+0yBmm1taVllCD2mc2vhsMRUoD1DUworSzQuTG9YlQ89Q2/1LsoQzYjBz9XIfYV4A
+MPr/PKPkKy3D7BYHi/DOnkcP9hLXJSCjgV5TpuWuCVX9aYU2Yb7BfY1OFORBCUaV
+B1YLAPtXqfqjz25pIQPDEUbpKzhEO7xNU4EPT8ZsSfqqOd3aMet8McieRfMd+VIe
+4J1OUIg1oYhJBBgRAgAJBQJBknlzAhsMAAoJEFmFiWTXBRKs/GgAn0R63qTEQd/e
+XhK8hFkPvXjudl7xAJ95+2fAHfmHheZJVaO8VaJiL54Tvw==
+=ZRIc
+-----END PGP PUBLIC KEY BLOCK-----
+  &lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.2 <a name="pgp_fingerprint">PGP Key Fingerprint</a>
+</h3>
+      <p class="" style="">The fingerprint (hashed value) of a PGP key.</p>
+      <p class="" style="">The Data Forms field that represents a PGP fingerprint is "pgp_fingerprint".</p>
+      <p class="caption">Example 85. PGP Fingerprint</p>
+<div class="indent"><pre>
+&lt;field var='pgp_fingerprint'&gt;
+  &lt;value&gt;E5CA EAE7 C8D6 CFE2 6D7A  8653 5985 8964 D705 12AC&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.3 <a name="pgpkey_id">PGP Key ID</a>
+</h3>
+      <p class="" style="">The ID of a PGP key.</p>
+      <p class="" style="">The Data Forms field that represents a PGP key ID is "pgpkey_id".</p>
+      <p class="caption">Example 86. PGP Key ID</p>
+<div class="indent"><pre>
+&lt;field var='pgpkey_id'&gt;
+  &lt;value&gt;D70512AC&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.4 <a name="x509_fingerprint_md5">X.509 Fingerprint (MD5)</a>
+</h3>
+      <p class="" style="">The fingerprint of an X.509 certificate, hashed using MD5.</p>
+      <p class="" style="">The Data Forms field representing such a value is "x509_fingerprint_md5".</p>
+      <p class="caption">Example 87. X.509 Fingerprint (MD5)</p>
+<div class="indent"><pre>
+&lt;field var='x509_fingerprint_md5'&gt;
+  &lt;value&gt;5D 41 20 54 7C 90 49 A1 78 36 07 29 75 9B A7 D0&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.10.5 <a name="x509_fingerprint_sha1">X.509 Fingerprint (SHA-1)</a>
+</h3>
+      <p class="" style="">The fingerprint of an X.509 certificate, hashed using SHA-1.</p>
+      <p class="" style="">The Data Forms field representing such a value is "x509_fingerprint_sha1".</p>
+      <p class="caption">Example 88. X.509 Fingerprint (SHA-1)</p>
+<div class="indent"><pre>
+&lt;field var='x509_fingerprint_sha1'&gt;
+  &lt;value&gt;C3 88 33 27 F3 47 3B 8B 07 71 3E 96 44 A7 EE E2 E0 50 4A 5B&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.11 <a name="fields-favorites">Personal Favorites</a>
+</h3>
+    <p class="" style="">Most people have favorite movies, authors, TV shows, musical artists, foods, games, etc.</p>
+    <div class="indent">
+<h3>5.11.1 <a name="fav_authors">Favorite Authors</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite authors is "fav_authors".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 89. Favorite Authors</p>
+<div class="indent"><pre>
+&lt;field var='fav_authors'&gt;
+  &lt;value&gt;Jacob Bronowski&lt;/value&gt;
+  &lt;value&gt;Friedrich Nietzsche&lt;/value&gt;
+  &lt;value&gt;Carroll Quigley&lt;/value&gt;
+  &lt;value&gt;Yevgeny Zamyatin&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.2 <a name="fav_athletes">Favorite Athletes</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite athletes is "fav_athletes".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 90. Favorite Athletes</p>
+<div class="indent"><pre>
+&lt;field var='fav_athletes'&gt;
+  &lt;value&gt;Lance Armstrong&lt;/value&gt;
+  &lt;value&gt;Andre Agassiz&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.3 <a name="fav_charities">Favorite Charities</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite charities is "fav_charities".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 91. Favorite Charities</p>
+<div class="indent"><pre>
+&lt;field var='fav_charities'&gt;
+  &lt;value&gt;Amnesty International&lt;/value&gt;
+  &lt;value&gt;Institute for Justice&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.4 <a name="fav_chatrooms">Favorite Chatrooms</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite chatrooms is "fav_chatrooms".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 92. Favorite Chatrooms</p>
+<div class="indent"><pre>
+&lt;field var='fav_chatrooms'&gt;
+  &lt;value&gt;jabber@conference.jabber.org&lt;/value&gt;
+  &lt;value&gt;jdev@conference.jabber.org&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.5 <a name="fav_drinks">Favorite Drinks</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite drinks is "fav_drinks".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 93. Favorite Drinks</p>
+<div class="indent"><pre>
+&lt;field var='fav_drinks'&gt;
+  &lt;value&gt;Guinness&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.6 <a name="fav_foods">Favorite Foods</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite foods is "fav_foods".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 94. Favorite Foods</p>
+<div class="indent"><pre>
+&lt;field var='fav_foods'&gt;
+  &lt;value&gt;Thai&lt;/value&gt;
+  &lt;value&gt;Mexican&lt;/value&gt;
+  &lt;value&gt;Italian&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.7 <a name="fav_games">Favorite Games</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite games is "fav_games".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 95. Favorite Games</p>
+<div class="indent"><pre>
+&lt;field var='fav_games'&gt;
+  &lt;value&gt;chess&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.8 <a name="fav_movies">Favorite Movies</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite movies is "fav_movies".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 96. Favorite Movies</p>
+<div class="indent"><pre>
+&lt;field var='fav_movies'&gt;
+  &lt;value&gt;In Search of Bobby Fischer&lt;/value&gt;
+  &lt;value&gt;Strictly Ballroom&lt;/value&gt;
+  &lt;value&gt;The Truth About Cats and Dogs&lt;/value&gt;
+  &lt;value&gt;Ray&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.9 <a name="fav_music">Favorite Music</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite music is "fav_music".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 97. Favorite Music</p>
+<div class="indent"><pre>
+&lt;field var='fav_music'&gt;
+  &lt;value&gt;J.S. Bach&lt;/value&gt;
+  &lt;value&gt;Duke Ellington&lt;/value&gt;
+  &lt;value&gt;Mellow Candle&lt;/value&gt;
+  &lt;value&gt;Yes&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.10 <a name="fav_quotes">Favorite Quotes</a>
+</h3>
+      <p class="" style="">A quote is a phrase or saying that a person identifies with in some way. According to the 2004 Pew Internet survey on instant messaging, quotes represent the most popular item to include in online profiles on major consumer-oriented instant messaging services.</p>
+      <p class="" style="">The Data Forms field that represents favorite quotes is "fav_quotes".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 98. Favorite Quotes</p>
+<div class="indent"><pre>
+&lt;field var='fav_quotes'&gt;
+  &lt;value&gt;I am large, I contain multitudes.&lt;/value&gt;
+  &lt;value&gt;&amp;quot;Think like a man of action, act like a man of thought.&amp;quot; --Henri Bergson&lt;/value&gt;
+  &lt;value&gt;One crowded hour of glorious life is worth an age without a name.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.11 <a name="fav_teams">Favorite Sports Teams</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite sports teams is "fav_teams".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 99. Favorite Sports Teams</p>
+<div class="indent"><pre>
+&lt;field var='fav_teams'&gt;
+  &lt;value&gt;New York Yankees&lt;/value&gt;
+  &lt;value&gt;Colorado Rockies&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.11.12 <a name="fav_tv">Favorite TV Shows</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite TV shows is "fav_tv".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 100. Favorite TV Shows</p>
+<div class="indent"><pre>
+&lt;field var='fav_tv'&gt;
+  &lt;value&gt;Antiques Road Show&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>5.12 <a name="fields-history">Personal History</a>
+</h3>
+    <div class="indent">
+<h3>5.12.1 <a name="places_lived">Places Lived</a>
+</h3>
+      <p class="" style="">Some people move around a lot.</p>
+      <p class="" style="">The Data Forms field that represents places lived is "places_lived".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 101. Places Lived</p>
+<div class="indent"><pre>
+&lt;field var='places_lived'&gt;
+  &lt;value&gt;Denver, Colorado, USA&lt;/value&gt;
+  &lt;value&gt;New Hope, Pennsylvania, USA&lt;/value&gt;
+  &lt;value&gt;Maplewood, New Jersey, USA&lt;/value&gt;
+  &lt;value&gt;Atlanta, Georgia, USA&lt;/value&gt;
+  &lt;value&gt;Fairfax, Virginia, USA&lt;/value&gt;
+  &lt;value&gt;Ceske Budejovice, Czech Republic&lt;/value&gt;
+  &lt;value&gt;New York City&lt;/value&gt;
+  &lt;value&gt;Readfield, Maine, USA&lt;/value&gt;
+  &lt;value&gt;Sea Cliff, NY, USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>5.12.2 <a name="schools">Schools Attended</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents schools attended is "schools".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 102. Schools Attended</p>
+<div class="indent"><pre>
+&lt;field var='schools'&gt;
+  &lt;value&gt;Columbia University&lt;/value&gt;
+  &lt;value&gt;American Renaissance School&lt;/value&gt;
+  &lt;value&gt;Maranacook Community School&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Profile data can be personally significant and even security critical. Due care should be taken in determining who shall have access to such information. However, this proposal merely defines the data formats for profile data; mechanisms for controlling access to such data will be defined in a separate proposal.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261898">23</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">To follow.</p>
+    
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250699">1</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2250881">2</a>. RFC 2426: vCard MIME Directory Profile &lt;<a href="http://www.ietf.org/rfc/rfc2426.txt">http://www.ietf.org/rfc/rfc2426.txt</a>&gt;.</p>
+<p><a name="nt-id2250862">3</a>. For links to the experimental XML representation of vCard, see <span style="font-weight: bold">JEP-0054</span>.</p>
+<p><a name="nt-id2250938">4</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2250971">5</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2250740">6</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2250770">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2250793">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2250833">9</a>. The extensibility requirement is critically important, because it would be best if the protocol specified herein could be used to represent data used within specialized communities. Examples of such communities include dating services, multiplayer gaming networks, IM services provided by portals and ISPs, and expert-location systems within large corporations. While such communities might use part or all of some common set of data fields (such as fields that map to familiar vCard elements), each community might also want to represent quite disparate kinds of information (dating criteria, favorite games, contact preferences, areas of expertise, and the like). Furthermore, data might be used to profile network actors that are not persons (e.g., bots, services, and other software agents). Therefore, the ideal proposal will provide an extensible framework for representing profile data and will not limit itself to representing the relatively small set of data fields covered by the vCard format.</p>
+<p><a name="nt-id2256362">10</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2256385">11</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2256451">12</a>. Resource Description Framework (RDF) &lt;<a href="http://www.w3.org/RDF/">http://www.w3.org/RDF/</a>&gt;.</p>
+<p><a name="nt-id2256501">13</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2256548">14</a>. JEP-0120: Infobits &lt;<a href="http://www.jabber.org/jeps/jep-0120.html">http://www.jabber.org/jeps/jep-0120.html</a>&gt;.</p>
+<p><a name="nt-id2256668">15</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256660">16</a>. Alternatively, specialized applications MAY define separate FORM_TYPEs for their particular data elements.</p>
+<p><a name="nt-id2250416">17</a>. RFC 2252: Lightweight Directory Access Protocol (v3): Attribute Syntax Definitions &lt;<a href="http://www.ietf.org/rfc/rfc2252.txt">http://www.ietf.org/rfc/rfc2252.txt</a>&gt;.</p>
+<p><a name="nt-id2250386">18</a>. RFC 2256: A Summary of the X.500(96) User Schema for use with LDAPv3 &lt;<a href="http://www.ietf.org/rfc/rfc2256.txt">http://www.ietf.org/rfc/rfc2256.txt</a>&gt;.</p>
+<p><a name="nt-id2256997">19</a>. RFC 2798: Definition of the inetOrgPerson LDAP Object Class &lt;<a href="http://www.ietf.org/rfc/rfc2798.txt">http://www.ietf.org/rfc/rfc2798.txt</a>&gt;.</p>
+<p><a name="nt-id2257522">20</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2258214">21</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2260620">22</a>. RFC 3066: Tags for the Identification of Languages &lt;<a href="http://www.ietf.org/rfc/rfc3066.txt">http://www.ietf.org/rfc/rfc3066.txt</a>&gt;.</p>
+<p><a name="nt-id2261898">23</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-11-11)</h4>
+<div class="indent">Added postaladdress, fav_chatrooms, alt_contact, teams; added various security-related fields. (psa)
+    </div>
+<h4>Version 0.2 (2005-07-25)</h4>
+<div class="indent">Added mappings to common LDAP schemas. (psa)
+    </div>
+<h4>Version 0.1 (2005-06-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.5 (2005-06-13)</h4>
+<div class="indent">Defined how to handle vCard types such as home vs. work addresses. (psa)
+    </div>
+<h4>Version 0.0.4 (2005-04-07)</h4>
+<div class="indent">Reworked field standardization; added support for telephony addresses, electronic addresses, and organizational data. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-03-11)</h4>
+<div class="indent">Added open issues. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-01-06)</h4>
+<div class="indent">Explained requirements and design decisions in more detail, especially with regard to extensibility; split photo into two elements (data and URL). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-11-10)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0154-0.4.html
+++ b/content/xep-0154-0.4.html
@@ -1,0 +1,2594 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0154: User Profile</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Profile">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies how to represent and manage profile data about IM users and other XMPP entities.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0154">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0154: User Profile</h1>
+<p>This JEP specifies how to represent and manage profile data about IM users and other XMPP entities.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0154<br>
+            Version: 0.4<br>
+            Last Updated: 2006-01-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0004, JEP-0060, JEP-0068, JEP-0163<br>Supersedes: JEP-0054<br>
+                Superseded By: None<br>
+            Short Name: profile<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Profile%20(JEP-0154)">http://wiki.jabber.org/index.php/User Profile (JEP-0154)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#approach-management">Data Management</a>
+</dt>
+<dt>3.2.  <a href="#approach-representation">Data Representation</a>
+</dt>
+</dl>
+<dt>4.  <a href="#producer">Producer Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#producer-full">Publishing a Full Profile</a>
+</dt>
+<dt>4.2.  <a href="#producer-pub">Updating One or More Profile Fields</a>
+</dt>
+</dl>
+<dt>5.  <a href="#consumer">Consumer Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#consumer-disco">Discovering Support</a>
+</dt>
+<dt>5.2.  <a href="#consumer-full">Requesting Full Profile</a>
+</dt>
+<dt>5.3.  <a href="#consumer-sub">Receiving Profile Updates</a>
+</dt>
+</dl>
+<dt>6.  <a href="#fields">Data Representation</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#fields-name">Name Data Aspects</a>
+</dt>
+<dl>
+<dt>6.1.1.  <a href="#display_name">Display Name</a>
+</dt>
+<dt>6.1.2.  <a href="#familiar_name">Familiar Name</a>
+</dt>
+<dt>6.1.3.  <a href="#family_name">Family Name</a>
+</dt>
+<dt>6.1.4.  <a href="#given_name">Given Name</a>
+</dt>
+<dt>6.1.5.  <a href="#middle_name">Middle Name</a>
+</dt>
+<dt>6.1.6.  <a href="#name_prefix">Name Prefix</a>
+</dt>
+<dt>6.1.7.  <a href="#name_suffix">Name Suffix</a>
+</dt>
+<dt>6.1.8.  <a href="#nickname">Nickname</a>
+</dt>
+<dt>6.1.9.  <a href="#patronymic">Patronymic</a>
+</dt>
+</dl>
+<dt>6.2.  <a href="#fields-physicaladdress">Physical Address Data Aspects</a>
+</dt>
+<dl>
+<dt>6.2.1.  <a href="#country">Country</a>
+</dt>
+<dt>6.2.2.  <a href="#region">Region</a>
+</dt>
+<dt>6.2.3.  <a href="#locality">Locality</a>
+</dt>
+<dt>6.2.4.  <a href="#area">Area</a>
+</dt>
+<dt>6.2.5.  <a href="#street">Street</a>
+</dt>
+<dt>6.2.6.  <a href="#building">Building</a>
+</dt>
+<dt>6.2.7.  <a href="#floor">Floor</a>
+</dt>
+<dt>6.2.8.  <a href="#room">Room</a>
+</dt>
+<dt>6.2.9.  <a href="#postalbox">Postal Box</a>
+</dt>
+<dt>6.2.10.  <a href="#postalcode">Postal Code</a>
+</dt>
+<dt>6.2.11.  <a href="#postaladdress">Postal Address</a>
+</dt>
+</dl>
+<dt>6.3.  <a href="#fields-geoloc">Geolocation Data Aspects</a>
+</dt>
+<dl>
+<dt>6.3.1.  <a href="#alt">Altitude</a>
+</dt>
+<dt>6.3.2.  <a href="#lat">Latitude</a>
+</dt>
+<dt>6.3.3.  <a href="#lat">Longitude</a>
+</dt>
+</dl>
+<dt>6.4.  <a href="#fields-tel">Telephony Address Data Aspects</a>
+</dt>
+<dl>
+<dt>6.4.1.  <a href="#fax">Fax Number</a>
+</dt>
+<dt>6.4.2.  <a href="#landline">Landline Telephone Number</a>
+</dt>
+<dt>6.4.3.  <a href="#mobile">Mobile Telephone Number</a>
+</dt>
+<dt>6.4.4.  <a href="#pager">Pager Number</a>
+</dt>
+<dt>6.4.5.  <a href="#sip_address">SIP Address</a>
+</dt>
+<dt>6.4.6.  <a href="#skype_address">Skype Address</a>
+</dt>
+<dt>6.4.7.  <a href="#video_phone">Videophone Address</a>
+</dt>
+</dl>
+<dt>6.5.  <a href="#fields-net">Electronic Address Data Aspects</a>
+</dt>
+<dl>
+<dt>6.5.1.  <a href="#aim_id">AIM Screen Name</a>
+</dt>
+<dt>6.5.2.  <a href="#email">Email Address</a>
+</dt>
+<dt>6.5.3.  <a href="#icq_id">ICQ Number</a>
+</dt>
+<dt>6.5.4.  <a href="#jid">Jabber ID</a>
+</dt>
+<dt>6.5.5.  <a href="#msn_id">MSN Address</a>
+</dt>
+<dt>6.5.6.  <a href="#yahoo_id">Yahoo ID</a>
+</dt>
+</dl>
+<dt>6.6.  <a href="#fields-www">World Wide Web Resource Aspects</a>
+</dt>
+<dl>
+<dt>6.6.1.  <a href="#avatar_url">Avatar URL</a>
+</dt>
+<dt>6.6.2.  <a href="#bio">Biographical URL</a>
+</dt>
+<dt>6.6.3.  <a href="#foaf_url">FOAF URL</a>
+</dt>
+<dt>6.6.4.  <a href="#homepage">Homepage URL</a>
+</dt>
+<dt>6.6.5.  <a href="#photo_url">Photo URL</a>
+</dt>
+<dt>6.6.6.  <a href="#publications">Publications URL</a>
+</dt>
+<dt>6.6.7.  <a href="#resume">Resume URL</a>
+</dt>
+<dt>6.6.8.  <a href="#status_url">Status URL</a>
+</dt>
+<dt>6.6.9.  <a href="#org_url">Organizational URL</a>
+</dt>
+<dt>6.6.10.  <a href="#weblog">Weblog URL</a>
+</dt>
+</dl>
+<dt>6.7.  <a href="#fields-org">Organizational Data Aspects</a>
+</dt>
+<dl>
+<dt>6.7.1.  <a href="#alt_contact">Alternative Contact</a>
+</dt>
+<dt>6.7.2.  <a href="#assistant">Assistant</a>
+</dt>
+<dt>6.7.3.  <a href="#department_name">Department Name</a>
+</dt>
+<dt>6.7.4.  <a href="#department_number">Department Number</a>
+</dt>
+<dt>6.7.5.  <a href="#employee_number">Employee Number</a>
+</dt>
+<dt>6.7.6.  <a href="#employee_number">Employee Type</a>
+</dt>
+<dt>6.7.7.  <a href="#job_title">Job Title</a>
+</dt>
+<dt>6.7.8.  <a href="#manager">Manager</a>
+</dt>
+<dt>6.7.9.  <a href="#org_name">Organizational Name</a>
+</dt>
+<dt>6.7.10.  <a href="#org_role">Organizational Role</a>
+</dt>
+<dt>6.7.11.  <a href="#org_unit">Organizational Unit</a>
+</dt>
+<dt>6.7.12.  <a href="#system_username">System Username</a>
+</dt>
+<dt>6.7.13.  <a href="#teams">Teams</a>
+</dt>
+<dt>6.7.14.  <a href="#workstation">Workstation Address</a>
+</dt>
+</dl>
+<dt>6.8.  <a href="#fields-basic">Basic Personal Data Aspects</a>
+</dt>
+<dl>
+<dt>6.8.1.  <a href="#birth_dayofmonth">Birth Day-of-Month</a>
+</dt>
+<dt>6.8.2.  <a href="#birth_month">Birth Month</a>
+</dt>
+<dt>6.8.3.  <a href="#birth_year">Birth Year</a>
+</dt>
+<dt>6.8.4.  <a href="#description">Description</a>
+</dt>
+<dt>6.8.5.  <a href="#eye_color">Eye Color</a>
+</dt>
+<dt>6.8.6.  <a href="#gender">Gender</a>
+</dt>
+<dt>6.8.7.  <a href="#hair_color">Hair Color</a>
+</dt>
+<dt>6.8.8.  <a href="#height">Height</a>
+</dt>
+<dt>6.8.9.  <a href="#weight">Weight</a>
+</dt>
+</dl>
+<dt>6.9.  <a href="#fields-extended">Extended Personal Data Aspects</a>
+</dt>
+<dl>
+<dt>6.9.1.  <a href="#expertise">Areas of Expertise</a>
+</dt>
+<dt>6.9.2.  <a href="#avatar_data">Avatar Data</a>
+</dt>
+<dt>6.9.3.  <a href="#clubs">Clubs</a>
+</dt>
+<dt>6.9.4.  <a href="#dietary_preferences">Dietary Preferences</a>
+</dt>
+<dt>6.9.5.  <a href="#hobby">Hobbies</a>
+</dt>
+<dt>6.9.6.  <a href="#interest">Interests</a>
+</dt>
+<dt>6.9.7.  <a href="#languages_lesswell">Languages Known Less Well</a>
+</dt>
+<dt>6.9.8.  <a href="#languages_well">Languages Known Well</a>
+</dt>
+<dt>6.9.9.  <a href="#car_license_number">License Plate Number</a>
+</dt>
+<dt>6.9.10.  <a href="#marital_status">Marital Status</a>
+</dt>
+<dt>6.9.11.  <a href="#mbti">Myers-Briggs Type Indicator</a>
+</dt>
+<dt>6.9.12.  <a href="#photo_data">Photo Data</a>
+</dt>
+<dt>6.9.13.  <a href="#profession">Profession</a>
+</dt>
+<dt>6.9.14.  <a href="#religion">Religious Affiliation</a>
+</dt>
+<dt>6.9.15.  <a href="#sexual_orientation">Sexual Orientation</a>
+</dt>
+<dt>6.9.16.  <a href="#smoker">Smoker</a>
+</dt>
+<dt>6.9.17.  <a href="#wishlist">Wishlist</a>
+</dt>
+<dt>6.9.18.  <a href="#zodiac_chinese">Zodiac Sign (Chinese)</a>
+</dt>
+<dt>6.9.19.  <a href="#zodiac_western">Zodiac Sign (Western)</a>
+</dt>
+</dl>
+<dt>6.10.  <a href="#fields-security">Security Data Aspects</a>
+</dt>
+<dl>
+<dt>6.10.1.  <a href="#pgpkey">PGP Key</a>
+</dt>
+<dt>6.10.2.  <a href="#pgp_fingerprint">PGP Key Fingerprint</a>
+</dt>
+<dt>6.10.3.  <a href="#pgpkey_id">PGP Key ID</a>
+</dt>
+<dt>6.10.4.  <a href="#x509_fingerprint_md5">X.509 Fingerprint (MD5)</a>
+</dt>
+<dt>6.10.5.  <a href="#x509_fingerprint_sha1">X.509 Fingerprint (SHA-1)</a>
+</dt>
+</dl>
+<dt>6.11.  <a href="#fields-favorites">Personal Favorites</a>
+</dt>
+<dl>
+<dt>6.11.1.  <a href="#fav_authors">Favorite Authors</a>
+</dt>
+<dt>6.11.2.  <a href="#fav_athletes">Favorite Athletes</a>
+</dt>
+<dt>6.11.3.  <a href="#favorite_beverages">Favorite Beverages</a>
+</dt>
+<dt>6.11.4.  <a href="#fav_charities">Favorite Charities</a>
+</dt>
+<dt>6.11.5.  <a href="#fav_chatrooms">Favorite Chatrooms</a>
+</dt>
+<dt>6.11.6.  <a href="#fav_drinks">Favorite Drinks</a>
+</dt>
+<dt>6.11.7.  <a href="#fav_foods">Favorite Foods</a>
+</dt>
+<dt>6.11.8.  <a href="#fav_games">Favorite Games</a>
+</dt>
+<dt>6.11.9.  <a href="#fav_movies">Favorite Movies</a>
+</dt>
+<dt>6.11.10.  <a href="#fav_music">Favorite Music</a>
+</dt>
+<dt>6.11.11.  <a href="#fav_quotes">Favorite Quotes</a>
+</dt>
+<dt>6.11.12.  <a href="#fav_teams">Favorite Sports Teams</a>
+</dt>
+<dt>6.11.13.  <a href="#fav_tv">Favorite TV Shows</a>
+</dt>
+</dl>
+<dt>6.12.  <a href="#fields-history">Personal History</a>
+</dt>
+<dl>
+<dt>6.12.1.  <a href="#places_lived">Places Lived</a>
+</dt>
+<dt>6.12.2.  <a href="#schools">Schools Attended</a>
+</dt>
+</dl>
+</dl>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>9.1.  <a href="#registrar-formtype">Field Standardization</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">It is widely acknowledged within the Jabber/XMPP community that the <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2250576">1</a>] specification (<span style="font-weight: bold">JEP-0054</span>) has outlived its usefulness. There are several reasons for this conclusion:</p>
+  <ol start="" type="">
+    <li>
+<span style="font-weight: bold">JEP-0054</span> is not fully consistent with the Internet-Draft on which it was based.</li>
+    <li>The Internet-Draft on which it was based was never approved by the IETF.</li>
+    <li>Because of confusion over aspects of the vcard-temp specification, there exist incompatible implementations.</li>
+    <li>vCard (<span class="ref" style="">RFC 2426</span>  [<a href="#nt-id2250630">2</a>]) captures only a limited set of information.</li>
+    <li>vCard (even in its XML representation  [<a href="#nt-id2250619">3</a>]) is not easily extensible, leading those who develop profiles for specialized communities to "roll their own" protocols, to the detriment of interoperability.</li>
+    <li>vCard data tends to be monolithic (the basic unit of information is the full vCard, not parts thereof).</li>
+    <li>The publication model for JEP-0054 is to set the full vCard, rather than only the parts that need to be modified.</li>
+    <li>The retrieval model for JEP-0054 is to get the full vCard, rather than only the parts that have been modified.</li>
+  </ol>
+  <p class="" style="">Given the weaknesses of vCard, there is interest across the broader Internet community in replacing vCard with something more modern and extensible. Unfortunately, no other standards development organization has developed an alternative to vCard. Part of the challenge is that quite detailed ontologies have been developed that might replace parts of the vCard specification (e.g., the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2250814">4</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2250664">5</a>]) while less-formal ontologies are being used to represent other parts of the problem space (e.g., <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2250691">6</a>]). The relevant protocols are in flux and it is unclear when (or even if) stability will emerge.</p>
+  <p class="" style="">Because of the unsettled landspace and the strong desire within the Jabber/XMPP community to move beyond JEP-0054, this JEP specifies methods for the representation of profile data in terms of the <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2250722">7</a>] protocol (further qualified using the standardization concepts specified in <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2250705">8</a>]) and for the management of profile data using standard IQ request-response semantics as well as, for more frequently-modified data, <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250758">9</a>] semantics (specifically the simplified subset of those semantics specified in <span class="ref" style="">Simplified Personal Publish-Subscribe</span>  [<a href="#nt-id2256432">10</a>]). The rationale behind these design decisions is provided below.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This JEP addresses the following requirements for data management:</p>
+  <ol start="" type="">
+    <li>Enable an entity to publish profile data about itself.</li>
+    <li>Enable requesting entities to retrieve profile data about other entities.</li>
+  </ol>
+  <p class="" style="">This JEP addresses the following requirements for data representation:</p>
+  <ol start="" type="">
+    <li>Specify how to represent profile data in an XMPP-friendly manner for communication over the wire.</li>
+    <li>Ensure that the protocol is extensible (e.g., not limited to existing vCard fields).  
+         [<a href="#nt-id2256487">11</a>]
+    </li> 
+    <li>Where possible, map profile data fields to existing vCard fields and other common formats.</li>
+  </ol>
+<h2>3.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="approach-management">Data Management</a>
+</h3>
+    <p class="" style="">There are several possible approaches to representing profile data for communication over XMPP networks, including the following:</p>
+    <ol start="" type="">
+      <li>
+        <p class="" style=""><span style="font-weight: bold">IQ (request-and-response) semantics.</span></p>
+        <p class="" style="">In the simplest case, an entity may store its own profile data and provide only the complete profile and only on request, using the request-response semantics of the XMPP &lt;iq/&gt; stanza type. This model is most appropriate for stable entities that are always online and whose profile data does not change frequently, such as servers and server-side components (entities that are not always online or that frequently modify their profile data, such as IM users, may prefer to publish their information to entities that are always online, such as an IM user's server). While it may seem desirable to embed profile data in the responses an entity provides to service discovery information requests using <span class="ref" style="">Service Discovery Extensions</span>  [<a href="#nt-id2256613">12</a>], it is likely that profile data will be quite extensive; therefore, we define a standalone "wrapper" element for profile data, qualified by the 'http://jabber.org/protocol/profile' namespace.</p>
+      </li>
+      <li>
+        <p class="" style=""><span style="font-weight: bold">Pubsub (publish-and-subscribe) semantics.</span></p>
+        <p class="" style="">A more complex model is for an entity to publish its profile data to a publish-subscribe node or nodes and allow other entities to subscribe to that node or nodes, thus receiving notifications whenever the profiled entity updates its data. This model is more appropriate for entities that modify their profile data on a regular basis or when other entities wish to be informed when the profile data changes. Because this model will most likely be used most often by IM users and other intermittently-connected network endpoints, we use the simplified subset of the XMPP publish-subscribe extension defined in <span style="font-weight: bold">JEP-0163</span> to implement this model.</p>
+      </li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="approach-representation">Data Representation</a>
+</h3>
+    <p class="" style="">As with data management, there are several possible approaches to representing profile data for communication over XMPP networks, including the following:</p>
+    <ul>
+      <li>
+        <p class="" style=""><span style="font-weight: bold">Structured data formats, such as <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2256739">13</a>] and <span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2256698">14</a>].</span></p>
+        <p class="" style="">Such data formats have the advantage of being human-readable. However:</p>
+        <ol start="" type="">
+          <li>They are not easily extensible: developers of specialized community services would need to write their own structured data formats, even to add one new field.</li>
+          <li>They are not easy to map to backend data storage facilities (e.g., database administrators generally would prefer to have generic database schemas and re-usable code for parsing the XML wire protocol into the database fields).</li>
+          <li>They would require specialized interface handlers for each data structure, rather than a generic interface handler.</li>
+        </ol>
+      </li>
+      <li>
+        <p class="" style=""><span style="font-weight: bold">A format represented by means of <span class="ref" style="">Resource Description Framework</span>  [<a href="#nt-id2256790">15</a>].</span></p>
+        <p class="" style="">An argument could be made that RDF is a reasonable approach for representing profile data for communication over the XMPP network; however, such an argument will not be made in the current proposal. The author has considered RDF and has concluded that there are several reasons why RDF is undesirable as an XMPP wire protocol:</p>
+        <ol start="" type="">
+          <li>RDF exists in an XML representation but the semantics of RDF impose a more complex conceptual structure (data triples) than does XML, which is sub-optimal since unnecessary complexity is to be avoided (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2256838">16</a>]).</li>
+          <li>RDF requires a specialized parser rather than the normal XML parser that comes standard with all XMPP implementations.</li>
+          <li>As long as it is possible to define a consistent mapping of profile data to RDF representations, it should be straightforward to convert the XMPP data formats into those RDF representations if desired (e.g., to output a FOAF file).</li>
+        </ol>
+      </li>
+      <li>
+        <p class="" style=""><span style="font-weight: bold">A format represented by means of <span class="ref" style="">Infobits</span>  [<a href="#nt-id2256881">17</a>].</span></p>
+        <p class="" style="">The infobits approach to representing profile data was deprecated in early 2004 because it provides few advantages over an approach based on Data Forms.</p>
+      </li>
+      <li>
+        <p class="" style=""><span style="font-weight: bold">A format represented by means of Data Forms (JEP-0004).</span></p>
+        <p class="" style="">The Data Forms protocol defined in JEP-0004 has several advantages for use over XMPP:</p>
+        <ol start="" type="">
+          <li>It can be parsed using an off-the-shelf XML parser.</li>
+          <li>It is already widely deployed in existing Jabber/XMPP clients, servers, and components.</li>
+          <li>The data forms protocol is easily extensible.</li>
+          <li>The Jabber/XMPP community possesses consistent methods for profiling and scoping data forms (as specified in JEP-0068).</li>
+          <li>Data forms have a generic schema that is easy to map to common data storage mechanisms (usually databases).</li>
+          <li>Data forms provide a consistent abstraction layer for XMPP applications, thus shielding them from changes in the profile data formats being defined by other Internet projects and standards development organizations.</li>
+          <li>The use of data forms as the medium of representation for communication over the wire does not prevent applications from storing backend profile data in some other underlying format (e.g., RDF or a database).</li> 
+        </ol>
+      </li>
+    </ul>
+    <p class="" style="">Therefore, this proposal specifies that profile data shall be scoped by a FORM_TYPE of 'http://jabber.org/protocol/profile', in accordance with the field standardization methods defined in JEP-0068. For the sake of interoperability, profile data fields that will be in common use SHOULD be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256996">18</a>] (although they may or may not be defined in a Jabber Enhancement Proposal). Profile data fields that are intended to be used only within the context of a specialized application MAY remain unregistered, but unregistered fields MUST begin with the string "x-" in accordance with Section 3.4 of JEP-0068.  [<a href="#nt-id2256982">19</a>]</p>
+    <p class="" style="">The following is a simple and incomplete example of profile data represented via the Data Forms protocol, containing two registered data fields and one unregistered field:</p>
+    <p class="caption">Example 1. A Basic Example</p>
+<div class="indent"><pre>
+&lt;x xmlns='jabber:x:data' type='result'&gt;
+  &lt;field var='FORM_TYPE' type='hidden'&gt;
+    &lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='common_name'&gt;
+    &lt;value&gt;Peter Saint-Andre&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='nickname'&gt;
+    &lt;value&gt;stpeter&lt;/value&gt;
+  &lt;/field&gt;
+  &lt;field var='x-favorite_painters'&gt;
+    &lt;value&gt;Joaquin Sorolla&lt;/value&gt;
+    &lt;value&gt;Jan Vermeer&lt;/value&gt;
+  &lt;/field&gt;
+&lt;/x&gt;
+    </pre></div>
+      <p class="" style="">By specifying that all fields are scoped by a FORM_TYPE of 'http://jabber.org/protocol/profile', this proposal does not mean to imply that all profile data will or should be gathered in one data form. In reality, most such data will probably be gathered at the time of registration either at a website or via a "wizard" interface that breaks the process into smaller bundles (such as "Basic Personal Data", "Physical Location", "Internet Addresses", "Hobbies and Interests", and "Favorite Things"). The use of one FORM_TYPE is simply meant to scope the data fields so that each field is unique within the context of profile data. Any form that uses these fields along with a FORM_TYPE of 'http://jabber.org/protocol/profile' is of the "profile type" (i.e., is a specific instance of that type), which does not limit the number of forms that can be of that type.</p>
+      <p class="" style="">However, scoping all data fields with a single FORM_TYPE implies it is necessary to define separate data fields for similar kinds of information. For example, the vCard specification (<span style="font-weight: bold">RFC 2426</span>) defines "types" for certains kinds of data, such as email addresses, telephone numbers, and physical addresses, making it possible to specify that a telephone number corresponds to a fax machine or mobile phone or that a physical address corresponds to one's home or work location. In the Data Forms representation, any desired piece of information (e.g., work phone) must be represented with a separate data field.</p>
+      <p class="" style="">In order to address most (if not all) of the pieces of information described in existing profile specifications, this JEP defines a great number of data fields. Even so, the data fields specified herein are not exhaustive, and it is expected that additional fields will be registered in the future through the mechanisms specified in the <a href="#registrar">Jabber Registrar Considerations</a> section of this JEP.</p>
+  </div>
+<h2>4.
+       <a name="producer">Producer Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="producer-full">Publishing a Full Profile</a>
+</h3>
+    <p class="" style="">In order to publish a full profile, an entity sends an IQ-set to its server with a child element of &lt;profile/&gt; containing the full profile information.</p>
+    <p class="caption">Example 2. Entity publishes full profile</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='setfull'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='nickname'&gt;
+        &lt;value&gt;Hamlet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='country'&gt;
+        &lt;value&gt;DK&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='locality'&gt;
+        &lt;value&gt;Elsinore&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;hamlet@denmark.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/profile&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can succesfully process the request and host the full profile, it MUST return an IQ-result:</p>
+    <p class="caption">Example 3. Server acknowledges success</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='hamlet@denmark.lit/elsinore' id='setfull'/&gt;
+    </pre></div>
+    <p class="" style="">Otherwise it MUST return an error. If the server does not support the profile data functionality, the error MUST be &lt;service-unavailable/&gt;.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="producer-pub">Updating One or More Profile Fields</a>
+</h3>
+    <p class="" style="">In order to update selected fields in a public profile, an entity SHOULD first create a pubsub node of "http://jabber.org/protocol/profile" using the Simplified Personal Publish-Subscribe subset of the publish-subscribe extension, as specified in <span style="font-weight: bold">JEP-0163</span>. The access model for the node SHOULD be "presence" but MAY be "roster".  [<a href="#nt-id2257186">20</a>]</p>
+    <p class="caption">Example 4. Account owner creates profile data node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/profile'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Once the node has been created, the entity may publish updated fields to that node:</p>
+    <p class="caption">Example 5. Account owner publishes profile field(s)</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/profile'&gt;
+      &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+        &lt;x xmlns='jabber:x:data' type='result'&gt;
+          &lt;field var='weblog'&gt;
+            &lt;value&gt;http://www.denmark.lit/blogs/princely_musings&lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/profile&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The SPPS service then MUST send notifications containing the updated field(s) to the node subscribers:</p>
+    <p class="caption">Example 6. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message to='francisco@denmark.lit' from='hamlet@denmark.lit/elsinore' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/profile'&gt;
+      &lt;item&gt;
+        &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+          &lt;x xmlns='jabber:x:data' type='result'&gt;
+            &lt;field var='weblog'&gt;
+              &lt;value&gt;http://www.denmark.lit/blogs/princely_musings&lt;/value&gt;
+            &lt;/field&gt;
+          &lt;/x&gt;
+        &lt;/profile&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If the field(s) published are "public", the publisher SHOULD then repost the full profile as described above in order to keep the full profile in sync.</p>
+    <p class="" style="">Note: The account owner MAY decide to effectively maintain two profile subsets: public profile fields (posted via the "full profile" protocol) and restricted profile fields (published only via SPPS). If so, the client MUST keep track of which fields are in the public profile subset and which fields are in the restricted profile subset, and MUST NOT update the full profile if the account owner has updated a field in the restricted profile set.</p>
+  </div>
+<h2>5.
+       <a name="consumer">Consumer Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="consumer-disco">Discovering Support</a>
+</h3>
+    <p class="" style="">If an entity can provide profile data directly using the standalone 'http://jabber.org/protocol/profile' namespace, it SHOULD advertise that feature in response to <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257322">21</a>] information requests:</p>
+    <p class="caption">Example 7. A request for service discovery information</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bard@shakespeare.lit/globe'
+    to='hamlet@denmark.lit'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. A service discovery information response</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='hamlet@denmark.lit'
+    to='bard@shakespeare.lit/globe'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='account' type='registered'/&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/profile'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: Because the foregoing request was sent to the bare JID &lt;hamlet@denmark.lit&gt;, the response is provided by the &lt;denmark.lit&gt; server on behalf of the registered account. The answer indicates that the server can also provide profile data on behalf of the registered account.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="consumer-full">Requesting Full Profile</a>
+</h3>
+    <p class="" style="">In order to request the full profile, the requesting entity sends an IQ-get to the providing entity's JID, where the request contains an empty &lt;profile/&gt; element qualified by the 'http://jabber.org/protocol/profile' namespace. In this example, the request is sent to a server:</p>
+    <p class="caption">Example 9. A request for profile data</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='hamlet@denmark.lit/elsinore'
+    to='shakespeare.lit'
+    id='iq1'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The server then replies:</p>
+    <p class="caption">Example 10. A basic profile data response</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='shakespeare.lit'
+    to='hamlet@denmark.lit/elsinore'
+    id='iq1'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='common_name'&gt;
+        &lt;value&gt;shakespeare.lit IM server&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='country'&gt;
+        &lt;value&gt;UK&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='region'&gt;
+        &lt;value&gt;England&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='locality'&gt;
+        &lt;value&gt;London&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='area'&gt;
+        &lt;value&gt;Bankside&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='street'&gt;
+        &lt;value&gt;21 New Globe Walk&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='postalcode'&gt;
+        &lt;value&gt;SE1 9DT&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lat'&gt;
+        &lt;value&gt;51.5076&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='lon'&gt;
+        &lt;value&gt;-0.0953&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='landline_phone'&gt;
+        &lt;value&gt;+44 20 7902 1400&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='fax'&gt;
+        &lt;value&gt;+44 20 7902 1401&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='building'&gt;
+        &lt;value&gt;Globe Theatre&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;admin@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/profile&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If a server supports stored profile data for user accounts that it hosts, a requesting entity can request the full profile for such an account:</p>
+    <p class="caption">Example 11. A request for hosted profile data</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bard@shakespeare.lit/globe'
+    to='hamlet@denmark.lit'
+    id='iq2'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requesting entity is not allowed to retrieve hosted profiles (e.g., because it is not on a whitelist of entities permitted to "spider" the server's users), the server SHOULD return a &lt;service-unavailable/&gt; error:</p>
+    <p class="caption">Example 12. Server returns service unavailable error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='hamlet@denmark.lit'
+    to='bard@shakespeare.lit/globe'
+    id='iq2'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'/&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the requested account does not exist or has not published profile data, the server also SHOULD return a &lt;service-unavailable/&gt; error.</p>
+    <p class="" style="">Otherwise, the server SHOULD return the profile for the hosted account.</p>
+    <p class="caption">Example 13. Server returns profile data</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='hamlet@denmark.lit'
+    to='bard@shakespeare.lit/globe'
+    id='iq2'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='nickname'&gt;
+        &lt;value&gt;Hamlet&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='country'&gt;
+        &lt;value&gt;DK&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='locality'&gt;
+        &lt;value&gt;Elsinore&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='email'&gt;
+        &lt;value&gt;hamlet@denmark.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='weblog'&gt;
+        &lt;value&gt;http://www.denmark.lit/blogs/princely_musings&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/profile&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="consumer-sub">Receiving Profile Updates</a>
+</h3>
+    <p class="" style="">In order to receive updated fields for a contact's profile, an entity shall send a pubsub subscription request to the contact's bare JID (&lt;node@domain.tld&gt;) and specify a node of "http://jabber.org/protocol/profile":</p>
+    <p class="caption">Example 14. Entity subscribes to profile node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='francisco@denmark.lit/barracks'
+    to='hamlet@denmark.lit'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/profile' jid='francisco@denmark.lit'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server allows the subscription, it MUST return an IQ-result (see <span style="font-weight: bold">JEP-0163</span> for error scenarios):</p>
+    <p class="caption">Example 15. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='hamlet@denmark.lit'
+    to='francisco@denmark.lit/barracks'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">When the contact sends updated fields to the profile node, the entity will receive notifications:</p>
+    <p class="caption">Example 16. Entity receives notification</p>
+<div class="indent"><pre>
+&lt;message to='francisco@denmark.lit' from='hamlet@denmark.lit/elsinore' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/profile'&gt;
+      &lt;item&gt;
+        &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+          &lt;x xmlns='jabber:x:data' type='result'&gt;
+            &lt;field var='weblog'&gt;
+              &lt;value&gt;http://www.denmark.lit/blogs/princely_musings&lt;/value&gt;
+            &lt;/field&gt;
+          &lt;/x&gt;
+        &lt;/profile&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">It is the responsibility of the receiving entity to correctly process the notification and update the contact's profile information accordingly.</p>
+  </div>
+<h2>6.
+       <a name="fields">Data Representation</a>
+</h2>
+  <p class="" style="">The following subsections specify common fields for defining various aspects of a person, which shall form the initial submission to the Jabber Registrar; many of these fields map to elements specified in vCard, LDAP (see <span class="ref" style="">RFC 2252</span>  [<a href="#nt-id2257774">22</a>], <span class="ref" style="">RFC 2256</span>  [<a href="#nt-id2257787">23</a>], and <span class="ref" style="">RFC 2798</span>  [<a href="#nt-id2257809">24</a>]), xNAL, FOAF, and other existing specifications.</p>
+  <div class="indent">
+<h3>6.1 <a name="fields-name">Name Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard, xNAL, and FOAF.</p>
+    <div class="indent">
+<h3>6.1.1 <a name="display_name">Display Name</a>
+</h3>
+      <p class="" style="">A display name is a version of a person's name intended for display in a user interface. Sometimes also called a "full name" or "formatted name".</p>
+      <p class="" style="">The Data Forms field that represents a display name is "display_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard FN</li>
+        <li>LDAP displayName</li>
+        <li>FOAF name</li>
+      </ul>
+      <p class="caption">Example 17. Display Name</p>
+<div class="indent"><pre>
+&lt;field var='display_name'&gt;
+  &lt;value&gt;Peter Saint-Andre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.2 <a name="familiar_name">Familiar Name</a>
+</h3>
+      <p class="" style="">A familiar name is a shortened or modified form of someone's given name that may be used in somewhat informal contexts or that is preferred by the person (e.g., "Chuck" instead of "Charles").</p>
+      <p class="" style="">The Data Forms field that represents a familiar name is "familiar_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP nickname</li>
+      </ul>
+      <p class="caption">Example 18. Familiar Name</p>
+<div class="indent"><pre>
+&lt;field var='familiar_name'&gt;
+  &lt;value&gt;Pete&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.3 <a name="family_name">Family Name</a>
+</h3>
+      <p class="" style="">A family name is that part of a person's name which signifies the person's primary family association. Sometimes also called a "last name" or "surname".</p>
+      <p class="" style="">The Data Forms field that represents a family name is "family_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard FAMILY</li>
+        <li>LDAP sn</li>
+        <li>xNAL LastName</li>
+        <li>FOAF family_name</li>
+        <li>FOAF surname</li>
+      </ul>
+      <p class="caption">Example 19. Family Name</p>
+<div class="indent"><pre>
+&lt;field var='family_name'&gt;
+  &lt;value&gt;Saint-Andre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.4 <a name="given_name">Given Name</a>
+</h3>
+      <p class="" style="">A given name is that part of a person's name which signifies the person's primary individual identity. Sometimes also called a "first name" or (in some countries) a "Christian name".</p>
+      <p class="" style="">The Data Forms field that represents a given name is "given_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard GIVEN</li>
+        <li>LDAP givenName</li>
+        <li>xNAL FirstName</li>
+        <li>FOAF first_name</li>
+        <li>FOAF givenname</li>
+      </ul>
+      <p class="caption">Example 20. Given Name</p>
+<div class="indent"><pre>
+&lt;field var='given_name'&gt;
+  &lt;value&gt;J.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.5 <a name="middle_name">Middle Name</a>
+</h3>
+      <p class="" style="">A middle name is that part of a person's name which signifies the person's secondary individual identity. Sometimes also called a "middle initial".</p>
+      <p class="" style="">The Data Forms field that represents a middle name is "middle_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard MIDDLE</li>
+        <li>xNAL MiddleName</li>
+      </ul>
+      <p class="caption">Example 21. Middle Name</p>
+<div class="indent"><pre>
+&lt;field var='middle_name'&gt;
+  &lt;value&gt;Peter&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.6 <a name="name_prefix">Name Prefix</a>
+</h3>
+      <p class="" style="">A name prefix is that part of a person's name which prepends the person's full name (e.g., Mr or Dr). Sometimes also called an "honorific" or "title".</p>
+      <p class="" style="">The Data Forms field that represents a name prefix is "name_prefix".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PREFIX</li>
+        <li>xNAL Title</li>
+        <li>FOAF title</li>
+      </ul>
+      <p class="caption">Example 22. Name Prefix</p>
+<div class="indent"><pre>
+&lt;field var='name_prefix'&gt;
+  &lt;value&gt;Mr&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.7 <a name="name_suffix">Name Suffix</a>
+</h3>
+      <p class="" style="">A name suffix is that part of a person's name which is appended to the person's full name (e.g., Jr or Esq).</p>
+      <p class="" style="">The Data Forms field that represents a name suffix is "name_suffix".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard SUFFIX</li>
+        <li>xNAL GeneralSuffix</li>
+      </ul>
+      <p class="caption">Example 23. Name Suffix</p>
+<div class="indent"><pre>
+&lt;field var='name_suffix'&gt;
+  &lt;value&gt;Esq&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.8 <a name="nickname">Nickname</a>
+</h3>
+      <p class="" style="">A nickname is a global, memorable (but not unique) friendly or informal name chosen by the owner of a JID. The purpose of a nickname is to associate a distinctive mapping between the person's unique JID and non-unique nickname. A nickname is normally used in informal contexts (e.g., in chatrooms). Sometimes also called an "alias". A person SHOULD specify only one nickname (i.e., not more than one).</p>
+      <p class="" style="">The Data Forms field that represents a nickname is "nickname".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard NICKNAME</li>
+        <li>xNAL Alias</li>
+        <li>FOAF nick</li>
+      </ul>
+      <p class="caption">Example 24. Nickname</p>
+<div class="indent"><pre>
+&lt;field var='nickname'&gt;
+  &lt;value&gt;stpeter&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.1.9 <a name="patronymic">Patronymic</a>
+</h3>
+      <p class="" style="">In some cultures, one's name includes a part that is derived from the given name of one's father; this part of one's name is called a "patronymic".</p>
+      <p class="" style="">The Data Forms field that represents a patronymic is "patronymic".</p>
+      <p class="caption">Example 25. A Patronymic</p>
+<div class="indent"><pre>
+&lt;field var='patronymic'&gt;
+  &lt;value&gt;Ivanovich&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="fields-physicaladdress">Physical Address Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard, xNAL, and JEP-0112 (<span class="ref" style="">User Physical Location</span>  [<a href="#nt-id2258343">25</a>]).</p>
+    <div class="indent">
+<h3>6.2.1 <a name="country">Country</a>
+</h3>
+      <p class="" style="">A country is the sovereign nation in which a person is located. Sometimes also called a "nation".</p>
+      <p class="" style="">The Data Forms fields that represent a country are "country", "home_country", and "work_country" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard COUNTRY (or JEP-0054 CTRY), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP c</li>
+        <li>xNAL CountryName</li>
+        <li>JEP-0112 country</li>
+      </ul>
+      <p class="caption">Example 26. Country</p>
+<div class="indent"><pre>
+&lt;field var='country'&gt;
+  &lt;value&gt;USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.2 <a name="region">Region</a>
+</h3>
+      <p class="" style="">A region is a second-level administrative unit within the nation in which a person is located. Sometimes also called a "province", "state", or "administrative area".</p>
+      <p class="" style="">The Data Forms field that represents a region is "region".</p>
+      <p class="" style="">The Data Forms fields that represent a region are "home_region" and "work_region" for home addresses and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard REGION, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP st</li>
+        <li>xNAL AdministrativeAreaName</li>
+        <li>JEP-0112 region</li>
+      </ul>
+      <p class="caption">Example 27. Region</p>
+<div class="indent"><pre>
+&lt;field var='region'&gt;
+  &lt;value&gt;New York&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.3 <a name="locality">Locality</a>
+</h3>
+      <p class="" style="">A locality is a defined place within the region in which a person is located. Sometimes also called a "city", "town", or "village".</p>
+      <p class="" style="">The Data Forms fields that represent a locality are "locality", "home_locality", and "work_locality" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LOCALITY, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP l</li>
+        <li>xNAL LocalityName</li>
+        <li>JEP-0112 locality</li>
+      </ul>
+      <p class="caption">Example 28. Locality</p>
+<div class="indent"><pre>
+&lt;field var='locality'&gt;
+  &lt;value&gt;New York City&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.4 <a name="area">Area</a>
+</h3>
+      <p class="" style="">An area is a sub-division within the locality in which a person is located. Sometimes also called a "neighborhood", "suburb", "district", or "section".</p>
+      <p class="" style="">The Data Forms fields that represent a area are "area", "home_area", and "work_area" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>xNAL DependentLocalityName</li>
+        <li>JEP-0112 area</li>
+      </ul>
+      <p class="caption">Example 29. Area</p>
+<div class="indent"><pre>
+&lt;field var='area'&gt;
+  &lt;value&gt;Manhattan&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.5 <a name="street">Street</a>
+</h3>
+      <p class="" style="">A street is the street address (number plus street name, or two street names at an intersection) at which a person is located, or a postal box number for physical mail delivery. Sometimes also called a "street address".</p>
+      <p class="" style="">The Data Forms fields that represent a street are "street", "home_street", and "work_street" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard STREET, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP street</li>
+        <li>xNAL ThoroughfareNumber + ThoroughfareName</li>
+        <li>JEP-0112 street</li>
+      </ul>
+      <p class="caption">Example 30. Street</p>
+<div class="indent"><pre>
+&lt;field var='street'&gt;
+  &lt;value&gt;Fifth Avenue and 34th Street&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.6 <a name="building">Building</a>
+</h3>
+      <p class="" style="">A building is the name for a specific structure on a street or within an area.</p>
+      <p class="" style="">The Data Forms fields that represent a building are "building", "home_building", and "work_building" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL BuildingName</li>
+        <li>JEP-0112 building</li>
+      </ul>
+      <p class="caption">Example 31. Building</p>
+<div class="indent"><pre>
+&lt;field var='building'&gt;
+  &lt;value&gt;Empire State Building&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.7 <a name="floor">Floor</a>
+</h3>
+      <p class="" style="">A floor is a named or numbered floor or level within a building. Sometimes also called a "level", "block", or "suite".</p>
+      <p class="" style="">The Data Forms fields that represent a floor are "floor", "home_floor", and "work_floor" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>xNAL SubPremiseNumber</li>
+        <li>JEP-0112 floor</li>
+      </ul>
+      <p class="caption">Example 32. Floor</p>
+<div class="indent"><pre>
+&lt;field var='floor'&gt;
+  &lt;value&gt;102&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.8 <a name="room">Room</a>
+</h3>
+      <p class="" style="">A room is a named or numbered subdivision of a floor. Sometimes also called a "unit" or "apartment".</p>
+      <p class="" style="">The Data Forms fields that represent a room are "room", "home_room", and "work_room" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EXTADR, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP roomNumber</li>
+        <li>xNAL SubPremiseNumber</li>
+        <li>JEP-0112 room</li>
+      </ul>
+      <p class="caption">Example 33. Room</p>
+<div class="indent"><pre>
+&lt;field var='room'&gt;
+  &lt;value&gt;Observatory&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.9 <a name="postalbox">Postal Box</a>
+</h3>
+      <p class="" style="">A postal box is a set of numeric or alphanumeric characters used to identify a mailbox at a postal delivery center.</p>
+      <p class="" style="">The Data Forms fields that represent a postal box are "postalbox", "home_postalbox", and "work_postalbox" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard POBOX, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP postOfficeBox</li>
+      </ul>
+      <p class="caption">Example 34. Postal Box</p>
+<div class="indent"><pre>
+&lt;field var='postalbox'&gt;
+  &lt;value&gt;1641&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.10 <a name="postalcode">Postal Code</a>
+</h3>
+      <p class="" style="">A postal code is a set of numeric or alphanumeric characters used to identify an area for postal delivery. Sometimes also called a "ZIP code" (in the U.S.).</p>
+      <p class="" style="">The Data Forms fields that represent a postal code are "postalcode", "home_postalcode", and "work_postalcode" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PCODE, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP postalCode</li>
+        <li>xNAL PostalCodeNumber</li>
+        <li>JEP-0112 postalcode</li>
+      </ul>
+      <p class="caption">Example 35. Postal Code</p>
+<div class="indent"><pre>
+&lt;field var='postalcode'&gt;
+  &lt;value&gt;10002&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.2.11 <a name="postaladdress">Postal Address</a>
+</h3>
+      <p class="" style="">A postal address is a free-form mailing address, which may be easier to enter (or, in some cultural contexts, more appropriate) than the atomic address parts such as street, floor, etc.</p>
+      <p class="" style="">The Data Forms fields that represent a postal address are "postaladdress", "home_postaladdress", and "work_postaladdress" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP postalAddress, homePostalAddress</li>
+      </ul>
+      <p class="caption">Example 36. Postal Address</p>
+<div class="indent"><pre>
+&lt;field var='work_postaladdress'&gt;
+  &lt;value&gt;1899 Wynkoop Street&lt;/value&gt;
+  &lt;value&gt;Suite 600&lt;/value&gt;
+  &lt;value&gt;Denver, CO 80202&lt;/value&gt;
+  &lt;value&gt;USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="fields-geoloc">Geolocation Data Aspects</a>
+</h3>
+    <p class="" style="">Mappings are provided to vCard and JEP-0080 (<span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2259040">26</a>]).</p>
+    <div class="indent">
+<h3>6.3.1 <a name="alt">Altitude</a>
+</h3>
+      <p class="" style="">Altitude is a person's height or depth in relationship to sea level, where positive altitude is meters above sea level and negative altitude is meters below sea level.</p>
+      <p class="" style="">The Data Forms field that represents altitude is "alt".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>JEP-0080 alt</li>
+      </ul>
+      <p class="caption">Example 37. Altitude</p>
+<div class="indent"><pre>
+&lt;field var='alt'&gt;
+  &lt;value&gt;1609&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.2 <a name="lat">Latitude</a>
+</h3>
+      <p class="" style="">Latitude is a person's latitude in relation to the equator, where positive latitude is north of the equator and negative latitude is south of the equator.</p>
+      <p class="" style="">The Data Forms field that represents latitude is "lat".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LAT</li>
+        <li>JEP-0080 lat</li>
+      </ul>
+      <p class="caption">Example 38. Latitude</p>
+<div class="indent"><pre>
+&lt;field var='lat'&gt;
+  &lt;value&gt;39.75477&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.3.3 <a name="lat">Longitude</a>
+</h3>
+      <p class="" style="">Longitude is a person's longitude in relation to the equator, where positive longitude is east of the meridian and negative longitude is west of the equator.</p>
+      <p class="" style="">The Data Forms field that represents longitude is "lon".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard LON</li>
+        <li>JEP-0080 lon</li>
+      </ul>
+      <p class="caption">Example 39. Latitude</p>
+<div class="indent"><pre>
+&lt;field var='lon'&gt;
+  &lt;value&gt;-104.99768&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="fields-tel">Telephony Address Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>6.4.1 <a name="fax">Fax Number</a>
+</h3>
+      <p class="" style="">A fax number is a number for a machine that handles fascimile transmissions.</p>
+      <p class="" style="">The Data Forms fields that represent a fax number are "fax", "home_fax", and "work_fax" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "FAX" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP facsimileTelephoneNumber</li>
+      </ul>
+      <p class="caption">Example 40. Fax Number</p>
+<div class="indent"><pre>
+&lt;field var='fax'&gt;
+  &lt;value&gt;303-308-3215&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.4.2 <a name="landline">Landline Telephone Number</a>
+</h3>
+      <p class="" style="">A landline telephone number is a number for a traditional "PSTN" or "POTS" telephone.</p>
+      <p class="" style="">The Data Forms fields that represent a landline telephone number are "landline", "home_landline", and "work_landline" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL, optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP telephoneNumber</li>
+        <li>FOAF phone</li>
+      </ul>
+      <p class="caption">Example 41. Landline Telephone Number</p>
+<div class="indent"><pre>
+&lt;field var='landline_phone'&gt;
+  &lt;value&gt;303-308-3282&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.4.3 <a name="mobile">Mobile Telephone Number</a>
+</h3>
+      <p class="" style="">A mobile telephone number is a number for a mobile phone or cell phone on a wireless network.</p>
+      <p class="" style="">The Data Forms fields that represent a mobile telephone number are "mobile", "home_mobile", and "work_mobile" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "CELL" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP mobile</li>
+        <li>FOAF phone</li>
+      </ul>
+      <p class="caption">Example 42. Mobile Telephone Number</p>
+<div class="indent"><pre>
+&lt;field var='mobile_phone'&gt;
+  &lt;value&gt;303-555-1212&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.4.4 <a name="pager">Pager Number</a>
+</h3>
+      <p class="" style="">A pager number is a number for a dedicated alphanumeric paging device.</p>
+      <p class="" style="">The Data Forms fields that represent a pager number are "pager", "home_pager", and "work_pager" for generic addresses, home addresses, and work addresses respectively.</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TEL (+ "PAGER" modifier), optionally supplemented with the "HOME" or "WORK" type</li>
+        <li>LDAP pager</li>
+      </ul>
+      <p class="caption">Example 43. Pager Number</p>
+<div class="indent"><pre>
+&lt;field var='pager'&gt;
+  &lt;value&gt;303-555-1212&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.4.5 <a name="sip_address">SIP Address</a>
+</h3>
+      <p class="" style="">A SIP address is a sip: or sips: URI at which a person can be contacted for Voice over Internet Protocol (VoIP) communications.</p>
+      <p class="" style="">The Data Forms field that represents a SIP address is "sip_address".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 44. SIP Address</p>
+<div class="indent"><pre>
+&lt;field var='sip_address'&gt;
+  &lt;value&gt;sip:stpeter@sipspeare.lit&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.4.6 <a name="skype_address">Skype Address</a>
+</h3>
+      <p class="" style="">A Skype address is an address on the popular Skype system for Voice over Internet Protocol (VoIP) communications.</p>
+      <p class="" style="">The Data Forms field that represents a Skype address is "skype_address".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 45. Skype Address</p>
+<div class="indent"><pre>
+&lt;field var='skype_address'&gt;
+  &lt;value&gt;SomeSkypeUser&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.4.7 <a name="video_phone">Videophone Address</a>
+</h3>
+      <p class="" style="">A videophone address is an address used for for H.323 video conferencing systems.</p>
+      <p class="" style="">The Data Forms field that represents a videophone address is "video_phone".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 46. Videophone Address</p>
+<div class="indent"><pre>
+&lt;field var='video_phone'&gt;
+  &lt;value&gt;foo&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="fields-net">Electronic Address Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>6.5.1 <a name="aim_id">AIM Screen Name</a>
+</h3>
+      <p class="" style="">An AIM screen name is an address at which a person or other entity can be contacted on the AOL Instant Messenger service.</p>
+      <p class="" style="">The Data Forms field that represents an AIM screen name is "aim_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF aimChatID</li>
+      </ul>
+      <p class="caption">Example 47. AIM Screen Name</p>
+<div class="indent"><pre>
+&lt;field var='aim_id'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.5.2 <a name="email">Email Address</a>
+</h3>
+      <p class="" style="">An email address is the value of a mailto: URI at which a person or other entity can be contacted using standard electronic mail protocols.</p>
+      <p class="" style="">The Data Forms field that represents longitude is "email".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard EMAIL</li>
+        <li>LDAP mail</li>
+      </ul>
+      <p class="caption">Example 48. Email address</p>
+<div class="indent"><pre>
+&lt;field var='email'&gt;
+  &lt;value&gt;stpeter@jabber.org&lt;/value&gt;
+  &lt;value&gt;stpeter@gmail.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.5.3 <a name="icq_id">ICQ Number</a>
+</h3>
+      <p class="" style="">An ICQ number is an address at which a person or other entity can be contacted on the ICQ instant messaging service.</p>
+      <p class="" style="">The Data Forms field that represents an ICQ number is "icq_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF icqChatID</li>
+      </ul>
+      <p class="caption">Example 49. ICQ number</p>
+<div class="indent"><pre>
+&lt;field var='icq_id'&gt;
+  &lt;value&gt;70902454&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.5.4 <a name="jid">Jabber ID</a>
+</h3>
+      <p class="" style="">A Jabber ID is the value of an xmpp: URI at which a person or other entity can be contacted over a Jabber/XMPP network.</p>
+      <p class="" style="">The Data Forms field that represents a Jabber ID is "jid".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF jabberID</li>
+      </ul>
+      <p class="caption">Example 50. Jabber ID</p>
+<div class="indent"><pre>
+&lt;field var='jid'&gt;
+  &lt;value&gt;stpeter@jabber.org&lt;/value&gt;
+  &lt;value&gt;peter@saint-andre.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.5.5 <a name="msn_id">MSN Address</a>
+</h3>
+      <p class="" style="">An MSN address is address at which a person or other entity can be contacted on the MSN instant messaging service.</p>
+      <p class="" style="">The Data Forms field that represents an MSN address is "msn_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF msnChatID</li>
+      </ul>
+      <p class="caption">Example 51. MSN Address</p>
+<div class="indent"><pre>
+&lt;field var='msn_id'&gt;
+  &lt;value&gt;petersaintandre@hotmail.com&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.5.6 <a name="yahoo_id">Yahoo ID</a>
+</h3>
+      <p class="" style="">A Yahoo ID is address at which a person or other entity can be contacted on the Yahoo! Instant Messenger service.</p>
+      <p class="" style="">The Data Forms field that represents a Yahoo ID is "yahoo_id".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF yahooChatID</li>
+      </ul>
+      <p class="caption">Example 52. Yahoo ID</p>
+<div class="indent"><pre>
+&lt;field var='yahoo_id'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="fields-www">World Wide Web Resource Aspects</a>
+</h3>
+    <div class="indent">
+<h3>6.6.1 <a name="avatar_url">Avatar URL</a>
+</h3>
+      <p class="" style="">An avatar is an often fanciful representation of a user's desired self-image or persona (e.g., in the context of a game). An avatar is usually not intended to be an accurate picture of the user's actual physical appearance (that is handled by the photo_url and photo_data fields).</p>
+      <p class="" style="">An avatar can come in two forms: the avatar data itself, or a URL for a avatar.</p>
+      <p class="" style="">The Data Forms field that represents the URL for an avatar is "avatar_url".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 53. Avatar URL</p>
+<div class="indent"><pre>
+&lt;field var='avatar_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_small.jpg&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.2 <a name="bio">Biographical URL</a>
+</h3>
+      <p class="" style="">A biographical URL is the value of an http: URI at which can be found biographical information about a person.</p>
+      <p class="" style="">The Data Forms field that represents a biographical URL is "bio".</p>
+      <p class="caption">Example 54. Biographical URL</p>
+<div class="indent"><pre>
+&lt;field var='bio'&gt;
+  &lt;value&gt;http://www.jabber.org/people/stpeter.shtml&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/me/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.3 <a name="foaf_url">FOAF URL</a>
+</h3>
+      <p class="" style="">A FOAF URL is the value of an http: URI at which can be found a "friend of a friend" (FOAF) file about a person or entity.</p>
+      <p class="" style="">The Data Forms field that represents a FOAF URL is "foaf_url".</p>
+      <p class="caption">Example 55. FOAF URL</p>
+<div class="indent"><pre>
+&lt;field var='foaf_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/me/foaf.rdf&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.4 <a name="homepage">Homepage URL</a>
+</h3>
+      <p class="" style="">A homepage URL is the value of an http: URI that is the default resource on the World Wide Web for a person or other entity.</p>
+      <p class="" style="">The Data Forms field that represents a homepage URL is "homepage".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP labelledURI</li>
+        <li>FOAF homepage</li>
+      </ul>
+      <p class="caption">Example 56. Homepage URL</p>
+<div class="indent"><pre>
+&lt;field var='homepage'&gt;
+  &lt;value&gt;http://www.saint-andre.com/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.5 <a name="photo_url">Photo URL</a>
+</h3>
+      <p class="" style="">A photograph provides a pictorial representation of a person. Sometimes also called a "mugshot".</p>
+      <p class="" style="">A photograph can come in two forms: the photo data itself (see below) or a URL for a photograph (e.g., the vCard PHOTO element can represent either, while the FOAF depiction and FOAF img can represent only a URL). The Data Forms field specified here identifies a URL for a photograph, not the data itself.</p>
+      <p class="" style="">The Data Forms field that represents the URL for a photograph is "photo_url".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PHOTO</li>
+        <li>FOAF depiction</li>
+        <li>FOAF img</li>
+      </ul>
+      <p class="caption">Example 57. Photo URL</p>
+<div class="indent"><pre>
+&lt;field var='photo_url'&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter.jpg&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_hell.jpg&lt;/value&gt;
+  &lt;value&gt;http://www.saint-andre.com/images/stpeter_oscon.jpg&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.6 <a name="publications">Publications URL</a>
+</h3>
+      <p class="" style="">A publications URL is the value of an http: URI at which can be found the list of a person's published writings.</p>
+      <p class="" style="">The Data Forms field that represents a publications URL is "publications".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF publications</li>
+      </ul>
+      <p class="caption">Example 58. Publications URL</p>
+<div class="indent"><pre>
+&lt;field var='publications'&gt;
+  &lt;value&gt;http://www.saint-andre.com/thoughts/publications.html&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.7 <a name="resume">Resume URL</a>
+</h3>
+      <p class="" style="">A resume URL is the value of an http: URI at which can be found a person's resume or curriculum vitae.</p>
+      <p class="" style="">The Data Forms field that represents a resume URL is "resume".</p>
+      <p class="caption">Example 59. Resume URL</p>
+<div class="indent"><pre>
+&lt;field var='resume'&gt;
+  &lt;value&gt;http://www.saint-andre.com/work/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.8 <a name="status_url">Status URL</a>
+</h3>
+      <p class="" style="">A status URL is the value of an http: URI that specifies the current status of a person or other entity (e.g., a person's online presence or a server's uptime).</p>
+      <p class="" style="">The Data Forms field that represents a homepage URL is "status_url".</p>
+      <p class="caption">Example 60. Status URL</p>
+<div class="indent"><pre>
+&lt;field var='status_url'&gt;
+  &lt;value&gt;http://status.jabber.org/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.9 <a name="org_url">Organizational URL</a>
+</h3>
+      <p class="" style="">An organizational URL is the value of an http: URI that specifies the homepage for an organization or employer.</p>
+      <p class="" style="">The Data Forms field that represents an organizational URL is "org_url".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF workplaceHomepage</li>
+      </ul>
+      <p class="caption">Example 61. Organizational URL</p>
+<div class="indent"><pre>
+&lt;field var='org_url'&gt;
+  &lt;value&gt;http://www.jabber.org/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.6.10 <a name="weblog">Weblog URL</a>
+</h3>
+      <p class="" style="">A weblog URL is the value of an http: URI at which a person or other entity maintains a weblog.</p>
+      <p class="" style="">The Data Forms field that represents a weblog URL is "weblog".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF weblog</li>
+      </ul>
+      <p class="caption">Example 62. Weblog URL</p>
+<div class="indent"><pre>
+&lt;field var='weblog'&gt;
+  &lt;value&gt;http://www.saint-andre.com/blog/&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="fields-org">Organizational Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>6.7.1 <a name="alt_contact">Alternative Contact</a>
+</h3>
+      <p class="" style="">It may be appropriate to list others who can be contacted if the individual is not available.</p>
+      <p class="caption">Example 63. Alternative Contact</p>
+<div class="indent"><pre>
+&lt;field var='alt_contact'&gt;
+  &lt;value&gt;xmpp:peter@jabber.org&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.2 <a name="assistant">Assistant</a>
+</h3>
+      <p class="" style="">In some organizations, a person may be assisted by another individual.</p>
+      <p class="" style="">The Data Forms field that represents an assistant is "assistant".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP secretary</li>
+      </ul>
+      <p class="caption">Example 64. Assistant</p>
+<div class="indent"><pre>
+&lt;field var='assistant'&gt;
+  &lt;value&gt;Peter Pan&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.3 <a name="department_name">Department Name</a>
+</h3>
+      <p class="" style="">Some organizations have departments, which can be named or numbered.</p>
+      <p class="" style="">The Data Forms field that represents a department name is "department_name".</p>
+      <p class="caption">Example 65. Department Name</p>
+<div class="indent"><pre>
+&lt;field var='department_name'&gt;
+  &lt;value&gt;Executive&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.4 <a name="department_number">Department Number</a>
+</h3>
+      <p class="" style="">Some organizations have departments, which can be named or numbered.</p>
+      <p class="" style="">The Data Forms field that represents a department number is "department_number".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP departmentNumber</li>
+      </ul>
+      <p class="caption">Example 66. Department Number</p>
+<div class="indent"><pre>
+&lt;field var='department_number'&gt;
+  &lt;value&gt;5674&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.5 <a name="employee_number">Employee Number</a>
+</h3>
+      <p class="" style="">Some organizations assign numbers to employees.</p>
+      <p class="" style="">The Data Forms field that represents an employee number is "employee_number".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP employeeNumber</li>
+      </ul>
+      <p class="caption">Example 67. Employee Number</p>
+<div class="indent"><pre>
+&lt;field var='employee_number'&gt;
+  &lt;value&gt;1&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.6 <a name="employee_number">Employee Type</a>
+</h3>
+      <p class="" style="">Some organizations have different types of employees, such as "full-time", "part-time", "contractor", and "temp".</p>
+      <p class="" style="">The Data Forms field that represents an employee type is "employee_type".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP employeeType</li>
+      </ul>
+      <p class="caption">Example 68. Employee Type</p>
+<div class="indent"><pre>
+&lt;field var='employee_type'&gt;
+  &lt;value&gt;volunteer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.7 <a name="job_title">Job Title</a>
+</h3>
+      <p class="" style="">A job title is the official name of a person's position within an organization.</p>
+      <p class="" style="">The Data Forms field that represents a job title is "job_title".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard TITLE</li>
+        <li>LDAP title</li>
+        <li>FOAF title</li>
+      </ul>
+      <p class="caption">Example 69. Job Title</p>
+<div class="indent"><pre>
+&lt;field var='job_title'&gt;
+  &lt;value&gt;Executive Director&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.8 <a name="manager">Manager</a>
+</h3>
+      <p class="" style="">In most organizations, a person is managed by or reports to another individual (often not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents a manager is "manager".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP manager</li>
+      </ul>
+      <p class="caption">Example 70. Manager</p>
+<div class="indent"><pre>
+&lt;field var='manager'&gt;
+  &lt;value&gt;William Shakespeare&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.9 <a name="org_name">Organizational Name</a>
+</h3>
+      <p class="" style="">An organizational name is the official name of an organization (company, school, etc.) within which a person works.</p>
+      <p class="" style="">The Data Forms field that represents the name of an organization is "org_name".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ORGNAME</li>
+        <li>LDAP o</li>
+      </ul>
+      <p class="caption">Example 71. Organizational Name</p>
+<div class="indent"><pre>
+&lt;field var='org_name'&gt;
+  &lt;value&gt;Jabber Software Foundation&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.10 <a name="org_role">Organizational Role</a>
+</h3>
+      <p class="" style="">An organizational role describes a person's profession or how a person contributes within an organization.</p>
+      <p class="" style="">The Data Forms field that represents an organizational role is "org_role".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ROLE</li>
+      </ul>
+      <p class="caption">Example 72. Organizational Role</p>
+<div class="indent"><pre>
+&lt;field var='org_role'&gt;
+  &lt;value&gt;Patron Saint&lt;/value&gt;
+  &lt;value&gt;Chief Evangelist&lt;/value&gt;
+  &lt;value&gt;Glorified Tech Writer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.11 <a name="org_unit">Organizational Unit</a>
+</h3>
+      <p class="" style="">An organizational unit is the name of part (subsidiary, department, etc.) of an organization.</p>
+      <p class="" style="">The Data Forms field that represents an organizational unit is "org_unit".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard ORGUNIT</li>
+        <li>LDAP ou</li>
+      </ul>
+      <p class="caption">Example 73. Organizational Unit</p>
+<div class="indent"><pre>
+&lt;field var='org_unit'&gt;
+  &lt;value&gt;Jabber Council&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.12 <a name="system_username">System Username</a>
+</h3>
+      <p class="" style="">Usually a person has a system or network username within an organization (usually not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents such a username is "system_username".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP uid</li>
+        <li>LDAP userid</li>
+      </ul>
+      <p class="caption">Example 74. System Username</p>
+<div class="indent"><pre>
+&lt;field var='system_username'&gt;
+  &lt;value&gt;psaintandre&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.13 <a name="teams">Teams</a>
+</h3>
+      <p class="" style="">People often work in teams. Sometimes it can be helpful to list those teams.</p>
+      <p class="" style="">The Data Forms field that represents a work team is "teams".</p>
+      <p class="caption">Example 75. Teams</p>
+<div class="indent"><pre>
+&lt;field var='teams'&gt;
+  &lt;value&gt;Infrastructure Team&lt;/value&gt;
+  &lt;value&gt;Jabber Council&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.7.14 <a name="workstation">Workstation Address</a>
+</h3>
+      <p class="" style="">Often a person has a dedicated workstation address or name within an organization (usually not exposed outside the organization).</p>
+      <p class="" style="">The Data Forms field that represents such a username is "workstation".</p>
+      <p class="caption">Example 76. Workstation Address</p>
+<div class="indent"><pre>
+&lt;field var='workstation'&gt;
+  &lt;value&gt;squire&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.8 <a name="fields-basic">Basic Personal Data Aspects</a>
+</h3>
+    <p class="" style="">These data fields are not necessarily permanent, but do not tend to change very often if at all.</p>
+    <div class="indent">
+<h3>6.8.1 <a name="birth_dayofmonth">Birth Day-of-Month</a>
+</h3>
+      <p class="" style="">A birth day-of-month is the day of the month in which a person was born. (Note: This data field is <span style="font-style: italic">not</span> what in English is usually referred to as a person's "birthday", i.e. the year+month+day on which the person was born; the "birthday" is split into three data fields in order to protect personal privacy, since a given individual might want to disclose his or her birth year, birth month, birth day-of-month, or some combination thereof but not all three.)</p>
+      <p class="" style="">The Data Forms field that represents a birth day-of-month is "birth_dayofmonth".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 77. Birth Day-of-Month</p>
+<div class="indent"><pre>
+&lt;field var='birth_dayofmonth'&gt;
+  &lt;value&gt;06&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.8.2 <a name="birth_month">Birth Month</a>
+</h3>
+      <p class="" style="">A birth month is the month of the year in which a person was born.</p>
+      <p class="" style="">The Data Forms field that represents a birth month is "birth_month".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 78. Birth Month</p>
+<div class="indent"><pre>
+&lt;field var='birth_month'&gt;
+  &lt;value&gt;08&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.8.3 <a name="birth_year">Birth Year</a>
+</h3>
+      <p class="" style="">A birth year is the year in which a person was born.</p>
+      <p class="" style="">The Data Forms field that represents a birth year is "birth_year".</p>
+      <p class="" style="">When combined with other birthday-related fields, this field maps to:</p>
+      <ul>
+        <li>vCard BDAY</li>
+      </ul>
+      <p class="caption">Example 79. Birth Year</p>
+<div class="indent"><pre>
+&lt;field var='birth_year'&gt;
+  &lt;value&gt;1966&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.8.4 <a name="description">Description</a>
+</h3>
+      <p class="" style="">It can be helpful to provide a natural-language description of a person.</p>
+      <p class="" style="">The Data Forms field that represents a description of a person is "description".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP description</li>
+      </ul>
+      <p class="caption">Example 80. Description</p>
+<div class="indent"><pre>
+&lt;field var='description'&gt;
+  &lt;value&gt;I'm a Jabber fanatic.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.8.5 <a name="eye_color">Eye Color</a>
+</h3>
+      <p class="" style="">Some people may want to know the color of a person's eyes. The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's eye color is "eye_color".</p>
+      <p class="caption">Example 81. Eye Color</p>
+<div class="indent"><pre>
+&lt;field var='eye_color'&gt;
+  &lt;value&gt;blue&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.8.6 <a name="gender">Gender</a>
+</h3>
+      <p class="" style="">Gender is the self-defined gender of a person (this is not limited to "male" and "female", although those are the expected values in most instances). Sometimes also called "sex" or "gender identification".</p>
+      <p class="" style="">The Data Forms field that represents a person's gender is "gender".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF gender</li>
+      </ul>
+      <p class="caption">Example 82. Gender</p>
+<div class="indent"><pre>
+&lt;field var='gender'&gt;
+  &lt;value&gt;male&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.8.7 <a name="hair_color">Hair Color</a>
+</h3>
+      <p class="" style="">Some people may want to know the color of a person's hair (if any). The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's hair color is "hair_color".</p>
+      <p class="caption">Example 83. Hair Color</p>
+<div class="indent"><pre>
+&lt;field var='hair_color'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.8.8 <a name="height">Height</a>
+</h3>
+      <p class="" style="">Some people may want to know a person's height. This SHOULD be expressed in centimeters (which can be transformed into other units if necessary by a client).</p>
+      <p class="" style="">The Data Forms field that represents a person's height is "height".</p>
+      <p class="caption">Example 84. Height</p>
+<div class="indent"><pre>
+&lt;field var='height'&gt;
+  &lt;value&gt;178&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.8.9 <a name="weight">Weight</a>
+</h3>
+      <p class="" style="">Yes, it is a sensitive topic, but some people may want to know a person's weight. This SHOULD be expressed in kilograms (which can be transformed into other units if necessary by a client).</p>
+      <p class="" style="">The Data Forms field that represents a person's weight is "weight".</p>
+      <p class="caption">Example 85. Weight</p>
+<div class="indent"><pre>
+&lt;field var='weight'&gt;
+  &lt;value&gt;75&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.9 <a name="fields-extended">Extended Personal Data Aspects</a>
+</h3>
+    <div class="indent">
+<h3>6.9.1 <a name="expertise">Areas of Expertise</a>
+</h3>
+      <p class="" style="">An area of expertise is a subject in which a person has a great deal of knowledge.</p>
+      <p class="" style="">The Data Forms field that represents an area of expertise is "expertise".</p>
+      <p class="caption">Example 86. Areas of Expertise</p>
+<div class="indent"><pre>
+&lt;field var='expertise'&gt;
+  &lt;value&gt;Jabber&lt;/value&gt;
+  &lt;value&gt;XMPP&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.2 <a name="avatar_data">Avatar Data</a>
+</h3>
+      <p class="" style="">An avatar is an often fanciful representation of a user's desired self-image or persona (e.g., in the context of a game). An avatar is usually not intended to be an accurate picture of the user's actual physical appearance (that is handled by the photo_url and photo_data fields).</p>
+      <p class="" style="">An avatar can come in two forms: the avatar data itself, or a URL for a avatar.</p>
+      <p class="" style="">The Data Forms field that represents avatar data is "avatar_data".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 87. Avatar Data</p>
+<div class="indent"><pre>
+&lt;field var='avatar_data'&gt;
+  &lt;value&gt;base64-encoded-image-data&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.3 <a name="clubs">Clubs</a>
+</h3>
+      <p class="" style="">Some people are members of clubs or other voluntary organizations.</p>
+      <p class="" style="">The Data Forms field that represents club memberships is "clubs".</p>
+      <p class="caption">Example 88. Club Memberships</p>
+<div class="indent"><pre>
+&lt;field var='clubs'&gt;
+  &lt;value&gt;DENSA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.4 <a name="dietary_preferences">Dietary Preferences</a>
+</h3>
+      <p class="" style="">Some people have dietary preferences (vegan, vegetarian, kosher, peanut allergy, no shellfish, etc.).</p>
+      <p class="" style="">The Data Forms field that represents dietary preferences is "dietary_preferences".</p>
+      <p class="caption">Example 89. Dietary Preferences</p>
+<div class="indent"><pre>
+&lt;field var='dietary_preferences'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.5 <a name="hobby">Hobbies</a>
+</h3>
+      <p class="" style="">A hobby is a non-work activity that a person enjoys pursuing. Also called an "avocation".</p>
+      <p class="" style="">The Data Forms field that represents a hobby is "hobby".</p>
+      <p class="caption">Example 90. Some Hobbies</p>
+<div class="indent"><pre>
+&lt;field var='hobby'&gt;
+  &lt;value&gt;guitar&lt;/value&gt;
+  &lt;value&gt;songwriting&lt;/value&gt;
+  &lt;value&gt;blogging&lt;/value&gt;
+  &lt;value&gt;reading&lt;/value&gt;
+  &lt;value&gt;hiking&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.6 <a name="interest">Interests</a>
+</h3>
+      <p class="" style="">An interest a thing that a person cares about or is curious about. It is, generally, less active than a hobby.</p>
+      <p class="" style="">The Data Forms field that represents an interest is "interest".</p>
+      <p class="caption">Example 91. Some Interests</p>
+<div class="indent"><pre>
+&lt;field var='interest'&gt;
+  &lt;value&gt;history&lt;/value&gt;
+  &lt;value&gt;baseball&lt;/value&gt;
+  &lt;value&gt;economics&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.7 <a name="languages_lesswell">Languages Known Less Well</a>
+</h3>
+      <p class="" style="">Some people know more than one language, but less than well (e.g., the person may not be able to speak fluently). The definition of "less well" is left to the user.</p>
+      <p class="" style="">The value of this field MUST be an abbreviation for a language as specified in <span class="ref" style="">RFC 3066</span>  [<a href="#nt-id2261655">27</a>].</p>
+      <p class="" style="">The Data Forms field that represents a language known less that well is "languages_lesswell".</p>
+      <p class="caption">Example 92. Languages Known Less than Well</p>
+<div class="indent"><pre>
+&lt;field var='languages_lesswell'&gt;
+  &lt;value&gt;cz&lt;/value&gt;
+  &lt;value&gt;de&lt;/value&gt;
+  &lt;value&gt;nl&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.8 <a name="languages_well">Languages Known Well</a>
+</h3>
+      <p class="" style="">Everyone knows at least one language well (e.g., they are able to speak or write the language with a fair degree of fluency). Determination of whether someone knows a language "well" or "fluently" is left to the user.</p>
+      <p class="" style="">The value of this field MUST be an abbreviation for a language as specified in <span style="font-weight: bold">RFC 3066</span>.</p>
+      <p class="" style="">The Data Forms field that represents a language known well is "languages_well".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP preferredLanguage</li>
+      </ul>
+      <p class="caption">Example 93. Languages Known Well</p>
+<div class="indent"><pre>
+&lt;field var='languages_well'&gt;
+  &lt;value&gt;en&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.9 <a name="car_license_number">License Plate Number</a>
+</h3>
+      <p class="" style="">Many people own automobiles, which usually have license or registration numbers.</p>
+      <p class="" style="">The Data Forms field that represents a car license or registration number is "car_license_number".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP carLicense</li>
+      </ul>
+      <p class="caption">Example 94. License Plate Number</p>
+<div class="indent"><pre>
+&lt;field var='car_license_number'&gt;
+  &lt;value&gt;JABBER&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.10 <a name="marital_status">Marital Status</a>
+</h3>
+      <p class="" style="">Human beings often get married, sometimes get divorced, become widowed, etc.</p>
+      <p class="" style="">The Data Forms field that represents whether a person's marital status is "marital_status".</p>
+      <p class="caption">Example 95. Marital Status</p>
+<div class="indent"><pre>
+&lt;field var='marital_status'&gt;
+  &lt;value&gt;married&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.11 <a name="mbti">Myers-Briggs Type Indicator</a>
+</h3>
+      <p class="" style="">A Myers-Briggs type indicator is four-letter acronym that is a popular way to characterize different personality types.</p>
+      <p class="" style="">The Data Forms field that represents a Myers-Briggs type indicator is "mbti".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>FOAF myersBriggs</li>
+      </ul>
+      <p class="caption">Example 96. Myers-Briggs Type Indicator</p>
+<div class="indent"><pre>
+&lt;field var='mbti'&gt;
+  &lt;value&gt;INTP&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.12 <a name="photo_data">Photo Data</a>
+</h3>
+      <p class="" style="">A photo provides a pictorial representation of a person. Sometimes also called a "mugshot".</p>
+      <p class="" style="">A photo can come in two forms: the photo data itself, or a URL for a photo (e.g., the vCard PHOTO element can represent either, while the FOAF depiction and FOAF img can represent only a URL).</p>
+      <p class="" style="">The Data Forms field that represents photo data is "photo_data".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard PHOTO</li>
+        <li>LDAP jpegPhoto</li>
+      </ul>
+      <p class="caption">Example 97. Photo Data</p>
+<div class="indent"><pre>
+&lt;field var='photo_data'&gt;
+  &lt;value&gt;base64-encoded-image-data&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.13 <a name="profession">Profession</a>
+</h3>
+      <p class="" style="">A profession is what a person does for his or her primary employment. Also known as a "vocation". The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a profession is "profession".</p>
+      <p class="caption">Example 98. A Profession</p>
+<div class="indent"><pre>
+&lt;field var='profession'&gt;
+  &lt;value&gt;software engineer&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.14 <a name="religion">Religious Affiliation</a>
+</h3>
+      <p class="" style="">Many people feel affiliated with a religious belief system.</p> 
+      <p class="" style="">The Data Forms field that represents a religious affiliation is "religion".</p>
+      <p class="caption">Example 99. Religious Affiliation</p>
+<div class="indent"><pre>
+&lt;field var='religion'&gt;
+  &lt;value&gt;none&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.15 <a name="sexual_orientation">Sexual Orientation</a>
+</h3>
+      <p class="" style="">The allowable or recommended values for this field are not specified.</p>
+      <p class="" style="">The Data Forms field that represents a person's sexual orientation is "sexual_orientation".</p>
+      <p class="caption">Example 100. Sexual Orientation</p>
+<div class="indent"><pre>
+&lt;field var='sexual_orientation'&gt;
+  &lt;value&gt;straight&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.16 <a name="smoker">Smoker</a>
+</h3>
+      <p class="" style="">Some people smoke tobacco in various forms (cigarettes, cigars, pipes, etc.).</p> 
+      <p class="" style="">The Data Forms field that represents whether a person smokes is "smoker".</p>
+      <p class="caption">Example 101. Smoker</p>
+<div class="indent"><pre>
+&lt;field var='smoker'&gt;
+  &lt;value&gt;no&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.17 <a name="wishlist">Wishlist</a>
+</h3>
+      <p class="" style="">A wishlist is a list of items that a person would like to receive as gifts.</p>
+      <p class="" style="">The Data Forms field that represents a wishlist is "wishlist".</p>
+      <p class="caption">Example 102. Wishlist</p>
+<div class="indent"><pre>
+&lt;field var='wishlist'&gt;
+  &lt;value&gt;A Mini Cooper&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.18 <a name="zodiac_chinese">Zodiac Sign (Chinese)</a>
+</h3>
+      <p class="" style="">A Chinese zodiac sign denotes the type of year in which a person was born according to the Chinese calendar (e.g., the year of the dragon).</p>
+      <p class="" style="">The Data Forms field that represents a Chinese zodiac sign is "zodiac_chinese".</p>
+      <p class="caption">Example 103. Zodiac Sign (Chinese)</p>
+<div class="indent"><pre>
+&lt;field var='zodiac_chinese'&gt;
+  &lt;value&gt;horse&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.9.19 <a name="zodiac_western">Zodiac Sign (Western)</a>
+</h3>
+      <p class="" style="">A Western zodiac sign is that part of the astrological belt under which a person was born; each sign is named after one of the constellations.</p>
+      <p class="" style="">The Data Forms field that represents a Western zodiac sign is "zodiac_western".</p>
+      <p class="caption">Example 104. Zodiac Sign (Western)</p>
+<div class="indent"><pre>
+&lt;field var='zodiac_western'&gt;
+  &lt;value&gt;Leo&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.10 <a name="fields-security">Security Data Aspects</a>
+</h3>
+    <p class="" style="">Some people have PGP keys, X.509 certificates, and the like.</p>
+    <div class="indent">
+<h3>6.10.1 <a name="pgpkey">PGP Key</a>
+</h3>
+      <p class="" style="">The ASCII armored output of a PGP key.</p>
+      <p class="" style="">The Data Forms field that represents a PGP key is "pgpkey".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>vCard KEY with TYPE of PGP</li>
+      </ul>
+      <p class="caption">Example 105. PGP Key</p>
+<div class="indent"><pre>
+&lt;field var='pgpkey'&gt;
+  &lt;value&gt;
+-----BEGIN PGP PUBLIC KEY BLOCK-----
+Version: GnuPG v1.2.4 (Darwin)
+
+mQGiBEGSeUQRBADTT8NqGpxDQ1GjmAJBDNET0blyb1LF6exYLxydX+hzcooE5WxP
+Zdo5Xx0RrLYlKmmcKv0Z8cG/kei2pkS05h/oqluphGmzMBIeC/ox22z87PKpVDfj
+OEYQOZqhqdFI+KRIa4M89CQOO1N5V2KlX9GaNjxRearKvLgsoeTzpPtybwCgl91i
+SqQnry1YV+PFOjRcDT7cX+UD/2JxXU5d1Z1WZf7ttM3QjSaPc9CA4fS+axinRkn/
+IbRJ/Lj8Tz+Vb4kBbBhmFG8JCoRtj2J8bsDdaFCh7nHqT2u4oXy0NJSCKrDRBcuL
+bEQfasT/cuBXIM2A7nB1UtlUCYXnINxakYLIsW9BvvFN935FhZ81EJvLW34W2Mf7
+Y+9ZA/0adScaI05UUE5RRcZSiXs8/p+R6SeaW2gjS5beL5Wv6ExRlDe92rGqrjtN
+PmBRiDiVBSoYlqOepBZk+wM+/B4WMsmUFVeXsXWjWMlghyyni2rI1Z2v1UH8KBKm
+259k7SlU/BbnEAHIzuHPSQHJNUX+YqWArz1v5tDcQn7L1Wo7PbRAUGV0ZXIgU2Fp
+bnQtQW5kcmUgKHhtcHA6c3RwZXRlckBqYWJiZXIub3JnKSA8c3RwZXRlckBqYWJi
+ZXIub3JnPoheBBMRAgAeBQJBknlEAhsDBgsJCAcDAgMVAgMDFgIBAh4BAheAAAoJ
+EFmFiWTXBRKsfeQAoJdO0PvP1Mi/kJ9U1zVpa4GPpXYCAJ9oFjonfr+Z3ZTefjSb
+tZpE2mny57kCDQRBknlzEAgAisWlkK6daVjrxouZK9KvX8tt3CKVse4CY52Lq7xi
+dtEAhDcXX9SgTnlxgrcCnBipj/OMi/B2M0U88qv3TcsZ0dWZt7H4FnHJvU4xloK8
+qRkJ7xa6gCEoPAc7ESdr//6J/eEvWMqixstOUyfRg2AQp/eSHX0Cl/TQImRVZbh6
+HYCehrqpErAnz0VY8nvun3709LgvIMUvKrnV7lF9wOuuhWCK9IYdpmgoD4d/Gr4t
+ZVuE1jYN4tBLyQXtJDAR/UvKHEiXUAhsfXOtfCUQV5MaxM6YQce63BGl05kS7oLH
+Sx+KYOX1vEi3k1OFfH5CpqYaxmfhSzdyz7Hhdsl+IbkhzwAECwf/YQfpx4z9dnJn
+3ePrZhz5SI4KjdbOCmqhLFd8aVoQ9BCriePH3kPjjoE9Qz+0NlFqzuG4/tkZkAok
+BA0GqYE4XXgvpwGpK95mlUvxDOowu0fLVQA8NfpU3U7YItZkfAPZ2M+PnmayRILi
+0yBmm1taVllCD2mc2vhsMRUoD1DUworSzQuTG9YlQ89Q2/1LsoQzYjBz9XIfYV4A
+MPr/PKPkKy3D7BYHi/DOnkcP9hLXJSCjgV5TpuWuCVX9aYU2Yb7BfY1OFORBCUaV
+B1YLAPtXqfqjz25pIQPDEUbpKzhEO7xNU4EPT8ZsSfqqOd3aMet8McieRfMd+VIe
+4J1OUIg1oYhJBBgRAgAJBQJBknlzAhsMAAoJEFmFiWTXBRKs/GgAn0R63qTEQd/e
+XhK8hFkPvXjudl7xAJ95+2fAHfmHheZJVaO8VaJiL54Tvw==
+=ZRIc
+-----END PGP PUBLIC KEY BLOCK-----
+  &lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.10.2 <a name="pgp_fingerprint">PGP Key Fingerprint</a>
+</h3>
+      <p class="" style="">The fingerprint (hashed value) of a PGP key.</p>
+      <p class="" style="">The Data Forms field that represents a PGP fingerprint is "pgp_fingerprint".</p>
+      <p class="caption">Example 106. PGP Fingerprint</p>
+<div class="indent"><pre>
+&lt;field var='pgp_fingerprint'&gt;
+  &lt;value&gt;E5CA EAE7 C8D6 CFE2 6D7A  8653 5985 8964 D705 12AC&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.10.3 <a name="pgpkey_id">PGP Key ID</a>
+</h3>
+      <p class="" style="">The ID of a PGP key.</p>
+      <p class="" style="">The Data Forms field that represents a PGP key ID is "pgpkey_id".</p>
+      <p class="caption">Example 107. PGP Key ID</p>
+<div class="indent"><pre>
+&lt;field var='pgpkey_id'&gt;
+  &lt;value&gt;D70512AC&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.10.4 <a name="x509_fingerprint_md5">X.509 Fingerprint (MD5)</a>
+</h3>
+      <p class="" style="">The fingerprint of an X.509 certificate, hashed using MD5.</p>
+      <p class="" style="">The Data Forms field representing such a value is "x509_fingerprint_md5".</p>
+      <p class="caption">Example 108. X.509 Fingerprint (MD5)</p>
+<div class="indent"><pre>
+&lt;field var='x509_fingerprint_md5'&gt;
+  &lt;value&gt;5D 41 20 54 7C 90 49 A1 78 36 07 29 75 9B A7 D0&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.10.5 <a name="x509_fingerprint_sha1">X.509 Fingerprint (SHA-1)</a>
+</h3>
+      <p class="" style="">The fingerprint of an X.509 certificate, hashed using SHA-1.</p>
+      <p class="" style="">The Data Forms field representing such a value is "x509_fingerprint_sha1".</p>
+      <p class="caption">Example 109. X.509 Fingerprint (SHA-1)</p>
+<div class="indent"><pre>
+&lt;field var='x509_fingerprint_sha1'&gt;
+  &lt;value&gt;C3 88 33 27 F3 47 3B 8B 07 71 3E 96 44 A7 EE E2 E0 50 4A 5B&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.11 <a name="fields-favorites">Personal Favorites</a>
+</h3>
+    <p class="" style="">Most people have favorite movies, authors, TV shows, musical artists, foods, games, etc.</p>
+    <div class="indent">
+<h3>6.11.1 <a name="fav_authors">Favorite Authors</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite authors is "fav_authors".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 110. Favorite Authors</p>
+<div class="indent"><pre>
+&lt;field var='fav_authors'&gt;
+  &lt;value&gt;Jacob Bronowski&lt;/value&gt;
+  &lt;value&gt;Friedrich Nietzsche&lt;/value&gt;
+  &lt;value&gt;Carroll Quigley&lt;/value&gt;
+  &lt;value&gt;Yevgeny Zamyatin&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.2 <a name="fav_athletes">Favorite Athletes</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite athletes is "fav_athletes".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 111. Favorite Athletes</p>
+<div class="indent"><pre>
+&lt;field var='fav_athletes'&gt;
+  &lt;value&gt;Lance Armstrong&lt;/value&gt;
+  &lt;value&gt;Andre Agassiz&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.3 <a name="favorite_beverages">Favorite Beverages</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite beverages is "favorite_beverages".</p>
+      <p class="" style="">This field maps to:</p>
+      <ul>
+        <li>LDAP drink</li>
+        <li>LDAP favoriteDrink</li>
+      </ul>
+      <p class="caption">Example 112. Favorite Beverages</p>
+<div class="indent"><pre>
+&lt;field var='favorite_beverages'&gt;
+  &lt;value&gt;Guinness&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.4 <a name="fav_charities">Favorite Charities</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite charities is "fav_charities".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 113. Favorite Charities</p>
+<div class="indent"><pre>
+&lt;field var='fav_charities'&gt;
+  &lt;value&gt;Institute for Justice&lt;/value&gt;
+  &lt;value&gt;PERC&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.5 <a name="fav_chatrooms">Favorite Chatrooms</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite chatrooms is "fav_chatrooms".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 114. Favorite Chatrooms</p>
+<div class="indent"><pre>
+&lt;field var='fav_chatrooms'&gt;
+  &lt;value&gt;jabber@conference.jabber.org&lt;/value&gt;
+  &lt;value&gt;jdev@conference.jabber.org&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.6 <a name="fav_drinks">Favorite Drinks</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite drinks is "fav_drinks".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 115. Favorite Drinks</p>
+<div class="indent"><pre>
+&lt;field var='fav_drinks'&gt;
+  &lt;value&gt;Guinness&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.7 <a name="fav_foods">Favorite Foods</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite foods is "fav_foods".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 116. Favorite Foods</p>
+<div class="indent"><pre>
+&lt;field var='fav_foods'&gt;
+  &lt;value&gt;Thai&lt;/value&gt;
+  &lt;value&gt;Mexican&lt;/value&gt;
+  &lt;value&gt;Italian&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.8 <a name="fav_games">Favorite Games</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite games is "fav_games".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 117. Favorite Games</p>
+<div class="indent"><pre>
+&lt;field var='fav_games'&gt;
+  &lt;value&gt;chess&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.9 <a name="fav_movies">Favorite Movies</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite movies is "fav_movies".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 118. Favorite Movies</p>
+<div class="indent"><pre>
+&lt;field var='fav_movies'&gt;
+  &lt;value&gt;In Search of Bobby Fischer&lt;/value&gt;
+  &lt;value&gt;Strictly Ballroom&lt;/value&gt;
+  &lt;value&gt;The Truth About Cats and Dogs&lt;/value&gt;
+  &lt;value&gt;Ray&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.10 <a name="fav_music">Favorite Music</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite music is "fav_music".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 119. Favorite Music</p>
+<div class="indent"><pre>
+&lt;field var='fav_music'&gt;
+  &lt;value&gt;J.S. Bach&lt;/value&gt;
+  &lt;value&gt;Duke Ellington&lt;/value&gt;
+  &lt;value&gt;Mellow Candle&lt;/value&gt;
+  &lt;value&gt;Yes&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.11 <a name="fav_quotes">Favorite Quotes</a>
+</h3>
+      <p class="" style="">A quote is a phrase or saying that a person identifies with in some way. According to the 2004 Pew Internet survey on instant messaging, quotes represent the most popular item to include in online profiles on major consumer-oriented instant messaging services.</p>
+      <p class="" style="">The Data Forms field that represents favorite quotes is "fav_quotes".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 120. Favorite Quotes</p>
+<div class="indent"><pre>
+&lt;field var='fav_quotes'&gt;
+  &lt;value&gt;I am large, I contain multitudes.&lt;/value&gt;
+  &lt;value&gt;&amp;quot;Think like a man of action, act like a man of thought.&amp;quot; --Henri Bergson&lt;/value&gt;
+  &lt;value&gt;One crowded hour of glorious life is worth an age without a name.&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.12 <a name="fav_teams">Favorite Sports Teams</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite sports teams is "fav_teams".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 121. Favorite Sports Teams</p>
+<div class="indent"><pre>
+&lt;field var='fav_teams'&gt;
+  &lt;value&gt;New York Yankees&lt;/value&gt;
+  &lt;value&gt;Colorado Rockies&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.11.13 <a name="fav_tv">Favorite TV Shows</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents favorite TV shows is "fav_tv".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 122. Favorite TV Shows</p>
+<div class="indent"><pre>
+&lt;field var='fav_tv'&gt;
+  &lt;value&gt;Antiques Road Show&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.12 <a name="fields-history">Personal History</a>
+</h3>
+    <div class="indent">
+<h3>6.12.1 <a name="places_lived">Places Lived</a>
+</h3>
+      <p class="" style="">Some people move around a lot.</p>
+      <p class="" style="">The Data Forms field that represents places lived is "places_lived".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 123. Places Lived</p>
+<div class="indent"><pre>
+&lt;field var='places_lived'&gt;
+  &lt;value&gt;Denver, Colorado, USA&lt;/value&gt;
+  &lt;value&gt;New Hope, Pennsylvania, USA&lt;/value&gt;
+  &lt;value&gt;Maplewood, New Jersey, USA&lt;/value&gt;
+  &lt;value&gt;Atlanta, Georgia, USA&lt;/value&gt;
+  &lt;value&gt;Fairfax, Virginia, USA&lt;/value&gt;
+  &lt;value&gt;Ceske Budejovice, Czech Republic&lt;/value&gt;
+  &lt;value&gt;New York City&lt;/value&gt;
+  &lt;value&gt;Readfield, Maine, USA&lt;/value&gt;
+  &lt;value&gt;Sea Cliff, NY, USA&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>6.12.2 <a name="schools">Schools Attended</a>
+</h3>
+      <p class="" style="">The Data Forms field that represents schools attended is "schools".</p>
+      <p class="" style="">This field does not map to data in vCard or any other profile representation format.</p>
+      <p class="caption">Example 124. Schools Attended</p>
+<div class="indent"><pre>
+&lt;field var='schools'&gt;
+  &lt;value&gt;Columbia University&lt;/value&gt;
+  &lt;value&gt;American Renaissance School&lt;/value&gt;
+  &lt;value&gt;Maranacook Community School&lt;/value&gt;
+&lt;/field&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Profile data can be personally significant and even security critical. Due care should be taken in determining who shall have access to such information. In particular, an entity SHOULD ensure that its public profile contains only information that it deems safe to be world-readable, SHOULD ensure that any pubsub node it may create for profile data has an access model of "presence" or "roster", and SHOULD NOT publish private or restricted data except to such a pubsub node.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2263028">28</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style="">To follow.</p>
+    
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250576">1</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2250630">2</a>. RFC 2426: vCard MIME Directory Profile &lt;<a href="http://www.ietf.org/rfc/rfc2426.txt">http://www.ietf.org/rfc/rfc2426.txt</a>&gt;.</p>
+<p><a name="nt-id2250619">3</a>. For links to the experimental XML representation of vCard, see <span style="font-weight: bold">JEP-0054</span>.</p>
+<p><a name="nt-id2250814">4</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2250664">5</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2250691">6</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2250722">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2250705">8</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2250758">9</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2256432">10</a>. JEP-0163: Simplified Personal Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2256487">11</a>. The extensibility requirement is critically important, because it would be best if the protocol specified herein could be used to represent data used within specialized communities. Examples of such communities include dating services, multiplayer gaming networks, IM services provided by portals and ISPs, and expert-location systems within large corporations. While such communities might use part or all of some common set of data fields (such as fields that map to familiar vCard elements), each community might also want to represent quite disparate kinds of information (dating criteria, favorite games, contact preferences, areas of expertise, and the like). Furthermore, data might be used to profile network actors that are not persons (e.g., bots, services, and other software agents). Therefore, the ideal proposal will provide an extensible framework for representing profile data and will not limit itself to representing the relatively small set of data fields covered by the vCard format.</p>
+<p><a name="nt-id2256613">12</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p><a name="nt-id2256739">13</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2256698">14</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2256790">15</a>. Resource Description Framework (RDF) &lt;<a href="http://www.w3.org/RDF/">http://www.w3.org/RDF/</a>&gt;.</p>
+<p><a name="nt-id2256838">16</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2256881">17</a>. JEP-0120: Infobits &lt;<a href="http://www.jabber.org/jeps/jep-0120.html">http://www.jabber.org/jeps/jep-0120.html</a>&gt;.</p>
+<p><a name="nt-id2256996">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256982">19</a>. Alternatively, specialized applications MAY define separate FORM_TYPEs for their particular data elements.</p>
+<p><a name="nt-id2257186">20</a>. Because publishing to an SPPS effectively reveals the presence of the account owner, the access model SHOULD NOT be "open".</p>
+<p><a name="nt-id2257322">21</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257774">22</a>. RFC 2252: Lightweight Directory Access Protocol (v3): Attribute Syntax Definitions &lt;<a href="http://www.ietf.org/rfc/rfc2252.txt">http://www.ietf.org/rfc/rfc2252.txt</a>&gt;.</p>
+<p><a name="nt-id2257787">23</a>. RFC 2256: A Summary of the X.500(96) User Schema for use with LDAPv3 &lt;<a href="http://www.ietf.org/rfc/rfc2256.txt">http://www.ietf.org/rfc/rfc2256.txt</a>&gt;.</p>
+<p><a name="nt-id2257809">24</a>. RFC 2798: Definition of the inetOrgPerson LDAP Object Class &lt;<a href="http://www.ietf.org/rfc/rfc2798.txt">http://www.ietf.org/rfc/rfc2798.txt</a>&gt;.</p>
+<p><a name="nt-id2258343">25</a>. JEP-0112: User Physical Location &lt;<a href="http://www.jabber.org/jeps/jep-0112.html">http://www.jabber.org/jeps/jep-0112.html</a>&gt;.</p>
+<p><a name="nt-id2259040">26</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2261655">27</a>. RFC 3066: Tags for the Identification of Languages &lt;<a href="http://www.ietf.org/rfc/rfc3066.txt">http://www.ietf.org/rfc/rfc3066.txt</a>&gt;.</p>
+<p><a name="nt-id2263028">28</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2006-01-16)</h4>
+<div class="indent">Defined data management methods using IQ and the SPPS subset of pubsub; added various data fields from LDAP; changed namespace from profiledata to profile. (psa)
+    </div>
+<h4>Version 0.3 (2005-11-11)</h4>
+<div class="indent">Added postaladdress, fav_chatrooms, alt_contact, teams; added various security-related fields. (psa)
+    </div>
+<h4>Version 0.2 (2005-07-25)</h4>
+<div class="indent">Added mappings to common LDAP schemas. (psa)
+    </div>
+<h4>Version 0.1 (2005-06-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.5 (2005-06-13)</h4>
+<div class="indent">Defined how to handle vCard types such as home vs. work addresses. (psa)
+    </div>
+<h4>Version 0.0.4 (2005-04-07)</h4>
+<div class="indent">Reworked field standardization; added support for telephony addresses, electronic addresses, and organizational data. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-03-11)</h4>
+<div class="indent">Added open issues. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-01-06)</h4>
+<div class="indent">Explained requirements and design decisions in more detail, especially with regard to extensibility; split photo into two elements (data and URL). (psa)
+    </div>
+<h4>Version 0.0.1 (2004-11-10)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0155-0.1.html
+++ b/content/xep-0155-0.1.html
@@ -1,0 +1,239 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0155: Chat Session Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat Session Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a feature negotiation profile for initiating a one-to-one chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-14">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0155">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0155: Chat Session Negotiation</h1>
+<p>This JEP specifies a feature negotiation profile for initiating a one-to-one chat session.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0155<br>
+            Version: 0.1<br>
+            Last Updated: 2005-07-14<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0020, JEP-0068<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: Not yet assigned<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#negotiation">Negotiation Flow</a>
+</dt>
+<dt>3.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The traditional model for one-to-one chat "sessions" in Jabber/XMPP is for a user to simply send a message to a contact without any formal negotiation of chat session parameters. This information approach to initiation of a chat session is perfectly acceptable in most contexts, environments, and cultures. However, in some contexts (e.g., if the parties are unknown to each other or have not exchanged presence), environments (e.g., mobile telephony), and cultures (e.g., an organization in which one would not simply beginning chatting with a superior), it may be desirable to formally request the chat and negotiate its parameters before beginning the chat session. This proposal defines best practices for such a negotiation, using the protocol defined in <span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2250501">1</a>].</p>
+<h2>2.
+       <a name="negotiation">Negotiation Flow</a>
+</h2>
+  <p class="" style="">In order to negotiate a chat session, the initiating party ("user") sends a &lt;message/&gt; stanza to the receiving party ("contact") containing a &lt;feature/&gt; child qualified by the 'http://jabber.org/protocol/feature-neg' namespace but containing no &lt;body/&gt; or other standard child elements (as specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250550">2</a>]). The &lt;message/&gt; stanza is used because the user does not necessarily know which of the contact's resources is most available (or indeed if the contact is online). The &lt;message/&gt; stanza type SHOULD be "normal" (either explicitly or by non-inclusion of the 'type' attribute). The stanza MAY include an 'id' attribute for tracking purposes. The data form MUST contain a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/chatneg".</p>
+  <p class="" style="">The following is an example of a negotiation request:</p>
+  <p class="caption">Example 1. User requests chat session</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' 
+             label='Accept this chat?'
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' 
+             label='Enable XHTML Formatting?'
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' 
+             label='Enable Chat State Notifications?'
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">In the foregoing example, Romeo requests a chat with Juliet and also queries her regarding whether she wants to support <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2251221">3</a>] and <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2251243">4</a>] extensions.</p>
+  <p class="" style="">Juliet's server delivers Romeo's request to her most available resource (which happens to be "balcony"). We assume that Juliet accepts the chat and specifies that she does not want to use XHTML formatting but that she does want to use Chat State Notifications:</p>
+  <p class="caption">Example 2. Contact accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support feature negotiation or does not support the "http://jabber.org/protocol/chatneg" FORM_TYPE, it SHOULD return a &lt;service-unavailable/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+  <p class="caption">Example 3. Contact returns service unavailable error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support one of the required features, it SHOULD return a &lt;feature-not-implemented/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+  <p class="caption">Example 4. Contact returns feature not implemented error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='boolean' var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support one of the optional features (e.g., Chat State Notifications) but it accepts the request, it MUST set the value of that boolean variable to "0".</p>
+<h2>3.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client MAY require a human user to approve each chat session negotiation request or MAY auto-accept and auto-reject requests based on some configurable policy.</p>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">If a contact accepts a user's request or returns an error to the user, the user will effectively discover the contact's presence (at least the presence of one of the contact's resources). Due care must be exercised in determining whether to accept the request or return an error (e.g., the contact's client must not automatically accept the user's request or return an error to the user if the user is in the contact's block list).</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2251436">5</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This proposal defines best practices for use of JEP-0020 and therefore does not require a separate schema.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250501">1</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2250550">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251221">3</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2251243">4</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2251436">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-07-14)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-07-12)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0155-0.2.html
+++ b/content/xep-0155-0.2.html
@@ -1,0 +1,379 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0155: Chat Session Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat Session Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a feature negotiation profile for initiating a one-to-one chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-07-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0155">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0155: Chat Session Negotiation</h1>
+<p>This JEP specifies a feature negotiation profile for initiating a one-to-one chat session.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0155<br>
+            Version: 0.2<br>
+            Last Updated: 2005-07-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0020, JEP-0068<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatneg<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Chat%20Session%20Negotiation%20(JEP-0155)">http://wiki.jabber.org/index.php/Chat Session Negotiation (JEP-0155)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#negotiation">Negotiation Flow</a>
+</dt>
+<dt>3.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>6.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The traditional model for one-to-one chat "sessions" in Jabber/XMPP is for a user to simply send a message to a contact without any formal negotiation of chat session parameters. This informal approach to initiation of a chat session is perfectly acceptable in most contexts, environments, and cultures. However, it may be desirable to formally request the chat and negotiate its parameters before beginning the chat session in some circumstances, such as:</p>
+  <ul>
+    <li>The parties are unknown to each other, have not exchanged presence, or have not discovered their respective capabilities via <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251646">1</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2251667">2</a>].</li>
+    <li>When an XMPP-based system interfaces with a SIP-based system built on top of <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2251692">3</a>].  [<a href="#nt-id2251680">4</a>]</li>
+    <li>Within an organization or culture in which one would not simply begin chatting with a superior without first receiving permission to do so.</li>
+  </ul>
+  <p class="" style="">This proposal defines best practices for such a negotiation, re-using the protocol defined in <span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2250543">5</a>].</p>
+<h2>2.
+       <a name="negotiation">Negotiation Flow</a>
+</h2>
+  <p class="" style="">In order to negotiate a chat session, the initiating party ("user") sends a &lt;message/&gt; stanza to the receiving party ("contact") containing a &lt;feature/&gt; child qualified by the 'http://jabber.org/protocol/feature-neg' namespace but containing no &lt;body/&gt; or other standard child elements (as specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250727">6</a>]). The &lt;message/&gt; stanza is used because the user does not necessarily know which of the contact's resources is most available (or indeed if the contact is online). The &lt;message/&gt; stanza type SHOULD be "normal" (either explicitly or by non-inclusion of the 'type' attribute). The stanza MAY include an 'id' attribute for tracking purposes. The data form MUST contain a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/chatneg".</p>
+  <p class="" style="">The following is an example of a negotiation request:</p>
+  <p class="caption">Example 1. User requests chat session</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">In the foregoing example, Romeo requests a chat with Juliet and also queries her regarding whether she wants to allow client-side message logging and support <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2250755">7</a>] and <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2250565">8</a>] extensions during this chat session. (Note: These fields are examples only; a full set of chat session negotiation parameters will be registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.)</p>
+  <p class="" style="">Juliet's server delivers Romeo's request to her most available resource (which happens to be "balcony").</p>
+  <p class="" style="">We assume that Juliet accepts the chat and specifies that she does not want to log messages or use XHTML formatting but that she does want to use Chat State Notifications:</p>
+  <p class="caption">Example 2. Contact accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sure, let's talk!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">However, it could be that Juliet is busy so she declines the invitation.</p>
+  <p class="caption">Example 3. Contact declines offer and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sorry, can't chat now! How about tonight?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support feature negotiation or does not support the "http://jabber.org/protocol/chatneg" FORM_TYPE, it SHOULD return a &lt;service-unavailable/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+  <p class="caption">Example 4. Contact returns service unavailable error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support one of the required features, it SHOULD return a &lt;feature-not-implemented/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+  <p class="caption">Example 5. Contact returns feature not implemented error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support one of the optional features (e.g., Chat State Notifications) but it accepts the request, it MUST set the value of that boolean variable to "0".</p>
+<h2>3.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client MAY require a human user to approve each chat session negotiation request or MAY auto-accept and auto-reject requests based on some user-configurable policy.</p>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">If a contact accepts a user's request or returns an error to the user, the user will effectively discover the contact's presence (at least the presence of one of the contact's resources). Due care must be exercised in determining whether to accept the request or return an error (e.g., the contact's client must not automatically accept the user's request or return an error to the user if the user is in the contact's block list).</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250374">9</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256520">10</a>] shall add 'http://jabber.org/protocol/chatneg' to its registry of Service Discovery features.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;desc&gt;Support for Chat Session Negotiation and its FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2256570">11</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling negotation of a one-to-one
+    chat session between two entities.
+  &lt;/desc&gt;
+  &lt;field
+      var='accept'
+      type='boolean'
+      label='Whether to accept the invitation'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable Chat State Notifications per JEP-0085'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable XHTML-IM formatting per JEP-0071'/&gt;
+  &lt;field
+      var='logging'
+      type='boolean'
+      label='Whether to allow client-side message logging'/&gt;
+  &lt;field
+      var='reason'
+      type='text-single'
+      label='A reason for chatting (or not)'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+  </div>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This proposal defines best practices for use of JEP-0020 and therefore does not require a separate schema.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251646">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251667">2</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2251692">3</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2251680">4</a>. In essence, a chat state negotiation request as specified herein is functionally equivalent to a SIP INVITE request, and acceptance of such a request is functionally equivalent to sending a SIP 200 OK response; see Section 17 of <span style="font-weight: bold">RFC 3261</span>.</p>
+<p><a name="nt-id2250543">5</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2250727">6</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250755">7</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2250565">8</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2250374">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256520">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256570">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-07-15)</h4>
+<div class="indent">Further described contexts in which chat session negotiation could be useful; added more examples; added reference to SIP RFC and explained basic mapping to SIP INVITE method; added Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2005-07-14)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-07-12)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0155-0.3.html
+++ b/content/xep-0155-0.3.html
@@ -1,0 +1,391 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0155: Chat Session Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat Session Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a feature negotiation profile for initiating a one-to-one chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0155">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0155: Chat Session Negotiation</h1>
+<p>This JEP specifies a feature negotiation profile for initiating a one-to-one chat session.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0155<br>
+            Version: 0.3<br>
+            Last Updated: 2005-12-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0020, JEP-0068<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatneg<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Chat%20Session%20Negotiation%20(JEP-0155)">http://wiki.jabber.org/index.php/Chat Session Negotiation (JEP-0155)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#negotiation">Negotiation Flow</a>
+</dt>
+<dt>3.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>6.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The traditional model for one-to-one chat "sessions" in Jabber/XMPP is for a user to simply send a message to a contact without any formal negotiation of chat session parameters. This informal approach to initiation of a chat session is perfectly acceptable in most contexts, environments, and cultures. However, it may be desirable to formally request the chat and negotiate its parameters before beginning the chat session in some circumstances, such as:</p>
+  <ul>
+    <li>The parties are unknown to each other, have not exchanged presence, or have not discovered their respective capabilities via <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251548">1</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2251510">2</a>].</li>
+    <li>When an XMPP-based system interfaces with a SIP-based system built on top of <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250538">3</a>].  [<a href="#nt-id2251522">4</a>]</li>
+    <li>Within an organization or culture in which one would not simply begin chatting with a superior without first receiving permission to do so.</li>
+  </ul>
+  <p class="" style="">This proposal defines best practices for such a negotiation, re-using the protocol defined in <span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2250582">5</a>].</p>
+<h2>2.
+       <a name="negotiation">Negotiation Flow</a>
+</h2>
+  <p class="" style="">In order to negotiate a chat session, the initiating party ("user") sends a &lt;message/&gt; stanza to the receiving party ("contact") containing a &lt;feature/&gt; child qualified by the 'http://jabber.org/protocol/feature-neg' namespace. The &lt;message/&gt; stanza MUST NOT contain a &lt;body/&gt; child element (as specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250762">6</a>]). The &lt;message/&gt; stanza is used because the user does not necessarily know which of the contact's resources is most available (or indeed if the contact is online). The &lt;message/&gt; stanza type SHOULD be "normal" (either explicitly or by non-inclusion of the 'type' attribute). The stanza SHOULD include an 'id' attribute and MAY contain a &lt;thread/&gt; element for tracking purposes. The data form MUST contain a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/chatneg".</p>
+  <p class="" style="">The following is an example of a negotiation request:</p>
+  <p class="caption">Example 1. User requests chat session</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com'
+         id='neg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">In the foregoing example, Romeo requests a chat with Juliet and also queries her regarding whether she wants to allow client-side message logging and support <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2250598">7</a>] and <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2250620">8</a>] extensions during this chat session. (Note: These fields are examples only; a full set of chat session negotiation parameters will be registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.)</p>
+  <p class="" style="">Juliet's server delivers Romeo's request to her most available resource (which happens to be "balcony").</p>
+  <p class="" style="">In any response to the request, the contact's client MUST mirror the 'id' attribute and &lt;thread/&gt;value (if provided) so that the user's client can correctly track the response.</p>
+  <p class="" style="">We assume that Juliet accepts the chat and specifies that she does not want to log messages or use XHTML formatting but that she does want to use Chat State Notifications:</p>
+  <p class="caption">Example 2. Contact accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sure, let's talk!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">However, it could be that Juliet is busy so she declines the invitation.</p>
+  <p class="caption">Example 3. Contact declines offer and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sorry, can't chat now! How about tonight?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support feature negotiation or does not support the "http://jabber.org/protocol/chatneg" FORM_TYPE, it SHOULD return a &lt;service-unavailable/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+  <p class="caption">Example 4. Contact returns service unavailable error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support one of the required features, it SHOULD return a &lt;feature-not-implemented/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+  <p class="caption">Example 5. Contact returns feature not implemented error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='neg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support one of the optional features (e.g., Chat State Notifications) but it accepts the request, it MUST set the value of that boolean variable to "0".</p>
+<h2>3.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client MAY require a human user to approve each chat session negotiation request or MAY auto-accept and auto-reject requests based on some user-configurable policy.</p>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">If a contact accepts a user's request or returns an error to the user, the user will effectively discover the contact's presence (at least the presence of one of the contact's resources). Due care must be exercised in determining whether to accept the request or return an error (e.g., the contact's client MUST NOT automatically accept the user's request or return an error to the user if the user is in the contact's block list).</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256518">9</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256568">10</a>] shall include 'http://jabber.org/protocol/chatneg' in its registry of Service Discovery features.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;desc&gt;Support for Chat Session Negotiation and its FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2256617">11</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling negotation of a one-to-one
+    chat session between two entities.
+  &lt;/desc&gt;
+  &lt;field
+      var='accept'
+      type='boolean'
+      label='Whether to accept the invitation'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable Chat State Notifications per JEP-0085'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable XHTML-IM formatting per JEP-0071'/&gt;
+  &lt;field
+      var='logging'
+      type='boolean'
+      label='Whether to allow client-side message logging'/&gt;
+  &lt;field
+      var='reason'
+      type='text-single'
+      label='A reason for chatting (or not)'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+  </div>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This proposal defines best practices for use of JEP-0020 and therefore does not require a separate schema.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251548">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251510">2</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2250538">3</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2251522">4</a>. In essence, a chat state negotiation request as specified herein is functionally equivalent to a SIP INVITE request, and acceptance of such a request is functionally equivalent to sending a SIP 200 OK response; see Section 17 of <span style="font-weight: bold">RFC 3261</span>.</p>
+<p><a name="nt-id2250582">5</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2250762">6</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250598">7</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2250620">8</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2256518">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256568">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256617">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2005-12-30)</h4>
+<div class="indent">Further specified use of id attribute and thread element. (psa)
+    </div>
+<h4>Version 0.2 (2005-07-15)</h4>
+<div class="indent">Further described contexts in which chat session negotiation could be useful; added more examples; added reference to SIP RFC and explained basic mapping to SIP INVITE method; added Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2005-07-14)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-07-12)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0155-0.4.html
+++ b/content/xep-0155-0.4.html
@@ -1,0 +1,441 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0155: Chat Session Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat Session Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This JEP specifies a feature negotiation profile for initiating a one-to-one chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-03">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0155">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0155: Chat Session Negotiation</h1>
+<p>This JEP specifies a feature negotiation profile for initiating a one-to-one chat session.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0155<br>
+            Version: 0.4<br>
+            Last Updated: 2006-01-03<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0020, JEP-0068<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatneg<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Chat%20Session%20Negotiation%20(JEP-0155)">http://wiki.jabber.org/index.php/Chat Session Negotiation (JEP-0155)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#initiate">Initiating a Chat</a>
+</dt>
+<dt>3.  <a href="#terminate">Terminating a Chat</a>
+</dt>
+<dt>4.  <a href="#sip">Mapping to SIP</a>
+</dt>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>8.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The traditional model for one-to-one chat "sessions" in Jabber/XMPP is for a user to simply send a message to a contact without any formal negotiation of chat session parameters. This informal approach to initiation of a chat session is perfectly acceptable in most contexts, environments, and cultures. However, it may be desirable to formally request the chat and negotiate its parameters before beginning the chat session in some circumstances, such as:</p>
+  <ul>
+    <li>The parties are unknown to each other, have not exchanged presence, or have not discovered their respective capabilities via <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251522">1</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2251550">2</a>].</li>
+    <li>When an XMPP-based system interfaces with a SIP-based system built on top of <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250555">3</a>].  [<a href="#nt-id2250542">4</a>]</li>
+    <li>Within an organization or culture in which one would not simply begin chatting with a superior without first receiving permission to do so.</li>
+  </ul>
+  <p class="" style="">This proposal defines best practices for such a negotiation, re-using the protocol defined in <span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2250735">5</a>].</p>
+<h2>2.
+       <a name="initiate">Initiating a Chat</a>
+</h2>
+  <p class="" style="">In order to initiate a negotiated chat session, the initiating party ("user") sends a &lt;message/&gt; stanza to the receiving party ("contact") containing a &lt;feature/&gt; child qualified by the 'http://jabber.org/protocol/feature-neg' namespace. The &lt;message/&gt; stanza MUST NOT contain a &lt;body/&gt; child element (as specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250782">6</a>]). The &lt;message/&gt; stanza is used because the user does not necessarily know which of the contact's resources is most available (or indeed if the contact is online). The &lt;message/&gt; stanza type SHOULD be "normal" (either explicitly or by non-inclusion of the 'type' attribute). The stanza SHOULD include an 'id' attribute and MUST contain a &lt;thread/&gt; element for tracking purposes. The data form MUST contain a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/chatneg" and MUST contain a boolean field named "accept".  [<a href="#nt-id2250774">7</a>]</p>
+  <p class="" style="">The following is an example of a negotiation request:</p>
+  <p class="caption">Example 1. User requests chat session</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">In the foregoing example, Romeo requests a chat with Juliet and also queries her regarding whether she wants to allow client-side message logging and support <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2250584">8</a>] and <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2250626">9</a>] extensions during this chat session. (Note: These fields are examples only; a full set of chat session negotiation parameters will be registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.)</p>
+  <p class="" style="">Juliet's server delivers Romeo's request to her most available resource (which happens to be "balcony").</p>
+  <p class="" style="">In any response to the request, the contact's client MUST mirror the 'id' attribute and &lt;thread/&gt;value so that the user's client can correctly track the response.</p>
+  <p class="" style="">We assume that Juliet accepts the chat and specifies that she does not want to log messages or use XHTML formatting but that she does want to use Chat State Notifications:</p>
+  <p class="caption">Example 2. Contact accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sure, let's talk!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">However, it could be that Juliet is busy so she declines the invitation.</p>
+  <p class="caption">Example 3. Contact declines offer and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sorry, can't chat now! How about tonight?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support feature negotiation or does not support the "http://jabber.org/protocol/chatneg" FORM_TYPE, it SHOULD return a &lt;service-unavailable/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+  <p class="caption">Example 4. Contact returns service unavailable error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support one of the required features, it SHOULD return a &lt;feature-not-implemented/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+  <p class="caption">Example 5. Contact returns feature not implemented error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's client does not support one of the optional features (e.g., Chat State Notifications) but it accepts the request, it MUST set the value of that boolean variable to "0".</p>
+<h2>3.
+       <a name="terminate">Terminating a Chat</a>
+</h2>
+  <p class="" style="">In order to explicitly terminate a negotiated chat, the party that wishes to end the chat MUST do so by sending a &lt;message/&gt; containing a data form. The &lt;message/&gt; stanza SHOULD possess an 'id' attribute and MUST contain a &lt;thread/&gt; element with the same XML character data as the original initiation request. The data form containing a boolean field set named "terminate" set to a value of "1" or "true" and MAY also contain a "reason" field.</p>
+  <p class="caption">Example 6. Contact terminates chat and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='term1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='terminate'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Gotta go!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Both parties MUST then consider the chat session to be ended.</p>
+<h2>4.
+       <a name="sip">Mapping to SIP</a>
+</h2>
+  <p class="" style="">When mapping instant messaging flows to SIP, implementations SHOULD adhere to <span class="ref" style="">draft-saintandre-xmpp-simple</span>  [<a href="#nt-id2256711">10</a>].</p>
+  <p class="" style="">In addition, the following mappings apply to chat session negotiation:</p>
+  <ul>
+    <li>Initiation of a negotiated chat maps to the semantics of the SIP INVITE method.</li>
+    <li>Termination of a negotiated chat maps to the semantics of the SIP BYE method.</li>
+    <li>The XMPP &lt;thread/&gt; value maps to the semantics of the SIP Call-ID attribute.</li>
+  </ul>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client MAY require a human user to approve each chat session negotiation request or MAY auto-accept and auto-reject requests based on some user-configurable policy.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">If a contact accepts a user's request or returns an error to the user, the user will effectively discover the contact's presence (at least the presence of one of the contact's resources). Due care must be exercised in determining whether to accept the request or return an error (e.g., the contact's client MUST NOT automatically accept the user's request or return an error to the user if the user is in the contact's block list).</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256861">11</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256876">12</a>] shall include 'http://jabber.org/protocol/chatneg' in its registry of Service Discovery features.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;desc&gt;Support for Chat Session Negotiation and its FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2256922">13</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling negotation of a one-to-one
+    chat session between two entities.
+  &lt;/desc&gt;
+  &lt;field
+      var='accept'
+      type='boolean'
+      label='Whether to accept the invitation'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable Chat State Notifications per JEP-0085'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable XHTML-IM formatting per JEP-0071'/&gt;
+  &lt;field
+      var='logging'
+      type='boolean'
+      label='Whether to allow client-side message logging'/&gt;
+  &lt;field
+      var='reason'
+      type='text-single'
+      label='A reason for chatting (or not)'/&gt;
+  &lt;field
+      var='terminate'
+      type='boolean'
+      label='Whether to terminate the session'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This proposal defines best practices for use of JEP-0020 and therefore does not require a separate schema.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251522">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251550">2</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2250555">3</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2250542">4</a>. In essence, a chat state negotiation request as specified herein is functionally equivalent to a SIP INVITE request, and acceptance of such a request is functionally equivalent to sending a SIP 200 OK response; see Section 17 of <span style="font-weight: bold">RFC 3261</span>.</p>
+<p><a name="nt-id2250735">5</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2250782">6</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250774">7</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2250584">8</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2250626">9</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2256711">10</a>. Basic Messaging and Presence Interoperability between the Extensible Messaging and Presence Protocol (XMPP) and Session Initiation Protocol (SIP) for Instant Messaging and Presence Leveraging Extensions (SIMPLE) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-simple-05.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-simple-05.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256861">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256876">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256922">13</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2006-01-03)</h4>
+<div class="indent">Added terminate use case; further specified mapping to SIP. (psa)
+    </div>
+<h4>Version 0.3 (2005-12-30)</h4>
+<div class="indent">Further specified use of id attribute and thread element. (psa)
+    </div>
+<h4>Version 0.2 (2005-07-15)</h4>
+<div class="indent">Further described contexts in which chat session negotiation could be useful; added more examples; added reference to SIP RFC and explained basic mapping to SIP INVITE method; added Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2005-07-14)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-07-12)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0155-0.5.html
+++ b/content/xep-0155-0.5.html
@@ -1,0 +1,534 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0155: Chat Session Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat Session Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a feature negotiation profile for initiating a one-to-one chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0155">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0155: Chat Session Negotiation</h1>
+<p>This document specifies a feature negotiation profile for initiating a one-to-one chat session.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0155<br>
+            Version: 0.5<br>
+            Last Updated: 2006-01-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0020, JEP-0068<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatneg<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Chat%20Session%20Negotiation%20(JEP-0155)">http://wiki.jabber.org/index.php/Chat Session Negotiation (JEP-0155)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#initiate">Initiating a Chat</a>
+</dt>
+<dt>2.2.  <a href="#renegotiate">Renegotiating a Chat</a>
+</dt>
+<dt>2.3.  <a href="#terminate">Terminating a Chat</a>
+</dt>
+</dl>
+<dt>3.  <a href="#sip">Mapping to SIP</a>
+</dt>
+<dt>4.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>7.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The traditional model for one-to-one chat "sessions" in Jabber/XMPP is for a user to simply send a message to a contact without any formal negotiation of chat session parameters. This informal approach to initiation of a chat session is perfectly acceptable in most contexts, environments, and cultures. However, it may be desirable to formally request the chat and negotiate its parameters before beginning the chat session in some circumstances, such as:</p>
+  <ul>
+    <li>The parties are unknown to each other, have not exchanged presence, or have not discovered their respective capabilities via <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250803">1</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2250965">2</a>].</li>
+    <li>When an XMPP-based system interfaces with a SIP-based system built on top of <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250825">3</a>].  [<a href="#nt-id2251111">4</a>]</li>
+    <li>Within an organization or culture in which one would not simply begin chatting with a superior without first receiving permission to do so.</li>
+  </ul>
+  <p class="" style="">This proposal defines best practices for such a negotiation, re-using the protocol defined in <span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2250869">5</a>].</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="initiate">Initiating a Chat</a>
+</h3>
+    <p class="" style="">In order to initiate a negotiated chat session, the initiating party ("user") sends a &lt;message/&gt; stanza to the receiving party ("contact") containing a &lt;feature/&gt; child qualified by the 'http://jabber.org/protocol/feature-neg' namespace. The &lt;message/&gt; stanza MUST NOT contain a &lt;body/&gt; child element (as specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250919">6</a>]). The &lt;message/&gt; stanza is used because the user does not necessarily know which of the contact's resources is most available (or indeed if the contact is online). The &lt;message/&gt; stanza type SHOULD be "normal" (either explicitly or by non-inclusion of the 'type' attribute). The stanza SHOULD include an 'id' attribute and MUST contain a &lt;thread/&gt; element for tracking purposes. The data form MUST contain a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/chatneg" and MUST contain a boolean field named "accept".  [<a href="#nt-id2250901">7</a>]</p>
+    <p class="" style="">The following is an example of a negotiation request:</p>
+    <p class="caption">Example 1. User requests chat session</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the foregoing example, Romeo requests a chat with Juliet and also queries her regarding whether she wants to allow client-side message logging and support <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2251037">8</a>] and <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2251059">9</a>] extensions during this chat session. (Note: These fields are examples only; a full set of chat session negotiation parameters will be registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.)</p>
+    <p class="" style="">Juliet's server delivers Romeo's request to her most available resource (which happens to be "balcony").</p>
+    <p class="" style="">In any response to the request, the contact's client MUST mirror the 'id' attribute and &lt;thread/&gt;value so that the user's client can correctly track the response.</p>
+    <p class="" style="">We assume that Juliet accepts the chat and specifies that she does not want to log messages or use XHTML formatting but that she does want to use Chat State Notifications:</p>
+    <p class="caption">Example 2. Contact accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sure, let's talk!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">However, it could be that Juliet is busy so she declines the invitation.</p>
+    <p class="caption">Example 3. Contact declines offer and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sorry, can't chat now! How about tonight?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support feature negotiation or does not support the "http://jabber.org/protocol/chatneg" FORM_TYPE, it SHOULD return a &lt;service-unavailable/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+    <p class="caption">Example 4. Contact returns service unavailable error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support one of the required features, it SHOULD return a &lt;feature-not-implemented/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+    <p class="caption">Example 5. Contact returns feature not implemented error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support one of the optional features (e.g., Chat State Notifications) but it accepts the request, it MUST set the value of that boolean variable to "0" or "false".</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="renegotiate">Renegotiating a Chat</a>
+</h3>
+    <p class="" style="">At any time during an existing chat session, either party MAY attempt to renegotiate the parameters of the session. The requesting party does this by sending a new &lt;message/&gt; stanza containing a feature negotiation form and a &lt;thread/&gt; element with the same value as that of the existing chat session.</p>
+    <p class="caption">Example 6. One party requests renegotiation</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net'
+         id='reneg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;false&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Gotta have formatting!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 7. Other party accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com/balcony'
+         id='reneg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Agreed, XHTML is fun.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="terminate">Terminating a Chat</a>
+</h3>
+    <p class="" style="">In order to explicitly terminate a negotiated chat, the party that wishes to end the chat MUST do so by sending a &lt;message/&gt; containing a data form. The &lt;message/&gt; stanza SHOULD possess an 'id' attribute and MUST contain a &lt;thread/&gt; element with the same XML character data as the original initiation request. The data form containing a boolean field set named "terminate" set to a value of "1" or "true" and MAY also contain a "reason" field.</p>
+    <p class="caption">Example 8. Contact terminates chat and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='term1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='terminate'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Gotta go!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Both parties MUST then consider the chat session to be ended.</p>
+  </div>
+<h2>3.
+       <a name="sip">Mapping to SIP</a>
+</h2>
+  <p class="" style="">When mapping instant messaging flows to SIP, implementations SHOULD adhere to <span class="ref" style="">draft-saintandre-xmpp-simple</span>  [<a href="#nt-id2256745">10</a>].</p>
+  <p class="" style="">In addition, the following mappings apply to chat session negotiation:</p>
+  <ul>
+    <li>Initiation of a negotiated chat session maps to the semantics of the SIP INVITE method.</li>
+    <li>Renegotiation of a negotiated chat session also maps to the semantics of the SIP INVITE method.</li>
+    <li>Termination of a negotiated chat session maps to the semantics of the SIP BYE method.</li>
+    <li>The XMPP &lt;thread/&gt; value maps to the semantics of the SIP Call-ID attribute.</li>
+  </ul>
+<h2>4.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client MAY require a human user to approve each chat session negotiation request or MAY auto-accept and auto-reject requests based on some user-configurable policy.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">If a contact accepts a user's request or returns an error to the user, the user will effectively discover the contact's presence (at least the presence of one of the contact's resources). Due care must be exercised in determining whether to accept the request or return an error (e.g., the contact's client MUST NOT automatically accept the user's request or return an error to the user if the user is in the contact's block list).</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256901">11</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256918">12</a>] shall include 'http://jabber.org/protocol/chatneg' in its registry of Service Discovery features.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;desc&gt;Support for Chat Session Negotiation and its FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2256963">13</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling negotation of a one-to-one
+    chat session between two entities.
+  &lt;/desc&gt;
+  &lt;field
+      var='accept'
+      type='boolean'
+      label='Whether to accept the invitation'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable Chat State Notifications per JEP-0085'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable XHTML-IM formatting per JEP-0071'/&gt;
+  &lt;field
+      var='logging'
+      type='boolean'
+      label='Whether to allow client-side message logging'/&gt;
+  &lt;field
+      var='reason'
+      type='text-single'
+      label='A reason for chatting (or not)'/&gt;
+  &lt;field
+      var='terminate'
+      type='boolean'
+      label='Whether to terminate the session'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This proposal defines best practices for use of JEP-0020 and therefore does not require a separate schema.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250803">1</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250965">2</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2250825">3</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2251111">4</a>. In essence, a chat state negotiation request as specified herein is functionally equivalent to a SIP INVITE request, and acceptance of such a request is functionally equivalent to sending a SIP 200 OK response; see Section 17 of <span style="font-weight: bold">RFC 3261</span>.</p>
+<p><a name="nt-id2250869">5</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2250919">6</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250901">7</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2251037">8</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2251059">9</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2256745">10</a>. Basic Messaging and Presence Interoperability between the Extensible Messaging and Presence Protocol (XMPP) and Session Initiation Protocol (SIP) for Instant Messaging and Presence Leveraging Extensions (SIMPLE) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-simple-05.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-simple-05.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2256901">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256918">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256963">13</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2006-01-24)</h4>
+<div class="indent">Added renegotiate use case. (psa)
+    </div>
+<h4>Version 0.4 (2006-01-03)</h4>
+<div class="indent">Added terminate use case; further specified mapping to SIP. (psa)
+    </div>
+<h4>Version 0.3 (2005-12-30)</h4>
+<div class="indent">Further specified use of id attribute and thread element. (psa)
+    </div>
+<h4>Version 0.2 (2005-07-15)</h4>
+<div class="indent">Further described contexts in which chat session negotiation could be useful; added more examples; added reference to SIP RFC and explained basic mapping to SIP INVITE method; added Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2005-07-14)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-07-12)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0155-0.6.html
+++ b/content/xep-0155-0.6.html
@@ -1,0 +1,550 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0155: Chat Session Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat Session Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a feature negotiation profile for initiating a one-to-one chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-13">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0155">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0155: Chat Session Negotiation</h1>
+<p>This document specifies a feature negotiation profile for initiating a one-to-one chat session.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0155<br>
+            Version: 0.6<br>
+            Last Updated: 2006-07-13<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0020, JEP-0068<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatneg<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Chat%20Session%20Negotiation%20(JEP-0155)">http://wiki.jabber.org/index.php/Chat Session Negotiation (JEP-0155)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#initiate">Initiating a Chat</a>
+</dt>
+<dt>2.2.  <a href="#renegotiate">Renegotiating a Chat</a>
+</dt>
+<dt>2.3.  <a href="#terminate">Terminating a Chat</a>
+</dt>
+</dl>
+<dt>3.  <a href="#sip">Mapping to SIP</a>
+</dt>
+<dt>4.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>7.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The traditional model for one-to-one chat "sessions" in Jabber/XMPP is for a user to simply send a message to a contact without any formal negotiation of chat session parameters (e.g., see <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250790">1</a>]). This informal approach to initiation of a chat session is perfectly acceptable in many contexts, environments, and cultures. However, it may be desirable to formally request the chat and negotiate its parameters before beginning the chat session in some circumstances, such as:</p>
+  <ul>
+    <li>The parties are unknown to each other, have not exchanged presence, or have not discovered their respective capabilities via <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250825">2</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2250816">3</a>].</li>
+    <li>When an XMPP-based system interfaces with a SIP-based system built on top of <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2251008">4</a>].  [<a href="#nt-id2250810">5</a>]</li>
+    <li>Within an organization or culture in which one would not simply begin chatting with another person (e.g., a superior) without first receiving permission to do so.</li>
+  </ul>
+  <p class="" style="">This proposal defines best practices for such a negotiation, re-using the protocol defined in <span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2250843">6</a>].</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="initiate">Initiating a Chat</a>
+</h3>
+    <p class="" style="">In order to initiate a negotiated chat session, the initiating party ("user") sends a &lt;message/&gt; stanza to the receiving party ("contact") containing a &lt;feature/&gt; child qualified by the 'http://jabber.org/protocol/feature-neg' namespace. The &lt;message/&gt; stanza MUST NOT contain a &lt;body/&gt; child element (as specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250896">7</a>]). The &lt;message/&gt; stanza is used because the user does not necessarily know which of the contact's resources is most available (or indeed if the contact is online). The &lt;message/&gt; stanza type SHOULD be "normal" (either explicitly or by non-inclusion of the 'type' attribute). The stanza SHOULD include an 'id' attribute and MUST contain a &lt;thread/&gt; element for tracking purposes (where the newly-generated ThreadID is unique to the proposed session). The data form MUST contain a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/chatneg" and MUST contain a boolean field named "accept".  [<a href="#nt-id2250878">8</a>]</p>
+    <p class="" style="">The following is an example of a negotiation request:</p>
+    <p class="caption">Example 1. User requests chat session</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the foregoing example, Romeo requests a chat with Juliet and also queries her regarding whether she wants to allow client-side message logging and support <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2250951">9</a>] and <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2259515">10</a>] extensions during this chat session. (Note: These fields are examples only; a full set of chat session negotiation parameters will be registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.)</p>
+    <p class="" style="">Juliet's server delivers Romeo's request to her most available resource (which happens to be "balcony").</p>
+    <p class="" style="">In any response to the request, the contact's client MUST mirror the 'id' attribute and &lt;thread/&gt;value so that the user's client can correctly track the response.</p>
+    <p class="" style="">We assume that Juliet accepts the chat and specifies that she does not want to log messages or use XHTML formatting but that she does want to use Chat State Notifications:</p>
+    <p class="caption">Example 2. Contact accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sure, let's talk!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">However, it could be that Juliet is busy so she declines the invitation.</p>
+    <p class="caption">Example 3. Contact declines offer and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sorry, can't chat now! How about tonight?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support feature negotiation or does not support the "http://jabber.org/protocol/chatneg" FORM_TYPE, it SHOULD return a &lt;service-unavailable/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+    <p class="caption">Example 4. Contact returns service unavailable error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support one of the required features, it SHOULD return a &lt;feature-not-implemented/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+    <p class="caption">Example 5. Contact returns feature not implemented error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support one of the optional features (e.g., Chat State Notifications) but it accepts the request, it MUST set the value of that boolean variable to "0" or "false".</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="renegotiate">Renegotiating a Chat</a>
+</h3>
+    <p class="" style="">At any time during an existing chat session, either party MAY attempt to renegotiate the parameters of the session. The requesting party does this by sending a new &lt;message/&gt; stanza containing a feature negotiation form and a &lt;thread/&gt; element with the same value as that of the existing chat session.</p>
+    <p class="caption">Example 6. One party requests renegotiation</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net'
+         id='reneg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;false&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Gotta have formatting!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 7. Other party accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com/balcony'
+         id='reneg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Agreed, XHTML is fun.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="terminate">Terminating a Chat</a>
+</h3>
+    <p class="" style="">In order to explicitly terminate a negotiated chat, the party that wishes to end the chat MUST do so by sending a &lt;message/&gt; containing a data form. The &lt;message/&gt; stanza SHOULD possess an 'id' attribute and MUST contain a &lt;thread/&gt; element with the same XML character data as the original initiation request. The data form containing a boolean field set named "terminate" set to a value of "1" or "true" and MAY also contain a "reason" field.</p>
+    <p class="caption">Example 8. Contact terminates chat and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='term1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='terminate'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Gotta go!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Both parties MUST then consider the chat session to be ended.</p>
+    <p class="" style="">If a party receives XMPP presence of type "unavailable" from the full JID (&lt;node@domain.tld/resource&gt;) of the other party (i.e., the resource with which it has had an active session), the receiving party MUST consider the session to be terminated. If the receiving party then receives presence of type "available" from that same resource or another resource associated with the other party and the receiving party desires to restart the chat session, it MUST initiate a new chat session (including a newly-generated ThreadID) with the other party rather than renegotiate parameters for the terminated session. (Note: This is consistent with the handling of chat states as specified in <span style="font-weight: bold">JEP-0085</span>.)</p>
+  </div>
+<h2>3.
+       <a name="sip">Mapping to SIP</a>
+</h2>
+  <p class="" style="">When mapping instant messaging flows to SIP, implementations SHOULD adhere to <span class="ref" style="">draft-saintandre-xmpp-simple</span>  [<a href="#nt-id2259815">11</a>].</p>
+  <p class="" style="">In addition, the following mappings apply to chat session negotiation:</p>
+  <ul>
+    <li>Initiation of a negotiated chat session maps to the semantics of the SIP INVITE method.</li>
+    <li>Renegotiation of a negotiated chat session also maps to the semantics of the SIP INVITE method.</li>
+    <li>Termination of a negotiated chat session maps to the semantics of the SIP BYE method.</li>
+    <li>The XMPP &lt;thread/&gt; value maps to the semantics of the SIP Call-ID attribute.</li>
+  </ul>
+<h2>4.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client MAY require a human user to approve each chat session negotiation request or MAY auto-accept and auto-reject requests based on some user-configurable policy.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">If a contact accepts a user's request or returns an error to the user, the user will effectively discover the contact's presence (at least the presence of one of the contact's resources). Due care must be exercised in determining whether to accept the request or return an error (e.g., the contact's client MUST NOT automatically accept the user's request or return an error to the user if the user is in the contact's block list).</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259654">12</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259698">13</a>] shall include 'http://jabber.org/protocol/chatneg' in its registry of Service Discovery features.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;desc&gt;Support for Chat Session Negotiation and its FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2260499">14</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling negotation of a one-to-one
+    chat session between two entities.
+  &lt;/desc&gt;
+  &lt;field
+      var='accept'
+      type='boolean'
+      label='Whether to accept the invitation'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable Chat State Notifications per JEP-0085'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/xhtml-im'
+      type='boolean'
+      label='Whether to enable XHTML-IM formatting per JEP-0071'/&gt;
+  &lt;field
+      var='logging'
+      type='boolean'
+      label='Whether to allow client-side message logging'/&gt;
+  &lt;field
+      var='reason'
+      type='text-single'
+      label='A reason for chatting (or not)'/&gt;
+  &lt;field
+      var='terminate'
+      type='boolean'
+      label='Whether to terminate the session'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This proposal re-uses the format defined in JEP-0020 and therefore does not require a separate schema.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250790">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250825">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250816">3</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2251008">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2250810">5</a>. In essence, a chat state negotiation request as specified herein is functionally equivalent to a SIP INVITE request, and acceptance of such a request is functionally equivalent to sending a SIP 200 OK response; see Section 17 of <span style="font-weight: bold">RFC 3261</span>.</p>
+<p><a name="nt-id2250843">6</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2250896">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250878">8</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2250951">9</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2259515">10</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2259815">11</a>. Basic Messaging and Presence Interoperability between the Extensible Messaging and Presence Protocol (XMPP) and Session Initiation Protocol (SIP) for Instant Messaging and Presence Leveraging Extensions (SIMPLE) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-simple-05.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-simple-05.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2259654">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259698">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2260499">14</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2006-07-13)</h4>
+<div class="indent">
+<p class="" style="">Specified that a client must re-initiate if it receives presence unavailable; changed JEP type to Standards Track.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Added renegotiate use case.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-01-03)</h4>
+<div class="indent">
+<p class="" style="">Added terminate use case; further specified mapping to SIP.</p> (psa)
+    </div>
+<h4>Version 0.3 (2005-12-30)</h4>
+<div class="indent">
+<p class="" style="">Further specified use of id attribute and thread element.</p> (psa)
+    </div>
+<h4>Version 0.2 (2005-07-15)</h4>
+<div class="indent">
+<p class="" style="">Further described contexts in which chat session negotiation could be useful; added more examples; added reference to SIP RFC and explained basic mapping to SIP INVITE method; added Jabber Registrar considerations.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-07-14)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-07-12)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0155-0.7.html
+++ b/content/xep-0155-0.7.html
@@ -1,0 +1,590 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0155: Chat Session Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Chat Session Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a feature negotiation profile for initiating a one-to-one chat session.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-14">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0155">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0155: Chat Session Negotiation</h1>
+<p>This document specifies a feature negotiation profile for initiating a one-to-one chat session.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0155<br>
+            Version: 0.7<br>
+            Last Updated: 2006-07-14<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0020, JEP-0068<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: chatneg<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Chat%20Session%20Negotiation%20(JEP-0155)">http://wiki.jabber.org/index.php/Chat Session Negotiation (JEP-0155)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#initiate">Initiating a Chat</a>
+</dt>
+<dt>2.2.  <a href="#renegotiate">Renegotiating a Chat</a>
+</dt>
+<dt>2.3.  <a href="#terminate">Terminating a Chat</a>
+</dt>
+</dl>
+<dt>3.  <a href="#sip">Mapping to SIP</a>
+</dt>
+<dt>4.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>7.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The traditional model for one-to-one chat "sessions" in Jabber/XMPP is for a user to simply send a message to a contact without any formal negotiation of chat session parameters (e.g., see <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250811">1</a>]). This informal approach to initiation of a chat session is perfectly acceptable in many contexts, environments, and cultures. However, it may be desirable to formally request the chat and negotiate its parameters before beginning the chat session in some circumstances, such as:</p>
+  <ul>
+    <li>The parties are unknown to each other, have not exchanged presence, or have not discovered their respective capabilities via <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250986">2</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2251007">3</a>].</li>
+    <li>When an XMPP-based system interfaces with a SIP-based system built on top of <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2251030">4</a>].  [<a href="#nt-id2251018">5</a>]</li>
+    <li>Within an organization or culture in which one would not simply begin chatting with another person (e.g., a superior) without first receiving permission to do so.</li>
+  </ul>
+  <p class="" style="">This proposal defines best practices for such a negotiation, re-using the protocol defined in <span class="ref" style="">Feature Negotiation</span>  [<a href="#nt-id2250849">6</a>].</p>
+<h2>2.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="initiate">Initiating a Chat</a>
+</h3>
+    <p class="" style="">In order to initiate a negotiated chat session, the initiating party ("user") sends a &lt;message/&gt; stanza to the receiving party ("contact") containing a &lt;feature/&gt; child qualified by the 'http://jabber.org/protocol/feature-neg' namespace. The &lt;message/&gt; stanza MUST NOT contain a &lt;body/&gt; child element (as specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250904">7</a>]). The &lt;message/&gt; stanza is used because the user does not necessarily know which of the contact's resources is most available (or indeed if the contact is online). The &lt;message/&gt; stanza type SHOULD be "normal" (either explicitly or by non-inclusion of the 'type' attribute). The stanza SHOULD include an 'id' attribute and MUST contain a &lt;thread/&gt; element for tracking purposes (where the newly-generated ThreadID is unique to the proposed session). The data form MUST contain a hidden FORM_TYPE field whose value is "http://jabber.org/protocol/chatneg" and MUST contain a boolean field named "accept".  [<a href="#nt-id2250878">8</a>]</p>
+    <p class="" style="">The following is an example of a negotiation request:</p>
+    <p class="caption">Example 1. User requests chat session</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Must Both Parties Be Securely Connected to Their Servers?'
+             type='boolean' 
+             var='secure'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">In the foregoing example, Romeo requests a chat with Juliet and also queries her regarding whether she wants to allow client-side message logging and support <span class="ref" style="">XHTML-IM</span>  [<a href="#nt-id2259496">9</a>] and <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2259538">10</a>] extensions during this chat session. (Note: These fields are examples only; a full set of chat session negotiation parameters will be registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.)</p>
+    <p class="" style="">Juliet's server delivers Romeo's request to her most available resource (which happens to be "balcony").</p>
+    <p class="" style="">In any response to the request, the contact's client MUST mirror the 'id' attribute and &lt;thread/&gt;value so that the user's client can correctly track the response.</p>
+    <p class="" style="">We assume that Juliet accepts the chat and specifies that she does not want to log messages or use XHTML formatting but that she does want to use Chat State Notifications:</p>
+    <p class="caption">Example 2. Contact accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='secure'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sure, let's talk!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">However, it could be that Juliet is busy so she declines the invitation.</p>
+    <p class="caption">Example 3. Contact declines offer and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Sorry, can't chat now! How about tonight?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support feature negotiation or does not support the "http://jabber.org/protocol/chatneg" FORM_TYPE, it SHOULD return a &lt;service-unavailable/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+    <p class="caption">Example 4. Contact returns service unavailable error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Must Both Parties Be Securely Connected to Their Servers?'
+             type='boolean' 
+             var='secure'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support one of the required features, it SHOULD return a &lt;feature-not-implemented/&gt; error (but MAY return no error if, for example, Juliet does not want to reveal her presence to Romeo for whatever reason):</p>
+    <p class="caption">Example 5. Contact returns feature not implemented error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Must Both Parties Be Securely Connected to Their Servers?'
+             type='boolean' 
+             var='secure'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Can we talk?&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+  &lt;error code='501' type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">If Juliet's client does not support one of the optional features (e.g., Chat State Notifications) but it accepts the request, it MUST set the value of that boolean variable to "0" or "false".</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="renegotiate">Renegotiating a Chat</a>
+</h3>
+    <p class="" style="">At any time during an existing chat session, either party MAY attempt to renegotiate the parameters of the session. The requesting party does this by sending a new &lt;message/&gt; stanza containing a feature negotiation form and a &lt;thread/&gt; element with the same value as that of the existing chat session.</p>
+    <p class="caption">Example 6. One party requests renegotiation</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net'
+         id='reneg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable XHTML Formatting?'
+             type='boolean' 
+             var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Chat State Notifications?'
+             type='boolean' 
+             var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Allow Message Logging?' 
+             type='boolean' 
+             var='logging'&gt;
+        &lt;value&gt;false&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Must Both Parties Be Securely Connected to Their Servers?'
+             type='boolean' 
+             var='secure'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Reason' 
+             type='text-single' 
+             var='reason'&gt;
+        &lt;value&gt;Gotta have formatting!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 7. Other party accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='romeo@montague.net/orchard'
+         to='juliet@capulet.com/balcony'
+         id='reneg1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/xhtml-im'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/chatstates'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='logging'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='secure'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Agreed, XHTML is fun.&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="terminate">Terminating a Chat</a>
+</h3>
+    <p class="" style="">In order to explicitly terminate a negotiated chat, the party that wishes to end the chat MUST do so by sending a &lt;message/&gt; containing a data form. The &lt;message/&gt; stanza SHOULD possess an 'id' attribute and MUST contain a &lt;thread/&gt; element with the same XML character data as the original initiation request. The data form containing a boolean field set named "terminate" set to a value of "1" or "true" and MAY also contain a "reason" field.</p>
+    <p class="caption">Example 8. Contact terminates chat and specifies reason</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         id='term1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='terminate'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='reason'&gt;
+        &lt;value&gt;Gotta go!&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Both parties MUST then consider the chat session to be ended.</p>
+    <p class="" style="">If a party receives XMPP presence of type "unavailable" from the full JID (&lt;node@domain.tld/resource&gt;) of the other party (i.e., the resource with which it has had an active session), the receiving party MUST consider the session to be terminated. If the receiving party then receives presence of type "available" from that same resource or another resource associated with the other party and the receiving party desires to restart the chat session, it MUST initiate a new chat session (including a newly-generated ThreadID) with the other party rather than renegotiate parameters for the terminated session. (Note: This is consistent with the handling of chat states as specified in <span style="font-weight: bold">JEP-0085</span>.)</p>
+  </div>
+<h2>3.
+       <a name="sip">Mapping to SIP</a>
+</h2>
+  <p class="" style="">When mapping instant messaging flows to SIP, implementations SHOULD adhere to <span class="ref" style="">draft-saintandre-xmpp-simple</span>  [<a href="#nt-id2259643">11</a>].</p>
+  <p class="" style="">In addition, the following mappings apply to chat session negotiation:</p>
+  <ul>
+    <li>Initiation of a negotiated chat session maps to the semantics of the SIP INVITE method.</li>
+    <li>Renegotiation of a negotiated chat session also maps to the semantics of the SIP INVITE method.</li>
+    <li>Termination of a negotiated chat session maps to the semantics of the SIP BYE method.</li>
+    <li>The XMPP &lt;thread/&gt; value maps to the semantics of the SIP Call-ID attribute.</li>
+  </ul>
+<h2>4.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">A client MAY require a human user to approve each chat session negotiation request or MAY auto-accept and auto-reject requests based on some user-configurable policy.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">If a contact accepts a user's request or returns an error to the user, the user will effectively discover the contact's presence (at least the presence of one of the contact's resources). Due care must be exercised in determining whether to accept the request or return an error (e.g., the contact's client MUST NOT automatically accept the user's request or return an error to the user if the user is in the contact's block list).</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259797">12</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259780">13</a>] shall include 'http://jabber.org/protocol/chatneg' in its registry of Service Discovery features.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;var&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;desc&gt;Support for Chat Session Negotiation and its FORM_TYPE&lt;/desc&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+&lt;/var&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2260533">14</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace. The following fields shall be registered for use in Chat Session Negotiation:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;doc&gt;JEP-0155&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling negotation of a one-to-one
+    chat session between two entities.
+  &lt;/desc&gt;
+  &lt;field
+      var='accept'
+      type='boolean'
+      label='Whether to accept the invitation'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/chatstates'
+      type='boolean'
+      label='Whether to enable Chat State Notifications per JEP-0085'/&gt;
+  &lt;field
+      var='http://jabber.org/protocol/xhtml-im'
+      type='boolean'
+      label='Whether to enable XHTML-IM formatting per JEP-0071'/&gt;
+  &lt;field
+      var='logging'
+      type='boolean'
+      label='Whether to allow client-side message logging'/&gt;
+  &lt;field
+      var='reason'
+      type='text-single'
+      label='A reason for chatting (or not)'/&gt;
+  &lt;field 
+      var='secure'
+      type='boolean' 
+      label='Whether both parties must be securely connected to their servers'/&gt;
+  &lt;field
+      var='terminate'
+      type='boolean'
+      label='Whether to terminate the session'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">This proposal re-uses the format defined in JEP-0020 and therefore does not require a separate schema.</p>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Thomas Charron, Ian Paterson, and Jean-Louis Seguineau for their feedback.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250811">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250986">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251007">3</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2251030">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2251018">5</a>. In essence, a chat state negotiation request as specified herein is functionally equivalent to a SIP INVITE request, and acceptance of such a request is functionally equivalent to sending a SIP 200 OK response; see Section 17 of <span style="font-weight: bold">RFC 3261</span>.</p>
+<p><a name="nt-id2250849">6</a>. JEP-0020: Feature Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0020.html">http://www.jabber.org/jeps/jep-0020.html</a>&gt;.</p>
+<p><a name="nt-id2250904">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250878">8</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2259496">9</a>. JEP-0071: XHTML-IM &lt;<a href="http://www.jabber.org/jeps/jep-0071.html">http://www.jabber.org/jeps/jep-0071.html</a>&gt;.</p>
+<p><a name="nt-id2259538">10</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2259643">11</a>. Basic Messaging and Presence Interoperability between the Extensible Messaging and Presence Protocol (XMPP) and Session Initiation Protocol (SIP) for Instant Messaging and Presence Leveraging Extensions (SIMPLE) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-simple-05.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-simple-05.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2259797">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259780">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2260533">14</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2006-07-14)</h4>
+<div class="indent">
+<p class="" style="">Added secure field from JEP-0116.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-13)</h4>
+<div class="indent">
+<p class="" style="">Specified that a client must re-initiate if it receives presence unavailable; changed JEP type to Standards Track.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Added renegotiate use case.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-01-03)</h4>
+<div class="indent">
+<p class="" style="">Added terminate use case; further specified mapping to SIP.</p> (psa)
+    </div>
+<h4>Version 0.3 (2005-12-30)</h4>
+<div class="indent">
+<p class="" style="">Further specified use of id attribute and thread element.</p> (psa)
+    </div>
+<h4>Version 0.2 (2005-07-15)</h4>
+<div class="indent">
+<p class="" style="">Further described contexts in which chat session negotiation could be useful; added more examples; added reference to SIP RFC and explained basic mapping to SIP INVITE method; added Jabber Registrar considerations.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-07-14)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-07-12)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0156-0.1.html
+++ b/content/xep-0156-0.1.html
@@ -1,0 +1,231 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0156: A DNS TXT Resource Record Format for XMPP Connection Methods</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="A DNS TXT Resource Record Format for XMPP Connection Methods">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a DNS TXT Resource Record format for use in specifying methods of connecting to an XMPP server.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-09-08">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0156">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0156: A DNS TXT Resource Record Format for XMPP Connection Methods</h1>
+<p>This document defines a DNS TXT Resource Record format for use in specifying methods of connecting to an XMPP server.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0156<br>
+            Version: 0.1<br>
+            Last Updated: 2005-09-08<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 1464<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/A%20DNS%20TXT%20Resource%20Record%20Format%20for%20XMPP%20Connection%20Methods%20(JEP-0156)">http://wiki.jabber.org/index.php/A DNS TXT Resource Record Format for XMPP Connection Methods (JEP-0156)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#format">Record Format</a>
+</dt>
+<dt>3.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>4.  <a href="#examples">Examples</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-dnstxt">DNS TXT Records Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-dnstxt-process">Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-dnstxt-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Although <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251704">1</a>] specifies the use of TCP as the method of connecting to an XMPP server, other connection methods are possible. These include the older <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2251666">2</a>] method, the more recent <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2251689">3</a>] method, and less common methods such as <span class="ref" style="">Wireless Access Protocol (WAP)</span>  [<a href="#nt-id2251656">4</a>]. For some of these methods, it is necessary to discover further parameters before connecting, such as the HTTP URL of an alternative connection manager. Currently, if a client application needs to discover connection methods before connecting to an XMPP service, the relevant information must be provided manually by a human user, which is cumbersome and error-prone. Thankfully, there are several potential ways to complete this pre-connection service discovery in an automated fashion:</p>
+  <ol start="" type="">
+    <li><p class="" style="">Specify a <span class="ref" style="">WSDL</span>  [<a href="#nt-id2250698">5</a>] definition (or other XML file format) and a canonical URL for that definition at a domain that offers XMPP services. Unfortunately, this approach requires access to the HTTP server for the domain (and quite possibly to the root directory thereof), which may be difficult for XMPP server administrators to arrange. In addition, it requires a client to retrieve the relevant file via HTTP before performing DNS lookups and XMPP connection; it would be more efficient to use recognized DNS methods since DNS lookups are already required by <span style="font-weight: bold">RFC 3920</span>.</p></li>
+    <li><p class="" style="">Specify a way to define the required service discovery information as part of the existing DNS SRV records (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2250773">6</a>]) for a domain that offers XMPP services. While this approach sounds promising, it is not feasible since the DNS SRV Target field can be used only to specify domain names and cannot be used to specify full URIs (such as the URL for an HTTP connection manager).</p></li>
+    <li><p class="" style="">Specify a way to define the required service discovery using the "straightforward NAPTR" (S-NAPTR) profile of the Dynamic Delegation Discovery System (see <span class="ref" style="">RFC 3958</span>  [<a href="#nt-id2250737">7</a>] and <span class="ref" style="">RFC 3401</span>  [<a href="#nt-id2250521">8</a>]). Unfortunately, S-NAPTR also does not allow inclusion of full URIs, and thus does meet the requirements for discovery of XMPP connection methods.</p></li>
+    <li><p class="" style="">Specify a way to define the required service discovery using a new profile of the Dynamic Delegation Discovery System, which would be nearly identical to S-NAPTR except that it would specify only one app-service (most likely "xmpp") and allow inclusion of the DDDS "U" flag (see <span class="ref" style="">RFC 3404</span>  [<a href="#nt-id2250558">9</a>]), so that the output of a DDDS rule could be a URI. While this is a valid approach that is worth pursuing, the authors are concerned about the deployability of such an approach, especially for client-side applications (the main focus of this specification).</p></li>
+    <li><p class="" style="">Specify a way to define the required service discovery information via properly-formatted DNS TXT records (see <span class="ref" style="">RFC 1464</span>  [<a href="#nt-id2250595">10</a>]). While this approach requires an update to the DNS records for the server domain, that is usually necessary in order to establish XMPP services in the first place. Furthermore, although there are some perils to be avoided in the use of DNS TXT records (e.g., wildcards), the technology is well understood and widely deployed (e.g., it is used by the SPF and SenderID systems). Therefore this document defines a way to encapsulate information about XMPP connection methods in DNS TXT resource records.</p></li>
+  </ol>
+<h2>2.
+       <a name="format">Record Format</a>
+</h2>
+  <p class="" style="">The following format for DNS TXT resource records is specified in <span style="font-weight: bold">RFC 1464</span>:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+  &lt;owner&gt; &lt;class&gt; &lt;ttl&gt; &lt;TXT&gt; &lt;"attribute name=attribute value"&gt;
+  </pre></div>
+  <p class="" style="">This document specifies that the following additional rules apply for DNS TXT resource records used to specify XMPP connection methods:</p>
+  <ol start="" type="">
+    <li>It is RECOMMENDED for the owner to be "_xmppconnect".</li>
+    <li>The class field SHOULD be IN.</li>
+    <li>The ttl field is OPTIONAL.</li>
+    <li>The attribute name SHOULD begin with the string "_xmpp-client-" or "_xmpp-server-" and SHOULD be registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.</li>
+    <li>If the txt-data field contains only an attribute name (i.e., no unquoted "=" character followed by additional characters), the receiving application SHOULD interpret it as indicating the presence of the attribute or feature with no defined value.</li>
+    <li>If the txt-data field contains an unquoted "=" character, it MUST also contain an attribute value.</li>
+  </ol>
+<h2>3.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <p class="" style="">The following business rules apply:</p>
+  <ol start="" type="">
+    <li>A domain SHOULD NOT present information in DNS TXT records that is available via the DNS SRV records defined in <span style="font-weight: bold">RFC 3920</span>.</li>
+    <li>The order of DNS TXT records SHOULD NOT be interpreted as significant by the presenting domain or the receiving client.</li>
+  </ol>
+<h2>4.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The following examples show four DNS TXT resource records: the first indicates support for the standard client-to-server TCP connection method with no additional details, the second indicates support for the httpbind connection method defined in JEP-0124 including the appropriate URL, the third indicates support for the httppoll connection method defined in JEP-0025 including the appropriate URL, and the fourth indicates support for WAP connections including the appropriate URL.</p>
+  <p class="caption">Example 1. TXT Resource Records</p>
+<div class="indent"><pre>
+_xmppconnect IN TXT "_xmpp-client-tcp"
+_xmppconnect IN TXT "_xmpp-client-httpbind=https://webconnect.jabber.org:8080/bind.cgi"
+_xmppconnect IN TXT "_xmpp-client-httppoll=https://webconnect.jabber.org:8081/poll.cgi"
+_xmppconnect IN TXT "_xmpp-client-wap=http://wap.jabber.org/connector.cgi"
+  </pre></div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is possible that advertisement of connection methods other than the standard TCP connection method may introduce security vulnerabilities, since a connecting entity (usually a client) might deliberately seek to connect using the method with the weakest security mechanisms (e.g., no channel encryption or relatively weak authentication). Care must be taken in determining which connection methods are appropriate to advertise.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250301">11</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-dnstxt">DNS TXT Records Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of attributes for use in DNS TXT resource records that advertise XMPP connection methods.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-dnstxt-process">Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;attribute&gt;
+  &lt;name&gt;the name of the attribute&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the connection method&lt;/desc&gt;
+  &lt;value&gt;the syntax or datatype of the attribute value&lt;/value&gt;
+  &lt;doc&gt;the document in which the connection method is specified&lt;/doc&gt;
+&lt;/attribute&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one attribute at a time, each contained in a separate &lt;attribute/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-dnstxt-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;attribute&gt;
+  &lt;name&gt;_xmpp-client-httpbind&lt;/name&gt;
+  &lt;desc&gt;the HTTP Binding connection method&lt;/desc&gt;
+  &lt;value&gt;the http: or https: URL at which to contact the HTTP Binding connection manager or proxy&lt;/value&gt;
+  &lt;doc&gt;JEP-0124&lt;/doc&gt;
+&lt;/attribute&gt;
+
+&lt;attribute&gt;
+  &lt;name&gt;_xmpp-client-httppoll&lt;/name&gt;
+  &lt;desc&gt;the HTTP Polling connection method&lt;/desc&gt;
+  &lt;value&gt;the http: or https: URL at which to contact the HTTP Polling connection manager or proxy&lt;/value&gt;
+  &lt;doc&gt;JEP-0025&lt;/doc&gt;
+&lt;/attribute&gt;
+
+&lt;attribute&gt;
+  &lt;name&gt;_xmpp-client-tcp&lt;/name&gt;
+  &lt;desc&gt;standard TCP connection method (usually on port 5222)&lt;/desc&gt;
+  &lt;value&gt;should contain no value, since the port number can be discovered via SRV&lt;/value&gt;
+  &lt;doc&gt;RFC 3920&lt;/doc&gt;
+&lt;/attribute&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251704">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251666">2</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2251689">3</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2251656">4</a>. Wireless Access Protocol (WAP) &lt;<a href="http://www.wapforum.org/">http://www.wapforum.org/</a>&gt;.</p>
+<p><a name="nt-id2250698">5</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2250773">6</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2250737">7</a>. RFC 3958: Domain-Based Application Service Location Using SRV RRs and the Dynamic Delegation Discovery Service (DDDS) &lt;<a href="http://www.ietf.org/rfc/rfc3958.txt">http://www.ietf.org/rfc/rfc3958.txt</a>&gt;.</p>
+<p><a name="nt-id2250521">8</a>. RFC 3401: Dynamic Delegation Discovery System (DDDS) Part One: The Comprehensive DDDS &lt;<a href="http://www.ietf.org/rfc/rfc3401.txt">http://www.ietf.org/rfc/rfc3401.txt</a>&gt;.</p>
+<p><a name="nt-id2250558">9</a>. RFC 3404: Dynamic Delegation Discovery System (DDDS) Part Four: The Uniform Resource Identifiers (URI) Resolution Application &lt;<a href="http://www.ietf.org/rfc/rfc3404.txt">http://www.ietf.org/rfc/rfc3404.txt</a>&gt;.</p>
+<p><a name="nt-id2250595">10</a>. RFC 1464: Using the Domain Name System To Store Arbitrary String Attributes &lt;<a href="http://www.ietf.org/rfc/rfc1464.txt">http://www.ietf.org/rfc/rfc1464.txt</a>&gt;.</p>
+<p><a name="nt-id2250301">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-09-08)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-09-07)</h4>
+<div class="indent">More fully specified the rationale for using DNS TXT records. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-08-27)</h4>
+<div class="indent">Added security considerations and registrar considerations. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-08-23)</h4>
+<div class="indent">First draft. (psa/jh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0156-0.2.html
+++ b/content/xep-0156-0.2.html
@@ -1,0 +1,227 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0156: A DNS TXT Resource Record Format for XMPP Connection Methods</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="A DNS TXT Resource Record Format for XMPP Connection Methods">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a DNS TXT Resource Record format for use in specifying methods of connecting to an XMPP server.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0156">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0156: A DNS TXT Resource Record Format for XMPP Connection Methods</h1>
+<p>This document defines a DNS TXT Resource Record format for use in specifying methods of connecting to an XMPP server.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0156<br>
+            Version: 0.2<br>
+            Last Updated: 2005-12-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 1464<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/A%20DNS%20TXT%20Resource%20Record%20Format%20for%20XMPP%20Connection%20Methods%20(JEP-0156)">http://wiki.jabber.org/index.php/A DNS TXT Resource Record Format for XMPP Connection Methods (JEP-0156)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#format">Record Format</a>
+</dt>
+<dt>3.  <a href="#bizrules">Business Rules</a>
+</dt>
+<dt>4.  <a href="#examples">Examples</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-dnstxt">DNS TXT Records Registry</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#registrar-dnstxt-process">Process</a>
+</dt>
+<dt>7.1.2.  <a href="#registrar-dnstxt-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Although <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251521">1</a>] specifies the use of TCP as the method of connecting to an XMPP server, other connection methods are possible. These include the older <span class="ref" style="">Jabber HTTP Polling</span>  [<a href="#nt-id2251549">2</a>] method, the more recent <span class="ref" style="">HTTP Binding</span>  [<a href="#nt-id2250558">3</a>] method, and less common methods such as <span class="ref" style="">Wireless Access Protocol (WAP)</span>  [<a href="#nt-id2250575">4</a>]. For some of these methods, it is necessary to discover further parameters before connecting, such as the HTTP URL of an alternative connection manager. Currently, if a client application needs to discover connection methods before connecting to an XMPP service, the relevant information must be provided manually by a human user, which is cumbersome and error-prone. Thankfully, there are several potential ways to complete this pre-connection service discovery in an automated fashion:</p>
+  <ol start="" type="">
+    <li><p class="" style="">Specify a <span class="ref" style="">WSDL</span>  [<a href="#nt-id2250620">5</a>] definition (or other XML file format) and a canonical URL for that definition at a domain that offers XMPP services. Unfortunately, this approach requires access to the HTTP server for the domain (and quite possibly to the root directory thereof), which may be difficult for XMPP server administrators to arrange. In addition, it requires a client to retrieve the relevant file via HTTP before performing DNS lookups and XMPP connection; it would be more efficient to use recognized DNS methods since DNS lookups are already required by <span style="font-weight: bold">RFC 3920</span>.</p></li>
+    <li><p class="" style="">Specify a way to define the required service discovery information as part of the existing DNS SRV records (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2250831">6</a>]) for a domain that offers XMPP services. While this approach sounds promising, it is not feasible since the DNS SRV Target field can be used only to specify domain names and cannot be used to specify full URIs (such as the URL for an HTTP connection manager).</p></li>
+    <li><p class="" style="">Specify a way to define the required service discovery using the "straightforward NAPTR" (S-NAPTR) profile of the Dynamic Delegation Discovery System (see <span class="ref" style="">RFC 3958</span>  [<a href="#nt-id2250675">7</a>] and <span class="ref" style="">RFC 3401</span>  [<a href="#nt-id2250700">8</a>]). Unfortunately, S-NAPTR also does not allow inclusion of full URIs, and thus does meet the requirements for discovery of XMPP connection methods.</p></li>
+    <li><p class="" style="">Specify a way to define the required service discovery using a new profile of the Dynamic Delegation Discovery System, which would be nearly identical to S-NAPTR except that it would specify only one app-service (most likely "xmpp") and allow inclusion of the DDDS "U" flag (see <span class="ref" style="">RFC 3404</span>  [<a href="#nt-id2250737">9</a>]), so that the output of a DDDS rule could be a URI. While this is a valid approach that is worth pursuing, the authors are concerned about the deployability of such an approach, especially for client-side applications (the main focus of this specification).</p></li>
+    <li><p class="" style="">Specify a way to define the required service discovery information via properly-formatted DNS TXT records (see <span class="ref" style="">RFC 1464</span>  [<a href="#nt-id2250810">10</a>]). While this approach requires an update to the DNS records for the server domain, that is usually necessary in order to establish XMPP services in the first place. Furthermore, although there are some perils to be avoided in the use of DNS TXT records (e.g., wildcards), the technology is well understood and widely deployed (e.g., it is used by the SPF and SenderID systems).</p></li>
+  </ol>
+  <p class="" style="">Therefore this document defines a way to encapsulate information about XMPP connection methods in DNS TXT resource records.</p>
+<h2>2.
+       <a name="format">Record Format</a>
+</h2>
+  <p class="" style="">The following format for DNS TXT resource records is specified in <span style="font-weight: bold">RFC 1464</span>:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+  &lt;owner&gt; &lt;class&gt; &lt;ttl&gt; &lt;TXT&gt; &lt;"attribute name=attribute value"&gt;
+  </pre></div>
+  <p class="" style="">This document specifies that the following additional rules apply for DNS TXT resource records used to specify XMPP connection methods:</p>
+  <ol start="" type="">
+    <li>It is RECOMMENDED for the owner to be "_xmppconnect".</li>
+    <li>The class field SHOULD be IN.</li>
+    <li>The ttl field is OPTIONAL.</li>
+    <li>The attribute name SHOULD begin with the string "_xmpp-client-" or "_xmpp-server-" and SHOULD be registered as described in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.</li>
+    <li>If the txt-data field contains only an attribute name (i.e., no unquoted "=" character followed by additional characters), the receiving application SHOULD interpret it as indicating the presence of the attribute or feature with no defined value.</li>
+    <li>If the txt-data field contains an unquoted "=" character, it MUST also contain an attribute value.</li>
+  </ol>
+<h2>3.
+       <a name="bizrules">Business Rules</a>
+</h2>
+  <p class="" style="">The following business rules apply:</p>
+  <ol start="" type="">
+    <li>A domain SHOULD NOT present information in DNS TXT records that is available via the DNS SRV records defined in <span style="font-weight: bold">RFC 3920</span>.</li>
+    <li>The order of DNS TXT records SHOULD NOT be interpreted as significant by the presenting domain or the receiving client.</li>
+  </ol>
+<h2>4.
+       <a name="examples">Examples</a>
+</h2>
+  <p class="" style="">The following examples show three DNS TXT resource records: the first indicates support for the httpbind connection method defined in JEP-0124 including the appropriate URL, the second indicates support for the httppoll connection method defined in JEP-0025 including the appropriate URL, and the third indicates support for WAP connections including the appropriate URL.</p>
+  <p class="caption">Example 1. TXT Resource Records</p>
+<div class="indent"><pre>
+_xmppconnect IN TXT "_xmpp-client-httpbind=https://webconnect.jabber.org:8080/bind.cgi"
+_xmppconnect IN TXT "_xmpp-client-httppoll=https://webconnect.jabber.org:8081/poll.cgi"
+_xmppconnect IN TXT "_xmpp-client-wap=http://wap.jabber.org/connector.cgi"
+  </pre></div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">It is possible that advertisement of connection methods other than the standard TCP connection method may introduce security vulnerabilities, since a connecting entity (usually a client) might deliberately seek to connect using the method with the weakest security mechanisms (e.g., no channel encryption or relatively weak authentication). Care must be taken in determining which connection methods are appropriate to advertise.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250321">11</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-dnstxt">DNS TXT Records Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of attributes for use in DNS TXT resource records that advertise XMPP connection methods.</p>
+    <div class="indent">
+<h3>7.1.1 <a name="registrar-dnstxt-process">Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;attribute&gt;
+  &lt;name&gt;the name of the attribute&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the connection method&lt;/desc&gt;
+  &lt;value&gt;the syntax or datatype of the attribute value&lt;/value&gt;
+  &lt;doc&gt;the document in which the connection method is specified&lt;/doc&gt;
+&lt;/attribute&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one attribute at a time, each contained in a separate &lt;attribute/&gt; element.</p>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="registrar-dnstxt-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;attribute&gt;
+  &lt;name&gt;_xmpp-client-httpbind&lt;/name&gt;
+  &lt;desc&gt;the HTTP Binding connection method&lt;/desc&gt;
+  &lt;value&gt;the http: or https: URL at which to contact the HTTP Binding connection manager or proxy&lt;/value&gt;
+  &lt;doc&gt;JEP-0124&lt;/doc&gt;
+&lt;/attribute&gt;
+
+&lt;attribute&gt;
+  &lt;name&gt;_xmpp-client-httppoll&lt;/name&gt;
+  &lt;desc&gt;the HTTP Polling connection method&lt;/desc&gt;
+  &lt;value&gt;the http: or https: URL at which to contact the HTTP Polling connection manager or proxy&lt;/value&gt;
+  &lt;doc&gt;JEP-0025&lt;/doc&gt;
+&lt;/attribute&gt;
+
+      </pre></div>
+    </div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251521">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251549">2</a>. JEP-0025: Jabber HTTP Polling &lt;<a href="http://www.jabber.org/jeps/jep-0025.html">http://www.jabber.org/jeps/jep-0025.html</a>&gt;.</p>
+<p><a name="nt-id2250558">3</a>. JEP-0124: HTTP Binding &lt;<a href="http://www.jabber.org/jeps/jep-0124.html">http://www.jabber.org/jeps/jep-0124.html</a>&gt;.</p>
+<p><a name="nt-id2250575">4</a>. Wireless Access Protocol (WAP) &lt;<a href="http://www.wapforum.org/">http://www.wapforum.org/</a>&gt;.</p>
+<p><a name="nt-id2250620">5</a>. WSDL 1.1 Specification &lt;<a href="http://www.w3.org/TR/wsdl">http://www.w3.org/TR/wsdl</a>&gt;.</p>
+<p><a name="nt-id2250831">6</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2250675">7</a>. RFC 3958: Domain-Based Application Service Location Using SRV RRs and the Dynamic Delegation Discovery Service (DDDS) &lt;<a href="http://www.ietf.org/rfc/rfc3958.txt">http://www.ietf.org/rfc/rfc3958.txt</a>&gt;.</p>
+<p><a name="nt-id2250700">8</a>. RFC 3401: Dynamic Delegation Discovery System (DDDS) Part One: The Comprehensive DDDS &lt;<a href="http://www.ietf.org/rfc/rfc3401.txt">http://www.ietf.org/rfc/rfc3401.txt</a>&gt;.</p>
+<p><a name="nt-id2250737">9</a>. RFC 3404: Dynamic Delegation Discovery System (DDDS) Part Four: The Uniform Resource Identifiers (URI) Resolution Application &lt;<a href="http://www.ietf.org/rfc/rfc3404.txt">http://www.ietf.org/rfc/rfc3404.txt</a>&gt;.</p>
+<p><a name="nt-id2250810">10</a>. RFC 1464: Using the Domain Name System To Store Arbitrary String Attributes &lt;<a href="http://www.ietf.org/rfc/rfc1464.txt">http://www.ietf.org/rfc/rfc1464.txt</a>&gt;.</p>
+<p><a name="nt-id2250321">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-12-05)</h4>
+<div class="indent">Removed _xmpp-client-tcp from TXT records (belongs in SRV records only). (psa)
+    </div>
+<h4>Version 0.1 (2005-09-08)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-09-07)</h4>
+<div class="indent">More fully specified the rationale for using DNS TXT records. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-08-27)</h4>
+<div class="indent">Added security considerations and registrar considerations. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-08-23)</h4>
+<div class="indent">First draft. (psa/jh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0157-0.1.html
+++ b/content/xep-0157-0.1.html
@@ -1,0 +1,213 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0157: Contact Addresses for XMPP Services</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Contact Addresses for XMPP Services">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Jacek Konieczny">
+<meta name="DC.Description" content="This document defines a method for specifying contact addresses related to an XMPP service.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-09-08">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0157">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0157: Contact Addresses for XMPP Services</h1>
+<p>This document defines a method for specifying contact addresses related to an XMPP service.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0157<br>
+            Version: 0.1<br>
+            Last Updated: 2005-09-08<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0030, JEP-0128<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Contact%20Addresses%20for%20XMPP%20Services%20(JEP-0157)">http://wiki.jabber.org/index.php/Contact Addresses for XMPP Services (JEP-0157)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Jacek Konieczny</h3>
+<p class="indent">
+        Email: jajcus@jajcus.net<br>
+        JID: jajcus@jabber.bnet.pl</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#server">Server Alias</a>
+</dt>
+<dt>3.  <a href="#disco">Extended Server Information</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>6.1.  <a href="#registrar-formtype">Field Standardization</a>
+</dt></dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">RFC 2142</span>  [<a href="#nt-id2253940">1</a>] specifies conventional electronic mailbox names for common services, roles, and functions related to SMTP, NNTP, and HTTP (such as postmaster@domain, usenet@domain, and webmaster@domain). However, no such conventional email address or Jabber ID (JID) has been specified for XMPP services. This document remedies that oversight.</p>
+<h2>2.
+       <a name="server">Server Alias</a>
+</h2>
+  <p class="" style="">Many existing Jabber servers use the bare domain of the server as an alias for the server administrators, such that a &lt;message/&gt; stanza addressed to that domain name (e.g., "jabber.org") is delivered to the JIDs of the server administrators (this does not apply to &lt;iq/&gt; or &lt;presence/&gt; stanzas). It is RECOMMENDED that all server implementations support this functionality, and the authors will work toward standardization of this functionality in the forthcoming revisions to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2254001">2</a>].</p>
+<h2>3.
+       <a name="disco">Extended Server Information</a>
+</h2>
+  <p class="" style="">The administrators of a Jabber/XMPP service may desire to advertise more detailed contact information related to that service. This contact information may include email addresses, web URLs, and JIDs for specific roles and functions such as abuse reports, customer feedback, sales inquiries, technical support, and security concerns. For this purpose, domains MUST support the electronic mailboxes required by <span style="font-weight: bold">RFC 2142</span>. However, additional contact mechanisms may be desirable, and it would be helpful if those who want to initiate contact could discover the contact information using standard XMPP extensions, specifically <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250576">3</a>]. To make such discovery possible, we specify a <span class="ref" style="">Service Discovery Extensions</span>  [<a href="#nt-id2250600">4</a>] mechanism that a server MAY return in response to service discovery information ("disco#info") requests sent to the bare domain of the server. This information SHOULD be scoped using a FORM_TYPE of "http://jabber.org/network/serverinfo" (as already specified in <span style="font-weight: bold">JEP-0128</span>) and data form fields registered for this purpose as defined in the <a href="#registrar">Jabber Registrar Considerations</a> section of this document.</p>
+  <p class="" style="">To illustrate this usage, consider the following example of a disco#info request sent to the mythical shakespeare.lit XMPP server:</p>
+  <p class="caption">Example 1. Entity queries server for information</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/chamber'
+    to='shakespeare.lit'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Server communicates information</p>
+<div class="indent"><pre>
+&lt;iq from='shakespeare.lit'
+    to='juliet@capulet.com/chamber'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='server' type='im'/&gt;
+    &lt;feature var='http://jabber.org/protocol/disco'/&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/network/serverinfo&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='abuse-addresses'&gt;
+        &lt;value&gt;mailto:abuse@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;xmpp:shakespeare.lit/abuse&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='feedback-addresses'&gt;
+        &lt;value&gt;http://shakespeare.lit/feedback.php&lt;/value&gt;
+        &lt;value&gt;mailto:feedback@shakespeare.lit&lt;/value&gt;
+        &lt;value&gt;xmpp:shakespeare.lit/feedback&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='sales-addresses'&gt;
+        &lt;value&gt;xmpp:bard@shakespeare.lit&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='security-addresses'&gt;
+        &lt;value&gt;xmpp:shakespeare.lit/security&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='support-addresses'&gt;
+        &lt;value&gt;http://shakespeare.lit/support.php&lt;/value&gt;
+        &lt;value&gt;xmpp:shakespeare.lit/support&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Advertising contact addresses may open those addresses to unwanted communication. Server administrators should balance the need for openness with the desire for control over communication with customers and peers. That said, certain contact addresses (e.g., abuse addresses and security addresses) may enable server administrators to more quickly learn of abusive usage and potential security holes, and advertisement of those addresses is strongly encouraged.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250715">5</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250759">6</a>] shall include the following information in its registries.</p>
+  <div class="indent">
+<h3>6.1 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2250804">7</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace, and <span style="font-weight: bold">JEP-0128</span> describes how to use field standardization in the context of service discovery. This section registers fields for server information scoped by the "http://jabber.org/network/serverinfo" FORM_TYPE.</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/network/serverinfo&lt;/name&gt;
+  &lt;doc&gt;JEP-0157&lt;/doc&gt;
+  &lt;desc&gt;
+    Forms enabling the communication of contact addresses
+    and other server information.
+  &lt;/desc&gt;
+  &lt;field
+      var='abuse-addresses'
+      type='list-multi'
+      label='One or more addresses for communication related to abusive traffic'/&gt;
+  &lt;field
+      var='feedback-addresses'
+      type='list-multi'
+      label='One or more addresses for customer feedback'/&gt;
+  &lt;field
+      var='sales-addresses'
+      type='list-multi'
+      label='One or more addresses for communication related to sales and marketing'/&gt;
+  &lt;field
+      var='security-addresses'
+      type='list-multi'
+      label='One or more addresses for communication related to security concerns'/&gt;
+  &lt;field
+      var='support-addresses'
+      type='list-multi'
+      label='One or more addresses for customer support'/&gt;
+&lt;/form_type&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2253940">1</a>. RFC 2142: Mailbox Names for Common Services, Roles and Functions &lt;<a href="http://www.ietf.org/rfc/rfc2142.txt">http://www.ietf.org/rfc/rfc2142.txt</a>&gt;.</p>
+<p><a name="nt-id2254001">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250576">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250600">4</a>. JEP-0128: Service Discovery Extensions &lt;<a href="http://www.jabber.org/jeps/jep-0128.html">http://www.jabber.org/jeps/jep-0128.html</a>&gt;.</p>
+<p><a name="nt-id2250715">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2250759">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250804">7</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-09-08)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-09-06)</h4>
+<div class="indent">Added security considerations and Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-08-27)</h4>
+<div class="indent">First draft. (psa/jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0157-0.2.html
+++ b/content/xep-0157-0.2.html
@@ -1,0 +1,129 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0157: Contact Addresses for XMPP Services</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Contact Addresses for XMPP Services">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Jacek Konieczny">
+<meta name="DC.Description" content="This document defines a method for specifying contact addresses related to an XMPP service.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0157">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0157: Contact Addresses for XMPP Services</h1>
+<p>This document defines a method for specifying contact addresses related to an XMPP service.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0157<br>
+            Version: 0.2<br>
+            Last Updated: 2006-07-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Contact%20Addresses%20for%20XMPP%20Services%20(JEP-0157)">http://wiki.jabber.org/index.php/Contact Addresses for XMPP Services (JEP-0157)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Jacek Konieczny</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jajcus@jajcus.net">jajcus@jajcus.net</a><br>
+        JID: 
+        <a href="xmpp:jajcus@jabber.bnet.pl">jajcus@jabber.bnet.pl</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#server">Server Alias</a>
+</dt>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This document describes a protocol or best practice that is intended for addition to the specification that will supersede either <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2252079">1</a>] or <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250904">2</a>] within the Internet Standards Process. This document is provided only for the purpose of open community discussion of the potential modification and will be obsoleted as soon as the relevant RFC is published.</span></p>
+  <p class="" style=""><span class="ref" style="">RFC 2142</span>  [<a href="#nt-id2250914">3</a>] specifies conventional electronic mailbox names for common services, roles, and functions related to SMTP, NNTP, and HTTP (such as postmaster@domain, usenet@domain, and webmaster@domain). However, no such conventional email address or Jabber ID (JID) has been specified for XMPP services. This document remedies that oversight.</p>
+<h2>2.
+       <a name="server">Server Alias</a>
+</h2>
+  <p class="" style="">Many existing Jabber servers use the bare domain of the server as an alias for the server administrators, such that a &lt;message/&gt; stanza addressed to that domain name (e.g., "jabber.org") is delivered to the JIDs of the server administrators (this does not apply to &lt;iq/&gt; or &lt;presence/&gt; stanzas). It is RECOMMENDED that all server implementations support this functionality, and the authors will work toward standardization of this functionality in the forthcoming revisions to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250942">4</a>].</p>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Advertising contact addresses may open those addresses to unwanted communication. Server administrators should balance the need for openness with the desire for control over communication with customers and peers. That said, certain contact addresses (e.g., abuse addresses and security addresses) may enable server administrators to more quickly learn of abusive usage and potential security holes, and advertisement of those addresses is strongly encouraged.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2251003">5</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2252079">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250904">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250914">3</a>. RFC 2142: Mailbox Names for Common Services, Roles and Functions &lt;<a href="http://www.ietf.org/rfc/rfc2142.txt">http://www.ietf.org/rfc/rfc2142.txt</a>&gt;.</p>
+<p><a name="nt-id2250942">4</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251003">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-07-18)</h4>
+<div class="indent">
+<p class="" style="">Removed extended addressing recommendations pending further review.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-09-08)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-09-06)</h4>
+<div class="indent">
+<p class="" style="">Added security considerations and Jabber Registrar considerations.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-08-27)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jk)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0158-0.1.html
+++ b/content/xep-0158-0.1.html
@@ -1,0 +1,804 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0158: Robot Challenges</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Robot Challenges">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This JEP specifies a protocol entities may use to discover whether an XMPP client is a human user or a robot.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-09-14">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0158">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;http://www.opencontent.org/openpub/&gt;).">
+</head>
+<body>
+<h1>JEP-0158: Robot Challenges</h1>
+<p>This JEP specifies a protocol entities may use to discover whether an XMPP client is a human user or a robot.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0158<br>
+            Version: 0.1<br>
+            Last Updated: 2005-09-14<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0004, JEP-0066<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: challenge<br></p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email: ian.paterson@clientside.co.uk<br>
+        JID: ian@zoofy.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Open Publication License, v1.0 or later (the latest version is presently available at &lt;<a href="http://www.opencontent.org/openpub/">http://www.opencontent.org/openpub/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#require">Requirements</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#require-extend">Extensibility</a>
+</dt>
+<dt>2.2.  <a href="#require-variety">Variety</a>
+</dt>
+</dl>
+<dt>3.  <a href="#media">Media Element</a>
+</dt>
+<dt>4.  <a href="#protocol">Protocol Usage</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#protocol-simple">Simple Challenge</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#protocol-challenge">Challenge Stanza</a>
+</dt>
+<dt>4.1.2.  <a href="#protocol-response">Response Stanza</a>
+</dt>
+<dt>4.1.3.  <a href="#protocol-result">Result Stanza</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#protocol-multiple">Multiple Challenges</a>
+</dt>
+</dl>
+<dt>5.  <a href="#register">Extended In-Band Registration</a>
+</dt>
+<dt>6.  <a href="#captcha">Challenge Types</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#captcha-intro">Introduction</a>
+</dt>
+<dt>6.2.  <a href="#captcha-hashcash">SHA-256 Hashcash</a>
+</dt>
+<dt>6.3.  <a href="#captcha-captcha">CAPTCHAs</a>
+</dt>
+</dl>
+<dt>7.  <a href="#stop">Discontinuation Policy</a>
+</dt>
+<dt>8.  <a href="#sec">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-formtypes">Field Standardization</a>
+</dt>
+<dl>
+<dt>10.2.1.  <a href="#registrar-formtypes-challenge">challenge FORM_TYPE</a>
+</dt>
+<dt>10.2.2.  <a href="#registrar-formtypes-register">jabber:iq:register FORM_TYPE</a>
+</dt>
+</dl>
+</dl>
+<dt>11.  <a href="#schemas">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schemas-challenge">http://jabber.org/protocol/challenge</a>
+</dt>
+<dt>11.2.  <a href="#schemas-media">http://jabber.org/protocol/media</a>
+</dt>
+</dl>
+<dt>12.  <a href="#open">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The appearance of large public IM services based on <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250497">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250557">2</a>] created an urgent need to implement protocols that <span style="font-style: italic">discourage</span> the sending of large quantities of IM SPAM (SPIM) from XMPP clients (connected to legitimate servers) and XMPP servers (with virtual clients) -- all hosted on networks of 'zombie' machines. SPIM is defined here as any type of unsolicited XMPP stanza sent by a 'robot' and delivered to a human, including messages and subscription requests. SPIM has the potential to disrupt people even more than SPAM, because each message interrupts the receiver (humans typically filter SPAM in batch mode).</p>
+  <p class="" style="">Several of the most effective techniques developed to combat SPAM require humans to be differentiated from bots using a "Completely Automated Public Turing Test to Tell Computers and Humans Apart" (CAPTCHA). These challenge techniques are easily adapted to discourage SPIM. The very occasional inconvenience of responding to a CAPTCHA (for example, when creating an IM account or sending a message to a new correspondent) is small and perfectly acceptable -- especially when compared to the countless robot-generated interruptions people might otherwise have to filter every day.</p>
+  <p class="" style="">An alternative technique to CAPTCHAs requires Desktop PC clients to undertake a <span class="ref" style="">Hashcash</span>  [<a href="#nt-id2250480">3</a>] challenge. These are completely transparent to PC users. They require clients to perform specified CPU-intensive work, making it difficult to send large amounts of SPIM.</p>
+  <p class="" style="">The generic challenge protocol described in this document is designed for incorporation into other protocols like <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2251206">4</a>] and <span class="ref" style="">SPIM-Blocking Control</span>  [<a href="#nt-id2251367">5</a>].</p>
+<h2>2.
+       <a name="require">Requirements</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="require-extend">Extensibility</a>
+</h3>
+    <p class="" style="">The CAPTCHAs in most common use today are Optical Character Recognition (OCR) challenges where an image containing deformed text is presented and the human enters the characters they can read. However if OCR software advances more rapidly than the techniques used to disguise text from Artificial Intelligence (AI) then very different CAPTCHAs will need to be deployed. This protocol must be extensible enough to allow the incorporation of CAPTCHA techniques that may not have been envisaged.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="require-variety">Variety</a>
+</h3>
+    <p class="" style="">Several common CAPTCHA techniques present major problems to users with disabilities (see <span class="ref" style="">Inaccessibility of Visually-Oriented Anti-Robot Tests</span>  [<a href="#nt-id2251435">6</a>]). Clients running in constrained environments may not be able to perform some challenges (for example, due to the absence of audio output or a lack of CPU performance). This protocol must allow clients to be offered a choice from a variety of challenges.</p>
+  </div>
+<h2>3.
+       <a name="media">Media Element</a>
+</h2>
+  <p class="" style="">This protocol requires multimedia to be included within <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2251245">7</a>]. This section defines a new namespace ('http://jabber.org/protocols/media') for that purpose. The root element for the namespace is &lt;media/&gt;. It MUST be contained within a &lt;field/&gt; element qualified by the 'jabber:x:data' namespace.</p>
+  <p class="" style="">The &lt;media/&gt; element MUST contain a 'type' atribute that specifies the MIME type (see <span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2251280">8</a>]) of the media. If the media is an image or video, 'width' and 'height' attributes SHOULD also be included, specifying the recommended display size of the media in pixels.</p>
+  <p class="" style="">The &lt;media/&gt; element SHOULD contain a &lt;uri/&gt; element to specify the out-of-band location of the media data.  [<a href="#nt-id2251266">9</a>] The &lt;uri/&gt; element MUST contain a URI that indicates the location.</p>
+  <p class="" style="">The &lt;media/&gt; element MAY also contain a &lt;data/&gt; element for distributing the media in-band. The &lt;data/&gt; element MUST contain the Base64 encoded (in accordance with Section 3 of <span class="ref" style="">RFC 3548</span>  [<a href="#nt-id2251343">10</a>]) media data. The <span style="font-style: italic">encoded</span> data SHOULD NOT be larger than 8 KB. Note that if a stanza contains more than one &lt;data/&gt; element then the sending entity MUST take care not to trigger karma limits.</p>
+  <p class="caption">Example 1. JPEG Photo</p>
+<div class="indent"><pre>
+&lt;media xmlns='xmlns='http://jabber.org/protocol/media'
+       type='image/jpeg'
+       width='100'
+       height='120'&gt;
+  &lt;uri&gt;http://www.mydomain.com/photo.jpeg&lt;/uri&gt;
+  &lt;data&gt; ** Base64 encoded image ** &lt;/data&gt;
+&lt;/media&gt;
+  </pre></div>
+<h2>4.
+       <a name="protocol">Protocol Usage</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="protocol-simple">Simple Challenge</a>
+</h3>
+    <p class="" style="">An entity (client or server) MAY send a challenge to a client immediately after receiving a stanza from the client. Entities MUST NOT send challenges under any other circumstances.</p>
+    <p class="caption">Example 2. Client Sends Stanza Via Server</p>
+<div class="indent"><pre>
+&lt;message from='robot@spimmer.com/zombie'
+    to='victim@mydomain.com'
+    xml:lang='en'
+    id='spam1'&gt;
+  &lt;body&gt;Love pills - 75% OFF&lt;/body&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;http://www.spimmer.com/lovepills.html&lt;/url&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <div class="indent">
+<h3>4.1.1 <a name="protocol-challenge">Challenge Stanza</a>
+</h3>
+    <p class="" style="">Each of the challenge form's &lt;field/&gt; elements (see <span style="font-weight: bold">Data Forms</span>) that are not hidden MAY contain a different challenge and any media required for the challenge. The hidden 'from' field MUST contain the value of the 'to' attribute of the client's stanza that triggered the challenge. If the stanza from the client included an 'id' attribute then the hidden 'sid' field MUST be set to that value. The 'xml:lang' attribute of the challenge stanza SHOULD be the same as the one received from the client. The hidden 'FORM_TYPE' field MUST have a value of "http://jabber.org/protocol/challenge" in accordance with <span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2255921">11</a>].</p>
+    <p class="" style="">The entity SHOULD include an explanation (in the &lt;body/&gt; element) for clients that do not support this protocol. The entity MAY also include a URL (typically a Web page with instructions) using <span class="ref" style="">Out-of-Band Data</span>  [<a href="#nt-id2255960">12</a>] as an alternative for clients that do not support the challenge form. Note: even if it provides a URL then an entity MUST provide a challenge form.  [<a href="#nt-id2255943">13</a>]</p>
+    <p class="caption">Example 3. Server Offers a Choice of Challenges to a Client</p>
+<div class="indent"><pre>
+&lt;message from='mydomain.com'
+    to='robot@spimmer.com/zombie'
+    xml:lang='en'
+    id='F3A6292C'&gt;
+  &lt;body&gt;Your messages to victim@mydomain.com are being blocked.
+    Visit the Web page to unblock them.&lt;/body&gt;
+  &lt;x xmlns='jabber:x:oob'&gt;
+    &lt;url&gt;http://www.mydomain.com/challenge.html?F3A6292C&lt;/url&gt;
+  &lt;/x&gt;
+  &lt;challenge xmlns='http://jabber.org/protocol/challenge'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/challenge&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='hidden' var='from'&gt;&lt;value&gt;victim@mydomain.com&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='hidden' var='sid'&gt;&lt;value&gt;spam1&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='text-single' var='ocr'&gt;
+        &lt;media xmlns='xmlns='http://jabber.org/protocol/media'
+               type='image/jpeg'
+               width='290'
+               height='80'&gt;
+          &lt;uri&gt;http://www.mydomain.com/challenges/ocr.jpeg?F3A6292C&lt;/uri&gt;
+          &lt;data&gt; ** Base64 encoded image ** &lt;/data&gt;
+        &lt;/media&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='picture'&gt;
+        &lt;media xmlns='xmlns='http://jabber.org/protocol/media'
+               type='image/jpeg'
+               width='150'
+               height='150'&gt;
+          &lt;uri&gt;http://www.mydomain.com/challenges/picture.jpeg?F3A6292C&lt;/uri&gt;
+          &lt;data&gt; ** Base64 encoded image ** &lt;/data&gt;
+        &lt;/media&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='speech'&gt;
+        &lt;media xmlns='xmlns='http://jabber.org/protocol/media'
+               type='audio/mpeg'&gt;
+          &lt;uri&gt;http://www.mydomain.com/challenges/speech.mp3?F3A6292C&lt;/uri&gt;
+          &lt;data&gt; ** Base64 encoded audio ** &lt;/data&gt;
+        &lt;/media&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='video'&gt;
+        &lt;media xmlns='xmlns='http://jabber.org/protocol/media'
+               type='video/mpeg'&gt;
+          &lt;uri&gt;http://www.mydomain.com/challenges/video.mpeg?F3A6292C&lt;/uri&gt;
+          &lt;data&gt; ** Base64 encoded video ** &lt;/data&gt;
+        &lt;/media&gt;
+      &lt;/field&gt;
+      &lt;field label='Type the color of a stop light'
+             type='text-single'
+             var='qa'/&gt;
+      &lt;field label='93C7A' type='text-single' var='sha256'/&gt;
+    &lt;/x&gt;
+  &lt;/challenge&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+
+    <div class="indent">
+<h3>4.1.2 <a name="protocol-response">Response Stanza</a>
+</h3>
+    <p class="" style="">The client SHOULD ignore the challenge stanza in either of the following cases:</p>
+    <ul>
+      <li>if it has not just sent (in the last two minutes for example) a stanza to the JID specified in the 'from' field of the form with the 'id' specified in the 'sid' field (or with no 'id' if no 'sid' field is included)  [<a href="#nt-id2255974">14</a>]</li>
+      <li>if the 'from' attribute of the challenge stanza does not match the 'from' field of the form (If the values are different, then they still match if the bare JIDs are the same, or if the 'from' attribute is the domain of the other JID.)</li>
+    </ul>
+    <p class="" style="">Otherwise, if the entity provided a URL using <span style="font-weight: bold">Out-of-Band Data</span>, then the client MAY present the URL to its user, instead of responding to the challenge form, in any of the following cases:</p>
+    <ul>
+      <li>if it does not understand the challenge form</li>
+      <li>if it does not support all of the required challenges (see <a href="#protocol-multiple">Multiple Challenges</a>)</li>
+      <li>if it does not support enough of the challenges (see <a href="#protocol-multiple">Multiple Challenges</a>)</li>
+    </ul>
+    <p class="" style="">Otherwise, the client MUST respond to the entity, preserving the 'id' attribute of the challenge stanza.</p>
+    <p class="" style="">The client MUST respond with a &lt;not-acceptable/&gt; error in any of the following cases:</p>
+    <ul>
+      <li>if it does not support all of the required challenges (see <a href="#protocol-multiple">Multiple Challenges</a>)</li>
+      <li>if it does not support enough of the challenges (see <a href="#protocol-multiple">Multiple Challenges</a>)</li>
+      <li>if its user declines the challenge</li>
+    </ul>
+    <p class="caption">Example 4. Client Reports an Error</p>
+<div class="indent"><pre>
+&lt;message type='error'
+    from='robot@spimmer.com/zombie'
+    to='mydomain.com'
+    xml:lang='en'
+    id='F3A6292C'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Otherwise, it MUST select one challenge according to the user's preferences and submit the user's response form to the entity.</p>
+    <p class="caption">Example 5. Client Sends one Response to the Server</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='robot@spimmer.com/zombie'
+    to='mydomain.com'
+    xml:lang='en'
+    id='F3A6292C'&gt;
+  &lt;challenge xmlns='http://jabber.org/protocol/challenge'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/challenge&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='from'&gt;&lt;value&gt;victim@mydomain.com&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='sid'&gt;&lt;value&gt;spam1&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='ocr'&gt;&lt;value&gt;7nHL3&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/challenge&gt;
+&lt;/iq&gt;
+    </pre></div>
+    </div>
+
+    <div class="indent">
+<h3>4.1.3 <a name="protocol-result">Result Stanza</a>
+</h3>
+    <p class="" style="">After receiving a correct response to its challenge, the entity SHOULD inform the client that it was successful.</p>
+    <p class="caption">Example 6. Server Tells the Client it Passed</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='mydomain.com'
+    to='robot@spimmer.com/zombie'
+    id='F3A6292C'/&gt;
+    </pre></div>
+    <p class="" style="">However, the entity SHOULD send a &lt;service-unavailable/&gt; error to the client if:</p>
+    <ul>
+      <li>The client submits an incorrect response.  [<a href="#nt-id2250248">15</a>]</li>
+      <li>The client already submitted its response to this challenge.</li>
+      <li>The entity did not send the specified challenge.</li>
+      <li>The client took too long to submit its response.</li>
+    </ul>
+    <p class="" style="">Note: This error MAY be sent even in cases where the challenge became unnecessary while the server was waiting for the response.</p>
+    <p class="caption">Example 7. Server Indicates an Error</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    from='mydomain.com'
+    to='robot@spimmer.com/zombie'
+    id='F3A6292C'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="protocol-multiple">Multiple Challenges</a>
+</h3>
+    <p class="" style="">The enitity may demand responses to more than one of the challenges it is offering by including an 'answers' &lt;field/&gt; element in the form. It may require responses to particular challenges by including &lt;required/&gt; elements in the compulsory fields.</p>
+    <p class="caption">Example 8. Server Sets Multiple Challenges</p>
+<div class="indent"><pre>
+&lt;message from='mydomain.com'
+    to='robot@spimmer.com/zombie'
+    xml:lang='en'
+    id='73DE28A2'&gt;
+  &lt;body&gt;Your messages to victim@mydomain.com are being blocked.
+    To unblock them, ask victim@mydomain.com to send you a message.&lt;/body&gt;
+  &lt;challenge xmlns='http://jabber.org/protocol/challenge'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/challenge&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='hidden' var='from'&gt;&lt;value&gt;victim@mydomain.com&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='hidden' var='sid'&gt;&lt;value&gt;spam2&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='hidden' var='answers'&gt;&lt;value&gt;2&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='text-single' var='ocr'&gt;
+        &lt;media xmlns='xmlns='http://jabber.org/protocol/media'
+               type='image/jpeg'
+               width='290'
+               height='80'&gt;
+          &lt;uri&gt;http://www.mydomain.com/challenges/ocr.jpeg?F3A6292C&lt;/uri&gt;
+        &lt;/media&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='audio'&gt;
+        &lt;media xmlns='xmlns='http://jabber.org/protocol/media'
+               type='audio/mpeg'&gt;
+          &lt;uri&gt;http://www.mydomain.com/challenges/audio.mp3?F3A6292C&lt;/uri&gt;
+        &lt;/media&gt;
+      &lt;/field&gt;
+      &lt;field label='Type the color of a stop light'
+             type='text-single'
+             var='qa'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='e03d7' type='text-single' var='sha256'/&gt;
+    &lt;/x&gt;
+  &lt;/challenge&gt;
+&lt;/message&gt;
+    </pre></div>
+
+    <p class="" style="">If the client finds the request acceptable, it MUST answer all challenges that include a &lt;required/&gt; element. If the total number of answers was specified and it is greater than the number of &lt;required/&gt; elements then the client MUST also answer one or more of the challenges without a &lt;required/&gt; element. In the example above, the client should respond to the 'qa' challenge <span style="font-style: italic">and</span> one of the other challenges ('ocr', 'audio' or 'sha256').</p>
+    <p class="caption">Example 9. Client Sends Multiple Responses to the Server</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='robot@spimmer.com/zombie'
+    to='mydomain.com'
+    xml:lang='en'
+    id='73DE28A2'&gt;
+  &lt;challenge xmlns='http://jabber.org/protocol/challenge'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/challenge&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='from'&gt;&lt;value&gt;victim@mydomain.com&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='sid'&gt;&lt;value&gt;spam2&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='answers'&gt;&lt;value&gt;2&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='qa'&gt;&lt;value&gt;divad&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='sha256'&gt;&lt;value&gt;victim@mydomain.com2450F06C173B05E3&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/challenge&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The entity MAY decide the client has passed a challenge even if the responses are not all perfectly correct.</p>
+  </div>
+<h2>5.
+       <a name="register">Extended In-Band Registration</a>
+</h2>
+  <p class="" style="">This section shows how challenges SHOULD be combined with the existing registration protocol according to the rules defined in the Extensibility section of <span style="font-weight: bold">In-Band Registration</span>. Note: The &lt;challenge/&gt; wrapper element is not required.</p>
+  <p class="caption">Example 10. Entity Requests Registration Fields from Host</p>
+<div class="indent"><pre>
+&lt;iq type='get' xml:lang='en' id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+  <p class="" style="">Note that the challenge form MUST be inside the &lt;query/&gt; element, and the server's challenge ID is specified within the form:</p>
+  <p class="caption">Example 11. Host Returns Registration and Challenge Fields to Entity</p>
+<div class="indent"><pre>
+&lt;iq type='result' xml:lang='en' id='reg1'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field type='hidden' var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/challenge&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field type='hidden' var='cid'&gt;&lt;value&gt;F3A6292C&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='hidden' var='answers'&gt;&lt;value&gt;3&lt;/value&gt;&lt;/field&gt;
+      &lt;field type='text-single' var='ocr'&gt;
+        &lt;media xmlns='xmlns='http://jabber.org/protocol/media'
+               type='image/jpeg'
+               width='290'
+               height='80'&gt;
+          &lt;uri&gt;http://www.mydomain.com/challenges/ocr.jpeg?F3A6292C&lt;/uri&gt;
+        &lt;/media&gt;
+      &lt;/field&gt;
+      &lt;field label='93C7A' type='text-single' var='sha256'/&gt;
+      &lt;field type='text-single' var='username'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field type='text-single' var='password'&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+    &lt;instructions&gt;
+      To register, visit http://www.mydomain.com/register.html
+    &lt;/instructions&gt;
+    &lt;x xmlns='jabber:x:oob'&gt;
+      &lt;url&gt;http://www.mydomain.com/register.html&lt;/url&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+
+    <p class="" style="">The server MAY include an &lt;instructions/&gt; element and a URL using <span style="font-weight: bold">Out-of-Band Data</span> (e.g., a web page) in the &lt;query/&gt; element (see example above). <span style="font-weight: bold">In-Band Registration</span> recommends that the entity SHOULD submit the completed x:data form, however if it does not understand the form, then it MAY present the instructions and the provided URL to the user instead of providing the required information in-band.</p>
+    <p class="caption">Example 12. Entity Provides Required Information In-Band</p>
+<div class="indent"><pre>
+&lt;iq type='set' xml:lang='en' id='reg2'&gt;
+  &lt;query xmlns='jabber:iq:register'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE'&gt;
+        &lt;value&gt;http://jabber.org/protocol/challenge&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='cid'&gt;&lt;value&gt;F3A6292C&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='answers'&gt;&lt;value&gt;3&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='ocr'&gt;&lt;value&gt;7nHL3&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='username'&gt;&lt;value&gt;bill&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='password'&gt;&lt;value&gt;Calliope&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+<h2>6.
+       <a name="captcha">Challenge Types</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="captcha-intro">Introduction</a>
+</h3>
+    <p class="" style="">Entities MUST address the needs of disabled people and CPU-constrained clients by offering people a reasonable choice of different types of challenges.</p>
+    <p class="" style="">Desktop clients running on modern PCs will typically be configured to automatically perform a specified 'sha256' Hashcash challenge (see below) whenever it is below a certain level of difficulty, with the result that many people may not even notice challenges most of the time. However, people using CPU-constrained clients (e.g. Web or mobile clients) would notice the performance hit. They might prefer to take a CAPTCHA challenge instead.  [<a href="#nt-id2256642">16</a>]</p>
+    <p class="" style="">Visually disabled people using a CPU-constrained client could configure their client to always present them with an 'audio' or 'speech' CAPTCHA challenge.</p>
+    <p class="" style="">Most of the challenges below are language sensitive. However, the evaluation of the OCR and Hashcash responses does not depend on the language the client is using.</p>
+    <p class="" style="">Challenge types are distinguished by the 'var' attribute of each &lt;field/&gt; element. Several types of challenges are described below. More challenges MAY be documented elsewhere and registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256705">17</a>] (see <a href="#registrar-formtypes">Field Standardization</a>).</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="captcha-hashcash">SHA-256 Hashcash</a>
+</h3>
+    <p class="" style="">The SHA-256 Hashcash challenge is transparent to average PC users. It is indicated when the value of the 'var' attribute is 'sha256'. It forces clients to perform CPU-intensive work, making it difficult to send large amounts of SPIM. This significantly reduces SPIM, but alone it will not completely stop SPIM being sent through large collections of 'zombie' computers.  [<a href="#nt-id2256741">18</a>]</p>
+    <p class="" style="">The entity MUST set the 'label' attribute of the &lt;field/&gt; element to a hexadecimal random number containing a configured number of bits (2<span class="super" style="">20</span> ≤ label &lt; 2<span class="super" style="">21</span>, for example).</p>
+    <p class="" style="">To pass the test, the client MUST return a text string that starts with the JID the client sent the first stanza to (i.e., the stanza that triggered the challenge). The least significant bits of the SHA-256 hash of the string MUST equal the hexadecimal value specified by the entity (in the 'label' attribute of the &lt;field/&gt; element). For example, if the 'label' attribute is the 20-bit value 'e03d7' then the following string would be correct:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>victim@mydomain.com2450F06C173B05E3</pre></div>
+    <p class="" style="">Note: When configuring the number of bits to be specified by an entity in the 'label' attribute values, administrators MUST balance the need to make mass SPIM as difficult as possible, with the inconvenience that may be caused to the users of less powerful computers. (Most clients will be challenged only very occasionally, so the consumption of 70% of a typical desktop CPU for 4 seconds might be considered appropriate.) Administrators SHOULD increment the configured number of bits from time to time to match increases in the performance of typical desktop PCs. If an administrator notices that SPIM robots never attempt the Hashcash challenge, then he SHOULD consider reducing the number of bits, to avoid inconveniencing people unnecessarily.</p>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="captcha-captcha">CAPTCHAs</a>
+</h3>
+    <p class="" style="">For those CAPTCHA types where generic instructions are possible (see table below) then the &lt;field/&gt; element SHOULD NOT include a 'label' attribute (the client MUST present generic instructions to its user in the language of its user interface). Otherwise the 'label' attribute SHOULD ask a specific question in the language indicated by the 'xml:lang' attribute of the challenge stanza.</p>
+    <p class="" style="">If a media type is specified (see table below) then the &lt;field/&gt; element MUST contain a &lt;media/&gt; element of that type. Clients that support the CAPTCHA type MUST be able to play or render the specified MIME-types (see table below). They MAY also support other formats.</p>
+    <p class="" style="">The 'type' attribute of the &lt;field/&gt; element SHOULD be 'text-single', 'text-private', or 'text-multi' (if no 'type' is specified, the default is 'text-single').  [<a href="#nt-id2256891">19</a>] The response MUST be provided in the language specified by the 'xml:lang' attribute of the challenge stanza.</p>
+    <p class="caption">Table 1: CAPTCHAs</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">'var'</th>
+        <th colspan="" rowspan="">Name</th>
+        <th colspan="" rowspan="">Media type</th>
+        <th colspan="" rowspan="">MIME-type</th>
+        <th colspan="" rowspan="">'label'</th>
+        <th colspan="" rowspan="">Example generic instructions</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">*ocr</td>
+        <td align="" colspan="" rowspan="">Optical Character Recognition</td>
+        <td align="" colspan="" rowspan="">image</td>
+        <td align="" colspan="" rowspan="">image/jpeg</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">Enter the code you see</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">picture</td>
+        <td align="" colspan="" rowspan="">Picture Recognition</td>
+        <td align="" colspan="" rowspan="">image</td>
+        <td align="" colspan="" rowspan="">image/jpeg</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">Describe the picture</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">video</td>
+        <td align="" colspan="" rowspan="">Video Recognition</td>
+        <td align="" colspan="" rowspan="">video</td>
+        <td align="" colspan="" rowspan="">video/jpeg</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">Describe the video</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">audio</td>
+        <td align="" colspan="" rowspan="">Audio Recognition</td>
+        <td align="" colspan="" rowspan="">audio</td>
+        <td align="" colspan="" rowspan="">audio/mp3</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">Describe the sound you hear</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">speech</td>
+        <td align="" colspan="" rowspan="">Speech Recognition</td>
+        <td align="" colspan="" rowspan="">audio</td>
+        <td align="" colspan="" rowspan="">audio/mp3</td>
+        <td align="" colspan="" rowspan="">No</td>
+        <td align="" colspan="" rowspan="">Enter the words you hear</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">qa</td>
+        <td align="" colspan="" rowspan="">Question and Answer</td>
+        <td align="" colspan="" rowspan="">-</td>
+        <td align="" colspan="" rowspan="">-</td>
+        <td align="" colspan="" rowspan="">**Yes</td>
+        <td align="" colspan="" rowspan="">-</td>
+      </tr>
+    </table>
+    <p class="" style="">* The image portrays random characters that humans can read but OCR software cannot.  [<a href="#nt-id2257272">20</a>] To pass the challenge, the user must simply type the characters. The correct answer SHOULD NOT depend on the language specified by the 'xml:lang' attribute of the challenge stanza.</p>
+    <p class="" style="">** To pass the challenge, the user must type the answer to the question in the 'label' attribute.</p>
+    <p class="" style="">Note: It may be profitable to send SPIM even if less than one percent of CAPTCHA responses are successful. The effectiveness of a CAPTCHA challenge needs to be close to perfect, unless it is used in combination with other anti-SPIM techniques.</p>
+  </div>
+<h2>7.
+       <a name="stop">Discontinuation Policy</a>
+</h2>
+  <p class="" style="">It is RECOMMENDED that entities employ other techniques to combat SPIM in addition to those described in this document. The expectation is that this protocol will be an important and successful tool for discouraging SPIM. However, much of its success is dependent on the quality of the CAPTCHAs employed by a particular implementation.</p>
+  <p class="" style="">The administrator of an entity MUST discontinue the use of Robot Challenges under the following circumstances:</p>
+  <ul>
+    <li>If he realises that the entity's challenges are largely ineffective in combating SPIM, and that the reduction in SPIM does not compensate for the inconvenience to humans of responding to the entity's challenges.</li>
+    <li>If other, <span style="font-style: italic">more transparent</span>, techniques being employed by the entity are so successful that challenges are only offering negligible additional protection against SPIM.</li>
+    <li>If the entity needs no protection at all because it receives only a negligible amount of SPIM.</li>
+  </ul>
+<h2>8.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations above and beyond those described in <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257428">21</a>]. </p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">Upon approval of this JEP, the <span style="font-weight: bold">Jabber Registrar</span> shall register the following protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/challenge</li>
+      <li>http://jabber.org/protocol/media</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-formtypes">Field Standardization</a>
+</h3>
+    <div class="indent">
+<h3>10.2.1 <a name="registrar-formtypes-challenge">challenge FORM_TYPE</a>
+</h3>
+      <p class="" style="">Upon approval of this JEP, the <span style="font-weight: bold">Jabber Registrar</span> shall register the following new FORM_TYPE. Additional fields will be defined in future submissions.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/challenge&lt;/name&gt;
+  &lt;doc&gt;JEP-0158&lt;/doc&gt;
+  &lt;desc&gt;forms enabling robot challenges&lt;/desc&gt;
+  &lt;field
+      var='from'
+      type='hidden'
+      label='to attribute of stanza that triggered challenge '/&gt;
+  &lt;field
+      var='sid'
+      type='hidden'
+      label='stanza ID'/&gt;
+  &lt;field
+      var='cid'
+      type='hidden'
+      label='challenge ID'/&gt;
+  &lt;field
+      var='answers'
+      type='hidden'
+      label='number of answers required'/&gt;
+  &lt;field
+      var='ocr'
+      type='text-single'
+      label='code appearing in an image'/&gt;
+  &lt;field
+      var='picture'
+      type='text-single'
+      label='text associated with a picture'/&gt;
+  &lt;field
+      var='video'
+      type='text-single'
+      label='text associated with a video'/&gt;
+  &lt;field
+      var='audio'
+      type='text-single'
+      label='text associated with a sound'/&gt;
+  &lt;field
+      var='speech'
+      type='text-single'
+      label='text associated with speech'/&gt;
+  &lt;field
+      var='qa'
+      type='text-single'
+      label='answer to a question'/&gt;
+  &lt;field
+      var='sha256'
+      type='text-single'
+      label='least significant bits of SHA-256 hash of text should equal hexadecimal label'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>10.2.2 <a name="registrar-formtypes-register">jabber:iq:register FORM_TYPE</a>
+</h3>
+      <p class="" style="">Upon approval of this JEP, the <span style="font-weight: bold">Jabber Registrar</span> shall register the following new fields for the existing jabber:iq:register FORM_TYPE. Additional fields will be defined in future submissions.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;jabber:iq:register&lt;/name&gt;
+  &lt;doc&gt;JEP-0077&lt;/doc&gt;
+  &lt;field
+      var='cid'
+      type='hidden'
+      label='challenge ID'/&gt;
+  &lt;field
+      var='answers'
+      type='hidden'
+      label='number of answers required'/&gt;
+  &lt;field
+      var='ocr'
+      type='text-single'
+      label='code appearing in an image'/&gt;
+  &lt;field
+      var='picture'
+      type='text-single'
+      label='text associated with a picture'/&gt;
+  &lt;field
+      var='video'
+      type='text-single'
+      label='text associated with a video'/&gt;
+  &lt;field
+      var='audio'
+      type='text-single'
+      label='text associated with a sound'/&gt;
+  &lt;field
+      var='speech'
+      type='text-single'
+      label='text associated with speech'/&gt;
+  &lt;field
+      var='qa'
+      type='text-single'
+      label='answer to a question'/&gt;
+  &lt;field
+      var='sha256'
+      type='text-single'
+      label='least significant bits of SHA-256 hash of text should equal hexadecimal label'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>11.
+       <a name="schemas">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schemas-challenge">http://jabber.org/protocol/challenge</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/challenge'
+    xmlns='http://jabber.org/protocol/challenge'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='challenge'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence xmlns:xdata='jabber:x:data'&gt;
+        &lt;xs:element ref='xdata:x' minOccurs='1' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+
+  <div class="indent">
+<h3>11.2 <a name="schemas-media">http://jabber.org/protocol/media</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/media'
+    xmlns='http://jabber.org/protocol/media'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='media'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='uri' minOccurs='1' maxOccurs='1'/&gt;
+        &lt;xs:element ref='data' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='height' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='width' type='xs:string' use='optional'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='uri' type='xs:string'/&gt;
+
+  &lt;xs:element name='data' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="open">Open Issues</a>
+</h2>
+  <p class="" style="">Another protocol could allow users to edit the challenges their server will make on their behalf. For example, the number of sha256 bits, a personal or original question and answer, a picture, a video, or a sound recording... Of course Aunt Tillie would typically only use this feature if she was plagued by SPIM.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250497">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250557">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250480">3</a>. Hashcash &lt;<a href="http://hashcash.org/">http://hashcash.org/</a>&gt;.</p>
+<p><a name="nt-id2251206">4</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2251367">5</a>. JEP-0159: SPIM-Blocking Control &lt;<a href="http://www.jabber.org/jeps/jep-0159.html">http://www.jabber.org/jeps/jep-0159.html
+</a>&gt;.</p>
+<p><a name="nt-id2251435">6</a>. Inaccessibility of Visually-Oriented Anti-Robot Tests &lt;<a href="http://www.w3.org/TR/turingtest/">http://www.w3.org/TR/turingtest/</a>&gt;.</p>
+<p><a name="nt-id2251245">7</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2251280">8</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2251266">9</a>. Constrained execution environments prevent some clients rendering media unless it has been received out-of-band (e.g., Web clients).</p>
+<p><a name="nt-id2251343">10</a>. RFC 3548: The Base16, Base32, and Base64 Data Encodings &lt;<a href="http://www.ietf.org/rfc/rfc3548.txt">http://www.ietf.org/rfc/rfc3548.txt</a>&gt;.</p>
+<p><a name="nt-id2255921">11</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+<p><a name="nt-id2255960">12</a>. JEP-0066: Out of Band Data &lt;<a href="http://www.jabber.org/jeps/jep-0066.html">http://www.jabber.org/jeps/jep-0066.html</a>&gt;.</p>
+<p><a name="nt-id2255943">13</a>. A constrained client, like a mobile phone, cannot present a Web page to its user.</p>
+<p><a name="nt-id2255974">14</a>. Otherwise the user's presence would be disclosed, or a SPIM robot might dupe the user into providing answers to other people's challenges!</p>
+<p><a name="nt-id2250248">15</a>. If a large proportion of the responses a server is receiving from another IP are incorrect then it SHOULD inform the administrator of the other server (using the protocol to be defined in a forthcoming proposal on SPIM reporting). It SHOULD also automatically block all stanzas from the abusive user, users, server or IP.</p>
+<p><a name="nt-id2256642">16</a>. A CPU-constrained client could ask a faster computer (its server, for example) to perform a Hashcash challenge for it.</p>
+<p><a name="nt-id2256705">17</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2256741">18</a>. The hope is that the extra CPU usage will often be noticed by the owners of the zombie machines, who will be more likely to fix them.</p>
+<p><a name="nt-id2256891">19</a>. The 'boolean' and 'list-single' field types would make it trivial for a robot to provide a correct response at least some of the time.</p>
+<p><a name="nt-id2257272">20</a>. See PWNtcha &lt;<a href="http://sam.zoy.org/pwntcha/">http://sam.zoy.org/pwntcha/</a>&gt; for some example OCR CAPTCHA images.</p>
+<p><a name="nt-id2257428">21</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-09-14)</h4>
+<div class="indent">Initial JEP version. (ip)
+    </div>
+<h4>Version 0.0.1 (2005-09-07)</h4>
+<div class="indent">First draft. (ip)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0160-0.1.html
+++ b/content/xep-0160-0.1.html
@@ -1,0 +1,180 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0160: Best Practices for Handling Offline Messages</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Best Practices for Handling Offline Messages">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies best practices to be followed by Jabber/XMPP servers in handling messages sent to recipients who are offline.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0160">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0160: Best Practices for Handling Offline Messages</h1>
+<p>This document specifies best practices to be followed by Jabber/XMPP servers in handling messages sent to recipients who are offline.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0160<br>
+            Version: 0.1<br>
+            Last Updated: 2005-10-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: msgoffline<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Best%20Practices%20for%20Handling%20Offline%20Messages%20(JEP-0160)">http://wiki.jabber.org/index.php/Best Practices for Handling Offline Messages (JEP-0160)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#flow">Process Flow</a>
+</dt>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251612">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2251636">2</a>] specify general rules for handling XML stanzas, but explicitly do not address how to handle message stanzas sent to recipients (e.g., IM users or other nodes) that are offline, except to say that a server MUST return a &lt;service-unavailable/&gt; error if offline message storage or message forwarding is not enabled (see Section 11.1 of <span style="font-weight: bold">RFC 3921</span>). This document partly fills the gap by specifying best practices for storage and delivery of so-called "offline messages".</p>
+<h2>2.
+       <a name="flow">Process Flow</a>
+</h2>
+  <p class="" style="">The RECOMMENDED process flow is as follows:</p>
+  <ol start="" type="">
+    <li>Sender generates XMPP message stanza  [<a href="#nt-id2251671">3</a>] for delivery to a recipient such as an IM user or other node, where the 'to' address is of the form &lt;node@domain&gt;.</li>
+    <li>Recipient's server determines that the intended recipient has no available resources that have specified non-negative presence priority.  [<a href="#nt-id2251692">4</a>]</li>
+    <li>Recipient's server does not return a &lt;service-unavailable/&gt; error but instead stores the message stanza for later delivery.</li>
+    <li>When the recipient next sends non-negative available presence to the server, the server deliver the message to the resource that has sent that presence. (Alternatively, the server may support <span class="ref" style="">Flexible Offline Message Retrieval</span>  [<a href="#nt-id2250542">5</a>], although that functionality is not described herein.)</li>
+  </ol>
+  <p class="" style="">This flow is described more fully below.</p>
+  <p class="" style="">First, the sender (in this example, romeo@montague.net) sends a message to an intended recipient (juliet@capulet.com).</p>
+  <p class="caption">Example 1. Sender Generates Message to Recipient</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard' to='juliet@capulet.com'&gt;
+  &lt;body&gt;
+    O blessed, blessed night! I am afeard.
+    Being in night, all this is but a dream,
+    Too flattering-sweet to be substantial.
+  &lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Next, the recipient's server determines if there are any available resources that have sent non-negative presence priority. If there are, the server immediately delivers the message stanza to the resource that it determines to be most available (based on its own algorithm). If there are not, the server stores the message for later delivery.</p>
+  <p class="" style="">Now the recipient authenticates with the server and sends initial presence (with a non-negative priority) to the server.</p>
+  <p class="caption">Example 2. Recipient Becomes Available</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony'&gt;
+  &lt;priority&gt;1&lt;/priority&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">The recipient's server now delivers the offline message to that resource, optionally with a <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2250808">6</a>] extension to indicate that the message was stored offline.</p>
+  <p class="caption">Example 3. Recipient's Server Delivers Message</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard' to='juliet@capulet.com'&gt;
+  &lt;body&gt;
+    O blessed, blessed night! I am afeard.
+    Being in night, all this is but a dream,
+    Too flattering-sweet to be substantial.
+  &lt;/body&gt;
+  &lt;x from='capulet.com' stamp='20020910T23:08:25' xmlns='jabber:x:delay'&gt;
+    Offline Storage
+  &lt;/x&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">If a server supports offline message handling as described herein, it SHOULD return a "msgoffline" feature in response to <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250664">7</a>] information requests:</p>
+  <p class="caption">Example 4. Recipient Queries Server About Support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/chamber' to='capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 5. Server Returns Information About Support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com' to='juliet@capulet.com/chamber'&gt;
+  &lt;query xmlns='http://jabber.org/disco#info'&gt;
+    ...
+    &lt;feature var='msgoffline'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A message stored offline may not be readable by the recipient if the message was encrypted using a session-based encryption method such as <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2250718">8</a>] or if the key used in object encryption is revoked after the message was sent but before it is read.</p>
+  <p class="" style="">In certain countries, offline storage of message stanzas may introduce legal requirements or privacy vulnerabilities that do not apply to messages that are delivered immediately and never stored on an intermediate server.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250768">9</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256246">10</a>], since the "msgoffline" service discovery feature is already registered.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251612">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251636">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2251671">3</a>. This JEP does not discuss IQ or presence stanzas, handling of which is described in <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>.</p>
+<p><a name="nt-id2251692">4</a>. As specified in <span style="font-weight: bold">RFC 3920</span>, available resources that have specified a negative presence priority shall never receive message stanzas addressed to &lt;node@domain&gt;.</p>
+<p><a name="nt-id2250542">5</a>. JEP-0013: Flexible Offline Message Retrieval &lt;<a href="http://www.jabber.org/jeps/jep-0013.html">http://www.jabber.org/jeps/jep-0013.html</a>&gt;.</p>
+<p><a name="nt-id2250808">6</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2250664">7</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250718">8</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2250768">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256246">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-10-05)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-27)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0160-0.2.html
+++ b/content/xep-0160-0.2.html
@@ -1,0 +1,199 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0160: Best Practices for Handling Offline Messages</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Best Practices for Handling Offline Messages">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies best practices to be followed by Jabber/XMPP servers in handling messages sent to recipients who are offline.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0160">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0160: Best Practices for Handling Offline Messages</h1>
+<p>This document specifies best practices to be followed by Jabber/XMPP servers in handling messages sent to recipients who are offline.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Informational<br>
+            Number: 0160<br>
+            Version: 0.2<br>
+            Last Updated: 2005-11-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: msgoffline<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Best%20Practices%20for%20Handling%20Offline%20Messages%20(JEP-0160)">http://wiki.jabber.org/index.php/Best Practices for Handling Offline Messages (JEP-0160)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#flow">Process Flow</a>
+</dt>
+<dt>3.  <a href="#types">Handling of Message Types</a>
+</dt>
+<dt>4.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2253928">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2253951">2</a>] specify general rules for handling XML stanzas, but explicitly do not address how to handle message stanzas sent to recipients (e.g., IM users or other nodes) that are offline, except to say that a server MUST return a &lt;service-unavailable/&gt; error if offline message storage or message forwarding is not enabled (see Section 11.1 of <span style="font-weight: bold">RFC 3921</span>). This document fills the gap by specifying best practices for storage and delivery of so-called "offline messages".</p>
+<h2>2.
+       <a name="flow">Process Flow</a>
+</h2>
+  <p class="" style="">The RECOMMENDED process flow is as follows:</p>
+  <ol start="" type="">
+    <li>Sender generates XMPP message stanza  [<a href="#nt-id2253988">3</a>] for delivery to a recipient such as an IM user or other node, where the 'to' address is of the form &lt;node@domain&gt; or &lt;node@domain/resource&gt; (see <span style="font-weight: bold">RFC 3921</span> for rules regarding server handling of such XMPP message stanzas).</li>
+    <li>Recipient's server determines that the intended recipient has no available resources that have specified non-negative presence priority.  [<a href="#nt-id2250541">4</a>]</li>
+    <li>Recipient's server does not return a &lt;service-unavailable/&gt; error but instead stores the message stanza for later delivery.</li>
+    <li>When the recipient next sends non-negative available presence to the server, the server delivers the message to the resource that has sent that presence. (Alternatively, the server may support <span class="ref" style="">Flexible Offline Message Retrieval</span>  [<a href="#nt-id2250583">5</a>], although that functionality is not described herein.)</li>
+  </ol>
+  <p class="" style="">This flow is described more fully below.</p>
+  <p class="" style="">First, the sender (in this example, romeo@montague.net) sends a message to an intended recipient (juliet@capulet.com).</p>
+  <p class="caption">Example 1. Sender Generates Message to Recipient</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard' to='juliet@capulet.com'&gt;
+  &lt;body&gt;
+    O blessed, blessed night! I am afeard.
+    Being in night, all this is but a dream,
+    Too flattering-sweet to be substantial.
+  &lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Next, the recipient's server determines if there are any available resources that have sent non-negative presence priority. If there are, the server immediately delivers the message stanza to the resource that it determines to be most available (based on its own algorithm). If there are not, the server stores the message for later delivery.</p>
+  <p class="" style="">Now the recipient authenticates with the server and sends initial presence (with a non-negative priority) to the server.</p>
+  <p class="caption">Example 2. Recipient Becomes Available</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony'&gt;
+  &lt;priority&gt;1&lt;/priority&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">The recipient's server now delivers the offline message to that resource (it is RECOMMENDED for the server to add a <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2250818">6</a>] extension to indicate that the message was stored offline).</p>
+  <p class="caption">Example 3. Recipient's Server Delivers Message</p>
+<div class="indent"><pre>
+&lt;message from='romeo@montague.net/orchard' to='juliet@capulet.com'&gt;
+  &lt;body&gt;
+    O blessed, blessed night! I am afeard.
+    Being in night, all this is but a dream,
+    Too flattering-sweet to be substantial.
+  &lt;/body&gt;
+  &lt;x from='capulet.com' stamp='20020910T23:08:25' xmlns='jabber:x:delay'&gt;
+    Offline Storage
+  &lt;/x&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>3.
+       <a name="types">Handling of Message Types</a>
+</h2>
+  <p class="" style="">Message stanzas SHOULD be handled by a server as follows (based on the values of the 'type' attribute specified in <span style="font-weight: bold">RFC 3921</span>):</p>
+  <ul>
+    <li><p class="" style=""><span style="font-weight: bold">normal</span> -- Messages with a 'type' attribute whose value is "normal" (or messages with no 'type' attribute) SHOULD be stored offline.</p></li>
+    <li><p class="" style=""><span style="font-weight: bold">chat</span> -- Messages with a 'type' attribute whose value is "chat" SHOULD be stored offline, with the exception of messages that contain only <span class="ref" style="">Chat State Notifications</span>  [<a href="#nt-id2250668">7</a>] content (such messages SHOULD NOT be stored offline).</p></li>
+    <li><p class="" style=""><span style="font-weight: bold">groupchat</span> -- Messages with a 'type' attribute whose value is "groupchat" SHOULD NOT be stored offline, since by definition a user without online presence cannot be in a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2250741">8</a>] room.</p></li>
+    <li><p class="" style=""><span style="font-weight: bold">headline</span> -- Messages with a 'type' attribute whose value is "headline" SHOULD NOT be stored offline, since such messages are usually time-sensitive.</p></li>
+    <li><p class="" style=""><span style="font-weight: bold">error</span> -- Messages with a 'type' attribute whose value is "error" SHOULD NOT be stored offline, although a server MAY store <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256448">9</a>] error messages offline.</p></li>
+  </ul>
+<h2>4.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">If a server supports offline message handling as described herein, it SHOULD return a "msgoffline" feature in response to <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256483">10</a>] information requests:</p>
+  <p class="caption">Example 4. Recipient Queries Server About Support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/chamber' to='capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 5. Server Returns Information About Support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com' to='juliet@capulet.com/chamber'&gt;
+  &lt;query xmlns='http://jabber.org/disco#info'&gt;
+    ...
+    &lt;feature var='msgoffline'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A message stored offline may not be readable by the recipient if the message was encrypted using a session-based encryption method such as <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2256533">11</a>] or if the key used in object encryption is revoked after the message was sent but before it is read.</p>
+  <p class="" style="">In certain countries, offline storage of message stanzas may introduce legal requirements or privacy vulnerabilities that do not apply to messages that are delivered immediately and never stored on an intermediate server.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256588">12</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256631">13</a>], since the "msgoffline" service discovery feature is already registered.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2253928">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2253951">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2253988">3</a>. This JEP does not discuss IQ or presence stanzas, handling of which is described in <span style="font-weight: bold">RFC 3920</span> and <span style="font-weight: bold">RFC 3921</span>.</p>
+<p><a name="nt-id2250541">4</a>. As specified in <span style="font-weight: bold">RFC 3920</span>, available resources that have specified a negative presence priority shall never receive message stanzas addressed to &lt;node@domain&gt;.</p>
+<p><a name="nt-id2250583">5</a>. JEP-0013: Flexible Offline Message Retrieval &lt;<a href="http://www.jabber.org/jeps/jep-0013.html">http://www.jabber.org/jeps/jep-0013.html</a>&gt;.</p>
+<p><a name="nt-id2250818">6</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2250668">7</a>. JEP-0085: Chat State Notifications &lt;<a href="http://www.jabber.org/jeps/jep-0085.html">http://www.jabber.org/jeps/jep-0085.html</a>&gt;.</p>
+<p><a name="nt-id2250741">8</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256448">9</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256483">10</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256533">11</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2256588">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256631">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-11-15)</h4>
+<div class="indent">Added section on handling of each message type. (psa)
+    </div>
+<h4>Version 0.1 (2005-10-05)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-27)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0161-0.1.html
+++ b/content/xep-0161-0.1.html
@@ -1,0 +1,295 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0161: SPIM Reporting</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="SPIM Reporting">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a protocol for reporting unsolicited bulk instant messaging (SPIM) over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0161">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0161: SPIM Reporting</h1>
+<p>This document specifies a protocol for reporting unsolicited bulk instant messaging (SPIM) over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Deferred<br>
+            Type: Standards Track<br>
+            Number: 0161<br>
+            Version: 0.1<br>
+            Last Updated: 2005-10-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: spimreport<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/SPIM%20Reporting%20(JEP-0161)">http://wiki.jabber.org/index.php/SPIM Reporting (JEP-0161)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#proto">Protocol</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#proto-stanza">Reporting a SPIM Stanza</a>
+</dt>
+<dt>2.2.  <a href="#proto-spimmer">Reporting a Spimmer</a>
+</dt>
+</dl>
+<dt>3.  <a href="#reporting">Reporting SPIM</a>
+</dt>
+<dt>4.  <a href="#processing">Processing SPIM Reports</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#processing-initial">Initial Processing</a>
+</dt>
+<dt>4.2.  <a href="#processing-spimmer">Determining Spimmer Status</a>
+</dt>
+</dl>
+<dt>5.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Unsolicited bulk email, commonly called "spam", is a widespread problem on today's email network. We want to make sure that unsolicited bulk instant messaging, commonly called "SPIM" (short for "spam over IM"), does not become a widespread problem on the XMPP instant messaging network. To that end, this document specifies a protocol for reporting particular instances of SPIM.</p>
+<h2>2.
+       <a name="proto">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="proto-stanza">Reporting a SPIM Stanza</a>
+</h3>
+    <p class="" style="">The protocol for SPIM reporting is quite simple: wrap the complete SPIM stanza in a &lt;spim/&gt; element qualified by the 'http://jabber.org/protocol/spimreport' namespace and send an IQ stanza of type "set" to the entity that shall receive the report. This protocol SHOULD be used by recipients of SPIM stanzas and by other entities (e.g., servers or services) that wish to pass around SPIM reports. The following is an example:</p>
+    <p class="caption">Example 1. Unsuspecting User Receives SPIM from Evil Bot</p>
+<div class="indent"><pre>
+&lt;presence from='makemoney@spimmersheaven.info/bot' 
+          to='unsuspectinguser@example.net'
+          type='subscribe'&gt;
+  &lt;status&gt;
+    You too can be rich! Find out how at 
+    http://spimmersheaven.info/makemoney
+    Let&amp;apos;s chat to make your dreams
+    come true!
+  &lt;/status&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="caption">Example 2. Unsuspecting User Reports SPIM</p>
+<div class="indent"><pre>
+&lt;iq from='unsuspectinguser@example.net'
+    to='example.net'
+    type='set'
+    id='report1'&gt;
+  &lt;spim xmlns='http://jabber.org/protocol/spimreport'&gt;
+    &lt;presence from='makemoney@spimmersheaven.info/bot' 
+              to='unsuspectinguser@example.net'
+              type='subscribe'
+              xmlns='jabber:client'&gt;
+      &lt;status&gt;
+        You too can be rich! Find out how at 
+        http://spimmersheaven.info/makemoney
+        Let&amp;apos;s chat to make your dreams
+        come true!
+      &lt;/status&gt;
+    &lt;/presence&gt;
+  &lt;/spim&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the entity that receives the report does not support the SPIM reporting protocol, it MUST return a &lt;service-unavailable/&gt; error to the reporting entity:</p>
+    <p class="caption">Example 3. Service Unavailable</p>
+<div class="indent"><pre>
+&lt;iq from='example.net'
+    to='unsuspectinguser@example.net'
+    type='error'
+    id='report1'&gt;
+  &lt;spim xmlns='http://jabber.org/protocol/spimreport'&gt;
+    &lt;presence from='makemoney@spimmersheaven.info/bot' 
+              to='unsuspectinguser@example.net'
+              type='subscribe'
+              xmlns='jabber:client'&gt;
+      &lt;status&gt;
+        You too can be rich! Find out how at 
+        http://spimmersheaven.info/makemoney
+        Let&amp;apos;s chat to make your dreams
+        come true!
+      &lt;/status&gt;
+    &lt;/presence&gt;
+  &lt;/spim&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the entity that receives the report is able to process the report, it MUST return an IQ-result to the reporting entity:</p>
+    <p class="caption">Example 4. Report Processed</p>
+<div class="indent"><pre>
+&lt;iq from='example.net'
+    to='unsuspectinguser@example.net'
+    type='result'
+    id='report1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="proto-spimmer">Reporting a Spimmer</a>
+</h3>
+    <p class="" style="">If an entity that processes SPIM reports determines that the suspected spimmer is indeed an actual spimmer, it SHOULD report its conclusions to appropriate other entities (e.g., the spimmer's server or dedicated SPIM reporting services). Here again, the protocol is quite simple: wrap the spimmer's JID in a &lt;spimmer/&gt; element qualified by the 'http://jabber.org/protocol/spimreport' namespace and send an IQ stanza of type "set" to the entity that shall receive the report. This protocol SHOULD NOT be used by recipients of SPIM stanzas. The following is an example:</p>
+    <p class="caption">Example 5. Server Reports Spimmer</p>
+<div class="indent"><pre>
+&lt;iq from='example.net'
+    to='spim.xmpp.net'
+    type='set'
+    id='spimmer1'&gt;
+  &lt;spimmer xmlns='http://jabber.org/protocol/spimreport'&gt;makemoney@spimmersheaven.info&lt;/spimmer&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>3.
+       <a name="reporting">Reporting SPIM</a>
+</h2>
+  <p class="" style="">The following rules and guidelines apply to the act of reporting SPIM.</p>
+  <ol start="" type="">
+    <li>The SPIM recipient SHOULD report the SPIM stanza to its own server (i.e., the server with which it has a registered account or other trust relationship).</li>
+    <li>The SPIM recipient MAY report the SPIM stanza to the suspected spimmer's server.</li>
+    <li>The SPIM recipient MAY report the SPIM stanza to dedicated SPIM reporting services.</li>
+    <li>The SPIM recipient SHOULD NOT report the SPIM stanza to the suspected spimmer.</li>
+    <li>The SPIM recipient SHOULD NOT report the SPIM stanza to a server or service until it determines that the server or service supports the SPIM reporting protocol (see the <a href="#disco">Discovering Support</a> section of this document).</li>
+  </ol>
+<h2>4.
+       <a name="processing">Processing SPIM Reports</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="processing-initial">Initial Processing</a>
+</h3>
+    <p class="" style="">The following rules and guidelines apply to initial processing of a SPIM report.</p>
+    <ol start="" type="">
+      <li>Before processing the report, the processor MAY respond to the report by sending a challenge to the sender (e.g., using <span class="ref" style="">Robot Challenges</span>  [<a href="#nt-id2250754">1</a>]) in order to make sure that the sender is not sending spurious reports or otherwise abusing the SPIM reporting system.</li>
+      <li>The processor MUST add the report to a list or database of pending SPIM reports.</li>
+      <li>If the suspected spimmer is not already on the processor's list of known spimmers, the processor SHOULD use the report in determining whether the suspected spimmer is an actual spimmer (see next section).</li>
+      <li>The processor MAY report the SPIM stanza to the suspected spimmer's server.</li>
+      <li>The processor MAY report the SPIM stanza to dedicated SPIM reporting services.</li>
+      <li>The processor MAY report the SPIM stanza to other servers it trusts.</li>
+      <li>The processor SHOULD NOT report the SPIM stanza to the suspected spimmer.</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="processing-spimmer">Determining Spimmer Status</a>
+</h3>
+    <p class="" style="">Not all SPIM reports are valid, and not all JIDs that send stanzas reported as SPIM are spimmers. Care must be taken in correctly determining if a suspected spimmer is an actual spimmer. The following rules apply:</p>
+    <ol start="" type="">
+      <li><p class="" style="">The processor SHOULD NOT add a suspected spimmer to its list of known spimmers until it has received at least three (3) valid SPIM reports with regard to that suspected spimmer.</p></li>
+      <li>
+<p class="" style="">If the processor determines that the suspected spimmer is an actual spimmer, the processor:</p>
+        <ol start="" type="">
+          <li>MUST add that JID to its list of known spimmers.</li>
+          <li>SHOULD send a spimmer report to the spimmer's server.</li>
+          <li>MAY send a spimmer report to SPIM reporting services or reputation services.</li>
+          <li>MAY send a spimmer report to other servers it trusts.</li>
+          <li>SHOULD NOT send a spimmer report to the spimmer.</li>
+        </ol>
+      </li>
+    </ol>
+  </div>
+<h2>5.
+       <a name="disco">Discovering Support</a>
+</h2>
+  <p class="" style="">In order to discover whether another entity supports SPIM reporting, <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257051">2</a>] SHOULD be used. If an entity supports SPIM reporting, it MUST return a feature of "http://jabber.org/protocol/spimreport" in responses to service discovery information requests, as shown in the following examples:</p>
+  <p class="caption">Example 6. User Queries Server Regarding Protocol Support</p>
+<div class="indent"><pre>
+&lt;iq from='unsuspectinguser@example.net'
+    to='example.net'
+    type='get'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 7. Server Replies Regarding Protocol Support</p>
+<div class="indent"><pre>
+&lt;iq from='example.net'
+    to='unsuspectinguser@example.net'
+    type='result'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/spimreport'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This proposal requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257122">3</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257164">4</a>] shall add 'http://jabber.org/protocol/spimreport' to its registry of protocol namespaces.</p>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250754">1</a>. JEP-0158: Robot Challenges &lt;<a href="http://www.jabber.org/jeps/jep-0158.html">http://www.jabber.org/jeps/jep-0158.html</a>&gt;.</p>
+<p><a name="nt-id2257051">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257122">3</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257164">4</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-10-19)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-28)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0162-0.1.html
+++ b/content/xep-0162-0.1.html
@@ -1,0 +1,230 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0162: Best Practices for Roster and Subscription Management</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Best Practices for Roster and Subscription Management">
+<meta name="DC.Creator" content="Lucas Nussbaum">
+<meta name="DC.Description" content="This document specifies best practices for roster and subscription management in Jabber/XMPP clients.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-10-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0162">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0162: Best Practices for Roster and Subscription Management</h1>
+<p>This document specifies best practices for roster and subscription management in Jabber/XMPP clients.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0162<br>
+            Version: 0.1<br>
+            Last Updated: 2005-10-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+            Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Best%20Practices%20for%20Roster%20and%20Subscription%20Management%20(JEP-0162)">http://wiki.jabber.org/index.php/Best Practices for Roster and Subscription Management (JEP-0162)</a>&gt;
+          </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Lucas Nussbaum</h3>
+<p class="indent">
+        Email: lucas@lucas-nussbaum.net<br>
+        JID: lucas@nussbaum.fr</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dl>
+<dt>1.1.  <a href="#intro-motive">Motivation</a>
+</dt>
+<dt>1.2.  <a href="#intro-oversub">Overview of subscription states</a>
+</dt>
+</dl>
+<dt>2.  <a href="#removal">Removal of Contacts</a>
+</dt>
+<dt>3.  <a href="#contacts">Display of Contacts in the Roster</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <div class="indent">
+<h3>1.1 <a name="intro-motive">Motivation</a>
+</h3>
+
+    <p class="" style=""><span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2251642">1</a>] explains how subscriptions and rosters integrate. However,
+    several points are left to the client author's discretion, and this can lead
+    to some confusion among client developers. This JEP specifies best practices 
+    that enable all Jabber clients to manage subscriptions and roster in a coherent 
+    way, thus making sure that such clients will not surprise end users with 
+    unexpected behavior.</p>
+
+  </div>
+
+  <div class="indent">
+<h3>1.2 <a name="intro-oversub">Overview of subscription states</a>
+</h3>
+
+    <p class="" style="">As defined in RFC 3921 (sections 6, 7, 8), a roster item can have one
+    of the following subscription states:</p>
+
+    <ul>
+
+      <li>
+<span style="font-style: italic">subscription='none'</span>: you aren't interested in the item's
+      presence, and neither is the item interested in yours.</li>
+      
+      <li>
+<span style="font-style: italic">subscription='from'</span>: the item is interested in your
+    presence information, but you don't care about the contact. (You must
+    be somebody important! ;)</li>
+
+      <li>
+<span style="font-style: italic">subscription='to'</span>: You are interested in the item's
+    presence information, but the contact is not interested in
+    yours.</li>
+      
+      <li>
+<span style="font-style: italic">subscription='both'</span>: You and the contact are interested in each other's presence information.</li>
+
+    </ul>
+
+   <p class="" style="">Additionally, if <span style="font-style: italic">subscription='from'</span> or
+   <span style="font-style: italic">subscription='none'</span>, you can have <span style="font-style: italic">ask='suscribe'</span>, which
+   means you sent a subscription request to the item but haven't received an
+   answer yet.</p>
+
+  </div>
+
+<h2>2.
+       <a name="removal">Removal of Contacts</a>
+</h2>
+  <p class="" style="">It is necessary to distinguish two things:</p>
+  <ul>
+  <li>Removal from the user's roster (does the user's roster include an entry
+  for this JID?) ;</li>
+  <li>Removal of presence subscription (cancellation of subscription).</li>
+  </ul>
+  <p class="" style="">Three problems have to be taken into consideration here:</p>
+  <ul>
+
+  <li>Removing an item from your roster (i.e., performing a roster set with <span style="font-style: italic">subscription='remove'</span>) cancels all subscriptions (both from
+  the item and to the item).</li>
+
+  <li>The fact that a user is no longer interested in the contact's
+  presence doesn't mean that the contaccontact is no longer interested in the
+  user's presence.</li>
+
+  <li>This is complex, and should be presented in a simple way to the
+  user.</li>
+
+  </ul>
+
+  <p class="" style="">Therefore, the following behavior is RECOMMENDED for Jabber clients:</p>
+
+  <ol start="" type="">
+    <li><p class="" style="">When the user asks for the removal of an item with
+  <span style="font-style: italic">subscription='both'</span>, the Jabber client SHOULD ask the user whether
+  he wants to revoke the contact's authorization to see the user's presence
+  too. This action SHOULD be called "Remove" since this is the convention used
+  by other IM systems.</p></li>
+    <li>
+      <p class="" style="">The Jabber client SHOULD NOT remove the contact from the roster. There
+  are two exceptions:</p>
+      <ol start="" type="a">
+        <li><p class="" style="">The Jabber client MAY remove the contact from the roster if the user
+  explicitely asked (so the user has to be informed he might remove both
+  presence subscriptions).</p></li>
+        <li><p class="" style="">The jabber client MAY transparently remove the contact from the roster if
+  the user asked to, and if <span style="font-style: italic">subscription='none'</span> or
+  <span style="font-style: italic">subscription='to'</span>.</p></li>
+      </ol>
+    </li>
+  </ol>
+  
+  <p class="" style="">In addition to the "Remove" action described above, the client MAY
+  provide a way to revoke the contact's subscription to the user's presence.
+  This action, if provided, SHOULD be called "Block" since this is the
+  convention used by other IM networks.</p>
+
+<h2>3.
+       <a name="contacts">Display of Contacts in the Roster</a>
+</h2>
+
+  <p class="" style="">Defining a sensible roster policy is difficult, because many users have different, special needs. We have to ensure that:</p>
+  <ul>
+  <li>Most contacts that everybody wants to hide are hidden.</li>
+  <li>No contact that someone wants to see is hidden.</li>
+  </ul>
+
+  <p class="" style="">The user's roster contains both contacts of interest for the user
+  (contacts with <span style="font-style: italic">subscription='both'</span> or <span style="font-style: italic">subscription='to'</span>) and contacts which
+  are only interested in receiving the user's presence information. Also, the
+  user might be interested in having some contacts even with
+  <span style="font-style: italic">subscription='none'</span>, because he often send messages to them but isn't
+  interested in their presence.</p>
+
+
+  <p class="" style="">Therefore, the following types of contacts SHOULD be displayed by clients:</p>
+  <ul>
+  <li>items with <span style="font-style: italic">subscription='both'</span> or <span style="font-style: italic">subscription='to'</span> ;</li>
+  <li>items with <span style="font-style: italic">subscription='none'</span> or <span style="font-style: italic">subscription='from'</span> and <span style="font-style: italic">ask='subscribe'</span> ;</li>
+  <li>items with <span style="font-style: italic">subscription='none'</span> or <span style="font-style: italic">subscription='from'</span> which have a 'name' attribute or a 'group' child set.</li>
+  </ul>
+
+  <p class="" style="">The client MAY display contacts with subscription='from' which don't match
+  one of the above cases in an additional 'Observers' group. If no 'Observers' group is
+  used, the client SHOULD NOT display contacts which don't match one of the
+  above rules.</p>
+
+  <p class="" style="">Some users give nicknames to contacts they do not want to see, to be able to remember who they are when cleaning the roster. An additional 'Hidden' group MAY be used to handle such contacts. The client SHOULD NOT display contacts if one of their groups is the 'Hidden' group. (This mean that if contact 'C' is in groups 'G' and 'Hidden', 'C' should never be displayed, even in group 'G'.)</p>
+
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent"><p><a name="nt-id2251642">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p></div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-10-19)</h4>
+<div class="indent">Initial JEP version. (lnu)
+    </div>
+<h4>Version 0.0.3 (2005-10-18)</h4>
+<div class="indent">Added a remark about "Remove" vs "Block" in other IM systems. (lnu)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">Integrated some feedback for standards-jig. (lnu)
+    </div>
+<h4>Version 0.0.1 (2005-10-04)</h4>
+<div class="indent">First draft. (lnu)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.10.html
+++ b/content/xep-0163-0.10.html
@@ -1,0 +1,600 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing via Pubsub</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing via Pubsub">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with an XMPP account or user.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-07">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing via Pubsub</h1>
+<p>This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with an XMPP account or user.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0163<br>
+            Version: 0.10<br>
+            Last Updated: 2006-07-07<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20via%20Pubsub%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing via Pubsub (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.5.  <a href="#approach-presence">Use Presence</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+<dt>4.3.  <a href="#pub-last">Sending the Last Published Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#rules">Business Rules</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#rules-notifications">Generating Notifications</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#rules-notifications-num">Number of Notifications</a>
+</dt>
+<dt>7.1.2.  <a href="#rules-notifications-when">When to Generate Notifications</a>
+</dt>
+</dl>
+<dt>7.2.  <a href="#rules-subscriptions">Cancelling Subscriptions</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250922">1</a>] extension ("pubsub") can be used to broadcast state change events associated with a Jabber/XMPP account or user, such as those described in <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2250950">2</a>].  [<a href="#nt-id2250912">3</a>] However, the full, generic pubsub protocol is thought of as complicated and therefore has not been widely implemented in clients. To make publish-subscribe functionality more accessible (especially to instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250986">4</a>]), this document defines best practices that can be followed by client and server developers, hopefully resulting in the deployment of personal eventing services across the Jabber/XMPP network.</p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Personal eventing via pubsub ("PEP") is based on five principles:</p>
+  <ol start="1" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One node per namespace.</li>
+    <li>One publisher per node.</li>
+    <li>Smart defaults.</li>
+    <li>Use presence.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at a Jabber/XMPP server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the account owner's personal pubsub nodes, since the root pubsub node simply <span style="font-style: italic">is</span> the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) for the owner-publisher. For example, there is one pubsub node for <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2259480">5</a>], one node for <span class="ref" style="">User Tune</span>  [<a href="#nt-id2259505">6</a>], one node for <span class="ref" style="">User Mood</span>  [<a href="#nt-id2259526">7</a>], and so on. This simplifies discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal eventing service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe service do not necessarily have access to presence information about subscribers, personal eventing services are closely integrated with presence, since each account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service and the recommended access models are "presence" and "roster" (both of which involve presence subscriptions in XMPP instant messaging and presence systems). This presence information can be used to make notifications more intelligent, thus simplifying the task of developing compliant clients (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2259609">8</a>]).</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports PEP, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259645">9</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep" and a feature of "http://jabber.org/protocol/pubsub#pep" (as well as any other <span style="font-weight: bold">JEP-0060</span> features it supports).</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#pep'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">It is RECOMMENDED for a PEP-aware client to advertise its support for PEP only if the server to which it is connected also supports PEP. This is true both for Service Discovery and for the dynamic "profile" of Service Discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259711">10</a>].</p>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node. (We use as our example a node to publish information about the user's current tune as specified in <span style="font-weight: bold">JEP-0118</span>.)</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="1" type="">
+      <li>Because the account owner's server supports PEP, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/tune".</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested (including the default access model of "presence as advertised via service discovery).</li>
+    </ol>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">In order to request an access model other than the default, the account owner MUST include a data form (see <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2259839">11</a>]) that contains a node configuration field of "pubsub#access_model" set to a value of "presence", "roster", or "open" (the value MAY be "authorize" or "whitelist" but these values are NOT RECOMMENDED for PEP nodes since maintenance of such nodes requires interaction on the part of the node owner).</p>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-roster-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 6. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 7. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers (see the <a href="#rules-notifications">Generating Notifications</a> section of this document regarding proper generation of the 'to' address):</p>
+    <p class="caption">Example 8. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The server MUST set the 'from' address on the notification to the bare JID (&lt;node@domain.tld&gt;) of the publishing entity (in this example, "juliet@capulet.com"). The server SHOULD include an <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2259991">12</a>] "replyto" extension specifying the publishing resource (in this example, "juliet@capulet.com/balcony"); this enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). However, any errors related to the notification MUST be directed to the JID of the 'from' address on the notification (i.e., the bare JID) so that bounce processing can be handled by the PEP service rather than by the publishing client.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="pub-last">Sending the Last Published Item</a>
+</h3>
+    <p class="" style="">As described in the <a href="#rules-notifications">Generating Notifications</a> section of this document, a PEP service MUST send the last published item to all new subscribers. In addition, a PEP service MUST send the last published item to all newly-available resources for each subscriber. (Both of these behaviors essentially mimic the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.)</p>
+    <p class="caption">Example 9. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'/&gt;
+    </pre></div>
+    <p class="caption">Example 10. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is straightforward since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 12. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return a list of all pubsub nodes (as well as any other associated items as described in <span style="font-weight: bold">JEP-0030</span>):</p>
+    <p class="caption">Example 13. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (&lt;node@domain.tld&gt;) and specifies the desired node:</p>
+    <p class="caption">Example 14. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="1" type="">
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "open", the server SHOULD allow the entity to subscribe.</li>
+    </ol>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements in the foregoing scenarios is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the account owner to subscribe and to retrieve items.)</p>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error conditions related to subscription requests), the server shall allow the subscription and return an IQ-result:</p>
+    <p class="caption">Example 15. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/home'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">The service then MUST send the last published item to the new subscriber:</p>
+    <p class="caption">Example 16. Server sends last published item</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com' to='romeo@montague.net' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">The default access model for a PEP service SHOULD be "presence" for IM servers and SHOULD be "open" for non-IM servers (a PEP service associated with an IM server SHOULD also support the "roster" access model).</p>
+  <p class="" style="">A PEP service SHOULD NOT support affiliations other than Owner and Subscriber.</p>
+  <p class="" style="">A PEP service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="1" type="">
+    <li>No item persistence (all nodes are transient).</li>
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No get-items.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">A PEP service SHOULD treat the owner-publisher's bare JID (&lt;node@domain.tld&gt;) as a collection node, but SHOULD NOT support any other collection nodes.</p>
+  <p class="" style="">A PEP service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="rules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="rules-notifications">Generating Notifications</a>
+</h3>
+    <div class="indent">
+<h3>7.1.1 <a name="rules-notifications-num">Number of Notifications</a>
+</h3>
+      <ol start="1" type="">
+        <li><p class="" style="">If a subscriber subscribed using a full JID (&lt;node@domain.tld/resource&gt;), domain identifier (&lt;domain.tld&gt;), or domain plus resource (&lt;domain.tld/resource&gt;), a PEP service MUST send one notification only, addressed to the subscribed JID.</p></li>
+        <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service has presence information about the subscriber, the service MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources that have specified non-negative presence priority.</p></li>
+        <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service does not have presence information about the subscriber, it MUST send one notification only, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="rules-notifications-when">When to Generate Notifications</a>
+</h3>
+      <ol start="1" type="">
+        <li><p class="" style="">When an account owner publishes an item to a node, a PEP service MUST generate a notification and send it to all subscribers (where the number of notifications is determined by the foregoing rules).</p></li>
+        <li><p class="" style="">When a PEP service successfully processes a new subscription, it MUST generate a notification containing the last published item for that node and send it to the subscribing JID (where the number of notifications is determined by the foregoing rules).</p></li>
+        <li><p class="" style="">When a PEP service receives initial presence information from a subscriber's resource with a non-negative priority, it MUST generate a notification containing the last published item for that node and send it to the newly-available resource.</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MAY choose not to send notifications to a particular resource for a subscriber if it knows via <span style="font-weight: bold">Entity Capabilities</span> that the resource does not support PEP or does not support the payload namespace associated with a particular node.</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MUST NOT send notifications to a subscriber if the user has blocked the subscriber from receiving all or any kinds of stanza (presence, message, IQ, or any combination thereof) using privacy lists as specified in <span style="font-weight: bold">XMPP IM</span>.</p></li>
+    <li>Specify impact of privacy rule changes on logic for generating notifications and cancelling subscriptions.</li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="rules-subscriptions">Cancelling Subscriptions</a>
+</h3>
+    <p class="" style="">In order to ensure appropriate access to information published at nodes of type "presence" and "roster"", a PEP service MUST re-calculate access controls when:</p>
+    <ol start="1" type="">
+      <li>A presence subscription state changes (e.g., when a subscription request is approved).</li>
+      <li>A roster item is modified (e.g., when the item is moved to a new roster group).</li>
+    </ol>
+    <p class="" style="">If the modification results in a loss of access, the service MUST cancel the entity's subscription and SHOULD send a message to the (former) subscriber informing it of the cancellation. For information about the format of messages sent to notify subscribers of subscription cancellation, see the "Notification of Subscription Denial or Cancellation" section of <span style="font-weight: bold">JEP-0060</span>.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260802">13</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260850">14</a>] shall include 'http://jabber.org/protocol/pubsub#pep' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;); as a result of this JEP, the Registrar shall add a type of "pep" to that category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the Personal Eventing Protocol is all and only a subset of Publish-Subscribe, the schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to PEP as well.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250922">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250950">2</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2250912">3</a>. Currently, many "extended presence" formats are sent using the &lt;presence/&gt; stanza type; however, this overloads presence, results in unnecessary presence traffic, and does not provide fine-grained control over access. The use of publish-subscribe rather than presence is therefore preferable.</p>
+<p><a name="nt-id2250986">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2259480">5</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2259505">6</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2259526">7</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2259609">8</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2259645">9</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259711">10</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2259839">11</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2259991">12</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2260802">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260850">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.10 (2006-07-07)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect version 1.8 of JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.9 (2006-06-15)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect use of data forms in JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.8 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology and defaults.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Specified that notifications are to be sent from bare JID, not full JID.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect pubsub changes; clarified business rules for generation of notifications and cancellation of subscriptions.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.11.html
+++ b/content/xep-0163-0.11.html
@@ -1,0 +1,606 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing via Pubsub</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing via Pubsub">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies best practices for using the publish-subscribe protocol to broadcast state change events associated with an XMPP user or account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-20">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing via Pubsub</h1>
+<p>This document specifies best practices for using the publish-subscribe protocol to broadcast state change events associated with an XMPP user or account.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0163<br>
+            Version: 0.11<br>
+            Last Updated: 2006-07-20<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20via%20Pubsub%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing via Pubsub (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.5.  <a href="#approach-presence">Use Presence</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+<dt>4.3.  <a href="#pub-last">Sending the Last Published Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#rules">Business Rules</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#rules-notifications">Generating Notifications</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#rules-notifications-num">Number of Notifications</a>
+</dt>
+<dt>7.1.2.  <a href="#rules-notifications-when">When to Generate Notifications</a>
+</dt>
+</dl>
+<dt>7.2.  <a href="#rules-subscriptions">Cancelling Subscriptions</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt></dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250944">1</a>] extension ("pubsub") can be used to broadcast state change events associated with a Jabber/XMPP account or user, such as those described in <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2250971">2</a>], <span class="ref" style="">User Mood</span>  [<a href="#nt-id2250994">3</a>], <span class="ref" style="">User Activity</span>  [<a href="#nt-id2251004">4</a>], and <span class="ref" style="">User Tune</span>  [<a href="#nt-id2251026">5</a>].  [<a href="#nt-id2251040">6</a>] However, the full, generic pubsub protocol is often thought of as complicated and therefore has not been widely implemented in clients. To make publish-subscribe functionality more accessible (especially to instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2259563">7</a>]), this document defines a set of best practices that can be followed by instant messaging client and server developers, hopefully resulting in the deployment of personal eventing services across the Jabber/XMPP network.</p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Personal eventing via pubsub ("PEP") is based on five principles:</p>
+  <ol start="1" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One node per namespace.</li>
+    <li>One publisher per node.</li>
+    <li>Smart defaults.</li>
+    <li>Use presence.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at a Jabber/XMPP server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the account owner's personal pubsub nodes, since the root pubsub node simply is the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) for the owner-publisher. For example, there is one pubsub node for location events, one node for tune events, one node for mood events, and so on. This simplifies discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal eventing service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe service do not necessarily have access to presence information about subscribers, personal eventing services are closely integrated with presence, since each account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service and the recommended access models are "presence" and "roster" (both of which involve presence subscriptions in XMPP instant messaging and presence systems). This presence information can be used to make notifications more intelligent, thus simplifying the task of developing compliant clients (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2259740">8</a>]).</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports PEP, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259780">9</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep" and a list of the <span style="font-weight: bold">JEP-0060</span> features it supports.</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">It is RECOMMENDED for a PEP-aware client to advertise its support for PEP only if the server to which it is connected also supports PEP. This is true both for Service Discovery and for the dynamic "profile" of Service Discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259846">10</a>].</p>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <p class="" style="">As described in the <a href="#defaults">Recommended Defaults</a> section of this document, a PEP service MUST support the node creation, node deletion, and publish item use cases (note: the node deletion use case is not shown below, since it is fully specified in <span style="font-weight: bold">JEP-0060</span>).</p>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node. (We use as our example a node to publish information about the user's current tune as specified in <span style="font-weight: bold">JEP-0118</span>.) Here we assume that the default access model for the service is "presence"  [<a href="#nt-id2259893">11</a>] and that the account owner desires a node with that access model.</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="1" type="">
+      <li>Because the account owner's server supports PEP, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/tune".</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested.</li>
+    </ol>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">In order to request an access model other than the default, the account owner MUST include a data form (see <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2259995">12</a>]) that contains a node configuration field of "pubsub#access_model" set to a value of "presence", "roster", or "open" (the value MAY be "authorize" or "whitelist" but these values are NOT RECOMMENDED for PEP nodes since maintenance of such nodes requires interaction on the part of the node owner).</p>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-roster-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 6. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 7. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers (see the <a href="#rules-notifications">Generating Notifications</a> section of this document regarding proper generation of the 'to' address):</p>
+    <p class="caption">Example 8. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The server MUST set the 'from' address on the notification to the bare JID (&lt;node@domain.tld&gt;) of the publishing entity (in this example, "juliet@capulet.com"). The server SHOULD include an <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2260147">13</a>] "replyto" extension specifying the publishing resource (in this example, "juliet@capulet.com/balcony"); this enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). However, any errors related to the notification MUST be directed to the JID of the 'from' address on the notification (i.e., the bare JID) so that bounce processing can be handled by the PEP service rather than by the publishing client.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="pub-last">Sending the Last Published Item</a>
+</h3>
+    <p class="" style="">As described in the <a href="#rules-notifications">Generating Notifications</a> section of this document, a PEP service MUST send the last published item to all new subscribers and to all newly-available resources for each subscriber.  [<a href="#nt-id2250515">14</a>]</p>
+    <p class="caption">Example 9. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'/&gt;
+    </pre></div>
+    <p class="caption">Example 10. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <p class="" style="">As described in the <a href="#defaults">Recommended Defaults</a> section of this document, a PEP service MUST support the discover nodes, subscribe, unsubscribe, and items retrieval use cases (note: the unsubscribe and items retrieval use cases are not shown below, since they are fully specified in <span style="font-weight: bold">JEP-0060</span>).</p>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is straightforward since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 12. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return a list of all pubsub nodes (as well as any other associated items as described in <span style="font-weight: bold">JEP-0030</span>):</p>
+    <p class="caption">Example 13. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (&lt;node@domain.tld&gt;) and specifies the desired node:</p>
+    <p class="caption">Example 14. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="1" type="">
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "open", the server SHOULD allow the entity to subscribe.</li>
+    </ol>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements in the foregoing scenarios is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the account owner to subscribe and to retrieve items.)</p>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error conditions related to subscription requests), the server shall allow the subscription and return an IQ-result:</p>
+    <p class="caption">Example 15. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/home'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscription
+        node='http://jabber.org/protocol/tune'
+        jid='romeo@montague.net'
+        subscription='subscribed'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The service then MUST send the last published item to the new subscriber:</p>
+    <p class="caption">Example 16. Server sends last published item</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com' to='romeo@montague.net' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">A PEP service MUST support the node discovery, node creation, node deletion, publish item, subscribe, unsubscribe, and items retrieval use cases specified in <span style="font-weight: bold">JEP-0060</span>, and MAY support other use cases according to implementation decisions or deployment policies.</p>
+  <p class="" style="">A PEP service MUST support the "owner" and "subscriber" affiliations but SHOULD NOT support other affiliations.</p>
+  <p class="" style="">The default access model for a PEP service SHOULD be "presence" for IM servers and SHOULD be "open" for non-IM servers; a PEP service associated with an IM server SHOULD also support the "roster" access model; a PEP service MAY also support the "authorize" and "whitelist" access models.</p>
+  <p class="" style="">A PEP service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="1" type="">
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No item persistence (all nodes are transient).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">A PEP service SHOULD treat the owner-publisher's bare JID (&lt;node@domain.tld&gt;) as a collection node (i.e., as the root collection node for the account's virtual pubsub service), but SHOULD NOT support any other collection nodes.</p>
+  <p class="" style="">A PEP service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="rules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="rules-notifications">Generating Notifications</a>
+</h3>
+    <div class="indent">
+<h3>7.1.1 <a name="rules-notifications-num">Number of Notifications</a>
+</h3>
+      <ol start="1" type="">
+        <li><p class="" style="">If a subscriber subscribed using a full JID (&lt;node@domain.tld/resource&gt;), domain identifier (&lt;domain.tld&gt;), or domain plus resource (&lt;domain.tld/resource&gt;), a PEP service MUST send one notification only, addressed to the subscribed JID.</p></li>
+        <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service has presence information about the subscriber, the service MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources that have specified non-negative presence priority.  [<a href="#nt-id2260939">15</a>]</p></li>
+        <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service does not have presence information about the subscriber, it MUST send at most one notification, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="rules-notifications-when">When to Generate Notifications</a>
+</h3>
+      <ol start="1" type="">
+        <li><p class="" style="">When an account owner publishes an item to a node, a PEP service MUST generate a notification and send it to all subscribers (where the number of notifications is determined by the foregoing rules).</p></li>
+        <li><p class="" style="">When a PEP service successfully processes a new subscription, it MUST generate a notification containing the last published item for that node and send it to the subscribing JID (where the number of notifications is determined by the foregoing rules).</p></li>
+        <li><p class="" style="">When a PEP service receives initial presence information from a subscriber's resource with a non-negative priority, it MUST generate a notification containing the last published item for that node and send it to the newly-available resource.</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MAY choose not to send notifications to a subscriber if the subscribed JID is a bare JID (&lt;node@domain.tld&gt;) and the service does not have presence information about the subscriber.  [<a href="#nt-id2260775">16</a>]</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MAY choose not to send notifications to a particular resource for a subscriber if it knows via <span style="font-weight: bold">Entity Capabilities</span> that the resource does not support PEP or does not support the payload namespace associated with a particular node.</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MUST NOT send notifications to a subscriber if the user has blocked the subscriber from receiving all or any kinds of stanza (presence, message, IQ, or any combination thereof) using privacy lists as specified in <span style="font-weight: bold">XMPP IM</span>.</p></li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="rules-subscriptions">Cancelling Subscriptions</a>
+</h3>
+    <p class="" style="">In order to ensure appropriate access to information published at nodes of type "presence" and "roster"", a PEP service MUST re-calculate access controls when:</p>
+    <ol start="1" type="">
+      <li>A presence subscription state changes (e.g., when a subscription request is approved).</li>
+      <li>A roster item is modified (e.g., when the item is moved to a new roster group).</li>
+    </ol>
+    <p class="" style="">If the modification results in a loss of access, the service MUST cancel the entity's subscription and SHOULD send a message to the (former) subscriber informing it of the cancellation. For information about the format of messages sent to notify subscribers of subscription cancellation, see the "Notification of Subscription Denial or Cancellation" section of <span style="font-weight: bold">JEP-0060</span>.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261019">17</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;); as a result of this JEP, the Registrar shall add a type of "pep" to that category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the Personal Eventing Protocol is all and only a subset of Publish-Subscribe, the schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to PEP as well.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250944">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250971">2</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2250994">3</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2251004">4</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p><a name="nt-id2251026">5</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2251040">6</a>. Currently, many "extended presence" formats are sent using the &lt;presence/&gt; stanza type; however, this overloads presence, results in unnecessary presence traffic, and does not provide fine-grained control over access. The use of publish-subscribe rather than presence is therefore preferable.</p>
+<p><a name="nt-id2259563">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2259740">8</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2259780">9</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259846">10</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2259893">11</a>. Naturally, the default node configuration needs to be discovered via the method defined in <span style="font-weight: bold">JEP-0060</span>.</p>
+<p><a name="nt-id2259995">12</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2260147">13</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2250515">14</a>. That is, the default value of the "pubsub#send_last_published_item" node configuration field must be "on_sub_and_presence"; this behavior essentially mimics the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.</p>
+<p><a name="nt-id2260939">15</a>. If the only presence information received by the service is from resources that have specified negative priorities, the service MUST NOT send any notifications.</p>
+<p><a name="nt-id2260775">16</a>. If the only presence information received by the service is from resources that have specified negative priorities, the service MUST NOT send any notifications.</p>
+<p><a name="nt-id2261019">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.11 (2006-07-20)</h4>
+<div class="indent">
+<p class="" style="">Clarified rules regarding number of notifications and when to generate notifications; corrected several errors in the text and examples.</p> (psa)
+    </div>
+<h4>Version 0.10 (2006-07-07)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect version 1.8 of JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.9 (2006-06-15)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect use of data forms in JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.8 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology and defaults.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Specified that notifications are to be sent from bare JID, not full JID.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect pubsub changes; clarified business rules for generation of notifications and cancellation of subscriptions.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.12.html
+++ b/content/xep-0163-0.12.html
@@ -1,0 +1,853 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing via Pubsub</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing via Pubsub">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies XMPP semantics for using the publish-subscribe protocol to broadcast state change events associated with a user or account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing via Pubsub</h1>
+<p>This document specifies XMPP semantics for using the publish-subscribe protocol to broadcast state change events associated with a user or account.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0163<br>
+            Version: 0.12<br>
+            Last Updated: 2006-08-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0060, JEP-0115<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20via%20Pubsub%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing via Pubsub (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.3.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.4.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.5.  <a href="#approach-presence">Use Presence</a>
+</dt>
+</dl>
+<dt>3.  <a href="#scenario">Scenario</a>
+</dt>
+<dt>4.  <a href="#owner-disco">Account Owner Service Discovery</a>
+</dt>
+<dt>5.  <a href="#owner-create">Account Owner Node Creation</a>
+</dt>
+<dt>6.  <a href="#contact-disco">Contact Service Discovery</a>
+</dt>
+<dt>7.  <a href="#contact-subscribe">Contact Subscription</a>
+</dt>
+<dt>8.  <a href="#owner-publish">Account Owner Publishing</a>
+</dt>
+<dt>9.  <a href="#contact-filter">Contact Notification Filtering</a>
+</dt>
+<dt>10.  <a href="#notifications">Generating Notifications</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#notifications-num">Number of Notifications</a>
+</dt>
+<dt>10.2.  <a href="#notifications-when">When to Generate Notifications</a>
+</dt>
+</dl>
+<dt>11.  <a href="#last">Sending the Last Published Item</a>
+</dt>
+<dt>12.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>13.  <a href="#imple">Implementation Notes</a>
+</dt>
+<dl><dt>13.1.  <a href="#impl-subscriptions">Cancelling Subscriptions</a>
+</dt></dl>
+<dt>14.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>15.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>16.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>16.1.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt></dl>
+<dt>17.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>18.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250971">1</a>] extension ("pubsub") can be used to broadcast state change events associated with a Jabber/XMPP account or user, such as those described in <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2250986">2</a>], <span class="ref" style="">User Mood</span>  [<a href="#nt-id2251006">3</a>], <span class="ref" style="">User Activity</span>  [<a href="#nt-id2251030">4</a>], and <span class="ref" style="">User Tune</span>  [<a href="#nt-id2259616">5</a>].  [<a href="#nt-id2251018">6</a>] However, the full, generic pubsub protocol is often thought of as complicated and therefore has not been widely implemented in clients. To make publish-subscribe functionality more accessible (especially to instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2259651">7</a>]), this document defines simplified protocol semantics that can be followed by instant messaging client and server developers, hopefully resulting in the deployment of personal eventing services across the Jabber/XMPP network.</p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Personal eventing via pubsub ("PEP") is based on five principles:</p>
+  <ol start="1" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One publisher per node.</li>
+    <li>One node per namespace.</li>
+    <li>Smart defaults.</li>
+    <li>Use presence.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at a Jabber/XMPP server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the account owner's personal pubsub nodes, since the root pubsub node simply is the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal eventing service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we recommend that there be only one publish-subscribe node associated with any given payload type (XML namespace) for the owner-publisher. For example, there should be one pubsub node for location events, one node for tune events, one node for mood events, and so on. This simplifies node creation, discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe service do not necessarily have access to presence information about subscribers, personal eventing services are integrated with presence in the following ways:</p>
+    <ul>
+      <li>Each messaging and presence account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service.</li>
+      <li>The recommended access models are "presence" and "roster" (both of which involve presence subscriptions in XMPP instant messaging and presence systems).</li>
+      <li>Subscriptions are handled via XMPP presence and the extended <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259880">8</a>] information contained in presence broadcasts.</li>
+      <li>Services take account of subscriber presence in the generation of notifications.</li>
+    </ul>
+    <p class="" style="">These uses of presence simplify the task of developing compliant clients (cf. <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2259847">9</a>]).</p>
+  </div>
+<h2>3.
+       <a name="scenario">Scenario</a>
+</h2>
+  <p class="" style="">This document illustrates PEP through a series of examples that use the following scenario:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">An owner-publisher juliet@capulet.com who publishes the following information:</p>
+      <ol start="" type="">
+        <li>Tune information that anyone may see (i.e., an access model of "open")</li>
+        <li>Activity information that only presence subscribers may see (i.e., an access model of "presence")</li>
+        <li>Geolocation information that only contacts in her "Friends" group may see (i.e., an access model of "roster" with a group of "Friends")</li>
+        <li>Bookmark information that only the account owner may see (i.e., an access model of "whitelist"; note that a PEP node with an access model of "whitelist" and no entities on the whitelist effectively results in a node that enables private data storage such as that defined in <span class="ref" style="">Private XML Storage</span>  [<a href="#nt-id2259964">10</a>])</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">Three users who have the following relationship to Juliet:</p>
+      <ol start="" type="">
+        <li>benvolio@montague.net, who has no subscription to Juliet's presence</li>
+        <li>nurse@capulet.com, who has a bidirectional subscription to Juliet's presence and who is in the "Servants" group in Juliet's roster</li>
+        <li>romeo@montague.net, who has a bidirectional subscription to Juliet's presence and who is in the "Friends" group in Juliet's roster</li>
+      </ol>
+    </li>
+  </ol>
+  <p class="" style="">The examples shown in the following sections walk through the protocol flows for node creation, discovery, publishing, and subscribing.</p>
+<h2>4.
+       <a name="owner-disco">Account Owner Service Discovery</a>
+</h2>
+  <p class="" style="">Naturally, before an account owner attempts to create nodes, its client SHOULD determine whether the account owner's server supports PEP; to do so, it MUST send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260050">11</a>] information request to the server:</p>
+  <p class="caption">Example 1. Account owner queries server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep" (as well as a list of the namespaces and other features it supports, including all supported <span style="font-weight: bold">JEP-0060</span> features):</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="owner-create">Account Owner Node Creation</a>
+</h2>
+  <p class="" style="">In order to create a node, an account owner MUST follow the node creation protocol specified in <span style="font-weight: bold">JEP-0060</span>.  [<a href="#nt-id2260104">12</a>]</p>
+  <p class="" style="">For example, Juliet would send the following stanzas in order to create the nodes mentioned above:</p>
+  <p class="caption">Example 3. Account owner creates open node for tune data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-open'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 4. Account owner creates presence node for activity data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-presence'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/activity'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 5. Account owner creates roster access node for geolocation data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-roster'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 6. Account owner creates whitelist node for bookmark data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-whitelist'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='storage:bookmarks'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="contact-disco">Contact Service Discovery</a>
+</h2>
+  <p class="" style="">A contact MAY send service discovery requests to the account owner's bare JID (&lt;node@domain.tld&gt;). Although this is not necessary in order to subscribe to the account owner's personal eventing data (as explained in the following section), it is shown here to further illustrate the role of access models.</p>
+  <p class="" style="">First, benvolio@montague.net sends a disco#info request to juliet@capulet.com:</p>
+  <p class="caption">Example 7. Unaffiliated entity queries account owner regarding information</p>
+<div class="indent"><pre>
+&lt;iq from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's server supports PEP (thereby making juliet@capulet.com a virtual pubsub service), it MUST return an identity of "pubsub/pep":</p>
+  <p class="caption">Example 8. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='benvolio@montague.net/home'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Second, benvolio@montague.net sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 9. Unaffiliated entity queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='disco2'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The account owner's server MUST check the access model for each of the account owner's PEP nodes and MUST return as service discovery items only those nodes to which the contact is allowed to subscribe or from which the contact is allowed to retrieve items.</p>
+  <p class="" style="">Therefore, in this case, the server would return only the "http://jabber.org/protocol/tune" node (since it has an open access model and the contact does not have a presence subscription to the account owner's presence):</p>
+  <p class="caption">Example 10. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='benvolio@montague.net/home'
+    id='disco2'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Next, nurse@capulet.com sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 11. Contact with presence subscription queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com'
+    id='disco3'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">However, in this case, the server would return the "http://jabber.org/protocol/tune" node (open access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/activity" node (presence access model):</p>
+  <p class="caption">Example 12. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='nurse@capulet.com/chamber'
+    id='disco3'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Finally, romeo@montague.net sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 13. Contact with presence subscription and in privileged roster group queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    id='disco4'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">In this case, the server would return the "http://jabber.org/protocol/tune" node (open access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/activity" node (presence access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/geoloc" node (roster access model):</p>
+  <p class="caption">Example 14. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    id='disco4'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>7.
+       <a name="contact-subscribe">Contact Subscription</a>
+</h2>
+  <p class="" style="">If an entity is not subscribed to the account owner's presence, it MUST subscribe to a node using the protocol defined in <span style="font-weight: bold">JEP-0060</span>. For instance, here is how benvolio@montague.net would subscribe Juliet's tune information:</p>
+  <p class="caption">Example 15. Unaffiliated entity subscribes to an open node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">However, when a contact is affiliated with the account owner through a presence subscription, PEP greatly simplifies the subscription process. Indeed, such a contact automatically receives notifications from all nodes of interest simply by being subscribed to the account owner's presence. This is done by associating the presence subscription with a pubsub subscription to the account owner's root collection node (i.e., bare JID), with a subscription_type of "items" and a subscription_depth of "all". As a result, a contact with a presence subscription to the account owner will receive all items published to all of the account owner's nodes with access models of "open" and "presence".</p>
+  <p class="" style="">Consider, then, the following presence subscription exchange:</p>
+  <p class="caption">Example 16. Presence subscription handshake</p>
+<div class="indent"><pre>
+&lt;presence from='nurse@capulet.com' to='juliet@capulet.com' type='subscribe'/&gt;
+
+&lt;presence from='juliet@capulet.com' to='nurse@capulet.com' type='subscribed'/&gt;
+  </pre></div>
+  <p class="" style="">This is equivalent to the following pubsub subscription exchange:</p>
+  <p class="caption">Example 17. Entity subscribes to a collection node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com
+    id='collsub'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe jid='nurse@capulet.com'/&gt;
+    &lt;options&gt;
+      &lt;x xmlns='jabber:x:data'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_type'&gt;
+          &lt;value&gt;items&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_depth'&gt;
+          &lt;value&gt;all&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+   &lt;/options&gt;
+ &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result' from='juliet@capulet.com' to='nurse@capulet.com/chamber' id='collsub'/&gt;
+  </pre></div>
+  <p class="" style="">Therefore, because both nurse@capulet.com and romeo@montague.net have presence subscriptions to juliet@capulet.com, they will receive all notifications generated by the "http://jabber.org/protocol/tune" and "http://jabber.org/protocol/activity" nodes.</p>
+  <p class="" style="">In addition, because romeo@montague.net is in the "Friends" group in Juliet's roster, he will receive the foregoing notifications as well as notifications generated by the "http://jabber.org/protocol/geoloc" node.</p>
+<h2>8.
+       <a name="owner-publish">Account Owner Publishing</a>
+</h2>
+  <p class="" style="">Consider what happens when the account owner publishes an item to a node:</p>
+  <p class="caption">Example 18. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Now the account owner's server generates notifications and sends them to all subscribers (in this case, all three entities):</p>
+  <p class="caption">Example 19. Server sends notification to subscribers</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='benvolio@montague.net'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='juliet@capulet.com'
+         to='nurse@capulet.com/chamber'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">The server MUST set the 'from' address on the notification to the bare JID (&lt;node@domain.tld&gt;) of the account owner (in this example, "juliet@capulet.com"). When sending notifications to entities that have presence subscription to the account owner, the server SHOULD include an <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2260615">13</a>] "replyto" extension specifying the publishing resource (in this example, "juliet@capulet.com/balcony"); this enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). However, a server MUST NOT include the "replyto" address when sending notifications to entities that do not have presence subscriptions to the account owner. In addition, any errors related to the notification MUST be directed to the JID of the 'from' address on the notification (i.e., the bare JID) so that bounce processing can be handled by the PEP service rather than by the publishing client.</p>
+  <p class="" style="">For further rules regarding notifications, see the <a href="#notifications">Contact Notification Filtering</a> and <a href="#notifications">Generating Notifications</a> sections of this document.</p>
+<h2>9.
+       <a name="contact-filter">Contact Notification Filtering</a>
+</h2>
+  <p class="" style="">A contact with a presence subscription to the account owner may not want to receive notifications from all nodes with an access model of "open" or "presence" (or "roster"). A contact MAY signal its preferences to the account owner's server by including <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2260706">14</a>] information that specifies the namespaces for which the contact wishes to receive notifications.</p>
+  <p class="" style="">In order to make this possible, all possible payload namespaces can be appended with the string "+notify" to indicate that the contact wishes to receive notifications for the payload format. Thus if Romeo wants to receive notifications for activity data and geolocation data but not tune data, his client would advertise support for the following namespaces in the disco#info results it sends:</p>
+  <ul>
+    <li>http://jabber.org/protocol/activity</li>
+    <li>http://jabber.org/protocol/activity+notify</li>
+    <li>http://jabber.org/protocol/geoloc</li>
+    <li>http://jabber.org/protocol/geoloc+notify</li>
+  </ul>
+  <p class="" style="">This set of namespaces would then be advertised as a <span style="font-weight: bold">JEP-0115</span> "ext" value, such as the following:</p>
+  <p class="caption">Example 20. Contact sends presence with caps</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">Note: In <span style="font-weight: bold">JEP-0115</span>, the "ext" values are opaque strings with no semantic meaning.</p>
+  <p class="" style="">It is the responsibility of the account owner's server to cache <span style="font-weight: bold">JEP-0115</span> information (including "ext" values and their associated namespaces). When the server receives presence from a contact, it MUST check that presence information for entity capabilities data and correlate that data with the supported and desired namespaces for the contact's client. The server MUST NOT send notifications related to any data formats that the contact's client has not asked for via the relevant "namespace+notify" disco#info feature. This enables a client to turn off all notifications (e.g., because of bandwidth restrictions) and to easily receive all desired data formats simply by adding support for the appropriate "namespace+notify" combination in its disco#info results and client capabililies. However, it also implies that a client can request notifications only on a global basis and cannot request, say, mood information only from certain contacts in the user's roster. Developer consensus is that this is an acceptable tradeoff. Also, note that this works only if the account owner has a presence subscription to the contact.</p>
+  <p class="" style="">Some examples may help to illustrate the concept. Here we show presence generated by two of the contacts listed above (benvolio@montague.net does have any presence subscriptions to or from juliet@capulet.com and therefore is not involved in these protocol flows).</p>
+  <p class="caption">Example 21. Presence with caps</p>
+<div class="indent"><pre>
+&lt;presence from='nurse@capulet.com/chamber'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://exodus.jabberstudio.org/caps'
+     ver='0.9'
+     ext='asdf fdsa bar baz'/&gt;
+&lt;/presence&gt;
+
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">We assume that Juliet's server doesn't know anything about these capabilities, so it sends service discovery information requests to each of the clients on Juliet's behalf (realistically, the capulet.com server will quickly build up a cache of client capabilities so will not need to send these services discovery requests):</p>
+  <p class="caption">Example 22. Account server queries contact</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='nurse@capulet.com/chamber'
+    type='get'
+    id='disco123'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com'
+    type='result'
+    id='disco123'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;feature var='http://jabber.org/protocol/tune'/&gt;
+    &lt;feature var='http://jabber.org/protocol/tune+notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity+notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc+notify'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 23. Account server queries contact</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    type='get'
+    id='disco234'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    type='result'
+    id='disco234'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;feature var='http://jabber.org/protocol/tune'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc+notify'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Now we revisit account owner publication and server generation of notifications, with filtering enabled because the server has caps information:</p>
+  <ul>
+    <li><p class="" style="">If Juliet publishes a tune item to the open-access "http://jabber.org/protocol/tune" node, her server will send notifications to &lt;benvolio@montague.net&gt; (bare JID) and to &lt;nurse@capulet.com/chamber&gt; (full JID) but not to &lt;romeo@montague.net/orchard&gt;.</p></li>
+    <li><p class="" style="">If Juliet publishes an activity item to the presence-access "http://jabber.org/protocol/activity" node, her server will send notifications only to &lt;nurse@capulet.com/chamber&gt;.</p></li>
+    <li><p class="" style="">If Juliet publishes a geolocation item to the roster-access "http://jabber.org/protocol/geolco" node, her server will send notifications only to &lt;romeo@montague.net/orchard&gt;.</p></li>
+  </ul>
+<h2>10.
+       <a name="notifications">Generating Notifications</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="notifications-num">Number of Notifications</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">If a subscriber subscribed using a full JID (&lt;node@domain.tld/resource&gt;), domain identifier (&lt;domain.tld&gt;), or domain plus resource (&lt;domain.tld/resource&gt;), a PEP service MUST send one notification only, addressed to the subscribed JID.</p></li>
+      <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service has presence information about the subscriber, the service MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources that have specified non-negative presence priority.  [<a href="#nt-id2261158">15</a>]</p></li>
+      <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service does not have presence information about the subscriber, it MUST send at most one notification, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="notifications-when">When to Generate Notifications</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">When an account owner publishes an item to a node, a PEP service MUST generate a notification and send it to all subscribers (where the number of notifications is determined by the foregoing rules).</p></li>
+      <li><p class="" style="">When a PEP service successfully processes a new subscription, it MUST generate a notification containing the last published item for that node and send it to the subscribing JID (where the number of notifications is determined by the foregoing rules).</p></li>
+      <li><p class="" style="">When a PEP service receives initial presence information from a subscriber's resource with a non-negative priority, it MUST generate a notification containing the last published item for that node and send it to the newly-available resource.</p></li>
+      <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MAY choose not to send notifications to a subscriber if the subscribed JID is a bare JID (&lt;node@domain.tld&gt;) and the service does not have presence information about the subscriber.  [<a href="#nt-id2260994">16</a>]</p></li>
+      <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MAY choose not to send notifications to a particular resource for a subscriber if it knows via <span style="font-weight: bold">Entity Capabilities</span> that the resource does not support PEP or does not support the payload namespace associated with a particular node.</p></li>
+      <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MUST NOT send notifications to a subscriber if the user has blocked the subscriber from receiving all or any kinds of stanza (presence, message, IQ, or any combination thereof) using privacy lists as specified in <span style="font-weight: bold">XMPP IM</span>.</p></li>
+    </ol>
+  </div>
+<h2>11.
+       <a name="last">Sending the Last Published Item</a>
+</h2>
+  <p class="" style="">As described in the <a href="#notifications">Generating Notifications</a> section of this document, a PEP service MUST send the last published item to all new subscribers and to all newly-available resources for each subscriber.  [<a href="#nt-id2261150">17</a>]</p>
+  <p class="caption">Example 24. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'/&gt;
+  </pre></div>
+  <p class="caption">Example 25. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'/&gt;
+  </pre></div>
+  <p class="caption">Example 26. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>12.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">A PEP service MUST support the node discovery, node creation, node deletion, publish item, subscribe, unsubscribe, and items retrieval use cases specified in <span style="font-weight: bold">JEP-0060</span>, and MAY support other use cases according to implementation decisions or deployment policies.</p>
+  <p class="" style="">A PEP service MUST support the "owner" and "subscriber" affiliations but SHOULD NOT support other affiliations.</p>
+  <p class="" style="">The default access model for a PEP service SHOULD be "presence" for IM servers and SHOULD be "open" for non-IM servers; a PEP service associated with an IM server SHOULD also support the "roster" access model; a PEP service MAY also support the "authorize" and "whitelist" access models.</p>
+  <p class="" style="">A PEP service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="1" type="">
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No item persistence (all nodes are transient).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">A PEP service MUST treat the owner-publisher's bare JID (&lt;node@domain.tld&gt;) as a collection node (i.e., as the root collection node for the account's virtual pubsub service), but SHOULD NOT support any other collection nodes.</p>
+  <p class="" style="">A PEP service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>13.
+       <a name="imple">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="impl-subscriptions">Cancelling Subscriptions</a>
+</h3>
+    <p class="" style="">In order to ensure appropriate access to information published at nodes of type "presence" and "roster"", a PEP service MUST re-calculate access controls when:</p>
+    <ol start="1" type="">
+      <li>A presence subscription state changes (e.g., when a subscription request is approved).</li>
+      <li>A roster item is modified (e.g., when the item is moved to a new roster group).</li>
+    </ol>
+    <p class="" style="">If the modification results in a loss of access, the service MUST cancel the entity's subscription and SHOULD send a message to the (former) subscriber informing it of the cancellation. For information about the format of messages sent to notify subscribers of subscription cancellation, see the "Notification of Subscription Denial or Cancellation" section of <span style="font-weight: bold">JEP-0060</span>.</p>
+  </div>
+<h2>14.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>15.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261434">18</a>].</p>
+<h2>16.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;); as a result of this JEP, the Registrar shall add a type of "pep" to that category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>17.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the Personal Eventing Protocol is all and only a subset of Publish-Subscribe, the schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to PEP as well.</p>
+<h2>18.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors wish to thank the participants in the XMPP Interoperability Testing Event held July 24 and 25, 2006, who provided valuable feedback that resulted in radical simplification of the protocol.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250971">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250986">2</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2251006">3</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2251030">4</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p><a name="nt-id2259616">5</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2251018">6</a>. Currently, many "extended presence" formats are sent using the &lt;presence/&gt; stanza type; however, this overloads presence, results in unnecessary presence traffic, and does not provide fine-grained control over access. The use of publish-subscribe rather than presence is therefore preferable.</p>
+<p><a name="nt-id2259651">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2259880">8</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2259847">9</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2259964">10</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p><a name="nt-id2260050">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260104">12</a>. The authors considered simpler node creation semantics, for example behavior in which a service automatically creates a given node when an account owner attempts to publish to it. Although this has the virtue of being similar to, say, room creation in <span style="font-weight: bold">JEP-0045</span>, it seriously complicates the task of determining the node access model (so much so that the publish semantics would in the end closely resemble the existing node creation semantics).</p>
+<p><a name="nt-id2260615">13</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2260706">14</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2261158">15</a>. If the only presence information received by the service is from resources that have specified negative priorities, the service MUST NOT send any notifications.</p>
+<p><a name="nt-id2260994">16</a>. If the only presence information received by the service is from resources that have specified negative priorities, the service MUST NOT send any notifications.</p>
+<p><a name="nt-id2261150">17</a>. That is, the default value of the "pubsub#send_last_published_item" node configuration field must be "on_sub_and_presence"; this behavior essentially mimics the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.</p>
+<p><a name="nt-id2261434">18</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.12 (2006-08-01)</h4>
+<div class="indent">
+<p class="" style="">Simplified the subscription process using XMPP presence and entity capabilities.</p> (psa)
+    </div>
+<h4>Version 0.11 (2006-07-20)</h4>
+<div class="indent">
+<p class="" style="">Clarified rules regarding number of notifications and when to generate notifications; corrected several errors in the text and examples.</p> (psa)
+    </div>
+<h4>Version 0.10 (2006-07-07)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect version 1.8 of JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.9 (2006-06-15)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect use of data forms in JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.8 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology and defaults.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Specified that notifications are to be sent from bare JID, not full JID.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect pubsub changes; clarified business rules for generation of notifications and cancellation of subscriptions.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.13.html
+++ b/content/xep-0163-0.13.html
@@ -1,0 +1,877 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing via Pubsub</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing via Pubsub">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies XMPP semantics for using the publish-subscribe protocol to broadcast state change events associated with an instant messaging and presence account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing via Pubsub</h1>
+<p>This document specifies XMPP semantics for using the publish-subscribe protocol to broadcast state change events associated with an instant messaging and presence account.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0163<br>
+            Version: 0.13<br>
+            Last Updated: 2006-08-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0060, JEP-0115<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20via%20Pubsub%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing via Pubsub (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.3.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.4.  <a href="#approach-presence">Use Presence</a>
+</dt>
+<dt>2.5.  <a href="#approach-filter">Filtered Notifications</a>
+</dt>
+<dt>2.6.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+</dl>
+<dt>3.  <a href="#scenario">Scenario</a>
+</dt>
+<dt>4.  <a href="#owner-disco">Account Owner Service Discovery</a>
+</dt>
+<dt>5.  <a href="#owner-create">Account Owner Node Creation</a>
+</dt>
+<dt>6.  <a href="#contact-disco">Contact Service Discovery</a>
+</dt>
+<dt>7.  <a href="#contact-subscribe">Contact Subscription</a>
+</dt>
+<dt>8.  <a href="#owner-publish">Account Owner Publishing</a>
+</dt>
+<dt>9.  <a href="#contact-filter">Contact Notification Filtering</a>
+</dt>
+<dt>10.  <a href="#notifications">Generating Notifications</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#notifications-num">Number of Notifications</a>
+</dt>
+<dt>10.2.  <a href="#notifications-when">When to Generate Notifications</a>
+</dt>
+</dl>
+<dt>11.  <a href="#last">Sending the Last Published Item</a>
+</dt>
+<dt>12.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>13.  <a href="#imple">Implementation Notes</a>
+</dt>
+<dl><dt>13.1.  <a href="#impl-subscriptions">Cancelling Subscriptions</a>
+</dt></dl>
+<dt>14.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>15.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>16.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>16.1.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt></dl>
+<dt>17.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>18.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2251036">1</a>] extension ("pubsub") can be used to broadcast state change events associated with a Jabber/XMPP account or user, such as those described in <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2250997">2</a>], <span class="ref" style="">User Mood</span>  [<a href="#nt-id2251018">3</a>], <span class="ref" style="">User Activity</span>  [<a href="#nt-id2259622">4</a>], and <span class="ref" style="">User Tune</span>  [<a href="#nt-id2259639">5</a>].  [<a href="#nt-id2259612">6</a>] However, the full, generic pubsub protocol is often thought of as complicated and therefore has not been widely implemented in clients. To make publish-subscribe functionality more accessible (especially to instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2259675">7</a>]), this document defines simplified protocol semantics that can be followed by instant messaging client and server developers, hopefully resulting in the deployment of personal eventing services across the Jabber/XMPP network.</p>
+  <p class="" style=""><span style="font-style: italic">Note: This document does not show error flows related to the various publish-subscribe use cases referenced herein, since they are exhaustively defined in <span style="font-weight: bold">JEP-0060</span>. The reader is referred to <span style="font-weight: bold">JEP-0060</span> for all relevant protocol details related to the XMPP publish-subscribe extension.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Personal eventing via pubsub ("PEP") is based on five principles:</p>
+  <ol start="1" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One publisher per node.</li>
+    <li>One node per namespace.</li>
+    <li>Use presence.</li>
+    <li>Notifications are filtered based on expressed interests.</li>
+    <li>Smart defaults.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at a Jabber/XMPP server that supports PEP, the server associated a virtual pubsub service with the account. This greatly simplifies the task of discovering the account owner's personal pubsub nodes, since the root pubsub node simply is the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a PEP service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">There is only one publish-subscribe node associated with any given payload type (XML namespace) for the account owner. For example, there is one pubsub node for geolocation events, one node for tune events, one node for mood events, and so on. This simplifies node creation, discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe services do not necessarily have access to presence information about subscribers, PEP services are integrated with presence in the following ways:</p>
+    <ul>
+      <li>Each messaging and presence account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service.</li>
+      <li>The default access model is "presence" (both of which involve presence subscriptions in XMPP instant messaging and presence systems).</li>
+      <li>A contact's subscription to an account owner's personal eventing data is normally are handled via the existence of an XMPP presence presence subscription.</li>
+      <li>Services take account of subscriber presence in the generation of notifications.  [<a href="#nt-id2259854">8</a>]</li>
+    </ul>
+    <p class="" style="">These uses of presence simplify the task of developing compliant clients (cf. <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2259929">9</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-filter">Filtered Notifications</a>
+</h3>
+    <p class="" style="">By default, the existence of an XMPP presence subscription is used to establish a PEP subscription to the account owner's personal eventing data. In order to filter which notifications are sent by the PEP service, the contact's client includes extended <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259898">10</a>] information in the presence notifications it sends to the account owner and the PEP service sends only those notifications that match the contact's expressed notification preferences.</p>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, PEP services offer smart defaults to simplify node creation and management.</p>
+  </div>
+<h2>3.
+       <a name="scenario">Scenario</a>
+</h2>
+  <p class="" style="">This document illustrates PEP through a series of examples that use the following scenario:</p>
+  <ol start="1" type="">
+    <li>
+      <p class="" style="">An owner-publisher juliet@capulet.com who publishes the following information:</p>
+      <ol start="1" type="">
+        <li>Tune information that anyone may see (i.e., an access model of "open")</li>
+        <li>Activity information that only presence subscribers may see (i.e., an access model of "presence")</li>
+        <li>Geolocation information that only contacts in her "Friends" group may see (i.e., an access model of "roster" with a group of "Friends")</li>
+        <li>Bookmark information that only the account owner may see (i.e., an access model of "whitelist"; note that a PEP node with an access model of "whitelist" and no entities on the whitelist effectively results in a node that enables private data storage such as that defined in <span class="ref" style="">Private XML Storage</span>  [<a href="#nt-id2260039">11</a>])</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">Three users who have the following relationship to Juliet:</p>
+      <ol start="1" type="">
+        <li>benvolio@montague.net, who has no subscription to Juliet's presence</li>
+        <li>nurse@capulet.com, who has a bidirectional subscription to Juliet's presence and who is in the "Servants" group in Juliet's roster</li>
+        <li>romeo@montague.net, who has a bidirectional subscription to Juliet's presence and who is in the "Friends" group in Juliet's roster</li>
+      </ol>
+    </li>
+  </ol>
+  <p class="" style="">The examples shown in the following sections walk through the protocol flows for node creation, discovery, publishing, and subscribing.</p>
+<h2>4.
+       <a name="owner-disco">Account Owner Service Discovery</a>
+</h2>
+  <p class="" style="">Naturally, before an account owner attempts to complete any PEP use cases, its client SHOULD determine whether the account owner's server supports PEP; to do so, it MUST send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260124">12</a>] information request to the server:</p>
+  <p class="caption">Example 1. Account owner queries server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep" (as well as a list of the namespaces and other features it supports, including all supported <span style="font-weight: bold">JEP-0060</span> features):</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#config-node'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#create-and-configure'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#create-nodes'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#persistent-items'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#publish'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#retrieve-items'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#subscribe'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="owner-create">Account Owner Node Creation</a>
+</h2>
+  <p class="" style="">When an account owner attempts to publish an item to a PEP node, the PEP service SHOULD automatically create the node (with default configuration) if it does not already exist.  [<a href="#nt-id2260184">13</a>] However, if the account owner wishes to create a node with a configuration other than the default (e.g., a node with an access model of "open" or "roster"), the account owner MUST follow the node creation protocol specified in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="" style="">For example, Juliet would send the following stanzas in order to create the nodes mentioned above:</p>
+  <p class="caption">Example 3. Account owner creates open node for tune data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-open'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 4. Account owner publishes initial item to presence node for activity data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-presence'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/activity'/&gt;
+      &lt;item&gt;
+        &lt;activity xmlns='http://jabber.org/protocol/activity'&gt;
+          &lt;relaxing&gt;
+            &lt;partying/&gt;
+          &lt;/relaxing&gt;
+          &lt;text xml:lang='en'&gt;My nurse&amp;apos;s birthday!&lt;/text&gt;
+        &lt;/activity&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 5. Account owner creates roster access node for geolocation data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-roster'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 6. Account owner creates whitelist node for bookmark data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-whitelist'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='storage:bookmarks'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="contact-disco">Contact Service Discovery</a>
+</h2>
+  <p class="" style="">A contact MAY send service discovery requests to the account owner's bare JID (&lt;node@domain.tld&gt;). Although this is not necessary in order to subscribe to the account owner's personal eventing data (as explained in the following section), it is shown here to further illustrate the role of access models.</p>
+  <p class="" style="">First, benvolio@montague.net sends a disco#info request to juliet@capulet.com:</p>
+  <p class="caption">Example 7. Unaffiliated entity queries account owner regarding information</p>
+<div class="indent"><pre>
+&lt;iq from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's server supports PEP (thereby making juliet@capulet.com a virtual pubsub service), it MUST return an identity of "pubsub/pep":</p>
+  <p class="caption">Example 8. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='benvolio@montague.net/home'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Second, benvolio@montague.net sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 9. Unaffiliated entity queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='disco2'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The account owner's server MUST check the access model for each of the account owner's PEP nodes and MUST return as service discovery items only those nodes to which the contact is allowed to subscribe or from which the contact is allowed to retrieve items.</p>
+  <p class="" style="">Therefore, in this case, the server would return only the "http://jabber.org/protocol/tune" node (since it has an open access model and the contact does not have a presence subscription to the account owner's presence):</p>
+  <p class="caption">Example 10. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='benvolio@montague.net/home'
+    id='disco2'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Next, nurse@capulet.com sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 11. Contact with presence subscription queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com'
+    id='disco3'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">However, in this case, the server would return the "http://jabber.org/protocol/tune" node (open access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/activity" node (presence access model):</p>
+  <p class="caption">Example 12. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='nurse@capulet.com/chamber'
+    id='disco3'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Finally, romeo@montague.net sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 13. Contact with presence subscription and in privileged roster group queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    id='disco4'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">In this case, the server would return the "http://jabber.org/protocol/tune" node (open access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/activity" node (presence access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/geoloc" node (roster access model):</p>
+  <p class="caption">Example 14. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    id='disco4'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>7.
+       <a name="contact-subscribe">Contact Subscription</a>
+</h2>
+  <p class="" style="">If an entity is not subscribed to the account owner's presence, it MUST subscribe to a node using the protocol defined in <span style="font-weight: bold">JEP-0060</span>. For instance, here is how benvolio@montague.net would subscribe Juliet's tune information:</p>
+  <p class="caption">Example 15. Unaffiliated entity subscribes to an open node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">However, when a contact is affiliated with the account owner through a presence subscription, PEP greatly simplifies the subscription process. This is done by associating the presence subscription with a pubsub subscription to the account owner's root collection node (i.e., bare JID), with a subscription_type of "items" and a subscription_depth of "all".</p>
+  <p class="" style="">Consider the following presence subscription exchange:</p>
+  <p class="caption">Example 16. Presence subscription handshake</p>
+<div class="indent"><pre>
+&lt;presence from='nurse@capulet.com' to='juliet@capulet.com' type='subscribe'/&gt;
+
+&lt;presence from='juliet@capulet.com' to='nurse@capulet.com' type='subscribed'/&gt;
+  </pre></div>
+  <p class="" style="">This is equivalent to the following pubsub subscription exchange:</p>
+  <p class="caption">Example 17. Entity subscribes to a collection node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com
+    id='collsub'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe jid='nurse@capulet.com'/&gt;
+    &lt;options&gt;
+      &lt;x xmlns='jabber:x:data'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_type'&gt;
+          &lt;value&gt;items&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_depth'&gt;
+          &lt;value&gt;all&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+   &lt;/options&gt;
+ &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result' from='juliet@capulet.com' to='nurse@capulet.com/chamber' id='collsub'/&gt;
+  </pre></div>
+  <p class="" style="">Note: Automated pubsub subscriptions MUST be based on the bare JID (&lt;node@domain.tld&gt;) of the subscribing entity.</p>
+<h2>8.
+       <a name="owner-publish">Account Owner Publishing</a>
+</h2>
+  <p class="" style="">An account owner publishes an item to a node by following the protocol specified in <span style="font-weight: bold">JEP-0060</span>:</p>
+  <p class="caption">Example 18. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">As a result, the account owner's server generates notifications and sends them to all subscribers who have requested the data as described in the <a href="#notifications">Contact Notification Filtering</a> and <a href="#notifications">Generating Notifications</a> sections of this document.</p>
+  <p class="" style="">The server MUST set the 'from' address on the notification to the bare JID (&lt;node@domain.tld&gt;) of the account owner (in this example, "juliet@capulet.com"). When sending notifications to entities that have presence subscription to the account owner, the server SHOULD include an <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2260809">14</a>] "replyto" extension specifying the publishing resource (in this example, "juliet@capulet.com/balcony"); this enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). However, a server MUST NOT include the "replyto" address when sending notifications to entities that do not have presence subscriptions to the account owner. In addition, any errors related to the notification MUST be directed to the JID of the 'from' address on the notification (i.e., the bare JID) so that bounce processing can be handled by the PEP service rather than by the publishing client.</p>
+  <p class="" style="">Assuming that all three entities previously mentioned would receive the notifications, the PEP service would generate the following stanzas:</p>
+  <p class="caption">Example 19. Server sends notification to subscribers</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='benvolio@montague.net'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='juliet@capulet.com'
+         to='nurse@capulet.com/chamber'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>9.
+       <a name="contact-filter">Contact Notification Filtering</a>
+</h2>
+  <p class="" style="">A contact with a presence subscription to the account owner may not want to receive notifications from all nodes with an access model of "open" or "presence" (or "roster"). A contact SHOULD signal its preferences to the account owner's server by including <span style="font-weight: bold">JEP-0115</span> information that specifies the namespaces for which the contact wishes to receive notifications.</p>
+  <p class="" style="">In order to make this possible, all possible payload namespaces can be appended with the string "+notify" to indicate that the contact wishes to receive notifications for the payload format. Thus if Romeo wants to receive notifications for activity data and geolocation data but not tune data, his client would advertise support for the following namespaces in the disco#info results it sends:  [<a href="#nt-id2260962">15</a>]</p>
+  <ul>
+    <li>http://jabber.org/protocol/activity+notify</li>
+    <li>http://jabber.org/protocol/geoloc+notify</li>
+  </ul>
+  <p class="" style="">This set of namespaces would then be advertised as a <span style="font-weight: bold">JEP-0115</span> "ext" value, such as the following:</p>
+  <p class="caption">Example 20. Contact sends presence with caps</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">Note: In <span style="font-weight: bold">JEP-0115</span>, the "ext" values are opaque strings with no semantic meaning.</p>
+  <p class="" style="">It is the responsibility of the account owner's server to cache <span style="font-weight: bold">JEP-0115</span> information (including "ext" values and their associated namespaces). When the server receives presence from a contact, it MUST check that presence information for entity capabilities data and correlate that data with the supported and desired namespaces for the contact's client. The server MUST NOT send notifications related to any data formats that the contact's client has not asked for via the relevant "namespace+notify" disco#info feature. This enables a client to turn off all notifications (e.g., because of bandwidth restrictions) and to easily receive all desired data formats simply by adding support for the appropriate "namespace+notify" combination in its disco#info results and client capabililies. However, it also implies that a client can request notifications only on a global basis and cannot request, say, mood information only from certain contacts in the user's roster. Community consensus is that this is an acceptable tradeoff. Also, note that this works only if the account owner has a presence subscription to the contact.</p>
+  <p class="" style="">Some examples may help to illustrate the concept. Here we show presence generated by two of the contacts listed above (benvolio@montague.net does have any presence subscriptions to or from juliet@capulet.com and therefore is not involved in these protocol flows).</p>
+  <p class="caption">Example 21. Presence with caps</p>
+<div class="indent"><pre>
+&lt;presence from='nurse@capulet.com/chamber'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://exodus.jabberstudio.org/caps'
+     ver='0.9'
+     ext='asdf fdsa bar baz'/&gt;
+&lt;/presence&gt;
+
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">We assume that Juliet's server doesn't know anything about these capabilities, so it sends service discovery information requests to each of the clients on Juliet's behalf (realistically, the capulet.com server will quickly build up a cache of client capabilities so will not need to send these services discovery requests):</p>
+  <p class="caption">Example 22. Account server queries contact</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='nurse@capulet.com/chamber'
+    type='get'
+    id='disco123'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#0.9'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com'
+    type='result'
+    id='disco123'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;feature var='http://jabber.org/protocol/tune'/&gt;
+    &lt;feature var='http://jabber.org/protocol/tune+notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity+notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc+notify'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 23. Account server queries contact</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    type='get'
+    id='disco234'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://www.chatopus.com/ec#2.1'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    type='result'
+    id='disco234'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;feature var='http://jabber.org/protocol/tune'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc+notify'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Now we revisit account owner publication and server generation of notifications, with filtering enabled because the server has caps information:</p>
+  <ul>
+    <li><p class="" style="">If Juliet publishes a tune item to the open-access "http://jabber.org/protocol/tune" node, her server will send notifications to &lt;benvolio@montague.net&gt; (bare JID) and to &lt;nurse@capulet.com/chamber&gt; (full JID) but not to &lt;romeo@montague.net/orchard&gt;.</p></li>
+    <li><p class="" style="">If Juliet publishes an activity item to the presence-access "http://jabber.org/protocol/activity" node, her server will send notifications only to &lt;nurse@capulet.com/chamber&gt;.</p></li>
+    <li><p class="" style="">If Juliet publishes a geolocation item to the roster-access "http://jabber.org/protocol/geolco" node, her server will send notifications only to &lt;romeo@montague.net/orchard&gt;.</p></li>
+  </ul>
+<h2>10.
+       <a name="notifications">Generating Notifications</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="notifications-num">Number of Notifications</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">If a subscriber subscribed using a full JID (&lt;node@domain.tld/resource&gt;), domain identifier (&lt;domain.tld&gt;), or domain plus resource (&lt;domain.tld/resource&gt;), a PEP service MUST send one notification only, addressed to the subscribed JID.</p></li>
+      <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service does not have presence information about the subscriber, it MUST send at most one notification, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p></li>
+      <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service has presence information about the subscriber, the service MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources that have specified non-negative presence priority and included <span style="font-weight: bold">JEP-0115</span> information that indicates an interest in the data format.  [<a href="#nt-id2261197">16</a>]</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="notifications-when">When to Generate Notifications</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">When an account owner publishes an item to a node, a PEP service MUST generate a notification and send it to all subscribers (where the number of notifications is determined by the foregoing rules).</p></li>
+      <li><p class="" style="">When a PEP service receives initial presence information from a subscriber's resource with a non-negative priority and including <span style="font-weight: bold">JEP-0115</span> information that indicates an interest in the data format, it MUST generate a notification containing the last published item for that node and send it to the newly-available resource.</p></li>
+      <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MAY choose not to send notifications to a subscriber if the subscribed JID is a bare JID (&lt;node@domain.tld&gt;) and the service does not have presence information about the subscriber.  [<a href="#nt-id2261185">17</a>]</p></li>
+      <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MUST NOT send notifications to a subscriber if the user has blocked the subscriber from receiving all or any kinds of stanza (presence, message, IQ, or any combination thereof) using privacy lists as specified in <span style="font-weight: bold">XMPP IM</span>.</p></li>
+    </ol>
+  </div>
+<h2>11.
+       <a name="last">Sending the Last Published Item</a>
+</h2>
+  <p class="" style="">As described in the <a href="#notifications">Generating Notifications</a> section of this document, a PEP service MUST send the last published item to all new subscribers and to all newly-available resources for each subscriber.  [<a href="#nt-id2261308">18</a>]</p>
+  <p class="caption">Example 24. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="caption">Example 25. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="caption">Example 26. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>12.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">A PEP service MUST:</p>
+  <ul>
+    <li>Support the publish item use case specified in <span style="font-weight: bold">JEP-0060</span>.</li>
+    <li>Support the "owner" and "subscriber" affiliations.</li>
+    <li>Support the "presence" access model and set it to the default.</li>
+    <li>Treat the account owner's bare JID (&lt;node@domain.tld&gt;) as a collection node (i.e., as the root collection node for the account's virtual pubsub service).</li>
+    <li>Deliver payloads (if included) in all notifications.</li>
+  </ul>
+  <p class="" style="">A PEP service SHOULD:</p>
+  <ul>
+    <li>Support the node discovery, node creation, node deletion, subscribe, unsubscribe, and item retrieval use cases specified in <span style="font-weight: bold">JEP-0060</span>.</li>
+    <li>Support the "open" and "roster" access models.</li>
+  </ul>
+  <p class="" style="">A PEP service MAY support other use cases, affiliations, access models, and features, but such support is OPTIONAL.</p>
+<h2>13.
+       <a name="imple">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>13.1 <a name="impl-subscriptions">Cancelling Subscriptions</a>
+</h3>
+    <p class="" style="">In order to ensure appropriate access to information published at nodes of type "presence" and "roster"", a PEP service MUST re-calculate access controls when:</p>
+    <ol start="1" type="">
+      <li>A presence subscription state changes (e.g., when a subscription request is approved).</li>
+      <li>A roster item is modified (e.g., when the item is moved to a new roster group).</li>
+    </ol>
+    <p class="" style="">If the modification results in a loss of access, the service MUST cancel the entity's subscription. In addition, the service MAY send a message to the (former) subscriber informing it of the cancellation (for information about the format of messages sent to notify subscribers of subscription cancellation, see the "Notification of Subscription Denial or Cancellation" section of <span style="font-weight: bold">JEP-0060</span>).</p>
+  </div>
+<h2>14.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>15.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261553">19</a>].</p>
+<h2>16.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>16.1 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;); as a result of this JEP, the Registrar shall add a type of "pep" to that category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>17.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the Personal Eventing Protocol is all and only a subset of Publish-Subscribe, the schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to PEP as well.</p>
+<h2>18.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors wish to thank the participants in the XMPP Interoperability Testing Event held July 24 and 25, 2006, who provided valuable feedback that resulted in radical simplification of the protocol.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251036">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250997">2</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2251018">3</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2259622">4</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p><a name="nt-id2259639">5</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2259612">6</a>. Currently, many "extended presence" formats are sent using the &lt;presence/&gt; stanza type; however, this overloads presence, results in unnecessary presence traffic, and does not provide fine-grained control over access. The use of publish-subscribe rather than presence is therefore preferable.</p>
+<p><a name="nt-id2259675">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2259854">8</a>. This works only if the subscription state is "both".</p>
+<p><a name="nt-id2259929">9</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2259898">10</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2260039">11</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p><a name="nt-id2260124">12</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260184">13</a>. This similar to the room creation process in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>.</p>
+<p><a name="nt-id2260809">14</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2260962">15</a>. Including, say, the 'http://jabber.org/protocol/geoloc' namespace indicates that the client understands the geolocation namespace, whereas including the 'http://jabber.org/protocol/geoloc+notify' namespace indicates that the client wishes to receive notifications related to geolocation.</p>
+<p><a name="nt-id2261197">16</a>. If the only presence information received by the service is from resources that have specified negative priorities, the service MUST NOT send any notifications.</p>
+<p><a name="nt-id2261185">17</a>. If the only presence information received by the service is from resources that have specified negative priorities, the service MUST NOT send any notifications.</p>
+<p><a name="nt-id2261308">18</a>. That is, the default value of the "pubsub#send_last_published_item" node configuration field must be "on_sub_and_presence"; this behavior essentially mimics the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.</p>
+<p><a name="nt-id2261553">19</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.13 (2006-08-01)</h4>
+<div class="indent">
+<p class="" style="">Recommended node creation with default configuration on initial publish; corrected several errors and clarified several points in the text.</p> (psa)
+    </div>
+<h4>Version 0.12 (2006-08-01)</h4>
+<div class="indent">
+<p class="" style="">Simplified the subscription process using XMPP presence and entity capabilities.</p> (psa)
+    </div>
+<h4>Version 0.11 (2006-07-20)</h4>
+<div class="indent">
+<p class="" style="">Clarified rules regarding number of notifications and when to generate notifications; corrected several errors in the text and examples.</p> (psa)
+    </div>
+<h4>Version 0.10 (2006-07-07)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect version 1.8 of JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.9 (2006-06-15)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect use of data forms in JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.8 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology and defaults.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Specified that notifications are to be sent from bare JID, not full JID.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect pubsub changes; clarified business rules for generation of notifications and cancellation of subscriptions.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.14.html
+++ b/content/xep-0163-0.14.html
@@ -1,0 +1,894 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing via Pubsub</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing via Pubsub">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies XMPP semantics for using the publish-subscribe protocol to broadcast state change events associated with an instant messaging and presence account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing via Pubsub</h1>
+<p>This document specifies XMPP semantics for using the publish-subscribe protocol to broadcast state change events associated with an instant messaging and presence account.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0163<br>
+            Version: 0.14<br>
+            Last Updated: 2006-08-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0060, JEP-0115<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20via%20Pubsub%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing via Pubsub (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.3.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.4.  <a href="#approach-presence">Use Presence</a>
+</dt>
+<dt>2.5.  <a href="#approach-filter">Filtered Notifications</a>
+</dt>
+<dt>2.6.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+</dl>
+<dt>3.  <a href="#scenario">Scenario</a>
+</dt>
+<dt>4.  <a href="#owner-disco">Account Owner Service Discovery</a>
+</dt>
+<dt>5.  <a href="#owner-create">Account Owner Node Creation</a>
+</dt>
+<dt>6.  <a href="#contact-disco">Contact Service Discovery</a>
+</dt>
+<dt>7.  <a href="#contact-subscribe">Contact Subscription</a>
+</dt>
+<dt>8.  <a href="#owner-publish">Account Owner Publishing</a>
+</dt>
+<dt>9.  <a href="#contact-filter">Contact Notification Filtering</a>
+</dt>
+<dt>10.  <a href="#notifications">Generating Notifications</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#notifications-num">Number of Notifications</a>
+</dt>
+<dt>10.2.  <a href="#notifications-when">When to Generate Notifications</a>
+</dt>
+</dl>
+<dt>11.  <a href="#last">Sending the Last Published Item</a>
+</dt>
+<dt>12.  <a href="#privatedata">Private Data Storage</a>
+</dt>
+<dt>13.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>14.  <a href="#imple">Implementation Notes</a>
+</dt>
+<dl><dt>14.1.  <a href="#impl-subscriptions">Cancelling Subscriptions</a>
+</dt></dl>
+<dt>15.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>16.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>17.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>17.1.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt></dl>
+<dt>18.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>19.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2251020">1</a>] extension ("pubsub") can be used to broadcast state change events associated with a Jabber/XMPP account or user, such as those described in <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2259657">2</a>], <span class="ref" style="">User Mood</span>  [<a href="#nt-id2259678">3</a>], <span class="ref" style="">User Activity</span>  [<a href="#nt-id2259695">4</a>], and <span class="ref" style="">User Tune</span>  [<a href="#nt-id2259717">5</a>].  [<a href="#nt-id2251033">6</a>] However, the full, generic pubsub protocol is often thought of as complicated and therefore has not been widely implemented in clients. To make publish-subscribe functionality more accessible (especially to instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2259750">7</a>]), this document defines simplified protocol semantics that can be followed by instant messaging client and server developers, hopefully resulting in the deployment of personal eventing services across the Jabber/XMPP network.</p>
+  <p class="" style=""><span style="font-style: italic">Note: This document does not show error flows related to the various publish-subscribe use cases referenced herein, since they are exhaustively defined in <span style="font-weight: bold">JEP-0060</span>. The reader is referred to <span style="font-weight: bold">JEP-0060</span> for all relevant protocol details related to the XMPP publish-subscribe extension.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Personal eventing via pubsub ("PEP") is based on six principles:</p>
+  <ol start="1" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One publisher per node.</li>
+    <li>One node per namespace.</li>
+    <li>Use presence.</li>
+    <li>Notifications are filtered based on expressed interests.</li>
+    <li>Smart defaults.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at a Jabber/XMPP server that supports PEP, the server associates a virtual pubsub service with the account. This greatly simplifies the task of discovering the account owner's personal pubsub nodes, since the root pubsub node simply is the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a PEP service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">There is only one publish-subscribe node associated with any given payload type (XML namespace) for the account owner (e.g., there is one pubsub node for geolocation events, one node for tune events, and one node for mood events). This simplifies node creation, discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe services do not necessarily have access to presence information about subscribers, PEP services are integrated with presence in the following ways:</p>
+    <ul>
+      <li>Each messaging and presence account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service.</li>
+      <li>The default access model is "presence".</li>
+      <li>A contact's subscription to an account owner's personal eventing data is normally handled via the existence of an XMPP presence subscription.</li>
+      <li>Services take account of subscriber presence in the generation of notifications.  [<a href="#nt-id2259928">8</a>]</li>
+    </ul>
+    <p class="" style="">These uses of presence simplify the task of developing compliant clients (cf. <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2260007">9</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-filter">Filtered Notifications</a>
+</h3>
+    <p class="" style="">By default, the existence of an XMPP presence subscription is used to establish a PEP subscription to the account owner's personal eventing data. In order to filter which notifications are sent by the PEP service, the contact's client includes extended <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259978">10</a>] information in the presence notifications it sends to the account owner and the PEP service sends only those notifications that match the contact's expressed notification preferences.</p>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, PEP services offer smart defaults to simplify node creation and management.</p>
+  </div>
+<h2>3.
+       <a name="scenario">Scenario</a>
+</h2>
+  <p class="" style="">This document illustrates PEP through a series of examples that use the following scenario:</p>
+  <ol start="1" type="">
+    <li>
+      <p class="" style="">An owner-publisher juliet@capulet.com who publishes the following information:</p>
+      <ol start="1" type="">
+        <li>Tune information that anyone may see (i.e., an access model of "open")</li>
+        <li>Activity information that only presence subscribers may see (i.e., an access model of "presence")</li>
+        <li>Geolocation information that only contacts in her "Friends" group may see (i.e., an access model of "roster" with a group of "Friends")</li>
+        <li>Bookmark information that only the account owner may see (i.e., an access model of "whitelist")</li>
+      </ol>
+      <p class="" style="">Note: A PEP node with an access model of "whitelist" and no entities on the whitelist effectively results in a node that enables private data storage; for details, see the <a href="#privatedata">Private Data Storage</a> section of this document.</p>
+    </li>
+    <li>
+      <p class="" style="">Three users who have the following relationship to Juliet:</p>
+      <ol start="1" type="">
+        <li>benvolio@montague.net, who has no subscription to Juliet's presence</li>
+        <li>nurse@capulet.com, who has a bidirectional subscription to Juliet's presence and who is in the "Servants" group in Juliet's roster</li>
+        <li>romeo@montague.net, who has a bidirectional subscription to Juliet's presence and who is in the "Friends" group in Juliet's roster</li>
+      </ol>
+    </li>
+  </ol>
+  <p class="" style="">The examples shown in the following sections walk through the protocol flows for node creation, discovery, publishing, and subscribing.</p>
+<h2>4.
+       <a name="owner-disco">Account Owner Service Discovery</a>
+</h2>
+  <p class="" style="">Naturally, before an account owner attempts to complete any PEP use cases, its client SHOULD determine whether the account owner's server supports PEP; to do so, it MUST send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260198">11</a>] information request to the server:</p>
+  <p class="caption">Example 1. Account owner queries server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep" (as well as a list of the namespaces and other features it supports, including all supported <span style="font-weight: bold">JEP-0060</span> features):</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='server' type='im'/&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#config-node'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#create-and-configure'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#create-nodes'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#persistent-items'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#publish'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#retrieve-items'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#subscribe'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="owner-create">Account Owner Node Creation</a>
+</h2>
+  <p class="" style="">When an account owner attempts to publish an item to a PEP node, the PEP service SHOULD automatically create the node (with default configuration) if it does not already exist.  [<a href="#nt-id2260257">12</a>] However, if the account owner wishes to create a node with a configuration other than the default (e.g., a node with an access model of "open", "roster", or "whitelist"), the account owner MUST follow the node creation protocol specified in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="" style="">For example, Juliet would send the following stanzas in order to create the nodes mentioned above:</p>
+  <p class="caption">Example 3. Account owner creates open node for tune data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-open'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create-open'/&gt;
+  </pre></div>
+  <p class="caption">Example 4. Account owner publishes initial item to presence node for activity data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-presence'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/activity'/&gt;
+      &lt;item&gt;
+        &lt;activity xmlns='http://jabber.org/protocol/activity'&gt;
+          &lt;relaxing&gt;
+            &lt;partying/&gt;
+          &lt;/relaxing&gt;
+          &lt;text xml:lang='en'&gt;My nurse&amp;apos;s birthday!&lt;/text&gt;
+        &lt;/activity&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create-presence'/&gt;
+  </pre></div>
+  <p class="caption">Example 5. Account owner creates roster access node for geolocation data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-roster'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;Friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create-roster'/&gt;
+  </pre></div>
+  <p class="caption">Example 6. Account owner creates whitelist node for bookmark data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-whitelist'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='storage:bookmarks'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create-whitelist'/&gt;
+  </pre></div>
+<h2>6.
+       <a name="contact-disco">Contact Service Discovery</a>
+</h2>
+  <p class="" style="">A contact MAY send service discovery requests to the account owner's bare JID (&lt;node@domain.tld&gt;). Although this is not necessary in order to subscribe to the account owner's personal eventing data (as explained in the following section), it is shown here to further illustrate the role of access models.</p>
+  <p class="" style="">First, benvolio@montague.net sends a disco#info request to juliet@capulet.com:</p>
+  <p class="caption">Example 7. Unaffiliated entity queries account owner regarding identity</p>
+<div class="indent"><pre>
+&lt;iq from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='disco2'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's server supports PEP (thereby making juliet@capulet.com a virtual pubsub service), it MUST return an identity of "pubsub/pep":</p>
+  <p class="caption">Example 8. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='benvolio@montague.net/home'
+    id='disco2'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;identity category='account' type='registered'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Second, benvolio@montague.net sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 9. Unaffiliated entity queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='disco3'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The account owner's server MUST check the access model for each of the account owner's PEP nodes and MUST return as service discovery items only those nodes to which the contact is allowed to subscribe or from which the contact is allowed to retrieve items.</p>
+  <p class="" style="">Therefore, in this case, the server would return only the "http://jabber.org/protocol/tune" node (since it has an open access model and the contact does not have a presence subscription to the account owner's presence):</p>
+  <p class="caption">Example 10. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='benvolio@montague.net/home'
+    id='disco3'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Next, nurse@capulet.com sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 11. Contact with presence subscription queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com'
+    id='disco4'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">However, in this case, the server would return the "http://jabber.org/protocol/tune" node (open access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/activity" node (presence access model):</p>
+  <p class="caption">Example 12. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='nurse@capulet.com/chamber'
+    id='disco4'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Finally, romeo@montague.net sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 13. Contact with presence subscription and in privileged roster group queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    id='disco5'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">In this case, the server would return the "http://jabber.org/protocol/tune" node (open access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/activity" node (presence access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/geoloc" node (roster access model):</p>
+  <p class="caption">Example 14. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    id='disco5'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>7.
+       <a name="contact-subscribe">Contact Subscription</a>
+</h2>
+  <p class="" style="">If an entity is not subscribed to the account owner's presence, it MUST subscribe to a node using the protocol defined in <span style="font-weight: bold">JEP-0060</span>. For instance, here is how benvolio@montague.net would subscribe Juliet's tune information:</p>
+  <p class="caption">Example 15. Unaffiliated entity subscribes to an open node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='benvolio@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">However, when a contact is affiliated with the account owner through a presence subscription, PEP greatly simplifies the subscription process. This is done by associating the presence subscription with a pubsub subscription to the account owner's root collection node (i.e., bare JID), with a subscription_type of "items" and a subscription_depth of "all".</p>
+  <p class="" style="">Consider the following presence subscription exchange:</p>
+  <p class="caption">Example 16. Presence subscription handshake</p>
+<div class="indent"><pre>
+&lt;presence from='nurse@capulet.com' to='juliet@capulet.com' type='subscribe'/&gt;
+
+&lt;presence from='juliet@capulet.com' to='nurse@capulet.com' type='subscribed'/&gt;
+  </pre></div>
+  <p class="" style="">For PEP purposes, this is equivalent to the following pubsub subscription exchange:</p>
+  <p class="caption">Example 17. Entity subscribes to a collection node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com
+    id='collsub'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe jid='nurse@capulet.com'/&gt;
+    &lt;options&gt;
+      &lt;x xmlns='jabber:x:data'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_type'&gt;
+          &lt;value&gt;items&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_depth'&gt;
+          &lt;value&gt;all&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+   &lt;/options&gt;
+ &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result' from='juliet@capulet.com' to='nurse@capulet.com/chamber' id='collsub'/&gt;
+  </pre></div>
+  <p class="" style="">Note: Automated pubsub subscriptions MUST be based on the JID contained in the 'from' address of the presence subscription request, which for IM contacts will be a bare JID (&lt;node@domain.tld&gt;).</p>
+<h2>8.
+       <a name="owner-publish">Account Owner Publishing</a>
+</h2>
+  <p class="" style="">An account owner publishes an item to a node by following the protocol specified in <span style="font-weight: bold">JEP-0060</span>:</p>
+  <p class="caption">Example 18. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">As a result, the account owner's server generates notifications and sends them to all subscribers who have requested or are interested in the data as described in the <a href="#notifications">Contact Notification Filtering</a> and <a href="#notifications">Generating Notifications</a> sections of this document.</p>
+  <p class="" style="">The server MUST set the 'from' address on the notification to the bare JID (&lt;node@domain.tld&gt;) of the account owner (in this example, "juliet@capulet.com"). When sending notifications to an entity that has presence subscription to the account owner, the server SHOULD include an <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2260891">13</a>] "replyto" extension specifying the publishing resource (in this example, "juliet@capulet.com/balcony"); this enables the subscriber's client to differentiate between information received from each of the account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). However, a server MUST NOT include the "replyto" address when sending a notification to an entity that does not have a presence subscription to the account owner. In addition, any errors related to the notification MUST be directed to the JID of the 'from' address on the notification (i.e., the bare JID) so that bounce processing can be handled by the PEP service rather than by the publishing client.</p>
+  <p class="" style="">Assuming that all three entities previously mentioned would receive the notifications, the PEP service would generate the following stanzas:</p>
+  <p class="caption">Example 19. Server sends notification to subscribers</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='benvolio@montague.net'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='juliet@capulet.com'
+         to='nurse@capulet.com/chamber'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>9.
+       <a name="contact-filter">Contact Notification Filtering</a>
+</h2>
+  <p class="" style="">A contact may not want to receive notifications from all nodes. A contact SHOULD signal its preferences to the account owner's server by including <span style="font-weight: bold">JEP-0115</span> information that specifies the namespaces for which the contact wishes to receive notifications (if any).</p>
+  <p class="" style="">In order to make this possible, all possible payload namespaces can be appended with the string "+notify" to indicate that the contact wishes to receive notifications for the payload format. Thus if Romeo wants to receive notifications for activity data and geolocation data but not tune data, his client would advertise support for the following namespaces in the disco#info results it sends:  [<a href="#nt-id2261042">14</a>]</p>
+  <ul>
+    <li>http://jabber.org/protocol/activity+notify</li>
+    <li>http://jabber.org/protocol/geoloc+notify</li>
+  </ul>
+  <p class="" style="">This set of namespaces would then be advertised as a <span style="font-weight: bold">JEP-0115</span> "ext" value, such as the following:</p>
+  <p class="caption">Example 20. Contact sends presence with caps</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">Note: In <span style="font-weight: bold">JEP-0115</span>, the "ext" values are opaque strings with no semantic meaning.</p>
+  <p class="" style="">It is the responsibility of the account owner's server to cache <span style="font-weight: bold">JEP-0115</span> information (including "ext" values and their associated namespaces). When the server receives presence from a contact, it MUST check that presence information for entity capabilities data and correlate that data with the desired namespaces for the contact's client. The server MUST NOT send notifications related to any data formats that the contact's client has not asked for via the relevant "namespace+notify" disco#info feature. This enables a client to turn off all notifications (e.g., because of bandwidth restrictions) and to easily receive all desired data formats simply by adding support for the appropriate "namespace+notify" combination in its disco#info results and client capabililies. However, it also implies that a client can request notifications only on a global basis and cannot request, say, mood information only from certain contacts in the user's roster. Community consensus is that this is an acceptable tradeoff. Also, note that this works only if the account owner has a presence subscription to the contact.</p>
+  <p class="" style="">Some examples may help to illustrate the concept of notification filtering. Here we show presence generated by two of the contacts listed above (benvolio@montague.net does have any presence subscriptions to or from juliet@capulet.com and therefore is not involved in these protocol flows).</p>
+  <p class="caption">Example 21. Presence with caps</p>
+<div class="indent"><pre>
+&lt;presence from='nurse@capulet.com/chamber'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://exodus.jabberstudio.org/caps'
+     ver='0.9'
+     ext='asdf fdsa bar baz'/&gt;
+&lt;/presence&gt;
+
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">We assume that Juliet's server doesn't know anything about these capabilities, so it sends service discovery information requests to each of the clients on Juliet's behalf (realistically, the capulet.com server will quickly build up a cache of client capabilities so it will not need to send these service discovery requests):</p>
+  <p class="caption">Example 22. Account server queries contact</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='nurse@capulet.com/chamber'
+    type='get'
+    id='disco123'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#0.9'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com'
+    type='result'
+    id='disco123'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#0.9'/&gt;
+    &lt;feature var='http://jabber.org/protocol/tune'/&gt;
+    &lt;feature var='http://jabber.org/protocol/tune+notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity+notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc+notify'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 23. Account server queries contact</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    type='get'
+    id='disco234'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://www.chatopus.com/ec#2.1'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    type='result'
+    id='disco234'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://www.chatopus.com/ec#2.1'/&gt;
+    &lt;feature var='http://jabber.org/protocol/tune'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc+notify'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Now we revisit account owner publication and server generation of notifications, with filtering enabled because the server has caps information:</p>
+  <ul>
+    <li><p class="" style="">If Juliet publishes a tune item to the open-access "http://jabber.org/protocol/tune" node, her server will send notifications to &lt;benvolio@montague.net&gt; (bare JID) and to &lt;nurse@capulet.com/chamber&gt; (full JID) but not to &lt;romeo@montague.net/orchard&gt;.</p></li>
+    <li><p class="" style="">If Juliet publishes an activity item to the presence-access "http://jabber.org/protocol/activity" node, her server will send notifications only to &lt;nurse@capulet.com/chamber&gt;.</p></li>
+    <li><p class="" style="">If Juliet publishes a geolocation item to the roster-access "http://jabber.org/protocol/geoloc" node, her server will send notifications only to &lt;romeo@montague.net/orchard&gt;.</p></li>
+  </ul>
+<h2>10.
+       <a name="notifications">Generating Notifications</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="notifications-num">Number of Notifications</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">If a subscriber subscribed using a full JID (&lt;node@domain.tld/resource&gt;), domain identifier (&lt;domain.tld&gt;), or domain plus resource (&lt;domain.tld/resource&gt;), a PEP service MUST send one notification only, addressed to the subscribed JID.</p></li>
+      <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service does not have appropriate presence information about the subscriber, a PEP service MUST send at most one notification, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber, and MAY choose not to send any notification. (By "appropriate presence information" is meant non-negative priority and <span style="font-weight: bold">JEP-0115</span> data that indicates interest in the relevant data format.)</p></li>
+      <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service has appropriate presence information about the subscriber, the PEP service MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources that have specified non-negative presence priority and included <span style="font-weight: bold">JEP-0115</span> information that indicates an interest in the data format.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="notifications-when">When to Generate Notifications</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">When an account owner publishes an item to a node, a PEP service MUST generate a notification and send it to all appropriate subscribers (where the number of notifications is determined by the foregoing rules).</p></li>
+      <li><p class="" style="">When a PEP service receives initial presence information from a subscriber's resource with a non-negative priority and including <span style="font-weight: bold">JEP-0115</span> information that indicates an interest in the data format, it MUST generate a notification containing the last published item for that node and send it to the newly-available resource.</p></li>
+      <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MUST NOT send notifications to a subscriber if the user has blocked the subscriber from receiving all or any kinds of stanza (presence, message, IQ, or any combination thereof) using communiations blocking as specified in <span style="font-weight: bold">XMPP IM</span>.</p></li>
+    </ol>
+  </div>
+<h2>11.
+       <a name="last">Sending the Last Published Item</a>
+</h2>
+  <p class="" style="">As described in the <a href="#notifications">Generating Notifications</a> section of this document, a PEP service MUST send the last published item to all new subscribers and to all newly-available resources for each subscriber.  [<a href="#nt-id2261372">15</a>]</p>
+  <p class="caption">Example 24. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="caption">Example 25. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="caption">Example 26. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>12.
+       <a name="privatedata">Private Data Storage</a>
+</h2>
+  <p class="" style="">As noted, PEP services may be used to implement private data storage, such as defined in <span class="ref" style="">Private XML Storage</span>  [<a href="#nt-id2261464">16</a>]. A future version of this document will specify this usage in more detail.</p>
+<h2>13.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">A PEP service MUST:</p>
+  <ul>
+    <li>Support the node discovery, node creation, node deletion, publish item, subscribe, unsubscribe, and item retrieval use cases specified in <span style="font-weight: bold">JEP-0060</span>.</li>
+    <li>Support the "owner" and "subscriber" affiliations.</li>
+    <li>Support the "presence" access model and set it to the default.</li>
+    <li>Support the "open", "roster", and "whitelist" access models.</li>
+    <li>Treat the account owner's bare JID (&lt;node@domain.tld&gt;) as a collection node (i.e., as the root collection node for the account's virtual pubsub service).</li>
+    <li>Deliver payloads (if included) in all notifications.</li>
+    <li>Send the last publish item as described above.</li>
+  </ul>
+  <p class="" style="">A PEP service MAY support other use cases, affiliations, access models, and features, but such support is OPTIONAL.</p>
+<h2>14.
+       <a name="imple">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="impl-subscriptions">Cancelling Subscriptions</a>
+</h3>
+    <p class="" style="">In order to ensure appropriate access to information published at nodes of type "presence" and "roster", a PEP service MUST re-calculate access controls when:</p>
+    <ol start="1" type="">
+      <li>A presence subscription state changes (e.g., when a subscription request is approved).</li>
+      <li>A roster item is modified (e.g., when the item is moved to a new roster group).</li>
+    </ol>
+    <p class="" style="">If the modification results in a loss of access, the service MUST cancel the entity's subscription. In addition, the service MAY send a message to the (former) subscriber informing it of the cancellation (for information about the format of messages sent to notify subscribers of subscription cancellation, see the "Notification of Subscription Denial or Cancellation" section of <span style="font-weight: bold">JEP-0060</span>).</p>
+  </div>
+<h2>15.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>16.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261646">17</a>].</p>
+<h2>17.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>17.1 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;); as a result of this JEP, the Registrar shall add a type of "pep" to that category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>18.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because Personal Eventing via Pubsub simply reuses existing protocols, a separate schema is not needed.</p>
+<h2>19.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors wish to thank the participants in the XMPP Interoperability Testing Event held July 24 and 25, 2006, who provided valuable feedback that resulted in radical simplification of the protocol.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251020">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2259657">2</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2259678">3</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2259695">4</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p><a name="nt-id2259717">5</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2251033">6</a>. Currently, many "extended presence" formats are sent using the &lt;presence/&gt; stanza type; however, this overloads presence, results in unnecessary presence traffic, and does not provide fine-grained control over access. The use of publish-subscribe rather than presence is therefore preferable.</p>
+<p><a name="nt-id2259750">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2259928">8</a>. This works only if the subscription state is "both" (see <span style="font-weight: bold">RFC 3921</span>).</p>
+<p><a name="nt-id2260007">9</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2259978">10</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2260198">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260257">12</a>. This similar to the room creation process in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>.</p>
+<p><a name="nt-id2260891">13</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2261042">14</a>. Including, say, the 'http://jabber.org/protocol/geoloc' namespace indicates that the client understands the geolocation namespace, whereas including the 'http://jabber.org/protocol/geoloc+notify' namespace indicates that the client wishes to receive notifications related to geolocation.</p>
+<p><a name="nt-id2261372">15</a>. That is, the default value of the "pubsub#send_last_published_item" node configuration field must be "on_sub_and_presence"; this behavior essentially mimics the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.</p>
+<p><a name="nt-id2261464">16</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p><a name="nt-id2261646">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.14 (2006-08-02)</h4>
+<div class="indent">
+<p class="" style="">Changed various recommended defaults from SHOULD to MUST; corrected several errors in the text and examples.</p> (psa)
+    </div>
+<h4>Version 0.13 (2006-08-01)</h4>
+<div class="indent">
+<p class="" style="">Recommended node creation with default configuration on initial publish; corrected several errors and clarified several points in the text.</p> (psa)
+    </div>
+<h4>Version 0.12 (2006-08-01)</h4>
+<div class="indent">
+<p class="" style="">Simplified the subscription process using XMPP presence and entity capabilities.</p> (psa)
+    </div>
+<h4>Version 0.11 (2006-07-20)</h4>
+<div class="indent">
+<p class="" style="">Clarified rules regarding number of notifications and when to generate notifications; corrected several errors in the text and examples.</p> (psa)
+    </div>
+<h4>Version 0.10 (2006-07-07)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect version 1.8 of JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.9 (2006-06-15)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect use of data forms in JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.8 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology and defaults.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Specified that notifications are to be sent from bare JID, not full JID.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect pubsub changes; clarified business rules for generation of notifications and cancellation of subscriptions.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.15.html
+++ b/content/xep-0163-0.15.html
@@ -1,0 +1,899 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing via Pubsub</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing via Pubsub">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies XMPP semantics for using the publish-subscribe protocol to broadcast state change events associated with an instant messaging and presence account.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing via Pubsub</h1>
+<p>This document specifies XMPP semantics for using the publish-subscribe protocol to broadcast state change events associated with an instant messaging and presence account.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0163<br>
+            Version: 0.15<br>
+            Last Updated: 2006-08-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030, JEP-0060, JEP-0115<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20via%20Pubsub%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing via Pubsub (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.3.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.4.  <a href="#approach-presence">Use Presence</a>
+</dt>
+<dt>2.5.  <a href="#approach-filter">Filtered Notifications</a>
+</dt>
+<dt>2.6.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+</dl>
+<dt>3.  <a href="#scenario">Scenario</a>
+</dt>
+<dt>4.  <a href="#owner-disco">Account Owner Service Discovery</a>
+</dt>
+<dt>5.  <a href="#owner-create">Account Owner Node Creation</a>
+</dt>
+<dt>6.  <a href="#contact-disco">Contact Service Discovery</a>
+</dt>
+<dt>7.  <a href="#contact-subscribe">Contact Subscription</a>
+</dt>
+<dt>8.  <a href="#owner-publish">Account Owner Publishing</a>
+</dt>
+<dt>9.  <a href="#contact-filter">Contact Notification Filtering</a>
+</dt>
+<dt>10.  <a href="#notifications">Generating Notifications</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#notifications-num">Number of Notifications</a>
+</dt>
+<dt>10.2.  <a href="#notifications-when">When to Generate Notifications</a>
+</dt>
+</dl>
+<dt>11.  <a href="#last">Sending the Last Published Item</a>
+</dt>
+<dt>12.  <a href="#privatedata">Private Data Storage</a>
+</dt>
+<dt>13.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>14.  <a href="#imple">Implementation Notes</a>
+</dt>
+<dl><dt>14.1.  <a href="#impl-subscriptions">Cancelling Subscriptions</a>
+</dt></dl>
+<dt>15.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>16.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>17.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>17.1.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt></dl>
+<dt>18.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>19.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257574">1</a>] extension ("pubsub") can be used to broadcast state change events associated with a Jabber/XMPP account or user, such as those described in <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2257595">2</a>], <span class="ref" style="">User Mood</span>  [<a href="#nt-id2257617">3</a>], <span class="ref" style="">User Activity</span>  [<a href="#nt-id2257634">4</a>], and <span class="ref" style="">User Tune</span>  [<a href="#nt-id2257656">5</a>].  [<a href="#nt-id2257605">6</a>] However, the full, generic pubsub protocol is often thought of as complicated and therefore has not been widely implemented in clients. To make publish-subscribe functionality more accessible (especially to instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2257690">7</a>]), this document defines simplified protocol semantics that can be followed by instant messaging client and server developers, hopefully resulting in the deployment of personal eventing services across the Jabber/XMPP network.</p>
+  <p class="" style=""><span style="font-style: italic">Note: This document does not show error flows related to the various publish-subscribe use cases referenced herein, since they are exhaustively defined in <span style="font-weight: bold">JEP-0060</span>. The reader is referred to <span style="font-weight: bold">JEP-0060</span> for all relevant protocol details related to the XMPP publish-subscribe extension.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Personal eventing via pubsub ("PEP") is based on six principles:</p>
+  <ol start="1" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One publisher per node.</li>
+    <li>One node per namespace.</li>
+    <li>Use presence.</li>
+    <li>Notifications are filtered based on expressed interests.</li>
+    <li>Smart defaults.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at a Jabber/XMPP server that supports PEP, the server associates a virtual pubsub service with the account. This greatly simplifies the task of discovering the account owner's personal pubsub nodes, since the root pubsub node simply is the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a PEP service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">There is only one publish-subscribe node associated with any given payload type (XML namespace) for the account owner (e.g., there is one pubsub node for geolocation events, one node for tune events, and one node for mood events). This simplifies node creation, discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe services do not necessarily have access to presence information about subscribers, PEP services are integrated with presence in the following ways:</p>
+    <ul>
+      <li>Each messaging and presence account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service.</li>
+      <li>The default access model is "presence".</li>
+      <li>A contact's subscription to an account owner's personal eventing data is normally handled via the existence of an XMPP presence subscription.</li>
+      <li>Services take account of subscriber presence in the generation of notifications.  [<a href="#nt-id2257866">8</a>]</li>
+    </ul>
+    <p class="" style="">These uses of presence simplify the task of developing compliant clients (cf. <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2257944">9</a>]).</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-filter">Filtered Notifications</a>
+</h3>
+    <p class="" style="">By default, the existence of an XMPP presence subscription is used to establish a PEP subscription to the account owner's personal eventing data. In order to filter which notifications are sent by the PEP service, the contact's client includes extended <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2257915">10</a>] information in the presence notifications it sends to the account owner and the PEP service sends only those notifications that match the contact's expressed notification preferences.</p>
+  </div>
+  <div class="indent">
+<h3>2.6 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, PEP services offer smart defaults to simplify node creation and management.</p>
+  </div>
+<h2>3.
+       <a name="scenario">Scenario</a>
+</h2>
+  <p class="" style="">This document illustrates PEP through a series of examples that use the following scenario:</p>
+  <ol start="1" type="">
+    <li>
+      <p class="" style="">An owner-publisher juliet@capulet.com who publishes the following information:</p>
+      <ol start="1" type="">
+        <li>Tune information that anyone may see (i.e., an access model of "open")</li>
+        <li>Activity information that only presence subscribers may see (i.e., an access model of "presence")</li>
+        <li>Geolocation information that only contacts in her "Friends" group may see (i.e., an access model of "roster" with a group of "Friends")</li>
+        <li>Bookmark information that only the account owner may see (i.e., an access model of "whitelist")</li>
+      </ol>
+      <p class="" style="">Note: A PEP node with an access model of "whitelist" and no entities on the whitelist effectively results in a node that enables private data storage; for details, see the <a href="#privatedata">Private Data Storage</a> section of this document.</p>
+    </li>
+    <li>
+      <p class="" style="">Three users who have the following relationship to Juliet:</p>
+      <ol start="1" type="">
+        <li>benvolio@montague.net, who has no subscription to Juliet's presence</li>
+        <li>nurse@capulet.com, who has a bidirectional subscription to Juliet's presence and who is in the "Servants" group in Juliet's roster</li>
+        <li>romeo@montague.net, who has a bidirectional subscription to Juliet's presence and who is in the "Friends" group in Juliet's roster</li>
+      </ol>
+    </li>
+  </ol>
+  <p class="" style="">The examples shown in the following sections walk through the protocol flows for node creation, discovery, publishing, and subscribing.</p>
+<h2>4.
+       <a name="owner-disco">Account Owner Service Discovery</a>
+</h2>
+  <p class="" style="">Naturally, before an account owner attempts to complete any PEP use cases, its client SHOULD determine whether the account owner's server supports PEP; to do so, it MUST send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2258402">11</a>] information request to the server:</p>
+  <p class="caption">Example 1. Account owner queries server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep" (as well as a list of the namespaces and other features it supports, including all supported <span style="font-weight: bold">JEP-0060</span> features):</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='server' type='im'/&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#config-node'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#create-and-configure'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#create-nodes'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#persistent-items'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#publish'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#retrieve-items'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#subscribe'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>5.
+       <a name="owner-create">Account Owner Node Creation</a>
+</h2>
+  <p class="" style="">When an account owner attempts to publish an item to a PEP node and that node does not already exist, the PEP service MUST automatically create the node with default configuration.  [<a href="#nt-id2258462">12</a>] However, if the account owner wishes to create a node with a configuration other than the default (e.g., a node with an access model of "open", "roster", or "whitelist"), the account owner MUST follow the node creation protocol specified in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="" style="">For example, Juliet would send the following stanzas in order to create the nodes mentioned above:</p>
+  <p class="caption">Example 3. Account owner creates open node for tune data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-open'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create-open'/&gt;
+  </pre></div>
+  <p class="caption">Example 4. Account owner publishes initial item to presence node for activity data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-presence'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/activity'/&gt;
+      &lt;item&gt;
+        &lt;activity xmlns='http://jabber.org/protocol/activity'&gt;
+          &lt;relaxing&gt;
+            &lt;partying/&gt;
+          &lt;/relaxing&gt;
+          &lt;text xml:lang='en'&gt;My nurse&amp;apos;s birthday!&lt;/text&gt;
+        &lt;/activity&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create-presence'/&gt;
+  </pre></div>
+  <p class="caption">Example 5. Account owner creates roster access node for geolocation data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-roster'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;Friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create-roster'/&gt;
+  </pre></div>
+  <p class="caption">Example 6. Account owner creates whitelist node for bookmark data</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-whitelist'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='storage:bookmarks'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='submit'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;whitelist&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create-whitelist'/&gt;
+  </pre></div>
+<h2>6.
+       <a name="contact-disco">Contact Service Discovery</a>
+</h2>
+  <p class="" style="">A contact MAY send service discovery requests to the account owner's bare JID (&lt;node@domain.tld&gt;). Although this is not necessary in order to subscribe to the account owner's personal eventing data (as explained in the following section), it is shown here to further illustrate the role of access models.</p>
+  <p class="" style="">First, benvolio@montague.net sends a disco#info request to juliet@capulet.com:</p>
+  <p class="caption">Example 7. Unaffiliated entity queries account owner regarding identity</p>
+<div class="indent"><pre>
+&lt;iq from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='disco2'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If Juliet's server supports PEP (thereby making juliet@capulet.com a virtual pubsub service), it MUST return an identity of "pubsub/pep":</p>
+  <p class="caption">Example 8. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='benvolio@montague.net/home'
+    id='disco2'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;identity category='account' type='registered'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Second, benvolio@montague.net sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 9. Unaffiliated entity queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='disco3'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The account owner's server MUST check the access model for each of the account owner's PEP nodes and MUST return as service discovery items only those nodes to which the contact is allowed to subscribe or from which the contact is allowed to retrieve items.</p>
+  <p class="" style="">Therefore, in this case, the server would return only the "http://jabber.org/protocol/tune" node (since it has an open access model and the contact does not have a presence subscription to the account owner's presence):</p>
+  <p class="caption">Example 10. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='benvolio@montague.net/home'
+    id='disco3'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Next, nurse@capulet.com sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 11. Contact with presence subscription queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com'
+    id='disco4'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">However, in this case, the server would return the "http://jabber.org/protocol/tune" node (open access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/activity" node (presence access model):</p>
+  <p class="caption">Example 12. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='nurse@capulet.com/chamber'
+    id='disco4'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Finally, romeo@montague.net sends a disco#items request to juliet@capulet.com:</p>
+  <p class="caption">Example 13. Contact with presence subscription and in privileged roster group queries account owner regarding items</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    id='disco5'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">In this case, the server would return the "http://jabber.org/protocol/tune" node (open access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/activity" node (presence access model) <span style="font-style: italic">and</span> the "http://jabber.org/protocol/geoloc" node (roster access model):</p>
+  <p class="caption">Example 14. Server returns appropriate items</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    id='disco5'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geoloc'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>7.
+       <a name="contact-subscribe">Contact Subscription</a>
+</h2>
+  <p class="" style="">If an entity is not subscribed to the account owner's presence, it MUST subscribe to a node using the protocol defined in <span style="font-weight: bold">JEP-0060</span>. For instance, here is how benvolio@montague.net would subscribe Juliet's tune information:</p>
+  <p class="caption">Example 15. Unaffiliated entity subscribes to an open node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='benvolio@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='benvolio@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">However, when a contact is affiliated with the account owner through a presence subscription, PEP greatly simplifies the subscription process. This is done by associating the presence subscription with a pubsub subscription to the account owner's root collection node (i.e., bare JID), with a subscription_type of "items" and a subscription_depth of "all".</p>
+  <p class="" style="">Consider the following presence subscription exchange:</p>
+  <p class="caption">Example 16. Presence subscription handshake</p>
+<div class="indent"><pre>
+&lt;presence from='nurse@capulet.com' to='juliet@capulet.com' type='subscribe'/&gt;
+
+&lt;presence from='juliet@capulet.com' to='nurse@capulet.com' type='subscribed'/&gt;
+  </pre></div>
+  <p class="" style="">For PEP purposes, this is equivalent to the following pubsub subscription exchange:</p>
+  <p class="caption">Example 17. Entity subscribes to a collection node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com
+    id='collsub'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe jid='nurse@capulet.com'/&gt;
+    &lt;options&gt;
+      &lt;x xmlns='jabber:x:data'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#subscribe_options&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_type'&gt;
+          &lt;value&gt;items&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#subscription_depth'&gt;
+          &lt;value&gt;all&lt;/value&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+   &lt;/options&gt;
+ &lt;/pubsub&gt;
+&lt;/iq&gt;
+
+&lt;iq type='result' from='juliet@capulet.com' to='nurse@capulet.com/chamber' id='collsub'/&gt;
+  </pre></div>
+  <p class="" style="">Note: Automated pubsub subscriptions MUST be based on the JID contained in the 'from' address of the presence subscription request, which for IM contacts will be a bare JID (&lt;node@domain.tld&gt;).</p>
+<h2>8.
+       <a name="owner-publish">Account Owner Publishing</a>
+</h2>
+  <p class="" style="">An account owner publishes an item to a node by following the protocol specified in <span style="font-weight: bold">JEP-0060</span>:</p>
+  <p class="caption">Example 18. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">As a result, the account owner's server generates notifications and sends them to all subscribers who have requested or are interested in the data as described in the <a href="#notifications">Contact Notification Filtering</a> and <a href="#notifications">Generating Notifications</a> sections of this document.</p>
+  <p class="" style="">The server MUST set the 'from' address on the notification to the bare JID (&lt;node@domain.tld&gt;) of the account owner (in this example, "juliet@capulet.com"). When sending notifications to an entity that has presence subscription to the account owner, the server SHOULD include an <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2259096">13</a>] "replyto" extension specifying the publishing resource (in this example, "juliet@capulet.com/balcony"); this enables the subscriber's client to differentiate between information received from each of the account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). However, a server MUST NOT include the "replyto" address when sending a notification to an entity that does not have a presence subscription to the account owner. In addition, any errors related to the notification MUST be directed to the JID of the 'from' address on the notification (i.e., the bare JID) so that bounce processing can be handled by the PEP service rather than by the publishing client.</p>
+  <p class="" style="">Assuming that all three entities previously mentioned would receive the notifications, the PEP service would generate the following stanzas:</p>
+  <p class="caption">Example 19. Server sends notification to subscribers</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='benvolio@montague.net'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+&lt;message from='juliet@capulet.com'
+         to='nurse@capulet.com/chamber'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>9.
+       <a name="contact-filter">Contact Notification Filtering</a>
+</h2>
+  <p class="" style="">A contact may not want to receive notifications from all nodes. A contact SHOULD signal its preferences to the account owner's server by including <span style="font-weight: bold">JEP-0115</span> information that specifies the namespaces for which the contact wishes to receive notifications (if any).</p>
+  <p class="" style="">In order to make this possible, all possible payload namespaces can be appended with the string "+notify" to indicate that the contact wishes to receive notifications for the payload format. Thus if Romeo wants to receive notifications for activity data and geolocation data but not tune data, his client would advertise support for the following namespaces in the disco#info results it sends:  [<a href="#nt-id2259247">14</a>]</p>
+  <ul>
+    <li>http://jabber.org/protocol/activity+notify</li>
+    <li>http://jabber.org/protocol/geoloc+notify</li>
+  </ul>
+  <p class="" style="">This set of namespaces would then be advertised as a <span style="font-weight: bold">JEP-0115</span> "ext" value, such as the following:</p>
+  <p class="caption">Example 20. Contact sends presence with caps</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">Note: In <span style="font-weight: bold">JEP-0115</span>, the "ext" values are opaque strings with no semantic meaning.</p>
+  <p class="" style="">It is the responsibility of the account owner's server to cache <span style="font-weight: bold">JEP-0115</span> information (including "ext" values and their associated namespaces). When the server receives presence from a contact, it MUST check that presence information for entity capabilities data and correlate that data with the desired namespaces for the contact's client. The server MUST NOT send notifications related to any data formats that the contact's client has not asked for via the relevant "namespace+notify" disco#info feature. This enables a client to turn off all notifications (e.g., because of bandwidth restrictions) and to easily receive all desired data formats simply by adding support for the appropriate "namespace+notify" combination in its disco#info results and client capabililies. However, it also implies that a client can request notifications only on a global basis and cannot request, say, mood information only from certain contacts in the user's roster. Community consensus is that this is an acceptable tradeoff. Also, note that this works only if the account owner has a presence subscription to the contact.</p>
+  <p class="" style="">Some examples may help to illustrate the concept of notification filtering. Here we show presence generated by two of the contacts listed above (benvolio@montague.net does have any presence subscriptions to or from juliet@capulet.com and therefore is not involved in these protocol flows).</p>
+  <p class="caption">Example 21. Presence with caps</p>
+<div class="indent"><pre>
+&lt;presence from='nurse@capulet.com/chamber'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://exodus.jabberstudio.org/caps'
+     ver='0.9'
+     ext='asdf fdsa bar baz'/&gt;
+&lt;/presence&gt;
+
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">We assume that Juliet's server doesn't know anything about these capabilities, so it sends service discovery information requests to each of the clients on Juliet's behalf (realistically, the capulet.com server will quickly build up a cache of client capabilities so it will not need to send these service discovery requests):</p>
+  <p class="caption">Example 22. Account server queries contact</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='nurse@capulet.com/chamber'
+    type='get'
+    id='disco123'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#0.9'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='nurse@capulet.com/chamber'
+    to='juliet@capulet.com'
+    type='result'
+    id='disco123'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://exodus.jabberstudio.org/caps#0.9'/&gt;
+    &lt;feature var='http://jabber.org/protocol/tune'/&gt;
+    &lt;feature var='http://jabber.org/protocol/tune+notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity+notify'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc+notify'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 23. Account server queries contact</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com'
+    to='romeo@montague.net/orchard'
+    type='get'
+    id='disco234'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://www.chatopus.com/ec#2.1'/&gt;
+&lt;/iq&gt;
+
+&lt;iq from='romeo@montague.net/orchard'
+    to='juliet@capulet.com'
+    type='result'
+    id='disco234'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://www.chatopus.com/ec#2.1'/&gt;
+    &lt;feature var='http://jabber.org/protocol/tune'/&gt;
+    &lt;feature var='http://jabber.org/protocol/activity'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;feature var='http://jabber.org/protocol/geoloc+notify'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Now we revisit account owner publication and server generation of notifications, with filtering enabled because the server has caps information:</p>
+  <ul>
+    <li><p class="" style="">If Juliet publishes a tune item to the open-access "http://jabber.org/protocol/tune" node, her server will send notifications to &lt;benvolio@montague.net&gt; (bare JID) and to &lt;nurse@capulet.com/chamber&gt; (full JID) but not to &lt;romeo@montague.net/orchard&gt;.</p></li>
+    <li><p class="" style="">If Juliet publishes an activity item to the presence-access "http://jabber.org/protocol/activity" node, her server will send notifications only to &lt;nurse@capulet.com/chamber&gt;.</p></li>
+    <li><p class="" style="">If Juliet publishes a geolocation item to the roster-access "http://jabber.org/protocol/geoloc" node, her server will send notifications only to &lt;romeo@montague.net/orchard&gt;.</p></li>
+  </ul>
+<h2>10.
+       <a name="notifications">Generating Notifications</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="notifications-num">Number of Notifications</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">If a subscriber subscribed using a full JID (&lt;node@domain.tld/resource&gt;), domain identifier (&lt;domain.tld&gt;), or domain plus resource (&lt;domain.tld/resource&gt;), a PEP service MUST send one notification only, addressed to the subscribed JID.</p></li>
+      <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service does not have appropriate presence information about the subscriber, a PEP service MUST send at most one notification, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber, and MAY choose not to send any notification. (By "appropriate presence information" is meant non-negative priority and <span style="font-weight: bold">JEP-0115</span> data that indicates interest in the relevant data format.)</p></li>
+      <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service has appropriate presence information about the subscriber, the PEP service MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources that have specified non-negative presence priority and included <span style="font-weight: bold">JEP-0115</span> information that indicates an interest in the data format.</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="notifications-when">When to Generate Notifications</a>
+</h3>
+    <ol start="1" type="">
+      <li><p class="" style="">When an account owner publishes an item to a node, a PEP service MUST generate a notification and send it to all appropriate subscribers (where the number of notifications is determined by the foregoing rules).</p></li>
+      <li><p class="" style="">When a PEP service receives initial presence information from a subscriber's resource with a non-negative priority and including <span style="font-weight: bold">JEP-0115</span> information that indicates an interest in the data format, it MUST generate a notification containing the last published item for that node and send it to the newly-available resource.</p></li>
+      <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MUST NOT send notifications to a subscriber if the user has blocked the subscriber from receiving all or any kinds of stanza (presence, message, IQ, or any combination thereof) using communiations blocking as specified in <span style="font-weight: bold">XMPP IM</span>.</p></li>
+    </ol>
+  </div>
+<h2>11.
+       <a name="last">Sending the Last Published Item</a>
+</h2>
+  <p class="" style="">As described in the <a href="#notifications">Generating Notifications</a> section of this document, a PEP service MUST send the last published item to all new subscribers and to all newly-available resources for each subscriber.  [<a href="#nt-id2259578">15</a>]</p>
+  <p class="caption">Example 24. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="caption">Example 25. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'&gt;
+  &lt;c xmlns='http://jabber.org/protocol/caps'
+     node='http://www.chatopus.com/ec'
+     ver='2.1'
+     ext='foobar pres+'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="caption">Example 26. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>12.
+       <a name="privatedata">Private Data Storage</a>
+</h2>
+  <p class="" style="">As noted, PEP services may be used to implement private data storage, such as defined in <span class="ref" style="">Private XML Storage</span>  [<a href="#nt-id2259669">16</a>]. A future version of this document will specify this usage in more detail.</p>
+<h2>13.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">A PEP service MUST:</p>
+  <ul>
+    <li>Support the node discovery, node creation, node deletion, publish item, subscribe, unsubscribe, and item retrieval use cases specified in <span style="font-weight: bold">JEP-0060</span>.</li>
+    <li>Support the "owner" and "subscriber" affiliations.</li>
+    <li>Support the "presence" access model and set it to the default.</li>
+    <li>Support the "open", "roster", and "whitelist" access models.</li>
+    <li>Treat the account owner's bare JID (&lt;node@domain.tld&gt;) as a collection node (i.e., as the root collection node for the account's virtual pubsub service).</li>
+    <li>Deliver payloads (if included) in all notifications.</li>
+    <li>Send the last publish item as described above.</li>
+    <li>Support the 'deliver_notifications' and 'send_last_published_item' configuration options.</li>
+  </ul>
+  <p class="" style="">A PEP service MAY support other use cases, affiliations, access models, and features, but such support is OPTIONAL.</p>
+<h2>14.
+       <a name="imple">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>14.1 <a name="impl-subscriptions">Cancelling Subscriptions</a>
+</h3>
+    <p class="" style="">In order to ensure appropriate access to information published at nodes of type "presence" and "roster", a PEP service MUST re-calculate access controls when:</p>
+    <ol start="1" type="">
+      <li>A presence subscription state changes (e.g., when a subscription request is approved).</li>
+      <li>A roster item is modified (e.g., when the item is moved to a new roster group).</li>
+    </ol>
+    <p class="" style="">If the modification results in a loss of access, the service MUST cancel the entity's subscription. In addition, the service MAY send a message to the (former) subscriber informing it of the cancellation (for information about the format of messages sent to notify subscribers of subscription cancellation, see the "Notification of Subscription Denial or Cancellation" section of <span style="font-weight: bold">JEP-0060</span>).</p>
+  </div>
+<h2>15.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>16.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259856">17</a>].</p>
+<h2>17.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>17.1 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;); as a result of this JEP, the Registrar shall add a type of "pep" to that category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>18.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because Personal Eventing via Pubsub simply reuses existing protocols, a separate schema is not needed.</p>
+<h2>19.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors wish to thank the participants in the XMPP Interoperability Testing Event held July 24 and 25, 2006, who provided valuable feedback that resulted in radical simplification of the protocol.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2257574">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257595">2</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2257617">3</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2257634">4</a>. JEP-0108: User Activity &lt;<a href="http://www.jabber.org/jeps/jep-0108.html">http://www.jabber.org/jeps/jep-0108.html</a>&gt;.</p>
+<p><a name="nt-id2257656">5</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2257605">6</a>. Currently, many "extended presence" formats are sent using the &lt;presence/&gt; stanza type; however, this overloads presence, results in unnecessary presence traffic, and does not provide fine-grained control over access. The use of publish-subscribe rather than presence is therefore preferable.</p>
+<p><a name="nt-id2257690">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257866">8</a>. This works only if the subscription state is "both" (see <span style="font-weight: bold">RFC 3921</span>).</p>
+<p><a name="nt-id2257944">9</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2257915">10</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2258402">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2258462">12</a>. This similar to the room creation process in <span style="font-weight: bold">JEP-0045: Multi-User Chat</span>.</p>
+<p><a name="nt-id2259096">13</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2259247">14</a>. Including, say, the 'http://jabber.org/protocol/geoloc' namespace indicates that the client understands the geolocation namespace, whereas including the 'http://jabber.org/protocol/geoloc+notify' namespace indicates that the client wishes to receive notifications related to geolocation.</p>
+<p><a name="nt-id2259578">15</a>. That is, the default value of the "pubsub#send_last_published_item" node configuration field must be "on_sub_and_presence"; this behavior essentially mimics the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.</p>
+<p><a name="nt-id2259669">16</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p><a name="nt-id2259856">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.15 (2006-08-30)</h4>
+<div class="indent">
+<p class="" style="">Added the deliver_notifications and send_last_published_item configuration options to the recommended defaults.</p> (psa)
+    </div>
+<h4>Version 0.14 (2006-08-02)</h4>
+<div class="indent">
+<p class="" style="">Changed various recommended defaults from SHOULD to MUST; corrected several errors in the text and examples.</p> (psa)
+    </div>
+<h4>Version 0.13 (2006-08-01)</h4>
+<div class="indent">
+<p class="" style="">Recommended node creation with default configuration on initial publish; corrected several errors and clarified several points in the text.</p> (psa)
+    </div>
+<h4>Version 0.12 (2006-08-01)</h4>
+<div class="indent">
+<p class="" style="">Simplified the subscription process using XMPP presence and entity capabilities.</p> (psa)
+    </div>
+<h4>Version 0.11 (2006-07-20)</h4>
+<div class="indent">
+<p class="" style="">Clarified rules regarding number of notifications and when to generate notifications; corrected several errors in the text and examples.</p> (psa)
+    </div>
+<h4>Version 0.10 (2006-07-07)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect version 1.8 of JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.9 (2006-06-15)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect use of data forms in JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.8 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology and defaults.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Specified that notifications are to be sent from bare JID, not full JID.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect pubsub changes; clarified business rules for generation of notifications and cancellation of subscriptions.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.2.html
+++ b/content/xep-0163-0.2.html
@@ -1,0 +1,446 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Simplified Personal Publish-Subscribe</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Simplified Personal Publish-Subscribe">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a simple profile of the publish-subscribe protocol for use in personal publishing and similar applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Simplified Personal Publish-Subscribe</h1>
+<p>This document specifies a simple profile of the publish-subscribe protocol for use in personal publishing and similar applications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0163<br>
+            Version: 0.2<br>
+            Last Updated: 2006-01-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: spps<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Simplified%20Personal%20Publish-Subscribe%20(JEP-0163)">http://wiki.jabber.org/index.php/Simplified Personal Publish-Subscribe (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#services">SPPS Service Types</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>12.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2253944">1</a>] extension is commonly thought of as complicated. This is unfortunate, since it would be good to use it for simple personal publishing tasks, such as those described in <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2254006">2</a>]. To make publish-subscribe functionality more accessible, this document defines best practices that can be followed by client and server developers, hopefully resulting in the deployment of simplified personal publish-subscribe ("SPPS") services across the Jabber/XMPP network.</p>
+  <p class="" style=""><span style="font-style: italic">Note Well: This document describes all and only a subset of the full publish-subscribe protocol; any new features needed by SPPS shall be defined in <span style="font-weight: bold">JEP-0060</span>, not in this document. Until the provisional changes to <span style="font-weight: bold">JEP-0060</span> are approved by the Jabber Council, readers of this document are referred to the version-in-progress located at &lt;<a href="http://www.jabber.org/jeps/tmp/jep-0060-1.8.html">http://www.jabber.org/jeps/tmp/jep-0060-1.8.html</a>&gt;.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Simplified personal publish-subscribe is based on four principles:</p>
+  <ol start="" type="">
+    <li>Every account a pubsub service.</li>
+    <li>Smart defaults.</li>
+    <li>One publisher per node.</li>
+    <li>One node per namespace.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at an XMPP server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the personal pubsub nodes associated with the account owner, since the root pubsub node simply <span style="font-style: italic">is</span> the account owner's bare JID (&lt;node@domain.tld&gt;). It also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for simplified personal publishing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal pubsub service, since by definition the service is personal. The owner and publisher for every node is the bare JID of the associated account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) for the publisher/owner. For example, there is one pubsub node for <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2250683">3</a>], one node for <span class="ref" style="">User Tune</span>  [<a href="#nt-id2250707">4</a>], one node for <span class="ref" style="">User Mood</span>  [<a href="#nt-id2250729">5</a>], and so on. This simplifies both publishing and subscribing.</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports simplified personal publish-subscribe, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250762">6</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports SPPS, it MUST return a feature of "http://jabber.org/protocol/pubsub#spps" and MUST specify its default access model as described in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='service'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#spps'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#default_access_model_presence'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node.</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/mood'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="" type="">
+      <li>Because the account owner's server supports SPPS, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/tune".</li>
+      <li>Following the principle of "smart defaults", the SPPS service has a default access model of "presence" so that the &lt;create/&gt; element does not need to include an 'access' attribute.</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested.</li>
+    </ol>
+    <p class="" style="">Now the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">The value of the 'access' attribute SHOULD be "open", "presence", or "roster" for SPPS nodes (i.e., the value SHOULD NOT be "authorize" or "whitelist" since maintenance of such nodes requires interaction on the part of the node owner). The default access model for SPPS nodes MUST be "presence" for IM servers but MAY be something other than "presence" for other SPPS service types (e.g., non-IM servers).</p>
+    <p class="" style="">If the account owner desires an open access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates open access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-open-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune' access='open'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 6. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-open-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc' access='roster'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/create&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 7. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">Again, the server acknowledges success.</p>
+    <p class="caption">Example 8. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers:</p>
+    <p class="caption">Example 9. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message to='stpeter@jabber.org' from='pgmillard@jabber.org/work' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">Because it may be desirable to specify which resource has published an item, the server MUST set the 'from' address on the notification to the full JID (&lt;node@domain.tld/resource&gt;) of the publishing resource (in the previous example, "pgmillard@jabber.org/work"). This will enable the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). Naturally, if there is only one active resource for the account owner, the subscriber's client can safely ignore the resource.</p>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is made easy since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 10. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='stpeter@jabber.org/roundabout' to='pgmillard@jabber.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return all pubsub nodes:</p>
+    <p class="caption">Example 11. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='stpeter@jabber.org/roundabout' from='pgmillard@jabber.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='pgmillard@jabber.org' node='http://jabber.org/protocol/mood'/&gt;
+    &lt;item jid='pgmillard@jabber.org' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='pgmillard@jabber.org' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the potential subscriber may send a disco#info request to the specific node of interest:</p>
+    <p class="caption">Example 12. Subscriber queries specific node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco2' from='stpeter@jabber.org/roundabout' to='pgmillard@jabber.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/tune'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The account owner's server would then return information about the node (if it exists) or an &lt;item-not-found/&gt; error if the node does not exist:</p>
+    <p class="caption">Example 13. Servers returns node info</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco2' to='stpeter@jabber.org/roundabout' from='pgmillard@jabber.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/tune'&gt;
+    &lt;identity category='pubsub' type='leaf'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (not full JID) and specifies the desired node:</p>
+    <p class="caption">Example 14. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/roundabout'
+    to='pgmillard@jabber.org'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='stpeter@jabber.org'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="" type="">
+      <li>If the access model is "open", the server MUST allow the entity to subscribe.</li>
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server MUST allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server MUST allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+    </ol>
+    <p class="" style="">If the server disallows the subscription, it MUST return a &lt;forbidden/&gt; error:</p> 
+    <p class="caption">Example 15. Server disallows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pgmillard@jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='stpeter@jabber.org'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code='403' type='cancel'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server allows the subscription, it MUST return an IQ-result:</p>
+    <p class="caption">Example 16. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pgmillard@jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='sub1'/&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">The default access model for an SPPS service SHOULD be "presence" (it MUST be "presence" for an SPPS service associated with an IM server but MAY be something other than "presence" for other kinds of SPPS services).</p>
+  <p class="" style="">An SPPS service SHOULD NOT support affiliations other than Owner and Subscriber.</p>
+  <p class="" style="">An SPPS service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="" type="">
+    <li>No item persistence (all nodes are transient).</li>
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No get-items.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">An SPPS service MAY allow the bare JID (&lt;node@domain.tld&gt;) to be a collection node, but SHOULD NOT support any other collection nodes.</p>
+  <p class="" style="">An SPPS service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="services">SPPS Service Types</a>
+</h2>
+  <p class="" style="">It is envisioned that most SPPS services will be associated with instant messaging and presence servers that conform to <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2256984">7</a>]. However, it is also possible for an SPPS service to be associated with a "mere" XMPP server that conforms only to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2257010">8</a>] or with a non-server implementation such as a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257034">9</a>] service.</p>
+  <p class="" style="">When the SPPS service is associated with an IM server, the default access model MUST be "presence".</p>
+  <p class="" style="">When the SPPS service is associated with a non-IM server, the default access model SHOULD be "open" but MAY be "whitelist" (how and by whom the whitelist is maintained are outside the scope of this document); the default access model MUST NOT be "presence" or "roster" since those concepts do not apply to non-IM servers and SHOULD NOT be "authorize".</p>
+  <p class="" style="">When the SPPS service is associated with a multi-user chat service, the default access model SHOULD be "roster" (where the roster is the room roster of occupants in the room) but MAY be "whitelist" (where the whitelist is the list of members in a members-only room); the default access model MUST NOT be "presence" since that concept does not apply to multi-user chat services and SHOULD NOT be "authorize" or "open".</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257117">10</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257166">11</a>] shall include 'http://jabber.org/protocol/pubsub#spps' in its registry of protocol namespaces.</p>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Not needed (see <span style="font-weight: bold">JEP-0060</span>).</p> 
+<h2>12.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Kevin Smith of the Psi project for his helpful comments.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2253944">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2254006">2</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2250683">3</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2250707">4</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2250729">5</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2250762">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256984">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257010">8</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2257034">9</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257117">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257166">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">Updated to reflect proposed JEP-0060 modifications. (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">Added more details and examples. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.3.html
+++ b/content/xep-0163-0.3.html
@@ -1,0 +1,463 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Simplified Personal Publish-Subscribe</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Simplified Personal Publish-Subscribe">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a simple profile of the publish-subscribe protocol for use in personal publishing and similar applications.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Simplified Personal Publish-Subscribe</h1>
+<p>This document specifies a simple profile of the publish-subscribe protocol for use in personal publishing and similar applications.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0163<br>
+            Version: 0.3<br>
+            Last Updated: 2006-01-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: spps<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Simplified%20Personal%20Publish-Subscribe%20(JEP-0163)">http://wiki.jabber.org/index.php/Simplified Personal Publish-Subscribe (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#services">SPPS Service Types</a>
+</dt>
+<dt>8.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>8.1.  <a href="#impl-roster">Roster States</a>
+</dt></dl>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>11.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>12.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>13.  <a href="#acknowledgements">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250636">1</a>] extension is commonly thought of as complicated. This is unfortunate, since it would be good to use it for simple personal publishing tasks, such as those described in <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2250659">2</a>]. To make publish-subscribe functionality more accessible, this document defines best practices that can be followed by client and server developers, hopefully resulting in the deployment of simplified personal publish-subscribe ("SPPS") services across the Jabber/XMPP network.</p>
+  <p class="" style=""><span style="font-style: italic">Note Well: This document describes all and only a subset of the full publish-subscribe protocol; any new features needed by SPPS shall be defined in <span style="font-weight: bold">JEP-0060</span>, not in this document. Until the provisional changes to <span style="font-weight: bold">JEP-0060</span> are approved by the Jabber Council, readers of this document are referred to the version-in-progress located at &lt;<a href="http://www.jabber.org/jeps/tmp/jep-0060-1.8.html">http://www.jabber.org/jeps/tmp/jep-0060-1.8.html</a>&gt;.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Simplified personal publish-subscribe is based on four principles:</p>
+  <ol start="" type="">
+    <li>Every account a pubsub service.</li>
+    <li>Smart defaults.</li>
+    <li>One publisher per node.</li>
+    <li>One node per namespace.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at an XMPP server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the personal pubsub nodes associated with the account owner, since the root pubsub node simply <span style="font-style: italic">is</span> the account owner's bare JID (&lt;node@domain.tld&gt;). It also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for simplified personal publishing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal pubsub service, since by definition the service is personal. The owner and publisher for every node is the bare JID of the associated account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) for the publisher/owner. For example, there is one pubsub node for <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2250823">3</a>], one node for <span class="ref" style="">User Tune</span>  [<a href="#nt-id2250840">4</a>], one node for <span class="ref" style="">User Mood</span>  [<a href="#nt-id2250862">5</a>], and so on. This simplifies both publishing and subscribing.</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports simplified personal publish-subscribe, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250933">6</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports SPPS, it MUST return a feature of "http://jabber.org/protocol/pubsub#spps" and MUST specify its default access model as described in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='service'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#spps'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#default_access_model_presence'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node.</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/mood'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="" type="">
+      <li>Because the account owner's server supports SPPS, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/tune".</li>
+      <li>Following the principle of "smart defaults", the SPPS service has a default access model of "presence" so that the &lt;create/&gt; element does not need to include an 'access' attribute.</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested.</li>
+    </ol>
+    <p class="" style="">Now the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">The value of the 'access' attribute SHOULD be "open", "presence", or "roster" for SPPS nodes (i.e., the value SHOULD NOT be "authorize" or "whitelist" since maintenance of such nodes requires interaction on the part of the node owner). The default access model for SPPS nodes MUST be "presence" for IM servers but MAY be something other than "presence" for other SPPS service types (e.g., non-IM servers).</p>
+    <p class="" style="">If the account owner desires an open access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates open access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-open-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune' access='open'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 6. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-open-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc' access='roster'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/create&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 7. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">Again, the server acknowledges success.</p>
+    <p class="caption">Example 8. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers:</p>
+    <p class="caption">Example 9. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message to='stpeter@jabber.org' from='pgmillard@jabber.org/work' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Ralph Vaughan Williams&lt;/artist&gt;
+          &lt;title&gt;Concerto in F for Bass Tuba&lt;/title&gt;
+          &lt;source&gt;Golden Brass: The Collector's Edition&lt;/source&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">Because it may be desirable to specify which resource has published an item, the server MUST set the 'from' address on the notification to the full JID (&lt;node@domain.tld/resource&gt;) of the publishing resource (in the previous example, "pgmillard@jabber.org/work"). This will enable the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). Naturally, if there is only one active resource for the account owner, the subscriber's client can safely ignore the resource.</p>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is made easy since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 10. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='stpeter@jabber.org/roundabout' to='pgmillard@jabber.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return all pubsub nodes:</p>
+    <p class="caption">Example 11. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='stpeter@jabber.org/roundabout' from='pgmillard@jabber.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='pgmillard@jabber.org' node='http://jabber.org/protocol/mood'/&gt;
+    &lt;item jid='pgmillard@jabber.org' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='pgmillard@jabber.org' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the potential subscriber may send a disco#info request to the specific node of interest:</p>
+    <p class="caption">Example 12. Subscriber queries specific node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco2' from='stpeter@jabber.org/roundabout' to='pgmillard@jabber.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/tune'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The account owner's server would then return information about the node (if it exists) or an &lt;item-not-found/&gt; error if the node does not exist:</p>
+    <p class="caption">Example 13. Servers returns node info</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco2' to='stpeter@jabber.org/roundabout' from='pgmillard@jabber.org'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/tune'&gt;
+    &lt;identity category='pubsub' type='leaf'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (not full JID) and specifies the desired node:</p>
+    <p class="caption">Example 14. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='stpeter@jabber.org/roundabout'
+    to='pgmillard@jabber.org'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='stpeter@jabber.org'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="" type="">
+      <li>If the access model is "open", the server SHOULD allow the entity to subscribe.</li>
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+    </ol>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements in the foregoing scenarios is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the account owner to subscribe and to retrieve items.)</p>
+    <p class="" style="">If the server disallows the subscription for whatever reason (including enforcement of local security policies), it MUST return a &lt;forbidden/&gt; error:</p> 
+    <p class="caption">Example 15. Server disallows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pgmillard@jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='stpeter@jabber.org'/&gt;
+  &lt;/pubsub&gt;
+  &lt;error code='403' type='cancel'&gt;
+    &lt;forbidden xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server allows the subscription, it MUST return an IQ-result:</p>
+    <p class="caption">Example 16. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='pgmillard@jabber.org'
+    to='stpeter@jabber.org/roundabout'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">As noted, a service MUST always allow the account owner to subscribe and to retrieve items.</p>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">The default access model for an SPPS service SHOULD be "presence" (it MUST be "presence" for an SPPS service associated with an IM server but MAY be something other than "presence" for other kinds of SPPS services).</p>
+  <p class="" style="">An SPPS service SHOULD NOT support affiliations other than Owner and Subscriber.</p>
+  <p class="" style="">An SPPS service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="" type="">
+    <li>No item persistence (all nodes are transient).</li>
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No get-items.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">An SPPS service MAY allow the bare JID (&lt;node@domain.tld&gt;) to be a collection node, but SHOULD NOT support any other collection nodes.</p>
+  <p class="" style="">An SPPS service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="services">SPPS Service Types</a>
+</h2>
+  <p class="" style="">It is envisioned that most SPPS services will be associated with instant messaging and presence servers that conform to <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2257082">7</a>]. However, it is also possible for an SPPS service to be associated with a "mere" XMPP server that conforms only to <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2257106">8</a>] or with a non-server implementation such as a <span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257127">9</a>] service.</p>
+  <p class="" style="">When the SPPS service is associated with an IM server, the default access model MUST be "presence".</p>
+  <p class="" style="">When the SPPS service is associated with a non-IM server, the default access model SHOULD be "open" but MAY be "whitelist" (how and by whom the whitelist is maintained are outside the scope of this document); the default access model MUST NOT be "presence" or "roster" since those concepts do not apply to non-IM servers and SHOULD NOT be "authorize".</p>
+  <p class="" style="">When the SPPS service is associated with a multi-user chat service, the default access model SHOULD be "roster" (where the roster is the room roster of occupants in the room) but MAY be "whitelist" (where the whitelist is the list of members in a members-only room); the default access model MUST NOT be "presence" since that concept does not apply to multi-user chat services and SHOULD NOT be "authorize" or "open".</p>
+<h2>8.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="impl-roster">Roster States</a>
+</h3>
+    <p class="" style="">In order to ensure coherency for nodes of type "presence" and "roster", a service SHOULD recalculate access controls whenever a roster item is modified (e.g., when a subscription request is approved or whhen the item is moved to a new roster group). If the modification results in a loss of access, a service MUST cancel the entity's subscription and MAY send a message to the (former) subscriber informing the entity of the cancellation.</p>
+  </div>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">An SPPS service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257249">10</a>].</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257296">11</a>] shall include 'http://jabber.org/protocol/pubsub#spps' in its registry of protocol namespaces.</p>
+  </div>
+<h2>12.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Not needed (see <span style="font-weight: bold">JEP-0060</span>).</p> 
+<h2>13.
+       <a name="acknowledgements">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Kevin Smith of the Psi project for his helpful comments.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250636">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250659">2</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2250823">3</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2250840">4</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2250862">5</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2250933">6</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257082">7</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257106">8</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2257127">9</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257249">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257296">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes. (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">Updated to reflect proposed JEP-0060 modifications. (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">Added more details and examples. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.4.html
+++ b/content/xep-0163-0.4.html
@@ -1,0 +1,533 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing Protocol</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing Protocol">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with instant messaging and presence user (e.g., extended presence).">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-02-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing Protocol</h1>
+<p>This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with instant messaging and presence user (e.g., extended presence).</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0163<br>
+            Version: 0.4<br>
+            Last Updated: 2006-02-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20Protocol%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing Protocol (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.5.  <a href="#approach-presence">Use Presence</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+<dt>4.3.  <a href="#pub-last">Sending the Last Published Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#impl-notifications">Generating Notifications</a>
+</dt>
+<dt>7.2.  <a href="#impl-roster">Roster States</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250880">1</a>] extension is commonly thought of as complicated. This is unfortunate, since it would be good to use it to broadcast personal state change events such as those described in <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2251040">2</a>]. To make publish-subscribe functionality more accessible in the context of instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2251072">3</a>], this document defines best practices that can be followed by IM and presence client and server developers, hopefully resulting in the deployment of personal eventing protocol ("PEP") services across the Jabber IM network.</p>
+  <p class="" style=""><span style="font-style: italic">Note Well: This document describes all and only a subset of the full publish-subscribe protocol; any new features needed by PEP shall be defined in <span style="font-weight: bold">JEP-0060</span>, not in this document. Until the provisional changes to <span style="font-weight: bold">JEP-0060</span> required for PEP are approved by the Jabber Council, readers of this document are referred to the version-in-progress located at &lt;<a href="http://www.jabber.org/jeps/tmp/jep-0060-1.8.html">http://www.jabber.org/jeps/tmp/jep-0060-1.8.html</a>&gt;.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">The personal eventing protocol (PEP) is based on five principles:</p>
+  <ol start="" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One node per namespace.</li>
+    <li>One publisher per node.</li>
+    <li>Smart defaults.</li>
+    <li>Use presence.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an instant messaging and presence account (or has an account provisioned) at a Jabber server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the personal pubsub nodes associated with the account owner, since the root pubsub node simply <span style="font-style: italic">is</span> the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) associated with the owner-publisher. For example, there is one pubsub node for <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2250929">4</a>], one node for <span class="ref" style="">User Tune</span>  [<a href="#nt-id2250952">5</a>], one node for <span class="ref" style="">User Mood</span>  [<a href="#nt-id2250967">6</a>], and so on. This simplifies discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal eventing service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe service do not necessarily have access to presence information about subscribers, personal eventing services are closely integrated with presence, since each instant messaging and presence account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service and the recommended access models are "presence" and "roster" (both of which involve presence subscriptions in XMPP instant messaging and presence systems). This presence information can be used to make notifications more intelligent, thus simplifying the task of developing compliant clients (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2256650">7</a>]).</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports the personal eventing protocol, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256685">8</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep", MUST return a feature of "http://jabber.org/protocol/pubsub#pep", and MUST specify its default access model as described in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#default_access_model_presence'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node.</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/mood'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="" type="">
+      <li>Because the account owner's server supports PEP, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/mood".</li>
+      <li>Following the principle of "smart defaults", the PEP service has a default access model of "presence" so that the &lt;create/&gt; element does not need to include an 'access' attribute.</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested.</li>
+    </ol>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">The value of the 'access' attribute SHOULD be "presence" or "roster" for PEP nodes but MAY be "open" (i.e., the value SHOULD NOT be "authorize" or "whitelist" since maintenance of such nodes requires interaction on the part of the node owner). The default access model for PEP nodes MUST be "presence" for IM servers but MAY be something other than "presence" for other PEP service types (e.g., non-IM servers).</p>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-roster-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure access='roster'&gt;
+      &lt;group&gt;Friends&lt;/group&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the account owner desires an open access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 6. Account owner creates open access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-open-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/mood'/&gt;
+    &lt;configure access='open'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 7. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 8. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers (see the <a href="impl-notifications">Generating Notifications</a> section of this document regarding proper generation of the 'to' address):</p>
+    <p class="caption">Example 9. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The server MUST set the 'from' address on the notification to the full JID (&lt;node@domain.tld/resource&gt;) of the publishing resource (in the previous example, "juliet@capulet.com/balcony"). This enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). Naturally, if there is only one active resource for the account owner, the subscriber's client can safely ignore the resource.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="pub-last">Sending the Last Published Item</a>
+</h3>
+    <p class="" style="">As described below, a PEP service MUST send the last published item to all new subscribers. In addition, a PEP service MUST send the last published item to all newly-available resources for each subscriber. (Both of these behaviors essentially mimic the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.)</p>
+    <p class="caption">Example 10. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'/&gt;
+    </pre></div>
+    <p class="caption">Example 12. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is made easy since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 13. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return a list of all pubsub nodes:</p>
+    <p class="caption">Example 14. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/mood'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the potential subscriber may send a disco#info request to the specific node of interest:</p>
+    <p class="caption">Example 15. Subscriber queries specific node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco2' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/mood'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The account owner's server would then return information about the node (if it exists) or an &lt;item-not-found/&gt; error if the node does not exist:</p>
+    <p class="caption">Example 16. Servers returns node info</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco2' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/mood'&gt;
+    &lt;identity category='pubsub' type='leaf'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (&lt;node@domain.tld&gt;) and specifies the desired node:</p>
+    <p class="caption">Example 17. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/mood' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="" type="">
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "open", the server SHOULD allow the entity to subscribe.</li>
+    </ol>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements in the foregoing scenarios is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the account owner to subscribe and to retrieve items.)</p>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error conditions related to subscription requests), the server shall allow the subscription and return an IQ-result:</p>
+    <p class="caption">Example 18. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/home'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">The service then MUST send the last published item to the new subscriber:</p>
+    <p class="caption">Example 19. Server sends last published item</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony' to='romeo@montague.net' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">The default access model for a PEP service MUST be "presence" (a PEP service SHOULD support the "roster" access model and MAY support the "open" access model).</p>
+  <p class="" style="">A PEP service SHOULD NOT support affiliations other than Owner and Subscriber.</p>
+  <p class="" style="">A PEP service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="" type="">
+    <li>No item persistence (all nodes are transient).</li>
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No get-items.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">A PEP service MAY allow the owner-publisher's bare JID (&lt;node@domain.tld&gt;) to be a collection node, but MUST NOT support any other collection nodes.</p>
+  <p class="" style="">A PEP service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-notifications">Generating Notifications</a>
+</h3>
+    <p class="" style="">If a PEP service has presence information about a subscriber, it MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources, except for those that have specified a non-negative presence priority.</p>
+    <p class="" style="">If a PEP service does not have presence information about a subscriber, it MUST send one notification only, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="impl-roster">Roster States</a>
+</h3>
+    <p class="" style="">In order to ensure coherency for nodes of type "presence" and "roster", a PEP service SHOULD recalculate access controls whenever a roster item is modified (e.g., when a subscription request is approved or when the item is moved to a new roster group). If the modification results in a loss of access, a service MUST cancel the entity's subscription and MAY send a message to the (former) subscriber informing the entity of the cancellation.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257480">9</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257531">10</a>] shall include 'http://jabber.org/protocol/pubsub#pep' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities; as a result of this JEP, the Registrar shall include an additional type of "pep".</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">The schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to the Personal Eventing Protocol.</p> 
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250880">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2251040">2</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2251072">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250929">4</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2250952">5</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2250967">6</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2256650">7</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2256685">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257480">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257531">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author. (psa)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes. (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">Updated to reflect proposed JEP-0060 modifications. (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">Added more details and examples. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.5.html
+++ b/content/xep-0163-0.5.html
@@ -1,0 +1,552 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing Protocol</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing Protocol">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with instant messaging and presence user (e.g., extended presence).">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing Protocol</h1>
+<p>This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with instant messaging and presence user (e.g., extended presence).</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0163<br>
+            Version: 0.5<br>
+            Last Updated: 2006-03-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20Protocol%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing Protocol (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.5.  <a href="#approach-presence">Use Presence</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+<dt>4.3.  <a href="#pub-last">Sending the Last Published Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#impl-notifications">Generating Notifications</a>
+</dt>
+<dt>7.2.  <a href="#impl-roster">Roster States</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250665">1</a>] extension is commonly thought of as complicated. This is unfortunate, since it would be good to use it to broadcast personal state change events such as those described in <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2250688">2</a>]. To make publish-subscribe functionality more accessible in the context of instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250710">3</a>], this document defines best practices that can be followed by IM and presence client and server developers, hopefully resulting in the deployment of personal eventing protocol ("PEP") services across the Jabber IM network.</p>
+  <p class="" style=""><span style="font-style: italic">Note Well: This document describes all and only a subset of the full publish-subscribe protocol; any new features needed by PEP shall be defined in <span style="font-weight: bold">JEP-0060</span>, not in this document. Until the provisional changes to <span style="font-weight: bold">JEP-0060</span> required for PEP are approved by the Jabber Council, readers of this document are referred to the version-in-progress located at &lt;<a href="http://www.jabber.org/jeps/tmp/jep-0060-1.8.html">http://www.jabber.org/jeps/tmp/jep-0060-1.8.html</a>&gt;.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">The personal eventing protocol (PEP) is based on five principles:</p>
+  <ol start="" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One node per namespace.</li>
+    <li>One publisher per node.</li>
+    <li>Smart defaults.</li>
+    <li>Use presence.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an instant messaging and presence account (or has an account provisioned) at a Jabber server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the personal pubsub nodes associated with the account owner, since the root pubsub node simply <span style="font-style: italic">is</span> the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) associated with the owner-publisher. For example, there is one pubsub node for <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2250862">4</a>], one node for <span class="ref" style="">User Tune</span>  [<a href="#nt-id2250884">5</a>], one node for <span class="ref" style="">User Mood</span>  [<a href="#nt-id2250875">6</a>], and so on. This simplifies discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal eventing service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe service do not necessarily have access to presence information about subscribers, personal eventing services are closely integrated with presence, since each instant messaging and presence account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service and the recommended access models are "presence" and "roster" (both of which involve presence subscriptions in XMPP instant messaging and presence systems). This presence information can be used to make notifications more intelligent, thus simplifying the task of developing compliant clients (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2256872">7</a>]).</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports the personal eventing protocol, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256910">8</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep", MUST return a feature of "http://jabber.org/protocol/pubsub#pep", and MUST specify its default access model as described in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#default_access_model_presence'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">It is RECOMMENDED for a PEP-aware client to advertise its support for PEP only if the server to which it is connected also supports PEP. This is true both for Service Discovery and for the dynamic "profile" of Service Discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2257015">9</a>].</p>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node.</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/mood'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="" type="">
+      <li>Because the account owner's server supports PEP, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/mood".</li>
+      <li>Following the principle of "smart defaults", the PEP service has a default access model of "presence" so that the &lt;create/&gt; element does not need to include an 'access' attribute.</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested.</li>
+    </ol>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">The value of the 'access' attribute SHOULD be "presence" or "roster" for PEP nodes but MAY be "open" (i.e., the value SHOULD NOT be "authorize" or "whitelist" since maintenance of such nodes requires interaction on the part of the node owner). The default access model for PEP nodes MUST be "presence" for IM servers but MAY be something other than "presence" for other PEP service types (e.g., non-IM servers).</p>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-roster-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure access='roster'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the account owner desires an open access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 6. Account owner creates open access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-open-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/mood'/&gt;
+    &lt;configure access='open'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 7. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 8. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers (see the <a href="impl-notifications">Generating Notifications</a> section of this document regarding proper generation of the 'to' address):</p>
+    <p class="caption">Example 9. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The server MUST set the 'from' address on the notification to the full JID (&lt;node@domain.tld/resource&gt;) of the publishing resource (in the previous example, "juliet@capulet.com/balcony"). This enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). Naturally, if there is only one active resource for the account owner, the subscriber's client can safely ignore the resource.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="pub-last">Sending the Last Published Item</a>
+</h3>
+    <p class="" style="">As described below, a PEP service MUST send the last published item to all new subscribers. In addition, a PEP service MUST send the last published item to all newly-available resources for each subscriber. (Both of these behaviors essentially mimic the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.)</p>
+    <p class="caption">Example 10. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'/&gt;
+    </pre></div>
+    <p class="caption">Example 12. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is made easy since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 13. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return a list of all pubsub nodes:</p>
+    <p class="caption">Example 14. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/mood'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the potential subscriber may send a disco#info request to the specific node of interest:</p>
+    <p class="caption">Example 15. Subscriber queries specific node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco2' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/mood'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The account owner's server would then return information about the node (if it exists) or an &lt;item-not-found/&gt; error if the node does not exist:</p>
+    <p class="caption">Example 16. Servers returns node info</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco2' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/mood'&gt;
+    &lt;identity category='pubsub' type='leaf'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (&lt;node@domain.tld&gt;) and specifies the desired node:</p>
+    <p class="caption">Example 17. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/mood' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="" type="">
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "open", the server SHOULD allow the entity to subscribe.</li>
+    </ol>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements in the foregoing scenarios is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the account owner to subscribe and to retrieve items.)</p>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error conditions related to subscription requests), the server shall allow the subscription and return an IQ-result:</p>
+    <p class="caption">Example 18. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/home'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">The service then MUST send the last published item to the new subscriber:</p>
+    <p class="caption">Example 19. Server sends last published item</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony' to='romeo@montague.net' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">The default access model for a PEP service MUST be "presence" (a PEP service SHOULD support the "roster" access model and MAY support the "open" access model).</p>
+  <p class="" style="">A PEP service SHOULD NOT support affiliations other than Owner and Subscriber.</p>
+  <p class="" style="">A PEP service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="" type="">
+    <li>No item persistence (all nodes are transient).</li>
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No get-items.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">A PEP service MAY allow the owner-publisher's bare JID (&lt;node@domain.tld&gt;) to be a collection node, but MUST NOT support any other collection nodes.</p>
+  <p class="" style="">A PEP service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-notifications">Generating Notifications</a>
+</h3>
+    <p class="" style="">If a PEP service has presence information about a subscriber, it MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources, except for those that have specified a non-negative presence priority.</p>
+    <p class="" style="">If a PEP service does not have presence information about a subscriber, it MUST send one notification only, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="impl-roster">Roster States</a>
+</h3>
+    <p class="" style="">In order to ensure coherency for nodes of type "presence" and "roster", a PEP service SHOULD recalculate access controls whenever a roster item is modified (e.g., when a subscription request is approved or when the item is moved to a new roster group). If the modification results in a loss of access, a service MUST cancel the entity's subscription and MAY send a message to the (former) subscriber informing the entity of the cancellation.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257732">10</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257783">11</a>] shall include 'http://jabber.org/protocol/pubsub#pep' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities; as a result of this JEP, the Registrar shall include an additional type of "pep".</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">The schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to the Personal Eventing Protocol.</p> 
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250665">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250688">2</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2250710">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250862">4</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2250884">5</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2250875">6</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2256872">7</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2256910">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257015">9</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2257732">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257783">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.6.html
+++ b/content/xep-0163-0.6.html
@@ -1,0 +1,552 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing Protocol</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing Protocol">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with instant messaging and presence user (e.g., extended presence).">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing Protocol</h1>
+<p>This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with instant messaging and presence user (e.g., extended presence).</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0163<br>
+            Version: 0.5<br>
+            Last Updated: 2006-03-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20Protocol%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing Protocol (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.5.  <a href="#approach-presence">Use Presence</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+<dt>4.3.  <a href="#pub-last">Sending the Last Published Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#impl-notifications">Generating Notifications</a>
+</dt>
+<dt>7.2.  <a href="#impl-roster">Roster States</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250665">1</a>] extension is commonly thought of as complicated. This is unfortunate, since it would be good to use it to broadcast personal state change events such as those described in <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2250688">2</a>]. To make publish-subscribe functionality more accessible in the context of instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250710">3</a>], this document defines best practices that can be followed by IM and presence client and server developers, hopefully resulting in the deployment of personal eventing protocol ("PEP") services across the Jabber IM network.</p>
+  <p class="" style=""><span style="font-style: italic">Note Well: This document describes all and only a subset of the full publish-subscribe protocol; any new features needed by PEP shall be defined in <span style="font-weight: bold">JEP-0060</span>, not in this document. Until the provisional changes to <span style="font-weight: bold">JEP-0060</span> required for PEP are approved by the Jabber Council, readers of this document are referred to the version-in-progress located at &lt;<a href="http://www.jabber.org/jeps/tmp/jep-0060-1.8.html">http://www.jabber.org/jeps/tmp/jep-0060-1.8.html</a>&gt;.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">The personal eventing protocol (PEP) is based on five principles:</p>
+  <ol start="" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One node per namespace.</li>
+    <li>One publisher per node.</li>
+    <li>Smart defaults.</li>
+    <li>Use presence.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an instant messaging and presence account (or has an account provisioned) at a Jabber server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the personal pubsub nodes associated with the account owner, since the root pubsub node simply <span style="font-style: italic">is</span> the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) associated with the owner-publisher. For example, there is one pubsub node for <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2250862">4</a>], one node for <span class="ref" style="">User Tune</span>  [<a href="#nt-id2250884">5</a>], one node for <span class="ref" style="">User Mood</span>  [<a href="#nt-id2250875">6</a>], and so on. This simplifies discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal eventing service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe service do not necessarily have access to presence information about subscribers, personal eventing services are closely integrated with presence, since each instant messaging and presence account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service and the recommended access models are "presence" and "roster" (both of which involve presence subscriptions in XMPP instant messaging and presence systems). This presence information can be used to make notifications more intelligent, thus simplifying the task of developing compliant clients (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2256872">7</a>]).</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports the personal eventing protocol, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256910">8</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep", MUST return a feature of "http://jabber.org/protocol/pubsub#pep", and MUST specify its default access model as described in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#default_access_model_presence'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">It is RECOMMENDED for a PEP-aware client to advertise its support for PEP only if the server to which it is connected also supports PEP. This is true both for Service Discovery and for the dynamic "profile" of Service Discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2257015">9</a>].</p>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node.</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/mood'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="" type="">
+      <li>Because the account owner's server supports PEP, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/mood".</li>
+      <li>Following the principle of "smart defaults", the PEP service has a default access model of "presence" so that the &lt;create/&gt; element does not need to include an 'access' attribute.</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested.</li>
+    </ol>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">The value of the 'access' attribute SHOULD be "presence" or "roster" for PEP nodes but MAY be "open" (i.e., the value SHOULD NOT be "authorize" or "whitelist" since maintenance of such nodes requires interaction on the part of the node owner). The default access model for PEP nodes MUST be "presence" for IM servers but MAY be something other than "presence" for other PEP service types (e.g., non-IM servers).</p>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-roster-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure access='roster'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the account owner desires an open access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 6. Account owner creates open access node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='create-open-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/mood'/&gt;
+    &lt;configure access='open'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 7. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 8. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers (see the <a href="impl-notifications">Generating Notifications</a> section of this document regarding proper generation of the 'to' address):</p>
+    <p class="caption">Example 9. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The server MUST set the 'from' address on the notification to the full JID (&lt;node@domain.tld/resource&gt;) of the publishing resource (in the previous example, "juliet@capulet.com/balcony"). This enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). Naturally, if there is only one active resource for the account owner, the subscriber's client can safely ignore the resource.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="pub-last">Sending the Last Published Item</a>
+</h3>
+    <p class="" style="">As described below, a PEP service MUST send the last published item to all new subscribers. In addition, a PEP service MUST send the last published item to all newly-available resources for each subscriber. (Both of these behaviors essentially mimic the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.)</p>
+    <p class="caption">Example 10. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'/&gt;
+    </pre></div>
+    <p class="caption">Example 12. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is made easy since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 13. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return a list of all pubsub nodes:</p>
+    <p class="caption">Example 14. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/mood'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Alternatively, the potential subscriber may send a disco#info request to the specific node of interest:</p>
+    <p class="caption">Example 15. Subscriber queries specific node</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco2' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/mood'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The account owner's server would then return information about the node (if it exists) or an &lt;item-not-found/&gt; error if the node does not exist:</p>
+    <p class="caption">Example 16. Servers returns node info</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco2' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'
+         node='http://jabber.org/protocol/mood'&gt;
+    &lt;identity category='pubsub' type='leaf'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (&lt;node@domain.tld&gt;) and specifies the desired node:</p>
+    <p class="caption">Example 17. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/mood' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="" type="">
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "open", the server SHOULD allow the entity to subscribe.</li>
+    </ol>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements in the foregoing scenarios is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the account owner to subscribe and to retrieve items.)</p>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error conditions related to subscription requests), the server shall allow the subscription and return an IQ-result:</p>
+    <p class="caption">Example 18. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/home'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">The service then MUST send the last published item to the new subscriber:</p>
+    <p class="caption">Example 19. Server sends last published item</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com/balcony' to='romeo@montague.net' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/mood'&gt;
+      &lt;item&gt;
+        &lt;mood xmlns='http://jabber.org/protocol/mood'&gt;
+          &lt;happy&gt;
+        &lt;/mood&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">The default access model for a PEP service MUST be "presence" (a PEP service SHOULD support the "roster" access model and MAY support the "open" access model).</p>
+  <p class="" style="">A PEP service SHOULD NOT support affiliations other than Owner and Subscriber.</p>
+  <p class="" style="">A PEP service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="" type="">
+    <li>No item persistence (all nodes are transient).</li>
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No get-items.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">A PEP service MAY allow the owner-publisher's bare JID (&lt;node@domain.tld&gt;) to be a collection node, but MUST NOT support any other collection nodes.</p>
+  <p class="" style="">A PEP service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-notifications">Generating Notifications</a>
+</h3>
+    <p class="" style="">If a PEP service has presence information about a subscriber, it MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources, except for those that have specified a non-negative presence priority.</p>
+    <p class="" style="">If a PEP service does not have presence information about a subscriber, it MUST send one notification only, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="impl-roster">Roster States</a>
+</h3>
+    <p class="" style="">In order to ensure coherency for nodes of type "presence" and "roster", a PEP service SHOULD recalculate access controls whenever a roster item is modified (e.g., when a subscription request is approved or when the item is moved to a new roster group). If the modification results in a loss of access, a service MUST cancel the entity's subscription and MAY send a message to the (former) subscriber informing the entity of the cancellation.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257732">10</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257783">11</a>] shall include 'http://jabber.org/protocol/pubsub#pep' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities; as a result of this JEP, the Registrar shall include an additional type of "pep".</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">The schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to the Personal Eventing Protocol.</p> 
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250665">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250688">2</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2250710">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250862">4</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2250884">5</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2250875">6</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2256872">7</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2256910">8</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257015">9</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2257732">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257783">11</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.8.html
+++ b/content/xep-0163-0.8.html
@@ -1,0 +1,595 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing Protocol</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing Protocol">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with an instant messaging and presence user (e.g., extended presence).">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-10">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing Protocol</h1>
+<p>This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with an instant messaging and presence user (e.g., extended presence).</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0163<br>
+            Version: 0.7<br>
+            Last Updated: 2006-04-10<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20Protocol%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing Protocol (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.5.  <a href="#approach-presence">Use Presence</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+<dt>4.3.  <a href="#pub-last">Sending the Last Published Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#rules">Business Rules</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#rules-notifications">Generating Notifications</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#rules-notifications-num">Number of Notifications</a>
+</dt>
+<dt>7.1.2.  <a href="#rules-notifications-when">When to Generate Notifications</a>
+</dt>
+</dl>
+<dt>7.2.  <a href="#rules-subscriptions">Cancelling Subscriptions</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250894">1</a>] extension is commonly thought of as complicated. This is unfortunate, since it would be good to use it to broadcast personal state change events such as those described in <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2250700">2</a>].  [<a href="#nt-id2250884">3</a>] To make publish-subscribe functionality more accessible in the context of instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250741">4</a>], this document defines best practices that can be followed by instant messaging and presence client and server developers, hopefully resulting in the deployment of personal eventing protocol ("PEP") services across the Jabber IM network.</p>
+  <p class="" style=""><span style="font-style: italic">Note Well: This document describes all and only a subset of the full publish-subscribe protocol; any new features needed by PEP shall be defined in <span style="font-weight: bold">JEP-0060</span>, not in this document. Until the provisional changes to <span style="font-weight: bold">JEP-0060</span> required for PEP are approved by the Jabber Council, readers of this document are referred to the version-in-progress located at &lt;<a href="http://www.jabber.org/jeps/tmp/jep-0060-1.8.html">http://www.jabber.org/jeps/tmp/jep-0060-1.8.html</a>&gt;.</span></p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">The personal eventing protocol (PEP) is based on five principles:</p>
+  <ol start="1" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One node per namespace.</li>
+    <li>One publisher per node.</li>
+    <li>Smart defaults.</li>
+    <li>Use presence.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an instant messaging and presence account (or has an account provisioned) at a Jabber server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the account owner's personal pubsub nodes, since the root pubsub node simply <span style="font-style: italic">is</span> the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) for the owner-publisher. For example, there is one pubsub node for <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2259173">5</a>], one node for <span class="ref" style="">User Tune</span>  [<a href="#nt-id2259195">6</a>], one node for <span class="ref" style="">User Mood</span>  [<a href="#nt-id2259211">7</a>], and so on. This simplifies discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal eventing service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe service do not necessarily have access to presence information about subscribers, personal eventing services are closely integrated with presence, since each account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service and the recommended access models are "presence" and "roster" (both of which involve presence subscriptions in XMPP instant messaging and presence systems). This presence information can be used to make notifications more intelligent, thus simplifying the task of developing compliant clients (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2259294">8</a>]).</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports the personal eventing protocol, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259331">9</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep", MUST return a feature of "http://jabber.org/protocol/pubsub#pep", and MUST specify its default access model as described in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#default_access_model_presence'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">It is RECOMMENDED for a PEP-aware client to advertise its support for PEP only if the server to which it is connected also supports PEP. This is true both for Service Discovery and for the dynamic "profile" of Service Discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259438">10</a>].</p>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node (we use as our example a node to publish information about the user's current tune as specified in <span style="font-weight: bold">JEP-0118</span>).</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="1" type="">
+      <li>Because the account owner's server supports PEP, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/tune".</li>
+      <li>Following the principle of "smart defaults", the PEP service has a default access model of "presence" so that the &lt;create/&gt; element does not need to include an 'access' attribute.</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested.</li>
+    </ol>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">The value of the 'access' attribute SHOULD be "presence" or "roster" for PEP nodes but MAY be "open" (i.e., the value SHOULD NOT be "authorize" or "whitelist" since maintenance of such nodes requires interaction on the part of the node owner). The default access model for PEP nodes MUST be "presence" for IM servers but MAY be something other than "presence" for other PEP service types (e.g., non-IM servers).</p>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-roster-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure access='roster'&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the account owner desires an open access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 6. Account owner creates open access node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-open-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure access='open'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 7. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 8. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers (see the <a href="rules-notifications">Generating Notifications</a> section of this document regarding proper generation of the 'to' address):</p>
+    <p class="caption">Example 9. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The server MUST set the 'from' address on the notification to the bare JID (&lt;node@domain.tld&gt;) of the publishing entity (in this example, "juliet@capulet.com"). The server SHOULD include an <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2259676">11</a>] "replyto" extension specifying the publishing resource (in this example, "juliet@capulet.com/balcony"); this enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). However, any errors related to the notification MUST be directed to the JID of the 'from' address on the notification (i.e., the bare JID) so that bounce processing can be handled by the PEP service rather than by the publishing client.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="pub-last">Sending the Last Published Item</a>
+</h3>
+    <p class="" style="">As described in the <a href="rules-notifications">Generating Notifications</a> section of this document, a PEP service MUST send the last published item to all new subscribers. In addition, a PEP service MUST send the last published item to all newly-available resources for each subscriber. (Both of these behaviors essentially mimic the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.)</p>
+    <p class="caption">Example 10. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'/&gt;
+    </pre></div>
+    <p class="caption">Example 12. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is straightforward since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 13. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return a list of all pubsub nodes (as well as any other associated items as described in <span style="font-weight: bold">JEP-0030</span>):</p>
+    <p class="caption">Example 14. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (&lt;node@domain.tld&gt;) and specifies the desired node:</p>
+    <p class="caption">Example 15. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="1" type="">
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "open", the server SHOULD allow the entity to subscribe.</li>
+    </ol>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements in the foregoing scenarios is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the account owner to subscribe and to retrieve items.)</p>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error conditions related to subscription requests), the server shall allow the subscription and return an IQ-result:</p>
+    <p class="caption">Example 16. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/home'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">The service then MUST send the last published item to the new subscriber:</p>
+    <p class="caption">Example 17. Server sends last published item</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com' to='romeo@montague.net' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">The default access model for a PEP service MUST be "presence" (a PEP service SHOULD support the "roster" access model and MAY support the "open" access model).</p>
+  <p class="" style="">A PEP service SHOULD NOT support affiliations other than Owner and Subscriber.</p>
+  <p class="" style="">A PEP service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="1" type="">
+    <li>No item persistence (all nodes are transient).</li>
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No get-items.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">A PEP service MAY allow the owner-publisher's bare JID (&lt;node@domain.tld&gt;) to be a collection node, but MUST NOT support any other collection nodes.</p>
+  <p class="" style="">A PEP service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="rules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="rules-notifications">Generating Notifications</a>
+</h3>
+    <div class="indent">
+<h3>7.1.1 <a name="rules-notifications-num">Number of Notifications</a>
+</h3>
+      <ol start="1" type="">
+        <li><p class="" style="">If a subscriber subscribed using a full JID (&lt;node@domain.tld/resource&gt;), domain identifier (&lt;domain.tld&gt;), or domain plus resource (&lt;domain.tld/resource&gt;), a PEP service MUST send one notification only, addressed to the subscribed JID.</p></li>
+        <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service has presence information about the subscriber, the service MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources that have specified non-negative presence priority.</p></li>
+        <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service does not have presence information about the subscriber, it MUST send one notification only, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="rules-notifications-when">When to Generate Notifications</a>
+</h3>
+      <ol start="1" type="">
+        <li><p class="" style="">When an account owner publishes an item to a node, a PEP service MUST generate a notification and send it to all subscribers (where the number of notifications is determined by the foregoing rules).</p></li>
+        <li><p class="" style="">When a PEP service successfully processes a new subscription, it MUST generate a notification containing the last published item for that node and send it to the subscribing JID (where the number of notifications is determined by the foregoing rules).</p></li>
+        <li><p class="" style="">When a PEP service receives non-negative presence information from a subscriber's resource, it MUST generate a notification containing the last published item for that node and send it to the newly-available resource.</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MAY choose not to send notifications to a particular resource for a subscriber if it knows via <span style="font-weight: bold">Entity Capabilities</span> that the resource does not support PEP or does not support the payload namespace associated with a particular node.</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MUST NOT send notifications to a subscriber if the user has blocked the subscriber from receiving all or any kinds of stanza (presence, message, IQ, or any combination thereof) using privacy lists as specified in <span style="font-weight: bold">XMPP IM</span>.</p></li>
+    <li>Specify impact of privacy rule changes on logic for generating notifications and cancelling subscriptions.</li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="rules-subscriptions">Cancelling Subscriptions</a>
+</h3>
+    <p class="" style="">In order to ensure appropriate access to information published at nodes of type "presence" and "roster"", a PEP service MUST re-calculate access controls when:</p>
+    <ol start="1" type="">
+      <li>A presence subscription state changes (e.g., when a subscription request is approved).</li>
+      <li>A roster item is modified (e.g., when the item is moved to a new roster group).</li>
+    </ol>
+    <p class="" style="">If the modification results in a loss of access, the service MUST cancel the entity's subscription and SHOULD send a message to the (former) subscriber informing it of the cancellation. For information about the format of messages sent to notify subscribers of subscription cancellation, see the "Notification of Subscription Denial or Cancellation" section of <span style="font-weight: bold">JEP-0060</span>.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260357">12</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260405">13</a>] shall include 'http://jabber.org/protocol/pubsub#pep' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;); as a result of this JEP, the Registrar shall add a type of "pep" to that category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the Personal Eventing Protocol is all and only a subset of Publish-Subscribe, the schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to PEP as well.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250894">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250700">2</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2250884">3</a>. Currently, many "extended presence" formats are sent using the &lt;presence/&gt; stanza type; however, this overloads presence, results in unnecessary presence traffic, and does not provide fine-grained control over access. The use of publish-subscribe rather than presence is therefore preferable.</p>
+<p><a name="nt-id2250741">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2259173">5</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2259195">6</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2259211">7</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2259294">8</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2259331">9</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259438">10</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2259676">11</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2260357">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260405">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Specified that notifications are to be sent from bare JID, not full JID.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect pubsub changes; clarified business rules for generation of notifications and cancellation of subscriptions.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0163-0.9.html
+++ b/content/xep-0163-0.9.html
@@ -1,0 +1,598 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0163: Personal Eventing via Pubsub</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Personal Eventing via Pubsub">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Kevin Smith">
+<meta name="DC.Description" content="This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with an XMPP account or user.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-06-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0163">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0163: Personal Eventing via Pubsub</h1>
+<p>This document specifies a simple subset of the publish-subscribe protocol for use in broadcasting state change events associated with an XMPP account or user.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0163<br>
+            Version: 0.9<br>
+            Last Updated: 2006-06-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0060<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pep<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Personal%20Eventing%20via%20Pubsub%20(JEP-0163)">http://wiki.jabber.org/index.php/Personal Eventing via Pubsub (JEP-0163)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Kevin Smith</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:kevin@kismith.co.uk">kevin@kismith.co.uk</a><br>
+        JID: 
+        <a href="xmpp:kevdadrum@jabber.ex.ac.uk">kevdadrum@jabber.ex.ac.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#approach">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#approach-everyjid">Every Account a Pubsub Service</a>
+</dt>
+<dt>2.2.  <a href="#approach-onenode">One Node Per Namespace</a>
+</dt>
+<dt>2.3.  <a href="#approach-publisher">One Publisher Per Node</a>
+</dt>
+<dt>2.4.  <a href="#approach-defaults">Smart Defaults</a>
+</dt>
+<dt>2.5.  <a href="#approach-presence">Use Presence</a>
+</dt>
+</dl>
+<dt>3.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>4.  <a href="#publisher">Publisher Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#pub-create">Creating a Node</a>
+</dt>
+<dt>4.2.  <a href="#pub-item">Publishing an Item</a>
+</dt>
+<dt>4.3.  <a href="#pub-last">Sending the Last Published Item</a>
+</dt>
+</dl>
+<dt>5.  <a href="#sub">Subscriber Use Cases</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#sub-disco">Discovering Nodes</a>
+</dt>
+<dt>5.2.  <a href="#sub-sub">Subscribing to a Node</a>
+</dt>
+</dl>
+<dt>6.  <a href="#defaults">Recommended Defaults</a>
+</dt>
+<dt>7.  <a href="#rules">Business Rules</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#rules-notifications">Generating Notifications</a>
+</dt>
+<dl>
+<dt>7.1.1.  <a href="#rules-notifications-num">Number of Notifications</a>
+</dt>
+<dt>7.1.2.  <a href="#rules-notifications-when">When to Generate Notifications</a>
+</dt>
+</dl>
+<dt>7.2.  <a href="#rules-subscriptions">Cancelling Subscriptions</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-disco">Service Discovery Category/Type</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The XMPP <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250900">1</a>] extension ("pubsub") can be used to broadcast state change events associated with a Jabber/XMPP account or user, such as those described in <span class="ref" style="">Extended Presence Protocol Suite</span>  [<a href="#nt-id2250922">2</a>].  [<a href="#nt-id2250890">3</a>] However, the full, generic pubsub protocol is thought of as complicated and therefore has not been widely implemented in clients. To make publish-subscribe functionality more accessible (especially to instant messaging and presence applications that conform to <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250959">4</a>]), this document defines best practices that can be followed by client and server developers, hopefully resulting in the deployment of personal eventing services across the Jabber/XMPP network.</p>
+<h2>2.
+       <a name="approach">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Personal eventing via pubsub ("PEP") is based on five principles:</p>
+  <ol start="1" type="">
+    <li>Every account a pubsub service.</li>
+    <li>One node per namespace.</li>
+    <li>One publisher per node.</li>
+    <li>Smart defaults.</li>
+    <li>Use presence.</li>
+  </ol>
+  <p class="" style="">These principles are described more fully below.</p>
+  <div class="indent">
+<h3>2.1 <a name="approach-everyjid">Every Account a Pubsub Service</a>
+</h3>
+    <p class="" style="">When a user creates an account (or has an account provisioned) at a Jabber/XMPP server, that account should have associated with it a virtual pubsub service. This greatly simplifies the task of discovering the account owner's personal pubsub nodes, since the root pubsub node simply <span style="font-style: italic">is</span> the account owner's bare JID (&lt;node@domain.tld&gt;). This assumption also simplifies publishing and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="approach-onenode">One Node Per Namespace</a>
+</h3>
+    <p class="" style="">To further simplify matters, we assume that there is only one publish-subscribe node associated with any given payload type (XML namespace) for the owner-publisher. For example, there is one pubsub node for <span class="ref" style="">User Geolocation</span>  [<a href="#nt-id2259433">5</a>], one node for <span class="ref" style="">User Tune</span>  [<a href="#nt-id2259456">6</a>], one node for <span class="ref" style="">User Mood</span>  [<a href="#nt-id2259478">7</a>], and so on. This simplifies discovery, publishing, and subscribing.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="approach-publisher">One Publisher Per Node</a>
+</h3>
+    <p class="" style="">There is no need for multiple publishers to a personal eventing service, since by definition the service generates information associated with only one entity. The owner-publisher for every node is the bare JID of the account owner.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="approach-defaults">Smart Defaults</a>
+</h3>
+    <p class="" style="">Most pubsub configuration options and metadata are not needed for personal eventing. Instead, servers should offer smart defaults to simplify node creation and management.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="approach-presence">Use Presence</a>
+</h3>
+    <p class="" style="">Although generic publish-subscribe service do not necessarily have access to presence information about subscribers, personal eventing services are closely integrated with presence, since each account simply <span style="font-style: italic">is</span> a virtual publish-subscribe service and the recommended access models are "presence" and "roster" (both of which involve presence subscriptions in XMPP instant messaging and presence systems). This presence information can be used to make notifications more intelligent, thus simplifying the task of developing compliant clients (see <span class="ref" style="">Protocol Design Guidelines</span>  [<a href="#nt-id2259548">8</a>]).</p>
+  </div>
+<h2>3.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports PEP, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259602">9</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If a server supports PEP, it MUST return an identity of "pubsub/pep", MUST return a feature of "http://jabber.org/protocol/pubsub#pep", and MUST specify its default access model as described in <span style="font-weight: bold">JEP-0060</span>.</p>
+  <p class="caption">Example 2. Server communicates protocol support</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    &lt;identity category='pubsub' type='pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#pep'/&gt;
+    &lt;feature var='http://jabber.org/protocol/pubsub#default_access_model_presence'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">It is RECOMMENDED for a PEP-aware client to advertise its support for PEP only if the server to which it is connected also supports PEP. This is true both for Service Discovery and for the dynamic "profile" of Service Discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259667">10</a>].</p>
+<h2>4.
+       <a name="publisher">Publisher Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="pub-create">Creating a Node</a>
+</h3>
+    <p class="" style="">First, the account owner creates the node. (We use as our example a node to publish information about the user's current tune as specified in <span style="font-weight: bold">JEP-0118</span>.)</p>
+    <p class="caption">Example 3. Account owner creates node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/tune'/&gt;
+    &lt;configure&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">There are several things to note about this node creation request:</p>
+    <ol start="1" type="">
+      <li>Because the account owner's server supports PEP, no 'to' address is needed.</li>
+      <li>Following the principle of "one node per namespace", the node name is "http://jabber.org/protocol/tune".</li>
+      <li>Following the principle of "smart defaults", the creation request contains an empty &lt;configure/&gt; child to denote that default node configuration is requested (including the default access model of "presence as advertised via service discovery).</li>
+    </ol>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 4. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='create1'/&gt;
+    </pre></div>
+    <p class="" style="">In order to request an access model other than the default, the account owner MUST include a data form (see <span class="ref" style="">Data Forms</span>  [<a href="#nt-id2259792">11</a>]) that contains a node configuration field of "pubsub#access_model" set to a value of "presence", "roster", or "open" (the value MAY be "authorize" or "whitelist" but these values are NOT RECOMMENDED for PEP nodes since maintenance of such nodes requires interaction on the part of the node owner).</p>
+    <p class="" style="">If the account owner desires a roster access model for a node, it MUST specify that in the creation request:</p>
+    <p class="caption">Example 5. Account owner creates roster access node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create-roster-1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/geoloc'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="pub-item">Publishing an Item</a>
+</h3>
+    <p class="" style="">Next, the account owner publishes an item to the node.</p>
+    <p class="caption">Example 6. Account owner publishes item</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error scenarios), the server acknowledges success.</p>
+    <p class="caption">Example 7. Server returns result</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' type='result' id='pub1'/&gt;
+    </pre></div>
+    <p class="" style="">The notification (with payload) is then delivered to all subscribers (see the <a href="#rules-notifications">Generating Notifications</a> section of this document regarding proper generation of the 'to' address):</p>
+    <p class="caption">Example 8. Server generates notifications</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/home'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The server MUST set the 'from' address on the notification to the bare JID (&lt;node@domain.tld&gt;) of the publishing entity (in this example, "juliet@capulet.com"). The server SHOULD include an <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2259944">12</a>] "replyto" extension specifying the publishing resource (in this example, "juliet@capulet.com/balcony"); this enables the subscriber's client to differentiate between information received from each of an account owner's resources (for example, different resources may be in different places and therefore may need to specify distinct geolocation data). However, any errors related to the notification MUST be directed to the JID of the 'from' address on the notification (i.e., the bare JID) so that bounce processing can be handled by the PEP service rather than by the publishing client.</p>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="pub-last">Sending the Last Published Item</a>
+</h3>
+    <p class="" style="">As described in the <a href="#rules-notifications">Generating Notifications</a> section of this document, a PEP service MUST send the last published item to all new subscribers. In addition, a PEP service MUST send the last published item to all newly-available resources for each subscriber. (Both of these behaviors essentially mimic the functionality of presence as defined in <span style="font-weight: bold">XMPP IM</span>.)</p>
+    <p class="caption">Example 9. Subscriber sends presence from newly-available resource</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard'/&gt;
+    </pre></div>
+    <p class="caption">Example 10. Subscriber's server sends presence from newly-available resource to publisher's bare JID (i.e., PEP service)</p>
+<div class="indent"><pre>
+&lt;presence from='romeo@montague.net/orchard' to='juliet@capulet.com'/&gt;
+    </pre></div>
+    <p class="caption">Example 11. PEP service sends last published item to newly-available resource</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com'
+         to='romeo@montague.net/orchard'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="sub">Subscriber Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="sub-disco">Discovering Nodes</a>
+</h3>
+    <p class="" style="">Node discovery is straightforward since there is only one node per namespace. The potential subscriber may send a service discovery items request to the bare JID to discover all active pubsub nodes.</p>
+    <p class="caption">Example 12. Subscriber queries bare JID</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='disco1' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Subject to access restrictions as described in <span style="font-weight: bold">JEP-0030</span>, the account owner's server would then return a list of all pubsub nodes (as well as any other associated items as described in <span style="font-weight: bold">JEP-0030</span>):</p>
+    <p class="caption">Example 13. Servers returns list of pubsub nodes</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' to='romeo@montague.net/home' from='juliet@capulet.com'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/tune'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/activity'/&gt;
+    &lt;item jid='juliet@capulet.com' node='http://jabber.org/protocol/geolocation'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="sub-sub">Subscribing to a Node</a>
+</h3>
+    <p class="" style="">In order to subscribe, a contact sends a subscription request to the account owner's bare JID (&lt;node@domain.tld&gt;) and specifies the desired node:</p>
+    <p class="caption">Example 14. Contact subscribes to a node</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='romeo@montague.net/home'
+    to='juliet@capulet.com'
+    id='sub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;subscribe node='http://jabber.org/protocol/tune' jid='romeo@montague.net'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The following scenarios are possible:</p>
+    <ol start="1" type="">
+      <li>If the access model is "presence", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "roster", the server MUST verify that the full JID of the 'from' address (or the bare JID portion of the full JID) has a presence subscription of type "both" or "from" in the account owner's roster and is in the specified roster group. If so, the server SHOULD allow the entity to subscribe; if not, the server MUST disallow the subscription request.</li> 
+      <li>If the access model is "open", the server SHOULD allow the entity to subscribe.</li>
+    </ol>
+    <p class="" style="">The only exception foreseen to the SHOULD requirements in the foregoing scenarios is the enforcement of local privacy and security policies as specified more fully in the <a href="#security">Security Considerations</a> section of this document. (In addition, a service MUST always allow the account owner to subscribe and to retrieve items.)</p>
+    <p class="" style="">If no error occurs (see <span style="font-weight: bold">JEP-0060</span> for error conditions related to subscription requests), the server shall allow the subscription and return an IQ-result:</p>
+    <p class="caption">Example 15. Server allows subscription</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='juliet@capulet.com'
+    to='romeo@montague.net/home'
+    id='sub1'/&gt;
+    </pre></div>
+    <p class="" style="">The service then MUST send the last published item to the new subscriber:</p>
+    <p class="caption">Example 16. Server sends last published item</p>
+<div class="indent"><pre>
+&lt;message from='juliet@capulet.com' to='romeo@montague.net' type='headline' id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/tune'&gt;
+      &lt;item&gt;
+        &lt;tune xmlns='http://jabber.org/protocol/tune'&gt;
+          &lt;artist&gt;Gerald Finzi&lt;/artist&gt;
+          &lt;title&gt;Introduction (Allegro vigoroso)&lt;/title&gt;
+          &lt;source&gt;Music for "Love's Labors Lost" (Suite for small orchestra)&lt;/source&gt;
+          &lt;track&gt;1&lt;/track&gt;
+          &lt;length&gt;255&lt;/length&gt;
+        &lt;/tune&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;x xmlns='jabber:x:delay' stamp='20031213T23:58:37'/&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="defaults">Recommended Defaults</a>
+</h2>
+  <p class="" style="">The default access model for a PEP service SHOULD be "presence" for IM servers and SHOULD be "open" for non-IM servers (a PEP service associated with an IM server SHOULD also support the "roster" access model).</p>
+  <p class="" style="">A PEP service SHOULD NOT support affiliations other than Owner and Subscriber.</p>
+  <p class="" style="">A PEP service SHOULD use the following "smart defaults" for every node:</p>
+  <ol start="1" type="">
+    <li>No item persistence (all nodes are transient).</li>
+    <li>Deliver payloads (no notification-only nodes).</li>
+    <li>No delete-items.</li>
+    <li>No get-affiliations.</li>
+    <li>No get-items.</li>
+    <li>No purge-items.</li>
+    <li>No node configuration.</li>
+    <li>No node metadata.</li>
+    <li>No configuration of subscription options.</li>
+    <li>No subscription IDs.</li>
+  </ol>
+  <p class="" style="">A PEP service SHOULD treat the owner-publisher's bare JID (&lt;node@domain.tld&gt;) as a collection node, but SHOULD NOT support any other collection nodes.</p>
+  <p class="" style="">A PEP service SHOULD NOT support instant nodes, since the "one node per namespace" rule makes instant nodes unnecessary.</p>
+<h2>7.
+       <a name="rules">Business Rules</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="rules-notifications">Generating Notifications</a>
+</h3>
+    <div class="indent">
+<h3>7.1.1 <a name="rules-notifications-num">Number of Notifications</a>
+</h3>
+      <ol start="1" type="">
+        <li><p class="" style="">If a subscriber subscribed using a full JID (&lt;node@domain.tld/resource&gt;), domain identifier (&lt;domain.tld&gt;), or domain plus resource (&lt;domain.tld/resource&gt;), a PEP service MUST send one notification only, addressed to the subscribed JID.</p></li>
+        <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service has presence information about the subscriber, the service MUST send one notification to the full JID (&lt;node@domain.tld/resource&gt;) of each of the subscriber's available resources that have specified non-negative presence priority.</p></li>
+        <li><p class="" style="">If a subscriber subscribed using a bare JID (&lt;node@domain.tld&gt;) and a PEP service does not have presence information about the subscriber, it MUST send one notification only, addressed to the bare JID (&lt;node@domain.tld&gt;) of the subscriber.</p></li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>7.1.2 <a name="rules-notifications-when">When to Generate Notifications</a>
+</h3>
+      <ol start="1" type="">
+        <li><p class="" style="">When an account owner publishes an item to a node, a PEP service MUST generate a notification and send it to all subscribers (where the number of notifications is determined by the foregoing rules).</p></li>
+        <li><p class="" style="">When a PEP service successfully processes a new subscription, it MUST generate a notification containing the last published item for that node and send it to the subscribing JID (where the number of notifications is determined by the foregoing rules).</p></li>
+        <li><p class="" style="">When a PEP service receives non-negative presence information from a subscriber's resource, it MUST generate a notification containing the last published item for that node and send it to the newly-available resource.</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MAY choose not to send notifications to a particular resource for a subscriber if it knows via <span style="font-weight: bold">Entity Capabilities</span> that the resource does not support PEP or does not support the payload namespace associated with a particular node.</p></li>
+        <li><p class="" style="">As an exception to the foregoing MUST rules, a PEP service MUST NOT send notifications to a subscriber if the user has blocked the subscriber from receiving all or any kinds of stanza (presence, message, IQ, or any combination thereof) using privacy lists as specified in <span style="font-weight: bold">XMPP IM</span>.</p></li>
+    <li>Specify impact of privacy rule changes on logic for generating notifications and cancelling subscriptions.</li>
+      </ol>
+    </div>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="rules-subscriptions">Cancelling Subscriptions</a>
+</h3>
+    <p class="" style="">In order to ensure appropriate access to information published at nodes of type "presence" and "roster"", a PEP service MUST re-calculate access controls when:</p>
+    <ol start="1" type="">
+      <li>A presence subscription state changes (e.g., when a subscription request is approved).</li>
+      <li>A roster item is modified (e.g., when the item is moved to a new roster group).</li>
+    </ol>
+    <p class="" style="">If the modification results in a loss of access, the service MUST cancel the entity's subscription and SHOULD send a message to the (former) subscriber informing it of the cancellation. For information about the format of messages sent to notify subscribers of subscription cancellation, see the "Notification of Subscription Denial or Cancellation" section of <span style="font-weight: bold">JEP-0060</span>.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A PEP service MAY enforce additional privacy and security policies when determining whether an entity is allowed to subscribe to a node or retrieve items from a node; however, any such policies shall be considered specific to an implementation or deployment and are out of scope for this document.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260754">13</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260802">14</a>] shall include 'http://jabber.org/protocol/pubsub#pep' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-disco">Service Discovery Category/Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar includes a category of "pubsub" in its registry of Service Discovery identities (see &lt;<a href="http://www.jabber.org/registrar/disco-features.html">http://www.jabber.org/registrar/disco-features.html</a>&gt;); as a result of this JEP, the Registrar shall add a type of "pep" to that category.</p>
+    <p class="" style="">The registry submission is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;category&gt;
+  &lt;name&gt;pubsub&lt;/name&gt;
+  &lt;type&gt;
+    &lt;name&gt;pep&lt;/name&gt;
+    &lt;desc&gt;
+      A personal eventing service that supports the 
+      publish-subscribe subset defined in JEP-0163.
+    &lt;/desc&gt;
+    &lt;doc&gt;JEP-0163&lt;/doc&gt;
+  &lt;/type&gt;
+&lt;/category&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="" style="">Because the Personal Eventing Protocol is all and only a subset of Publish-Subscribe, the schemas defined in <span style="font-weight: bold">JEP-0060</span> apply to PEP as well.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250900">1</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250922">2</a>. JEP-0119: Extended Presence Protocol Suite &lt;<a href="http://www.jabber.org/jeps/jep-0119.html">http://www.jabber.org/jeps/jep-0119.html</a>&gt;.</p>
+<p><a name="nt-id2250890">3</a>. Currently, many "extended presence" formats are sent using the &lt;presence/&gt; stanza type; however, this overloads presence, results in unnecessary presence traffic, and does not provide fine-grained control over access. The use of publish-subscribe rather than presence is therefore preferable.</p>
+<p><a name="nt-id2250959">4</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2259433">5</a>. JEP-0080: User Geolocation &lt;<a href="http://www.jabber.org/jeps/jep-0080.html">http://www.jabber.org/jeps/jep-0080.html</a>&gt;.</p>
+<p><a name="nt-id2259456">6</a>. JEP-0118: User Tune &lt;<a href="http://www.jabber.org/jeps/jep-0118.html">http://www.jabber.org/jeps/jep-0118.html</a>&gt;.</p>
+<p><a name="nt-id2259478">7</a>. JEP-0107: User Mood &lt;<a href="http://www.jabber.org/jeps/jep-0107.html">http://www.jabber.org/jeps/jep-0107.html</a>&gt;.</p>
+<p><a name="nt-id2259548">8</a>. JEP-0134: Protocol Design Guidelines &lt;<a href="http://www.jabber.org/jeps/jep-0134.html">http://www.jabber.org/jeps/jep-0134.html</a>&gt;.</p>
+<p><a name="nt-id2259602">9</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259667">10</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2259792">11</a>. JEP-0004: Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0004.html">http://www.jabber.org/jeps/jep-0004.html</a>&gt;.</p>
+<p><a name="nt-id2259944">12</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2260754">13</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260802">14</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2006-06-15)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect use of data forms in JEP-0060.</p> (psa)
+    </div>
+<h4>Version 0.8 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology and defaults.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Specified that notifications are to be sent from bare JID, not full JID.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-04-10)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect pubsub changes; clarified business rules for generation of notifications and cancellation of subscriptions.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Modified roster groups example to use jabber:x:data; added note about advertising client support for PEP.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-02-02)</h4>
+<div class="indent">
+<p class="" style="">Specified rules for generation of notifications, including use of presence in determining address of intended recipient for notifications and sending of last published item on receipt of presence information; changed name to Personal Eventing Protocol; specified service discovery identity of pubsub/pep; removed section on service types; added Kevin Smith as co-author.</p> (psa/ks)
+    </div>
+<h4>Version 0.3 (2006-01-30)</h4>
+<div class="indent">
+<p class="" style="">Specified that a service may enforce additional privacy and security policies; specified that an account owner must always be allowed to subscribe and to retrieve items; specified that an implementation should enforce access modifications resulting from roster state changes.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-01-11)</h4>
+<div class="indent">
+<p class="" style="">Updated to reflect proposed JEP-0060 modifications.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-11-02)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-25)</h4>
+<div class="indent">
+<p class="" style="">Added more details and examples.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0165-0.2.html
+++ b/content/xep-0165-0.2.html
@@ -1,0 +1,230 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0165: Prevention of JID Spoofing</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Prevention of JID Spoofing">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document recommends best practices to prevent the spoofing of Jabber IDs.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-11-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0165">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0165: Prevention of JID Spoofing</h1>
+<p>This document recommends best practices to prevent the spoofing of Jabber IDs.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0165<br>
+            Version: 0.1<br>
+            Last Updated: 2005-11-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Prevention%20of%20JID%20Spoofing%20(JEP-0165)">http://wiki.jabber.org/index.php/Prevention of JID Spoofing (JEP-0165)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#rec">Recommendations</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#rec-jids">Presentation of JIDs</a>
+</dt>
+<dt>2.2.  <a href="#rec-petname">The Jabber Roster as a Petname System</a>
+</dt>
+<dt>2.3.  <a href="#rec-secure">Further Securing the Petname System</a>
+</dt>
+<dt>2.4.  <a href="#rec-subscriptions">Subscription Requests</a>
+</dt>
+<dt>2.5.  <a href="#rec-referrals">Referrals</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There are two forms of address spoofing: forging and mimicking. In the context of Jabber technologies, an address is <span style="font-style: italic">forged</span> when a entity is able to generate an XML stanza whose 'from' address does not correspond to the account credentials with which the entity authenticated onto the network -- for example, if an entity authenticated as "stpeter@jabber.org" but is able to send XML stanzas from "MaineBoy@jabber.org" or "peter@saint-andre.com". An address is <span style="font-style: italic">mimicked</span> when an entity provides legitimate authentication credentials for and sends XML stanzas from an account whose Jabber ID (JID) appears to a human user to be the same as another JID -- for example, in some clients "paypa1@jabber.org" (spelled with the number one as the final character of the node identifier) may appear to be the same as "paypal@jabber.org (spelled with the lower-case version of the letter "L"). A more sophisticated example (which may not render correctly in all browsers) is the following:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+ᏚᎢᎵᎬᎢᎬᏒ@ᎫᎪᏴᏴᎬᏒ.org
+  </pre></div>
+  <p class="" style="">That JID is not an uppercase version of "stpeter@jabber.org" in US-ASCII characters, but a fake JID made up mostly of Cherokee characters, namely:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>U+13DA U+13A2 U+13B5 U+13AC U+13A2 U+13AC U+13D2 @ U+13AB U+13AA U+13F4 U+13F4 U+13AC U+13D2 .org</pre></div>
+  <p class="" style="">In this example, it is unlikely that the average user could tell the difference between the real JID and the fake JID.  [<a href="#nt-id2250624">1</a>]</p>
+  <p class="" style="">Traditionally, forging of JIDs has been very difficult in Jabber/XMPP systems given the requirement for servers to stamp 'from' addresses and for servers to verify sending domains via server dialback or server-to-server authentication (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250663">2</a>]). However, it may be relatively easy to mimic (some) JIDs in Jabber/XMPP systems, especially because JIDs can contain almost any Unicode character. The possibility of address mimicking introduces security vulnerabilities of the kind that have also plagued the World Wide Web, specifically the phenomenon known as phishing.  [<a href="#nt-id2250650">3</a>]</p>
+  <p class="" style="">To combat those vulnerabilities, this document recommends a set of best practices to minimize the potential impact of address mimicking on the Jabber/XMPP network.  [<a href="#nt-id2250699">4</a>]</p>
+<h2>2.
+       <a name="rec">Recommendations</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="rec-jids">Presentation of JIDs</a>
+</h3>
+    <p class="" style="">Every human user of Jabber/XMPP technologies presumably has a preferred language (or, in some cases, a small set of preferred languages), which an XMPP application SHOULD gather either explicitly from the user or implicitly via the user's operating system. Furthermore, every language has a range of characters normally used to represent that language in textual form. Therefore, an XMPP application SHOULD warn the user when presenting a JID that uses characters outside the normal range of the user's preferred language(s).  [<a href="#nt-id2250735">5</a>]</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="rec-petname">The Jabber Roster as a Petname System</a>
+</h3>
+    <p class="" style="">As explained in <span class="ref" style="">Introduction to Petname Systems</span>  [<a href="#nt-id2250803">6</a>], no one naming or address scheme can provide names that are simultaneously global, memorable, and securely unique. However, certain <span style="font-style: italic">combinations</span> of names and addresses can provide all three properties, and such combinations are commonly called "petname systems". Consider the following combination of names:</p>
+    <ol start="" type="">
+      <li>The JID "stpeter@jabber.org" is globally unique on the Jabber network, but it is not necessarily memorable.</li>
+      <li>The nickname "psa" (asserted by the user associated with the address "stpeter@jabber.org") is memorable but it is neither unique nor global.</li>
+      <li>The alias or petname "that JSF dude" (assigned by a contact who adds "stpeter@jabber.org" to her contact list) is memorable and securely unique but by no means global since it has meaning only to the person who assigns it.</li>
+    </ol>
+    <p class="" style="">A client SHOULD require an end user to assign a petname for every contact added to the person's roster, which SHOULD be stored as the value of the &lt;item/&gt; element's 'name' attribute qualified by the 'jabber:iq:roster' namespace. A client SHOULD then present that petname instead of or in addition to the contact's JID or nickname (e.g., in the user's roster and in chat interfaces). This will help to prevent mimicked addresses from being presented as equivalent to the address that is being mimicked.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="rec-secure">Further Securing the Petname System</a>
+</h3>
+     <p class="" style="">Although a Jabber ID can be considered globally unique, the petname system in which it is embedded can be strengthened by associating that JID with a key or certificate that can be used for signing and encryption (such as a PGP key or X.509 certificate), preferably a key or certificate that encapsulates the associated XMPP address (e.g., as described in Section 5.1.1 of <span style="font-weight: bold">RFC 3920</span>). A client SHOULD associate a key or certificate with the user of that client, and SHOULD generate such a key or certificate if the user does not have one.</p>
+     <p class="" style="">Unfortunately, keys, certificates, and fingerprints are even less memorable than JIDs, which makes the specification of a petname or alias even more important. Therefore, a client SHOULD keep track of the keys or certificates associated with the contacts in a user's roster in order to further strengthen the petname system.</p>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="rec-subscriptions">Subscription Requests</a>
+</h3>
+    <p class="" style="">We have seen that, at a minimum, three name or address types are needed to provide a petname system: a JID, a nickname, and an alias (preferably strengthened by inclusion of a key or certificate). However, at present a subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 1. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='stpeter@jabber.org to='MaineBoy@jabber.org' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID, it is possible to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2250933">7</a>] node, or future profile system. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender, encapsulated via the <span class="ref" style="">Profile Data Representation</span>  [<a href="#nt-id2250957">8</a>] format:  [<a href="#nt-id2250942">9</a>]</p>
+    <p class="caption">Example 2. Subscription Request With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='stpeter@jabber.org to='MaineBoy@jabber.org' type='subscribe'&gt;
+  &lt;x xmlns='jabber:x:data' type='submit'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profiledata&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;psa&lt;/value&gt;&lt;/field&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">In addition, the subscription request SHOULD also include the fingerprint of a key or certificate associated with the sender (encapsulated via the fingerprint protocol described below):</p>
+    <p class="caption">Example 3. Subscription Request With Nickname and Fingerprint</p>
+<div class="indent"><pre>
+&lt;presence from='stpeter@jabber.org to='MaineBoy@jabber.org' type='subscribe'&gt;
+  &lt;x xmlns='jabber:x:data' type='submit'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profiledata&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;psa&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='x509_fingerprint_sha1'&gt;
+      &lt;value&gt;C3 88 33 27 F3 47 3B 8B 07 71 3E 96 44 A7 EE E2 E0 50 4A 5B&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">The key or certificate SHOULD include the user's XMPP address, e.g. as described in Section 5.1.1 of <span style="font-weight: bold">RFC 3920</span>.</p>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="rec-referrals">Referrals</a>
+</h3>
+    <p class="" style="">In order to strengthen the web of interaction and trust between Jabber/XMPP users, it is helpful for them to share roster items. In particular, when a user wants to subscribe to the presence of a potential contact, the user SHOULD seek a referral from a third person who knows both the user and the contact. Such a referral consists of a roster item sent from the third person to the potential contact, encapsulated using the <span class="ref" style="">Roster Item Exchange</span>  [<a href="#nt-id2256380">10</a>] protocol:</p>
+    <p class="caption">Example 4. A Basic Referral</p>
+<div class="indent"><pre>
+&lt;message from='peter@saint-andre.com' to='MaineBoy@jabber.org'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt;
+    &lt;item jid='stpeter@jabber.org' name='Peter Saint-Andre'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Here, the 'name' attribute encapsulates what in petname systems is known as an "alleged name", that is, the name for an entity proposed by a third party.</p>
+    <p class="" style="">Such a referral SHOULD also include the nick and fingerprint of the user as understood by the third person:</p>
+    <p class="caption">Example 5. Referral With Nickname and Fingerprint</p>
+<div class="indent"><pre>
+&lt;message from='peter@saint-andre.com' to='MaineBoy@jabber.org'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/rosterx'&gt;
+    &lt;item jid='stpeter@jabber.org' name='Peter Saint-Andre'/&gt;
+  &lt;/x&gt;
+  &lt;x xmlns='jabber:x:data' type='submit'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profiledata&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;psa&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='x509_fingerprint_sha1'&gt;
+      &lt;value&gt;C3 88 33 27 F3 47 3B 8B 07 71 3E 96 44 A7 EE E2 E0 50 4A 5B&lt;/value&gt;
+    &lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Here again, when a Jabber/XMPP client receives a referral, it SHOULD warn the contact if the JID uses characters outside the normal range of the contact's preferred language(s).</p>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This entire document addresses security considerations.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256528">11</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256507">12</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250624">1</a>. Naturally, there is no way to distinguish with full certainty which is the fake JID and which is the real JID. For example, in some communication contexts, the Cherokee JID may be the real JID and the US-ASCII JID may thus appear to be the fake JID.</p>
+<p><a name="nt-id2250663">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250650">3</a>. Phishing has been defined as "a broadly launched social engineering attack in which an electronic identity is misrepresented in an attempt to trick individuals into revealing personal credentials that can be used fraudulently against them" (see <a href="http://fstc.org/projects/counter-phishing-phase-1/">Financial Services Technology Consortium Counter-Phishing Initiative: Phase I</a>). To be precise, the current document (1) does not assume that such attacks will be broadly launched and (2) focuses on the misrepresentation only of Jabber IDs within the context of Jabber/XMPP systems.</p>
+<p><a name="nt-id2250699">4</a>. This document does not cover handling of non-XMPP addresses, for example HTTP URLs. Jabber/XMPP clients SHOULD handle such addresses in accordance with best practices for the relevant non-XMPP technology.</p>
+<p><a name="nt-id2250735">5</a>. This recommendation is not intended to discourage communication across language communities; instead, it simply recognizes the existence of such language communities and encourages due caution when presenting unfamiliar character sets to human users.</p>
+<p><a name="nt-id2250803">6</a>. Introduction to Petname Systems &lt;<a href="http://www.skyhunter.com/marcs/petnames/IntroPetNames.html">http://www.skyhunter.com/marcs/petnames/IntroPetNames.html</a>&gt;.</p>
+<p><a name="nt-id2250933">7</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2250957">8</a>. JEP-0154: Profile Data Representation &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2250942">9</a>. While it could be argued that a less verbose format would be preferable (e.g., a specialized XML format), presence subscription requests are infrequent enough that the slightly more verbose format of Profile Data Representation is acceptable in this context.</p>
+<p><a name="nt-id2256380">10</a>. JEP-0144: Roster Item Exchange &lt;<a href="http://www.jabber.org/jeps/jep-0144.html">http://www.jabber.org/jeps/jep-0144.html</a>&gt;.</p>
+<p><a name="nt-id2256528">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256507">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-11-16)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-11-14)</h4>
+<div class="indent">Further defined petname practices; specified how to include nicknames and fingerprints. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-28)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.1.html
+++ b/content/xep-0166-0.1.html
@@ -1,0 +1,1196 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle Signalling</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle Signalling">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines signalling methods for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle Signalling</h1>
+<p>This document defines signalling methods for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0166<br>
+            Version: 0.1<br>
+            Last Updated: 2005-12-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20Signalling%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle Signalling (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email: scottlu@google.com<br>
+        JID: scottlu@google.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email: jbeda@google.com<br>
+        JID: jbeda@google.com</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>4.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts-state">Session Management State Machine</a>
+</dt>
+<dt>4.2.  <a href="#concepts-desc">Session Descriptions</a>
+</dt>
+</dl>
+<dt>5.  <a href="#explain">Explanatory Example: Basic One-to-One Signalling</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#explain-resource">Resource Determination (Example)</a>
+</dt>
+<dt>5.2.  <a href="#explain-initiate">Initiation (Example)</a>
+</dt>
+<dt>5.3.  <a href="#explain-negotiate">Negotiation (Example)</a>
+</dt>
+<dt>5.4.  <a href="#explain-accept">Acceptance (Example)</a>
+</dt>
+<dt>5.5.  <a href="#explain-term">Termination (Example)</a>
+</dt>
+</dl>
+<dt>6.  <a href="#protocol">Protocol Description</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>6.2.  <a href="#protocol-actions">Required and Optional Actions</a>
+</dt>
+<dt>6.3.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>6.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>6.5.  <a href="#protocol-negotiate">Negotiation</a>
+</dt>
+<dl>
+<dt>6.5.1.  <a href="#protocol-negotiate-candidate">Candidate Format</a>
+</dt>
+<dt>6.5.2.  <a href="#protocol-negotiate-modes">Negotiation Modes</a>
+</dt>
+<dl>
+<dt>6.5.2.1.  <a href="#protocol-negotiate-modes-dribble">Dribble Mode</a>
+</dt>
+<dt>6.5.2.2.  <a href="#protocol-negotiate-modes-burst">Burst Mode</a>
+</dt>
+</dl>
+<dt>6.5.3.  <a href="#protocol-negotiate-check">Checking Connectivity</a>
+</dt>
+</dl>
+<dt>6.6.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>6.7.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>6.8.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>7.  <a href="#errors">Error Handling</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#errors-initiate">Initiation-Related Error Conditions</a>
+</dt>
+<dt>7.2.  <a href="#errors-other">Other Error Conditions</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-features">Service Discovery Features</a>
+</dt>
+<dt>10.3.  <a href="#registrar-jingle">Jingle Session Types Registry</a>
+</dt>
+<dl><dt>10.3.1.  <a href="#registrar-jingle-process">Registration Process</a>
+</dt></dl>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-signalling">Signalling</a>
+</dt>
+<dt>11.2.  <a href="#schema-errors">Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#issues">Open Issues</a>
+</dt>
+<dt>13.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) multimedia interactions (such as voice and video exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions (TINS)</span>  [<a href="#nt-id2250674">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2250656">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2250722">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team, it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2250781">4</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li>Formats for describing various session types (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2256357">5</a>]).</li>
+    <li>Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2256382">6</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2256404">7</a>]).</li>
+  </ul>
+<h2>3.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="" style="">The following terminology is used in this document.</p>
+  <p class="caption">Table 1: Terminology</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Session</td>
+      <td align="" colspan="" rowspan="">A set of 1+ negotiated channels between endpoints for the purpose of exchanging data related to 1+ session types, delimited in time by a session initiation request and session ending event.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Session Type</td>
+      <td align="" colspan="" rowspan="">A formal description of the purpose of the session. Common session types are voice, voice+video, and file sharing. A session consists of one and only one session type, for which 1+ channels will be negotiated and used.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Channel</td>
+      <td align="" colspan="" rowspan="">A direct communication channel in the context of a session. The channel is ideally a peer-to-peer connection. A channel ends when the session ends.</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="concepts-state">Session Management State Machine</a>
+</h3>
+    <p class="" style="">A simplified state machine for basic session management is shown below:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | initiate
+           |   
+           |  _____________________
+           | /                     \
+[PENDING]  o________                |
+           |  |     | info,         |
+           |  |_____| negotiate     | 
+           |                        |
+           | accept                 | decline,
+           |                        | redirect,
+ [ACTIVE]  o________                | terminate
+           |  |     | info,         |
+           |  |     | modify,       |
+           |  |     | join,         |
+           |  |     | replace,      |
+           |  |_____| transfer      |
+           |                        |
+            \_______________________o [ENDED]
+                  decline, 
+                  redirect, 
+                  terminate
+    </pre></div>
+    <p class="" style="">There are three basic states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">There are ten basic "verbs" or actions:</p>
+    <ol start="" type="">
+      <li>accept</li>
+      <li>info</li>
+      <li>initiate</li>
+      <li>join</li>
+      <li>modify</li>
+      <li>negotiate</li>
+      <li>redirect</li>
+      <li>replace</li>
+      <li>terminate</li>
+      <li>transfer</li>
+    </ol>
+    <p class="" style="">Many of these states and actions correspond to (or can be mapped to) the states and actions defined in the Session Initiation Protocol (SIP), but such a mapping is out of scope here and will be provided in a separate specification.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="concepts-desc">Session Descriptions</a>
+</h3>
+    <p class="" style="">Parallel to the signalling flows outlined above, the entities involved in the session need to exchange descriptions of the desired session. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach taken in TINS), this is not necessarily helpful, since in practice (1) not all SDP data is needed or used in the most common use cases and (2) SDP has been heavily extended in several useful directions, especially for NAT traversal (see <span class="ref" style="">RFC 3489</span>  [<a href="#nt-id2256670">8</a>] and <span class="ref" style="">Interactive Connectivity Establishment (ICE)</span>  [<a href="#nt-id2256697">9</a>]). The approach taken herein is to specify pure session-description information in separate documents, one for each session type (audio, video, etc.). However, we include the NAT traversal semantics as a native part of Jingle signalling, since they are necessary for any kind of peer-to-peer session (no matter what the session description is).</p>
+  </div>
+<h2>5.
+       <a name="explain">Explanatory Example: Basic One-to-One Signalling</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="explain-resource">Resource Determination (Example)</a>
+</h3>
+    <p class="" style="">To illustrate the basic concepts, we use our standard characters Romeo and Juliet and assume that Romeo wants to initiate a one-to-one audio session with Juliet. (See the <a href="#protocol">Protocol Description</a> section of this document for a more formal description.)</p>
+    <p class="" style="">First Romeo must discover which of Juliet's XMPP resources is best for audio interaction. If a Juliet has only one XMPP resource, this task is best completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256772">10</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2256795">11</a>]:</p>
+    <p class="caption">Example 1. Romeo Requests Service Discovery Information</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    id='disco1'
+    to='juliet@capulet.com/balcony' 
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 2. Juliet Provides Service Discovery Information</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='disco1'
+    to='romeo@montague.net/orchard' 
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/jingle'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle/sessions/audio'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle?mode=dribble'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle?mode=burst'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle?stun=inline'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle?action=initiate'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle?action=redirect'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle?action=accept'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle?action=negotiate'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle?action=terminate'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If Juliet has more than one XMPP resource, it may be that only one of the resources supports Jingle and the audio session type, in which case Romeo would initiate Jingle signalling with that resource.</p>
+    <p class="" style="">If Juliet has more than one XMPP resource that supports Jingle and the audio session type, Romeo's client should use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2256865">12</a>] in order to determine the best resource with which to initiate a Jingle audio session.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="explain-initiate">Initiation (Example)</a>
+</h3>
+    <p class="" style="">Once Romeo has discovered which of Juliet's XMPP resources is ideal for audio interaction, he sends a session initiation request to Juliet and specifies an audio session (see <span class="ref" style="">Jingle Audio</span>  [<a href="#nt-id2256904">13</a>]):</p>
+    <p class="caption">Example 3. Romeo Initiates Call</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='initiate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description xmlns='http://jabber.org/protocol/jingle/sessions/audio'&gt;
+      &lt;payload-type id='18' name='G729'/&gt;
+      &lt;payload-type id='97' name='IPCMWB'/&gt;
+      &lt;payload-type id='98' name='L16'/&gt;
+      &lt;payload-type id='103' name='ISAC'/&gt;
+      &lt;payload-type id='102' name='iLBC'/&gt;
+      &lt;payload-type id='4' name='G723'/&gt;
+      &lt;payload-type id='100' name='EG711U'/&gt;
+      &lt;payload-type id='101' name='EG711A'/&gt;
+      &lt;payload-type id='0' name='PCMU'/&gt;
+      &lt;payload-type id='8' name='PCMA'/&gt;
+      &lt;payload-type id='13' name='CN'/&gt;
+    &lt;/description&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">At this point, Juliet can do one of three things:</p>
+    <ul>
+      <li>Decline the session initiation request.</li>
+      <li>Redirect the request to another resource.</li>
+      <li>Provisionally accept the session.</li>
+    </ul>
+    <p class="" style="">Here we assume that Juliet provisionally accepts the session:</p>
+    <p class="caption">Example 4. Juliet Provisionally Accepts the Session Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="explain-negotiate">Negotiation (Example)</a>
+</h3>
+    <p class="" style="">As soon as Juliet provisionally accepts the session initiation request, the next phase of the session flow begins: negotiation of connectivity. Here we assume that both Romeo and Juliet support dribble mode for connectivity negotation (for burst mode, see the <a href="#protocol-negotiate-modes-burst">Burst Mode</a> section of this document) and that therefore their clients immediately begin sending candidate transport mechanisms to each other.</p>
+    <p class="caption">Example 5. Romeo Sends a Candidate Transport</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='candidate1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='negotiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='1.0'
+               username='/38UHtocC941jdS4' 
+               password='pcd+Z/WmsthSFIcz'
+               type='local'
+               network='0'
+               generation='0' 
+               ip='10.1.1.104' 
+               port='13540'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If Juliet successfully receives the candidate, she returns an IQ-result (if not, for example because the candidate data is improperly formatted, she returns an error):</p>
+    <p class="caption">Example 6. Juliet Indicates Receipt of the First Candidate</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='candidate1'/&gt;
+    </pre></div>
+    <p class="" style="">Note well that Juliet is only indicating receipt of the candidate, not telling Romeo that the candidate will be used.</p>
+    <p class="" style="">Romeo keeps sending candidates, one after the other (without stopping to receive an acknowledgement of receipt from the target entity for each candidate) until he has exhausted his supply of possible or desirable candidate transports:</p>
+    <p class="caption">Example 7. Romeo Sends a Second Candidate Transport</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='candidate2' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='negotiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='0.8'
+               type='stun'
+               username='ld6Hi+PfVtnmU8cf'
+               password='gzoufy3aMXBRtiWs'
+               network='1'
+               generation='0' 
+               ip='1.2.3.4' 
+               port='6459'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 8. Romeo Sends a Third Candidate Transport</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='candidate2' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='negotiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='0.1'
+               type='relay'
+               username='XKqUmqiftjPUYAbF'
+               password='G4116MkgTzb8+1N/'
+               network='2'
+               generation='0' 
+               ip='5.6.7.8' 
+               port='9823'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As above, Juliet keeps acknowledging receipt of the candidates:</p>
+    <p class="caption">Example 9. Juliet Indicates Receipt of the Second and Third Candidates</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='candidate2'/&gt;
+
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='candidate3'/&gt;
+    </pre></div>
+    <p class="" style="">At the same time (i.e., immediately after provisionally accepting the session, not waiting for Romeo to begin or finish sending candidates), Juliet also begins sending candidates that may work for her:</p>
+    <p class="caption">Example 10. Juliet Sends a First Candidate</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='can1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='negotiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='0.7'
+               type='stun'
+               username='5ilRe0u+EF17aUQU'
+               password='VXrUejbQILvnEMIJ'
+               network='0'
+               generation='0' 
+               ip='3.4.5.6' 
+               port='7676'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 11. Juliet Sends a Second Candidate</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='can2' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='negotiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='0.3'
+               type='relay'
+               username='ph+H8epib3+I8aB8'
+               password='o+bUsKt+SzkBPlOF'
+               network='0'
+               generation='0' 
+               ip='4.5.6.7' 
+               port='8135'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">As above, Romeo acknowledges receipt of the candidates:</p>
+    <p class="caption">Example 12. Romeo Indicates Receipt of Candidates from Juliet</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='romeo@montague.net/orchard' to='juliet@capulet.com/balcony' id='can1'/&gt;
+
+&lt;iq type='result' from='romeo@montague.net/orchard' to='juliet@capulet.com/balcony' id='can2'/&gt;
+    </pre></div>
+    <p class="" style="">As Romeo and Juliet receive candidates, they probe the various candidate transports for connectivity. (This process is described in the <a href="#protocol-negotiate-check">Checking Connectivity</a> section of this document.)</p>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="explain-accept">Acceptance (Example)</a>
+</h3>
+    <p class="" style="">If, based on the connectivity checks, Juliet determines that she will be able to establish a connection, she sends a definitive acceptance to Romeo:</p>
+    <p class="caption">Example 13. Juliet Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='accept' 
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Romeo then acknowledges Juliet's definitive acceptance:</p>
+    <p class="caption">Example 14. Romeo Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now Romeo and Juliet can begin sending media over the negotiated connection.</p>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="explain-term">Termination (Example)</a>
+</h3>
+    <p class="" style="">We assume that after a pleasant voice chat, Juliet decides to gracefully end the session, so she sends a "terminate" action to Romeo:</p>
+    <p class="caption">Example 15. Juliet Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='term1' 
+    to='romeo@montague.net/orchard' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Romeo then acknowledges termination of the session:</p>
+    <p class="caption">Example 16. Romeo Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+  </div>
+<h2>6.
+       <a name="protocol">Protocol Description</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired session type. If a contact has only one XMPP resource, this task MUST be completed using <span style="font-weight: bold">Service Discovery</span> or the presence-based profile of service discovery specified in <span style="font-weight: bold">Entity Capabilities</span> (see example above).</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for the Jingle protocol (including negotiation mode and STUN style as described below) and various Jingle session types is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired session type, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired session type, it is RECOMMENDED for a client to use <span style="font-weight: bold">Resource Application Priority (RAP)</span> in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="protocol-actions">Required and Optional Actions</a>
+</h3>
+    <p class="" style="">Support for the 'accept', 'info', 'initiate', 'negotiate', 'redirect', and 'terminate' actions is REQUIRED.</p>
+    <p class="" style="">Support for the 'join', 'modify', 'replace', and 'transfer' actions is OPTIONAL.</p>
+    <p class="" style="">An entity MUST disclose which actions it supports in its response to service discovery information requests via the following features:</p>
+    <ul>
+      <li>http://jabber.org/protocol/jingle?action=accept</li>
+      <li>http://jabber.org/protocol/jingle?action=info</li>
+      <li>http://jabber.org/protocol/jingle?action=initiate</li>
+      <li>http://jabber.org/protocol/jingle?action=join</li>
+      <li>http://jabber.org/protocol/jingle?action=initiate</li>
+      <li>http://jabber.org/protocol/jingle?action=negotiate</li>
+      <li>http://jabber.org/protocol/jingle?action=modify</li>
+      <li>http://jabber.org/protocol/jingle?action=redirect</li>
+      <li>http://jabber.org/protocol/jingle?action=replace</li>
+      <li>http://jabber.org/protocol/jingle?action=terminate</li>
+      <li>http://jabber.org/protocol/jingle?action=transfer</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for audio interaction, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace; the &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes as described below; for initiation the 'action' attribute MUST have a value of "initiate", the 'mode' attribute SHOULD be included (if not, its value defaults to "dribble"), the 'stun' attribute SHOULD be included (if not, its value defaults to "inline"), and the &lt;jingle/&gt; element MUST contain one and only one child element that describes desired session (different elements will be defined for different session types). Here is an example:</p>
+    <p class="caption">Example 17. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='initiate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description xmlns='http://jabber.org/protocol/jingle/sessions/audio'&gt;
+      ...
+    &lt;/description&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is a Jingle action as listed in this document (in this case, "initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'mode' attribute specifies whether candidates for session negotiation are provided all at once ("burst" mode) or one at a time ("dribble" mode); the default value is "dribble".</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2257665">14</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+      <li>The 'stun' attribute specifies whether STUN packets are mixed into the channel to determine connectivity, provided in some other fashion (e.g., outside the channel), or not provided at all; the allowable values are "inline", "none", and "upfront", and the default value is "inline".</li>
+    </ul>
+    <p class="" style="">At this point, the target entity can do one of three things:</p>
+    <ul>
+      <li>Decline the session initiation request (e.g., because Juliet is busy).</li>
+      <li>Redirect the request to another resource.</li>
+      <li>Provisionally accept the session.</li>
+    </ul>
+    <p class="" style="">To decline the session initiation request, the target entity MUST return an XMPP &lt;not-acceptable/&gt; error. There are five defined error cases:</p>
+    <ul>
+      <li>&lt;busy/&gt; -- The target entity or principal is busy with other sessions or tasks and therefore is unable or unwilling to accept the session; this maps to SIP codes 486 and 600.</li>
+      <li>&lt;unsupported-media/&gt; -- The target entity does not support any of the payload-types (e.g., codecs) offered by the initiating entity; this maps to SIP code 415.</li>
+      <li>&lt;unsupported-negotiation-mode/&gt; -- The target entity does not support the session negotiation mode (dribble or burst) specified in the session initiation request.</li>
+      <li>&lt;unsupported-session-type/&gt; -- The target entity does not support the session type specified in the session initiation request.</li>
+      <li>&lt;unsupported-stun-method/&gt; -- The target entity does not support the STUN testing method (inline or none) specified in the session initiation request.</li>
+    </ul>
+    <p class="caption">Example 18. Juliet Declines the Session Request</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1' type='error'&gt;
+  &lt;error code='406' type='modify'&gt;
+    &lt;not-acceptable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;busy xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">To immediately redirect the session initiation request to another address (e.g., because of a change in resource application priority generated right before the session initiation request was received), the target entity returns an XMPP &lt;redirect/&gt; error:</p>
+    <p class="caption">Example 19. Juliet Redirects the Session Request</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1' type='error'&gt;
+  &lt;error code='302' type='modify'&gt;
+    &lt;redirect xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'&gt;xmpp:juliet@capulet.com/chamber&lt;/redirect&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">(Note: <span style="font-weight: bold">RFC 3920</span> specifies that the optional XML character data of the XMPP &lt;redirect/&gt; error shall be an XMPP address (JID) rather than a full URI/IRI; however, since it is possible for an XMPP entity to desire redirection to a non-XMPP address (e.g., a SIP address or telephone number), in this specification we recommend inclusion of a full URI/IRI such as a sip: or sips: URI, a tel: URI or an XMPP URI/IRI that is consistent with <span class="ref" style="">XMPP URI Scheme</span>  [<a href="#nt-id2257853">15</a>].)</p>
+    <p class="" style="">If the session initiation request is declined or redirected, the original session MUST be considered in the ENDED state and the new session initiation request (if any) sent to the target entity or redirected entity MUST possess a newly-generated session ID.</p>
+    <p class="" style="">To provisionally accept the session initiation request, the target entity returns an IQ-result:</p>
+    <p class="caption">Example 20. Juliet Provisionally Accepts the Session Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+      </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After provisionally accepting the session, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 21. Juliet Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='jingle2' 
+    to='romeo@montague.net/orchard' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='redirect' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 22. Romeo Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    id='jingle2' 
+    to='juliet@capulet.com/balcony' 
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="protocol-negotiate">Negotiation</a>
+</h3>
+    <p class="" style="">As soon as the target entity provisionally accepts the session initiation request, the next phase of the session flow begins: negotiation of connectivity by exchanging XML-formatted candidate transports for the channel. The process for this negotiation is largely the same in Jingle as it is in <span style="font-weight: bold">Interactive Connectivity Establishment (ICE)</span>. The main exception is that, when operating in dribble mode, Jingle takes advantage of the request-response semantics of the XMPP &lt;iq/&gt; stanza type by sending each candidate transport in a separate IQ exchange. Jingle burst negotiation is more similar to ICE in this respect. The candidate format and negotiation modes are described below.</p>
+    <div class="indent">
+<h3>6.5.1 <a name="protocol-negotiate-candidate">Candidate Format</a>
+</h3>
+      <p class="" style="">In contrast to <span style="font-weight: bold">ICE</span>, in Jingle candidates are encoded into XML rather than into SDP. In addition, in Jingle a candidate is a single XML element (rather than the candidate pairs recommended in <span style="font-weight: bold">ICE</span>) to save bandwidth.</p>
+      <p class="" style="">The following is an example of the candidate format:</p>
+      <p class="caption">Example 23. Romeo Sends a Candidate Transport</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='candidate1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='negotiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='1.0'
+               username='/38UHtocC941jdS4' 
+               password='pcd+Z/WmsthSFIcz'
+               type='local'
+               network='0'
+               generation='0' 
+               ip='10.1.1.104' 
+               port='13540'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The attributes of the &lt;candidate/&gt; element are as follows:</p>
+      <ul>
+        <li>The 'name' attribute identifies a channel within the context of the specified session type; possible values might include 'rtp' (for Real-time Transfer Protocol) and 'rtcp' (for Real-Time Control Protocol).</li>
+        <li>The allowable values for the 'protocol' attribute are "udp", "tcp", and "ssltcp" as described below.</li>
+        <li>The 'username', 'password', and 'preference' attributes directly map to the same entities in <span style="font-weight: bold">ICE</span>.</li>
+        <li>The 'type' attribute is used for diagnostics; the allowable values are "local", "stun" (see <span class="ref" style="">RFC 3489</span>  [<a href="#nt-id2258071">16</a>]), and "relay".</li>
+        <li>The 'network' attribute is also used for diagnostics; it is an index, starting at 0, referencing which network this candidate is on for a given peer (useful if the calling hardware has more than one Network Interface Card or NIC).</li>
+        <li>The 'generation' attribute is an index, starting at 0, that enables the parties to keep track of updates to the candidate throughout the life of the session (see below).</li>
+        <li>The 'ip' attribute specifies the Internet Protocol (IP) address for the candidate transport mechanism; this may be either an IPv4 address or an IPv6 address.</li>
+        <li>The 'port' attribute specifies the port at the candidate IP address.</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>6.5.2 <a name="protocol-negotiate-modes">Negotiation Modes</a>
+</h3>
+      <p class="" style="">An implementation SHOULD support both modes: dribble and burst. An entity MUST disclose which mode(s) it supports in its response to service discovery information requests via the "http://jabber.org/protocol/jingle?mode=dribble" and "http://jabber.org/protocol/jingle?mode=burst" features. If the target entity supports both modes, the initiating entity MUST specify its desired mode in the session initiation request, either explicitly by including the 'mode' attribute with a value of "burst" or "dribble", or implicitly specifying dribble mode by not including the 'mode' attribute (since the default value of the 'mode' attribute is "dribble"). If the target entity supports only one mode, then the initiating entity MUST specify that mode in the session initiation request; however, if the only mode supported by the target entity is not supported by the initiating entity, then the initiating MUST NOT send a session initiation request. An intermediary such as a SIP-to-XMPP gateway MUST insert its supported negotiation mode or modes (both in service discovery responses and session initiation requests) on behalf of entities it represents on the XMPP network.</p>
+      <div class="indent">
+<h3>6.5.2.1 <a name="protocol-negotiate-modes-dribble">Dribble Mode</a>
+</h3>
+        <p class="" style="">In dribble mode, each candidate is sent in a separate IQ stanza and acknowledged by the other party.</p>
+        <p class="" style="">If dribble mode is used, the first step in negotiating connectivity is for each client to immediately begin sending candidate transport mechanisms to the other client. These candidates SHOULD be gathered by following the procedure specified in Section 7.1 of <span style="font-weight: bold">ICE</span> and prioritied by following the procedure specified in Section 7.2 of <span style="font-weight: bold">ICE</span>.</p>
+        <p class="" style="">If the target entity successfully receives the candidate, it returns an IQ-result (if not, for example because the candidate data is improperly formatted, it returns an error).</p>
+        <p class="" style="">Note well that the target entity is only indicating receipt of the candidate, not telling the initiating entity that the candidate will be used.</p>
+        <p class="" style="">The initiating entity keeps sending candidates, one after the other (without stopping to receive an acknowledgement of receipt from the target entity for each candidate) until it has exhausted its supply of possible or desirable candidate transports:  [<a href="#nt-id2258212">17</a>] For each candidate, the target entity acknowledges receipt.</p>
+        <p class="" style="">At the same time (i.e., immediately after provisionally accepting the session, not waiting for the initiating entity to begin or finish sending candidates), the target entity also begins sending candidates that may work for it. As above, the initiating entity acknowledges receipt of the candidates.</p>
+        <p class="" style="">As the initiating entity and target entity receive candidates, they probe the various candidate transports for connectivity. In performing these connectivity checks, client SHOULD follow the procedure specified in Section 7.6 of <span style="font-weight: bold">ICE</span>.</p>
+      </div>
+      <div class="indent">
+<h3>6.5.2.2 <a name="protocol-negotiate-modes-burst">Burst Mode</a>
+</h3>
+        <p class="" style="">Burst mode closely follows the offer-answer model specified in <span class="ref" style="">RFC 3264</span>  [<a href="#nt-id2258286">18</a>]. In particular, the initiating entity MUST send a complete set of candidate transports in the session initiation request, as in the following example:</p>
+        <p class="caption">Example 24. Romeo Initiates Call (Burst Mode)</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='initiate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='1.0'
+               username='/38UHtocC941jdS4' 
+               password='pcd+Z/WmsthSFIcz'
+               type='local'
+               network='0'
+               generation='0' 
+               ip='10.1.1.104' 
+               port='13540'/&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='0.8'
+               type='stun'
+               username='ld6Hi+PfVtnmU8cf'
+               password='gzoufy3aMXBRtiWs'
+               network='1'
+               generation='0' 
+               ip='1.2.3.4' 
+               port='6459'/&gt;
+    &lt;candidate name='rtp'
+               protocol='udp'
+               preference='0.1'
+               type='relay'
+               username='XKqUmqiftjPUYAbF'
+               password='G4116MkgTzb8+1N/'
+               network='2'
+               generation='0' 
+               ip='5.6.7.8' 
+               port='9823'/&gt;
+    &lt;description xmlns='http://jabber.org/protocol/jingle/sessions/audio'&gt;
+      &lt;payload-type id='18' name='G729'/&gt;
+      &lt;payload-type id='97' name='IPCMWB'/&gt;
+      &lt;payload-type id='98' name='L16'/&gt;
+      &lt;payload-type id='103' name='ISAC'/&gt;
+      &lt;payload-type id='102' name='iLBC'/&gt;
+      &lt;payload-type id='4' name='G723'/&gt;
+      &lt;payload-type id='100' name='EG711U'/&gt;
+      &lt;payload-type id='101' name='EG711A'/&gt;
+      &lt;payload-type id='0' name='PCMU'/&gt;
+      &lt;payload-type id='8' name='PCMA'/&gt;
+      &lt;payload-type id='13' name='CN'/&gt;
+    &lt;/description&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+        </pre></div>
+      </div>
+    </div>
+    <div class="indent">
+<h3>6.5.3 <a name="protocol-negotiate-check">Checking Connectivity</a>
+</h3>
+      <p class="" style="">It is possible to check connectivity via STUN only "upfront" before the session is negotiated or also "inline" during the life of the session (e.g., to determine if a connectivity method other than that chosen initially is now more efficient); it is also possible to perform no STUN connectivity checking at all (e.g., this may be true of older SIP implementations that do no support STUN). An implementation SHOULD support inline STUN checking but MAY support only upfront STUN checking or no STUN checking at all. An entity MUST disclose which method(s) of connectivity checking it supports in its response to service discovery information requests via the "http://jabber.org/protocol/jingle?stun=inline", "http://jabber.org/protocol/jingle?stun=none", and "http://jabber.org/protocol/jingle?stun=upfront" features. If the target entity supports both upfront and inline STUN checking, the initiating entity MUST specify its desired mode in the session initiation request, either explicitly by including the 'stun' attribute with a value of "inline" or "upfront", or implicitly specifying inline checking by not including the 'stun' attribute (since the default value of the 'stun' attribute is "inline"). If the target entity supports only one of upfront or inline, then the initiating entity MUST specify that checking method in the session initiation request; however, if the only method supported by the target entity is not supported by the initiating entity, then the initiating MUST fall back to no STUN checking at all. An intermediary such as a SIP-to-XMPP gateway MUST insert its supported STUN checking method or methods (both in service discovery responses and session initiation requests) on behalf of entities it represents on the XMPP network.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>6.6 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If, based on the connectivity checks, the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 25. Juliet Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='accept' 
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MAY contain a &lt;description/&gt; element that specifies the supported codecs (and other session description details) and SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity. If provided, all future commmunications SHOULD be sent to the JID provided in the 'responder' attribute.</p> 
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 26. Romeo Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending media over the negotiated connection.</p>
+    <p class="" style="">In the unlikely event that the target entity cannot find a suitable candidate transport, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>6.7 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session, either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 27. Juliet Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='term1' 
+    to='romeo@montague.net/orchard' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity then acknowledges termination of the session:</p>
+    <p class="caption">Example 28. Romeo Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further communication for the session type MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'redirect' or 'terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 29. Juliet Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>6.8 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message takes the form of an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "info"; the &lt;jingle/&gt; element MUST further contain a "payload" child element that specifies the information being communicated. The syntax of this payload element is undefined in this signalling specification and shall be defined by the appropriate session type specification.</p>
+  </div>
+<h2>7.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The following sections describe error handling related to Jingle signalling. For general information regarding XMPP error handling, refer to <span style="font-weight: bold">RFC 3920</span> and <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2258632">19</a>].</p>
+  <div class="indent">
+<h3>7.1 <a name="errors-initiate">Initiation-Related Error Conditions</a>
+</h3>
+    <p class="" style="">There are several possible reasons why the target entity might specify an error of &lt;not-acceptable/&gt; in response to the session initiation request. The target entity SHOULD specify the precise reason for not accepting the session by including an appropriate error condition element qualified by the 'http://jabber.org/protocol/jingle#errors' namespace along with the &lt;not-acceptable/&gt; error.  [<a href="#nt-id2258644">20</a>] The defined initiation-related error conditions are:</p>
+    <p class="caption">Table 2: Initiation-Related Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Jingle Condition</th>
+        <th colspan="" rowspan="">XMPP Condition</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;busy/&gt;</td>
+        <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+        <td align="" colspan="" rowspan="">The target entity or principal is busy with other sessions or tasks and therefore is unable or unwilling to accept the session; this maps to SIP codes 486 and 600.  [<a href="#nt-id2258726">21</a>]</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;unsupported-media/&gt;</td>
+        <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+        <td align="" colspan="" rowspan="">The target entity does not support any of the payload-types (e.g., codecs) offered by the initiating entity; this maps to SIP code 415.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;unsupported-negotiation-mode/&gt;</td>
+        <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+        <td align="" colspan="" rowspan="">The target entity does not support the session negotiation mode (dribble or burst) specified in the session initiation request.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;unsupported-session-type/&gt;</td>
+        <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+        <td align="" colspan="" rowspan="">The target entity does not support the session type specified in the session initiation request.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;unsupported-stun-method/&gt;</td>
+        <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+        <td align="" colspan="" rowspan="">The target entity does not support the STUN testing method (inline or none) specified in the session initiation request.</td>
+      </tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="errors-other">Other Error Conditions</a>
+</h3>
+    <p class="" style="">At any point during a session, one of the entities may send a faulty signalling stanza to the other party. The error conditions defined for such cases are:</p>
+    <p class="caption">Table 3: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Jingle Condition</th>
+        <th colspan="" rowspan="">XMPP Condition</th>
+        <th colspan="" rowspan="">Description</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+        <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+        <td align="" colspan="" rowspan="">The request cannot be at this point in the state machine (e.g., initiate after accept).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+        <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+        <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;unsupported-action/&gt;</td>
+        <td align="" colspan="" rowspan="">&lt;feature-not-implemented/&gt;</td>
+        <td align="" colspan="" rowspan="">The 'action' attribute specifies an action that is not supported by the recipient.</td>
+      </tr>
+    </table>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>8.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Media sessions are resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many media sessions. Care must be taken to accept media sessions only from known entities.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259097">22</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259142">23</a>] shall include 'http://jabber.org/protocol/jingle' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-features">Service Discovery Features</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the following values in its registry of service discovery features.</p>
+    <ul>
+      <li>http://jabber.org/protocol/jingle?action=accept</li>
+      <li>http://jabber.org/protocol/jingle?action=info</li>
+      <li>http://jabber.org/protocol/jingle?action=initiate</li>
+      <li>http://jabber.org/protocol/jingle?action=join</li>
+      <li>http://jabber.org/protocol/jingle?action=initiate</li>
+      <li>http://jabber.org/protocol/jingle?action=negotiate</li>
+      <li>http://jabber.org/protocol/jingle?action=modify</li>
+      <li>http://jabber.org/protocol/jingle?action=redirect</li>
+      <li>http://jabber.org/protocol/jingle?action=replace</li>
+      <li>http://jabber.org/protocol/jingle?action=terminate</li>
+      <li>http://jabber.org/protocol/jingle?action=transfer</li>
+      <li>http://jabber.org/protocol/jingle?mode=burst</li>
+      <li>http://jabber.org/protocol/jingle?mode=dribble</li>
+      <li>http://jabber.org/protocol/jingle?stun=inline</li>
+      <li>http://jabber.org/protocol/jingle?stun=none</li>
+      <li>http://jabber.org/protocol/jingle?stun=upfront</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="registrar-jingle">Jingle Session Types Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle session types. All session type registrations shall be defined in separate documents (not in this JEP). Session types defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/session/name" (where "name" is the registered name of the session type)..</p>
+    <div class="indent">
+<h3>10.3.1 <a name="registrar-jingle-process">Registration Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;session&gt;
+  &lt;name&gt;the name of the session type (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the session type&lt;/desc&gt;
+  &lt;doc&gt;the document in which this session type is specified&lt;/doc&gt;
+&lt;/session&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-signalling">Signalling</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='candidate' minOccurs='0' maxOccur='unbounded'/&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;/xs:sequence&gt;
+        &lt;xs:element ref='redirect' type='xs:anyURI'/&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='accept'/&gt;
+            &lt;xs:enumeration value='info'/&gt;
+            &lt;xs:enumeration value='initiate'/&gt;
+            &lt;xs:enumeration value='join'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+            &lt;xs:enumeration value='negotiate'/&gt;
+            &lt;xs:enumeration value='redirect'/&gt;
+            &lt;xs:enumeration value='replace'/&gt;
+            &lt;xs:enumeration value='terminate'/&gt;
+            &lt;xs:enumeration value='transfer'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='mode' use='optional' default='dribble'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='burst'/&gt;
+            &lt;xs:enumeration value='dribble'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='candidate'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='generation' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='ip' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='network' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='password' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='port' type='xs:short' use='required'/&gt;
+          &lt;xs:attribute name='preference' type='xs:decimal' use='required'/&gt;
+          &lt;xs:attribute name='protocol' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='ssltcp'/&gt;
+                &lt;xs:enumeration value='tcp'/&gt;
+                &lt;xs:enumeration value='udp'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='type' use='required'&gt;
+            &lt;xs:simpleType&gt;
+              &lt;xs:restriction base='xs:NCName'&gt;
+                &lt;xs:enumeration value='local'/&gt;
+                &lt;xs:enumeration value='relay'/&gt;
+                &lt;xs:enumeration value='stun'/&gt;
+              &lt;/xs:restriction&gt;
+            &lt;/xs:simpleType&gt;
+          &lt;/xs:attribute&gt;
+          &lt;xs:attribute name='username' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-errors">Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='busy' type='empty'/&gt;
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-action' type='empty'/&gt;
+  &lt;xs:element name='unsupported-media' type='empty'/&gt;
+  &lt;xs:element name='unsupported-negotiation-mode' type='empty'/&gt;
+  &lt;xs:element name='unsupported-session-type' type='empty'/&gt;
+  &lt;xs:element name='unsupported-stun-method' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">The open issues include:</p>
+  <ul>
+    <li>Describe all supported use cases, including third-party call control.</li>
+    <li>Define modify (e.g., put caller on hold), join, replace, and transfer.</li>
+    <li>Specify how to include call history (e.g., for transfer).</li>
+    <li>Specify multi-user scenarios.</li>
+    <li>Specify how to initiate a session with a bare JID.</li>
+  </ul>
+<h2>13.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his helpful feedback on this document. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2259475">24</a>] and (earlier) Jingle  [<a href="#nt-id2259404">25</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250674">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2250656">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2250722">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2250781">4</a>. Possible other session types include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2256357">5</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2256382">6</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256404">7</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2256670">8</a>. RFC 3489: STUN - Simple Traversal of User Datagram Protocol (UDP) Through Network Address Translators (NATs) &lt;<a href="http://www.ietf.org/rfc/rfc3489.txt">http://www.ietf.org/rfc/rfc3489.txt</a>&gt;.</p>
+<p><a name="nt-id2256697">9</a>. Interactive Connectivity Establishment (ICE): A Methodology for Network Address Translator (NAT) Traversal for Offer/Answer Protocols &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-06.txt">http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-06.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256772">10</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256795">11</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2256865">12</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2256904">13</a>. JEP-0167: Jingle Audio &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2257665">14</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2257853">15</a>. Internationalized Resource Identifiers (IRIs) and Uniform Resource Identifiers (URIs) for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-03.txt">http://www.ietf.org/internet-drafts/draft-saintandre-xmpp-iri-03.txt</a>&gt; (work in progress).</p>
+<p><a name="nt-id2258071">16</a>. RFC 3489: STUN - Simple Traversal of User Datagram Protocol (UDP) Through Network Address Translators (NATs) &lt;<a href="http://www.ietf.org/rfc/rfc3489.txt">http://www.ietf.org/rfc/rfc3489.txt</a>&gt;.</p>
+<p><a name="nt-id2258212">17</a>. Because certain candidates may be more "expensive" in terms of bandwidth or processing power, the initiator may not want to advertise their existence unless necessary.</p>
+<p><a name="nt-id2258286">18</a>. RFC 3264: An Offer/Answer Model with the Session Description Protocol (SDP) &lt;<a href="http://www.ietf.org/rfc/rfc3264.txt">http://www.ietf.org/rfc/rfc3264.txt</a>&gt;.</p>
+<p><a name="nt-id2258632">19</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2258644">20</a>. While it may seem that some of these Jingle-specific conditions would be more appropriate in conjunction with other XMPP conditions, such as &lt;feature-not-implemented/&gt;, the &lt;not-acceptable/&gt; XMPP condition is used for all cases of declining a session initiation request in order to simplify handling of session initiation.</p>
+<p><a name="nt-id2258726">21</a>. We deliberately do not specify a separate error of "resource-constrained" in order to help prevent denial of service attacks.</p>
+<p><a name="nt-id2259097">22</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259142">23</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2259475">24</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2259404">25</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">More fully documented burst mode, connectivity checks, error cases, etc. (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">Restructured document flow; provided example of burst mode. (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author. (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">Added more detail to basic session flow; harmonized candidate negotiation process with ICE. (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup. (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">Separated description formats from signalling protocol. (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author. (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">Added more detail to basic session flow. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">Protocol cleanup. (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">First draft. (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.2.html
+++ b/content/xep-0166-0.2.html
@@ -1,0 +1,687 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-02-13">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle</h1>
+<p>This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0166<br>
+            Version: 0.2<br>
+            Last Updated: 2006-02-13<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#concepts-session">Session Management</a>
+</dt>
+<dt>3.2.  <a href="#concepts-media">Media Descriptions</a>
+</dt>
+<dt>3.3.  <a href="#concepts-transport">Transport Methods</a>
+</dt>
+</dl>
+<dt>4.  <a href="#protocol">Protocol Description</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>4.2.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>4.3.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>4.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>4.5.  <a href="#protocol-decline">Decline</a>
+</dt>
+<dt>4.6.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>4.7.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>4.8.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>6.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-media">Jingle Media Descriptions Registry</a>
+</dt>
+<dt>8.3.  <a href="#registrar-transports">Jingle Transport Methods Registry</a>
+</dt>
+</dl>
+<dt>9.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schema-jingle">Jingle</a>
+</dt>
+<dt>9.2.  <a href="#schema-errors">Jingle Errors</a>
+</dt>
+</dl>
+<dt>10.  <a href="#issues">Open Issues</a>
+</dt>
+<dt>11.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) multimedia interactions (such as voice and video exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions (TINS)</span>  [<a href="#nt-id2251112">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2251127">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2251164">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team,  [<a href="#nt-id2251187">4</a>] it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2256671">5</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li><p class="" style="">Formats for various media descriptions (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2256733">6</a>]); one example is <span class="ref" style="">Jingle Audio Media Description Format</span>  [<a href="#nt-id2256761">7</a>].</p></li>
+    <li><p class="" style="">Formats for various transport methods.</p></li>
+    <li><p class="" style="">Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2256797">8</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2256788">9</a>]).</p></li>
+  </ul>
+<h2>3.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Jingle consists of three parts:</p>
+  <ol start="" type="">
+    <li>Overall session management</li>
+    <li>Media description (the "what")</li>
+    <li>Transport method (the "how")</li>
+  </ol>
+  <p class="" style="">This JEP defines the semantics and syntax for overall session management, and provides pluggable "slots" for media descriptions and transport methods, which are specified in separate documents.</p>
+  <div class="indent">
+<h3>3.1 <a name="concepts-session">Session Management</a>
+</h3>
+    <p class="" style="">The state machine for session management is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         o
+         |
+         | initiate
+         |
+         | +-------------+
+         |/              |
+PENDING  o-----------+   |
+         |  | info   |   |
+         |  +--------+   |
+         |               |
+         | accept        |
+         |               |
+ ACTIVE  o-----------+   |
+         |  | info,  |   |
+         |  | modify |   |
+         |  +--------+   |
+         |               |
+         +---------------+ redirect,
+                         | terminate
+                         |
+                         |
+                         o ENDED
+    </pre></div>
+    <p class="" style="">There are three session states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">There are six session-related "verbs" or actions:</p>
+    <ol start="" type="">
+      <li>accept</li>
+      <li>info</li>
+      <li>initiate</li>
+      <li>modify</li>
+      <li>redirect</li>
+      <li>terminate</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="concepts-media">Media Descriptions</a>
+</h3>
+    <p class="" style="">The media description specifies the "what" of the session (e.g., bidirectional audio). When negotiating the session, the entities involved in the session need to exchange descriptions of the desired session. The approach taken herein is to specify pure session-description information in separate specifications, one for each media description (audio, video, etc.).  [<a href="#nt-id2256968">10</a>] The session negotiation must contain some session description, but the definitions of those session descriptions are not defined herein.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="concepts-transport">Transport Methods</a>
+</h3>
+    <p class="" style="">The transport method defines "how" the data shall be exchanged. As with the media descriptions, the transport methods are specified in separate specifications. Possible transport methods include peer-to-peer RTP, local UDP, and SSL-TCP.</p>
+  </div>
+<h2>4.
+       <a name="protocol">Protocol Description</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired media description. If a contact has only one XMPP resource, this task MUST be completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257052">11</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2257075">12</a>].</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for Jingle and various Jingle media description and transport methods is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired media description, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired media description, it is RECOMMENDED for a client to use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2257136">13</a>] in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for the desired media description, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace. The &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes; for initiation the 'action' attribute MUST have a value of "initiate" and the &lt;jingle/&gt; element MUST contain one or more &lt;description/&gt; child elements that specify the desired media descriptions and one or more &lt;transport/&gt; child elements that specify the desired transport methods. Here is an example:</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='initiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The syntax and semantics of the description and transport elements are out of scope for this specification.</p>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is REQUIRED; it specifies a Jingle action as listed in this document (e.g., "initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'responder' attribute (see examples below) is the full JID of the entity that has replied to the initiation (which may be different from the 'to' address on the IQ-set).</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2257229">14</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">Unless an error occurs, the target entity MUST acknowledge receipt of the initiation request:</p>
+    <p class="caption">Example 2. Target Entity Acknowledges Receipt of Initiation Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">If the target entity acknowledges receipt of the initation request, both parties must consider the session to be in the PENDING state.</p>
+    <p class="" style="">There are several reasons why the target entity might return an error instead of acknowledging receipt of the initiation request:</p>
+    <ul>
+      <li>The initiating entity is unknown to the target entity (e.g., via presence subscription).</li>
+      <li>The target entity does not support Jingle.</li>
+      <li>The target entity does not support any of the specified media descriptions.</li>
+      <li>The target entity does not support any of the specified transport methods.</li>
+      <li>The initiation request was malformed.</li>
+    </ul>
+    <p class="" style="">The initiating entity is unknown to the target entity (e.g., via presence subscription) and the target entity has a policy of not communicating via Jingle with unknown entities, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 3. Initiating Entity Unknown to Target Entity</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support Jingle, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 4. Target Entity Does Not Support Jingle</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified media descriptions, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-media/&gt;.</p>
+    <p class="caption">Example 5. Target Entity Does Not Support Any Media Descriptions</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-media xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified transport methods, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-transports/&gt;.</p>
+    <p class="caption">Example 6. Target Entity Does Not Support Any Transport Methods</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-transports xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initiation request was malformed, the target entity MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 7. Initiation Request Malformed</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After acknowledging receipt of the initiation request, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 8. Target Entity Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='jingle2'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='redirect'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 9. Initiating Entity Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='jingle2'
+    to='juliet@capulet.com/balcony'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="protocol-decline">Decline</a>
+</h3>
+    <p class="" style="">In order to decline the session initiation request, the target entity MUST acknowledge receipt of the session initiation request, then terminate the session as described in the <a href="#protocol-terminate">Termination</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If (after negotiation of transport methods and media descriptions) the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 10. Target Entity Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='accept'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MAY contain one or more &lt;description/&gt; elements that specify the desired media description(s) and MAY contain one or more &lt;transport/&gt; elements that specify the desired transport methodl(s). The &lt;jingle/&gt; element SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity, and the initiating entity SHOULD send all future commmunications about this Jingle session o the JID provided in the 'responder' attribute.</p>
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 11. Initiating Entity Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending media over the negotiated connection.</p>
+    <p class="" style="">If one of the parties cannot find a suitable transport method, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session (which MAY be done at any point after acknowledging receipt of the initiation request, including immediately thereafter in order to decline the request), either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 12. Target Entity Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='term1'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity MUST then acknowledge termination of the session:</p>
+    <p class="caption">Example 13. Initiating Entity Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further Jingle communication for the negotiated media description and transport method MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'redirect' or 'terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 14. Target Entity Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message takes the form of an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "info"; the &lt;jingle/&gt; element MUST further contain a "payload" child element that specifies the information being communicated. The syntax of this payload element is undefined in this signalling specification and shall be defined by a companion document specifying a media description or transport method.</p>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The Jingle-specific error conditions are as follows.</p>
+  <p class="caption">Table 1: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jingle Condition</th>
+      <th colspan="" rowspan="">XMPP Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The request cannot occur at this point in the state machine (e.g., initiate after accept).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-media/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired media descriptions.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-transports/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired transport methods.</td>
+    </tr>
+  </table>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>6.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Jingle sessions may be resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many Jingle sessions. Care must be taken to accept media sessions only from known entities and only if the entity's device is able to process such sessions.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258039">15</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258055">16</a>] shall include 'http://jabber.org/protocol/jingle' and 'http://jabber.org/protocol/jingle#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-media">Jingle Media Descriptions Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle media descriptions. All media description registrations shall be defined in separate documents (not in this JEP). Media descriptions defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/media/name" (where "name" is the registered name of the media description).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;media&gt;
+  &lt;name&gt;the name of the media description (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the media&lt;/desc&gt;
+  &lt;doc&gt;the document in which this media description is specified&lt;/doc&gt;
+&lt;/media&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="registrar-transports">Jingle Transport Methods Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle transport methods. All transport method registrations shall be defined in separate documents (not in this JEP). Transport methods defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/transport/name" (where "name" is the registered name of the transport method).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;the name of the transport method (e.g., "p2p")&lt;/name&gt;
+  &lt;desc&gt;a natural-language description of the transport&lt;/desc&gt;
+  &lt;doc&gt;the document in which this transport method is specified&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schema-jingle">Jingle</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='accept'/&gt;
+            &lt;xs:enumeration value='info'/&gt;
+            &lt;xs:enumeration value='initiate'/&gt;
+            &lt;xs:enumeration value='modify'/&gt;
+            &lt;xs:enumeration value='redirect'/&gt;
+            &lt;xs:enumeration value='terminate'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='responder' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schema-errors">Jingle Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-media' type='empty'/&gt;
+  &lt;xs:element name='unsupported-transports' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">The open issues include:</p>
+  <ul>
+    <li>Describe all supported use cases, including third-party call control and call transfer.</li>
+    <li>Specify how to include call history (e.g., for transfer).</li>
+    <li>Specify session modification.</li>
+    <li>Specify how to initiate a session with a bare JID.</li>
+  </ul>
+<h2>11.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his helpful feedback on this document. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2258288">17</a>] and (earlier) Jingle  [<a href="#nt-id2258274">18</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251112">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2251127">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2251164">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2251187">4</a>. Google Talk is a messaging and voice chat service and client provided by Google; see &lt;<a href="http://www.google.com/talk/">http://www.google.com/talk/</a>&gt;.</p>
+<p><a name="nt-id2256671">5</a>. Possible other media descriptions include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2256733">6</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2256761">7</a>. JEP-0167: Jingle Audio Media Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2256797">8</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256788">9</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2256968">10</a>. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach that was taken in <span style="font-weight: bold">JEP-0111</span>), this is not necessarily helpful, since SDP is not structured data, not all SDP data is needed or used in the most common use cases, and SDP has been heavily extended in several useful directions.</p>
+<p><a name="nt-id2257052">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257075">12</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2257136">13</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2257229">14</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2258039">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258055">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2258288">17</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2258274">18</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Per agreement among the co-authors, moved transport definition to separate specification, simplified state machine, and made other associated changes to the text, examples, and schemas; also harmonized redirect, decline, and terminate processes.</p> (psa/jb)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">
+<p class="" style="">More fully documented burst mode, connectivity checks, error cases, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">
+<p class="" style="">Restructured document flow; provided example of burst mode.</p> (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author.</p> (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow; harmonized candidate negotiation process with ICE.</p> (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup.</p> (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Separated description formats from signalling protocol.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">
+<p class="" style="">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">
+<p class="" style="">Protocol cleanup.</p> (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.3.html
+++ b/content/xep-0166-0.3.html
@@ -1,0 +1,722 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-02-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle</h1>
+<p>This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0166<br>
+            Version: 0.3<br>
+            Last Updated: 2006-02-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#concepts-session">Session Management</a>
+</dt>
+<dt>3.2.  <a href="#concepts-media">Media Description Formats</a>
+</dt>
+<dt>3.3.  <a href="#concepts-transport">Transport Methods</a>
+</dt>
+</dl>
+<dt>4.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>4.2.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>4.3.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>4.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>4.5.  <a href="#protocol-decline">Decline</a>
+</dt>
+<dt>4.6.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>4.7.  <a href="#protocol-modify">Modifying an Active Session</a>
+</dt>
+<dt>4.8.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>4.9.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>5.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>6.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-media">Jingle Media Description Formats Registry</a>
+</dt>
+<dt>8.3.  <a href="#registrar-transports">Jingle Transport Methods Registry</a>
+</dt>
+</dl>
+<dt>9.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schema-jingle">Jingle</a>
+</dt>
+<dt>9.2.  <a href="#schema-errors">Jingle Errors</a>
+</dt>
+</dl>
+<dt>10.  <a href="#issues">Open Issues</a>
+</dt>
+<dt>11.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) multimedia interactions (such as voice and video exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions (TINS)</span>  [<a href="#nt-id2251177">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2251166">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2251190">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team,  [<a href="#nt-id2256699">4</a>] it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2256745">5</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li><p class="" style="">Various media description formats (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2256807">6</a>]); one example is <span class="ref" style="">Jingle Audio Media Description Format</span>  [<a href="#nt-id2256835">7</a>].</p></li>
+    <li><p class="" style="">Various transport methods.</p></li>
+    <li><p class="" style="">Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2256872">8</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2256894">9</a>]).</p></li>
+  </ul>
+<h2>3.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Jingle consists of three parts:</p>
+  <ol start="" type="">
+    <li>Overall session management</li>
+    <li>Media description formats (the "what")</li>
+    <li>Transport methods (the "how")</li>
+  </ol>
+  <p class="" style="">This JEP defines the semantics and syntax for overall session management, and provides pluggable "slots" for media description formats and transport methods, which are specified in separate documents.</p>
+  <div class="indent">
+<h3>3.1 <a name="concepts-session">Session Management</a>
+</h3>
+    <p class="" style="">The state machine for session management is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         o
+         |
+         | session-initiate
+         |
+         | +----------------------+
+         |/                       |
+PENDING  o------------------+     |
+         |  | session-info, |     |
+         |  | media-*,      |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         | session-accept         |
+         |                        |
+ ACTIVE  o------------------+     |
+         |  | session-info, |     |
+         |  | media-*,      |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         +------------------------+ session-redirect,
+                                  | session-terminate
+                                  |
+                                  |
+                                  o ENDED
+    </pre></div>
+    <p class="" style="">There are three overall session states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of the overall Jingle session are:</p>
+    <ol start="" type="">
+      <li>session-initiate (request a new session)</li>
+      <li>session-accept (definitively accept a session request)</li>
+      <li>session-redirect (redirect an initiate request to another address)</li>
+      <li>session-info (session-level information / messages)</li>
+      <li>session-terminate (end an existing session)</li>
+    </ol>
+    <p class="" style="">The actions related to management of media description formats are:</p>
+    <ol start="" type="">
+      <li>media-info (media-level information / messages)</li>
+      <li>media-modify (request a change to the media description formats)</li>
+      <li>media-accept (accept a proposed media change)</li>
+      <li>media-decline (decline a proposed media change)</li>
+    </ol>
+    <p class="" style="">The actions related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>transport-info (transport-level information / messages)</li>
+      <li>transport-modify (request a change to the transport methods)</li>
+      <li>transport-accept (accept a proposed transport change)</li>
+      <li>transport-decline (decline a proposed transport change)</li>
+    </ol>
+    <p class="" style="">This specification defines the state machine for overall session management. Each media description format and transport method will also have its own state machine, but these are out of scope here.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="concepts-media">Media Description Formats</a>
+</h3>
+    <p class="" style="">The media description format specifies the "what" of the session (e.g., bidirectional audio). When negotiating the session, the entities involved in the session need to exchange media description formats. The approach taken herein is to specify pure session description information in separate specifications, one for each media description format (audio, video, etc.).  [<a href="#nt-id2257126">10</a>] The session negotiation must contain some media description format(s), which are to be defined in separate specifications. Those specifications will also define the state chart for the media description format in question.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="concepts-transport">Transport Methods</a>
+</h3>
+    <p class="" style="">The transport method defines "how" the data shall be exchanged. As with the media description formats, the transport methods are specified in separate specifications. Possible transport methods include peer-to-peer RTP, local UDP, and SSL-TCP. Those specifications will also define the state chart for the transport method in question.</p>
+  </div>
+<h2>4.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired media description format. If a contact has only one XMPP resource, this task MUST be completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257213">11</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2257237">12</a>].</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for Jingle and various Jingle media description formats and transport methods is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired media description format, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired media description format, it is RECOMMENDED for a client to use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2257297">13</a>] in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for the desired media description format, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace. The &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes; for initiation the 'action' attribute MUST have a value of "initiate" and the &lt;jingle/&gt; element MUST contain one or more &lt;description/&gt; child elements that specify the desired media description formats and one or more &lt;transport/&gt; child elements that specify the desired transport methods. Here is an example:</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='initiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The syntax and semantics of the description and transport elements are out of scope for this specification.</p>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is REQUIRED; it specifies a Jingle action as listed in this document (e.g., "initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'responder' attribute (see examples below) is the full JID of the entity that has replied to the initiation (which may be different from the 'to' address on the IQ-set).</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2257392">14</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">Unless an error occurs, the target entity MUST acknowledge receipt of the initiation request:</p>
+    <p class="caption">Example 2. Target Entity Acknowledges Receipt of Initiation Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">If the target entity acknowledges receipt of the initation request, both parties must consider the session to be in the PENDING state.</p>
+    <p class="" style="">There are several reasons why the target entity might return an error instead of acknowledging receipt of the initiation request:</p>
+    <ul>
+      <li>The initiating entity is unknown to the target entity (e.g., via presence subscription).</li>
+      <li>The target entity does not support Jingle.</li>
+      <li>The target entity does not support any of the specified media description formats.</li>
+      <li>The target entity does not support any of the specified transport methods.</li>
+      <li>The initiation request was malformed.</li>
+    </ul>
+    <p class="" style="">The initiating entity is unknown to the target entity (e.g., via presence subscription) and the target entity has a policy of not communicating via Jingle with unknown entities, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 3. Initiating Entity Unknown to Target Entity</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support Jingle, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 4. Target Entity Does Not Support Jingle</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified media description formats, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-media/&gt;.</p>
+    <p class="caption">Example 5. Target Entity Does Not Support Any Media Description Formats</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-media xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified transport methods, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-transports/&gt;.</p>
+    <p class="caption">Example 6. Target Entity Does Not Support Any Transport Methods</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-transports xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initiation request was malformed, the target entity MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 7. Initiation Request Malformed</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After acknowledging receipt of the initiation request, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 8. Target Entity Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='jingle2'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='redirect'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 9. Initiating Entity Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='jingle2'
+    to='juliet@capulet.com/balcony'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="protocol-decline">Decline</a>
+</h3>
+    <p class="" style="">In order to decline the session initiation request, the target entity MUST acknowledge receipt of the session initiation request, then terminate the session as described in the <a href="#protocol-terminate">Termination</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>4.6 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If (after negotiation of transport methods and media description formats) the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 10. Target Entity Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='accept'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MAY contain one or more &lt;description/&gt; elements that specify the desired media description format(s) and MAY contain one or more &lt;transport/&gt; elements that specify the desired transport methodl(s). The &lt;jingle/&gt; element SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity, and the initiating entity SHOULD send all future commmunications about this Jingle session o the JID provided in the 'responder' attribute.</p>
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 11. Initiating Entity Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending media over the negotiated connection.</p>
+    <p class="" style="">If one of the parties cannot find a suitable transport method, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>4.7 <a name="protocol-modify">Modifying an Active Session</a>
+</h3>
+    <p class="" style="">In order to modify an active session, either party may send a "media-modify" or "transport-modify" action to the other party containing a modified media description format or transport method. The receiving party then sends an appropriate "-accept" or "-decline" action, and may first send an appropriate "-info" action.</p>
+    <p class="" style="">If both parties send modify messages at the same time, the modify message from the session initiator MUST trump the modify message from the recipient and the initiator SHOULD return an &lt;unexpected-request/&gt; error to the other party.</p>
+  </div>
+  <div class="indent">
+<h3>4.8 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session (which MAY be done at any point after acknowledging receipt of the initiation request, including immediately thereafter in order to decline the request), either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 12. Target Entity Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='term1'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity MUST then acknowledge termination of the session:</p>
+    <p class="caption">Example 13. Initiating Entity Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further Jingle communication for the negotiated media description format and transport method MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'redirect' or 'terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 14. Target Entity Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>4.9 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message takes the form of an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "session-info", "media-info", or "transport-info"; the &lt;jingle/&gt; element MUST further contain a "payload" child element that specifies the information being communicated. The syntax of this payload element is undefined in this signalling specification and shall be defined by a companion document specifying a media description format or transport method. (A future version of this specification will define payloads related to the "session-info" action.)</p>
+  </div>
+<h2>5.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The Jingle-specific error conditions are as follows.</p>
+  <p class="caption">Table 1: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jingle Condition</th>
+      <th colspan="" rowspan="">XMPP Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The request cannot occur at this point in the state machine (e.g., initiate after accept).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-media/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired media description formats.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-transports/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired transport methods.</td>
+    </tr>
+  </table>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>6.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Jingle sessions may be resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many Jingle sessions. Care must be taken to accept media sessions only from known entities and only if the entity's device is able to process such sessions.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258237">15</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258252">16</a>] shall include 'http://jabber.org/protocol/jingle' and 'http://jabber.org/protocol/jingle#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-media">Jingle Media Description Formats Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle media description formats. All media description format registrations shall be defined in separate documents (not in this JEP). Media description formats defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/media/name" (where "name" is the registered name of the media description format).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;media&gt;
+  &lt;name&gt;the name of the media description format (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the media description format&lt;/desc&gt;
+  &lt;doc&gt;the document in which this media description format is specified&lt;/doc&gt;
+&lt;/media&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>8.3 <a name="registrar-transports">Jingle Transport Methods Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle transport methods. All transport method registrations shall be defined in separate documents (not in this JEP). Transport methods defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/transport/name" (where "name" is the registered name of the transport method).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;the name of the transport method (e.g., "p2p")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the transport method&lt;/desc&gt;
+  &lt;doc&gt;the document in which this transport method is specified&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schema-jingle">Jingle</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='media-accept'/&gt;
+            &lt;xs:enumeration value='media-decline'/&gt;
+            &lt;xs:enumeration value='media-info'/&gt;
+            &lt;xs:enumeration value='media-modify'/&gt;
+            &lt;xs:enumeration value='session-accept'/&gt;
+            &lt;xs:enumeration value='session-info'/&gt;
+            &lt;xs:enumeration value='session-initiate'/&gt;
+            &lt;xs:enumeration value='session-redirect'/&gt;
+            &lt;xs:enumeration value='session-terminate'/&gt;
+            &lt;xs:enumeration value='transport-accept'/&gt;
+            &lt;xs:enumeration value='transport-decline'/&gt;
+            &lt;xs:enumeration value='transport-info'/&gt;
+            &lt;xs:enumeration value='transport-modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='responder' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schema-errors">Jingle Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-media' type='empty'/&gt;
+  &lt;xs:element name='unsupported-transports' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">The open issues include:</p>
+  <ul>
+    <li>Describe all supported use cases, including third-party call control and call transfer.</li>
+    <li>Specify how to include call history (e.g., for transfer).</li>
+    <li>Specify how to initiate a session with a bare JID.</li>
+  </ul>
+<h2>11.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his helpful feedback on this document. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2250381">17</a>] and (earlier) Jingle  [<a href="#nt-id2250403">18</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251177">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2251166">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2251190">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2256699">4</a>. Google Talk is a messaging and voice chat service and client provided by Google; see &lt;<a href="http://www.google.com/talk/">http://www.google.com/talk/</a>&gt;.</p>
+<p><a name="nt-id2256745">5</a>. Possible other media description formats include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2256807">6</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2256835">7</a>. JEP-0167: Jingle Audio Media Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2256872">8</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256894">9</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2257126">10</a>. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach that was taken in <span style="font-weight: bold">JEP-0111</span>), this is not necessarily helpful, since SDP is not structured data, not all SDP data is needed or used in the most common use cases, and SDP has been heavily extended in several useful directions.</p>
+<p><a name="nt-id2257213">11</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257237">12</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2257297">13</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2257392">14</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2258237">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258252">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250381">17</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2250403">18</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-02-24)</h4>
+<div class="indent">
+<p class="" style="">Provided more detail about modify scenarios; defined media-specific and transport-specific actions and adjusted state machine accordingly.</p> (psa/jb)
+    </div>
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Per agreement among the co-authors, moved transport definition to separate specification, simplified state machine, and made other associated changes to the text, examples, and schemas; also harmonized redirect, decline, and terminate processes.</p> (psa/jb)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">
+<p class="" style="">More fully documented burst mode, connectivity checks, error cases, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">
+<p class="" style="">Restructured document flow; provided example of burst mode.</p> (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author.</p> (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow; harmonized candidate negotiation process with ICE.</p> (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup.</p> (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Separated  methoddescription formats from signalling protocol.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">
+<p class="" style="">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">
+<p class="" style="">Protocol cleanup.</p> (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.4.html
+++ b/content/xep-0166-0.4.html
@@ -1,0 +1,828 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle</h1>
+<p>This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0166<br>
+            Version: 0.4<br>
+            Last Updated: 2006-03-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>4.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts-session">Session Management</a>
+</dt>
+<dt>4.2.  <a href="#concepts-media">Media Description Formats</a>
+</dt>
+<dt>4.3.  <a href="#concepts-transport">Transport Methods</a>
+</dt>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>5.2.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>5.3.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>5.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>5.5.  <a href="#protocol-decline">Decline</a>
+</dt>
+<dt>5.6.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>5.7.  <a href="#protocol-modify">Modifying an Active Session</a>
+</dt>
+<dt>5.8.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>5.9.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#deploy">Deployment Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-media">Jingle Media Description Formats Registry</a>
+</dt>
+<dt>10.3.  <a href="#registrar-transports">Jingle Transport Methods Registry</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-jingle">Jingle</a>
+</dt>
+<dt>11.2.  <a href="#schema-errors">Jingle Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#issues">Open Issues</a>
+</dt>
+<dt>13.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) multimedia interactions (such as voice and video exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions (TINS)</span>  [<a href="#nt-id2250881">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2250908">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2256770">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team,  [<a href="#nt-id2256794">4</a>] it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2256841">5</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li><p class="" style="">Various media description formats (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2256904">6</a>]); one example is <span class="ref" style="">Jingle Audio Media Description Format</span>  [<a href="#nt-id2256931">7</a>].</p></li>
+    <li><p class="" style="">Various transport methods.</p></li>
+    <li><p class="" style="">Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2256968">8</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2256990">9</a>]).</p></li>
+  </ul>
+<h2>3.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Session</td>
+      <td align="" colspan="" rowspan="">A negotiated transport method and media description format connecting two entities. It is delimited in time by an initiate request and session ending events.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Media Type</td>
+      <td align="" colspan="" rowspan="">A formal declaration of the purpose of the session. Common session types might be "voice", "voice+video", and "file sharing". A session consists of one active negotiated media type at a time.  Depending on the media type and the media description, 1+ channels will be negotiated and used. This is the 'what' of the session. In Jingle XML syntax this is the namespace of the &lt;description/&gt; element. (Note: The term "media type" is used here in a rather loose fashion; it is not meant to limit Jingle communication to traditional multimedia exchanges or to imply any mapping to MIME types as specified in <span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2257089">10</a>].)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Media Description</td>
+      <td align="" colspan="" rowspan="">The details of the media type being established. For instance, this might describe the acceptable codecs when establishing a voice conversation. The XML elements for the media description are qualified by the namespace of the media type.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Transport Method</td>
+      <td align="" colspan="" rowspan="">The method for establishing communication channels between entities. Possible transports might include <span class="ref" style="">Jingle RTP-ICE Transport Method</span>  [<a href="#nt-id2257150">11</a>], <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2257173">12</a>], inband data, IAX, etc. This is the 'how' of the session. In Jingle XML syntax this is the namespace of the &lt;transport/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Channel</td>
+      <td align="" colspan="" rowspan="">A channel is a named way to get information between the endpoints for a given media type in the context of a given session. It is up to the transport to negotiate the details of each channel. For instance, a channel for the voice media type might be named 'myvoicedata'.</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Jingle consists of three parts, each with its own syntax, semantics, and state machine:</p>
+  <ol start="" type="">
+    <li>Overall session management</li>
+    <li>Media description formats (the "what")</li>
+    <li>Transport methods (the "how")</li>
+  </ol>
+  <p class="" style="">This JEP defines the semantics and syntax for overall session management, and provides pluggable "slots" for media description formats and transport methods, which are specified in separate documents.</p>
+  <div class="indent">
+<h3>4.1 <a name="concepts-session">Session Management</a>
+</h3>
+    <p class="" style="">The state machine for overall session management is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         o
+         |
+         | session-initiate
+         |
+         | +----------------------+
+         |/                       |
+PENDING  o------------------+     |
+         |  | session-info, |     |
+         |  | media-*,      |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         | session-accept         |
+         |                        |
+ ACTIVE  o------------------+     |
+         |  | session-info, |     |
+         |  | media-*,      |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         +------------------------+ session-redirect,
+                                  | session-terminate
+                                  |
+                                  |
+                                  o ENDED
+    </pre></div>
+    <p class="" style="">There are three overall session states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of the overall Jingle session are:</p>
+    <ol start="" type="">
+      <li>session-initiate (request a new session)</li>
+      <li>session-accept (definitively accept a session request)</li>
+      <li>session-redirect (redirect an initiate request to another address)</li>
+      <li>session-info (session-level information / messages)</li>
+      <li>session-terminate (end an existing session)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="concepts-media">Media Description Formats</a>
+</h3>
+    <p class="" style="">The media description format specifies the "what" of the session (e.g., bidirectional audio). When negotiating the session, the entities involved in the session need to exchange media description formats. The approach taken herein is to specify pure session description information in separate specifications, one for each media description format (audio, video, etc.).  [<a href="#nt-id2257377">13</a>] The session negotiation must contain some media description format(s), which are to be defined in separate specifications. Those specifications will also define the state chart for the media description format in question.</p>
+    <p class="" style="">The generic state machine for management of media description formats is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate [+ media-info]
+           |
+[PENDING]  o
+           |
+           | media-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / media-modify     / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\  media-decline       |
+           | \____________________/
+           |    media-accept
+           |
+           | session-terminate
+           |
+           o [ENDED]
+    </pre></div>
+    <p class="" style="">The states related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>MODIFYING</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of media description formats are:</p>
+    <ol start="" type="">
+      <li>media-info (media-level information / messages)</li>
+      <li>media-modify (request a change to the media description formats)</li>
+      <li>media-accept (accept a proposed media change)</li>
+      <li>media-decline (decline a proposed media change)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="concepts-transport">Transport Methods</a>
+</h3>
+    <p class="" style="">The transport method defines "how" the data shall be exchanged. As with the media description formats, the transport methods are specified in separate specifications. Possible transport methods include peer-to-peer RTP, local UDP, and SSL-TCP. Those specifications will also define the state chart for the transport method in question.</p>
+    <p class="" style="">The generic state machine for transport methods is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate [+ transport-info]
+           |
+[PENDING]  o
+           |
+           | transport-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / transport-modify / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\ transport-decline    |
+           | \____________________/
+           |    transport-accept
+           |
+           | session-terminate
+           |
+           o [ENDED]
+    </pre></div>
+    <p class="" style="">The states related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>MODIFYING</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>transport-info (transport-level information / messages)</li>
+      <li>transport-modify (request a change to the transport methods)</li>
+      <li>transport-accept (accept a proposed transport change)</li>
+      <li>transport-decline (decline a proposed transport change)</li>
+    </ol>
+  </div>
+<h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired media description format. If a contact has only one XMPP resource, this task MUST be completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257643">14</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2257667">15</a>].</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for Jingle and various Jingle media description formats and transport methods is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired media description format, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired media description format, it is RECOMMENDED for a client to use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2257728">16</a>] in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for the desired media description format, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace. The &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes; for initiation the 'action' attribute MUST have a value of "initiate" and the &lt;jingle/&gt; element MUST contain one or more &lt;description/&gt; child elements that specify the desired media description formats and one or more &lt;transport/&gt; child elements that specify the desired transport methods. Here is an example:</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='initiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The syntax and semantics of the description and transport elements are out of scope for this specification.</p>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is REQUIRED; it specifies a Jingle action as listed in this document (e.g., "initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'responder' attribute (see examples below) is the full JID of the entity that has replied to the initiation (which may be different from the 'to' address on the IQ-set).</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2257822">17</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">Unless an error occurs, the target entity MUST acknowledge receipt of the initiation request:</p>
+    <p class="caption">Example 2. Target Entity Acknowledges Receipt of Initiation Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">If the target entity acknowledges receipt of the initation request, both parties must consider the session to be in the PENDING state.</p>
+    <p class="" style="">There are several reasons why the target entity might return an error instead of acknowledging receipt of the initiation request:</p>
+    <ul>
+      <li>The initiating entity is unknown to the target entity (e.g., via presence subscription).</li>
+      <li>The target entity does not support Jingle.</li>
+      <li>The target entity does not support any of the specified media description formats.</li>
+      <li>The target entity does not support any of the specified transport methods.</li>
+      <li>The initiation request was malformed.</li>
+    </ul>
+    <p class="" style="">The initiating entity is unknown to the target entity (e.g., via presence subscription) and the target entity has a policy of not communicating via Jingle with unknown entities, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 3. Initiating Entity Unknown to Target Entity</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support Jingle, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 4. Target Entity Does Not Support Jingle</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified media description formats, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-media/&gt;.</p>
+    <p class="caption">Example 5. Target Entity Does Not Support Any Media Description Formats</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-media xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified transport methods, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-transports/&gt;.</p>
+    <p class="caption">Example 6. Target Entity Does Not Support Any Transport Methods</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-transports xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initiation request was malformed, the target entity MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 7. Initiation Request Malformed</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After acknowledging receipt of the initiation request, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 8. Target Entity Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='jingle2'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='redirect'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 9. Initiating Entity Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='jingle2'
+    to='juliet@capulet.com/balcony'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="protocol-decline">Decline</a>
+</h3>
+    <p class="" style="">In order to decline the session initiation request, the target entity MUST acknowledge receipt of the session initiation request, then terminate the session as described in the <a href="#protocol-terminate">Termination</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If (after negotiation of transport methods and media description formats) the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 10. Target Entity Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='accept'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MAY contain one or more &lt;description/&gt; elements that specify the desired media description format(s) and MAY contain one or more &lt;transport/&gt; elements that specify the desired transport methodl(s). The &lt;jingle/&gt; element SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity, and the initiating entity SHOULD send all future commmunications about this Jingle session o the JID provided in the 'responder' attribute.</p>
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 11. Initiating Entity Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending media over the negotiated connection.</p>
+    <p class="" style="">If one of the parties cannot find a suitable transport method, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="protocol-modify">Modifying an Active Session</a>
+</h3>
+    <p class="" style="">In order to modify an active session, either party may send a "media-modify" or "transport-modify" action to the other party containing a modified media description format or transport method. The receiving party then sends an appropriate "-accept" or "-decline" action, and may first send an appropriate "-info" action.</p>
+    <p class="" style="">If both parties send modify messages at the same time, the modify message from the session initiator MUST trump the modify message from the recipient and the initiator SHOULD return an &lt;unexpected-request/&gt; error to the other party.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session (which MAY be done at any point after acknowledging receipt of the initiation request, including immediately thereafter in order to decline the request), either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 12. Target Entity Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='term1'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity MUST then acknowledge termination of the session:</p>
+    <p class="caption">Example 13. Initiating Entity Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further Jingle communication for the negotiated media description format and transport method MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'redirect' or 'terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 14. Target Entity Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to change a transport method or media description format parameter, inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message takes the form of an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "session-info", "media-info", or "transport-info"; the &lt;jingle/&gt; element MUST further contain a "payload" child element (speciific to the session, media description format, or transport method) that specifies the information being communicated. (A future version of this specification will define payloads related to the "session-info" action.)</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The Jingle-specific error conditions are as follows.</p>
+  <p class="caption">Table 2: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jingle Condition</th>
+      <th colspan="" rowspan="">XMPP Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The request cannot occur at this point in the state machine (e.g., initiate after accept).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-media/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired media description formats.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-transports/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired transport methods.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="deploy">Deployment Notes</a>
+</h2>
+  <p class="" style="">This specification applies exclusively to Jabber/XMPP clients and places no additional requirements on Jabber/XMPP servers. However, depending on the transport methods in use, domains may wish to deploy a STUN server and/or Jingle data relay service.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>8.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Jingle sessions may be resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many Jingle sessions. Care must be taken to accept media sessions only from known entities and only if the entity's device is able to process such sessions.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258646">18</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258696">19</a>] shall include 'http://jabber.org/protocol/jingle' and 'http://jabber.org/protocol/jingle#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-media">Jingle Media Description Formats Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle media description formats. All media description format registrations shall be defined in separate documents (not in this JEP). Media description formats defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/media/name" (where "name" is the registered name of the media description format).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;media&gt;
+  &lt;name&gt;the name of the media description format (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the media description format&lt;/desc&gt;
+  &lt;doc&gt;the document in which this media description format is specified&lt;/doc&gt;
+&lt;/media&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="registrar-transports">Jingle Transport Methods Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle transport methods. All transport method registrations shall be defined in separate documents (not in this JEP). Transport methods defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/transport/name" (where "name" is the registered name of the transport method).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;the name of the transport method (e.g., "p2p")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the transport method&lt;/desc&gt;
+  &lt;doc&gt;the document in which this transport method is specified&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-jingle">Jingle</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='media-accept'/&gt;
+            &lt;xs:enumeration value='media-decline'/&gt;
+            &lt;xs:enumeration value='media-info'/&gt;
+            &lt;xs:enumeration value='media-modify'/&gt;
+            &lt;xs:enumeration value='session-accept'/&gt;
+            &lt;xs:enumeration value='session-info'/&gt;
+            &lt;xs:enumeration value='session-initiate'/&gt;
+            &lt;xs:enumeration value='session-redirect'/&gt;
+            &lt;xs:enumeration value='session-terminate'/&gt;
+            &lt;xs:enumeration value='transport-accept'/&gt;
+            &lt;xs:enumeration value='transport-decline'/&gt;
+            &lt;xs:enumeration value='transport-info'/&gt;
+            &lt;xs:enumeration value='transport-modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='responder' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-errors">Jingle Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-media' type='empty'/&gt;
+  &lt;xs:element name='unsupported-transports' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">The open issues include:</p>
+  <ul>
+    <li>Describe all supported use cases, including third-party call control and call transfer.</li>
+    <li>Specify how to include call history (e.g., for transfer).</li>
+    <li>Specify how to initiate a session with a bare JID.</li>
+  </ul>
+<h2>13.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his helpful feedback on this document. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2250474">20</a>] and (earlier) Jingle  [<a href="#nt-id2250461">21</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250881">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2250908">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2256770">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2256794">4</a>. Google Talk is a messaging and voice chat service and client provided by Google; see &lt;<a href="http://www.google.com/talk/">http://www.google.com/talk/</a>&gt;.</p>
+<p><a name="nt-id2256841">5</a>. Possible other media description formats include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2256904">6</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2256931">7</a>. JEP-0167: Jingle Audio Media Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2256968">8</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256990">9</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2257089">10</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2257150">11</a>. JEP-0176: Jingle RTP-ICE Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0176.html">http://www.jabber.org/jeps/jep-0176.html</a>&gt;.</p>
+<p><a name="nt-id2257173">12</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2257377">13</a>. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach that was taken in <span style="font-weight: bold">JEP-0111</span>), this is not necessarily helpful, since SDP is not structured data, not all SDP data is needed or used in the most common use cases, and SDP has been heavily extended in several useful directions.</p>
+<p><a name="nt-id2257643">14</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257667">15</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2257728">16</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2257822">17</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2258646">18</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258696">19</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250474">20</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2250461">21</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2006-03-01)</h4>
+<div class="indent">
+<p class="" style="">Added glossary; clarified state machines; updated to reflect publication of JEP-0176 and JEP-0177.</p> (psa/jb)
+    </div>
+<h4>Version 0.3 (2006-02-24)</h4>
+<div class="indent">
+<p class="" style="">Provided more detail about modify scenarios; defined media-specific and transport-specific actions and adjusted state machine accordingly.</p> (psa/jb)
+    </div>
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Per agreement among the co-authors, moved transport definition to separate specification, simplified state machine, and made other associated changes to the text, examples, and schemas; also harmonized redirect, decline, and terminate processes.</p> (psa/jb)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">
+<p class="" style="">More fully documented burst mode, connectivity checks, error cases, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">
+<p class="" style="">Restructured document flow; provided example of burst mode.</p> (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author.</p> (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow; harmonized candidate negotiation process with ICE.</p> (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup.</p> (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Separated  methoddescription formats from signalling protocol.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">
+<p class="" style="">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">
+<p class="" style="">Protocol cleanup.</p> (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.5.html
+++ b/content/xep-0166-0.5.html
@@ -1,0 +1,832 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-20">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle</h1>
+<p>This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0166<br>
+            Version: 0.5<br>
+            Last Updated: 2006-03-20<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>4.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts-session">Session Management</a>
+</dt>
+<dt>4.2.  <a href="#concepts-media">Media Description Formats</a>
+</dt>
+<dt>4.3.  <a href="#concepts-transport">Transport Methods</a>
+</dt>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>5.2.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>5.3.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>5.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>5.5.  <a href="#protocol-decline">Decline</a>
+</dt>
+<dt>5.6.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>5.7.  <a href="#protocol-modify">Modifying an Active Session</a>
+</dt>
+<dt>5.8.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>5.9.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>7.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-media">Jingle Media Description Formats Registry</a>
+</dt>
+<dt>9.3.  <a href="#registrar-transports">Jingle Transport Methods Registry</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#schema-jingle">Jingle</a>
+</dt>
+<dt>10.2.  <a href="#schema-errors">Jingle Errors</a>
+</dt>
+</dl>
+<dt>11.  <a href="#issues">Open Issues</a>
+</dt>
+<dt>12.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) multimedia interactions (such as voice and video exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions (TINS)</span>  [<a href="#nt-id2256806">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2250903">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2256851">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team,  [<a href="#nt-id2256874">4</a>] it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2256923">5</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li><p class="" style="">Various media description formats (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2256984">6</a>]); one example is <span class="ref" style="">Jingle Audio Media Description Format</span>  [<a href="#nt-id2257011">7</a>].</p></li>
+    <li><p class="" style="">Various transport methods.</p></li>
+    <li><p class="" style="">Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2257049">8</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2257072">9</a>]).</p></li>
+  </ul>
+<h2>3.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Session</td>
+      <td align="" colspan="" rowspan="">A negotiated transport method and media description format connecting two entities. It is delimited in time by an initiate request and session ending events.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Media Type</td>
+      <td align="" colspan="" rowspan="">A formal declaration of the purpose of the session. Common session types might be "voice", "voice+video", and "file sharing". A session consists of one active negotiated media type at a time.  Depending on the media type and the media description, 1+ channels will be negotiated and used. This is the 'what' of the session. In Jingle XML syntax this is the namespace of the &lt;description/&gt; element. (Note: The term "media type" is used here in a rather loose fashion; it is not meant to limit Jingle communication to traditional multimedia exchanges or to imply any mapping to MIME types as specified in <span class="ref" style="">RFC 2045</span>  [<a href="#nt-id2257172">10</a>].)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Media Description</td>
+      <td align="" colspan="" rowspan="">The details of the media type being established. For instance, this might describe the acceptable codecs when establishing a voice conversation. The XML elements for the media description are qualified by the namespace of the media type.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Transport Method</td>
+      <td align="" colspan="" rowspan="">The method for establishing communication channels between entities. Possible transports might include <span class="ref" style="">Jingle RTP-ICE Transport Method</span>  [<a href="#nt-id2257231">11</a>], <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2257254">12</a>], inband data, IAX, etc. This is the 'how' of the session. In Jingle XML syntax this is the namespace of the &lt;transport/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Channel</td>
+      <td align="" colspan="" rowspan="">A channel is a named way to get information between the endpoints for a given media type in the context of a given session. It is up to the transport to negotiate the details of each channel. For instance, a channel for the voice media type might be named 'myvoicedata'.</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Jingle consists of three parts, each with its own syntax, semantics, and state machine:</p>
+  <ol start="" type="">
+    <li>Overall session management</li>
+    <li>Media description formats (the "what")</li>
+    <li>Transport methods (the "how")</li>
+  </ol>
+  <p class="" style="">This JEP defines the semantics and syntax for overall session management, and provides pluggable "slots" for media description formats and transport methods, which are specified in separate documents.</p>
+  <div class="indent">
+<h3>4.1 <a name="concepts-session">Session Management</a>
+</h3>
+    <p class="" style="">The state machine for overall session management (i.e., the state per Session ID) is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         o
+         |
+         | session-initiate
+         |
+         | +----------------------+
+         |/                       |
+PENDING  o------------------+     |
+         |  | session-info, |     |
+         |  | media-*,      |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         | session-accept         |
+         |                        |
+ ACTIVE  o------------------+     |
+         |  | session-info, |     |
+         |  | media-*,      |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         +------------------------+ session-redirect,
+                                  | session-terminate
+                                  |
+                                  |
+                                  o ENDED
+    </pre></div>
+    <p class="" style="">There are three overall session states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of the overall Jingle session are:</p>
+    <ol start="" type="">
+      <li>session-initiate (request a new session)</li>
+      <li>session-accept (definitively accept a session request)</li>
+      <li>session-redirect (redirect an initiate request to another address)</li>
+      <li>session-info (session-level information / messages)</li>
+      <li>session-terminate (end an existing session)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="concepts-media">Media Description Formats</a>
+</h3>
+    <p class="" style="">The media description format specifies the "what" of the session (e.g., bidirectional audio). When negotiating the session, the entities involved in the session need to exchange media description formats. The approach taken herein is to specify pure session description information in separate specifications, one for each media description format (audio, video, etc.).  [<a href="#nt-id2257458">13</a>] The session negotiation must contain some media description format(s), which are to be defined in separate specifications. Those specifications will also define the state chart for the media description format in question.</p>
+    <p class="" style="">The generic state machine for management of media description formats is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           |
+           |
+[PENDING]  o-------------+
+           |   |_________| media-info
+           |
+           | media-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / media-modify     / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\  media-decline       |
+           | \____________________/
+           |    media-accept
+           |
+           | session-terminate
+           |
+           o [ENDED]
+    </pre></div>
+    <p class="" style="">The states related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>MODIFYING</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of media description formats are:</p>
+    <ol start="" type="">
+      <li>media-info (media-level information / messages)</li>
+      <li>media-modify (request a change to the media description formats)</li>
+      <li>media-accept (accept a proposed media change)</li>
+      <li>media-decline (decline a proposed media change)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="concepts-transport">Transport Methods</a>
+</h3>
+    <p class="" style="">The transport method defines "how" the data shall be exchanged. As with the media description formats, the transport methods are specified in separate specifications. Possible transport methods include peer-to-peer RTP, local UDP, and SSL-TCP. Those specifications will also define the state chart for the transport method in question.</p>
+    <p class="" style="">The generic state machine for transport methods is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           |
+[PENDING]  o-------------+
+           |   |_________| transport-info
+           |
+           | transport-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / transport-modify / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\ transport-decline    |
+           | \____________________/
+           |    transport-accept
+           |
+           | session-terminate
+           |
+           o [ENDED]
+    </pre></div>
+    <p class="" style="">The states related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>MODIFYING</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>transport-info (transport-level information / messages)</li>
+      <li>transport-modify (request a change to the transport methods)</li>
+      <li>transport-accept (accept a proposed transport change)</li>
+      <li>transport-decline (decline a proposed transport change)</li>
+    </ol>
+  </div>
+<h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired media description format. If a contact has only one XMPP resource, this task MUST be completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2257717">14</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2257740">15</a>].</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for Jingle and various Jingle media description formats and transport methods is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired media description format, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired media description format, it is RECOMMENDED for a client to use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2257801">16</a>] in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for the desired media description format, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace. The &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes (the latter two uniquely identify the session); for initiation the 'action' attribute MUST have a value of "initiate" and the &lt;jingle/&gt; element MUST contain one or more &lt;description/&gt; child elements that specify the desired media description formats and one or more &lt;transport/&gt; child elements that specify the desired transport methods. Here is an example:</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-initiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The syntax and semantics of the description and transport elements are out of scope for this specification.</p>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is REQUIRED; it specifies a Jingle action as listed in this document (e.g., "initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'responder' attribute (see examples below) is the full JID of the entity that has replied to the initiation (which may be different from the 'to' address on the IQ-set).</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2257895">17</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">Unless an error occurs, the target entity MUST acknowledge receipt of the initiation request:</p>
+    <p class="caption">Example 2. Target Entity Acknowledges Receipt of Initiation Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">If the target entity acknowledges receipt of the initation request, both parties must consider the session to be in the PENDING state.</p>
+    <p class="" style="">There are several reasons why the target entity might return an error instead of acknowledging receipt of the initiation request:</p>
+    <ul>
+      <li>The initiating entity is unknown to the target entity (e.g., via presence subscription).</li>
+      <li>The target entity does not support Jingle.</li>
+      <li>The target entity does not support any of the specified media description formats.</li>
+      <li>The target entity does not support any of the specified transport methods.</li>
+      <li>The initiation request was malformed.</li>
+    </ul>
+    <p class="" style="">The initiating entity is unknown to the target entity (e.g., via presence subscription) and the target entity has a policy of not communicating via Jingle with unknown entities, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 3. Initiating Entity Unknown to Target Entity</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support Jingle, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 4. Target Entity Does Not Support Jingle</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified media description formats, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-media/&gt;.</p>
+    <p class="caption">Example 5. Target Entity Does Not Support Any Media Description Formats</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-media xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified transport methods, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-transports/&gt;.</p>
+    <p class="caption">Example 6. Target Entity Does Not Support Any Transport Methods</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-transports xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initiation request was malformed, the target entity MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 7. Initiation Request Malformed</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After acknowledging receipt of the initiation request, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 8. Target Entity Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='jingle2'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='redirect'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 9. Initiating Entity Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='jingle2'
+    to='juliet@capulet.com/balcony'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="protocol-decline">Decline</a>
+</h3>
+    <p class="" style="">In order to decline the session initiation request, the target entity MUST acknowledge receipt of the session initiation request, then terminate the session as described in the <a href="#protocol-terminate">Termination</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If (after negotiation of transport methods and media description formats) the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 10. Target Entity Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-accept'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MUST contain one or more &lt;description/&gt; elements that specify the desired media description format(s) and MUST contain one or more &lt;transport/&gt; elements that specify the desired transport methodl(s). The &lt;jingle/&gt; element SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity, and the initiating entity SHOULD send all future commmunications about this Jingle session o the JID provided in the 'responder' attribute.</p>
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 11. Initiating Entity Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending media over the negotiated connection.</p>
+    <p class="" style="">If one of the parties cannot find a suitable transport method, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="protocol-modify">Modifying an Active Session</a>
+</h3>
+    <p class="" style="">In order to modify an active session, either party may send a "media-modify" or "transport-modify" action to the other party containing a modified media description format or transport method. The receiving party then sends an appropriate "-accept" or "-decline" action, and may first send an appropriate "-info" action.</p>
+    <p class="" style="">If both parties send modify messages at the same time, the modify message from the session initiator MUST trump the modify message from the recipient and the initiator SHOULD return an &lt;unexpected-request/&gt; error to the other party.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session (which MAY be done at any point after acknowledging receipt of the initiation request, including immediately thereafter in order to decline the request), either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 12. Target Entity Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='term1'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity MUST then acknowledge termination of the session:</p>
+    <p class="caption">Example 13. Initiating Entity Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further Jingle communication for the negotiated media description format and transport method MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'redirect' or 'terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 14. Target Entity Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to change a transport method or media description format parameter, inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message MUST be an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "session-info", "media-info", or "transport-info"; the &lt;jingle/&gt; element MUST further contain a payload child element (speciific to the session, media description format, or transport method) that specifies the information being communicated. (A future version of this specification will define payloads related to the "session-info" action.)</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The Jingle-specific error conditions are as follows.</p>
+  <p class="caption">Table 2: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jingle Condition</th>
+      <th colspan="" rowspan="">XMPP Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The request cannot occur at this point in the state machine (e.g., initiate after accept).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-media/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired media description formats.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-transports/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired transport methods.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>7.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Jingle sessions may be resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many Jingle sessions. Care must be taken to accept media sessions only from known entities and only if the entity's device is able to process such sessions.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258743">18</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258759">19</a>] shall include 'http://jabber.org/protocol/jingle' and 'http://jabber.org/protocol/jingle#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="registrar-media">Jingle Media Description Formats Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle media description formats. All media description format registrations shall be defined in separate documents (not in this JEP). Media description formats defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/media/name" (where "name" is the registered name of the media description format).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;media&gt;
+  &lt;name&gt;the name of the media description format (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the media description format&lt;/desc&gt;
+  &lt;doc&gt;the document in which this media description format is specified&lt;/doc&gt;
+&lt;/media&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="registrar-transports">Jingle Transport Methods Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle transport methods. All transport method registrations shall be defined in separate documents (not in this JEP). Transport methods defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/transport/name" (where "name" is the registered name of the transport method).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;the name of the transport method (e.g., "p2p")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the transport method&lt;/desc&gt;
+  &lt;doc&gt;the document in which this transport method is specified&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="schema-jingle">Jingle</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='media-accept'/&gt;
+            &lt;xs:enumeration value='media-decline'/&gt;
+            &lt;xs:enumeration value='media-info'/&gt;
+            &lt;xs:enumeration value='media-modify'/&gt;
+            &lt;xs:enumeration value='session-accept'/&gt;
+            &lt;xs:enumeration value='session-info'/&gt;
+            &lt;xs:enumeration value='session-initiate'/&gt;
+            &lt;xs:enumeration value='session-redirect'/&gt;
+            &lt;xs:enumeration value='session-terminate'/&gt;
+            &lt;xs:enumeration value='transport-accept'/&gt;
+            &lt;xs:enumeration value='transport-decline'/&gt;
+            &lt;xs:enumeration value='transport-info'/&gt;
+            &lt;xs:enumeration value='transport-modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='responder' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="schema-errors">Jingle Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-media' type='empty'/&gt;
+  &lt;xs:element name='unsupported-transports' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">The open issues include:</p>
+  <ul>
+    <li>Describe all supported use cases, including third-party call control and call transfer.</li>
+    <li>Specify how to include call history (e.g., for transfer).</li>
+    <li>Specify how to initiate a session with a bare JID.</li>
+  </ul>
+<h2>12.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his helpful feedback on this document. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2258989">20</a>] and (earlier) Jingle  [<a href="#nt-id2258976">21</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2256806">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2250903">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2256851">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2256874">4</a>. Google Talk is a messaging and voice chat service and client provided by Google; see &lt;<a href="http://www.google.com/talk/">http://www.google.com/talk/</a>&gt;.</p>
+<p><a name="nt-id2256923">5</a>. Possible other media description formats include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2256984">6</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2257011">7</a>. JEP-0167: Jingle Audio Media Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2257049">8</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2257072">9</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2257172">10</a>. RFC 2045: Multipurpose Internet Mail Extensions (MIME) Part One: Format of Internet Message Bodies &lt;<a href="http://www.ietf.org/rfc/rfc2045.txt">http://www.ietf.org/rfc/rfc2045.txt</a>&gt;.</p>
+<p><a name="nt-id2257231">11</a>. JEP-0176: Jingle RTP-ICE Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0176.html">http://www.jabber.org/jeps/jep-0176.html</a>&gt;.</p>
+<p><a name="nt-id2257254">12</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2257458">13</a>. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach that was taken in <span style="font-weight: bold">JEP-0111</span>), this is not necessarily helpful, since SDP is not structured data, not all SDP data is needed or used in the most common use cases, and SDP has been heavily extended in several useful directions.</p>
+<p><a name="nt-id2257717">14</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257740">15</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2257801">16</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2257895">17</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2258743">18</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258759">19</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2258989">20</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2258976">21</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">Further clarified state machine diagrams; specified that session accept must include agreed-upon media format and transport description; moved deployment notes to appropriate transport spec.</p> (psa/jb)
+    </div>
+<h4>Version 0.4 (2006-03-01)</h4>
+<div class="indent">
+<p class="" style="">Added glossary; clarified state machines; updated to reflect publication of JEP-0176 and JEP-0177.</p> (psa/jb)
+    </div>
+<h4>Version 0.3 (2006-02-24)</h4>
+<div class="indent">
+<p class="" style="">Provided more detail about modify scenarios; defined media-specific and transport-specific actions and adjusted state machine accordingly.</p> (psa/jb)
+    </div>
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Per agreement among the co-authors, moved transport definition to separate specification, simplified state machine, and made other associated changes to the text, examples, and schemas; also harmonized redirect, decline, and terminate processes.</p> (psa/jb)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">
+<p class="" style="">More fully documented burst mode, connectivity checks, error cases, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">
+<p class="" style="">Restructured document flow; provided example of burst mode.</p> (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author.</p> (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow; harmonized candidate negotiation process with ICE.</p> (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup.</p> (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Separated  methoddescription formats from signalling protocol.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">
+<p class="" style="">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">
+<p class="" style="">Protocol cleanup.</p> (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.6.html
+++ b/content/xep-0166-0.6.html
@@ -1,0 +1,844 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Sean Egan">
+<meta name="DC.Description" content="This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle</h1>
+<p>This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0166<br>
+            Version: 0.6<br>
+            Last Updated: 2006-07-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+<h3>Sean Egan</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:seanegan@google.com">seanegan@google.com</a><br>
+        JID: 
+        <a href="xmpp:seanegan@google.com">seanegan@google.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>4.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts-session">Session Management</a>
+</dt>
+<dt>4.2.  <a href="#concepts-content">Content Description Formats</a>
+</dt>
+<dt>4.3.  <a href="#concepts-transport">Transport Methods</a>
+</dt>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>5.2.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>5.3.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>5.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>5.5.  <a href="#protocol-decline">Decline</a>
+</dt>
+<dt>5.6.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>5.7.  <a href="#protocol-modify">Modifying an Active Session</a>
+</dt>
+<dt>5.8.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>5.9.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>7.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-content">Jingle Content Description Formats Registry</a>
+</dt>
+<dt>9.3.  <a href="#registrar-transports">Jingle Transport Methods Registry</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#schema-jingle">Jingle</a>
+</dt>
+<dt>10.2.  <a href="#schema-errors">Jingle Errors</a>
+</dt>
+</dl>
+<dt>11.  <a href="#issues">Open Issues</a>
+</dt>
+<dt>12.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) interactions (such as voice, video, or file sharing exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions (TINS)</span>  [<a href="#nt-id2259520">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2259506">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2259572">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team,  [<a href="#nt-id2259596">4</a>] it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2259644">5</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li><p class="" style="">Various content description formats (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2250517">6</a>]); one example is <span class="ref" style="">Jingle Audio Content Description Format</span>  [<a href="#nt-id2250542">7</a>].</p></li>
+    <li><p class="" style="">Various transport methods.</p></li>
+    <li><p class="" style="">Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250618">8</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2250575">9</a>]).</p></li>
+  </ul>
+<h2>3.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Session</td>
+      <td align="" colspan="" rowspan="">A negotiated transport method and content description format connecting two entities. It is delimited in time by an initiate request and session ending events.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Content Type</td>
+      <td align="" colspan="" rowspan="">A formal declaration of the purpose of the session. Common session types might be "voice", "voice+video", and "file sharing". A session consists of one active negotiated content type at a time.  Depending on the content type and the content description, 1+ channels will be negotiated and used. This is the 'what' of the session. In Jingle XML syntax this is the namespace of the &lt;description/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Content Description</td>
+      <td align="" colspan="" rowspan="">The details of the content type being established. For instance, this might describe the acceptable codecs when establishing a voice conversation. The XML elements for the content description are qualified by the namespace of the content type. The content description defines the bits to be transferred</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Transport Method</td>
+      <td align="" colspan="" rowspan="">The method for establishing communication channels between entities. Possible transports might include <span class="ref" style="">Jingle RTP-ICE Transport Method</span>  [<a href="#nt-id2260063">10</a>], <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2260086">11</a>], inband data, etc. This is the 'how' of the session. In Jingle XML syntax this is the namespace of the &lt;transport/&gt; element. The transport method defines how to transfer bits from one host to another.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Channel</td>
+      <td align="" colspan="" rowspan="">A channel is a named way to get information between the endpoints for a given content type in the context of a given session. It is up to the transport to negotiate the details of each channel. For instance, a channel for the voice content type might be named 'myvoicedata'.</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Jingle consists of three parts, each with its own syntax, semantics, and state machine:</p>
+  <ol start="" type="">
+    <li>Overall session management</li>
+    <li>Content description formats (the "what")</li>
+    <li>Transport methods (the "how")</li>
+  </ol>
+  <p class="" style="">This JEP defines the semantics and syntax for overall session management, and provides pluggable "slots" for content description formats and transport methods, which are specified in separate documents.</p>
+  <div class="indent">
+<h3>4.1 <a name="concepts-session">Session Management</a>
+</h3>
+    <p class="" style="">The state machine for overall session management (i.e., the state per Session ID) is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         o
+         |
+         | session-initiate
+         |
+         | +----------------------+
+         |/                       |
+PENDING  o------------------+     |
+         |  | session-info, |     |
+         |  | content-*,    |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         | session-accept         |
+         |                        |
+ ACTIVE  o------------------+     |
+         |  | session-info, |     |
+         |  | content-*,    |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         +------------------------+ session-redirect,
+                                  | session-terminate
+                                  |
+                                  |
+                                  o ENDED
+    </pre></div>
+    <p class="" style="">There are three overall session states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of the overall Jingle session are:</p>
+    <ol start="" type="">
+      <li>session-initiate (request a new session)</li>
+      <li>session-accept (definitively accept a session request)</li>
+      <li>session-redirect (redirect an initiate request to another address)</li>
+      <li>session-info (session-level information / messages)</li>
+      <li>session-terminate (end an existing session)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="concepts-content">Content Description Formats</a>
+</h3>
+    <p class="" style="">The content description format specifies the "what" of the session (e.g., bidirectional audio). When negotiating the session, the entities involved in the session need to exchange content description formats. The approach taken herein is to specify pure session description information in separate specifications, one for each content description format (audio, video, etc.).  [<a href="#nt-id2260278">12</a>] The session negotiation must contain some content description format(s), which are to be defined in separate specifications. Those specifications will also define the state chart for the content description format in question.</p>
+    <p class="" style="">The generic state machine for management of content description formats is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           |
+           |
+[PENDING]  o-------------+
+           |   |_________| content-info
+           |
+           | content-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / content-modify     / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\  content-decline     |
+           | \____________________/
+           |    content-accept
+           |
+           | session-terminate
+           |
+           o [ENDED]
+    </pre></div>
+    <p class="" style="">The states related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>MODIFYING</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of content description formats are:</p>
+    <ol start="" type="">
+      <li>content-info (content-level information / messages)</li>
+      <li>content-modify (request a change to the content description formats)</li>
+      <li>content-accept (accept a proposed content change)</li>
+      <li>content-decline (decline a proposed content change)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="concepts-transport">Transport Methods</a>
+</h3>
+    <p class="" style="">The transport method defines "how" the data shall be exchanged. As with the content description formats, the transport methods are specified in separate specifications. Possible transport methods include peer-to-peer RTP, local UDP, and SSL-TCP. Those specifications will also define the state chart for the transport method in question.</p>
+    <p class="" style="">The generic state machine for transport methods is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           |
+[PENDING]  o-------------+
+           |   |_________| transport-info
+           |
+           | transport-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / transport-modify / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\ transport-decline    |
+           | \____________________/
+           |    transport-accept
+           |
+           | session-terminate
+           |
+           o [ENDED]
+    </pre></div>
+    <p class="" style="">The states related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>MODIFYING</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>transport-info (transport-level information / messages)</li>
+      <li>transport-modify (request a change to the transport methods)</li>
+      <li>transport-accept (accept a proposed transport change)</li>
+      <li>transport-decline (decline a proposed transport change)</li>
+    </ol>
+  </div>
+<h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired content description format. If a contact has only one XMPP resource, this task MUST be completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260543">13</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2260567">14</a>].</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for Jingle and various Jingle content description formats and transport methods is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired content description format, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired content description format, it is RECOMMENDED for a client to use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2260629">15</a>] in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for the desired content description format, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace. The &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes (the latter two uniquely identify the session); for initiation the 'action' attribute MUST have a value of "initiate" and the &lt;jingle/&gt; element MUST contain one or more &lt;description/&gt; child elements that specify the desired content description formats and one or more &lt;transport/&gt; child elements that specify the desired transport methods. Here is an example:</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-initiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The syntax and semantics of the description and transport elements are out of scope for this specification.</p>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is REQUIRED; it specifies a Jingle action as listed in this document (e.g., "initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'responder' attribute (see examples below) is the full JID of the entity that has replied to the initiation (which may be different from the 'to' address on the IQ-set).</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2260722">16</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">Unless an error occurs, the target entity MUST acknowledge receipt of the initiation request:</p>
+    <p class="caption">Example 2. Target Entity Acknowledges Receipt of Initiation Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">If the target entity acknowledges receipt of the initation request, both parties must consider the session to be in the PENDING state.</p>
+    <p class="" style="">There are several reasons why the target entity might return an error instead of acknowledging receipt of the initiation request:</p>
+    <ul>
+      <li>The initiating entity is unknown to the target entity (e.g., via presence subscription).</li>
+      <li>The target entity does not support Jingle.</li>
+      <li>The target entity does not support any of the specified content description formats.</li>
+      <li>The target entity does not support any of the specified transport methods.</li>
+      <li>The initiation request was malformed.</li>
+    </ul>
+    <p class="" style="">The initiating entity is unknown to the target entity (e.g., via presence subscription) and the target entity has a policy of not communicating via Jingle with unknown entities, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 3. Initiating Entity Unknown to Target Entity</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support Jingle, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 4. Target Entity Does Not Support Jingle</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified content description formats, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-content/&gt;.</p>
+    <p class="caption">Example 5. Target Entity Does Not Support Any Content Description Formats</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-content xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified transport methods, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-transports/&gt;.</p>
+    <p class="caption">Example 6. Target Entity Does Not Support Any Transport Methods</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-transports xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initiation request was malformed, the target entity MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 7. Initiation Request Malformed</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After acknowledging receipt of the initiation request, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 8. Target Entity Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='jingle2'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-redirect'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 9. Initiating Entity Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='jingle2'
+    to='juliet@capulet.com/balcony'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="protocol-decline">Decline</a>
+</h3>
+    <p class="" style="">In order to decline the session initiation request, the target entity MUST acknowledge receipt of the session initiation request, then terminate the session as described in the <a href="#protocol-terminate">Termination</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If (after negotiation of transport methods and content description formats) the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 10. Target Entity Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-accept'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MUST contain one or more &lt;description/&gt; elements that specify the desired content description format(s) and MUST contain one or more &lt;transport/&gt; elements that specify the desired transport methodl(s). The &lt;jingle/&gt; element SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity, and the initiating entity SHOULD send all future commmunications about this Jingle session o the JID provided in the 'responder' attribute.</p>
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 11. Initiating Entity Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending content over the negotiated connection.</p>
+    <p class="" style="">If one of the parties cannot find a suitable transport method, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="protocol-modify">Modifying an Active Session</a>
+</h3>
+    <p class="" style="">In order to modify an active session, either party may send a "content-modify" or "transport-modify" action to the other party containing a modified content description format or transport method. The receiving party then sends an appropriate "-accept" or "-decline" action, and may first send an appropriate "-info" action.</p>
+    <p class="" style="">If both parties send modify messages at the same time, the modify message from the session initiator MUST trump the modify message from the recipient and the initiator SHOULD return an &lt;unexpected-request/&gt; error to the other party.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session (which MAY be done at any point after acknowledging receipt of the initiation request, including immediately thereafter in order to decline the request), either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 12. Target Entity Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='term1'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-terminate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity MUST then acknowledge termination of the session:</p>
+    <p class="caption">Example 13. Initiating Entity Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further Jingle communication for the negotiated content description format and transport method MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'session-redirect' or 'session-terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 14. Target Entity Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to change a transport method or content description format parameter, inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message MUST be an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "session-info", "content-info", or "transport-info"; the &lt;jingle/&gt; element MUST further contain a payload child element (speciific to the session, content description format, or transport method) that specifies the information being communicated. (A future version of this specification will define payloads related to the "session-info" action.)</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The Jingle-specific error conditions are as follows.</p>
+  <p class="caption">Table 2: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jingle Condition</th>
+      <th colspan="" rowspan="">XMPP Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The request cannot occur at this point in the state machine (e.g., initiate after accept).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-content/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired content description formats.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-transports/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired transport methods.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>7.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Jingle sessions may be resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many Jingle sessions. Care must be taken to accept content sessions only from known entities and only if the entity's device is able to process such sessions.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261571">17</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261585">18</a>] shall include 'http://jabber.org/protocol/jingle' and 'http://jabber.org/protocol/jingle#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="registrar-content">Jingle Content Description Formats Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle content description formats. All content description format registrations shall be defined in separate documents (not in this JEP). Content description formats defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/content/name" (where "name" is the registered name of the content description format).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;content&gt;
+  &lt;name&gt;the name of the content description format (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the content description format&lt;/desc&gt;
+  &lt;doc&gt;the document in which this content description format is specified&lt;/doc&gt;
+&lt;/content&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.3 <a name="registrar-transports">Jingle Transport Methods Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle transport methods. All transport method registrations shall be defined in separate documents (not in this JEP). Transport methods defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/transport/name" (where "name" is the registered name of the transport method).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;the name of the transport method (e.g., "p2p")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the transport method&lt;/desc&gt;
+  &lt;doc&gt;the document in which this transport method is specified&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>10.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="schema-jingle">Jingle</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='content-accept'/&gt;
+            &lt;xs:enumeration value='content-decline'/&gt;
+            &lt;xs:enumeration value='content-info'/&gt;
+            &lt;xs:enumeration value='content-modify'/&gt;
+            &lt;xs:enumeration value='session-accept'/&gt;
+            &lt;xs:enumeration value='session-info'/&gt;
+            &lt;xs:enumeration value='session-initiate'/&gt;
+            &lt;xs:enumeration value='session-redirect'/&gt;
+            &lt;xs:enumeration value='session-terminate'/&gt;
+            &lt;xs:enumeration value='transport-accept'/&gt;
+            &lt;xs:enumeration value='transport-decline'/&gt;
+            &lt;xs:enumeration value='transport-info'/&gt;
+            &lt;xs:enumeration value='transport-modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='responder' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="schema-errors">Jingle Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-content' type='empty'/&gt;
+  &lt;xs:element name='unsupported-transports' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">The open issues include:</p>
+  <ul>
+    <li>Describe all supported use cases, including third-party call control and call transfer.</li>
+    <li>Specify how to include call history (e.g., for transfer).</li>
+    <li>Specify how to initiate a session with a bare JID.</li>
+  </ul>
+<h2>12.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his helpful feedback on this document. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2261818">19</a>] and (earlier) Jingle  [<a href="#nt-id2261806">20</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2259520">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions (TINS &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2259506">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2259572">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2259596">4</a>. Google Talk is a messaging and voice chat service and client provided by Google; see &lt;<a href="http://www.google.com/talk/">http://www.google.com/talk/</a>&gt;.</p>
+<p><a name="nt-id2259644">5</a>. Possible other content description formats include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2250517">6</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2250542">7</a>. JEP-0167: Jingle Audio Content Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2250618">8</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2250575">9</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2260063">10</a>. JEP-0176: Jingle RTP-ICE Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0176.html">http://www.jabber.org/jeps/jep-0176.html</a>&gt;.</p>
+<p><a name="nt-id2260086">11</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2260278">12</a>. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach that was taken in <span style="font-weight: bold">JEP-0111</span>), this is not necessarily helpful, since SDP is not structured data, not all SDP data is needed or used in the most common use cases, and SDP has been heavily extended in several useful directions.</p>
+<p><a name="nt-id2260543">13</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260567">14</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2260629">15</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2260722">16</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2261571">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261585">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2261818">19</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2261806">20</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Changed media type to content type.</p> (se/psa)
+    </div>
+<h4>Version 0.5 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">Further clarified state machine diagrams; specified that session accept must include agreed-upon media format and transport description; moved deployment notes to appropriate transport spec.</p> (psa/jb)
+    </div>
+<h4>Version 0.4 (2006-03-01)</h4>
+<div class="indent">
+<p class="" style="">Added glossary; clarified state machines; updated to reflect publication of JEP-0176 and JEP-0177.</p> (psa/jb)
+    </div>
+<h4>Version 0.3 (2006-02-24)</h4>
+<div class="indent">
+<p class="" style="">Provided more detail about modify scenarios; defined media-specific and transport-specific actions and adjusted state machine accordingly.</p> (psa/jb)
+    </div>
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Per agreement among the co-authors, moved transport definition to separate specification, simplified state machine, and made other associated changes to the text, examples, and schemas; also harmonized redirect, decline, and terminate processes.</p> (psa/jb)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">
+<p class="" style="">More fully documented burst mode, connectivity checks, error cases, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">
+<p class="" style="">Restructured document flow; provided example of burst mode.</p> (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author.</p> (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow; harmonized candidate negotiation process with ICE.</p> (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup.</p> (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Separated  methoddescription formats from signalling protocol.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">
+<p class="" style="">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">
+<p class="" style="">Protocol cleanup.</p> (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.7.html
+++ b/content/xep-0166-0.7.html
@@ -1,0 +1,855 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Sean Egan">
+<meta name="DC.Description" content="This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-17">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle</h1>
+<p>This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0166<br>
+            Version: 0.7<br>
+            Last Updated: 2006-07-17<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+<h3>Sean Egan</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:seanegan@google.com">seanegan@google.com</a><br>
+        JID: 
+        <a href="xmpp:seanegan@google.com">seanegan@google.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>4.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts-session">Session Management</a>
+</dt>
+<dt>4.2.  <a href="#concepts-content">Content Description Formats</a>
+</dt>
+<dt>4.3.  <a href="#concepts-transport">Transport Methods</a>
+</dt>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>5.2.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>5.3.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>5.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>5.5.  <a href="#protocol-decline">Decline</a>
+</dt>
+<dt>5.6.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>5.7.  <a href="#protocol-modify">Modifying an Active Session</a>
+</dt>
+<dt>5.8.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>5.9.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-content">Jingle Content Description Formats Registry</a>
+</dt>
+<dt>10.3.  <a href="#registrar-transports">Jingle Transport Methods Registry</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-jingle">Jingle</a>
+</dt>
+<dt>11.2.  <a href="#schema-errors">Jingle Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#issues">Open Issues</a>
+</dt>
+<dt>13.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) interactions (such as voice, video, or file sharing exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions</span>  [<a href="#nt-id2259542">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2259528">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2259595">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team,  [<a href="#nt-id2259619">4</a>] it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2259665">5</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li><p class="" style="">Various content description formats (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2259730">6</a>]); one example is <span class="ref" style="">Jingle Audio Content Description Format</span>  [<a href="#nt-id2259753">7</a>].</p></li>
+    <li><p class="" style="">Various transport methods.</p></li>
+    <li><p class="" style="">Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2259796">8</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2259818">9</a>]).</p></li>
+  </ul>
+<h2>3.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Session</td>
+      <td align="" colspan="" rowspan="">A negotiated transport method and content description format connecting two entities. It is delimited in time by an initiate request and session ending events.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Content Type</td>
+      <td align="" colspan="" rowspan="">A formal declaration of the purpose of the session. Common session types might be "voice", "voice+video", and "file sharing". A session consists of one active negotiated content type at a time.  Depending on the content type and the content description, 1+ channels will be negotiated and used. This is the 'what' of the session. In Jingle XML syntax this is the namespace of the &lt;description/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Content Description</td>
+      <td align="" colspan="" rowspan="">The details of the content type being established. For instance, this might describe the acceptable codecs when establishing a voice conversation. The XML elements for the content description are qualified by the namespace of the content type. The content description defines the bits to be transferred</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Transport Method</td>
+      <td align="" colspan="" rowspan="">The method for establishing communication channels between entities. Possible transports might include <span class="ref" style="">Jingle RTP-ICE Transport Method</span>  [<a href="#nt-id2259950">10</a>], <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2259974">11</a>], inband data, etc. This is the 'how' of the session. In Jingle XML syntax this is the namespace of the &lt;transport/&gt; element. The transport method defines how to transfer bits from one host to another.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Channel</td>
+      <td align="" colspan="" rowspan="">A channel is a named way to get information between the endpoints for a given content type in the context of a given session. It is up to the transport to negotiate the details of each channel. For instance, a channel for the voice content type might be named 'myvoicedata'.</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Jingle consists of three parts, each with its own syntax, semantics, and state machine:</p>
+  <ol start="" type="">
+    <li>Overall session management</li>
+    <li>Content description formats (the "what")</li>
+    <li>Transport methods (the "how")</li>
+  </ol>
+  <p class="" style="">This JEP defines the semantics and syntax for overall session management, and provides pluggable "slots" for content description formats and transport methods, which are specified in separate documents.</p>
+  <div class="indent">
+<h3>4.1 <a name="concepts-session">Session Management</a>
+</h3>
+    <p class="" style="">The state machine for overall session management (i.e., the state per Session ID) is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         o
+         |
+         | session-initiate
+         |
+         | +----------------------+
+         |/                       |
+PENDING  o------------------+     |
+         |  | session-info, |     |
+         |  | content-*,    |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         | session-accept         |
+         |                        |
+ ACTIVE  o------------------+     |
+         |  | session-info, |     |
+         |  | content-*,    |     |
+         |  | transport-*   |     |
+         |  +---------------+     |
+         |                        |
+         +------------------------+ session-redirect,
+                                  | session-terminate
+                                  |
+                                  |
+                                  o ENDED
+    </pre></div>
+    <p class="" style="">There are three overall session states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of the overall Jingle session are:</p>
+    <ol start="" type="">
+      <li>session-initiate (request a new session)</li>
+      <li>session-accept (definitively accept a session request)</li>
+      <li>session-redirect (redirect an initiate request to another address)</li>
+      <li>session-info (session-level information / messages)</li>
+      <li>session-terminate (end an existing session)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="concepts-content">Content Description Formats</a>
+</h3>
+    <p class="" style="">The content description format specifies the "what" of the session (e.g., bidirectional audio). When negotiating the session, the entities involved in the session need to exchange content description formats. The approach taken herein is to specify pure session description information in separate specifications, one for each content description format (audio, video, etc.).  [<a href="#nt-id2260166">12</a>] The session negotiation must contain some content description format(s), which are to be defined in separate specifications. Those specifications will also define the state chart for the content description format in question.</p>
+    <p class="" style="">The generic state machine for management of content description formats is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           |
+           |
+[PENDING]  o-------------+
+           |   |_________| content-info
+           |
+           | content-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / content-modify     / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\  content-decline     |
+           | \____________________/
+           |    content-accept
+           |
+           | session-terminate
+           |
+           o [ENDED]
+    </pre></div>
+    <p class="" style="">The states related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>MODIFYING</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of content description formats are:</p>
+    <ol start="" type="">
+      <li>content-info (content-level information / messages)</li>
+      <li>content-modify (request a change to the content description formats)</li>
+      <li>content-accept (accept a proposed content change)</li>
+      <li>content-decline (decline a proposed content change)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="concepts-transport">Transport Methods</a>
+</h3>
+    <p class="" style="">The transport method defines "how" the data shall be exchanged. As with the content description formats, the transport methods are specified in separate specifications. Possible transport methods include peer-to-peer RTP, local UDP, and SSL-TCP. Those specifications will also define the state chart for the transport method in question.</p>
+    <p class="" style="">The generic state machine for transport methods is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           |
+[PENDING]  o-------------+
+           |   |_________| transport-info
+           |
+           | transport-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / transport-modify / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\ transport-decline    |
+           | \____________________/
+           |    transport-accept
+           |
+           | session-terminate
+           |
+           o [ENDED]
+    </pre></div>
+    <p class="" style="">The states related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>MODIFYING</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of transport methods are:</p>
+    <ol start="" type="">
+      <li>transport-info (transport-level information / messages)</li>
+      <li>transport-modify (request a change to the transport methods)</li>
+      <li>transport-accept (accept a proposed transport change)</li>
+      <li>transport-decline (decline a proposed transport change)</li>
+    </ol>
+  </div>
+<h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired content description format. If a contact has only one XMPP resource, this task MUST be completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260425">13</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2260448">14</a>].</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for Jingle and various Jingle content description formats and transport methods is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired content description format, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired content description format, it is RECOMMENDED for a client to use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2260510">15</a>] in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for the desired content description format, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace. The &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes (the latter two uniquely identify the session); for initiation the 'action' attribute MUST have a value of "initiate" and the &lt;jingle/&gt; element MUST contain one or more &lt;description/&gt; child elements that specify the desired content description formats and one or more &lt;transport/&gt; child elements that specify the desired transport methods. Here is an example:</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-initiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The syntax and semantics of the description and transport elements are out of scope for this specification.</p>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is REQUIRED; it specifies a Jingle action as listed in this document (e.g., "initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'responder' attribute (see examples below) is the full JID of the entity that has replied to the initiation (which may be different from the 'to' address on the IQ-set).</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2260604">16</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">Unless an error occurs, the target entity MUST acknowledge receipt of the initiation request:</p>
+    <p class="caption">Example 2. Target Entity Acknowledges Receipt of Initiation Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">If the target entity acknowledges receipt of the initation request, both parties must consider the session to be in the PENDING state.</p>
+    <p class="" style="">There are several reasons why the target entity might return an error instead of acknowledging receipt of the initiation request:</p>
+    <ul>
+      <li>The initiating entity is unknown to the target entity (e.g., via presence subscription).</li>
+      <li>The target entity does not support Jingle.</li>
+      <li>The target entity does not support any of the specified content description formats.</li>
+      <li>The target entity does not support any of the specified transport methods.</li>
+      <li>The initiation request was malformed.</li>
+    </ul>
+    <p class="" style="">The initiating entity is unknown to the target entity (e.g., via presence subscription) and the target entity has a policy of not communicating via Jingle with unknown entities, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 3. Initiating Entity Unknown to Target Entity</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support Jingle, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 4. Target Entity Does Not Support Jingle</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified content description formats, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-content/&gt;.</p>
+    <p class="caption">Example 5. Target Entity Does Not Support Any Content Description Formats</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-content xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified transport methods, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-transports/&gt;.</p>
+    <p class="caption">Example 6. Target Entity Does Not Support Any Transport Methods</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-transports xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initiation request was malformed, the target entity MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 7. Initiation Request Malformed</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After acknowledging receipt of the initiation request, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 8. Target Entity Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='jingle2'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-redirect'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 9. Initiating Entity Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='jingle2'
+    to='juliet@capulet.com/balcony'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="protocol-decline">Decline</a>
+</h3>
+    <p class="" style="">In order to decline the session initiation request, the target entity MUST acknowledge receipt of the session initiation request, then terminate the session as described in the <a href="#protocol-terminate">Termination</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If (after negotiation of transport methods and content description formats) the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 10. Target Entity Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-accept'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport ...&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MUST contain one or more &lt;description/&gt; elements that specify the desired content description format(s) and MUST contain one or more &lt;transport/&gt; elements that specify the desired transport methodl(s). The &lt;jingle/&gt; element SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity, and the initiating entity SHOULD send all future commmunications about this Jingle session o the JID provided in the 'responder' attribute.</p>
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 11. Initiating Entity Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending content over the negotiated connection.</p>
+    <p class="" style="">If one of the parties cannot find a suitable transport method, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="protocol-modify">Modifying an Active Session</a>
+</h3>
+    <p class="" style="">In order to modify an active session, either party may send a "content-modify" or "transport-modify" action to the other party containing a modified content description format or transport method. The receiving party then sends an appropriate "-accept" or "-decline" action, and may first send an appropriate "-info" action.</p>
+    <p class="" style="">If both parties send modify messages at the same time, the modify message from the session initiator MUST trump the modify message from the recipient and the initiator SHOULD return an &lt;unexpected-request/&gt; error to the other party.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session (which MAY be done at any point after acknowledging receipt of the initiation request, including immediately thereafter in order to decline the request), either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 12. Target Entity Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='term1'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-terminate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity MUST then acknowledge termination of the session:</p>
+    <p class="caption">Example 13. Initiating Entity Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further Jingle communication for the negotiated content description format and transport method MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'session-redirect' or 'session-terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 14. Target Entity Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to change a transport method or content description format parameter, inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message MUST be an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "session-info", "content-info", or "transport-info"; the &lt;jingle/&gt; element MUST further contain a payload child element (speciific to the session, content description format, or transport method) that specifies the information being communicated. (A future version of this specification will define payloads related to the "session-info" action.)</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The Jingle-specific error conditions are as follows.</p>
+  <p class="caption">Table 2: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jingle Condition</th>
+      <th colspan="" rowspan="">XMPP Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The request cannot occur at this point in the state machine (e.g., initiate after accept).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-content/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired content description formats.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-transports/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired transport methods.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">There is a one-to-one relationship between content types and sessions. This reduces the complexity of managing a given session, since it avoids the need to de-multiplex traffic for different content types sent over the same connection. However, it may be desirable to share different kinds of content at the same time (e.g., during a video chat one party may want to share a file); in order to do this, the parties must establish a separate session for each content type. Management of multiple sessions is a client implementation matter and is not discussed in this specification.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>8.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Jingle sessions may be resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many Jingle sessions. Care must be taken to accept content sessions only from known entities and only if the entity's device is able to process such sessions.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261580">17</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261625">18</a>] shall include 'http://jabber.org/protocol/jingle' and 'http://jabber.org/protocol/jingle#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-content">Jingle Content Description Formats Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle content description formats. All content description format registrations shall be defined in separate documents (not in this JEP). Content description formats defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/content/name" (where "name" is the registered name of the content description format).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;content&gt;
+  &lt;name&gt;the name of the content description format (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the content description format&lt;/desc&gt;
+  &lt;doc&gt;the document in which this content description format is specified&lt;/doc&gt;
+&lt;/content&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="registrar-transports">Jingle Transport Methods Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle transport methods. All transport method registrations shall be defined in separate documents (not in this JEP). Transport methods defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/transport/name" (where "name" is the registered name of the transport method).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;the name of the transport method (e.g., "p2p")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the transport method&lt;/desc&gt;
+  &lt;doc&gt;the document in which this transport method is specified&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-jingle">Jingle</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='content-accept'/&gt;
+            &lt;xs:enumeration value='content-decline'/&gt;
+            &lt;xs:enumeration value='content-info'/&gt;
+            &lt;xs:enumeration value='content-modify'/&gt;
+            &lt;xs:enumeration value='session-accept'/&gt;
+            &lt;xs:enumeration value='session-info'/&gt;
+            &lt;xs:enumeration value='session-initiate'/&gt;
+            &lt;xs:enumeration value='session-redirect'/&gt;
+            &lt;xs:enumeration value='session-terminate'/&gt;
+            &lt;xs:enumeration value='transport-accept'/&gt;
+            &lt;xs:enumeration value='transport-decline'/&gt;
+            &lt;xs:enumeration value='transport-info'/&gt;
+            &lt;xs:enumeration value='transport-modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='responder' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-errors">Jingle Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-content' type='empty'/&gt;
+  &lt;xs:element name='unsupported-transports' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">The open issues include:</p>
+  <ul>
+    <li>Specify how to use redirect for transfer use case.</li>
+    <li>Specify how to include call history (e.g., for transfer).</li>
+    <li>Specify how to do third-party call control.</li>
+    <li>Specify how to initiate a session with a bare JID.</li>
+  </ul>
+<h2>13.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his helpful feedback on this document. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2261861">19</a>] and (earlier) Jingle  [<a href="#nt-id2261848">20</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2259542">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2259528">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2259595">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2259619">4</a>. Google Talk is a messaging and voice chat service and client provided by Google; see &lt;<a href="http://www.google.com/talk/">http://www.google.com/talk/</a>&gt;.</p>
+<p><a name="nt-id2259665">5</a>. Possible other content description formats include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2259730">6</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2259753">7</a>. JEP-0167: Jingle Audio Content Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2259796">8</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2259818">9</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2259950">10</a>. JEP-0176: Jingle RTP-ICE Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0176.html">http://www.jabber.org/jeps/jep-0176.html</a>&gt;.</p>
+<p><a name="nt-id2259974">11</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2260166">12</a>. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach that was taken in <span style="font-weight: bold">JEP-0111</span>), this is not necessarily helpful, since SDP is not structured data, not all SDP data is needed or used in the most common use cases, and SDP has been heavily extended in several useful directions.</p>
+<p><a name="nt-id2260425">13</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260448">14</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2260510">15</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2260604">16</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2261580">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261625">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2261861">19</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2261848">20</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2006-07-17)</h4>
+<div class="indent">
+<p class="" style="">Added implementation note about handling multiple content types.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Changed media type to content type.</p> (se/psa)
+    </div>
+<h4>Version 0.5 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">Further clarified state machine diagrams; specified that session accept must include agreed-upon media format and transport description; moved deployment notes to appropriate transport spec.</p> (psa/jb)
+    </div>
+<h4>Version 0.4 (2006-03-01)</h4>
+<div class="indent">
+<p class="" style="">Added glossary; clarified state machines; updated to reflect publication of JEP-0176 and JEP-0177.</p> (psa/jb)
+    </div>
+<h4>Version 0.3 (2006-02-24)</h4>
+<div class="indent">
+<p class="" style="">Provided more detail about modify scenarios; defined media-specific and transport-specific actions and adjusted state machine accordingly.</p> (psa/jb)
+    </div>
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Per agreement among the co-authors, moved transport definition to separate specification, simplified state machine, and made other associated changes to the text, examples, and schemas; also harmonized redirect, decline, and terminate processes.</p> (psa/jb)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">
+<p class="" style="">More fully documented burst mode, connectivity checks, error cases, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">
+<p class="" style="">Restructured document flow; provided example of burst mode.</p> (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author.</p> (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow; harmonized candidate negotiation process with ICE.</p> (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup.</p> (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Separated  methoddescription formats from signalling protocol.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">
+<p class="" style="">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">
+<p class="" style="">Protocol cleanup.</p> (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.8.html
+++ b/content/xep-0166-0.8.html
@@ -1,0 +1,990 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Sean Egan">
+<meta name="DC.Creator" content="Robert McQueen">
+<meta name="DC.Description" content="This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-23">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle</h1>
+<p>This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0166<br>
+            Version: 0.8<br>
+            Last Updated: 2006-08-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+<h3>Sean Egan</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:seanegan@google.com">seanegan@google.com</a><br>
+        JID: 
+        <a href="xmpp:seanegan@google.com">seanegan@google.com</a></p>
+<h3>Robert McQueen</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:robert.mcqueen@collabora.co.uk">robert.mcqueen@collabora.co.uk</a><br>
+        JID: 
+        <a href="xmpp:robert.mcqueen@collabora.co.uk">robert.mcqueen@collabora.co.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>4.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts-session">Overall Session Management</a>
+</dt>
+<dt>4.2.  <a href="#concepts-content">Session Content</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#concepts-description">Content Description Formats</a>
+</dt>
+<dt>4.2.2.  <a href="#concepts-transport">Content Transport Methods</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>5.2.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>5.3.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>5.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>5.5.  <a href="#protocol-decline">Decline</a>
+</dt>
+<dt>5.6.  <a href="#protocol-negotiation">Negotiation</a>
+</dt>
+<dt>5.7.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>5.8.  <a href="#protocol-modify">Modifying an Active Session</a>
+</dt>
+<dt>5.9.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>5.10.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-content">Jingle Content Description Formats Registry</a>
+</dt>
+<dt>10.3.  <a href="#registrar-transports">Jingle Content Transport Methods Registry</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-jingle">Jingle</a>
+</dt>
+<dt>11.2.  <a href="#schema-errors">Jingle Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) interactions (such as voice, video, or file sharing exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions</span>  [<a href="#nt-id2257631">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2257617">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2257684">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team,  [<a href="#nt-id2257708">4</a>] it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2257753">5</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li><p class="" style="">Various content description formats (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 4566</span>  [<a href="#nt-id2257818">6</a>]); one example is <span class="ref" style="">Jingle Audio Content Description Format</span>  [<a href="#nt-id2257842">7</a>].</p></li>
+    <li><p class="" style="">Various content transport methods.</p></li>
+    <li><p class="" style="">Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2257884">8</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2257906">9</a>]).</p></li>
+  </ul>
+<h2>3.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Session</td>
+      <td align="" colspan="" rowspan="">A number of pairs of negotiated content transport methods and content description formats connecting two entities. It is delimited in time by an initiate request and session ending events. During the lifetime of a session, pairs of content descriptions and content transport methods can be added or removed.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Content Type</td>
+      <td align="" colspan="" rowspan="">A formal declaration of the purpose(s) of the session. Common sessions might include types such as "voice", both "voice" and "video", and "file sharing". A session consists of at least one active negotiated content type at a time. Depending on the content type and the content description, one content description may require multiple components to be communicated by the transport. This is the 'what' of the session. In Jingle XML syntax the content type is the namespace of the &lt;description/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Content Description</td>
+      <td align="" colspan="" rowspan="">The details of the content type being established. For instance, this might describe the acceptable codecs when establishing a voice conversation. The XML elements for the content description are qualified by the namespace of the content type. The content description defines the bits to be transferred.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Transport Method</td>
+      <td align="" colspan="" rowspan="">The method for establishing data stream(s) between entities. Possible transports might include <span class="ref" style="">Jingle RTP-ICE Transport Method</span>  [<a href="#nt-id2258044">10</a>], <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2258068">11</a>], inband data, etc. This is the 'how' of the session. In Jingle XML syntax this is the namespace of the &lt;transport/&gt; element. The content transport method defines how to transfer bits from one host to another.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Component</td>
+      <td align="" colspan="" rowspan="">A component is a numbered stream of data which needs to be transmitted between the endpoints for a given content type in the context of a given session. It is up to the transport to negotiate the details of each component. For instance, the voice content type might use two components, one to transmit an RTP stream, and another to transmit RTCP timing information.</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Jingle consists of three parts, each with its own syntax, semantics, and state machine:</p>
+  <ol start="" type="">
+    <li>Overall session management</li>
+    <li>Content description formats (the "what")</li>
+    <li>Transport methods (the "how")</li>
+  </ol>
+  <p class="" style="">This document defines the semantics and syntax for overall session management, and provides pluggable "slots" for content description formats and content transport methods, which are specified in separate documents.</p>
+  <div class="indent">
+<h3>4.1 <a name="concepts-session">Overall Session Management</a>
+</h3>
+    <p class="" style="">The state machine for overall session management (i.e., the state per Session ID) is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         o
+         |
+         | session-initiate
+         |
+         | +-----------------------+
+         |/                        |
+PENDING  o---------------------+   |
+         |  | session-extend,  |   |
+         |  | session-info,    |   |
+         |  | session-reduce,  |   |
+         |  +------------------+   |
+         |                         |
+         | session-accept          |
+         |                         |
+ ACTIVE  o---------------------+   |
+         |  | session-extend,  |   |
+         |  | session-info,    |   |
+         |  | session-reduce,  |   |
+         |  +------------------+   |
+         |                         |
+         +-------------------------+
+                                   |
+                                   | session-decline,
+                                   | session-redirect,
+                                   | session-terminate
+                                   |
+                                   o ENDED
+    </pre></div>
+    <p class="" style="">There are three overall session states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of the overall Jingle session are:</p>
+    <ol start="" type="">
+      <li>session-initiate (request a new Jingle session)</li>
+      <li>session-decline (decline an initiate request)</li>
+      <li>session-redirect (redirect an initiate request to another address)</li>
+      <li>session-extend (add a new content type to the session)</li>
+      <li>session-reduce (remove a content type from the session)</li>
+      <li>session-accept (definitively accept a session request)</li>
+      <li>session-info (session-level information / messages)</li>
+      <li>session-terminate (end an existing session)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="concepts-content">Session Content</a>
+</h3>
+    <p class="" style="">The content type of a session is made up of two aspects:</p>
+    <ol start="1" type="">
+      <li>The content description format specifies the "what" of the session (e.g., audio).</li>
+      <li>The content transport method defines "how" the data shall be exchanged (e.g., raw UDP).</li>
+    </ol>
+    <p class="" style="">The &lt;content/&gt; element also specifies who will be sending content (the initiator, the recipient, or both).</p>
+    <div class="indent">
+<h3>4.2.1 <a name="concepts-description">Content Description Formats</a>
+</h3>
+      <p class="" style="">When negotiating the session and its content type, the entities involved in the session need to exchange content description formats. The approach taken herein is to specify pure session description information in separate specifications, one for each content description format (audio, video, etc.).  [<a href="#nt-id2258327">12</a>] The session negotiation must contain some content description format(s), which are defined in separate specifications. Those specifications also define the state chart for the content description format in question.</p>
+      <p class="" style="">The generic state machine for management of any given content description format is as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           | session-extend
+           |
+[PENDING]  o-------------+
+           |   |         | description-info
+           |   |_________| description-modify
+           |
+           | description-accept
+           |
+           |  _____________________o [MODIFYING]
+           | / description-modify / \
+           |/                    /   |
+ [ACTIVE]  o--------------------/    | 
+           |\  description-decline   |
+           | \______________________/
+           |   description-accept
+           |
+           | session-reduce
+           | session-terminate
+           |
+           o [ENDED]
+      </pre></div>
+      <p class="" style="">The states related to management of content description formats are:</p>
+      <ol start="" type="">
+        <li>PENDING</li>
+        <li>ACTIVE</li>
+        <li>MODIFYING</li>
+        <li>ENDED</li>
+      </ol>
+      <p class="" style="">The actions related to management of content description formats are:</p>
+      <ol start="" type="">
+        <li>description-info (description-level information / messages)</li>
+        <li>description-modify (request a change to the content description formats)</li>
+        <li>description-accept (accept a proposed content change)</li>
+        <li>description-decline (decline a proposed content change)</li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="concepts-transport">Content Transport Methods</a>
+</h3>
+      <p class="" style="">As with the content description formats, the content transport methods are specified in separate specifications. Possible content transport methods include Real-time Transport Protocol (RTP) with Interactive Connectivity Establishment (ICE) and raw UDP. Those specifications will also define the state chart for the content transport method in question.</p>
+      <p class="" style="">The generic state machine for any given content transport method is as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           | session-extend
+           |
+[PENDING]  o-------------+
+           |   |         | transport-info
+           |   |_________| transport-modify
+           |
+           | transport-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / transport-modify / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\  transport-decline   |
+           | \____________________/
+           |   transport-accept
+           |
+           | session-reduce
+           | session-terminate
+           |
+           o [ENDED]
+      </pre></div>
+      <p class="" style="">The states related to management of content transport methods are:</p>
+      <ol start="" type="">
+        <li>PENDING</li>
+        <li>ACTIVE</li>
+        <li>MODIFYING</li>
+        <li>ENDED</li>
+      </ol>
+      <p class="" style="">The actions related to management of content transport methods are:</p>
+      <ol start="" type="">
+        <li>transport-info (transport-level information / messages)</li>
+        <li>transport-modify (request a change to the content transport methods)</li>
+        <li>transport-accept (accept a proposed transport change)</li>
+        <li>transport-decline (decline a proposed transport change)</li>
+      </ol>
+    </div>
+  </div>
+<h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired content description format. If a contact has only one XMPP resource, this task MUST be completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2258598">13</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2258621">14</a>].</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for Jingle and various Jingle content description formats and content transport methods is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired content description format, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired content description format, it is RECOMMENDED for a client to use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2258684">15</a>] in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for the desired content description format, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace. The &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes (the latter two uniquely identify the session). For initiation, the 'action' attribute MUST have a value of "session-initiate" and the &lt;jingle/&gt; element MUST contain one or more &lt;content/&gt; elements, each of which defines a content type to be transferred during the session; each &lt;content/&gt; element in turn contains one &lt;description/&gt; child element that specifies a desired content description format and one or more &lt;transport/&gt; child elements that specify potential content transport methods.</p>
+    <p class="" style="">The following example shows a Jingle session initiation request for a session that contains both audio and video content:</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-initiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;content name='this-is-the-audio-content'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/audio'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+    &lt;/content&gt;
+    &lt;content name='this-is-the-video-content'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/video'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+    &lt;/content&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The syntax and semantics of the &lt;description/&gt; and &lt;transport/&gt; elements are out of scope for this specification, but are defined in related specifications.</p>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is REQUIRED; it specifies a Jingle action as listed in this document (e.g., "session-initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'responder' attribute (see examples below) is the full JID of the entity that has replied to the initiation (which may be different from the 'to' address on the IQ-set).</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2258793">16</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+    </ul>
+    <p class="" style="">The attributes of the &lt;content/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'name' attribute is REQUIRED; it specifies a unique name or identifier for the content type (this identifier is opaque and does not have semantic meaning).</li>
+      <li>The 'senders' attribute specifies which entities in the session will be generating content; the allowable values are "initiator", "recipient", or "both" (where "both" is the default).</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">Unless an error occurs, the target entity MUST acknowledge receipt of the initiation request:</p>
+    <p class="caption">Example 2. Target Entity Acknowledges Receipt of Initiation Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">If the target entity acknowledges receipt of the initation request, both parties must consider the session to be in the PENDING state.</p>
+    <p class="" style="">There are several reasons why the target entity might return an error instead of acknowledging receipt of the initiation request:</p>
+    <ul>
+      <li>The initiating entity is unknown to the target entity (e.g., via presence subscription).</li>
+      <li>The target entity does not support Jingle.</li>
+      <li>The target entity does not support any of the specified content description formats.</li>
+      <li>The target entity does not support any of the specified content transport methods.</li>
+      <li>The initiation request was malformed.</li>
+    </ul>
+    <p class="" style="">The initiating entity is unknown to the target entity (e.g., via presence subscription) and the target entity has a policy of not communicating via Jingle with unknown entities, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 3. Initiating Entity Unknown to Target Entity</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support Jingle, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 4. Target Entity Does Not Support Jingle</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified content description formats, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-content/&gt;.</p>
+    <p class="caption">Example 5. Target Entity Does Not Support Any Content Description Formats</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-content xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified content transport methods, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-transports/&gt;.</p>
+    <p class="caption">Example 6. Target Entity Does Not Support Any Transport Methods</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-transports xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initiation request was malformed, the target entity MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 7. Initiation Request Malformed</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After acknowledging receipt of the initiation request, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 8. Target Entity Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='jingle2'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-redirect'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 9. Initiating Entity Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='jingle2'
+    to='juliet@capulet.com/balcony'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="protocol-decline">Decline</a>
+</h3>
+    <p class="" style="">In order to decline the session initiation request, the target entity MUST acknowledge receipt of the session initiation request, then terminate the session as described in the <a href="#protocol-terminate">Termination</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="protocol-negotiation">Negotiation</a>
+</h3>
+    <p class="" style="">In general, negotiation will be necessary before the parties can agree on an acceptable set of content types, content description formats, and content transport methods. The potential combinations of parameters to be negotiated are many, and not all are shown herein (some are shown in the relevant specifications for various content description formats and content transport methods).</p>
+    <p class="" style="">One session-level negotiation is to <span style="font-style: italic">reduce</span> the number of content types. For example, let us imagine that Juliet is having a bad hair day. She certainly does not want to include video in her Jingle session with Romeo, so she sends a "session-reduce" request to Romeo:</p>
+    <p class="caption">Example 10. Session Reduction</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='reduce1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-reduce'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;content name='this-is-the-video-content'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The entity receiving the session reduction request then acknowledges the request:</p>
+    <p class="caption">Example 11. Acknowledgement</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' to='juliet@capulet.com/balcony' id='reduce1' type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Another session-level negotiation is to <span style="font-style: italic">extend</span> the session by adding a content type. For example, let us imagine that Juliet gets her hair in order and now wants to add video. She now sends a "session-extend" request to Romeo:</p>
+    <p class="caption">Example 12. Session Extension</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='extend1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-reduce'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;content name='video-is-back'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/video'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+    &lt;/content&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The entity receiving the session extension request then acknowledges (or declines) the request:</p>
+    <p class="caption">Example 13. Acknowledgement</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' to='juliet@capulet.com/balcony' id='extend1' type='result'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If (after negotiation of content transport methods and content description formats) the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 14. Target Entity Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-accept'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;content name='some-opaque-name'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/audio'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+    &lt;/content&gt;
+    &lt;content name='another-opaque-name'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/video'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MUST contain one or more &lt;description/&gt; elements that specify the desired content description format(s) and MUST contain one or more &lt;transport/&gt; elements that specify the desired content transport methodl(s). The &lt;jingle/&gt; element SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity, and the initiating entity SHOULD send all future commmunications about this Jingle session o the JID provided in the 'responder' attribute.</p>
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 15. Initiating Entity Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending content over the negotiated connection.</p>
+    <p class="" style="">If one of the parties cannot find a suitable content transport method, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="protocol-modify">Modifying an Active Session</a>
+</h3>
+    <p class="" style="">In order to modify an active session, either party may send a "description-modify" or "transport-modify" action to the other party containing a modified content description format or content transport method. The receiving party then sends an appropriate "-accept" or "-decline" action, and may first send an appropriate "-info" action.</p>
+    <p class="" style="">If both parties send modify messages at the same time, the modify message from the session initiator MUST trump the modify message from the recipient and the initiator SHOULD return an &lt;unexpected-request/&gt; error to the other party.</p>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session (which MAY be done at any point after acknowledging receipt of the initiation request, including immediately thereafter in order to decline the request), either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 16. Target Entity Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='term1'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-terminate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity MUST then acknowledge termination of the session:</p>
+    <p class="caption">Example 17. Initiating Entity Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further Jingle communication for the negotiated content description format and content transport method MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'session-redirect' or 'session-terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 18. Target Entity Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>5.10 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to change a content transport method or content description format parameter, inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message MUST be an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "session-info", "description-info", or "transport-info"; the &lt;jingle/&gt; element MUST further contain a payload child element (speciific to the session, content description format, or content transport method) that specifies the information being communicated. (A future version of this specification will define payloads related to the "session-info" action.)</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The Jingle-specific error conditions are as follows.</p>
+  <p class="caption">Table 2: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jingle Condition</th>
+      <th colspan="" rowspan="">XMPP Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The request cannot occur at this point in the state machine (e.g., initiate after accept).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-content/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired content description formats.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-transports/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired content transport methods.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">There is a one-to-one relationship between content types and sessions. This reduces the complexity of managing a given session, since it avoids the need to de-multiplex traffic for different content types sent over the same connection. However, it may be desirable to share different kinds of content at the same time (e.g., during a video chat one party may want to share a file); in order to do this, the parties must establish a separate session for each content type. Management of multiple sessions is a client implementation matter and is not discussed in this specification.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>8.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Jingle sessions may be resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many Jingle sessions. Care must be taken to accept content sessions only from known entities and only if the entity's device is able to process such sessions.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259788">17</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259834">18</a>] shall include 'http://jabber.org/protocol/jingle' and 'http://jabber.org/protocol/jingle#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-content">Jingle Content Description Formats Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle content description formats. All content description format registrations shall be defined in separate documents (not in this JEP). Content description formats defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/description/name" (where "name" is the registered name of the content description format).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;content&gt;
+  &lt;name&gt;the name of the content description format (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the content description format&lt;/desc&gt;
+  &lt;doc&gt;the document in which this content description format is specified&lt;/doc&gt;
+&lt;/content&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="registrar-transports">Jingle Content Transport Methods Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle content transport methods. All content transport method registrations shall be defined in separate documents (not in this JEP). Content transport methods defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/transport/name" (where "name" is the registered name of the content transport method).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;the name of the content transport method (e.g., "raw-udp")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the content transport method&lt;/desc&gt;
+  &lt;doc&gt;the document in which this content transport method is specified&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-jingle">Jingle</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='1' maxOccurs='unlimited'&gt;
+        &lt;xs:element ref='content'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='description-info'/&gt;
+            &lt;xs:enumeration value='description-modify'/&gt;
+            &lt;xs:enumeration value='session-accept'/&gt;
+            &lt;xs:enumeration value='session-decline'/&gt;
+            &lt;xs:enumeration value='session-extend'/&gt;
+            &lt;xs:enumeration value='session-info'/&gt;
+            &lt;xs:enumeration value='session-initiate'/&gt;
+            &lt;xs:enumeration value='session-redirect'/&gt;
+            &lt;xs:enumeration value='session-reduce'/&gt;
+            &lt;xs:enumeration value='session-terminate'/&gt;
+            &lt;xs:enumeration value='transport-info'/&gt;
+            &lt;xs:enumeration value='transport-modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='responder' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='content'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0'&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='senders' use='optional' default='both'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='both'&gt;
+            &lt;xs:enumeration value='initiator'&gt;
+            &lt;xs:enumeration value='responder'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-errors">Jingle Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-content' type='empty'/&gt;
+  &lt;xs:element name='unsupported-transports' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his valuable input on early versions of this document. Rob Taylor, Dafydd Harries, Jussi Laako, Saku Vainio, Antti Ijäs, Brian West, Anthony Minessale, Matt O'Gorman, and others have also provided helpful input. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2260057">19</a>] and (earlier) Jingle  [<a href="#nt-id2260044">20</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2257631">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2257617">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2257684">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2257708">4</a>. Google Talk is a messaging and voice chat service and client provided by Google; see &lt;<a href="http://www.google.com/talk/">http://www.google.com/talk/</a>&gt;.</p>
+<p><a name="nt-id2257753">5</a>. Possible other content description formats include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2257818">6</a>. RFC 4566: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc4566.txt">http://www.ietf.org/rfc/rfc4566.txt</a>&gt;.</p>
+<p><a name="nt-id2257842">7</a>. JEP-0167: Jingle Audio Content Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2257884">8</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2257906">9</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2258044">10</a>. JEP-0176: Jingle RTP-ICE Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0176.html">http://www.jabber.org/jeps/jep-0176.html</a>&gt;.</p>
+<p><a name="nt-id2258068">11</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2258327">12</a>. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach that was taken in <span style="font-weight: bold">JEP-0111</span>), this is not necessarily helpful, since SDP is not structured data, not all SDP data is needed or used in the most common use cases, and SDP has been heavily extended in several useful directions that are not captured in the core SDP specification.</p>
+<p><a name="nt-id2258598">13</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2258621">14</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2258684">15</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2258793">16</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2259788">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259834">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2260057">19</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2260044">20</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2006-08-23)</h4>
+<div class="indent">
+<p class="" style="">Changed channels to components in line with ICE; changed various action names for consistency; added session-extend and session-reduce actions to add and remove description/transport pairs; added description-modify action; added sender attribute to specify directionality.</p> (ram/psa)
+    </div>
+<h4>Version 0.7 (2006-07-17)</h4>
+<div class="indent">
+<p class="" style="">Added implementation note about handling multiple content types.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Changed media type to content type.</p> (se/psa)
+    </div>
+<h4>Version 0.5 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">Further clarified state machine diagrams; specified that session accept must include agreed-upon media format and transport description; moved deployment notes to appropriate transport spec.</p> (psa/jb)
+    </div>
+<h4>Version 0.4 (2006-03-01)</h4>
+<div class="indent">
+<p class="" style="">Added glossary; clarified state machines; updated to reflect publication of JEP-0176 and JEP-0177.</p> (psa/jb)
+    </div>
+<h4>Version 0.3 (2006-02-24)</h4>
+<div class="indent">
+<p class="" style="">Provided more detail about modify scenarios; defined media-specific and transport-specific actions and adjusted state machine accordingly.</p> (psa/jb)
+    </div>
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Per agreement among the co-authors, moved transport definition to separate specification, simplified state machine, and made other associated changes to the text, examples, and schemas; also harmonized redirect, decline, and terminate processes.</p> (psa/jb)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">
+<p class="" style="">More fully documented burst mode, connectivity checks, error cases, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">
+<p class="" style="">Restructured document flow; provided example of burst mode.</p> (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author.</p> (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow; harmonized candidate negotiation process with ICE.</p> (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup.</p> (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Separated  methoddescription formats from signalling protocol.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">
+<p class="" style="">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">
+<p class="" style="">Protocol cleanup.</p> (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0166-0.9.html
+++ b/content/xep-0166-0.9.html
@@ -1,0 +1,1012 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0166: Jingle</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Sean Egan">
+<meta name="DC.Creator" content="Robert McQueen">
+<meta name="DC.Description" content="This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-09-08">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0166">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0166: Jingle</h1>
+<p>This document defines a framework for initiating and managing peer-to-peer sessions (e.g., voice and video exchanges) between Jabber/XMPP clients in a way that is interoperable with existing Internet standards.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0166<br>
+            Version: 0.9<br>
+            Last Updated: 2006-09-08<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20(JEP-0166)">http://wiki.jabber.org/index.php/Jingle (JEP-0166)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+<h3>Sean Egan</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:seanegan@google.com">seanegan@google.com</a><br>
+        JID: 
+        <a href="xmpp:seanegan@google.com">seanegan@google.com</a></p>
+<h3>Robert McQueen</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:robert.mcqueen@collabora.co.uk">robert.mcqueen@collabora.co.uk</a><br>
+        JID: 
+        <a href="xmpp:robert.mcqueen@collabora.co.uk">robert.mcqueen@collabora.co.uk</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>4.  <a href="#concepts">Concepts and Approach</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#concepts-session">Overall Session Management</a>
+</dt>
+<dt>4.2.  <a href="#concepts-content">Session Content</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#concepts-description">Content Description Formats</a>
+</dt>
+<dt>4.2.2.  <a href="#concepts-transport">Content Transport Methods</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#protocol">Protocol</a>
+</dt>
+<dl>
+<dt>5.1.  <a href="#protocol-resource">Resource Determination</a>
+</dt>
+<dt>5.2.  <a href="#protocol-initiate">Initiation</a>
+</dt>
+<dt>5.3.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>5.4.  <a href="#protocol-redirect">Redirection</a>
+</dt>
+<dt>5.5.  <a href="#protocol-decline">Decline</a>
+</dt>
+<dt>5.6.  <a href="#protocol-negotiation">Negotiation</a>
+</dt>
+<dt>5.7.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>5.8.  <a href="#protocol-modify">Modifying an Active Session</a>
+</dt>
+<dt>5.9.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>5.10.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>6.  <a href="#errors">Error Handling</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#security-dos">Denial of Service</a>
+</dt>
+<dt>8.2.  <a href="#security-gateways">Communication Through Gateways</a>
+</dt>
+</dl>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-content">Jingle Content Description Formats Registry</a>
+</dt>
+<dt>10.3.  <a href="#registrar-transports">Jingle Content Transport Methods Registry</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-jingle">Jingle</a>
+</dt>
+<dt>11.2.  <a href="#schema-errors">Jingle Errors</a>
+</dt>
+</dl>
+<dt>12.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There exists no widely-adopted standard for initiating and managing peer-to-peer (p2p) interactions (such as voice, video, or file sharing exchanges) from within Jabber/XMPP clients. Although several large service providers and Jabber/XMPP clients have written and implemented their own proprietary XMPP extensions for p2p signalling (usually only for voice), those technologies are not open and do not always take into account requirements to interoperate with the Public Switched Telephone Network (PSTN) or emerging SIP-based Internet voice networks. By contrast, the only existing open protocol has been <span class="ref" style="">A Transport for Initiating and Negotiating Sessions</span>  [<a href="#nt-id2257680">1</a>], which made it possible to initiate and manage p2p sessions, but which did not provide enough of the key signalling semantics to be easily implemented in Jabber/XMPP clients.  [<a href="#nt-id2257666">2</a>]</p>
+  <p class="" style="">The result has been an unfortunate fragmentation within the XMPP community regarding signalling protocols. There are, essentially, two approaches to solving the problem:</p>
+  <ol start="" type="">
+    <li>Recommend that all client developers implement a dual-stack (XMPP + SIP) solution.</li>
+    <li>Define a full-featured protocol for XMPP signalling.</li>
+  </ol>
+  <p class="" style="">Implementation experience indicates that a dual-stack approach may not be feasible on all the computing platforms for which Jabber clients have been written, or even desirable on platforms where it is feasible.  [<a href="#nt-id2257733">3</a>] Therefore, it seems reasonable to define an XMPP signalling protocol that can provide the necessary signalling semantics while also making it possible to interoperate with existing Internet standards.</p>
+  <p class="" style="">As a result of feedback received on <span style="font-weight: bold">JEP-0111</span>, the second and fourth authors of this document began to define such a signalling protocol, code-named Jingle. Upon communication with members of the Google Talk team,  [<a href="#nt-id2257757">4</a>] it was discovered that the emerging Jingle approach was conceptually (and even syntactically) quite similar to the signalling protocol used in the Google Talk application. Therefore, in the interest of interoperability and adoption, we decided to harmonize the two approaches. The signalling protocol specified therein is, therefore, substantially equivalent to the existing Google Talk protocol, with several adjustments based on feedback received from implementors as well as for publication within the Jabber Software Foundation's standards process.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to manage a wide variety of peer-to-peer sessions (not limited to voice and video) within XMPP.  [<a href="#nt-id2257803">5</a>]</li>
+    <li>Make it relatively easy to implement support for the protocol in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+  <p class="" style="">This document defines the signalling protocol only. Additional documents will specify the following:</p>
+  <ul>
+    <li><p class="" style="">Various content description formats (audio, video, etc.) and, where possible, mapping those types to the Session Description Protocol (SDP; see <span class="ref" style="">RFC 4566</span>  [<a href="#nt-id2257868">6</a>]); one example is <span class="ref" style="">Jingle Audio Content Description Format</span>  [<a href="#nt-id2257891">7</a>].</p></li>
+    <li><p class="" style="">Various content transport methods.</p></li>
+    <li><p class="" style="">Procedures for mapping the Jingle signalling protocol to existing signalling standards such as the IETF's Session Initiation Protocol (SIP; see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2257932">8</a>]) and the ITU's H.323 protocol (see <span class="ref" style="">H.323</span>  [<a href="#nt-id2257955">9</a>]).</p></li>
+  </ul>
+<h2>3.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Session</td>
+      <td align="" colspan="" rowspan="">A number of pairs of negotiated content transport methods and content description formats connecting two entities. It is delimited in time by an initiate request and session ending events. During the lifetime of a session, pairs of content descriptions and content transport methods can be added or removed.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Content Type</td>
+      <td align="" colspan="" rowspan="">A formal declaration of the purpose(s) of the session. Common sessions might include types such as "voice", both "voice" and "video", and "file sharing". A session consists of at least one active negotiated content type at a time. Depending on the content type and the content description, one content description may require multiple components to be communicated by the transport. This is the 'what' of the session. In Jingle XML syntax the content type is the namespace of the &lt;description/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Content Description</td>
+      <td align="" colspan="" rowspan="">The details of the content type being established. For instance, this might describe the acceptable codecs when establishing a voice conversation. The XML elements for the content description are qualified by the namespace of the content type. The content description defines the bits to be transferred.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Transport Method</td>
+      <td align="" colspan="" rowspan="">The method for establishing data stream(s) between entities. Possible transports might include <span class="ref" style="">Jingle RTP-ICE Transport Method</span>  [<a href="#nt-id2258359">10</a>], <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2258384">11</a>], inband data, etc. This is the 'how' of the session. In Jingle XML syntax this is the namespace of the &lt;transport/&gt; element. The content transport method defines how to transfer bits from one host to another.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Component</td>
+      <td align="" colspan="" rowspan="">A component is a numbered stream of data which needs to be transmitted between the endpoints for a given content type in the context of a given session. It is up to the transport to negotiate the details of each component. For instance, the voice content type might use two components, one to transmit an RTP stream, and another to transmit RTCP timing information.</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="concepts">Concepts and Approach</a>
+</h2>
+  <p class="" style="">Jingle consists of three parts, each with its own syntax, semantics, and state machine:</p>
+  <ol start="" type="">
+    <li>Overall session management</li>
+    <li>Content description formats (the "what")</li>
+    <li>Content transport methods (the "how")</li>
+  </ol>
+  <p class="" style="">This document defines the semantics and syntax for overall session management, and provides pluggable "slots" for content description formats and content transport methods, which are specified in separate documents.</p>
+  <div class="indent">
+<h3>4.1 <a name="concepts-session">Overall Session Management</a>
+</h3>
+    <p class="" style="">The state machine for overall session management (i.e., the state per Session ID) is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+         o
+         |
+         | session-initiate
+         |
+         | +-----------------------+
+         |/                        |
+PENDING  o---------------------+   |
+         |  | session-info,    |   |
+         |  | content-remove,  |   |
+         |  | content-modify,  |   |
+         |  | content-accept,  |   |
+         |  | content-decline, |   |
+         |  +------------------+   |
+         |                         |
+         | session-accept          |
+         |                         |
+ ACTIVE  o---------------------+   |
+         |  | session-info,    |   |
+         |  | content-add,     |   |
+         |  | content-remove,  |   |
+         |  | content-modify,  |   |
+         |  | content-accept,  |   |
+         |  | content-decline, |   |
+         |  +------------------+   |
+         |                         |
+         +-------------------------+
+                                   |
+                                   | session-decline,
+                                   | session-redirect,
+                                   | session-terminate
+                                   |
+                                   o ENDED
+    </pre></div>
+    <p class="" style="">There are three overall session states:</p>
+    <ol start="" type="">
+      <li>PENDING</li>
+      <li>ACTIVE</li>
+      <li>ENDED</li>
+    </ol>
+    <p class="" style="">The actions related to management of the overall Jingle session are:</p>
+    <ol start="1" type="">
+      <li>content-accept (accept a content-add, content-modify, or content-remove; implicitly also serves as a description-accept and transport-accept)</li>
+      <li>content-add (add one or more new content types to the session; this MUST NOT be sent while the session is in the PENDING state)</li>
+      <li>content-decline (reject a content-add, content-modify, or content-remove)</li>
+      <li>content-modify (change an existing content type, mainly the directionality)</li>
+      <li>content-remove (remove one or more content types from the session)</li>
+      <li>session-accept (definitively accept a session request; implicitly also serves as a description-accept and transport-accept)</li>
+      <li>session-decline (decline an initiate request)</li>
+      <li>session-initiate (request a new Jingle session)</li>
+      <li>session-info (session-level information / messages)</li>
+      <li>session-redirect (redirect an initiate request to another address)</li>
+      <li>session-terminate (end an existing session)</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="concepts-content">Session Content</a>
+</h3>
+    <p class="" style="">The content type of a session is made up of two aspects:</p>
+    <ol start="1" type="">
+      <li>The content description format specifies the "what" of the session (e.g., audio).</li>
+      <li>The content transport method defines "how" the data shall be exchanged (e.g., raw UDP).</li>
+    </ol>
+    <p class="" style="">The &lt;content/&gt; element also specifies who will be sending content (the initiator, the recipient, or both).</p>
+    <div class="indent">
+<h3>4.2.1 <a name="concepts-description">Content Description Formats</a>
+</h3>
+      <p class="" style="">When negotiating the session and its content type, the entities involved in the session need to exchange content description formats. The approach taken herein is to specify pure session description information in separate specifications, one for each content description format (audio, video, etc.).  [<a href="#nt-id2258656">12</a>] The session negotiation must contain some content description format(s), which are defined in separate specifications. Those specifications also define the state chart for the content description format in question.</p>
+      <p class="" style="">The generic state machine for management of any given content description format is as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           |
+[PENDING]  o-------------+
+           |   |         | description-info
+           |   |_________| description-modify
+           |
+           | description-accept
+           | session-accept
+           |
+           |  _____________________o [MODIFYING]
+           | / description-modify / \
+           |/                    /   |
+ [ACTIVE]  o--------------------/    | 
+           |\  description-decline   |
+           | \______________________/
+           |   description-accept
+           |
+           | content-remove
+           | session-terminate
+           |
+           o [ENDED]
+      </pre></div>
+      <p class="" style="">The states related to management of content description formats are:</p>
+      <ol start="" type="">
+        <li>PENDING</li>
+        <li>ACTIVE</li>
+        <li>MODIFYING</li>
+        <li>ENDED</li>
+      </ol>
+      <p class="" style="">The actions related to management of content description formats are:</p>
+      <ol start="" type="">
+        <li>description-info (description-level information / messages)</li>
+        <li>description-modify (request a change to a content description format)</li>
+        <li>description-accept (accept a proposed content change)</li>
+        <li>description-decline (decline a proposed content change)</li>
+      </ol>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="concepts-transport">Content Transport Methods</a>
+</h3>
+      <p class="" style="">As with the content description formats, the content transport methods are specified in separate specifications. Possible content transport methods include Real-time Transport Protocol (RTP) with Interactive Connectivity Establishment (ICE) and raw UDP. Those specifications will also define the state chart for the content transport method in question.</p>
+      <p class="" style="">The generic state machine for any given content transport method is as follows:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+         START
+           o  
+           |   
+           | session-initiate
+           | session-extend
+           |
+[PENDING]  o-------------+
+           |   |         | transport-info
+           |   |_________| transport-modify
+           |
+           | transport-accept
+           | session-accept
+           |
+           |  ___________________o [MODIFYING]
+           | / transport-modify / \
+           |/                  /   |
+ [ACTIVE]  o------------------/    | 
+           |\  transport-decline   |
+           | \____________________/
+           |   transport-accept
+           |
+           | session-reduce
+           | session-terminate
+           |
+           o [ENDED]
+      </pre></div>
+      <p class="" style="">The states related to management of content transport methods are:</p>
+      <ol start="" type="">
+        <li>PENDING</li>
+        <li>ACTIVE</li>
+        <li>MODIFYING</li>
+        <li>ENDED</li>
+      </ol>
+      <p class="" style="">The actions related to management of content transport methods are:</p>
+      <ol start="" type="">
+        <li>transport-info (transport-level information / messages)</li>
+        <li>transport-modify (request a change to the content transport methods)</li>
+        <li>transport-accept (accept a proposed transport change)</li>
+        <li>transport-decline (decline a proposed transport change)</li>
+      </ol>
+    </div>
+  </div>
+<h2>5.
+       <a name="protocol">Protocol</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="protocol-resource">Resource Determination</a>
+</h3>
+    <p class="" style="">In order to initiate a Jingle session, the initiating entity must determine which of the target entity's XMPP resources is best for the desired content description format. If a contact has only one XMPP resource, this task MUST be completed using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2258928">13</a>] or the presence-based profile of service discovery specified in <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2258951">14</a>].</p>
+    <p class="" style="">Naturally, instead of sending service discovery requests to every contact in a user's roster, it is more efficient to use <span style="font-weight: bold">Entity Capabilities</span>, whereby support for Jingle and various Jingle content description formats and content transport methods is determined for a client version in general (rather than on a per-JID basis) and then cached. Refer to <span style="font-weight: bold">JEP-0115</span> for details.</p>
+    <p class="" style="">If a contact has more than one XMPP resource, it may be that only one of the resources supports Jingle and the desired content description format, in which case the user MUST initiate the Jingle signalling with that resource.</p>
+    <p class="" style="">If a contact has more than one XMPP resource that supports Jingle and the desired content description format, it is RECOMMENDED for a client to use <span class="ref" style="">Resource Application Priority</span>  [<a href="#nt-id2259014">15</a>] in order to determine which is the best resource with which to initiate the desired Jingle session.</p>
+  </div>
+  <div class="indent">
+<h3>5.2 <a name="protocol-initiate">Initiation</a>
+</h3>
+    <p class="" style="">Once the initiating entity has discovered which of the target entity's XMPP resources is ideal for the desired content description format, it sends a session initiation request to the target entity. This request is an IQ-set containing a &lt;jingle/&gt; element qualified by the 'http://jabber.org/protocol/jingle' namespace. The &lt;jingle/&gt; element MUST possess the 'action', 'initiator', and 'sid' attributes (the latter two uniquely identify the session). For initiation, the 'action' attribute MUST have a value of "session-initiate" and the &lt;jingle/&gt; element MUST contain one or more &lt;content/&gt; elements, each of which defines a content type to be transferred during the session; each &lt;content/&gt; element in turn contains one &lt;description/&gt; child element that specifies a desired content description format and one or more &lt;transport/&gt; child elements that specify potential content transport methods.</p>
+    <p class="" style="">The following example shows a Jingle session initiation request for a session that contains both audio and video content:</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-initiate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;content name='this-is-the-audio-content'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/audio'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+    &lt;/content&gt;
+    &lt;content name='this-is-the-video-content'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/video'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+    &lt;/content&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The syntax and semantics of the &lt;description/&gt; and &lt;transport/&gt; elements are out of scope for this specification, but are defined in related specifications.</p>
+    <p class="" style="">The attributes of the &lt;jingle/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'action' attribute is REQUIRED; it specifies a Jingle action as listed in this document (e.g., "session-initiate").</li>
+      <li>The 'initiator' attribute is the full JID of the entity that has initiated the session flow (which may be different from the 'from' address on the IQ-set).</li>
+      <li>The 'responder' attribute (see examples below) is the full JID of the entity that has replied to the initiation (which may be different from the 'to' address on the IQ-set).</li>
+      <li>The 'sid' attribute is a random session identifier generated by the initiator; this SHOULD match the XML Nmtoken production  [<a href="#nt-id2250541">16</a>] so that XML character escaping is not needed for characters such as &amp;. (Note: the 'sid' attribute effectively maps to the SIP "Call-ID" parameter.)</li>
+    </ul>
+    <p class="" style="">The attributes of the &lt;content/&gt; element are as follows:</p>
+    <ul>
+      <li>The 'name' attribute is REQUIRED; it specifies a unique name or identifier for the content type (this identifier is opaque and does not have semantic meaning).</li>
+      <li>The 'senders' attribute specifies which entities in the session will be generating content; the allowable values are "initiator", "recipient", or "both" (where "both" is the default).</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>5.3 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">Unless an error occurs, the target entity MUST acknowledge receipt of the initiation request:</p>
+    <p class="caption">Example 2. Target Entity Acknowledges Receipt of Initiation Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">If the target entity acknowledges receipt of the initation request, both parties must consider the session to be in the PENDING state.</p>
+    <p class="" style="">There are several reasons why the target entity might return an error instead of acknowledging receipt of the initiation request:</p>
+    <ul>
+      <li>The initiating entity is unknown to the target entity (e.g., via presence subscription).</li>
+      <li>The target entity does not support Jingle.</li>
+      <li>The target entity does not support any of the specified content description formats.</li>
+      <li>The target entity does not support any of the specified content transport methods.</li>
+      <li>The initiation request was malformed.</li>
+    </ul>
+    <p class="" style="">The initiating entity is unknown to the target entity (e.g., via presence subscription) and the target entity has a policy of not communicating via Jingle with unknown entities, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 3. Initiating Entity Unknown to Target Entity</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support Jingle, it MUST return a &lt;service-unavailable/&gt; error.</p>
+    <p class="caption">Example 4. Target Entity Does Not Support Jingle</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified content description formats, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-content/&gt;.</p>
+    <p class="caption">Example 5. Target Entity Does Not Support Any Content Description Formats</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-content xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the target entity does not support any of the specified content transport methods, it MUST return a &lt;feature-not-implemented/&gt; error with a Jingle-specific error condition of &lt;unsupported-transports/&gt;.</p>
+    <p class="caption">Example 6. Target Entity Does Not Support Any Transport Methods</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;feature-not-implemented xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+    &lt;unsupported-transports xmlns='http://jabber.org/protocol/jingle#errors'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the initiation request was malformed, the target entity MUST return a &lt;bad-request/&gt; error.</p>
+    <p class="caption">Example 7. Initiation Request Malformed</p>
+<div class="indent"><pre>
+&lt;iq type='error' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'&gt;
+  &lt;error type='cancel'&gt;
+    &lt;bad-request xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.4 <a name="protocol-redirect">Redirection</a>
+</h3>
+    <p class="" style="">After acknowledging receipt of the initiation request, the target entity MAY redirect the session to another address (e.g., because the principal is not answering at the original resource). This is done by sending a Jingle redirect action to the initiating entity:</p>
+    <p class="caption">Example 8. Target Entity Redirects the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='jingle2'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-redirect'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;redirect&gt;xmpp:voicemail@capulet.com&lt;/redirect&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The recipient then acknowledges the redirection:</p>
+    <p class="caption">Example 9. Initiating Entity Acknowledges Redirection</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='jingle2'
+    to='juliet@capulet.com/balcony'
+    type='result'/&gt;
+    </pre></div>
+    <p class="" style="">Both entities MUST now consider the original session to be in the ENDED state, and if the initiating entity wishes to initiate a session with the redirected address it MUST do so by sending a session initiation request to that address with a new session ID.</p>
+  </div>
+  <div class="indent">
+<h3>5.5 <a name="protocol-decline">Decline</a>
+</h3>
+    <p class="" style="">In order to decline the session initiation request, the target entity MUST acknowledge receipt of the session initiation request, then terminate the session as described in the <a href="#protocol-terminate">Termination</a> section of this document.</p>
+  </div>
+  <div class="indent">
+<h3>5.6 <a name="protocol-negotiation">Negotiation</a>
+</h3>
+    <p class="" style="">In general, negotiation will be necessary before the parties can agree on an acceptable set of content types, content description formats, and content transport methods. The potential combinations of parameters to be negotiated are many, and not all are shown herein (some are shown in the relevant specifications for various content description formats and content transport methods).</p>
+    <p class="" style="">One session-level negotiation is to <span style="font-style: italic">remove</span> a content types. For example, let us imagine that Juliet is having a bad hair day. She certainly does not want to include video in her Jingle session with Romeo, so she sends a "content-remove" request to Romeo:</p>
+    <p class="caption">Example 10. Content Type Removal</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='reduce1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='content-remove'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;content name='this-is-the-video-content'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The entity receiving the session reduction request then acknowledges the request:</p>
+    <p class="caption">Example 11. Acknowledgement</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' to='juliet@capulet.com/balcony' id='reduce1' type='result'/&gt;
+    </pre></div>
+    <p class="" style="">If the reduction results in no more content types for the session, the entity that receives teh session-reduce SHOULD send a session-terminate action to the other party (since a session with no content types is void).</p>
+    <p class="" style="">Another session-level negotiation is to <span style="font-style: italic">add</span> a content type; however, this MUST NOT be done during while the session is in the PENDING state and is allowed only while the session is in the ACTIVE state (see below).</p>
+  </div>
+  <div class="indent">
+<h3>5.7 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If (after negotiation of content transport methods and content description formats) the target entity determines that it will be able to establish a connection, it sends a definitive acceptance to the initiating entity:</p>
+    <p class="caption">Example 12. Target Entity Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-accept'
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;content name='some-opaque-name'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/audio'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+    &lt;/content&gt;
+    &lt;content name='another-opaque-name'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/video'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the accept stanza MUST contain one or more &lt;description/&gt; elements that specify the desired content description format(s) and MUST contain one or more &lt;transport/&gt; elements that specify the desired content transport methodl(s). The &lt;jingle/&gt; element SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity, and the initiating entity SHOULD send all future commmunications about this Jingle session o the JID provided in the 'responder' attribute.</p>
+    <p class="" style="">The initiating entity then acknowledges the target entity's definitive acceptance:</p>
+    <p class="caption">Example 13. Initiating Entity Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending content over the negotiated connection.</p>
+    <p class="" style="">If one of the parties cannot find a suitable content transport method, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>5.8 <a name="protocol-modify">Modifying an Active Session</a>
+</h3>
+    <p class="" style="">In order to modify an active session, either party may send a "content-remove", "content-add", "content-modify", "description-modify", or "transport-modify" action to the other party. The receiving party then sends an appropriate "-accept" or "-decline" action, and may first send an appropriate "-info" action.</p>
+    <p class="" style="">If both parties send modify messages at the same time, the modify message from the session initiator MUST trump the modify message from the recipient and the initiator SHOULD return an &lt;unexpected-request/&gt; error to the other party.</p>
+    <p class="" style="">One example of modifying an active session is to <span style="font-style: italic">add</span> a content type. For example, let us imagine that Juliet gets her hair in order and now wants to add video. She now sends a "content-add" request to Romeo:</p>
+    <p class="caption">Example 14. Adding a Content Type</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='add1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='content-add'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;content name='video-is-back'&gt;
+      &lt;description xmlns='http://jabber.org/protocol/jingle/description/video'&gt;
+        ...
+      &lt;/description&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+        ...
+      &lt;/transport&gt;
+      &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+        ...
+      &lt;/transport&gt;
+    &lt;/content&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The entity receiving the session extension request then acknowledges (or declines) the request:</p>
+    <p class="caption">Example 15. Acknowledgement</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' to='juliet@capulet.com/balcony' id='add1' type='result'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>5.9 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session (which MAY be done at any point after acknowledging receipt of the initiation request, including immediately thereafter in order to decline the request), either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 16. Target Entity Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='term1'
+    to='romeo@montague.net/orchard'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='session-terminate'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity MUST then acknowledge termination of the session:</p>
+    <p class="caption">Example 17. Initiating Entity Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further Jingle communication for the negotiated content description format and content transport method MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'session-redirect' or 'session-terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 18. Target Entity Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>5.10 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">At any point after initiation of a Jingle session, either entity MAY send an informational message to the other party, for example to change a content transport method or content description format parameter, inform the other party that a session initiation request is queued, that a device is ringing, or that a scheduled event has occurred or will occur. An information message MUST be an IQ-set containing a &lt;jingle/&gt; element whose 'action' attribute is set to a value of "session-info", "description-info", or "transport-info"; the &lt;jingle/&gt; element MUST further contain a payload child element (speciific to the session, content description format, or content transport method) that specifies the information being communicated. (A future version of this specification will define payloads related to the "session-info" action.)</p>
+  </div>
+<h2>6.
+       <a name="errors">Error Handling</a>
+</h2>
+  <p class="" style="">The Jingle-specific error conditions are as follows.</p>
+  <p class="caption">Table 2: Other Error Conditions</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Jingle Condition</th>
+      <th colspan="" rowspan="">XMPP Condition</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;out-of-order/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;unexpected-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The request cannot occur at this point in the state machine (e.g., initiate after accept).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unknown-session/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;bad-request/&gt;</td>
+      <td align="" colspan="" rowspan="">The 'sid' attribute specifies a session that is unknown to the recipient.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-content/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired content description formats.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;unsupported-transports/&gt;</td>
+      <td align="" colspan="" rowspan="">&lt;not-acceptable/&gt;</td>
+      <td align="" colspan="" rowspan="">The recipient does not support any of the desired content transport methods.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">There is a one-to-one relationship between content types and sessions. This reduces the complexity of managing a given session, since it avoids the need to de-multiplex traffic for different content types sent over the same connection. However, it may be desirable to share different kinds of content at the same time (e.g., during a video chat one party may want to share a file); in order to do this, the parties must establish a separate session for each content type. Management of multiple sessions is a client implementation matter and is not discussed in this specification.</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This section is not yet complete.</span></p>
+  <div class="indent">
+<h3>8.1 <a name="security-dos">Denial of Service</a>
+</h3>
+    <p class="" style="">Jingle sessions may be resource-intensive. Therefore, it is possible to launch a denial-of-service attack against an entity by burdening it with too many Jingle sessions. Care must be taken to accept content sessions only from known entities and only if the entity's device is able to process such sessions.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="security-gateways">Communication Through Gateways</a>
+</h3>
+    <p class="" style="">Jingle communications may be enabled through gateways to non-XMPP networks, whose security characteristics may be quite different from those of XMPP networks. (For example, on some SIP networks authentication is optional and "from" addresses can be easily forged.) Care must be taken in communicating through such gateways.</p>
+  </div>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260279">17</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260324">18</a>] shall include 'http://jabber.org/protocol/jingle' and 'http://jabber.org/protocol/jingle#errors' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-content">Jingle Content Description Formats Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle content description formats. All content description format registrations shall be defined in separate documents (not in this JEP). Content description formats defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/description/name" (where "name" is the registered name of the content description format).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;content&gt;
+  &lt;name&gt;the name of the content description format (e.g., "audio")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the content description format&lt;/desc&gt;
+  &lt;doc&gt;the document in which this content description format is specified&lt;/doc&gt;
+&lt;/content&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.3 <a name="registrar-transports">Jingle Content Transport Methods Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of Jingle content transport methods. All content transport method registrations shall be defined in separate documents (not in this JEP). Content transport methods defined within the JEP series MUST be registered with the Jabber Registrar, resulting in protocol URIs of the form "http://jabber.org/protocol/jingle/transport/name" (where "name" is the registered name of the content transport method).</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;the name of the content transport method (e.g., "raw-udp")&lt;/name&gt;
+  &lt;desc&gt;a natural-language summary of the content transport method&lt;/desc&gt;
+  &lt;doc&gt;the document in which this content transport method is specified&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-jingle">Jingle</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle'
+    xmlns='http://jabber.org/protocol/jingle'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='jingle'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence minOccurs='1' maxOccurs='unlimited'&gt;
+        &lt;xs:element ref='content'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='action' use='required'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='content-accept'/&gt;
+            &lt;xs:enumeration value='content-add'/&gt;
+            &lt;xs:enumeration value='content-decline'/&gt;
+            &lt;xs:enumeration value='content-modify'/&gt;
+            &lt;xs:enumeration value='content-remove'/&gt;
+            &lt;xs:enumeration value='description-accept'/&gt;
+            &lt;xs:enumeration value='description-decline'/&gt;
+            &lt;xs:enumeration value='description-info'/&gt;
+            &lt;xs:enumeration value='description-modify'/&gt;
+            &lt;xs:enumeration value='session-accept'/&gt;
+            &lt;xs:enumeration value='session-decline'/&gt;
+            &lt;xs:enumeration value='session-info'/&gt;
+            &lt;xs:enumeration value='session-initiate'/&gt;
+            &lt;xs:enumeration value='session-redirect'/&gt;
+            &lt;xs:enumeration value='session-terminate'/&gt;
+            &lt;xs:enumeration value='transport-accept'/&gt;
+            &lt;xs:enumeration value='transport-decline'/&gt;
+            &lt;xs:enumeration value='transport-info'/&gt;
+            &lt;xs:enumeration value='transport-modify'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+      &lt;xs:attribute name='initiator' type='xs:string' use='required'/&gt;
+      &lt;xs:attribute name='responder' type='xs:string' use='optional'/&gt;
+      &lt;xs:attribute name='sid' type='xs:NMTOKEN' use='required'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='content'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice minOccurs='0'&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:any namespace='##other' minOccurs='0' maxOccurs='unbounded'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+      &lt;xs:attribute name='senders' use='optional' default='both'&gt;
+        &lt;xs:simpleType&gt;
+          &lt;xs:restriction base='xs:NCName'&gt;
+            &lt;xs:enumeration value='both'&gt;
+            &lt;xs:enumeration value='initiator'&gt;
+            &lt;xs:enumeration value='responder'/&gt;
+          &lt;/xs:restriction&gt;
+        &lt;/xs:simpleType&gt;
+      &lt;/xs:attribute&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-errors">Jingle Errors</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle#errors'
+    xmlns='http://jabber.org/protocol/jingle#errors'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='out-of-order' type='empty'/&gt;
+  &lt;xs:element name='unknown-session' type='empty'/&gt;
+  &lt;xs:element name='unsupported-content' type='empty'/&gt;
+  &lt;xs:element name='unsupported-transports' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<h2>12.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">The authors would like to thank Rohan Mahy for his valuable input on early versions of this document. Rob Taylor, Dafydd Harries, Jussi Laako, Saku Vainio, Antti Ijäs, Brian West, Anthony Minessale, Matt O'Gorman, and others have also provided helpful input. Thanks also to those who have commented on the <span class="ref" style="">Standards JIG</span>  [<a href="#nt-id2260515">19</a>] and (earlier) Jingle  [<a href="#nt-id2260501">20</a>] mailing lists.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2257680">1</a>. JEP-0111: A Transport for Initiating and Negotiating Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0111.html">http://www.jabber.org/jeps/jep-0111.html</a>&gt;.</p>
+<p><a name="nt-id2257666">2</a>. It is true that TINS made it relatively easy to implement an XMPP-to-SIP gateway; however, in line with the long-time Jabber philosophy of "simple clients, complex servers", it would be better to force complexity onto the server-side gateway and to keep the client as simple as possible.</p>
+<p><a name="nt-id2257733">3</a>. For example, one large ISP recently decided to switch to a pure XMPP approach after having implemented and deployed a dual-stack client for several years.</p>
+<p><a name="nt-id2257757">4</a>. Google Talk is a messaging and voice chat service and client provided by Google; see &lt;<a href="http://www.google.com/talk/">http://www.google.com/talk/</a>&gt;.</p>
+<p><a name="nt-id2257803">5</a>. Possible other content description formats include file sharing, application casting, application sharing, whiteboarding, torrent broadcasting, shared real-time editing, and distributed musical performance, to name but a few.</p>
+<p><a name="nt-id2257868">6</a>. RFC 4566: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc4566.txt">http://www.ietf.org/rfc/rfc4566.txt</a>&gt;.</p>
+<p><a name="nt-id2257891">7</a>. JEP-0167: Jingle Audio Content Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2257932">8</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2257955">9</a>. ITU Recommendation H.323: Packet-based Multimedia Communications Systems (September 1999).</p>
+<p><a name="nt-id2258359">10</a>. JEP-0176: Jingle RTP-ICE Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0176.html">http://www.jabber.org/jeps/jep-0176.html</a>&gt;.</p>
+<p><a name="nt-id2258384">11</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2258656">12</a>. While it is possible to send raw Session Description Protocol (SDP) data for the session descriptions (the approach that was taken in <span style="font-weight: bold">JEP-0111</span>), this is not necessarily helpful, since SDP is not structured data, not all SDP data is needed or used in the most common use cases, and SDP has been heavily extended in several useful directions that are not captured in the core SDP specification.</p>
+<p><a name="nt-id2258928">13</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2258951">14</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2259014">15</a>. JEP-0168: Resource Application Priority &lt;<a href="http://www.jabber.org/jeps/jep-0168.html">http://www.jabber.org/jeps/jep-0168.html</a>&gt;.</p>
+<p><a name="nt-id2250541">16</a>. See &lt;<a href="http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken">http://www.w3.org/TR/2000/WD-xml-2e-20000814#NT-Nmtoken</a>&gt;</p>
+<p><a name="nt-id2260279">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260324">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2260515">19</a>. The Standards JIG is a standing Jabber Interest Group devoted to discussion of Jabber Enhancement Proposals. The discussion list of the Standards JIG is the primary venue for discussion of Jabber protocol development, as well as for announcements by the JEP Editor and Jabber Registrar. To subscribe to the list or view the list archives, visit &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig/">http://mail.jabber.org/mailman/listinfo/standards-jig/</a>&gt;.</p>
+<p><a name="nt-id2260501">20</a>. Before this specification was accepted as a Jabber Enhancement Proposal, it was discussed on the semi-private &lt;jingle@jabber.org&gt; mailing list; although that list is no longer used (the Standards-JIG list is the preferred discussion venue), for historical purposes it is publicly archived at &lt;<a href="http://mail.jabber.org/pipermail/jingle/">http://mail.jabber.org/pipermail/jingle/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2006-09-08)</h4>
+<div class="indent">
+<p class="" style="">Further cleaned up state machines and state-related actions.</p> (ram/psa)
+    </div>
+<h4>Version 0.8 (2006-08-23)</h4>
+<div class="indent">
+<p class="" style="">Changed channels to components in line with ICE; changed various action names for consistency; added session-extend and session-reduce actions to add and remove description/transport pairs; added description-modify action; added sender attribute to specify directionality.</p> (ram/psa)
+    </div>
+<h4>Version 0.7 (2006-07-17)</h4>
+<div class="indent">
+<p class="" style="">Added implementation note about handling multiple content types.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Changed media type to content type.</p> (se/psa)
+    </div>
+<h4>Version 0.5 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">Further clarified state machine diagrams; specified that session accept must include agreed-upon media format and transport description; moved deployment notes to appropriate transport spec.</p> (psa/jb)
+    </div>
+<h4>Version 0.4 (2006-03-01)</h4>
+<div class="indent">
+<p class="" style="">Added glossary; clarified state machines; updated to reflect publication of JEP-0176 and JEP-0177.</p> (psa/jb)
+    </div>
+<h4>Version 0.3 (2006-02-24)</h4>
+<div class="indent">
+<p class="" style="">Provided more detail about modify scenarios; defined media-specific and transport-specific actions and adjusted state machine accordingly.</p> (psa/jb)
+    </div>
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Per agreement among the co-authors, moved transport definition to separate specification, simplified state machine, and made other associated changes to the text, examples, and schemas; also harmonized redirect, decline, and terminate processes.</p> (psa/jb)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.10 (2005-12-11)</h4>
+<div class="indent">
+<p class="" style="">More fully documented burst mode, connectivity checks, error cases, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.9 (2005-12-08)</h4>
+<div class="indent">
+<p class="" style="">Restructured document flow; provided example of burst mode.</p> (psa)
+    </div>
+<h4>Version 0.0.8 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Distinguished between dribble mode and burst mode, including mode attribute, service discovery features, and implementation notes; provided detailed resource discovery examples; corrected state chart; specified session termination; specified error conditions; specified semantics of informational messages; began to define security considerations; added Joe Beda as co-author.</p> (psa/sl/jb)
+    </div>
+<h4>Version 0.0.7 (2005-11-08)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow; harmonized candidate negotiation process with ICE.</p> (psa)
+    </div>
+<h4>Version 0.0.6 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added Jabber Registrar considerations; defined schema; completed slight syntax cleanup.</p> (psa)
+    </div>
+<h4>Version 0.0.5 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">Separated  methoddescription formats from signalling protocol.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.4 (2005-10-19)</h4>
+<div class="indent">
+<p class="" style="">Harmonized basic session flow with Google Talk protocol; added Scott Ludwig as co-author.</p> (psa/sl)
+    </div>
+<h4>Version 0.0.3 (2005-10-10)</h4>
+<div class="indent">
+<p class="" style="">Added more detail to basic session flow.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-07)</h4>
+<div class="indent">
+<p class="" style="">Protocol cleanup.</p> (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-10-06)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0167-0.1.html
+++ b/content/xep-0167-0.1.html
@@ -1,0 +1,349 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0167: Jingle Audio</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle Audio">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a session description format for Jingle audio sessions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0167">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0167: Jingle Audio</h1>
+<p>This document defines a session description format for Jingle audio sessions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0167<br>
+            Version: 0.1<br>
+            Last Updated: 2005-12-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, Jingle Signalling<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle-audio<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20Audio%20(JEP-0167)">http://wiki.jabber.org/index.php/Jingle Audio (JEP-0167)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email: scottlu@google.com<br>
+        JID: scottlu@google.com</p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#format">Description Format</a>
+</dt>
+<dt>4.  <a href="#sdp">Mapping to SDP</a>
+</dt>
+<dt>5.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>6.  <a href="#info">Informational Messages</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>7.1.  <a href="#impl-ring">Ringing</a>
+</dt></dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-jingle">Jingle Session Type</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-desc">Session Description</a>
+</dt>
+<dt>11.2.  <a href="#schema-info">Informational Messages</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle Signalling</span>  [<a href="#nt-id2251547">1</a>] can be used to initiate and negotiate a wide range of peer-to-peer sessions. The first session type of interest is audio chat. This document specifies a format for describing Jingle audio sessions.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle session description format defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable negotiation of parameters necessary for audio chat.</li>
+    <li>Map these parameters to <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2250550">2</a>] to enable interoperability.</li>
+  </ol>
+<h2>3.
+       <a name="format">Description Format</a>
+</h2>
+  <p class="" style="">A Jingle audio session is described by one or more encodings contained within a wrapper &lt;description/&gt; element. In the language of <span style="font-weight: bold">RFC 2327</span> these encodings are payload-types; therefore, each &lt;payload-type/&gt; element specifies an encoding that can be used for the audio stream. Such encodings are often used in the context of the Real-time Transfer Protocol (RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2250597">3</a>]) but may be used in other contexts as well. The most common encodings for the Audio/Video Profile (AVP) of RTP are listed in <span class="ref" style="">RFC 3551</span>  [<a href="#nt-id2250757">4</a>] (these "static" types are reserved from payload ID 0 through payload ID 96), although other encodings are allowed (these "dynamic" types use payload IDs 97 to 127) in accordance with the dynamic assignment rules described in Section 3 of <span style="font-weight: bold">RFC 3551</span>. The 'id' attribute is REQUIRED and the 'name' attribute is RECOMMENDED. The encodings SHOULD be provided in order of preference.</p>
+  <p class="caption">Example 1. Audio Description Format</p>
+<div class="indent"><pre>
+    &lt;description xmlns='http://jabber.org/protocol/jingle/sessions/audio'&gt;
+      &lt;payload-type id='18' name='G729'/&gt;
+      &lt;payload-type id="97" name="IPCMWB"/&gt;
+      &lt;payload-type id='98' name='L16' rate='16000' channels='2'/&gt;
+      &lt;payload-type id="96" name="ISAC" rate="8000"/&gt;
+      &lt;payload-type id="102" name="iLBC"/&gt;
+      &lt;payload-type id="4" name="G723"/&gt;
+      &lt;payload-type id="100" name="EG711U"/&gt;
+      &lt;payload-type id="101" name="EG711A"/&gt;
+      &lt;payload-type id="0" name="PCMU" rate="16000"/&gt;
+      &lt;payload-type id="8" name="PCMA"/&gt;
+      &lt;payload-type id="13" name="CN"/&gt;
+    &lt;/description&gt;
+  </pre></div>
+  <p class="" style="">The &lt;description/&gt; element is intended to be a child of a &lt;jingle/&gt; element used in Jingle signalling.</p>
+<h2>4.
+       <a name="sdp">Mapping to SDP</a>
+</h2>
+  <p class="" style="">If the payload type is static (payload-type IDs 0 through 96 inclusive), it SHOULD be mapped to an SDP media field. The generic format for the media field is as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+m=&lt;media&gt; &lt;port&gt; &lt;transport&gt; &lt;fmt list&gt;
+  </pre></div>
+  <p class="" style="">In the context of Jingle audio sessions, the &lt;media&gt; is "audio", the &lt;port&gt; is the preferred port for such communications (which may be determined dynamically), the &lt;transport&gt; is "RTP/AVP", and the &lt;fmt list&gt; is the payload-type ID.</p>
+  <p class="" style="">For example, consider the following static payload-type:</p>
+  <p class="caption">Example 2. Jingle Format for Static Payload-Type</p>
+<div class="indent"><pre>
+&lt;payload-type id="13" name="CN"/&gt;
+  </pre></div>
+  <p class="caption">Example 3. SDP Mapping of Static Payload-Type</p>
+<div class="indent"><pre>
+m=audio 9999 RTP/AVP 13
+  </pre></div>
+  <p class="" style="">If the payload type is dynamic (payload-type IDs 97 through 127 inclusive), it SHOULD be mapped to an SDP media field plus an SDP attribute field named "rtpmap".</p>
+  <p class="" style="">For example, consider a payload of 16-bit linear-encoded stereo audio sampled at 16KHz associated with dynamic payload-type 98:</p>
+  <p class="caption">Example 4. Jingle Format for Dynamic Payload-Type</p>
+<div class="indent"><pre>
+&lt;payload-type id='98' name='L16' rate='16000' channels='2'/&gt;
+  </pre></div>
+  <p class="caption">Example 5. SDP Mapping of Dynamic Payload-Type</p>
+<div class="indent"><pre>
+m=audio 9999 RTP/AVP 98
+a=rtpmap:98 L16/16000/2
+  </pre></div>
+<h2>5.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">If an entity supports Jingle audio sessions, it MUST advertise that fact by returning a feature of "http://jabber.org/protocol/jingle/sessions/audio" in response to <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250742">5</a>] information requests.</p>
+  <p class="caption">Example 6. Service Discovery Information Request</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    id='disco1'
+    to='juliet@capulet.com/balcony' 
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 7. Service Discovery Information Response</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='disco1'
+    to='romeo@montague.net/orchard' 
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/jingle'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle/sessions/audio'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="info">Informational Messages</a>
+</h2>
+  <p class="" style="">Informational messages may be sent within the context of Jingle signalling to communicate the status of a Jingle audio session. The following payload elements are defined for Jingle audio session information, qualified by the 'http://jabber.org/protocol/jingle/info/audio' namespace:</p>
+  <p class="caption">Table 1: Information Payload Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Element</th>
+      <th colspan="" rowspan="">Meaning</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;queued/&gt;</td>
+      <td align="" colspan="" rowspan="">The session initiation request is queued for pickup.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">&lt;ringing/&gt;</td>
+      <td align="" colspan="" rowspan="">The device is ringing but the principal has not yet interact with it to answer.</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-ring">Ringing</a>
+</h3>
+    <p class="" style="">An implementation SHOULD return an informational &lt;ringing/&gt; message when it knows that it has an active candidate.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The description of encodings for audio sessions introduces no known security vulnerabilities.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256489">6</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256537">7</a>] shall include 'http://jabber.org/protocol/jingle/sessions/audio' and 'http://jabber.org/protocol/jingle/info/audio' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-jingle">Jingle Session Type</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall add a Jingle session type named "audio" to its registry of Jingle session types. The registration is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;session&gt;
+  &lt;name&gt;audio&lt;/name&gt;
+  &lt;desc&gt;audio-only sessions&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/session&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-desc">Session Description</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/sessions/audio'
+    xmlns='http://jabber.org/protocol/jingle/sessions/audio'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='description'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='payload-type' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='payload-type'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='channels' type='xs:byte' use='optional'/&gt;
+          &lt;xs:attribute name='id' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='rate' type='xs:short' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-info">Informational Messages</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/info/audio'
+    xmlns='http://jabber.org/protocol/jingle/info/audio'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='queued' type='empty'/&gt;
+
+  &lt;xs:element name='ringing' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251547">1</a>. JEP-0166: Jingle Signalling &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2250550">2</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2250597">3</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2250757">4</a>. RFC 3551: RTP Profile for Audio and Video Conferences with Minimal Control &lt;<a href="http://www.ietf.org/rfc/rfc3551.txt">http://www.ietf.org/rfc/rfc3551.txt</a>&gt;.</p>
+<p><a name="nt-id2250742">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256489">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256537">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-12-05)</h4>
+<div class="indent">Described service discovery usage; defined initial informational messages. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-27)</h4>
+<div class="indent">Added SDP mapping, security considerations, IANA considerations, Jabber Registrar considerations, and XML schema. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-21)</h4>
+<div class="indent">First draft. (psa/sl)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0167-0.2.html
+++ b/content/xep-0167-0.2.html
@@ -1,0 +1,418 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0167: Jingle Audio Media Description Format</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle Audio Media Description Format">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a media description format for Jingle audio sessions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-02-13">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0167">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0167: Jingle Audio Media Description Format</h1>
+<p>This document defines a media description format for Jingle audio sessions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0167<br>
+            Version: 0.2<br>
+            Last Updated: 2006-02-13<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle-audio<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20Audio%20Media%20Description%20Format%20(JEP-0167)">http://wiki.jabber.org/index.php/Jingle Audio Media Description Format (JEP-0167)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#format">Media Description Format</a>
+</dt>
+<dt>4.  <a href="#sdp">Mapping to Session Description Protocol</a>
+</dt>
+<dt>5.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>6.  <a href="#info">Informational Messages</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#info-format">Format</a>
+</dt>
+<dt>6.2.  <a href="#info-examples">Examples</a>
+</dt>
+</dl>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>7.1.  <a href="#impl-codecs">Codecs</a>
+</dt></dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-media">Jingle Media Description</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-media">Media Description</a>
+</dt>
+<dt>11.2.  <a href="#schema-info">Informational Messages</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2250860">1</a>] can be used to initiate and negotiate a wide range of peer-to-peer sessions. The first session type of interest is audio chat. This document specifies a format for describing Jingle audio sessions.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle media description format defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable negotiation of parameters necessary for audio chat.</li>
+    <li>Map these parameters to Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2250916">2</a>]) to enable interoperability.</li>
+    <li>Define informational messages related to audio chat (e.g., busy and ringing).</li>
+  </ol>
+<h2>3.
+       <a name="format">Media Description Format</a>
+</h2>
+  <p class="" style="">A Jingle audio session is described by one or more encodings contained within a wrapper &lt;description/&gt; element. In the language of <span style="font-weight: bold">RFC 2327</span> these encodings are payload-types; therefore, each &lt;payload-type/&gt; element specifies an encoding that can be used for the audio stream. Such encodings are often used in the context of the Real-time Transfer Protocol (RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2250973">3</a>]) but may be used in other contexts as well. The most common encodings for the Audio/Video Profile (AVP) of RTP are listed in <span class="ref" style="">RFC 3551</span>  [<a href="#nt-id2251169">4</a>] (these "static" types are reserved from payload ID 0 through payload ID 96), although other encodings are allowed (these "dynamic" types use payload IDs 97 to 127) in accordance with the dynamic assignment rules described in Section 3 of <span style="font-weight: bold">RFC 3551</span>. The 'id' attribute is REQUIRED and the 'name' attribute is RECOMMENDED. The encodings SHOULD be provided in order of preference.</p>
+  <p class="caption">Example 1. Audio Description Format</p>
+<div class="indent"><pre>
+    &lt;description xmlns='http://jabber.org/protocol/jingle/media/audio'&gt;
+      &lt;payload-type id='18' name='G729'/&gt;
+      &lt;payload-type id="97" name="IPCMWB"/&gt;
+      &lt;payload-type id='98' name='L16' rate='16000' channels='2'/&gt;
+      &lt;payload-type id="96" name="ISAC" rate="8000"/&gt;
+      &lt;payload-type id="102" name="iLBC"/&gt;
+      &lt;payload-type id="4" name="G723"/&gt;
+      &lt;payload-type id="100" name="EG711U"/&gt;
+      &lt;payload-type id="101" name="EG711A"/&gt;
+      &lt;payload-type id="0" name="PCMU" rate="16000"/&gt;
+      &lt;payload-type id="8" name="PCMA"/&gt;
+      &lt;payload-type id="13" name="CN"/&gt;
+    &lt;/description&gt;
+  </pre></div>
+  <p class="" style="">The &lt;description/&gt; element is intended to be a child of a &lt;jingle/&gt; element as specified in <span style="font-weight: bold">JEP-0166</span>.</p>
+<h2>4.
+       <a name="sdp">Mapping to Session Description Protocol</a>
+</h2>
+  <p class="" style="">If the payload type is static (payload-type IDs 0 through 96 inclusive), it SHOULD be mapped to a media field defined in <span style="font-weight: bold">RFC 2327: Session Description Protocol</span> (SDP). The generic format for the media field is as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+m=&lt;media&gt; &lt;port&gt; &lt;transport&gt; &lt;fmt list&gt;
+  </pre></div>
+  <p class="" style="">In the context of Jingle audio sessions, the &lt;media&gt; is "audio", the &lt;port&gt; is the preferred port for such communications (which may be determined dynamically), the &lt;transport&gt; is "RTP/AVP", and the &lt;fmt list&gt; is the payload-type ID.</p>
+  <p class="" style="">For example, consider the following static payload-type:</p>
+  <p class="caption">Example 2. Jingle Format for Static Payload-Type</p>
+<div class="indent"><pre>
+&lt;payload-type id="13" name="CN"/&gt;
+  </pre></div>
+  <p class="caption">Example 3. SDP Mapping of Static Payload-Type</p>
+<div class="indent"><pre>
+m=audio 9999 RTP/AVP 13
+  </pre></div>
+  <p class="" style="">If the payload type is dynamic (payload-type IDs 97 through 127 inclusive), it SHOULD be mapped to an SDP media field plus an SDP attribute field named "rtpmap".</p>
+  <p class="" style="">For example, consider a payload of 16-bit linear-encoded stereo audio sampled at 16KHz associated with dynamic payload-type 98:</p>
+  <p class="caption">Example 4. Jingle Format for Dynamic Payload-Type</p>
+<div class="indent"><pre>
+&lt;payload-type id='98' name='L16' rate='16000' channels='2'/&gt;
+  </pre></div>
+  <p class="caption">Example 5. SDP Mapping of Dynamic Payload-Type</p>
+<div class="indent"><pre>
+m=audio 9999 RTP/AVP 98
+a=rtpmap:98 L16/16000/2
+  </pre></div>
+<h2>5.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">If an entity supports the Jingle audio media description format, it MUST advertise that fact by returning a feature of "http://jabber.org/protocol/jingle/media/audio" in response to <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2251146">5</a>] information requests.</p>
+  <p class="caption">Example 6. Service Discovery Information Request</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    id='disco1'
+    to='juliet@capulet.com/balcony' 
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 7. Service Discovery Information Response</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='disco1'
+    to='romeo@montague.net/orchard' 
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/jingle'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle/media/audio'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="info">Informational Messages</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="info-format">Format</a>
+</h3>
+    <p class="" style="">Informational messages may be sent within the context of Jingle to communicate the status of a Jingle audio session. The following payload elements are defined for Jingle audio session information, qualified by the 'http://jabber.org/protocol/jingle/info/audio' namespace:</p>
+    <p class="caption">Table 1: Information Payload Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Meaning</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;busy/&gt;</td>
+        <td align="" colspan="" rowspan="">The device is currently unavailable for a session because busy with another audio session.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;queued/&gt;</td>
+        <td align="" colspan="" rowspan="">The audio session request is queued for pickup.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;ringing/&gt;</td>
+        <td align="" colspan="" rowspan="">The device is ringing but the principal has not yet interacted with it to answer.</td>
+      </tr>
+    </table>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="info-examples">Examples</a>
+</h3>
+    <p class="caption">Example 8. Target Entity Returns Busy Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    to='romeo@montague.net/orchard' 
+    id='info1' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;busy xmlns='http://jabber.org/protocol/jingle/info/audio'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 9. Target Entity Returns Queued Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    to='romeo@montague.net/orchard' 
+    id='info2' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;queued xmlns='http://jabber.org/protocol/jingle/info/audio'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 10. Target Entity Returns Ringing Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    to='romeo@montague.net/orchard' 
+    id='info3' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;ringing xmlns='http://jabber.org/protocol/jingle/info/audio'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-codecs">Codecs</a>
+</h3>
+    <p class="" style="">Support for the Speex codec  [<a href="#nt-id2256808">6</a>] is RECOMMENDED.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The description of a format for audio sessions introduces no known security vulnerabilities.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256876">7</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256927">8</a>] shall include 'http://jabber.org/protocol/jingle/media/audio' and 'http://jabber.org/protocol/jingle/info/audio' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-media">Jingle Media Description</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the name "audio" in its registry of Jingle media descriptions. The registration is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;media&gt;
+  &lt;name&gt;audio&lt;/name&gt;
+  &lt;desc&gt;Jingle sessions that support audio exchanges&lt;/desc&gt;
+  &lt;doc&gt;JEP-0167&lt;/doc&gt;
+&lt;/media&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-media">Media Description</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/media/audio'
+    xmlns='http://jabber.org/protocol/jingle/media/audio'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='description'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='payload-type' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='payload-type'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='channels' type='xs:byte' use='optional'/&gt;
+          &lt;xs:attribute name='id' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='rate' type='xs:short' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-info">Informational Messages</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/info/audio'
+    xmlns='http://jabber.org/protocol/jingle/info/audio'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='busy' type='empty'/&gt;
+  &lt;xs:element name='queued' type='empty'/&gt;
+  &lt;xs:element name='ringing' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250860">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2250916">2</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2250973">3</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2251169">4</a>. RFC 3551: RTP Profile for Audio and Video Conferences with Minimal Control &lt;<a href="http://www.ietf.org/rfc/rfc3551.txt">http://www.ietf.org/rfc/rfc3551.txt</a>&gt;.</p>
+<p><a name="nt-id2251146">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256808">6</a>. See &lt;<a href="http://www.speex.org/">http://www.speex.org/</a>&gt;.</p>
+<p><a name="nt-id2256876">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256927">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">Defined info message for busy; added info message examples; recommended use of Speex; updated schema and Jabber Registrar considerations. (psa)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.3 (2005-12-05)</h4>
+<div class="indent">Described service discovery usage; defined initial informational messages. (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-27)</h4>
+<div class="indent">Added SDP mapping, security considerations, IANA considerations, Jabber Registrar considerations, and XML schema. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-21)</h4>
+<div class="indent">First draft. (psa/sl)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0167-0.4.html
+++ b/content/xep-0167-0.4.html
@@ -1,0 +1,491 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0167: Jingle Audio Content Description Format</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle Audio Content Description Format">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Sean Egan">
+<meta name="DC.Description" content="This document defines a content description format for Jingle audio sessions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0167">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0167: Jingle Audio Content Description Format</h1>
+<p>This document defines a content description format for Jingle audio sessions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0167<br>
+            Version: 0.4<br>
+            Last Updated: 2006-07-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle-audio<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20Audio%20Content%20Description%20Format%20(JEP-0167)">http://wiki.jabber.org/index.php/Jingle Audio Content Description Format (JEP-0167)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Sean Egan</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:seanegan@google.com">seanegan@google.com</a><br>
+        JID: 
+        <a href="xmpp:seanegan@google.com">seanegan@google.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#format">Content Description Format</a>
+</dt>
+<dt>4.  <a href="#sdp">Mapping to Session Description Protocol</a>
+</dt>
+<dt>5.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>6.  <a href="#info">Informational Messages</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#info-format">Format</a>
+</dt>
+<dt>6.2.  <a href="#info-examples">Examples</a>
+</dt>
+</dl>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#impl-codecs">Codecs</a>
+</dt>
+<dt>7.2.  <a href="#impl-dtmf">DTMF</a>
+</dt>
+</dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-content">Jingle Content Description Formats</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-content">Content Description Format</a>
+</dt>
+<dt>11.2.  <a href="#schema-info">Informational Messages</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2250818">1</a>] can be used to initiate and negotiate a wide range of peer-to-peer sessions. The first session type of interest is audio chat. This document specifies a format for describing Jingle audio sessions.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle content description format defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable negotiation of parameters necessary for audio chat over Realtime Transport Protocol (RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2251046">2</a>]).</li>
+    <li>Map these parameters to Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2251020">3</a>]) to enable interoperability.</li>
+    <li>Define informational messages related to audio chat (e.g., busy and ringing).</li>
+  </ol>
+<h2>3.
+       <a name="format">Content Description Format</a>
+</h2>
+  <p class="" style="">A Jingle audio session is described by one or more encodings contained within a wrapper &lt;description/&gt; element. In the language of <span style="font-weight: bold">RFC 2327</span> these encodings are payload-types; therefore, each &lt;payload-type/&gt; element specifies an encoding that can be used for the audio stream. In Jingle Audio, these encodings are used in the context of RTP. The most common encodings for the Audio/Video Profile (AVP) of RTP are listed in <span class="ref" style="">RFC 3551</span>  [<a href="#nt-id2250884">4</a>] (these "static" types are reserved from payload ID 0 through payload ID 96), although other encodings are allowed (these "dynamic" types use payload IDs 97 to 127) in accordance with the dynamic assignment rules described in Section 3 of <span style="font-weight: bold">RFC 3551</span>. The 'id' attribute is REQUIRED. The 'name' attribute is RECOMMENDED for static payload types, and REQUIRED for dynamic payload types. The 'clockrate' attribute is RECOMMENDED and should specify the sampling frequency in hertz. The 'channels' attribute is RECOMMENDED and should specify the number of channels. If omitted, it SHOULD be assumed to contain one channel.</p>
+<p class="" style="">The encodings SHOULD be provided in order of preference.</p>
+  <p class="caption">Example 1. Audio Description Format</p>
+<div class="indent"><pre>
+    &lt;description xmlns='http://jabber.org/protocol/jingle/content/audio'&gt;
+      &lt;payload-type id='18' name='G729'/&gt;
+      &lt;payload-type id="97" name="IPCMWB"/&gt;
+      &lt;payload-type id='98' name='L16' clockrate='16000' channels='2'/&gt;
+      &lt;payload-type id="96" name="ISAC" clockrate="8000"/&gt;
+      &lt;payload-type id="102" name="iLBC"/&gt;
+      &lt;payload-type id="4" name="G723"/&gt;
+      &lt;payload-type id="100" name="EG711U"/&gt;
+      &lt;payload-type id="101" name="EG711A"/&gt;
+      &lt;payload-type id="0" name="PCMU" clockrate="16000"/&gt;
+      &lt;payload-type id="8" name="PCMA"/&gt;
+      &lt;payload-type id="13" name="CN"/&gt;
+    &lt;/description&gt;
+  </pre></div>
+  <p class="" style="">The &lt;description/&gt; element is intended to be a child of a &lt;jingle/&gt; element as specified in <span style="font-weight: bold">JEP-0166</span>.</p>
+  <p class="" style="">When the session is provisionally accepted, as indicated by the target entity sending an empty IQ result in response to an 'initiate' message, both receiving and sending entities SHOULD start listening for audio as defined by the negotiated transport method. For interoperability with telephony systems, each entity SHOULD play any audio received at this time, before the target sends an 'accept' message.</p>
+<h2>4.
+       <a name="sdp">Mapping to Session Description Protocol</a>
+</h2>
+  <p class="" style="">If the payload type is static (payload-type IDs 0 through 96 inclusive), it MUST be mapped to a media field defined in <span style="font-weight: bold">RFC 2327: Session Description Protocol</span> (SDP). The generic format for the media field is as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+m=&lt;media&gt; &lt;port&gt; &lt;transport&gt; &lt;fmt list&gt;
+  </pre></div>
+  <p class="" style="">In the context of Jingle audio sessions, the &lt;content&gt; is "audio", the &lt;port&gt; is the preferred port for such communications (which may be determined dynamically), the &lt;transport&gt; is whatever transport method is negotiated via the Jingle negotiation (e.g., "RTP/AVT"), and the &lt;fmt list&gt; is the payload-type ID.</p>
+  <p class="" style="">For example, consider the following static payload-type:</p>
+  <p class="caption">Example 2. Jingle Format for Static Payload-Type</p>
+<div class="indent"><pre>
+&lt;payload-type id="13" name="CN"/&gt;
+  </pre></div>
+  <p class="caption">Example 3. SDP Mapping of Static Payload-Type</p>
+<div class="indent"><pre>
+m=audio 9999 RTP/AVP 13
+  </pre></div>
+  <p class="" style="">If the payload type is dynamic (payload-type IDs 97 through 127 inclusive), it SHOULD be mapped to an SDP media field plus an SDP attribute field named "rtpmap".</p>
+  <p class="" style="">For example, consider a payload of 16-bit linear-encoded stereo audio sampled at 16KHz associated with dynamic payload-type 98:</p>
+  <p class="caption">Example 4. Jingle Format for Dynamic Payload-Type</p>
+<div class="indent"><pre>
+&lt;payload-type id='98' name='L16' clockrate='16000' channels='2'/&gt;
+  </pre></div>
+  <p class="caption">Example 5. SDP Mapping of Dynamic Payload-Type</p>
+<div class="indent"><pre>
+m=audio 9999 RTP/AVP 98
+a=rtpmap:98 L16/16000/2
+  </pre></div>
+<h2>5.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">If an entity supports the Jingle audio content description format, it MUST advertise that fact by returning a feature of "http://jabber.org/protocol/jingle/content/audio" in response to <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259590">5</a>] information requests.</p>
+  <p class="caption">Example 6. Service Discovery Information Request</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard'
+    id='disco1'
+    to='juliet@capulet.com/balcony'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 7. Service Discovery Information Response</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    id='disco1'
+    to='romeo@montague.net/orchard'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/jingle'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle/content/audio'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="info">Informational Messages</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="info-format">Format</a>
+</h3>
+    <p class="" style="">Informational messages may be sent by either party within the context of Jingle to communicate the status of a Jingle audio session, device, or principal. The informational message MUST be an IQ-set containing a &lt;jingle/&gt; element of type "content-info", where the informational message is a payload  element qualified by the 'http://jabber.org/protocol/jingle/info/audio' namespace; the following payload elements are defined:</p>
+    <p class="caption">Table 1: Information Payload Elements</p>
+<table border="1" cellpadding="3" cellspacing="0">
+      <tr class="body">
+        <th colspan="" rowspan="">Element</th>
+        <th colspan="" rowspan="">Meaning</th>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;busy/&gt;</td>
+        <td align="" colspan="" rowspan="">The principal or device is currently unavailable for a session because busy with another (audio or other) session.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;hold/&gt;</td>
+        <td align="" colspan="" rowspan="">The principal is temporarily pausing the chat (i.e., putting the other party on hold).</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;mute/&gt;</td>
+        <td align="" colspan="" rowspan="">The principal is temporarily stopping audio input but continues to accept audio output.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;queued/&gt;</td>
+        <td align="" colspan="" rowspan="">The audio session request is queued for pickup by the principal.</td>
+      </tr>
+      <tr class="body">
+        <td align="" colspan="" rowspan="">&lt;ringing/&gt;</td>
+        <td align="" colspan="" rowspan="">The device is ringing but the principal has not yet interacted with it to answer.</td>
+      </tr>
+    </table>
+    <p class="" style="">Note: Because the informational message is sent in an IQ-set, the receiving party MUST return either an IQ-result or an IQ-error (normally only an IQ-result to acknowledge receipt; no error flows are defined or envisioned at this time).</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="info-examples">Examples</a>
+</h3>
+    <p class="caption">Example 8. Target Entity Sends Busy Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/orchard'
+    id='busy1'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='content-info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;busy xmlns='http://jabber.org/protocol/jingle/info/audio'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 9. Target Entity Sends Hold Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/orchard'
+    id='hold1'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='content-info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;hold xmlns='http://jabber.org/protocol/jingle/info/audio'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 10. Target Entity Sends Mute Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/orchard'
+    id='mute1'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='content-info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;mute xmlns='http://jabber.org/protocol/jingle/info/audio'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 11. Target Entity Sends Queued Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/orchard'
+    id='queued1'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='content-info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;queued xmlns='http://jabber.org/protocol/jingle/info/audio'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 12. Target Entity Sends Ringing Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='romeo@montague.net/orchard'
+    id='ringing1'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='content-info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;ringing xmlns='http://jabber.org/protocol/jingle/info/audio'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-codecs">Codecs</a>
+</h3>
+    <p class="" style="">Support for the Speex codec  [<a href="#nt-id2259873">6</a>] is RECOMMENDED.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="impl-dtmf">DTMF</a>
+</h3>
+    <p class="" style="">Support for Dual Tone Multi-Frequency (DTMF) MUST use the protocol described in <span class="ref" style="">Jingle DTMF </span>  [<a href="#nt-id2259921">7</a>].</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The description of a format for audio sessions introduces no known security vulnerabilities.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259978">8</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260064">9</a>] shall include 'http://jabber.org/protocol/jingle/content/audio' and 'http://jabber.org/protocol/jingle/info/audio' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-content">Jingle Content Description Formats</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the name "audio" in its registry of Jingle content description formats. The registration is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;content&gt;
+  &lt;name&gt;audio&lt;/name&gt;
+  &lt;desc&gt;Jingle sessions that support audio exchanges&lt;/desc&gt;
+  &lt;doc&gt;JEP-0167&lt;/doc&gt;
+&lt;/content&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-content">Content Description Format</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/content/audio'
+    xmlns='http://jabber.org/protocol/jingle/content/audio'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='description'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='payload-type' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='payload-type'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='channels' type='xs:byte' use='optional'/&gt;
+          &lt;xs:attribute name='id' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='rate' type='xs:short' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-info">Informational Messages</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/info/audio'
+    xmlns='http://jabber.org/protocol/jingle/info/audio'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='busy' type='empty'/&gt;
+  &lt;xs:element name='hold' type='empty'/&gt;
+  &lt;xs:element name='mute' type='empty'/&gt;
+  &lt;xs:element name='queued' type='empty'/&gt;
+  &lt;xs:element name='ringing' type='empty'/&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250818">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2251046">2</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2251020">3</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2250884">4</a>. RFC 3551: RTP Profile for Audio and Video Conferences with Minimal Control &lt;<a href="http://www.ietf.org/rfc/rfc3551.txt">http://www.ietf.org/rfc/rfc3551.txt</a>&gt;.</p>
+<p><a name="nt-id2259590">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259873">6</a>. See &lt;<a href="http://www.speex.org/">http://www.speex.org/</a>&gt;.</p>
+<p><a name="nt-id2259921">7</a>. JEP-0181: Jingle DTMF &lt;<a href="http://www.jabber.org/jeps/jep-0181.html">http://www.jabber.org/jeps/jep-0181.html</a>&gt;.</p>
+<p><a name="nt-id2259978">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260064">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Specified when to play received audio (early media); specified that DTMF must use in-band signalling (JEP-0181).</p> (se/psa)
+    </div>
+<h4>Version 0.3 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">Defined info messages for hold and mute.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-02-13)</h4>
+<div class="indent">
+<p class="" style="">Defined info message for busy; added info message examples; recommended use of Speex; updated schema and Jabber Registrar considerations.</p> (psa)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2005-12-05)</h4>
+<div class="indent">
+<p class="" style="">Described service discovery usage; defined initial informational messages.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2005-10-27)</h4>
+<div class="indent">
+<p class="" style="">Added SDP mapping, security considerations, IANA considerations, Jabber Registrar considerations, and XML schema.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-10-21)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/sl)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0168-0.1.html
+++ b/content/xep-0168-0.1.html
@@ -1,0 +1,383 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0168: Resource Application Priority (RAP)</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Resource Application Priority (RAP)">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines an XMPP presence extension to indicate the priority of XMPP resources for applications other than messaging.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-15">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0168">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0168: Resource Application Priority (RAP)</h1>
+<p>This document defines an XMPP presence extension to indicate the priority of XMPP resources for applications other than messaging.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0168<br>
+            Version: 0.1<br>
+            Last Updated: 2005-12-15<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rap<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Resource%20Application%20Priority%20(RAP)%20(JEP-0168)">http://wiki.jabber.org/index.php/Resource Application Priority (RAP) (JEP-0168)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email: jhildebrand@jabber.com<br>
+        JID: hildjj@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>3.  <a href="#primary">Application Priority</a>
+</dt>
+<dt>4.  <a href="#primary">Flagging the Primary Resource for a Given Application Type</a>
+</dt>
+<dt>5.  <a href="#raprequest">Requesting RAP Data Via IQ</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-apps">Application Types Registry</a>
+</dt>
+<dl>
+<dt>8.2.1.  <a href="#registrar-apps-process">Process</a>
+</dt>
+<dt>8.2.2.  <a href="#registrar-apps-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Within the Extensible Messaging and Presence Protocol (XMPP; see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250552">1</a>]), presence indicates availability for communication -- specifically, communication via XMPP messaging (usually in the form of "instant messaging" or IM as described in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250713">2</a>]). However, a wide variety of entities might provide XMPP presence, including entities that are not primarily focused on IM (e.g., phones) or even entities that do not support XMPP messaging at all.</p>
+  <p class="" style="">Consider a scenario in which a contact wants to initiate a voice chat with a user who has the following three XMPP resources:</p>
+  <p class="caption">Table 1: Application Presence</p>
+<table border="1" cellpadding="3" cellspacing="0">
+  <tr class="body">
+    <th colspan="" rowspan="">Resource</th>
+    <th colspan="" rowspan="">Messaging Priority</th>
+    <th colspan="" rowspan="">Voice Chat Priority</th>
+  </tr>
+  <tr class="body">
+    <td align="" colspan="" rowspan="">desktop</td>
+    <td align="" colspan="" rowspan="">10</td>
+    <td align="" colspan="" rowspan="">5</td>
+  </tr>
+  <tr class="body">
+    <td align="" colspan="" rowspan="">pda</td>
+    <td align="" colspan="" rowspan="">5</td>
+    <td align="" colspan="" rowspan="">-1</td>
+  </tr>
+  <tr class="body">
+    <td align="" colspan="" rowspan="">mobile</td>
+    <td align="" colspan="" rowspan="">-1</td>
+    <td align="" colspan="" rowspan="">10</td>
+  </tr>
+  </table>
+  <p class="" style="">If the contact chooses the resource with which it initiates a voice chat based on the user's default XMPP presence priority (i.e., priority for XMPP messaging), the resulting behavior could be misleading (i.e., initiating the voice chat with the "desktop" resource rather than the "mobile" resource).</p>
+  <p class="" style="">What is needed is a way for the user's clients to indicate that the application priority for the three resources is different from the standard XMPP messaging priority. This document defines such a mechanism via an optional XMPP presence extension.</p>
+  <p class="" style="">In addition, this document also defines a way for an XMPP server to flag which resource it considers to be primary for any given application type, if it has information -- such as communication preferences -- that can help determine the primary resource.</p>
+<h2>2.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports this protocol, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250684">3</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the queried entity supports resource application presence, it MUST return a feature of "http://jabber.org/protocol/rap":</p>
+  <p class="caption">Example 2. Server communicates protocol support for RAP</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rap'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the queried entity supports resource application presence as well as RAP requests (see the <a href="raprequest">Requesting RAP Data Via IQ</a> section of this document), it MUST return features of "http://jabber.org/protocol/rap" and "http://jabber.org/protocol/raprequest":</p>
+  <p class="caption">Example 3. Server communicates protocol support for RAP as well as RAP Request</p>
+<div class="indent"><pre>
+&lt;iq from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rap'/&gt;
+    &lt;feature var='http://jabber.org/protocol/raprequest'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>3.
+       <a name="primary">Application Priority</a>
+</h2>
+  <p class="" style="">Consider the three resources ("desktop", "pda", and "mobile") mentioned above. The presence stanzas received by a contact for those three resources would be as follows:</p>
+  <p class="caption">Example 4. Contact receives presence from user</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/desktop' to='romeo@montague.net/home'&gt;
+  &lt;priority&gt;10&lt;/priority&gt;
+  &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='5'/&gt;
+&lt;/presence&gt;
+
+&lt;presence from='juliet@capulet.com/pda' to='romeo@montague.net/home'&gt;
+  &lt;priority&gt;5&lt;/priority&gt;
+  &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='-1'/&gt;
+&lt;/presence&gt;
+
+&lt;presence from='juliet@capulet.com/mobile' to='romeo@montague.net/home'&gt;
+  &lt;priority&gt;-1&lt;/priority&gt;
+  &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='10'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">(Note: This protocol uses a 'num' attribute rather than a 'priority' attribute to reduce confusion with XMPP presence and also to save some bytes.)</p>
+  <p class="" style="">The following business rules apply to resource application presence provided by the client:</p>
+  <ol start="" type="">
+    <li>A client SHOULD NOT specify resource application presence if the priority for that application is not different from the resource's XMPP messaging priority.</li>
+    <li>A client MUST NOT generate a &lt;rap/&gt; element that has an 'app' attribute whose value is "im" or that has no 'app' attribute (since the default 'app' is "im").</li>
+  </ol>
+<h2>4.
+       <a name="primary">Flagging the Primary Resource for a Given Application Type</a>
+</h2>
+  <p class="" style="">The user's server may have special information that enables it to flag a resource as primary for a given application type. For instance, the server may include a communication policy service that enables the user to define (outside the context of any presence priorities) that she would prefer to be called at her "desktop" resource only between the hours of 9:00 AM and 5:00 PM local time, prefer to be called on her mobile at all other times, and so on.</p>
+  <p class="" style="">The XML for representing the primary resource related to a specific application type is extremely simple: the server may add a &lt;primary/&gt; child to the relevant RAP element. Here is an example:</p>
+  <p class="caption">Example 5. Primary resource flag</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/mobile'&gt;
+  &lt;priority&gt;-1&lt;/priority&gt;
+  &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='10'&gt;
+    &lt;primary/&gt;
+  &lt;/rap&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">The following business rules apply to resource flagging by the server:</p>
+  <ol start="" type="">
+    <li>A server MAY add the primary resource flag to the presence broadcasts generated by the resource it determines is "most available" for a given application type.</li>
+    <li>Because the default 'app' is "im", to flag the primary resource for XMPP messaging the server SHOULD NOT include an 'app' attribute, SHOULD NOT include a 'num' attribute, and MUST include a &lt;primary/&gt; child.</li>
+    <li>An available resource that has specified a negative priority for an application type MUST NOT be flagged as the primary resource for that application type.</li>
+    <li>A client SHOULD NOT include the primary resource flag in presence stanzas that it generates; however, if a client includes the primary resource flag in a presence stanza, the server SHOULD remove or overwrite the flag.</li>
+    <li>In response to a presence probe, a server SHOULD send presence from the primary resource first (this enables the receiving client to skip any local most-available algorithms it might implement).</li>
+    <li>If the primary resource changes, a server MUST push presence (including the primary resource flag) for the new primary resource. If the change in primary resource occurs because of a presence broadcast from the current primary resource, the server MUST push presence from the current primary resource (without the primary resource flag) before pushing presence from the new primary resource (including the primary resource flag).</li>
+  </ol>
+<h2>5.
+       <a name="raprequest">Requesting RAP Data Via IQ</a>
+</h2>
+  <p class="" style="">In the interest of saving bandwidth, a server MAY choose to strip all RAP data out of presence stanzas and instead provide RAP data only on request via IQ interactions. A likely scenario is as follows:</p>
+  <ol start="" type="">
+    <li>Contact's client sends disco#info request to user's client and discovers that user's client supports the 'http://jabber.org/protocol/rap' namespace.</li>
+    <li>User's client publishes RAP extensions but user's server strips them out in presence broadcasts.</li>
+    <li>User decides to initiate a non-IM interaction with contact.</li>
+    <li>Contact's client notices the lack of RAP data from user (despite discovered support) and sends disco#info request to user's server, which signals that it supports the 'http://jabber.org/protocol/raprequest' namespace.</li>
+    <li>Contact's client sends RAP request to user's bare JID.</li>
+    <li>If contact is authorized to view user's presence data, user's server returns the latest RAP data for all of the user's resources.</li>
+  </ol>
+  <p class="" style="">An example protocol flow for the last two steps is as follows:</p>
+  <p class="caption">Example 6. Contact requests RAP data from user's server</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;raprequest xmlns='http://jabber.org/protocol/raprequest'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 7. User's server returns RAP data</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;raprequest xmlns='http://jabber.org/protocol/raprequest'&gt;
+    &lt;presence from='juliet@capulet.com/desktop' xmlns='jabber:client'&gt;
+      &lt;priority&gt;10&lt;/priority&gt;
+      &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='5'/&gt;
+    &lt;/presence&gt;
+    &lt;presence from='juliet@capulet.com/pda' xmlns='jabber:client'&gt;
+      &lt;priority&gt;5&lt;/priority&gt;
+      &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='-1'/&gt;
+    &lt;/presence&gt;
+    &lt;presence from='juliet@capulet.com/mobile' xmlns='jabber:client'&gt;
+      &lt;priority&gt;-1&lt;/priority&gt;
+      &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='10'/&gt;
+    &lt;/presence&gt;
+  &lt;/raprequest&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">See the <a href="#security">Security Considerations</a> section of this document for an important proviso regarding access to RAP data.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Neither client publishing of resource application priority nor server flagging of the primary resource introduces any known security vulnerabilities or compromises of user privacy.</p>
+  <p class="" style="">If a server supports RAP requests, it MUST carefully control access to RAP data in order to guard against presence leaks and directory harvest attacks. Specifically, if the requesting entity is not authorized (e.g., a contact with a presence subscription of "both" or "from" as described in <span style="font-weight: bold">RFC 3921</span>) or is not explicitly trusted (e.g., a server in a trusted network), the server MUST return a &lt;forbidden/&gt; error in response to RAP requests.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256718">4</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256762">5</a>] shall include the following namespaces in its registry of protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/rap</li>
+      <li>http://jabber.org/protocol/raprequest</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-apps">Application Types Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of application types. Although strictly speaking this should not be necessary, it is desirable to maintain a list of "short names" for various application types rather than using long XML namespaces, especially in presence broadcasts. For example, a short name of "jingle-audio" is only 12 characters long, whereas the full XML namespace "http://jabber.org/protocol/jingle/sessions/audio" is 48 characters long. The difference can be quite significant when many presence stanzas are sent.</p>
+    <div class="indent">
+<h3>8.2.1 <a name="registrar-apps-process">Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;app&gt;
+  &lt;name&gt;the value of the 'app' attribute&lt;/name&gt;
+  &lt;ns&gt;the full namespace associated with the relevant protocol&lt;/ns&gt;
+  &lt;desc&gt;a natural-language description of the application type&lt;/desc&gt;
+  &lt;doc&gt;the document in which this application type is specified&lt;/doc&gt;
+&lt;/app&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>8.2.2 <a name="registrar-apps-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;app&gt;
+  &lt;name&gt;im&lt;/name&gt;
+  &lt;ns&gt;jabber:client&lt;/ns&gt;
+  &lt;desc&gt;Standard XMPP messaging&lt;/desc&gt;
+  &lt;doc&gt;RFC 3921&lt;/doc&gt;
+&lt;/app&gt;
+
+&lt;app&gt;
+  &lt;name&gt;jingle-audio&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/jingle/sessions/audio&lt;/ns&gt;
+  &lt;desc&gt;Jingle audio sessions&lt;/desc&gt;
+  &lt;doc&gt;JEP-0167&lt;/doc&gt;
+&lt;/app&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rap'
+    xmlns='http://jabber.org/protocol/rap'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='rap'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='primary' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='app' type='xs:nmtoken' default='message'/&gt;
+      &lt;xs:attribute name='num' type='xs:byte'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+&lt;/xs:schema&gt;
+
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250552">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250713">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250684">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256718">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256762">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.6 (2005-11-29)</h4>
+<div class="indent">Document cleanup. (psa)
+    </div>
+<h4>Version 0.0.5 (2005-11-17)</h4>
+<div class="indent">Added support for RAP requests via IQ. (psa)
+    </div>
+<h4>Version 0.0.4 (2005-10-27)</h4>
+<div class="indent">Defined registry of application types; clarified business rules; corrected schema. (psa/jjh)
+    </div>
+<h4>Version 0.0.3 (2005-10-24)</h4>
+<div class="indent">Broadened previous resource flagging proposal to include priority for applications other than messaging. (psa/jjh)
+    </div>
+<h4>Version 0.0.2 (2005-09-26)</h4>
+<div class="indent">Added more business rules and examples; defined service discovery guidelines. (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-09-23)</h4>
+<div class="indent">First draft. (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0168-0.2.html
+++ b/content/xep-0168-0.2.html
@@ -1,0 +1,433 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0168: Resource Application Priority</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Resource Application Priority">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines an XMPP presence extension to indicate the priority of XMPP resources for applications other than messaging.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2005-12-19">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0168">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0168: Resource Application Priority</h1>
+<p>This document defines an XMPP presence extension to indicate the priority of XMPP resources for applications other than messaging.</p>
+<p><hr></p>
+<p style="color:red">WARNING: Consideration of this JEP has been Deferred by the Jabber Software Foundation. Implementation of the protocol described herein is not recommended.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Deferred">Deferred</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0168<br>
+            Version: 0.2<br>
+            Last Updated: 2005-12-19<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rap<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Resource%20Application%20Priority%20(JEP-0168)">http://wiki.jabber.org/index.php/Resource Application Priority (JEP-0168)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>3.  <a href="#primary">Application Priority</a>
+</dt>
+<dt>4.  <a href="#primary">Flagging the Primary Resource for a Given Application Type</a>
+</dt>
+<dt>5.  <a href="#raprequest">Requesting RAP Data Via IQ</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-apps">Application Types Registry</a>
+</dt>
+<dl>
+<dt>8.2.1.  <a href="#registrar-apps-process">Process</a>
+</dt>
+<dt>8.2.2.  <a href="#registrar-apps-init">Initial Registration</a>
+</dt>
+</dl>
+</dl>
+<dt>9.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#schema-rap">RAP</a>
+</dt>
+<dt>9.2.  <a href="#schema-raprequest">RAP Request</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Within the Extensible Messaging and Presence Protocol (XMPP; see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250776">1</a>]), presence indicates availability for communication -- specifically, communication via XMPP messaging (usually in the form of "instant messaging" or IM as described in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250936">2</a>]). However, a wide variety of entities might provide XMPP presence, including entities that are not primarily focused on IM (e.g., phones) or even entities that do not support XMPP messaging at all.</p>
+  <p class="" style="">Consider a scenario in which a contact wants to initiate a voice chat with a user who has the following three XMPP resources:</p>
+  <p class="caption">Table 1: Application Presence</p>
+<table border="1" cellpadding="3" cellspacing="0">
+  <tr class="body">
+    <th colspan="" rowspan="">Resource</th>
+    <th colspan="" rowspan="">Messaging Priority</th>
+    <th colspan="" rowspan="">Voice Chat Priority</th>
+  </tr>
+  <tr class="body">
+    <td align="" colspan="" rowspan="">desktop</td>
+    <td align="" colspan="" rowspan="">10</td>
+    <td align="" colspan="" rowspan="">5</td>
+  </tr>
+  <tr class="body">
+    <td align="" colspan="" rowspan="">pda</td>
+    <td align="" colspan="" rowspan="">5</td>
+    <td align="" colspan="" rowspan="">-1</td>
+  </tr>
+  <tr class="body">
+    <td align="" colspan="" rowspan="">mobile</td>
+    <td align="" colspan="" rowspan="">-1</td>
+    <td align="" colspan="" rowspan="">10</td>
+  </tr>
+  </table>
+  <p class="" style="">If the contact chooses the resource with which it initiates a voice chat based on the user's default XMPP presence priority (i.e., priority for XMPP messaging), the resulting behavior could be misleading (i.e., initiating the voice chat with the "desktop" resource rather than the "mobile" resource).</p>
+  <p class="" style="">What is needed is a way for the user's clients to indicate that the application priority for the three resources is different from the standard XMPP messaging priority. This document defines such a mechanism via an optional XMPP presence extension.</p>
+  <p class="" style="">In addition, this document also defines a way for an XMPP server to flag which resource it considers to be primary for any given application type, if it has information -- such as communication preferences -- that can help determine the primary resource.</p>
+<h2>2.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">In order to discover whether a server or other entity supports this protocol, an entity MUST use <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250924">3</a>].</p>
+  <p class="caption">Example 1. Entity queries a server regarding protocol support</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='juliet@capulet.com/balcony'
+    to='capulet.com'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the queried entity supports resource application presence, it MUST return a feature of "http://jabber.org/protocol/rap":</p>
+  <p class="caption">Example 2. Server communicates protocol support for RAP</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rap'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the queried entity supports resource application presence as well as RAP requests (see the <a href="raprequest">Requesting RAP Data Via IQ</a> section of this document), it MUST return features of "http://jabber.org/protocol/rap" and "http://jabber.org/protocol/raprequest":</p>
+  <p class="caption">Example 3. Server communicates protocol support for RAP as well as RAP Request</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    from='capulet.com'
+    to='juliet@capulet.com/balcony'
+    id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/rap'/&gt;
+    &lt;feature var='http://jabber.org/protocol/raprequest'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>3.
+       <a name="primary">Application Priority</a>
+</h2>
+  <p class="" style="">Consider the three resources ("desktop", "pda", and "mobile") mentioned above. The presence stanzas received by a contact for those three resources would be as follows:</p>
+  <p class="caption">Example 4. Contact receives presence from user</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/desktop' to='romeo@montague.net/home'&gt;
+  &lt;priority&gt;10&lt;/priority&gt;
+  &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='5'/&gt;
+&lt;/presence&gt;
+
+&lt;presence from='juliet@capulet.com/pda' to='romeo@montague.net/home'&gt;
+  &lt;priority&gt;5&lt;/priority&gt;
+  &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='-1'/&gt;
+&lt;/presence&gt;
+
+&lt;presence from='juliet@capulet.com/mobile' to='romeo@montague.net/home'&gt;
+  &lt;priority&gt;-1&lt;/priority&gt;
+  &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='10'/&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">(Note: This protocol uses a 'num' attribute rather than a 'priority' attribute to reduce confusion with XMPP presence and also to save some bytes.)</p>
+  <p class="" style="">The following business rules apply to resource application presence provided by the client:</p>
+  <ol start="" type="">
+    <li>A client SHOULD NOT specify resource application presence if the priority for that application is not different from the resource's XMPP messaging priority.</li>
+    <li>A client MUST NOT generate a &lt;rap/&gt; element that has an 'app' attribute whose value is "im" or that has no 'app' attribute (since the default 'app' is "im").</li>
+  </ol>
+<h2>4.
+       <a name="primary">Flagging the Primary Resource for a Given Application Type</a>
+</h2>
+  <p class="" style="">The user's server may have special information that enables it to flag a resource as primary for a given application type. For instance, the server may include a communication policy service that enables the user to define (outside the context of any presence priorities) that she would prefer to be called at her "desktop" resource only between the hours of 9:00 AM and 5:00 PM local time, prefer to be called on her mobile at all other times, and so on.</p>
+  <p class="" style="">The XML for representing the primary resource related to a specific application type is extremely simple: the server may add a &lt;primary/&gt; child to the relevant RAP element. Here is an example:</p>
+  <p class="caption">Example 5. Primary resource flag</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/mobile'&gt;
+  &lt;priority&gt;-1&lt;/priority&gt;
+  &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='10'&gt;
+    &lt;primary/&gt;
+  &lt;/rap&gt;
+&lt;/presence&gt;
+  </pre></div>
+  <p class="" style="">The following business rules apply to resource flagging by the server:</p>
+  <ol start="" type="">
+    <li>A server MAY add the primary resource flag to the presence broadcasts generated by the resource it determines is "most available" for a given application type.</li>
+    <li>Because the default 'app' is "im", to flag the primary resource for XMPP messaging the server SHOULD NOT include an 'app' attribute, SHOULD NOT include a 'num' attribute, and MUST include a &lt;primary/&gt; child.</li>
+    <li>An available resource that has specified a negative priority for an application type MUST NOT be flagged as the primary resource for that application type.</li>
+    <li>A client SHOULD NOT include the primary resource flag in presence stanzas that it generates; however, if a client includes the primary resource flag in a presence stanza, the server SHOULD remove or overwrite the flag.</li>
+    <li>In response to a presence probe, a server SHOULD send presence from the primary resource first (this enables the receiving client to skip any local most-available algorithms it might implement).</li>
+    <li>If the primary resource changes, a server MUST push presence (including the primary resource flag) for the new primary resource. If the change in primary resource occurs because of a presence broadcast from the current primary resource, the server MUST push presence from the current primary resource (without the primary resource flag) before pushing presence from the new primary resource (including the primary resource flag).</li>
+  </ol>
+<h2>5.
+       <a name="raprequest">Requesting RAP Data Via IQ</a>
+</h2>
+  <p class="" style="">In the interest of saving bandwidth, a server MAY choose to strip all RAP data out of presence stanzas and instead provide RAP data only on request via IQ interactions. (Note: see the <a href="#security">Security Considerations</a> section of this document for an important proviso regarding access to RAP data.) A likely scenario is as follows:</p>
+  <ol start="" type="">
+    <li>Contact's client sends disco#info request to user's client and discovers that user's client supports the 'http://jabber.org/protocol/rap' namespace.</li>
+    <li>User's client publishes RAP extensions but user's server strips them out in presence broadcasts.</li>
+    <li>User decides to initiate a non-IM interaction with contact.</li>
+    <li>Contact's client notices the lack of RAP data from user (despite discovered support) and sends disco#info request to user's server, which signals that it supports the 'http://jabber.org/protocol/raprequest' namespace.</li>
+    <li>Contact's client sends RAP request to user's bare JID.</li>
+    <li>If contact is authorized to view user's presence data, user's server returns the latest RAP data for all of the user's resources.</li>
+  </ol>
+  <p class="" style="">An example protocol flow for the last two steps is as follows...</p>
+  <p class="" style="">First, the contact's client requests the user's RAP data by sending a request to the user's bare JID:</p>
+  <p class="caption">Example 6. Contact requests RAP data from user's server</p>
+<div class="indent"><pre>
+&lt;iq type='get' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;raprequest xmlns='http://jabber.org/protocol/raprequest'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">On behalf of the user, the user's server then returns the full &lt;presence/&gt; stanzas (containing RAP data) for each of the user's connected clients:</p>
+  <p class="caption">Example 7. User's server returns RAP data</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='romeo@montague.net/home' to='juliet@capulet.com'&gt;
+  &lt;raprequest xmlns='http://jabber.org/protocol/raprequest'&gt;
+    &lt;presence from='juliet@capulet.com/desktop' xmlns='jabber:client'&gt;
+      &lt;priority&gt;10&lt;/priority&gt;
+      &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='5'/&gt;
+    &lt;/presence&gt;
+    &lt;presence from='juliet@capulet.com/pda' xmlns='jabber:client'&gt;
+      &lt;priority&gt;5&lt;/priority&gt;
+      &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='-1'/&gt;
+    &lt;/presence&gt;
+    &lt;presence from='juliet@capulet.com/mobile' xmlns='jabber:client'&gt;
+      &lt;priority&gt;-1&lt;/priority&gt;
+      &lt;rap xmlns='http://jabber.org/protocol/rap' app='jingle-audio' num='10'/&gt;
+    &lt;/presence&gt;
+  &lt;/raprequest&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Note: The XML data of the server's response to a RAP request may seem to be potentially confusing, but it is fully consistent with <span class="ref" style="">Namespaces in XML</span>  [<a href="#nt-id2260033">4</a>] as well as the schemas for the 'jabber:client' and 'http://jabber.org/protocol/raprequest' namespaces.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Neither client publishing of resource application priority nor server flagging of the primary resource introduces any known security vulnerabilities or compromises of user privacy.</p>
+  <p class="" style="">If a server supports RAP requests, it MUST carefully control access to RAP data in order to guard against presence leaks and directory harvest attacks. Specifically, if the requesting entity is not authorized (e.g., a contact with a presence subscription of "both" or "from" as described in <span style="font-weight: bold">RFC 3921</span>) or is not explicitly trusted (e.g., a server in a trusted network), the server MUST return a &lt;forbidden/&gt; error in response to RAP requests.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260145">5</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260159">6</a>] shall include the following namespaces in its registry of protocol namespaces:</p>
+    <ul>
+      <li>http://jabber.org/protocol/rap</li>
+      <li>http://jabber.org/protocol/raprequest</li>
+    </ul>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-apps">Application Types Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall maintain a registry of application types. Although strictly speaking this should not be necessary, it is desirable to maintain a list of "short names" for various application types rather than using long XML namespaces, especially in presence broadcasts. For example, a short name of "jingle-audio" is only 12 characters long, whereas the full XML namespace "http://jabber.org/protocol/jingle/sessions/audio" is 48 characters long. The difference can be quite significant when many presence stanzas are sent.</p>
+    <div class="indent">
+<h3>8.2.1 <a name="registrar-apps-process">Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;app&gt;
+  &lt;name&gt;the value of the 'app' attribute&lt;/name&gt;
+  &lt;ns&gt;the full namespace associated with the relevant protocol&lt;/ns&gt;
+  &lt;desc&gt;a natural-language description of the application type&lt;/desc&gt;
+  &lt;doc&gt;the document in which this application type is specified&lt;/doc&gt;
+&lt;/app&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>8.2.2 <a name="registrar-apps-init">Initial Registration</a>
+</h3>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;app&gt;
+  &lt;name&gt;im&lt;/name&gt;
+  &lt;ns&gt;jabber:client&lt;/ns&gt;
+  &lt;desc&gt;Standard XMPP messaging&lt;/desc&gt;
+  &lt;doc&gt;RFC 3921&lt;/doc&gt;
+&lt;/app&gt;
+
+&lt;app&gt;
+  &lt;name&gt;jingle-audio&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/jingle/sessions/audio&lt;/ns&gt;
+  &lt;desc&gt;Jingle audio sessions&lt;/desc&gt;
+  &lt;doc&gt;JEP-0167&lt;/doc&gt;
+&lt;/app&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="schema-rap">RAP</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/rap'
+    xmlns='http://jabber.org/protocol/rap'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='rap'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element name='primary' type='empty' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='app' type='xs:nmtoken' default='message'/&gt;
+      &lt;xs:attribute name='num' type='xs:byte'/&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+&lt;/xs:schema&gt;
+
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="schema-raprequest">RAP Request</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/raprequest'
+    xmlns='http://jabber.org/protocol/raprequest'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:import namespace='jabber:client'/&gt;
+
+  &lt;xs:element name='raprequest'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence xmlns:xmpp='jabber:client'&gt;
+        &lt;xs:element name='xmpp:presence' minOccurs='0'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250776">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250936">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250924">3</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260033">4</a>. Namespaces in XML &lt;<a href="http://www.w3.org/TR/REC-xml-names/">http://www.w3.org/TR/REC-xml-names/</a>&gt;.</p>
+<p><a name="nt-id2260145">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260159">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2005-12-19)</h4>
+<div class="indent">Clarified structure of, and added schema for, RAP request namespace. (psa)
+    </div>
+<h4>Version 0.1 (2005-12-15)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.6 (2005-11-29)</h4>
+<div class="indent">Document cleanup. (psa)
+    </div>
+<h4>Version 0.0.5 (2005-11-17)</h4>
+<div class="indent">Added support for RAP requests via IQ. (psa)
+    </div>
+<h4>Version 0.0.4 (2005-10-27)</h4>
+<div class="indent">Defined registry of application types; clarified business rules; corrected schema. (psa/jjh)
+    </div>
+<h4>Version 0.0.3 (2005-10-24)</h4>
+<div class="indent">Broadened previous resource flagging proposal to include priority for applications other than messaging. (psa/jjh)
+    </div>
+<h4>Version 0.0.2 (2005-09-26)</h4>
+<div class="indent">Added more business rules and examples; defined service discovery guidelines. (psa/jjh)
+    </div>
+<h4>Version 0.0.1 (2005-09-23)</h4>
+<div class="indent">First draft. (psa/jjh)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0170-0.1.html
+++ b/content/xep-0170-0.1.html
@@ -1,0 +1,186 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0170: Recommended Order of Stream Feature Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Recommended Order of Stream Feature Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a recommended order for negotiation of XMPP stream features.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0170">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0170: Recommended Order of Stream Feature Negotiation</h1>
+<p>This document specifies a recommended order for negotiation of XMPP stream features.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0170<br>
+            Version: 0.1<br>
+            Last Updated: 2006-01-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0077, JEP-0079, JEP-0138<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Recommended%20Order%20of%20Stream%20Feature%20Negotiation%20(JEP-0170)">http://wiki.jabber.org/index.php/Recommended Order of Stream Feature Negotiation (JEP-0170)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#rec">Recommendations</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#rec-xmpp">Standard XMPP Features</a>
+</dt>
+<dt>2.2.  <a href="#rec-iqauth">Non-SASL Authentication</a>
+</dt>
+<dt>2.3.  <a href="#rec-register">In-Band Registration</a>
+</dt>
+<dt>2.4.  <a href="#rec-compress">Stream Compression</a>
+</dt>
+<dt>2.5.  <a href="#rec-amp">Advanced Message Processing</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">During its formalization of the core Jabber protocols, the IETF's XMPP WG introduced the concept of XML stream features. While the order in which features shall be negotiated is clearly defined for the features specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2253915">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2253940">2</a>], the number of possible features is open-ended (which is why the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2253965">3</a>] maintains a registry of stream features). This document specifies the recommended order for negotiation of various stream features.</p>
+<h2>2.
+       <a name="rec">Recommendations</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="rec-xmpp">Standard XMPP Features</a>
+</h3>
+    <p class="" style="">The XMPP RFCs define an ordering for the features defined therein, namely:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+    <p class="" style="">That order MUST be followed if no other stream features are negotiated.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="rec-iqauth">Non-SASL Authentication</a>
+</h3>
+    <p class="" style="">The legacy <span class="ref" style="">Non-SASL Authentication</span>  [<a href="#nt-id2250585">4</a>] protocol can be used by clients to log into older (pre-XMPP) servers. In essence the "jabber:iq:auth" protocol is an older way of doing what the XMPP RFCs specify in the SASL, resource binding, and IM session stream features. Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:auth</li>
+    </ol>
+    <p class="" style="">If the "jabber:iq:auth" feature is negotiated, then SASL, resource binding, and IM session establishment MUST NOT be negotiated. TLS SHOULD be negotiated, but some older software will instead connect to an SSL-enabled port rather than upgrading port 5222 using TLS.</p>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="rec-register">In-Band Registration</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2250828">5</a>] protocol can be used to establish an account before logging in. That step would be completed before SASL because an entity cannot authenticate if it does not first create an account. Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:register</li>
+      <li>SASL</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="rec-compress">Stream Compression</a>
+</h3>
+    <p class="" style="">Stream compression is negotiated when it is not possible to set TLS compression for whatever reason. It seems sensible to negotiate stream compression after TLS (to safely complete the negotiation) and before SASL (to compress as much traffic as possible). Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>Stream compression</li>
+      <li>SASL</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+    <p class="" style="">If both stream compression and in-band registration are negotiated, stream compression SHOULD be negotiated first. Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>Stream compression</li>
+      <li>jabber:iq:register</li>
+      <li>SASL</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="rec-amp">Advanced Message Processing</a>
+</h3>
+    <p class="" style="">Support for the <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2250715">6</a>] protocol is advertised as a stream feature but its use is not negotiated, therefore no recommendation is needed.</p>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The order of negotiated stream features has security implications and may be security-critical. In particular, TLS MUST be negotiated first.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256466">7</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the Jabber Registrar.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2253915">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2253940">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2253965">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250585">4</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p><a name="nt-id2250828">5</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2250715">6</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256466">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-01-11)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2006-01-10)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0170-0.2.html
+++ b/content/xep-0170-0.2.html
@@ -1,0 +1,196 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0170: Recommended Order of Stream Feature Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Recommended Order of Stream Feature Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a recommended order for negotiation of XMPP stream features.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0170">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2005 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0170: Recommended Order of Stream Feature Negotiation</h1>
+<p>This document specifies a recommended order for negotiation of XMPP stream features.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0170<br>
+            Version: 0.2<br>
+            Last Updated: 2006-01-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0077, JEP-0079, JEP-0138<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Recommended%20Order%20of%20Stream%20Feature%20Negotiation%20(JEP-0170)">http://wiki.jabber.org/index.php/Recommended Order of Stream Feature Negotiation (JEP-0170)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2005 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#rec">Recommendations</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#rec-xmpp">Standard XMPP Features</a>
+</dt>
+<dt>2.2.  <a href="#rec-compress">Stream Compression</a>
+</dt>
+<dt>2.3.  <a href="#rec-register">In-Band Registration</a>
+</dt>
+<dt>2.4.  <a href="#rec-iqauth">Non-SASL Authentication</a>
+</dt>
+<dt>2.5.  <a href="#rec-amp">Advanced Message Processing</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">During its formalization of the core Jabber protocols, the IETF's XMPP WG introduced the concept of XML stream features. While the order in which features shall be negotiated is clearly defined for the features specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2253933">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2253993">2</a>], the number of possible features is open-ended (which is why the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2253948">3</a>] maintains a registry of stream features). This document specifies the recommended order for negotiation of various stream features.</p>
+<h2>2.
+       <a name="rec">Recommendations</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="rec-xmpp">Standard XMPP Features</a>
+</h3>
+    <p class="" style="">The XMPP RFCs define an ordering for the features defined therein, namely:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+    <p class="" style="">That order MUST be followed if no other stream features are negotiated.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="rec-compress">Stream Compression</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Stream Compression</span>  [<a href="#nt-id2250602">4</a>] is negotiated when it is not possible to set TLS compression for whatever reason. It seems safest to negotiate stream compression after negotiation fo both TLS (to safely complete the negotiation) and SASL (to prevent certain denial-of-service attacks). Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL</li>
+      <li>Stream compression</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="rec-register">In-Band Registration</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2250803">5</a>] protocol can be used to establish an account before logging in. That step would be completed before SASL because an entity cannot authenticate if it does not first create an account. Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:register</li>
+      <li>SASL</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+    <p class="" style="">If both stream compression and in-band registration are negotiated, the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:register</li>
+      <li>SASL</li>
+      <li>Stream compression</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="rec-iqauth">Non-SASL Authentication</a>
+</h3>
+    <p class="" style="">The legacy <span class="ref" style="">Non-SASL Authentication</span>  [<a href="#nt-id2250700">6</a>] protocol can be used by clients to log into older (pre-XMPP) servers. In essence the "jabber:iq:auth" protocol is an older way of doing what the XMPP RFCs specify in the SASL, resource binding, and IM session stream features. Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:auth</li>
+    </ol>
+    <p class="" style="">If the "jabber:iq:auth" feature is negotiated, then SASL, resource binding, and IM session establishment MUST NOT be negotiated. TLS SHOULD be negotiated, but some older software will instead connect to an SSL-enabled port rather than upgrading port 5222 using TLS.</p>
+    <p class="" style="">If both stream compression and non-SASL authentication are negotiated, the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:auth</li>
+      <li>Stream compression</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="rec-amp">Advanced Message Processing</a>
+</h3>
+    <p class="" style="">Support for the <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256469">7</a>] protocol is advertised as a stream feature but its use is not negotiated, therefore no recommendation is needed.</p>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The order of negotiated stream features has security implications and may be security-critical. In particular, TLS MUST be negotiated first.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256528">8</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the Jabber Registrar.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2253933">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2253993">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2253948">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250602">4</a>. JEP-0138: Stream Compression &lt;<a href="http://www.jabber.org/jeps/jep-0138.html">http://www.jabber.org/jeps/jep-0138.html</a>&gt;.</p>
+<p><a name="nt-id2250803">5</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2250700">6</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p><a name="nt-id2256469">7</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256528">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-01-16)</h4>
+<div class="indent">Changed order of SASL and stream compression to reflect list discussion. (psa)
+    </div>
+<h4>Version 0.1 (2006-01-11)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2006-01-10)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0170-0.3.html
+++ b/content/xep-0170-0.3.html
@@ -1,0 +1,252 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0170: Recommended Order of Stream Feature Negotiation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Recommended Order of Stream Feature Negotiation">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies a recommended order for negotiation of XMPP stream features.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0170">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0170: Recommended Order of Stream Feature Negotiation</h1>
+<p>This document specifies a recommended order for negotiation of XMPP stream features.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0170<br>
+            Version: 0.3<br>
+            Last Updated: 2006-01-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0077, JEP-0079, JEP-0138<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Recommended%20Order%20of%20Stream%20Feature%20Negotiation%20(JEP-0170)">http://wiki.jabber.org/index.php/Recommended Order of Stream Feature Negotiation (JEP-0170)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#c2s">Client-to-Server Recommendations</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#c2s-xmpp">Standard XMPP Features</a>
+</dt>
+<dt>2.2.  <a href="#c2s-compress">Stream Compression</a>
+</dt>
+<dt>2.3.  <a href="#c2s-register">In-Band Registration</a>
+</dt>
+<dt>2.4.  <a href="#c2s-iqauth">Non-SASL Authentication</a>
+</dt>
+<dt>2.5.  <a href="#c2s-amp">Advanced Message Processing</a>
+</dt>
+</dl>
+<dt>3.  <a href="#s2s">Server-to-Server Recommendations</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#s2s-xmpp">Standard XMPP Features</a>
+</dt>
+<dt>3.2.  <a href="#s2s-compress">Stream Compression</a>
+</dt>
+<dt>3.3.  <a href="#s2s-dialback">Dialback</a>
+</dt>
+</dl>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">During its formalization of the core Jabber protocols, the IETF's XMPP WG introduced the concept of XML stream features. While the order in which features shall be negotiated is clearly defined for the features specified in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250622">1</a>] and <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250646">2</a>], the number of possible features is open-ended (which is why the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250954">3</a>] maintains a registry of stream features). This document specifies the recommended order for negotiation of various stream features.</p>
+<h2>2.
+       <a name="c2s">Client-to-Server Recommendations</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="c2s-xmpp">Standard XMPP Features</a>
+</h3>
+    <p class="" style="">The XMPP RFCs define an ordering for the features defined therein, namely:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+    <p class="" style="">That order MUST be followed if no other stream features are negotiated.</p>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="c2s-compress">Stream Compression</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Stream Compression</span>  [<a href="#nt-id2250869">4</a>] is negotiated when it is not possible to set TLS compression for whatever reason. It seems safest to negotiate stream compression after negotiation of both TLS (to safely complete the negotiation) and SASL (to prevent certain denial-of-service attacks). Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL</li>
+      <li>Stream compression</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>2.3 <a name="c2s-register">In-Band Registration</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2250939">5</a>] protocol can be used to establish an account before logging in. That step would be completed before SASL because an entity cannot authenticate if it does not first create an account. Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:register</li>
+      <li>SASL</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+    <p class="" style="">If both stream compression and in-band registration are negotiated, the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:register</li>
+      <li>SASL</li>
+      <li>Stream compression</li>
+      <li>Resource binding</li>
+      <li>IM session establishment</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>2.4 <a name="c2s-iqauth">Non-SASL Authentication</a>
+</h3>
+    <p class="" style="">The legacy <span class="ref" style="">Non-SASL Authentication</span>  [<a href="#nt-id2250790">6</a>] protocol can be used by clients to log into older (pre-XMPP) servers. In essence the "jabber:iq:auth" protocol is an older way of doing what the XMPP RFCs specify in the SASL, resource binding, and IM session stream features. Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:auth</li>
+    </ol>
+    <p class="" style="">If the "jabber:iq:auth" feature is negotiated, then SASL, resource binding, and IM session establishment MUST NOT be negotiated. TLS SHOULD be negotiated, but some older software will instead connect to an SSL-enabled port rather than upgrading port 5222 using TLS.</p>
+    <p class="" style="">If both stream compression and non-SASL authentication are negotiated, the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>jabber:iq:auth</li>
+      <li>Stream compression</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>2.5 <a name="c2s-amp">Advanced Message Processing</a>
+</h3>
+    <p class="" style="">Support for the <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2256533">7</a>] protocol is advertised as a stream feature but its use is not negotiated; therefore no recommendation is needed.</p>
+  </div>
+<h2>3.
+       <a name="s2s">Server-to-Server Recommendations</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="s2s-xmpp">Standard XMPP Features</a>
+</h3>
+    <p class="" style="">The XMPP RFCs define an ordering for the features defined therein, namely:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL  [<a href="#nt-id2256573">8</a>]</li>
+    </ol>
+    <p class="" style="">That order MUST be followed if no other stream features are negotiated.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="s2s-compress">Stream Compression</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Stream Compression</span>  [<a href="#nt-id2256609">9</a>] is negotiated when it is not possible to set TLS compression for whatever reason. It seems safest to negotiate stream compression after negotiation fo both TLS (to safely complete the negotiation) and SASL (to prevent certain denial-of-service attacks). Therefore the following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL</li>
+      <li>Stream compression</li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="s2s-dialback">Dialback</a>
+</h3>
+    <p class="" style="">RFC 3920 requires SASL negotiation after TLS negotiation. When the certificate presented by the initiating entity makes reference to a trusted root certification authority, SASL negotiation provides meaningful authentication. However, it is possible that the initiating entity will present a self-signed certificate or a certificate whose associated root certification authority is not trusted by the receiving entity. In this situation, service provisioning policies at the receiving entity may dictate the use of server dialback in order to provide a stronger level of trust for the server-to-server stream (where such trust is essentially trust in the underlying Domain Name System), even though server dialback explicitly does not provide authentication. The following order is RECOMMENDED:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL</li>
+      <li>Dialback</li>
+    </ol>
+    <p class="" style="">Note: Even though it may appear that SASL does not provide meaningful authentication in the case of self-signed certificates or certificates whose root certification authority is not trusted by the receiving entity, <span style="font-weight: bold">RFC 3920</span> requires its use, a recommendation which this document does not override.</p>
+    <p class="" style="">If stream compression is negotiated in addition to TLS and dialback, it is RECOMMENDED to negotiate it after both TLS and dialback:</p>
+    <ol start="" type="">
+      <li>TLS</li>
+      <li>SASL</li>
+      <li>Dialback</li>
+      <li>Stream compression</li>
+    </ol>
+  </div>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The order of negotiated stream features has security implications and may be security-critical. In particular, TLS MUST be negotiated first.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256793">10</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the Jabber Registrar.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250622">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250646">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250954">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250869">4</a>. JEP-0138: Stream Compression &lt;<a href="http://www.jabber.org/jeps/jep-0138.html">http://www.jabber.org/jeps/jep-0138.html</a>&gt;.</p>
+<p><a name="nt-id2250939">5</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2250790">6</a>. JEP-0078: Non-SASL Authentication &lt;<a href="http://www.jabber.org/jeps/jep-0078.html">http://www.jabber.org/jeps/jep-0078.html</a>&gt;.</p>
+<p><a name="nt-id2256533">7</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2256573">8</a>. Typically, the mechanism used in server-to-server negotiation will be SASL EXTERNAL.</p>
+<p><a name="nt-id2256609">9</a>. JEP-0138: Stream Compression &lt;<a href="http://www.jabber.org/jeps/jep-0138.html">http://www.jabber.org/jeps/jep-0138.html</a>&gt;.</p>
+<p><a name="nt-id2256793">10</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-01-24)</h4>
+<div class="indent">Split into client-to-server and server-to-server sections; specified recommended order of server-to-server negotiations. (psa)
+    </div>
+<h4>Version 0.2 (2006-01-16)</h4>
+<div class="indent">Changed order of SASL and stream compression to reflect list discussion. (psa)
+    </div>
+<h4>Version 0.1 (2006-01-11)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.1 (2006-01-10)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0171-0.1.html
+++ b/content/xep-0171-0.1.html
@@ -1,0 +1,620 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0171: Language Translation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Language Translation">
+<meta name="DC.Creator" content="Boyd Fletcher">
+<meta name="DC.Creator" content="Daniel LaPrade">
+<meta name="DC.Creator" content="Keith Lirette">
+<meta name="DC.Creator" content="Brian Raymond">
+<meta name="DC.Description" content="This JEP defines a protocol for providing language translation facilities over XMPP. It supports human, machine, client-based, and server-based translations.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0171">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0171: Language Translation</h1>
+<p>This JEP defines a protocol for providing language translation facilities over XMPP. It supports human, machine, client-based, and server-based translations.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0171<br>
+            Version: 0.1<br>
+            Last Updated: 2006-01-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, JEP-0030<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: langtrans<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Language%20Translation%20(JEP-0171)">http://wiki.jabber.org/index.php/Language Translation (JEP-0171)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Boyd Fletcher</h3>
+<p class="indent">
+        Email: boyd@spawar.navy.mil<br></p>
+<h3>Daniel LaPrade</h3>
+<p class="indent">
+        Email: daniel.laprade@je.jfcom.mil<br></p>
+<h3>Keith Lirette</h3>
+<p class="indent">
+        Email: keith.lirette@je.jfcom.mil<br></p>
+<h3>Brian Raymond</h3>
+<p class="indent">
+        Email: brian.raymond@je.jfcom.mil<br></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#delivery">Message Delivery</a>
+</dt>
+<dl>
+<dt>4.1.1.  <a href="#message-direct">Direct Translation</a>
+</dt>
+<dt>4.1.2.  <a href="#message-pivot">Translation With Pivot</a>
+</dt>
+<dt>4.1.3.  <a href="#message-pivot-details">Translation With Pivot Specifying Details</a>
+</dt>
+</dl>
+<dt>4.2.  <a href="#disco">Discovering Translation Providers</a>
+</dt>
+<dl>
+<dt>4.2.1.  <a href="#disco-items">Discovering Translation Providers On a Server</a>
+</dt>
+<dt>4.2.2.  <a href="#disco-identity">Discovering Identity of Providers</a>
+</dt>
+<dt>4.2.3.  <a href="#disco-lang">Discovering Language Support</a>
+</dt>
+</dl>
+<dt>4.3.  <a href="#request">Requesting a Translation from a Service</a>
+</dt>
+<dl>
+<dt>4.3.1.  <a href="#request-basic">Requesting a Basic Translation</a>
+</dt>
+<dt>4.3.2.  <a href="#request-multiple">Requesting a Translation With Multiple Destination Languages</a>
+</dt>
+<dt>4.3.3.  <a href="#request-dictionary">Requesting a Translation With a Specific Dictionary</a>
+</dt>
+</dl>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>9.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>9.2.  <a href="#registrar-identity">Service Discovery Identities</a>
+</dt>
+</dl>
+<dt>10.  <a href="#schema">XML Schema</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#schema-langtrans">langtrans</a>
+</dt>
+<dt>10.2.  <a href="#schema-langtrans-items">langtrans#items</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">There currently exists no standard for describing language translations over a text chat protocol. While numerous products and services exist to provide translation of text, there exists no standardized protocol extension for requesting a translation and expressing the details of the translation XMPP (see <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250676">1</a>]). This document describes how to express a translation and its components in an XMPP message as well as a method to request translation.</p>
+  <p class="" style="">Direct translation can be realized by either client-side translation before sending or transparent components translating messages on the fly. Discovering XMPP entities capable of translation allows for clients to request translation from them based on their capabilities. The remote XMPP entity could be either an automated translation service or a human providing translation.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Glossary</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+<th colspan="" rowspan="">Term</th>
+<th colspan="" rowspan="">Definition</th>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Original Text</td>
+<td align="" colspan="" rowspan="">This is the message text that was originally created by the sender. This is the text that is translated.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Translated Text</td>
+<td align="" colspan="" rowspan="">This is the message text that has been translated by the language translation engines. This also called the destination text. For any given message there can be multiple destination text message bodies.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Pivot Language</td>
+<td align="" colspan="" rowspan="">Pivoting is the process of using one or more intermediate languages to translate from a given source language to a specific destination language.  For example, if you needed to translate from English to Russian but only had translators that went from English to French and French to Russian then you could use French as a pivot language.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Pivot Text</td>
+<td align="" colspan="" rowspan="">This is the translated text of the original message in a pivot language. For any given destination language, there can be zero or more pivot text bodies. The ordering of pivoting is required to be specified for the destination language.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Language Translation Engine</td>
+<td align="" colspan="" rowspan="">Since not all language translation engines are the same quality it is important to some classes of users that they know what translation engine was used. It is equally important to also be able to select a specific translation engine for a given language pairing if more than one engine is available.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Language Translation Character Set</td>
+<td align="" colspan="" rowspan="">Some language translation engines can only translate text between languages if certain character sets (or code pages) are used.</td>
+</tr>
+    <tr class="body">
+<td align="" colspan="" rowspan="">Language Translation Dictionary</td>
+<td align="" colspan="" rowspan=""> In order to enhance the accuracy of translation engines most support the concept of mission specific dictionaries.</td>
+</tr>
+  </table>
+<h2>3.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The protocol defined herein addresses the following requirements:</p>
+  <ol start="" type="">
+    <li><p class="" style="">Enable an XMPP entity to request a translation from a remote XMPP entity.</p></li>
+    <li>
+      <p class="" style="">Enable an XMPP entity to express the following mandatory elements of a translation for any receiving entities.</p>
+      <ol start="" type="a">
+        <li>Identification of Original Text</li>
+        <li>Identification of Translated Text</li>
+        <li>Identification of any Pivot Language(s) and Text</li>
+        <li>Identification of the method and order of translation</li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">Enable an XMPP entity to express the following optional elements of a translation for any receiving entities.</p>
+      <ol start="" type="a">
+        <li>Identification of Language Translation Engines used.</li>
+        <li>Identification of Location of the translation.</li>
+        <li>Identification of Sender and Destination language of choice.</li>
+        <li>Discovery of Server support for translation including which language pair, dictionaries, and engines are available.</li>
+        <li>Identification of desire to text to be translated or not to be translated.</li>
+      </ol>
+    </li>
+  </ol>
+  <p class="" style="">The following methods of translation are supported:</p>
+  <ol start="" type="">
+    <li>Manual or Human</li>
+    <li>Machine or Automated</li>
+    <li>Machine with Human Review</li>
+  </ol>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">The following use cases simple scenarios for expression translation as well as requesting them from remote entities.</p>
+  <div class="indent">
+<h3>4.1 <a name="delivery">Message Delivery</a>
+</h3>
+    <p class="" style="">A message directly translated by the originating XMPP entity or a transparent XMPP entity delivered to a remote entity with only the required elements of source and destination language; this is the simplest case for a translation from one language to another. The source language is known because there is no &lt;translation/&gt; tag describing it. Three translation methods are supported by doing the following:</p>
+    <ol start="" type="">
+      <li>If no 'engine' attribute is present, then manual (or human) translation was performed.</li>
+      <li>If an 'engine' attribute is present then machine (or automated) translation was performed, where the translation engine is identified by the value of the 'engine' attribute. If the 'engine' attribute is present its value is an empty string, then the name of the translation engine was not available.</li>
+      <li>If the 'engine' attribute and the 'reviewed' attribute are present, then machine translation was performed but the message text was reviewed and possibly modified by a human.</li>
+    </ol>
+    <div class="indent">
+<h3>4.1.1 <a name="message-direct">Direct Translation</a>
+</h3>
+      <p class="caption">Example 1. Entity sends a message translated from English to French</p>
+<div class="indent"><pre>
+&lt;message from='bard@shakespeare.lit/globe' to='playwright@marlowe.lit/theatre'&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;subject xml:lang='fr'&gt;Bonjour&lt;/subject&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;body xml:lang='fr'&gt;comment allez-vous?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='fr' derived_from='en'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.1.2 <a name="message-pivot">Translation With Pivot</a>
+</h3>
+      <p class="" style="">A message translated by the originating XMPP entity or a transparent XMPP entity delivered to a remote entity with the pivot languages used to accomplish the translation. The source language is known because there is no  translation tag describing it. When a translation is done via a pivot language, the pivot languages and their order of use MUST be specified.</p>
+      <p class="caption">Example 2. Entity sends a message translated from French to Russian via English using human translators</p>
+<div class="indent"><pre>
+&lt;message from='bard@shakespeare.lit/globe' to='playwright@marlowe.lit/theatre'&gt;
+  &lt;subject xml:lang='fr'&gt;Bonjour&lt;/subject&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;subject xml:lang='ru'&gt;x443;&amp;#x43B;&amp;#x442;&amp;#x435;&lt;/subject&gt;
+  &lt;body xml:lang='fr'&gt;comment allez-vous?&lt;/body&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;body xml:lang='ru'&gt;&amp;#x41A;&amp;#x430;&amp;#x43A; &amp;#x432;&amp;#x44B;?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='en' derived_from='fr'/&gt;
+    &lt;translation destination='ru' derived_from='en'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.1.3 <a name="message-pivot-details">Translation With Pivot Specifying Details</a>
+</h3>
+      <p class="" style="">A message translated by the originating XMPP entity or a transparent XMPP entity delivered to a remote entity using pivot languages and machine translation. The source language is known because there is no &lt;x/&gt; translation tag describing it.</p>
+      <p class="caption">Example 3. Entity sends a message translated from French to Russian via English using a machine translation engine.</p>
+<div class="indent"><pre>
+
+&lt;message from='bard@shakespeare.lit/globe' to='playwright@marlowe.lit/theatre'&gt;
+  &lt;subject xml:lang='fr'&gt;Bonjour&lt;/subject&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;subject xml:lang='ru'&gt;x443;&amp;#x43B;&amp;#x442;&amp;#x435;&lt;/subject&gt;
+  &lt;body xml:lang='fr'&gt;comment allez-vous?&lt;/body&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;body xml:lang='ru'&gt;&amp;#x41A;&amp;#x430;&amp;#x43A; &amp;#x432;&amp;#x44B;?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='en' derived_from='fr' engine='SYSTRANS'/&gt;
+    &lt;translation destination='ru' derived_from='en' engine='SYSTRANS'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="disco">Discovering Translation Providers</a>
+</h3>
+    <div class="indent">
+<h3>4.2.1 <a name="disco-items">Discovering Translation Providers On a Server</a>
+</h3>
+      <p class="" style="">When connected to a server, a XMPP entity can locate translation providers by asking a server which translation providers are attached to the server; this MUST be done using <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256724">2</a>]. The server SHOULD return the availability of of translation providers and language pairings for which the user has rights to use.</p>
+      <p class="caption">Example 4. Entity sends discovery request to server</p>
+<div class="indent"><pre>
+&lt;iq type='get' id='disco1' to='shakespeare.lit'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 5. Server returns items, including translation providers</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='disco1' from='shakespeare.lit' to='bard@shakespeare.lit/globe'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#items'&gt;
+    ...
+    &lt;item jid='towerofbabel@shakespeare.lit'
+          name='Tower of Babel Translation Bot'/&gt;
+    &lt;item jid='translation.shakespeare.lit'
+          name='Translation Provider Service'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.2.2 <a name="disco-identity">Discovering Identity of Providers</a>
+</h3>
+      <p class="" style="">Service Discovery is used to determine if a JID provides translation services. The JID can also be a bot (e.g., &lt;towerofbabel@shakespeare.lit&gt;) or a server component (e.g., &lt;translation.shakespeare.lit&gt;).</p>
+      <p class="caption">Example 6. Entity queries service regarding identity</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='translation.shakespeare.lit' from='bard@shakespeare.lit/globe'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 7. Service reports identity</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='bard@shakespeare.lit/globe' from='translation.shakespeare.lit'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;identity category='automation' type='translation'/&gt;
+    &lt;feature var='http://jabber.org/protocol/langtrans'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.2.3 <a name="disco-lang">Discovering Language Support</a>
+</h3>
+      <p class="" style="">The supported languages and other details for the service must be known to use it. It is permissible for a translation service to provide multiple translation engines for the same language pairing -- if this is done, then a separate &lt;item/&gt; tag MUST be used for each pairing. A 'dictionary' attribute MAY be used to specify the dictionary for a specific &lt;item/&gt;. In order to specify more than one dictionary for a given language pairing then a separate &lt;item/&gt; tag MUST be used for each dictionary specification for that language pairing.</p>
+      <p class="caption">Example 8. Entity queries service for further information</p>
+<div class="indent"><pre>
+&lt;iq type='get' to='translation.shakespeare.lit' from='bard@shakespeare.lit/globe'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/langtrans#items'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 9. Service replies with language details</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='bard@shakespeare.lit/globe' from=' translation.shakespeare.lit'&gt;
+  &lt;query xmlns=' http://jabber.org/protocol/langtrans#items'&gt;
+    &lt;item src_lang='en' jid='translation.shakespeare.lit' dst_lang='fr' 
+          engine='SYSTRANS 2005 Release 2' pivotable='true'/&gt;
+    &lt;item src_lang='en' jid='translation.shakespeare.lit' dst_lang='ko' 
+          engine='SYSTRANS 2005 Release 2' pivotable='true'/&gt;
+    &lt;item src_lang='en' jid='translation.shakespeare.lit' dst_lang='ru' 
+          engine='SYSTRANS 2005 Release 2' pivotable='true'/&gt;
+    &lt;item src_lang='en' jid='translation.shakespeare.lit' dst_lang='ru' 
+          engine='SYSTRANS 2005 Release 2' pivotable='true' dictionary='medical'/&gt;
+    &lt;item src_lang='fr' jid='translation.shakespeare.lit' dst_lang='en' 
+          engine='SYSTRANS 2005 Release 2' pivotable='true' dictionary='standard'/&gt;
+    &lt;item src_lang='ru' jid='translation.shakespeare.lit' dst_lang='en' 
+          engine='SYSTRANS 2005 Release 2' pivotable='true' dictionary='Medical 1.0'/&gt;
+    &lt;item src_lang='ko' jid='translation.shakespeare.lit' dst_lang='en' 
+          engine='SYSTRANS 2005 Release 2' pivotable='true'/&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="request">Requesting a Translation from a Service</a>
+</h3>
+    <div class="indent">
+<h3>4.3.1 <a name="request-basic">Requesting a Basic Translation</a>
+</h3>
+      <p class="" style="">To request service from a translation provider you can send a message to a provider requesting translations. The lack of a 'derived_from' attribute in the &lt;translation/&gt; element indicates a request for a translation.</p>
+      <p class="caption">Example 10. Entity requests a translation from English to French</p>
+<div class="indent"><pre>
+&lt;message from='bard@shakespeare.lit/globe' to='translation.shakespeare.lit'&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='fr'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 11. Translation is returned from translation provider</p>
+<div class="indent"><pre>
+&lt;message from='translation.shakespeare.lit' to='bard@shakespeare.lit/globe'&gt;
+  &lt;subject xml:lang='fr'&gt;Bonjour&lt;/subject&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;body xml:lang='fr'&gt;comment allez-vous?&lt;/body&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='fr' derived_from='en'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.2 <a name="request-multiple">Requesting a Translation With Multiple Destination Languages</a>
+</h3>
+      <p class="caption">Example 12. bard requests a translation from English to French and Russian</p>
+<div class="indent"><pre>
+&lt;message from='bard@shakespeare.lit/globe' to='translation.shakespeare.lit'&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='fr'/&gt;
+    &lt;translation destination='ru'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 13. Translation is returned from translation provider</p>
+<div class="indent"><pre>
+&lt;message from='translation.shakespeare.lit' to='bard@shakespeare.lit/globe'&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;subject xml:lang='fr'&gt;Bonjour&lt;/subject&gt;
+  &lt;subject xml:lang='ru'&gt;x443;&amp;#x43B;&amp;#x442;&amp;#x435;&lt;/subject&gt;
+  &lt;body xml:lang='fr'&gt;comment allez-vous?&lt;/body&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;body xml:lang='ru'&gt;&amp;#x41A;&amp;#x430;&amp;#x43A; &amp;#x432;&amp;#x44B;?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='fr' derived_from='en'/&gt;
+    &lt;translation destination='ru' derived_from='en'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+    <div class="indent">
+<h3>4.3.3 <a name="request-dictionary">Requesting a Translation With a Specific Dictionary</a>
+</h3>
+      <p class="" style="">If a specific dictionary is required you MAY request a dictionary. This SHOULD have been returned when discoing the server although a dictionary MAY be requested which was not. The dictionaries are translation engine specific and are free form text.</p>
+      <p class="caption">Example 14. Requests a translation from English to French using the 'medical' dictionary</p>
+<div class="indent"><pre>
+&lt;message from='bard@shakespeare.lit/globe' to='translation.shakespeare.lit'&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='fr' dictionary='medical'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="caption">Example 15. Translation provider returns translation with dictionary details</p>
+<div class="indent"><pre>
+
+&lt;message from='translation.shakespeare.lit' to='bard@shakespeare.lit/globe'&gt;
+  &lt;subject xml:lang='fr'&gt;Bonjour&lt;/subject&gt;
+  &lt;subject xml:lang='en'&gt;Hello&lt;/subject&gt;
+  &lt;body xml:lang='fr'&gt;comment allez-vous?&lt;/body&gt;
+  &lt;body xml:lang='en'&gt;How are you?&lt;/body&gt;
+  &lt;x xmlns='http://jabber.org/protocol/langtrans'&gt;
+    &lt;translation destination='fr' derived_from='en' dictionary='medical'/&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">If the translation service cannot complete the translation it SHOULD return a  error indicating some part of the translation request was problematic, unless doing so would violate the privacy and security considerations in XMPP Core and XMPP IM, or local security and privacy policies.</p>
+      <p class="caption">Example 16. Translation could not be completed</p>
+<div class="indent"><pre>
+&lt;message from='translation.shakespeare.lit' to='bard@shakespeare.lit/globe' type='error'&gt;
+  &lt;error code='404' type='cancel'&gt;
+        &lt;item-not-found xmlns='urn:ietf:xml:params:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+      <p class="" style="">If privacy or security considerations make returning an  error not feasible it SHOULD return a  error.</p>
+      <p class="caption">Example 17. Service unavailable</p>
+<div class="indent"><pre>
+&lt;message from='translation.shakespeare.lit' to='bard@shakespeare.lit/globe' type='error'&gt;
+&lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:xml:params:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/message&gt;
+      </pre></div>
+    </div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">In order to reduce user confusion and misunderstanding of a translated message body, it is RECOMMENDED that implementations of langtran implement the following user interface features.</p>
+  <ol start="" type="">
+    <li>Translated messages should be clearly identified as being a translation.</li>
+    <li>The display of translated message should clearly show how (automated, manual, automated with human review) a messaged was translated.</li>
+    <li>The display of a message should clearly show if the translation is the destination, original or pivot language.</li>
+    <li>If pivoting is used, the destination message text should be marked in such a way as to indicate that it was translated on one or more pivot languages, what those language are, in what order they were used, and the actual pivot language text should be accessible to the user.</li>
+    <li>It is recommended that only one level of pivoting be used as quality of the destination translation degrades significantly after each pivot.</li>
+  </ol>
+  <p class="" style="">Note: The 'reviewed' and 'pivotable' attributes are of type "boolean" and MUST be handled accordingly.  [<a href="#nt-id2257250">3</a>]</p>
+<h2>6.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">In order to properly process multi-language messages, clients MUST implement support for multiple message bodies differentiated by the 'xml:lang' attribute as described in <span style="font-weight: bold">RFC 3920</span>.</p>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">Potential attacks may be easier against services that implement translation because of the potential disclosure of information regarding language pairings, engines, and dictionaries used however no specific vulnerabilities are introduced.</p>
+  <p class="" style="">This possible weakness can be mitigated by not returning specifics to requesting entities and the responding entity MAY perform authorization checks in order to determine how to respond.</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257351">4</a>].</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>9.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257399">5</a>] shall include 'http://jabber.org/protocol/langtrans' and 'http://jabber.org/protocol/langtrans#items' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>9.2 <a name="registrar-identity">Service Discovery Identities</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall add a type of "translation" to the "automation" category in its registry of service discovery identities.</p>
+  </div>
+<h2>10.
+       <a name="schema">XML Schema</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="schema-langtrans">langtrans</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;xs:schema
+    xmlns='http://jabber.org/protocol/langtrans' 
+    xmlns:xs='http://www.w3.org/2001/XMLSchema' 
+    targetNamespace='http://jabber.org/protocol/langtrans' 
+    elementFormDefault='qualified'&gt;
+    
+  &lt;xs:element name='x'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='translation'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='translation'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='charset' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='derived_from' type='xs:language' use='optional' /&gt;
+          &lt;xs:attribute name='destination' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='dictionary' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='engine' type='xs:string' use='optional' /&gt;
+          &lt;xs:attribute name='reviewed' type='xs:boolean' use='optional' default='false'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+        
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="schema-langtrans-items">langtrans#items</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+&lt;xs:schema
+    xmlns='http://jabber.org/protocol/langtrans#info' 
+    xmlns:xs='http://www.w3.org/2001/XMLSchema' 
+    targetNamespace='http://jabber.org/protocol/langtrans#info' 
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='query'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='item' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='item'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='dictionary' type='xs:string'/&gt;
+          &lt;xs:attribute name='dst_lang' type='xs:language'/&gt;
+          &lt;xs:attribute name='engine' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='jid' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='pivotable' type='xs:boolean' use='optional' default='false'/&gt;
+          &lt;xs:attribute name='src_lang' type='xs:language' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+        
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250676">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2256724">2</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2257250">3</a>. In accordance with Section 3.2.2.1 of <span style="font-weight: bold">XML Schema Part 2: Datatypes</span>, the allowable lexical representations for the xs:boolean datatype are the strings "0" and "false" for the concept 'false' and the strings "1" and "true" for the concept 'true'; implementations MUST support both styles of lexical representation.</p>
+<p><a name="nt-id2257351">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257399">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.4 (2006-01-17)</h4>
+<div class="indent">Converted to JEP format, cleaned up text, modified examples, changed pivotable and reviewed attributes to xs:boolean, corrected schema. (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-16)</h4>
+<div class="indent">Changed xml:lang to destination, derived to derived_from; added service discovery identity. (bf)
+    </div>
+<h4>Version 0.0.2 (2005-12-28)</h4>
+<div class="indent">Miscellaneous edits. (bf)
+    </div>
+<h4>Version 0.0.1 (2005-12-21)</h4>
+<div class="indent">First draft. (bf)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.1.html
+++ b/content/xep-0172-0.1.html
@@ -1,0 +1,274 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines best practices for handling of user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-01-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines best practices for handling of user nicknames.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0172<br>
+            Version: 0.1<br>
+            Last Updated: 2006-01-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email: stpeter@jabber.org<br>
+        JID: stpeter@jabber.org</p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email: valerie.mercier@francetelecom.com<br>
+        JID: vmercier@jabber.com</p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.2.  <a href="#subscription">Presence Subscription</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250775">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250809">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2250962">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250936">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname SHOULD be encapsulated via the <span class="ref" style="">User Profile</span>  [<a href="#nt-id2251010">5</a>] format.  [<a href="#nt-id2250989">6</a>] Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+  &lt;x xmlns='jabber:x:data' type='result'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+  &lt;/x&gt;
+  </pre></div>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include the nickname when establishing initial communication with a contact or group of contacts. Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Message exchange</li>
+    <li>Presence subscription</li>
+    <li>Multi-user chat</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 2. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;x xmlns='jabber:x:data' type='result'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="subscription">Presence Subscription</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 3. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2256505">7</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 4. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;x xmlns='jabber:x:data' type='result'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256558">8</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='jdev@conference.jabber.org/stpeter'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well:  [<a href="#nt-id2256575">9</a>]</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='jdev@conference.jabber.org/stpeter'&gt;
+  &lt;x xmlns='jabber:x:data' type='result'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='jdev@conference.jabber.org/stpeter'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;x xmlns='jabber:x:data' type='result'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+  &lt;/x&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use the protocol defined in <span style="font-weight: bold">JEP-0154</span>. If a <span class="ref" style="">Simplified Personal Publish-Subscribe</span>  [<a href="#nt-id2256661">10</a>] service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2250300">11</a>] service. If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname:</p>
+    <p class="caption">Example 8. Nickname Change</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;x xmlns='jabber:x:data' type='result'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The client SHOULD send the messages in a staggered fashion in order to avoid rate limiting.</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The best practices described in this document introduce no known security vulnerabilities.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250367">12</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256950">13</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250775">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250809">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2250962">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2250936">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2251010">5</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2250989">6</a>. While it could be argued that a less verbose format would be preferable (e.g., a specialized XML format), the use cases described herein are infrequent enough that the slightly more verbose format of User Profiles (<span style="font-weight: bold">JEP-0154</span>) is acceptable.</p>
+<p><a name="nt-id2256505">7</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2256558">8</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256575">9</a>. This may be desirable because the user's preferred room nickname is already taken, because the user would like to log in to the same room from multiple resources, or because the service "locks down" room nicknames.</p>
+<p><a name="nt-id2256661">10</a>. JEP-0163: Simplified Personal Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2250300">11</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2250367">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256950">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">Initial JEP version. (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">Added message exchange use case. (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">Added MUC and nickname management use cases; specified profile data syntax. (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">Initial version. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.2.html
+++ b/content/xep-0172-0.2.html
@@ -1,0 +1,296 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines best practices for handling of user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-08">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines best practices for handling of user nicknames.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0172<br>
+            Version: 0.2<br>
+            Last Updated: 2006-03-08<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.2.  <a href="#subscription">Presence Subscription</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250621">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250652">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2250776">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250766">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname SHOULD be encapsulated via the <span class="ref" style="">User Profile</span>  [<a href="#nt-id2250894">5</a>] format.  [<a href="#nt-id2250880">6</a>] Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+  &lt;x xmlns='jabber:x:data' type='result'&gt;
+    &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+    &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+  &lt;/x&gt;
+  </pre></div>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include the nickname when establishing initial communication with a contact or group of contacts. Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Message exchange</li>
+    <li>Presence subscription</li>
+    <li>Multi-user chat</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 2. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/profile&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="subscription">Presence Subscription</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 3. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2256834">7</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 4. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/profile&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2256889">8</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='jdev@conference.jabber.org/stpeter'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well:  [<a href="#nt-id2256905">9</a>]</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='jdev@conference.jabber.org/stpeter'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/profile&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='jdev@conference.jabber.org/stpeter'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/profile&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use the protocol defined in <span style="font-weight: bold">JEP-0154</span>. If a <span class="ref" style="">Personal Eventing Protocol</span>  [<a href="#nt-id2256993">10</a>] service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257018">11</a>] service. If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname:</p>
+    <p class="caption">Example 8. Nickname Change</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;profile xmlns='http://jabber.org/protocol/profile'&gt;
+    &lt;x xmlns='jabber:x:data' type='result'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;&lt;value&gt;http://jabber.org/protocol/profile&lt;/value&gt;&lt;/field&gt;
+      &lt;field var='nickname'&gt;&lt;value&gt;BernieBoy&lt;/value&gt;&lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/profile&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The client SHOULD send the messages in a staggered fashion in order to avoid rate limiting.</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The best practices described in this document introduce no known security vulnerabilities.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257100">12</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257179">13</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250621">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250652">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2250776">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2250766">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2250894">5</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2250880">6</a>. While it could be argued that a less verbose format would be preferable (e.g., a specialized XML format), the use cases described herein are infrequent enough that the slightly more verbose format of User Profiles (<span style="font-weight: bold">JEP-0154</span>) is acceptable.</p>
+<p><a name="nt-id2256834">7</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2256889">8</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2256905">9</a>. This may be desirable because the user's preferred room nickname is already taken, because the user would like to log in to the same room from multiple resources, or because the service "locks down" room nicknames.</p>
+<p><a name="nt-id2256993">10</a>. JEP-0163: Personal Eventing Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2257018">11</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257100">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257179">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-03-08)</h4>
+<div class="indent">
+<p class="" style="">Added wrapper element from JEP-0154.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">
+<p class="" style="">Added message exchange use case.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">
+<p class="" style="">Added MUC and nickname management use cases; specified profile data syntax.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.3.html
+++ b/content/xep-0172-0.3.html
@@ -1,0 +1,307 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines best practices for handling of user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines best practices for handling of user nicknames.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0172<br>
+            Version: 0.3<br>
+            Last Updated: 2006-03-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.2.  <a href="#subscription">Presence Subscription</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt>9.  <a href="#issues">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250642">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250674">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2250806">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250829">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname MUST be encapsulated as the XML character data of a &lt;nick/&gt; element qualified by the 'http://jabber.org/protocol/nick' namespace. Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+&lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  </pre></div>
+  <p class="" style="">A nickname of this form has the same semantic meaning as the following data fields:</p>
+  <ul>
+    <li>The "NICKNAME" field specified in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2256798">5</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">User Profile</span>  [<a href="#nt-id2256821">6</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256843">7</a>].</li>
+    <li>The "nick" field specified in <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2256866">8</a>].</li>
+    <li>The "Alias" field specified in the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2250901">9</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2256898">10</a>].</li>
+  </ul>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include his or her nickname when establishing initial communication with a contact or group of contacts (i.e., the user has never been in communication with and does not have a prior relationship with the contact or group of contacts). Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Message exchange</li>
+    <li>Presence subscription</li>
+    <li>Multi-user chat</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 2. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="subscription">Presence Subscription</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 3. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257012">11</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 4. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257079">12</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well. This may be desirable because the user's preferred room nickname is already taken, because the user would like to log in to the same room from multiple resources, or because the service "locks down" room nicknames.</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">A nickname may also be included in a MUC room invitation:</p>
+    <p class="caption">Example 8. Occupant Sends an Invitation by Way of Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='francisco@shakespeare.lit'/&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use the protocol defined in <span style="font-weight: bold">JEP-0154</span>. If a <span class="ref" style="">Personal Eventing Protocol</span>  [<a href="#nt-id2257191">13</a>] service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257215">14</a>] service. If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname:</p>
+    <p class="caption">Example 9. Nickname Change</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The client SHOULD send the messages in a staggered fashion in order to avoid rate limiting (commonly known as "karma").</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The best practices described in this document introduce no known security vulnerabilities.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257335">15</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257311">16</a>].</p>
+<h2>8.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Unbeknownst to the authors of this document, work on user nicknames was previously done by Richard Dobson (see &lt;<a href="http://richard.dobson-i.net/jep.php?html=jep-01xx.xml">http://richard.dobson-i.net/jep.php?html=jep-01xx.xml</a>&gt;).</p>
+<h2>9.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">Add examples for <span class="ref" style="">Waiting Lists</span>  [<a href="#nt-id2257408">17</a>] and <span class="ref" style="">Jingle</span>  [<a href="#nt-id2257430">18</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250642">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250674">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2250806">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2250829">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256798">5</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2256821">6</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2256843">7</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2256866">8</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2250901">9</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2256898">10</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2257012">11</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257079">12</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257191">13</a>. JEP-0163: Personal Eventing Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2257215">14</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257335">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257311">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2257408">17</a>. JEP-0130: Waiting Lists &lt;<a href="http://www.jabber.org/jeps/jep-0130.html">http://www.jabber.org/jeps/jep-0130.html</a>&gt;.</p>
+<p><a name="nt-id2257430">18</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Modified to use dedicated namespace; added example for multi-user chat invitations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-03-08)</h4>
+<div class="indent">
+<p class="" style="">Added wrapper element from JEP-0154.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">
+<p class="" style="">Added message exchange use case.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">
+<p class="" style="">Added MUC and nickname management use cases; specified profile data syntax.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.4.html
+++ b/content/xep-0172-0.4.html
@@ -1,0 +1,317 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines best practices for handling of user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-20">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines best practices for handling of user nicknames.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0172<br>
+            Version: 0.4<br>
+            Last Updated: 2006-03-20<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.2.  <a href="#subscription">Presence Subscription</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt>9.  <a href="#issues">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250663">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250838">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2250725">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250749">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname MUST be encapsulated as the XML character data of a &lt;nick/&gt; element qualified by the 'http://jabber.org/protocol/nick' namespace. Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+&lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  </pre></div>
+  <p class="" style="">A nickname of this form has the same semantic meaning as the following data fields:</p>
+  <ul>
+    <li>The "NICKNAME" field specified in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2256825">5</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">User Profile</span>  [<a href="#nt-id2256848">6</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256872">7</a>].</li>
+    <li>The "nick" field specified in <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2256894">8</a>].</li>
+    <li>The "Alias" field specified in the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2256810">9</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2256927">10</a>].</li>
+  </ul>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include his or her nickname when establishing initial communication with a contact or group of contacts (i.e., the user has never been in communication with and does not have a prior relationship with the contact or group of contacts). Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Message exchange</li>
+    <li>Presence subscription</li>
+    <li>Multi-user chat</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 2. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="subscription">Presence Subscription</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 3. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257043">11</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 4. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257104">12</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well. This may be desirable because the user's preferred room nickname is already taken, because the user would like to log in to the same room from multiple resources, or because the service "locks down" room nicknames.</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">A nickname may also be included in a MUC room invitation:</p>
+    <p class="caption">Example 8. Occupant Sends an Invitation by Way of Room (Multi-User Chat)</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='francisco@shakespeare.lit'/&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use the protocol defined in <span style="font-weight: bold">JEP-0154</span>. If a <span class="ref" style="">Personal Eventing Protocol</span>  [<a href="#nt-id2257256">13</a>] service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257220">14</a>] service. If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname:</p>
+    <p class="caption">Example 9. Nickname Change</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The client SHOULD send the messages in a staggered fashion in order to avoid rate limiting (commonly known as "karma").</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The best practices described in this document introduce no known security vulnerabilities.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257325">15</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257371">16</a>] shall include 'http://jabber.org/protocol/shim' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Unbeknownst to the authors of this document, work on user nicknames was previously done by Richard Dobson (see &lt;<a href="http://richard.dobson-i.net/jep.php?html=jep-01xx.xml">http://richard.dobson-i.net/jep.php?html=jep-01xx.xml</a>&gt;).</p>
+<h2>9.
+       <a name="issues">Open Issues</a>
+</h2>
+  <p class="" style="">Add examples for <span class="ref" style="">Waiting Lists</span>  [<a href="#nt-id2257481">17</a>] and <span class="ref" style="">Jingle</span>  [<a href="#nt-id2257451">18</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250663">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250838">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2250725">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2250749">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256825">5</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2256848">6</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2256872">7</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2256894">8</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2256810">9</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2256927">10</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2257043">11</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257104">12</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257256">13</a>. JEP-0163: Personal Eventing Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2257220">14</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257325">15</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257371">16</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2257481">17</a>. JEP-0130: Waiting Lists &lt;<a href="http://www.jabber.org/jeps/jep-0130.html">http://www.jabber.org/jeps/jep-0130.html</a>&gt;.</p>
+<p><a name="nt-id2257451">18</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">To reflect use of dedicated namespace, (1) changed JEP type from Informational to Standards Track and (2) updated Jabber Registrar Considerations.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Modified to use dedicated namespace; added example for multi-user chat invitations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-03-08)</h4>
+<div class="indent">
+<p class="" style="">Added wrapper element from JEP-0154.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">
+<p class="" style="">Added message exchange use case.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">
+<p class="" style="">Added MUC and nickname management use cases; specified profile data syntax.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.5.html
+++ b/content/xep-0172-0.5.html
@@ -1,0 +1,364 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines a protocol for communicating user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines a protocol for communicating user nicknames.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0172<br>
+            Version: 0.5<br>
+            Last Updated: 2006-03-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.2.  <a href="#subscription">Presence Subscription</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#waitlist">Waiting Lists</a>
+</dt>
+<dt>4.5.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250688">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250899">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2250773">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250797">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname MUST be encapsulated as the XML character data of a &lt;nick/&gt; element qualified by the 'http://jabber.org/protocol/nick' namespace. Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+&lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  </pre></div>
+  <p class="" style="">A nickname of this form has the same semantic meaning as the following data fields:</p>
+  <ul>
+    <li>The "NICKNAME" field specified in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2256849">5</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">User Profile</span>  [<a href="#nt-id2256872">6</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256895">7</a>].</li>
+    <li>The "nick" field specified in <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2256918">8</a>].</li>
+    <li>The "Alias" field specified in the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2256830">9</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2256952">10</a>].</li>
+  </ul>
+  <p class="" style="">The entity to which the &lt;nick/&gt; refers is the from address (no matter how encapsulated in XML) of the nearest ancestor element that specifies the sender (which might be a parent or grandparent element, e.g. the 'from' attribute of an &lt;iq/&gt; stanza).</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include his or her nickname when establishing initial communication with a contact or group of contacts (i.e., the user has never been in communication with and does not have a prior relationship with the contact or group of contacts). Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Message exchange</li>
+    <li>Presence subscription</li>
+    <li>Multi-user chat</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 2. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="subscription">Presence Subscription</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 3. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257078">11</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 4. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257139">12</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well. This may be desirable because the user's preferred room nickname is already taken, because the user would like to log in to the same room from multiple resources, or because the service "locks down" room nicknames.</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">A nickname may also be included in a MUC room invitation:</p>
+    <p class="caption">Example 8. Occupant Sends MUC Invitation</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='francisco@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Although the foregoing stanza may seem to violate the rule about associating a nick with the nearest ancestor element that specifies the sender's JID, the output from the MUC room does not violate that rule, since the room swaps the to and from addresses before sending the invitation to the invitee:</p>
+    <p class="caption">Example 9. MUC Room Forwards Invitation</p>
+<div class="indent"><pre>
+&lt;message from='elsinore@muc.shakespeare.lit' to='francisco@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='bernardo@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="waitlist">Waiting Lists</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Waiting Lists</span>  [<a href="#nt-id2257263">13</a>] defines a protocol that enables a user to be informed when a contact signs up for an IM account. The user MAY include his or her nick in the request so that the contact can associate a nickname with the request.</p>
+    <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bernardo@shakespeare.lit'
+    to='waitlist.shakespeare.lit'
+    id='wl1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+    &lt;/item&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user's waiting list service knows the contact's nickname when it sends a notification to the user, it SHOULD include the nickname:</p>
+    <p class="caption">Example 11. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.shakespeare.lit'
+    to='bernardo@shakespeare.lit'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='francisco@shakespeare.lit'&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;Frisco&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use the protocol defined in <span style="font-weight: bold">JEP-0154</span>. If a <span class="ref" style="">Personal Eventing Protocol</span>  [<a href="#nt-id2257353">14</a>] service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257377">15</a>] service. If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname:</p>
+    <p class="caption">Example 12. Nickname Change</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The client SHOULD send the messages in a staggered fashion in order to avoid rate limiting (commonly known as "karma").</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The best practices described in this document introduce no known security vulnerabilities.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257498">16</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257481">17</a>] shall include 'http://jabber.org/protocol/nick' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Ian Paterson for his feedback.</p>
+  <p class="" style="">Unbeknownst to the authors of this document, work on user nicknames was previously done by Richard Dobson (see &lt;<a href="http://richard.dobson-i.net/jep.php?html=jep-01xx.xml">http://richard.dobson-i.net/jep.php?html=jep-01xx.xml</a>&gt;).</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250688">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250899">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2250773">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2250797">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256849">5</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2256872">6</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2256895">7</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2256918">8</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2256830">9</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2256952">10</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2257078">11</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257139">12</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257263">13</a>. JEP-0130: Waiting Lists &lt;<a href="http://www.jabber.org/jeps/jep-0130.html">http://www.jabber.org/jeps/jep-0130.html</a>&gt;.</p>
+<p><a name="nt-id2257353">14</a>. JEP-0163: Personal Eventing Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2257377">15</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257498">16</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257481">17</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2006-03-22)</h4>
+<div class="indent">
+<p class="" style="">Fixed MUC invite example; clarified that nick refers to entity associated with nearest ancestor element that specifies a sender; added waitlist example.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">To reflect use of dedicated namespace, (1) changed JEP type from Informational to Standards Track and (2) updated Jabber Registrar Considerations.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Modified to use dedicated namespace; added example for multi-user chat invitations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-03-08)</h4>
+<div class="indent">
+<p class="" style="">Added wrapper element from JEP-0154.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">
+<p class="" style="">Added message exchange use case.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">
+<p class="" style="">Added MUC and nickname management use cases; specified profile data syntax.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.6.html
+++ b/content/xep-0172-0.6.html
@@ -1,0 +1,369 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines a protocol for communicating user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-27">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines a protocol for communicating user nicknames.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0172<br>
+            Version: 0.6<br>
+            Last Updated: 2006-03-27<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.2.  <a href="#subscription">Presence Subscription</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#waitlist">Waiting Lists</a>
+</dt>
+<dt>4.5.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250697">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250876">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2250856">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2250825">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname MUST be encapsulated as the XML character data of a &lt;nick/&gt; element qualified by the 'http://jabber.org/protocol/nick' namespace. Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+&lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  </pre></div>
+  <p class="" style="">A nickname of this form has the same semantic meaning as the following data fields:</p>
+  <ul>
+    <li>The "NICKNAME" field specified in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2256904">5</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">User Profile</span>  [<a href="#nt-id2256965">6</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2256926">7</a>].</li>
+    <li>The "nick" field specified in <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2256978">8</a>].</li>
+    <li>The "Alias" field specified in the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2256884">9</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2257010">10</a>].</li>
+  </ul>
+  <p class="" style="">The entity to which the &lt;nick/&gt; refers is the from address (no matter how encapsulated in XML) of the nearest ancestor element that specifies the sender (which might be a parent or grandparent element, e.g. the 'from' attribute of an &lt;iq/&gt; stanza).</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include his or her nickname when establishing initial communication with a contact or group of contacts (i.e., the user has never been in communication with and does not have a prior relationship with the contact or group of contacts). Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Message exchange</li>
+    <li>Presence subscription</li>
+    <li>Multi-user chat</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 2. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="subscription">Presence Subscription</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 3. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257137">11</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 4. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257198">12</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well. This may be desirable because the user's preferred room nickname is already taken, because the user would like to log in to the same room from multiple resources, or because the service "locks down" room nicknames.</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">A nickname may also be included in a MUC room invitation:</p>
+    <p class="caption">Example 8. Occupant Sends MUC Invitation</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='francisco@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Although the foregoing stanza may seem to violate the rule about associating a nick with the nearest ancestor element that specifies the sender's JID, the output from the MUC room does not violate that rule, since the room swaps the to and from addresses before sending the invitation to the invitee:</p>
+    <p class="caption">Example 9. MUC Room Forwards Invitation</p>
+<div class="indent"><pre>
+&lt;message from='elsinore@muc.shakespeare.lit' to='francisco@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='bernardo@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="waitlist">Waiting Lists</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Waiting Lists</span>  [<a href="#nt-id2257321">13</a>] defines a protocol that enables a user to be informed when a contact signs up for an IM account. The user MAY include his or her nick in the request so that the contact can associate a nickname with the request.</p>
+    <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bernardo@shakespeare.lit'
+    to='waitlist.shakespeare.lit'
+    id='wl1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+    &lt;/item&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the user's waiting list service knows the contact's nickname when it sends a notification to the user, it SHOULD include the nickname:</p>
+    <p class="caption">Example 11. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.shakespeare.lit'
+    to='bernardo@shakespeare.lit'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='francisco@shakespeare.lit'&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;Frisco&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use the protocol defined in <span style="font-weight: bold">JEP-0154</span>. If a <span class="ref" style="">Personal Eventing Protocol</span>  [<a href="#nt-id2257411">14</a>] service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257435">15</a>] service. If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname:</p>
+    <p class="caption">Example 12. Nickname Change</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The client SHOULD send the messages in a staggered fashion in order to avoid rate limiting (commonly known as "karma").</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A nickname is a memorable, friendly name asserted by a user. There is no guarantee that any given nickname will be unique even within given community (such as an enterprise or university), let alone across the Internet through federation of communities. Clients SHOULD warn users that nicknames asserted by contacts are not unique and that nickname collisions are possible. Clients also MUST NOT depend on nicknames to validate the identity of contacts; instead, nicknames SHOULD be used in conjunction with JIDs (which are globally unique) and user-assigned aliases or "petnames" (which are private and unique) as described in <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2257494">16</a>] in order to provide a three-pronged approach to identity validation, preferably in combination with X.509 certificates.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257544">17</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257596">18</a>] shall include 'http://jabber.org/protocol/nick' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Ian Paterson for his feedback.</p>
+  <p class="" style="">Unbeknownst to the authors of this document, work on user nicknames was previously done by Richard Dobson (see &lt;<a href="http://richard.dobson-i.net/jep.php?html=jep-01xx.xml">http://richard.dobson-i.net/jep.php?html=jep-01xx.xml</a>&gt;).</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250697">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250876">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2250856">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2250825">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2256904">5</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2256965">6</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2256926">7</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2256978">8</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2256884">9</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2257010">10</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2257137">11</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257198">12</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257321">13</a>. JEP-0130: Waiting Lists &lt;<a href="http://www.jabber.org/jeps/jep-0130.html">http://www.jabber.org/jeps/jep-0130.html</a>&gt;.</p>
+<p><a name="nt-id2257411">14</a>. JEP-0163: Personal Eventing Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2257435">15</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257494">16</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2257544">17</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257596">18</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2006-03-27)</h4>
+<div class="indent">
+<p class="" style="">Specified security considerations.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-22)</h4>
+<div class="indent">
+<p class="" style="">Fixed MUC invite example; clarified that nick refers to entity associated with nearest ancestor element that specifies a sender; added waitlist example.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">To reflect use of dedicated namespace, (1) changed JEP type from Informational to Standards Track and (2) updated Jabber Registrar Considerations.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Modified to use dedicated namespace; added example for multi-user chat invitations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-03-08)</h4>
+<div class="indent">
+<p class="" style="">Added wrapper element from JEP-0154.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">
+<p class="" style="">Added message exchange use case.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">
+<p class="" style="">Added MUC and nickname management use cases; specified profile data syntax.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.7.html
+++ b/content/xep-0172-0.7.html
@@ -1,0 +1,422 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines a protocol for communicating user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-21">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines a protocol for communicating user nicknames.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0172<br>
+            Version: 0.7<br>
+            Last Updated: 2006-04-21<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: nick<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.2.  <a href="#subscription">Presence Subscription</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#waitlist">Waiting Lists</a>
+</dt>
+<dt>4.5.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>8.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>9.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2251052">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250885">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2251010">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2257048">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname MUST be encapsulated as the XML character data of a &lt;nick/&gt; element qualified by the 'http://jabber.org/protocol/nick' namespace. Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+&lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  </pre></div>
+  <p class="" style="">A nickname of this form has the same semantic meaning as the following data fields:</p>
+  <ul>
+    <li>The "NICKNAME" field specified in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257132">5</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">User Profile</span>  [<a href="#nt-id2257155">6</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2257181">7</a>].</li>
+    <li>The "nick" field specified in <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2257204">8</a>].</li>
+    <li>The "Alias" field specified in the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2257111">9</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2257275">10</a>].</li>
+  </ul>
+  <p class="" style="">The entity to which the &lt;nick/&gt; refers is the from address (no matter how encapsulated in XML) of the nearest ancestor element that specifies the sender (which might be a parent or grandparent element, e.g. the 'from' attribute of an &lt;iq/&gt; stanza).</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include his or her nickname when establishing initial communication with a contact or group of contacts (i.e., the user has never been in communication with and does not have a prior relationship with the contact or group of contacts). Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Message exchange</li>
+    <li>Presence subscription</li>
+    <li>Multi-user chat</li>
+    <li>Waiting lists</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 2. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="subscription">Presence Subscription</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 3. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257367">11</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 4. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257428">12</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well. This may be desirable because the user's preferred room nickname is already taken or because the service "locks down" room nicknames.</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">A nickname may also be included in a MUC room invitation:</p>
+    <p class="caption">Example 8. Occupant Sends MUC Invitation</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='francisco@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Although the foregoing stanza may seem to violate the rule about associating a nick with the nearest ancestor element that specifies the sender's JID, the output from the MUC room does not violate that rule, since the room swaps the to and from addresses before sending the invitation to the invitee:</p>
+    <p class="caption">Example 9. MUC Room Forwards Invitation</p>
+<div class="indent"><pre>
+&lt;message from='elsinore@muc.shakespeare.lit' to='francisco@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='bernardo@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="waitlist">Waiting Lists</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Waiting Lists</span>  [<a href="#nt-id2257549">13</a>] defines a protocol that enables a user to be informed when a contact signs up for an IM account. The user MAY include his or her nick in the request so that the contact can associate a nickname with the request.</p>
+    <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bernardo@shakespeare.lit'
+    to='waitlist.shakespeare.lit'
+    id='wl1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+    &lt;/item&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the WaitingListService SHOULD pass the nick on to its InteropPartners as well:</p>
+    <p class="caption">Example 11. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If an InteropPartner knows a contact's nickname when it returns results to the WaitingListService it SHOULD include the nickname:</p>
+    <p class="caption">Example 12. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;Frisco&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Finally, if the user's waiting list service knows the contact's nickname when it sends a notification to the user, it SHOULD include the nickname:</p>
+    <p class="caption">Example 13. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.shakespeare.lit'
+    to='bernardo@shakespeare.lit'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='francisco@shakespeare.lit'&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;Frisco&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use the protocol defined in <span style="font-weight: bold">JEP-0154: User Profile</span>. If a <span class="ref" style="">Personal Eventing Protocol</span>  [<a href="#nt-id2257684">14</a>] service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257708">15</a>] service. If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname:</p>
+    <p class="caption">Example 14. Nickname Change</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The client SHOULD send the messages in a staggered fashion in order to avoid server-enforced rate limiting (commonly known as "karma").</p>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A nickname is a memorable, friendly name asserted by a user. There is no guarantee that any given nickname will be unique even within a particulat community (such as an enterprise or university), let alone across the Internet through federation of communities. Clients SHOULD warn users that nicknames asserted by contacts are not unique and that nickname collisions are possible. Clients also MUST NOT depend on nicknames to validate the identity of contacts; instead, nicknames SHOULD be used in conjunction with JIDs (which are globally unique) and user-assigned handles (which are private and unique) as described in <span style="font-weight: bold">JEP-0165</span> in order to provide a three-pronged approach to identity validation, preferably in combination with X.509 certificates.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257787">16</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257857">17</a>] shall include 'http://jabber.org/protocol/nick' in its registry of protocol namespaces.</p>
+  </div>
+<h2>8.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/nick'
+    xmlns='http://jabber.org/protocol/nick'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='nick' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>9.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Ian Paterson for his feedback.</p>
+  <p class="" style="">Unbeknownst to the authors of this document, work on user nicknames was previously done by Richard Dobson (see &lt;<a href="http://richard.dobson-i.net/jep.php?html=jep-01xx.xml">http://richard.dobson-i.net/jep.php?html=jep-01xx.xml</a>&gt;).</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251052">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250885">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2251010">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2257048">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2257132">5</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257155">6</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2257181">7</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2257204">8</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2257111">9</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2257275">10</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2257367">11</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257428">12</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257549">13</a>. JEP-0130: Waiting Lists &lt;<a href="http://www.jabber.org/jeps/jep-0130.html">http://www.jabber.org/jeps/jep-0130.html</a>&gt;.</p>
+<p><a name="nt-id2257684">14</a>. JEP-0163: Personal Eventing Protocol &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2257708">15</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257787">16</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257857">17</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added further detail to waitlist example; added schema.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-03-27)</h4>
+<div class="indent">
+<p class="" style="">Specified security considerations.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-22)</h4>
+<div class="indent">
+<p class="" style="">Fixed MUC invite example; clarified that nick refers to entity associated with nearest ancestor element that specifies a sender; added waitlist example.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">To reflect use of dedicated namespace, (1) changed JEP type from Informational to Standards Track and (2) updated Jabber Registrar Considerations.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Modified to use dedicated namespace; added example for multi-user chat invitations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-03-08)</h4>
+<div class="indent">
+<p class="" style="">Added wrapper element from JEP-0154.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">
+<p class="" style="">Added message exchange use case.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">
+<p class="" style="">Added MUC and nickname management use cases; specified profile data syntax.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.8.html
+++ b/content/xep-0172-0.8.html
@@ -1,0 +1,435 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines a protocol for communicating user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines a protocol for communicating user nicknames.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0172<br>
+            Version: 0.8<br>
+            Last Updated: 2006-04-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: nick<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#subscription">Presence Subscription Requests</a>
+</dt>
+<dt>4.2.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#waitlist">Waiting Lists</a>
+</dt>
+<dt>4.5.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>10.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250766">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250800">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2257082">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2257102">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" or "alias" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.  [<a href="#nt-id2257117">5</a>]</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname MUST be encapsulated as the XML character data of a &lt;nick/&gt; element qualified by the 'http://jabber.org/protocol/nick' namespace. Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+&lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  </pre></div>
+  <p class="" style="">A nickname of this form has the same semantic meaning as the following data fields:</p>
+  <ul>
+    <li>The "NICKNAME" field specified in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257188">6</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">User Profile</span>  [<a href="#nt-id2257211">7</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2257236">8</a>].</li>
+    <li>The "nick" field specified in <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2257259">9</a>].</li>
+    <li>The "Alias" field specified in the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2257167">10</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2257331">11</a>].</li>
+  </ul>
+  <p class="" style="">The entity to which the &lt;nick/&gt; refers is the from address (no matter how encapsulated in XML) of the nearest ancestor element that specifies the sender (which might be a parent or grandparent element, e.g. the 'from' attribute of an &lt;iq/&gt; stanza).</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include his or her nickname when establishing initial communication with a contact or group of contacts (i.e., the user has never been in communication with and does not have a prior relationship with the contact or group of contacts). Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Presence subscription requests</li>
+    <li>Message exchange</li>
+    <li>Multi-user chat</li>
+    <li>Waiting lists</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="subscription">Presence Subscription Requests</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a presence subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 2. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2257395">12</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 3. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Note: This document recommends sending the nickname only in presence subscription requests; the nickname MUST NOT be included in presence broadcasts (i.e., &lt;presence/&gt; stanzas with no 'type' attribute or of type "unavailable").</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 4. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2257500">13</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well. This may be desirable because the user's preferred room nickname is already taken or because the service "locks down" room nicknames.</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">A nickname may also be included in a MUC room invitation:</p>
+    <p class="caption">Example 8. Occupant Sends MUC Invitation</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='francisco@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Although the foregoing stanza may seem to violate the rule about associating a nick with the nearest ancestor element that specifies the sender's JID, the output from the MUC room does not violate that rule, since the room swaps the to and from addresses before sending the invitation to the invitee:</p>
+    <p class="caption">Example 9. MUC Room Forwards Invitation</p>
+<div class="indent"><pre>
+&lt;message from='elsinore@muc.shakespeare.lit' to='francisco@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='bernardo@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="waitlist">Waiting Lists</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Waiting Lists</span>  [<a href="#nt-id2257635">14</a>] defines a protocol that enables a user to be informed when a contact signs up for an IM account. The user MAY include his or her nick in the request so that the contact can associate a nickname with the request.</p>
+    <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bernardo@shakespeare.lit'
+    to='waitlist.shakespeare.lit'
+    id='wl1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+    &lt;/item&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the WaitingListService SHOULD pass the nick on to its InteropPartners as well:</p>
+    <p class="caption">Example 11. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If an InteropPartner knows a contact's nickname when it returns results to the WaitingListService it SHOULD include the nickname:</p>
+    <p class="caption">Example 12. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;Frisco&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Finally, if the user's waiting list service knows the contact's nickname when it sends a notification to the user, it SHOULD include the nickname:</p>
+    <p class="caption">Example 13. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.shakespeare.lit'
+    to='bernardo@shakespeare.lit'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='francisco@shakespeare.lit'&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;Frisco&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use <span class="ref" style="">Personal Eventing via Pubsub</span>  [<a href="#nt-id2257749">15</a>]. If a personal eventing service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2257772">16</a>] service. If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname:</p>
+    <p class="caption">Example 14. Nickname Change</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">The client SHOULD send the messages in a staggered fashion in order to avoid server-enforced rate limiting (commonly known as "karma").</p>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">An IM client MAY use the user's own nickname as all or part of the "display name" shown to the user of that client (e.g., as the sending name in one-to-one chats and groupchats). For example, if the user whose JID is bernardo@shakespeare.lit asserts that his nickname is "BernieBoy", that user's client may show "BernieBoy" as all or part of the user's display name. How the client shall store the display name is out of scope for this document; possible mechanisms include the user's local vCard, an organizational LDAP directory, <span class="ref" style="">Private XML Storage</span>  [<a href="#nt-id2257845">17</a>], or <span style="font-weight: bold">JEP-0154</span>.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A nickname is a memorable, friendly name asserted by a user. There is no guarantee that any given nickname will be unique even within a particulat community (such as an enterprise or university), let alone across the Internet through federation of communities. Clients SHOULD warn users that nicknames asserted by contacts are not unique and that nickname collisions are possible. Clients also MUST NOT depend on nicknames to validate the identity of contacts; instead, nicknames SHOULD be used in conjunction with JIDs (which are globally unique) and user-assigned handles (which are private and unique) as described in <span style="font-weight: bold">JEP-0165</span> in order to provide a three-pronged approach to identity validation, preferably in combination with X.509 certificates.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250373">18</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250418">19</a>] shall include 'http://jabber.org/protocol/nick' in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/nick'
+    xmlns='http://jabber.org/protocol/nick'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='nick' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>10.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Ian Paterson for his feedback.</p>
+  <p class="" style="">Unbeknownst to the authors of this document, work on user nicknames was previously done by Richard Dobson (see &lt;<a href="http://richard.dobson-i.net/jep.php?html=jep-01xx.xml">http://richard.dobson-i.net/jep.php?html=jep-01xx.xml</a>&gt;).</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250766">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250800">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2257082">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2257102">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2257117">5</a>. In RFC 3921, the name here called a "handle" is described as an "alias"; rfc3921 will be modified to use the term "handle" instead.</p>
+<p><a name="nt-id2257188">6</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257211">7</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2257236">8</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2257259">9</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2257167">10</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2257331">11</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2257395">12</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2257500">13</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2257635">14</a>. JEP-0130: Waiting Lists &lt;<a href="http://www.jabber.org/jeps/jep-0130.html">http://www.jabber.org/jeps/jep-0130.html</a>&gt;.</p>
+<p><a name="nt-id2257749">15</a>. JEP-0163: Personal Eventing via Pubsub &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2257772">16</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2257845">17</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p><a name="nt-id2250373">18</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2250418">19</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.8 (2006-04-28)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology; explicitly mentioned that nickanmes must not be included in presence broadcasts (only subscription requests); added implementation note about display names.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added further detail to waitlist example; added schema.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-03-27)</h4>
+<div class="indent">
+<p class="" style="">Specified security considerations.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-22)</h4>
+<div class="indent">
+<p class="" style="">Fixed MUC invite example; clarified that nick refers to entity associated with nearest ancestor element that specifies a sender; added waitlist example.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">To reflect use of dedicated namespace, (1) changed JEP type from Informational to Standards Track and (2) updated Jabber Registrar Considerations.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Modified to use dedicated namespace; added example for multi-user chat invitations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-03-08)</h4>
+<div class="indent">
+<p class="" style="">Added wrapper element from JEP-0154.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">
+<p class="" style="">Added message exchange use case.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">
+<p class="" style="">Added MUC and nickname management use cases; specified profile data syntax.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0172-0.9.html
+++ b/content/xep-0172-0.9.html
@@ -1,0 +1,511 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0172: User Nickname</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="User Nickname">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Valerie Mercier">
+<meta name="DC.Description" content="This document defines a protocol for communicating user nicknames.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-05-10">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0172">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0172: User Nickname</h1>
+<p>This document defines a protocol for communicating user nicknames.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Standards Track<br>
+            Number: 0172<br>
+            Version: 0.9<br>
+            Last Updated: 2006-05-10<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: nick<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/User%20Nickname%20(JEP-0172)">http://wiki.jabber.org/index.php/User Nickname (JEP-0172)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Valerie Mercier</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:valerie.mercier@francetelecom.com">valerie.mercier@francetelecom.com</a><br>
+        JID: 
+        <a href="xmpp:vmercier@jabber.com">vmercier@jabber.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#terms">Terminology</a>
+</dt>
+<dt>3.  <a href="#format">Format</a>
+</dt>
+<dt>4.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#subscription">Presence Subscription Requests</a>
+</dt>
+<dt>4.2.  <a href="#message">Message Exchange</a>
+</dt>
+<dt>4.3.  <a href="#muc">Multi-User Chat</a>
+</dt>
+<dt>4.4.  <a href="#waitlist">Waiting Lists</a>
+</dt>
+<dt>4.5.  <a href="#manage">Nickname Management</a>
+</dt>
+</dl>
+<dt>5.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>9.  <a href="#schema">XML Schema</a>
+</dt>
+<dt>10.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">A nickname is a global, memorable (but not necessarily unique) friendly or informal name chosen by the owner of a bare JID (&lt;node@domain.tld&gt;) for the purpose of associating a distinctive mapping between the person's unique JID and non-unique nickname. While nicknames have been a common feature of instant messaging systems for many years, they have not always featured prominently in Jabber/XMPP IM systems (e.g., nicknames are not specified in <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250837">1</a>]). However, there are several reasons why nicknames are important:</p>
+  <ul>
+    <li>Users like them.</li>
+    <li>They are easier to remember than JIDs.</li>
+    <li>They can be used to help prevent mimicking of JIDs (see <span class="ref" style="">Prevention of JID Spoofing</span>  [<a href="#nt-id2250873">2</a>]).</li>
+  </ul>
+  <p class="" style="">This document defines best practices that enable IM users to advertise their preferred nicknames over Jabber/XMPP instant messaging networks.</p>
+<h2>2.
+       <a name="terms">Terminology</a>
+</h2>
+  <p class="" style="">This proposal draws a distinction between the following kinds of names, where a JID is an innate feature of a user's identity on an XMPP system, a nickname is asserted by a user, and a handle is assigned by a contact to a user.</p>
+  <p class="caption">Table 1: JIDs, Nicknames, and Handles</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Definition</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Jabber ID (JID)</td>
+      <td align="" colspan="" rowspan="">A global and unique XMPP identifier registered to a particular user, of the form &lt;node@domain.tld&gt;; represented in the 'from' attribute of XML stanzas sent by that user, the 'jid' attribute of items associated with that user in a contact's roster, etc.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Nickname</td>
+      <td align="" colspan="" rowspan="">A global and memorable (but not necessarily unique) friendly name or informal name asserted by an IM user. Typically, a nickname is different from a familiar name, such as "Chuck" for "Charles", "Bill" for "William", "Pete" for "Peter", or "Dave" for "David"; instead, a nickname is even less formal, such as "stpeter" or "dizzyd". A nickname is thus typically different from a "display name" as that term is understood in SMTP (see <span class="ref" style="">RFC 2821</span>  [<a href="#nt-id2259322">3</a>]) and SIP (see <span class="ref" style="">RFC 3261</span>  [<a href="#nt-id2259345">4</a>]).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Handle</td>
+      <td align="" colspan="" rowspan="">A private, unique, and memorable "petname" or "alias" assigned by a contact to a user; represented in the 'name' attribute of the item associated with that user's JID in the contact's roster.  [<a href="#nt-id2259364">5</a>]</td>
+    </tr>
+  </table>
+<h2>3.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">A nickname MUST be encapsulated as the XML character data of a &lt;nick/&gt; element qualified by the 'http://jabber.org/protocol/nick' namespace. Here is an example:</p>
+  <p class="caption">Example 1. A Nickname</p>
+<div class="indent"><pre>
+&lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  </pre></div>
+  <p class="" style="">A nickname of this form has the same semantic meaning as the following data fields:</p>
+  <ul>
+    <li>The "NICKNAME" field specified in <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2259473">6</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">User Profile</span>  [<a href="#nt-id2259438">7</a>].</li>
+    <li>The "nickname" field specified in <span class="ref" style="">In-Band Registration</span>  [<a href="#nt-id2259485">8</a>].</li>
+    <li>The "nick" field specified in <span class="ref" style="">Friend of a Friend (FOAF)</span>  [<a href="#nt-id2259509">9</a>].</li>
+    <li>The "Alias" field specified in the <span style="font-weight: bold">Extensible Name and Address Language</span>  [<a href="#nt-id2259416">10</a>] developed by <span class="ref" style="">OASIS</span>  [<a href="#nt-id2259541">11</a>].</li>
+  </ul>
+  <p class="" style="">The entity to which the &lt;nick/&gt; refers is the from address (no matter how encapsulated in XML) of the nearest ancestor element that specifies the sender (which might be a parent or grandparent element, e.g. the 'from' attribute of an &lt;iq/&gt; stanza).</p>
+<h2>4.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <p class="" style="">In general, a user SHOULD include his or her nickname when establishing initial communication with a contact or group of contacts (i.e., the user has never been in communication with and does not have a prior relationship with the contact or group of contacts). Appropriate use cases therefore include:</p>
+  <ul>
+    <li>Presence subscription requests</li>
+    <li>Message exchange</li>
+    <li>Multi-user chat</li>
+    <li>Waiting lists</li>
+  </ul>
+  <div class="indent">
+<h3>4.1 <a name="subscription">Presence Subscription Requests</a>
+</h3>
+    <p class="" style="">As defined in <span style="font-weight: bold">RFC 3921</span>, a presence subscription request contains only the JID of the sender:</p>
+    <p class="caption">Example 2. A Basic Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, based on the JID of the sender, it is possible for the client to pull information about the sender from a persistent data store such as an LDAP database, <span class="ref" style="">vcard-temp</span>  [<a href="#nt-id2259643">12</a>] node, or <span style="font-weight: bold">JEP-0154</span> store. However, to speed interactions, this document recommends that when a client sends a subscription request, it SHOULD include the preferred nickname of the sender:</p>
+    <p class="caption">Example 3. Including Nickname with Subscription Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit' to='francisco@shakespeare.lit' type='subscribe'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">Note: This document recommends sending the nickname only in presence subscription requests; the nickname MUST NOT be included in presence broadcasts (i.e., &lt;presence/&gt; stanzas with no 'type' attribute or of type "unavailable").</p>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="message">Message Exchange</a>
+</h3>
+    <p class="" style="">When a user begins to chat with a contact but the two parties have no pre-existing relationship or prior communications (e.g., no presence subscription or previous message exchange), the user SHOULD include the nickname with the first message sent to the contact:</p>
+    <p class="caption">Example 4. Including Nickname with First Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/pda' to='francisco@shakespeare.lit' type='chat'&gt;
+  &lt;body&gt;Who's there?&lt;/body&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="muc">Multi-User Chat</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Multi-User Chat</span>  [<a href="#nt-id2259746">13</a>] defines a protocol for groupchat rooms. A user specifies a "room nickname" when joining such a room (the resource identifier of the 'to' address):</p>
+    <p class="caption">Example 5. A Basic Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'/&gt;
+    </pre></div>
+    <p class="" style="">A user MAY specify his or her persistent nickname as well. This may be desirable because the user's preferred room nickname is already taken or because the service "locks down" room nicknames.</p>
+    <p class="caption">Example 6. Including Nickname with Room Join Request</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">If a user includes his or her persistent nickname in the room join request, the nickname SHOULD also be included in any presence changes sent to the room:</p>
+    <p class="caption">Example 7. Presence Change With Nickname</p>
+<div class="indent"><pre>
+&lt;presence from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit/bernie'&gt;
+  &lt;show&gt;away&lt;/show&gt;
+  &lt;status&gt;Out to lunch&lt;/status&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+&lt;/presence&gt;
+    </pre></div>
+    <p class="" style="">A nickname may also be included in a MUC room invitation:</p>
+    <p class="caption">Example 8. Occupant Sends MUC Invitation</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='elsinore@muc.shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite to='francisco@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Although the foregoing stanza may seem to violate the rule about associating a nick with the nearest ancestor element that specifies the sender's JID, the output from the MUC room does not violate that rule, since the room swaps the to and from addresses before sending the invitation to the invitee:</p>
+    <p class="caption">Example 9. MUC Room Forwards Invitation</p>
+<div class="indent"><pre>
+&lt;message from='elsinore@muc.shakespeare.lit' to='francisco@shakespeare.lit'&gt;
+  &lt;x xmlns='http://jabber.org/protocol/muc#user'&gt;
+    &lt;invite from='bernardo@shakespeare.lit'&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+    &lt;/invite&gt;
+  &lt;/x&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="waitlist">Waiting Lists</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Waiting Lists</span>  [<a href="#nt-id2259865">14</a>] defines a protocol that enables a user to be informed when a contact signs up for an IM account. The user MAY include his or her nick in the request so that the contact can associate a nickname with the request.</p>
+    <p class="caption">Example 10. IM User Requests Addition of Contact to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='bernardo@shakespeare.lit'
+    to='waitlist.shakespeare.lit'
+    id='wl1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+    &lt;/item&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Naturally, the WaitingListService SHOULD pass the nick on to its InteropPartners as well:</p>
+    <p class="caption">Example 11. ServiceProvider's WaitingListService Adds New Item to WaitingList</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.service-provider.com'
+    to='waitlist.interop-partner.com'
+    id='waitinglist2'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+    &lt;/item&gt;
+    &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BernieBoy&lt;/nick&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If an InteropPartner knows a contact's nickname when it returns results to the WaitingListService it SHOULD include the nickname:</p>
+    <p class="caption">Example 12. InteropPartner's WaitingListService Pushes Contact's JID to ServiceProvider's WaitingListService</p>
+<div class="indent"><pre>
+&lt;iq type='set'
+    from='waitlist.interop-partner.com'
+    to='waitlist.service-provider.com'
+    id='jidpush1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='user@domain'&gt;
+      &lt;uri scheme='tel'&gt;contact-number&lt;/uri&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;Frisco&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Finally, if the user's waiting list service knows the contact's nickname when it sends a notification to the user, it SHOULD include the nickname:</p>
+    <p class="caption">Example 13. WaitingListService Pushes Contact's JID to IM User</p>
+<div class="indent"><pre>
+&lt;message
+    from='waitlist.shakespeare.lit'
+    to='bernardo@shakespeare.lit'&gt;
+  &lt;body&gt;This message contains a WaitingList item.&lt;/body&gt;
+  &lt;waitlist xmlns='http://jabber.org/protocol/waitinglist'&gt;
+    &lt;item id='34567' jid='francisco@shakespeare.lit'&gt;
+      &lt;uri scheme='tel'&gt;+45-555-1212&lt;/uri&gt;
+      &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;Frisco&lt;/nick&gt;
+    &lt;/item&gt;
+  &lt;/waitlist&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.5 <a name="manage">Nickname Management</a>
+</h3>
+    <p class="" style="">In order for a user to modify his or her nickname and notify contacts of that change, it is RECOMMENDED for clients to use <span class="ref" style="">Personal Eventing via Pubsub</span>  [<a href="#nt-id2259996">15</a>] (a.k.a. PEP).</p>
+    <p class="caption">Example 14. User Publishes Updated Nickname to PEP Node</p>
+<div class="indent"><pre>
+&lt;iq from='bernardo@shakespeare.lit/patrol' 
+    type='set' 
+    id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/nick'&gt;
+      &lt;item&gt;
+        &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BBoD&lt;/nick&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 15. PEP Node Generates Notifications</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit' 
+         to='francisco@shakespeare.lit'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/nick'&gt;
+      &lt;item&gt;
+        &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BBoD&lt;/nick&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='bernardo@shakespeare.lit/patrol'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a JEP-0163-compliant personal eventing service is not available, a client SHOULD use a standalone <span class="ref" style="">Publish-Subscribe</span>  [<a href="#nt-id2260055">16</a>] service.</p>
+    <p class="caption">Example 16. User Publishes Updated Nickname to PubSub Node</p>
+<div class="indent"><pre>
+&lt;iq from='bernardo@shakespeare.lit/patrol' 
+    to='pubsub.shakespeare.lit' 
+    type='set' 
+    id='pub2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='841f3c8955c4c41a0cf99620d78a33b996659ded'&gt;
+      &lt;item&gt;
+        &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BBoD&lt;/nick&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="caption">Example 17. PubSub Node Generates Notifications</p>
+<div class="indent"><pre>
+&lt;message from='pubsub.shakespeare.lit' 
+         to='francisco@shakespeare.lit'
+         type='headline'
+         id='foo'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='841f3c8955c4c41a0cf99620d78a33b996659ded'&gt;
+      &lt;item&gt;
+        &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BBoD&lt;/nick&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='bernardo@shakespeare.lit/patrol'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+    <p class="" style="">If a client does not support <span style="font-weight: bold">JEP-0060</span> or the subset thereof specified in <span style="font-weight: bold">JEP-0163</span>, it MAY send one &lt;message/&gt; stanza to each of its contacts, containing the updated nickname (note: the client SHOULD send the messages in a staggered fashion in order to avoid server-enforced rate limiting, commonly known as "karma").</p>
+    <p class="caption">Example 18. Nickname Change Notification via Message</p>
+<div class="indent"><pre>
+&lt;message from='bernardo@shakespeare.lit/patrol' to='francisco@shakespeare.lit'&gt;
+  &lt;nick xmlns='http://jabber.org/protocol/nick'&gt;BBoD&lt;/nick&gt;
+&lt;/message&gt;
+.
+.
+.
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <p class="" style="">An IM client MAY use the user's own nickname as all or part of the "display name" shown to the user of that client (e.g., as the sending name in one-to-one chats and groupchats). For example, if the user whose JID is bernardo@shakespeare.lit asserts that his nickname is "BernieBoy", that user's client may show "BernieBoy" as all or part of the user's display name. How the client shall store the display name is out of scope for this document; possible mechanisms include the user's local vCard, an organizational LDAP directory, <span class="ref" style="">Private XML Storage</span>  [<a href="#nt-id2260153">17</a>], or <span style="font-weight: bold">JEP-0154</span>.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">A nickname is a memorable, friendly name asserted by a user. There is no guarantee that any given nickname will be unique even within a particulat community (such as an enterprise or university), let alone across the Internet through federation of communities. Clients SHOULD warn users that nicknames asserted by contacts are not unique and that nickname collisions are possible. Clients also MUST NOT depend on nicknames to validate the identity of contacts; instead, nicknames SHOULD be used in conjunction with JIDs (which are globally unique) and user-assigned handles (which are private and unique) as described in <span style="font-weight: bold">JEP-0165</span> in order to provide a three-pronged approach to identity validation, preferably in combination with X.509 certificates.</p>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260263">18</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260278">19</a>] shall include 'http://jabber.org/protocol/nick' in its registry of protocol namespaces.</p>
+  </div>
+<h2>9.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/nick'
+    xmlns='http://jabber.org/protocol/nick'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='nick' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<h2>10.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Ian Paterson for his feedback.</p>
+  <p class="" style="">Unbeknownst to the authors of this document, work on user nicknames was previously done by Richard Dobson (see &lt;<a href="http://richard.dobson-i.net/jep.php?html=jep-01xx.xml">http://richard.dobson-i.net/jep.php?html=jep-01xx.xml</a>&gt;).</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250837">1</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250873">2</a>. JEP-0165: Prevention of JID Spoofing &lt;<a href="http://www.jabber.org/jeps/jep-0165.html">http://www.jabber.org/jeps/jep-0165.html</a>&gt;.</p>
+<p><a name="nt-id2259322">3</a>. RFC 2821: Simple Mail Transfer Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2821.txt">http://www.ietf.org/rfc/rfc2821.txt</a>&gt;.</p>
+<p><a name="nt-id2259345">4</a>. RFC 3261: Session Initiation Protocol (SIP) &lt;<a href="http://www.ietf.org/rfc/rfc3261.txt">http://www.ietf.org/rfc/rfc3261.txt</a>&gt;.</p>
+<p><a name="nt-id2259364">5</a>. In RFC 3921, the name here called a "handle" is described as an "alias"; rfc3921 will be modified to use the term "handle" instead.</p>
+<p><a name="nt-id2259473">6</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2259438">7</a>. JEP-0154: User Profile &lt;<a href="http://www.jabber.org/jeps/jep-0154.html">http://www.jabber.org/jeps/jep-0154.html</a>&gt;.</p>
+<p><a name="nt-id2259485">8</a>. JEP-0077: In-Band Registration &lt;<a href="http://www.jabber.org/jeps/jep-0077.html">http://www.jabber.org/jeps/jep-0077.html</a>&gt;.</p>
+<p><a name="nt-id2259509">9</a>. Friend of a Friend (FOAF) &lt;<a href="http://xmlns.com/foaf/0.1/">http://xmlns.com/foaf/0.1/</a>&gt;.</p>
+<p><a name="nt-id2259416">10</a>. See &lt;<a href="http://xml.coverpages.org/xnal.html">http://xml.coverpages.org/xnal.html</a>&gt;.</p>
+<p><a name="nt-id2259541">11</a>. OASIS is a not-for-profit, international consortium that drives the development, convergence and adoption of e-business standards. For further information, see &lt;<a href="http://www.oasis-open.org/">http://www.oasis-open.org/</a>&gt;.</p>
+<p><a name="nt-id2259643">12</a>. JEP-0054: vcard-temp &lt;<a href="http://www.jabber.org/jeps/jep-0054.html">http://www.jabber.org/jeps/jep-0054.html</a>&gt;.</p>
+<p><a name="nt-id2259746">13</a>. JEP-0045: Multi-User Chat &lt;<a href="http://www.jabber.org/jeps/jep-0045.html">http://www.jabber.org/jeps/jep-0045.html</a>&gt;.</p>
+<p><a name="nt-id2259865">14</a>. JEP-0130: Waiting Lists &lt;<a href="http://www.jabber.org/jeps/jep-0130.html">http://www.jabber.org/jeps/jep-0130.html</a>&gt;.</p>
+<p><a name="nt-id2259996">15</a>. JEP-0163: Personal Eventing via Pubsub &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2260055">16</a>. JEP-0060: Publish-Subscribe &lt;<a href="http://www.jabber.org/jeps/jep-0060.html">http://www.jabber.org/jeps/jep-0060.html</a>&gt;.</p>
+<p><a name="nt-id2260153">17</a>. JEP-0049: Private XML Storage &lt;<a href="http://www.jabber.org/jeps/jep-0049.html">http://www.jabber.org/jeps/jep-0049.html</a>&gt;.</p>
+<p><a name="nt-id2260263">18</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260278">19</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.9 (2006-05-10)</h4>
+<div class="indent">
+<p class="" style="">Added pubsub examples.</p> (psa)
+    </div>
+<h4>Version 0.8 (2006-04-28)</h4>
+<div class="indent">
+<p class="" style="">Clarified terminology; explicitly mentioned that nickanmes must not be included in presence broadcasts (only subscription requests); added implementation note about display names.</p> (psa)
+    </div>
+<h4>Version 0.7 (2006-04-21)</h4>
+<div class="indent">
+<p class="" style="">Added further detail to waitlist example; added schema.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-03-27)</h4>
+<div class="indent">
+<p class="" style="">Specified security considerations.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-03-22)</h4>
+<div class="indent">
+<p class="" style="">Fixed MUC invite example; clarified that nick refers to entity associated with nearest ancestor element that specifies a sender; added waitlist example.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">To reflect use of dedicated namespace, (1) changed JEP type from Informational to Standards Track and (2) updated Jabber Registrar Considerations.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Modified to use dedicated namespace; added example for multi-user chat invitations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-03-08)</h4>
+<div class="indent">
+<p class="" style="">Added wrapper element from JEP-0154.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-01-22)</h4>
+<div class="indent">
+<p class="" style="">Added message exchange use case.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-01-18)</h4>
+<div class="indent">
+<p class="" style="">Added MUC and nickname management use cases; specified profile data syntax.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2005-09-12)</h4>
+<div class="indent">
+<p class="" style="">Initial version.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0174-0.1.html
+++ b/content/xep-0174-0.1.html
@@ -1,0 +1,247 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0174: Link-Local Messaging</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Link-Local Messaging">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document describes how to establish Jabber communications over local networks using zero-configuration networking.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-02-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0174">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0174: Link-Local Messaging</h1>
+<p>This document describes how to establish Jabber communications over local networks using zero-configuration networking.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0174<br>
+            Version: 0.1<br>
+            Last Updated: 2006-02-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 3927, draft-cheshire-dnsext-dns-sd, draft-cheshire-dnsext-multicastdns<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Link-Local%20Messaging%20(JEP-0174)">http://wiki.jabber.org/index.php/Link-Local Messaging (JEP-0174)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#addresses">Addresses</a>
+</dt>
+<dt>4.  <a href="#presence">Exchanging Presence</a>
+</dt>
+<dt>5.  <a href="#communication">Exchanging Jabber Communications</a>
+</dt>
+<dt>6.  <a href="#txtkeys">TXT Keys</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>10.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">XMPP as defined in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250802">1</a>] does not support direct client-to-client interactions, since it requires authentication with a server: an XMPP client is allowed access to the network only once it has authentication with a server, and the client is not granted access to the network if authentication fails for any reason. If a client attempts to communicate directly with another client, such communication will fail because all XMPP communications are sent through a server and a client cannot inject messages onto the network without first authenticating with a server.</p>
+  <p class="" style="">However, it is possible to establish an XMPP-like communications system on a local network using zero-configuration networking. In this situation, the clients obviate the XMPP requirement for authentication with a server by relying on zero-configuration networking to establish link-local addresses using the _presence._tcp DNS SRV service type. Once discovery has been completed, the clients are then able to exchange messages and other structured data using the XMPP &lt;message/&gt; and &lt;iq/&gt; stanzas. Note well that such communications are restricted to the local network because of how zero-configuration networking works. It is impossible for clients that communicate via link-local addresses to insert messages into an XMPP network, which is why this kind of "client mesh" is most accurately referred to as an XMPP-like system that exists outside the context of existing XMPP networks.</p>
+  <p class="" style="">Such local, peer-to-peer Jabber meshes can be quite valuable in certain circumstances. For instance, participants in a trade show or conference, users of the same WiFi hotspot, or employees on the same local area network can communicate without the need for a pre-configured server. For this reason, support for local Jabber communication has been built into Apple's iChat client when operating in Bonjour (formerly Rendezvous) mode. Because it is desirable for other Jabber clients to support such functionality, this document describes how to use zero-configuration networking as the basis for local Jabber communication.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Terminology</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Bonjour</td>
+      <td align="" colspan="" rowspan="">Apple Computer's implementation of zero-configuration networking, formerly known as Rendezvous. See &lt;<a href="http://www.apple.com/macosx/features/bonjour/">http://www.apple.com/macosx/features/bonjour/</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">DNS-SD</td>
+      <td align="" colspan="" rowspan="">A convention for naming and structuring DNS SRV records (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2250991">2</a>]) such that a client can dynamically discover a domain for a service using only standard DNS queries. See <span class="ref" style="">DNS-Based Service Discovery</span>  [<a href="#nt-id2250949">3</a>]. For a full list of registered DNS-SD records, see &lt;<a href="http://www.dns-sd.org/ServiceTypes.html">http://www.dns-sd.org/ServiceTypes.html</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Link-local address</td>
+      <td align="" colspan="" rowspan="">An IPv4 or IPv6 address that is valid for communication with other devices connected to the same physical or logical link. See <span class="ref" style="">RFC 3927</span>  [<a href="#nt-id2251027">4</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Multicast DNS</td>
+      <td align="" colspan="" rowspan="">A technology that provides the ability to perform DNS-like operations on the local link in the absence of any conventional unicast DNS server. See <span class="ref" style="">Multicast DNS</span>  [<a href="#nt-id2251069">5</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Zero-configuration networking</td>
+      <td align="" colspan="" rowspan="">A set of technologies that enable the use of the Internet Protocol for local communications. See &lt;<a href="http://www.zeroconf.org/">http://www.zeroconf.org/</a>&gt;.</td> 
+    </tr>
+  </table>
+<h2>3.
+       <a name="addresses">Addresses</a>
+</h2>
+  <p class="" style="">In order to advertise its availability on a local network, a client MUST advertise a DNS-SD service of "_presence._tcp.machine-name.local.". For example, if the machine is "roundabout", the advertised service would be "_presence._tcp.roundabout.local.". The IPv4 and IPv6 addresses associated with that machine will vary depending on the local network to which the machine is connected. For example, on an Ethernet connection the physical address might be as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+10.2.1.187:5298
+[fe80:20d:93ff:fe2c:5c18]:5298
+  </pre></div>
+  <p class="" style="">However, when the machine is connected to a wireless network at a conference, its physical address might change to the following:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+10.10.1.179:5298
+[fe80::20d:93ff:fe89:4eba]:5298
+  </pre></div>
+  <p class="" style="">The JID shown to other entities on the network SHOULD be of the form "user@machine-name". For instance, in the foregoing examples, the user's address would be shown as "stpeter@roundabout".</p>
+<h2>4.
+       <a name="presence">Exchanging Presence</a>
+</h2>
+  <p class="" style="">When the _presence._tcp service is used, presence is exchanged via the format described in the <a href="#txtkeys">TXT Keys</a> section of this document. In particular, presence information is not pushed as in XMPP (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2256590">6</a>]). Instead, clients poll for the presence of other local entities by periodically sending new DNS SRV requests for the _presence._tcp service. When the number of local entities is large, polling can result in a large number of request and response packets being sent over the local network. Therefore, care should be taken to minimize the number of polls (e.g., polling no more than once a minute on networks with a small number of entities and no more than once every several minutes on networks with a large number of entities).</p>
+<h2>5.
+       <a name="communication">Exchanging Jabber Communications</a>
+</h2>
+  <p class="" style="">In order to exchange Jabber communications, the sender specifies 'to' and 'from' addresses using the logical local addresses:</p>
+  <p class="caption">Example 1. Sending a Message</p>
+<div class="indent"><pre>
+&lt;message to='hildjj@wolfram' from='stpeter@roundabout'&gt;
+  &lt;body&gt;hey, testing out link-local communications&lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>6.
+       <a name="txtkeys">TXT Keys</a>
+</h2>
+  <p class="" style="">DNS-SD enables service definitions to include various TXT keys that specify parameters to be used in the context of the service type. The TXT keys defined for the _presence._tcp service are as follows:</p>
+  <p class="caption">Table 2: TXT Keys</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Key</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">1st</td>
+      <td align="" colspan="" rowspan="">The first name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">email</td>
+      <td align="" colspan="" rowspan="">The email address of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jid</td>
+      <td align="" colspan="" rowspan="">The Jabber ID of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">last</td>
+      <td align="" colspan="" rowspan="">The last name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">msg</td>
+      <td align="" colspan="" rowspan="">Natural-language text describing the user's state. This is equivalent to the XMPP &lt;status/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">phsh</td>
+      <td align="" colspan="" rowspan="">The SHA-1 hash of the user's avatar icon or photo.  [<a href="#nt-id2256776">7</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">port.p2pj</td>
+      <td align="" colspan="" rowspan="">The port for peer-to-peer Jabber communications. The port SHOULD be 5298.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">status</td>
+      <td align="" colspan="" rowspan="">The presence availability of the user. Allowable values are "avail" and "dnd".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">txtvers</td>
+      <td align="" colspan="" rowspan="">The version of the TXT fields supported by the client. This document describes txtvers "1".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">vc</td>
+      <td align="" colspan="" rowspan="">A flag advertising the user's ability to engage in video conferencing. Allowable values are "C!".</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP networks depend on TLS (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2256899">8</a>]) for channel encryption, SASL (<span class="ref" style="">RFC 2222</span>  [<a href="#nt-id2256921">9</a>]) for authentication, and the Domain Name System (<span class="ref" style="">RFC 1034</span>  [<a href="#nt-id2256956">10</a>]) for validation of server hostnames; these technologies help to ensure the identity of sending entities. By contrast, zero-configuration networking uses dynamic discovery and asserted machine names as the basis of sender identity. Because of the extremely different nature of full XMPP networks and localized client meshes, local entities MUST NOT attempt to inject local traffic onto an XMPP network and an XMPP server MUST reject communications until an entity is properly authenticated. However, a client on a local peer-to-peer mesh MAY forward traffic to an XMPP network after having properly authenticated on such a network (e.g., to forward a message received on a local client mesh to a contact on an XMPP network).</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The p2pj port of 5298 is not included in the <span class="ref" style="">IANA Port Numbers Registry</span>  [<a href="#nt-id2256998">11</a>] maintained by the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257021">12</a>]. The author will investigate whether the port needs to be registered.</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257061">13</a>].</p>
+<h2>10.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jens Alfke for his assistance.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250802">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250991">2</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2250949">3</a>. DNS-Based Service Discovery &lt;<a href="http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt">http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2251027">4</a>. RFC 3927: Dynamic Configuration of IPv4 Link-Local Addresses &lt;<a href="http://www.ietf.org/rfc/rfc3927.txt">http://www.ietf.org/rfc/rfc3927.txt</a>&gt;.</p>
+<p><a name="nt-id2251069">5</a>. Multicast DNS &lt;<a href="http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt">http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256590">6</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256776">7</a>. The client should keep a local cache of icons keyed by hash. If the phsh value is not in the cache, the client should fetch the unknown icon and then caches it. Implementations should also include logic for expiring avatar icons.</p>
+<p><a name="nt-id2256899">8</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2256921">9</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p><a name="nt-id2256956">10</a>. RFC 1034: Domain Names - Concepts and Facilities &lt;<a href="http://www.ietf.org/rfc/rfc1034.txt">http://www.ietf.org/rfc/rfc1034.txt</a>&gt;.</p>
+<p><a name="nt-id2256998">11</a>. IANA registry of port numbers &lt;<a href="http://www.iana.org/assignments/port-numbers">http://www.iana.org/assignments/port-numbers</a>&gt;.</p>
+<p><a name="nt-id2257021">12</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257061">13</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-02-09)</h4>
+<div class="indent">Initial JEP version; changed title to Link-Local Messaging. (psa)
+    </div>
+<h4>Version 0.0.1 (2006-02-07)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0174-0.2.html
+++ b/content/xep-0174-0.2.html
@@ -1,0 +1,265 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0174: Link-Local Messaging</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Link-Local Messaging">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document describes how to establish Jabber communications over local networks using zero-configuration networking.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-02-22">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0174">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0174: Link-Local Messaging</h1>
+<p>This document describes how to establish Jabber communications over local networks using zero-configuration networking.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0174<br>
+            Version: 0.2<br>
+            Last Updated: 2006-02-22<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 3927, draft-cheshire-dnsext-dns-sd, draft-cheshire-dnsext-multicastdns<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Link-Local%20Messaging%20(JEP-0174)">http://wiki.jabber.org/index.php/Link-Local Messaging (JEP-0174)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#addresses">Addresses</a>
+</dt>
+<dt>4.  <a href="#presence">Exchanging Presence</a>
+</dt>
+<dt>5.  <a href="#communication">Exchanging Jabber Communications</a>
+</dt>
+<dt>6.  <a href="#txtkeys">TXT Keys</a>
+</dt>
+<dt>7.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>8.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>9.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>10.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">XMPP as defined in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2254000">1</a>] does not support direct client-to-client interactions, since it requires authentication with a server: an XMPP client is allowed access to the network only once it has authentication with a server, and the client is not granted access to the network if authentication fails for any reason. If a client attempts to communicate directly with another client, such communication will fail because all XMPP communications are sent through a server and a client cannot inject messages onto the network without first authenticating with a server.</p>
+  <p class="" style="">However, it is possible to establish an XMPP-like communications system on a local network using zero-configuration networking. In this situation, the clients obviate the XMPP requirement for authentication with a server by relying on zero-configuration networking to establish link-local communiation using the _presence._tcp DNS SRV service type. Once discovery has been completed, the clients are then able to exchange messages and other structured data using the XMPP &lt;message/&gt; and &lt;iq/&gt; stanzas. Note well that such communications are restricted to the local network because of how zero-configuration networking works. It is impossible for clients that communicate via link-local addresses to insert messages into an XMPP network, which is why this kind of "client mesh" is most accurately referred to as an XMPP-like system that exists outside the context of existing XMPP networks.</p>
+  <p class="" style="">Such local, peer-to-peer Jabber meshes can be quite valuable in certain circumstances. For instance, participants in a trade show or conference, users of the same WiFi hotspot, or employees on the same local area network can communicate without the need for a pre-configured server. For this reason, support for local Jabber communication has been built into Apple's iChat client when operating in Bonjour (formerly Rendezvous) mode. Because it is desirable for other Jabber clients to support such functionality, this document describes how to use zero-configuration networking as the basis for local Jabber communication.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Terminology</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Bonjour</td>
+      <td align="" colspan="" rowspan="">Apple Computer's implementation of zero-configuration networking, formerly known as Rendezvous. See &lt;<a href="http://www.apple.com/macosx/features/bonjour/">http://www.apple.com/macosx/features/bonjour/</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">DNS-SD</td>
+      <td align="" colspan="" rowspan="">A convention for naming and structuring DNS SRV records (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2250709">2</a>]) such that a client can dynamically discover a domain for a service using only standard DNS queries. See <span class="ref" style="">DNS-Based Service Discovery</span>  [<a href="#nt-id2250869">3</a>]. For a full list of registered DNS-SD records, see &lt;<a href="http://www.dns-sd.org/ServiceTypes.html">http://www.dns-sd.org/ServiceTypes.html</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Link-local address</td>
+      <td align="" colspan="" rowspan="">An IPv4 or IPv6 address that is valid for communication with other devices connected to the same physical or logical link. See <span class="ref" style="">RFC 3927</span>  [<a href="#nt-id2250734">4</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Multicast DNS</td>
+      <td align="" colspan="" rowspan="">A technology that provides the ability to perform DNS-like operations on the local link in the absence of any conventional unicast DNS server. See <span class="ref" style="">Multicast DNS</span>  [<a href="#nt-id2250776">5</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">PTR record</td>
+      <td align="" colspan="" rowspan="">A DNS pointer record, which enables reverse DNS lookups. For IPv4, see <span class="ref" style="">RFC 2317</span>  [<a href="#nt-id2250818">6</a>]; for IPv6, see <span class="ref" style="">RFC 1886</span>  [<a href="#nt-id2250840">7</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Zero-configuration networking</td>
+      <td align="" colspan="" rowspan="">A set of technologies that enable the use of the Internet Protocol for local communications. See &lt;<a href="http://www.zeroconf.org/">http://www.zeroconf.org/</a>&gt;.</td> 
+    </tr>
+  </table>
+<h2>3.
+       <a name="addresses">Addresses</a>
+</h2>
+  <p class="" style="">In order to advertise its availability on a local network, a client MUST advertise a DNS-SD service of "machine-name._presence._tcp.local." (where "machine-name" is the &lt;Instance&gt; portion of the Service Instance Name, "_presence._tcp" is the &lt;Service&gt; portion, and "local." is the &lt;Domain&gt; portion). For example, if the machine is "roundabout", the advertised service would be "roundabout._presence._tcp.local.". The IPv4 and IPv6 addresses associated with that machine will vary depending on the local network to which the machine is connected. For example, on an Ethernet connection the physical address might be as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+10.2.1.187:7363
+[fe80:20d:93ff:fe2c:5c18]:7363
+  </pre></div>
+  <p class="" style="">However, when the machine is connected to a wireless network at a conference, its physical address might change to the following:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+10.10.1.179:7363
+[fe80::20d:93ff:fe89:4eba]:7363
+  </pre></div>
+  <p class="" style="">A client MUST also advertise an appropriate DNS PTR record, such as:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+187.1.2.10.in-addr.arpa 7363 IN PTR 
+  </pre></div>
+  <p class="" style="">In order to determine the port to use for link-local messaging, a client MUST use the port as discovered via DNS SRV lookup as validated via the PTR record.</p>
+  <p class="" style="">The JID shown to other entities on the network SHOULD be of the form "user@machine-name". For instance, in the foregoing examples, the user's address would be shown as "stpeter@roundabout".</p>
+<h2>4.
+       <a name="presence">Exchanging Presence</a>
+</h2>
+  <p class="" style="">When the _presence._tcp service is used, presence is exchanged via the format described in the <a href="#txtkeys">TXT Keys</a> section of this document. In particular, presence information is not pushed as in XMPP (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2256781">8</a>]). Instead, clients listen for presence announcements from other local entities. Recommended rates for sending updates can be found in <span style="font-weight: bold">draft-cheshire-dnsext-multicastdns</span>.</p>
+<h2>5.
+       <a name="communication">Exchanging Jabber Communications</a>
+</h2>
+  <p class="" style="">In order to exchange Jabber communications, the sender specifies 'to' and 'from' addresses using the logical local addresses:</p>
+  <p class="caption">Example 1. Sending a Message</p>
+<div class="indent"><pre>
+&lt;message to='hildjj@wolfram' from='stpeter@roundabout'&gt;
+  &lt;body&gt;hey, testing out link-local communications&lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>6.
+       <a name="txtkeys">TXT Keys</a>
+</h2>
+  <p class="" style="">DNS-SD enables service definitions to include various TXT keys that specify parameters to be used in the context of the service type. The TXT keys defined for the _presence._tcp service are as follows:</p>
+  <p class="caption">Table 2: TXT Keys</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Key</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">1st</td>
+      <td align="" colspan="" rowspan="">The first name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">email</td>
+      <td align="" colspan="" rowspan="">The email address of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jid</td>
+      <td align="" colspan="" rowspan="">The Jabber ID of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">last</td>
+      <td align="" colspan="" rowspan="">The last name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">msg</td>
+      <td align="" colspan="" rowspan="">Natural-language text describing the user's state. This is equivalent to the XMPP &lt;status/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">phsh</td>
+      <td align="" colspan="" rowspan="">The SHA-1 hash of the user's avatar icon or photo.  [<a href="#nt-id2256975">9</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">port.p2pj</td>
+      <td align="" colspan="" rowspan="">The (hardcoded) port for peer-to-peer Jabber communications. Clients MUST use the port discovered via SRV lookups and MUST ignore the value of this TXT field.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">status</td>
+      <td align="" colspan="" rowspan="">The presence availability of the user. Allowable values are "avail" and "dnd".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">txtvers</td>
+      <td align="" colspan="" rowspan="">The version of the TXT fields supported by the client. This document describes txtvers "1".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">vc</td>
+      <td align="" colspan="" rowspan="">A flag advertising the user's ability to engage in video conferencing. Allowable values are "C!".</td>
+    </tr>
+  </table>
+<h2>7.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP networks depend on TLS (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2257097">10</a>]) for channel encryption, SASL (<span class="ref" style="">RFC 2222</span>  [<a href="#nt-id2257119">11</a>]) for authentication, and the Domain Name System (<span class="ref" style="">RFC 1034</span>  [<a href="#nt-id2257149">12</a>]) for validation of server hostnames; these technologies help to ensure the identity of sending entities. By contrast, zero-configuration networking uses dynamic discovery and asserted machine names as the basis of sender identity. Because of the extremely different nature of full XMPP networks and localized client meshes, local entities MUST NOT attempt to inject local traffic onto an XMPP network and an XMPP server MUST reject communications until an entity is properly authenticated. However, a client on a local peer-to-peer mesh MAY forward traffic to an XMPP network after having properly authenticated on such a network (e.g., to forward a message received on a local client mesh to a contact on an XMPP network).</p>
+<h2>8.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The p2pj port of 5298 is not included in the <span class="ref" style="">IANA Port Numbers Registry</span>  [<a href="#nt-id2257194">13</a>] maintained by the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257218">14</a>]. The author will investigate whether the port needs to be registered.</p>
+<h2>9.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257257">15</a>].</p>
+<h2>10.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jens Alfke and Marc Krochmal for their input.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2254000">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250709">2</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2250869">3</a>. DNS-Based Service Discovery &lt;<a href="http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt">http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250734">4</a>. RFC 3927: Dynamic Configuration of IPv4 Link-Local Addresses &lt;<a href="http://www.ietf.org/rfc/rfc3927.txt">http://www.ietf.org/rfc/rfc3927.txt</a>&gt;.</p>
+<p><a name="nt-id2250776">5</a>. Multicast DNS &lt;<a href="http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt">http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250818">6</a>. RFC 2317: Classless IN-ADDR.ARPA delegation &lt;<a href="http://www.ietf.org/rfc/rfc2317.txt">http://www.ietf.org/rfc/rfc2317.txt</a>&gt;.</p>
+<p><a name="nt-id2250840">7</a>. RFC 1886: DNS Extensions to support IP version 6 &lt;<a href="http://www.ietf.org/rfc/rfc1886.txt">http://www.ietf.org/rfc/rfc1886.txt</a>&gt;.</p>
+<p><a name="nt-id2256781">8</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2256975">9</a>. The client should keep a local cache of icons keyed by hash. If the phsh value is not in the cache, the client should fetch the unknown icon and then caches it. Implementations should also include logic for expiring avatar icons.</p>
+<p><a name="nt-id2257097">10</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2257119">11</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p><a name="nt-id2257149">12</a>. RFC 1034: Domain Names - Concepts and Facilities &lt;<a href="http://www.ietf.org/rfc/rfc1034.txt">http://www.ietf.org/rfc/rfc1034.txt</a>&gt;.</p>
+<p><a name="nt-id2257194">13</a>. IANA registry of port numbers &lt;<a href="http://www.iana.org/assignments/port-numbers">http://www.iana.org/assignments/port-numbers</a>&gt;.</p>
+<p><a name="nt-id2257218">14</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257257">15</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-02-22)</h4>
+<div class="indent">
+<p class="" style="">Corrected information about Service Instance Name format, p2pj port, and presence discovery process.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version; changed title to Link-Local Messaging.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-02-07)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0174-0.3.html
+++ b/content/xep-0174-0.3.html
@@ -1,0 +1,344 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0174: Link-Local Messaging</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Link-Local Messaging">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-02-23">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0174">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0174: Link-Local Messaging</h1>
+<p>This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0174<br>
+            Version: 0.3<br>
+            Last Updated: 2006-02-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 3927, draft-cheshire-dnsext-dns-sd, draft-cheshire-dnsext-multicastdns<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Link-Local%20Messaging%20(JEP-0174)">http://wiki.jabber.org/index.php/Link-Local Messaging (JEP-0174)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#dns">DNS Records</a>
+</dt>
+<dl><dt>3.1.  <a href="#txt">TXT Records</a>
+</dt></dl>
+<dt>4.  <a href="#disco">Discovering Other Users</a>
+</dt>
+<dt>5.  <a href="#presence">Exchanging Presence</a>
+</dt>
+<dt>6.  <a href="#comms">Exchanging Messages</a>
+</dt>
+<dt>7.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>11.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">XMPP as defined in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250854">1</a>] does not support direct client-to-client interactions, since it requires authentication with a server: an XMPP client is allowed access to the network only once it has authentication with a server, and the client is not granted access to the network if authentication fails for any reason. If a client attempts to communicate directly with another client, such communication will fail because all XMPP communications are sent through a server and a client cannot inject messages onto the network without first authenticating with a server.</p>
+  <p class="" style="">However, it is possible to establish an XMPP-like communications system on a local network using zero-configuration networking. In this situation, the clients obviate the XMPP requirement for authentication with a server by relying on zero-configuration networking to establish link-local communiation using the _presence._tcp DNS SRV service type. Once discovery has been completed, the clients are then able to exchange messages and other structured data using the XMPP &lt;message/&gt; and &lt;iq/&gt; stanzas. Note well that such communications are restricted to the local network because of how zero-configuration networking works. It is impossible for clients that communicate via link-local addresses to insert messages into an XMPP network, which is why this kind of local "mesh" is most accurately referred to as an XMPP-like system that exists outside the context of existing XMPP networks.</p>
+  <p class="" style="">Such a local "mesh" can be quite valuable in certain circumstances. For instance, participants in a trade show or conference, users of the same WiFi hotspot, or employees on the same local area network can communicate without the need for a pre-configured server. For this reason, support for link-local messaging has been built into Apple's iChat client when operating in Bonjour (formerly Rendezvous) mode. Because it is desirable for other Jabber clients to support such functionality, this document describes how to use zero-configuration networking as the basis for local Jabber communication.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Terminology</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Bonjour</td>
+      <td align="" colspan="" rowspan="">Apple Computer's implementation of zero-configuration networking, formerly known as Rendezvous. See &lt;<a href="http://www.apple.com/macosx/features/bonjour/">http://www.apple.com/macosx/features/bonjour/</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">DNS-SD</td>
+      <td align="" colspan="" rowspan="">A convention for naming and structuring DNS SRV records such that a client can dynamically discover a domain for a service using only standard DNS queries. See <span class="ref" style="">DNS-Based Service Discovery</span>  [<a href="#nt-id2251010">2</a>]. For a full list of registered DNS-SD records, see &lt;<a href="http://www.dns-sd.org/ServiceTypes.html">http://www.dns-sd.org/ServiceTypes.html</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Link-local address</td>
+      <td align="" colspan="" rowspan="">An IPv4 or IPv6 address that is valid for communication with other devices connected to the same physical or logical link. See <span class="ref" style="">RFC 3927</span>  [<a href="#nt-id2251027">3</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Multicast DNS</td>
+      <td align="" colspan="" rowspan="">A technology that provides the ability to perform DNS-like operations on a local link in the absence of any conventional unicast DNS server. See <span class="ref" style="">Multicast DNS</span>  [<a href="#nt-id2251070">4</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Zero-configuration networking</td>
+      <td align="" colspan="" rowspan="">A set of technologies that enable the use of the Internet Protocol for local communications. See &lt;<a href="http://www.zeroconf.org/">http://www.zeroconf.org/</a>&gt;.</td> 
+    </tr>
+  </table>
+<h2>3.
+       <a name="dns">DNS Records</a>
+</h2>
+  <p class="" style="">In order to advertise its availability for link-local messaging, a client MUST publish four different kinds of DNS records:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">An "A" record of the form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+machine-name.local. A ip-address
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">An "SRV" record (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2256693">5</a>]) of the form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp &lt;ttl&gt; IN SRV &lt;priority&gt; &lt;weight&gt; port-number username@machine-name.local. 
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">A "PTR" record (see <span class="ref" style="">RFC 2317</span>  [<a href="#nt-id2256728">6</a>] and <span class="ref" style="">RFC 1886</span>  [<a href="#nt-id2256750">7</a>]) of the form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+reverse-ip-address.in-addr-arpa. port-number IN PTR username@machine-name.local.
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Various "TXT" records (see <span class="ref" style="">RFC 1464</span>  [<a href="#nt-id2256783">8</a>]) of the following form (see the <a href="#txt">TXT Records</a> section of this document for an explanation of these fields):</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;owner&gt; IN &lt;ttl&gt; TXT "1st=user-first-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "email=user-email-address"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "jid=user-jabber-id"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "last=user-last-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "msg=freeform-availability-status"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "phsh=sha1-hash-of-avatar"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "port.p2pj=5298"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "status=avail-or-dnd"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "txtvers=1"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "vc=CU!-or-C!"
+      </pre></div>
+    </li>
+  </ol>
+  <p class="" style="">The "machine-name" is the name of the computer, the "username" is the system username of the principal currently logged into the computer, the "port" may be any unassigned port number, the "ip-address" is the physical address of the computer on the local network, and the "reverse-ip-address" is the physical address in reverse order (as specified in <span style="font-weight: bold">RFC 2317</span> for IPv4 and <span style="font-weight: bold">RFC 1886</span> for IPv6).</p>
+  <p class="" style="">So, for example, if the machine name is "roundabout", the username is "stpeter", the chosen port is "5526", the IP address is "10.2.1.187" (resulting in a reverse IP address of "187.1.2.10"), and the personal information is that associated with the author of this document, the DNS records would be as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+roundabout.local. A 10.2.1.187
+
+_presence._tcp IN SRV 5526 stpeter@roundabout.local. 
+
+187.1.2.10.in-addr-arpa. 5526 IN PTR stpeter@roundabout.local.
+
+psa IN TXT "1st=Peter"
+psa IN TXT "email=stpeter@jabber.org"
+psa IN TXT "jid=stpeter@jabber.org"
+psa IN TXT "last=Saint-Andre"
+psa IN TXT "msg=on the phone"
+psa IN TXT "phsh=a3839614e1a382bcfebbcf20464f519e81770813"
+psa IN TXT "port.p2pj=5298"
+psa IN TXT "status=dnd"
+psa IN TXT "txtvers=1"
+psa IN TXT "vc=CU!"
+  </pre></div>
+  <p class="" style="">The IPv4 and IPv6 addresses associated with a machine will vary depending on the local network to which the machine is connected. For example, on an Ethernet connection the physical address might be "10.2.1.187" but when the machine is connected to a wireless network, its physical address might change to "10.10.1.179".</p>
+  <div class="indent">
+<h3>3.1 <a name="txt">TXT Records</a>
+</h3>
+  <p class="" style="">DNS-SD enables service definitions to include various TXT keys that specify parameters to be used in the context of the service type. The TXT keys defined for the _presence._tcp service are as follows:</p>
+  <p class="caption">Table 2: TXT Records</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">1st</td>
+      <td align="" colspan="" rowspan="">The first name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">email</td>
+      <td align="" colspan="" rowspan="">The email address of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jid</td>
+      <td align="" colspan="" rowspan="">The Jabber ID of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">last</td>
+      <td align="" colspan="" rowspan="">The last name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">msg</td>
+      <td align="" colspan="" rowspan="">Natural-language text describing the user's state. This is equivalent to the XMPP &lt;status/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">phsh</td>
+      <td align="" colspan="" rowspan="">The SHA-1 hash of the user's avatar icon or photo.  [<a href="#nt-id2250435">9</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">port.p2pj</td>
+      <td align="" colspan="" rowspan="">The (hardcoded) port for peer-to-peer Jabber communications. Clients MUST use the port discovered via SRV lookups and MUST ignore the value of this TXT field.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">status</td>
+      <td align="" colspan="" rowspan="">The presence availability of the user. Allowable values are "avail" and "dnd".  [<a href="#nt-id2250486">10</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">txtvers</td>
+      <td align="" colspan="" rowspan="">The version of the TXT fields supported by the client. This document describes txtvers "1".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">vc</td>
+      <td align="" colspan="" rowspan="">A flag advertising the user's ability to engage in video conferencing. Allowable values are "C!" and "CU!".</td>
+    </tr>
+  </table>
+</div>
+<h2>4.
+       <a name="disco">Discovering Other Users</a>
+</h2>
+  <p class="" style="">In order to discover other users, a client sends out a broadcast request for PTR records. The client then queries each entity by sending PTR, SRV, and TXT requests to those entities.</p>
+  <p class="" style="">(Details to follow.)</p>
+<h2>5.
+       <a name="presence">Exchanging Presence</a>
+</h2>
+  <p class="" style="">When the _presence._tcp service is used, presence is exchanged via the format described in the <a href="#txt">TXT Records</a> section of this document. In particular, presence information is not pushed as in XMPP (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2257329">11</a>]). Instead, clients listen for presence announcements from other local entities. Recommended rates for sending updates can be found in <span style="font-weight: bold">draft-cheshire-dnsext-multicastdns</span>.</p>
+<h2>6.
+       <a name="comms">Exchanging Messages</a>
+</h2>
+  <p class="" style="">In order to exchange Jabber communications, the sender opens a TCP connection on the discovered port and opens a stream to the recipient with no 'to' or 'from' address:</p>
+  <p class="caption">Example 1. Opening a Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The recipient then responds with a stream header as well:</p>
+  <p class="caption">Example 2. Stream Header Response</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The sender then can send messages (or IQs) by specifying 'to' and 'from' addresses using the logical local addresses:  [<a href="#nt-id2257386">12</a>]</p>
+  <p class="caption">Example 3. Sending a Message</p>
+<div class="indent"><pre>
+&lt;message to='hildjj@wolfram' from='stpeter@roundabout'&gt;
+  &lt;body&gt;hey, testing out link-local messaging&lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">To end the chat, close the stream:</p>
+  <p class="caption">Example 4. Ending the Chat</p>
+<div class="indent"><pre>
+&lt;/stream:stream&gt;
+  </pre></div>
+<h2>7.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">The DNS does not allow characters outside of the <span class="ref" style="">US-ASCII</span>  [<a href="#nt-id2257438">13</a>] character set in A, SRV, PTR, or TXT records. This can pose problems when using the DNS in conjunction with XMPP-like systems, since XMPP allows virtually the full range of <span class="ref" style="">Unicode</span>  [<a href="#nt-id2257458">14</a>] characters in usernames and availability status messages. If any non-US-ASCII characters are to be included, they MUST be converted to percent-encoded octets following the rules specified in Section 2.6 of <span class="ref" style="">RFC 4395</span>  [<a href="#nt-id2257474">15</a>].</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP networks depend on TLS (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2257522">16</a>]) for channel encryption, SASL (<span class="ref" style="">RFC 2222</span>  [<a href="#nt-id2257545">17</a>]) for authentication, and the Domain Name System (<span class="ref" style="">RFC 1034</span>  [<a href="#nt-id2257566">18</a>]) for validation of server hostnames; these technologies help to ensure the identity of sending entities. By contrast, zero-configuration networking uses dynamic discovery and asserted machine names as the basis of sender identity. Therefore, zero-configuration networking does not result in authenticated identities in the same way that XMPP itself does, nor does it provide for an encrypted channel between local entities. (TLS could be negotiated on the local streams, but is out of scope for this specification.)</p>
+  <p class="" style="">Because of the extremely different nature of a true XMPP network and a localized client "mesh", local entities MUST NOT attempt to inject local traffic onto an XMPP network and an XMPP server MUST reject communications until an entity is properly authenticated. However, a client on a local mesh MAY forward traffic to an XMPP network after having properly authenticated on such a network (e.g., to forward a message received on a local client mesh to a contact on an XMPP network).</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The p2pj port number 5298 is not included in the <span class="ref" style="">IANA Port Numbers Registry</span>  [<a href="#nt-id2257661">19</a>] maintained by the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257610">20</a>]. The author will investigate whether that port number (or some other port number) needs to be registered.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257695">21</a>].</p>
+<h2>11.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jens Alfke, Marc Krochmal, and Justin Karneges for their input.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250854">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251010">2</a>. DNS-Based Service Discovery &lt;<a href="http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt">http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2251027">3</a>. RFC 3927: Dynamic Configuration of IPv4 Link-Local Addresses &lt;<a href="http://www.ietf.org/rfc/rfc3927.txt">http://www.ietf.org/rfc/rfc3927.txt</a>&gt;.</p>
+<p><a name="nt-id2251070">4</a>. Multicast DNS &lt;<a href="http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt">http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256693">5</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2256728">6</a>. RFC 2317: Classless IN-ADDR.ARPA delegation &lt;<a href="http://www.ietf.org/rfc/rfc2317.txt">http://www.ietf.org/rfc/rfc2317.txt</a>&gt;.</p>
+<p><a name="nt-id2256750">7</a>. RFC 1886: DNS Extensions to support IP version 6 &lt;<a href="http://www.ietf.org/rfc/rfc1886.txt">http://www.ietf.org/rfc/rfc1886.txt</a>&gt;.</p>
+<p><a name="nt-id2256783">8</a>. RFC 1464: Using the Domain Name System To Store Arbitrary String Attributes &lt;<a href="http://www.ietf.org/rfc/rfc1464.txt">http://www.ietf.org/rfc/rfc1464.txt</a>&gt;.</p>
+<p><a name="nt-id2250435">9</a>. The client should keep a local cache of icons keyed by hash. If the phsh value is not in the cache, the client should fetch the unknown icon and then cache it. Implementations should also include logic for expiring avatar icons.</p>
+<p><a name="nt-id2250486">10</a>. These values effectively map to mere XMPP presence (the user is online or available) and the XMPP &lt;show/&gt; value of "away".</p>
+<p><a name="nt-id2257329">11</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257386">12</a>. The "JIDs" MUST be of the form "username@machine-name" as discovered via SRV (this is the &lt;Instance&gt; portion of the Service Instance Name).</p>
+<p><a name="nt-id2257438">13</a>. Coded Character Set - 7-bit American Standard Code for Information Interchange (American National Standards Institute X3.4, 1986).</p>
+<p><a name="nt-id2257458">14</a>. The Unicode Standard, Version 3.2.0 (The Unicode Consortium, 2000).</p>
+<p><a name="nt-id2257474">15</a>. RFC 4395: Guidelines and Registration Procedures for New URI Schemes &lt;<a href="http://www.ietf.org/rfc/rfc4395.txt">http://www.ietf.org/rfc/rfc4395.txt</a>&gt;.</p>
+<p><a name="nt-id2257522">16</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2257545">17</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p><a name="nt-id2257566">18</a>. RFC 1034: Domain Names - Concepts and Facilities &lt;<a href="http://www.ietf.org/rfc/rfc1034.txt">http://www.ietf.org/rfc/rfc1034.txt</a>&gt;.</p>
+<p><a name="nt-id2257661">19</a>. IANA registry of port numbers &lt;<a href="http://www.iana.org/assignments/port-numbers">http://www.iana.org/assignments/port-numbers</a>&gt;.</p>
+<p><a name="nt-id2257610">20</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257695">21</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-02-23)</h4>
+<div class="indent">
+<p class="" style="">Added more details about DNS setup and stream initiation; specified internationalization considerations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-02-22)</h4>
+<div class="indent">
+<p class="" style="">Corrected information about Service Instance Name format, p2pj port, and presence discovery process.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version; changed title to Link-Local Messaging.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-02-07)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0174-0.4.html
+++ b/content/xep-0174-0.4.html
@@ -1,0 +1,347 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0174: Link-Local Messaging</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Link-Local Messaging">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-16">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0174">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0174: Link-Local Messaging</h1>
+<p>This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0174<br>
+            Version: 0.4<br>
+            Last Updated: 2006-03-16<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 3927, draft-cheshire-dnsext-dns-sd, draft-cheshire-dnsext-multicastdns<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Link-Local%20Messaging%20(JEP-0174)">http://wiki.jabber.org/index.php/Link-Local Messaging (JEP-0174)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#dns">DNS Records</a>
+</dt>
+<dl><dt>3.1.  <a href="#txt">TXT Records</a>
+</dt></dl>
+<dt>4.  <a href="#disco">Discovering Other Users</a>
+</dt>
+<dt>5.  <a href="#presence">Exchanging Presence</a>
+</dt>
+<dt>6.  <a href="#comms">Exchanging Messages</a>
+</dt>
+<dt>7.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>11.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">XMPP as defined in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251610">1</a>] does not support direct client-to-client interactions, since it requires authentication with a server: an XMPP client is allowed access to the network only once it has authentication with a server, and the client is not granted access to the network if authentication fails for any reason. If a client attempts to communicate directly with another client, such communication will fail because all XMPP communications are sent through a server and a client cannot inject messages onto the network without first authenticating with a server.</p>
+  <p class="" style="">However, it is possible to establish an XMPP-like communications system on a local network using zero-configuration networking. In this situation, the clients obviate the XMPP requirement for authentication with a server by relying on zero-configuration networking to establish link-local communiation using the _presence._tcp DNS SRV service type. Once discovery has been completed, the clients are then able to exchange messages and other structured data using the XMPP &lt;message/&gt; and &lt;iq/&gt; stanzas. Note well that such communications are restricted to the local network because of how zero-configuration networking works. It is impossible for clients that communicate via link-local addresses to insert messages into an XMPP network, which is why this kind of local "mesh" is most accurately referred to as an XMPP-like system that exists outside the context of existing XMPP networks.</p>
+  <p class="" style="">Such a local "mesh" can be quite valuable in certain circumstances. For instance, participants in a trade show or conference, users of the same WiFi hotspot, or employees on the same local area network can communicate without the need for a pre-configured server. For this reason, support for link-local messaging has been built into Apple's iChat client when operating in Bonjour (formerly Rendezvous) mode. Because it is desirable for other Jabber clients to support such functionality, this document describes how to use zero-configuration networking as the basis for local Jabber communication.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Terminology</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Bonjour</td>
+      <td align="" colspan="" rowspan="">Apple Computer's implementation of zero-configuration networking, formerly known as Rendezvous. See &lt;<a href="http://www.apple.com/macosx/features/bonjour/">http://www.apple.com/macosx/features/bonjour/</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">DNS-SD</td>
+      <td align="" colspan="" rowspan="">A convention for naming and structuring DNS SRV records such that a client can dynamically discover a domain for a service using only standard DNS queries. See <span class="ref" style="">DNS-Based Service Discovery</span>  [<a href="#nt-id2250655">2</a>]. For a full list of registered DNS-SD records, see &lt;<a href="http://www.dns-sd.org/ServiceTypes.html">http://www.dns-sd.org/ServiceTypes.html</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Link-local address</td>
+      <td align="" colspan="" rowspan="">An IPv4 or IPv6 address that is valid for communication with other devices connected to the same physical or logical link. See <span class="ref" style="">RFC 3927</span>  [<a href="#nt-id2250703">3</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Multicast DNS</td>
+      <td align="" colspan="" rowspan="">A technology that provides the ability to perform DNS-like operations on a local link in the absence of any conventional unicast DNS server. See <span class="ref" style="">Multicast DNS</span>  [<a href="#nt-id2250752">4</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Zero-configuration networking</td>
+      <td align="" colspan="" rowspan="">A set of technologies that enable the use of the Internet Protocol for local communications. See &lt;<a href="http://www.zeroconf.org/">http://www.zeroconf.org/</a>&gt;.</td> 
+    </tr>
+  </table>
+<h2>3.
+       <a name="dns">DNS Records</a>
+</h2>
+  <p class="" style="">In order to advertise its availability for link-local messaging, a client MUST publish four different kinds of DNS records:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">An "A" record of the form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+machine-name.local. A ip-address
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">An "SRV" record (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2256830">5</a>]) of the form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp &lt;ttl&gt; IN SRV &lt;priority&gt; &lt;weight&gt; port-number username@machine-name.local. 
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">A "PTR" record (see <span class="ref" style="">RFC 2317</span>  [<a href="#nt-id2256874">6</a>] and <span class="ref" style="">RFC 1886</span>  [<a href="#nt-id2256891">7</a>]) of the form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp.local. port-number IN PTR username@machine-name._presence._tcp.local.
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Various "TXT" records (see <span class="ref" style="">RFC 1464</span>  [<a href="#nt-id2256926">8</a>]) of the following form (see the <a href="#txt">TXT Records</a> section of this document for an explanation of these fields):</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;owner&gt; IN &lt;ttl&gt; TXT "1st=user-first-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "email=user-email-address"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "jid=user-jabber-id"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "last=user-last-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "msg=freeform-availability-status"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "phsh=sha1-hash-of-avatar"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "port.p2pj=5298"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "status=avail-or-dnd"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "txtvers=1"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "vc=CU!-or-C!"
+      </pre></div>
+    </li>
+  </ol>
+  <p class="" style="">The "machine-name" is the name of the computer, the "username" is the system username of the principal currently logged into the computer, the "port" may be any unassigned port number, and the "ip-address" is the physical address of the computer on the local network.</p>
+  <p class="" style="">So, for example, if the machine name is "roundabout", the username is "stpeter", the chosen port is "5526", the IP address is "10.2.1.187", and the personal information is that associated with the author of this document, the DNS records would be as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+roundabout.local. A 10.2.1.187
+
+_presence._tcp IN SRV 5526 stpeter@roundabout.local. 
+
+_presence._tcp.local. 5526 IN PTR stpeter@roundabout._presence._tcp.local.
+
+psa IN TXT "1st=Peter"
+psa IN TXT "email=stpeter@jabber.org"
+psa IN TXT "jid=stpeter@jabber.org"
+psa IN TXT "last=Saint-Andre"
+psa IN TXT "msg=on the phone"
+psa IN TXT "phsh=a3839614e1a382bcfebbcf20464f519e81770813"
+psa IN TXT "port.p2pj=5298"
+psa IN TXT "status=dnd"
+psa IN TXT "txtvers=1"
+psa IN TXT "vc=CU!"
+  </pre></div>
+  <p class="" style="">The IPv4 and IPv6 addresses associated with a machine will vary depending on the local network to which the machine is connected. For example, on an Ethernet connection the physical address might be "10.2.1.187" but when the machine is connected to a wireless network, its physical address might change to "10.10.1.179".</p>
+  <div class="indent">
+<h3>3.1 <a name="txt">TXT Records</a>
+</h3>
+  <p class="" style="">DNS-SD enables service definitions to include various TXT keys that specify parameters to be used in the context of the service type. The TXT keys defined for the _presence._tcp service are as follows:</p>
+  <p class="caption">Table 2: TXT Records</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">1st</td>
+      <td align="" colspan="" rowspan="">The first name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">email</td>
+      <td align="" colspan="" rowspan="">The email address of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jid</td>
+      <td align="" colspan="" rowspan="">The Jabber ID of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">last</td>
+      <td align="" colspan="" rowspan="">The last name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">msg</td>
+      <td align="" colspan="" rowspan="">Natural-language text describing the user's state. This is equivalent to the XMPP &lt;status/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">phsh</td>
+      <td align="" colspan="" rowspan="">The SHA-1 hash of the user's avatar icon or photo.  [<a href="#nt-id2257290">9</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">port.p2pj</td>
+      <td align="" colspan="" rowspan="">The (hardcoded) port for peer-to-peer Jabber communications. Clients MUST use the port discovered via SRV lookups and MUST ignore the value of this TXT field.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">status</td>
+      <td align="" colspan="" rowspan="">The presence availability of the user. Allowable values are "avail" and "dnd".  [<a href="#nt-id2257339">10</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">txtvers</td>
+      <td align="" colspan="" rowspan="">The version of the TXT fields supported by the client. This document describes txtvers "1".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">vc</td>
+      <td align="" colspan="" rowspan="">A flag advertising the user's ability to engage in video conferencing. Allowable values are "C!" and "CU!".</td>
+    </tr>
+  </table>
+</div>
+<h2>4.
+       <a name="disco">Discovering Other Users</a>
+</h2>
+  <p class="" style="">In order to discover other users, a client sends out a broadcast request for PTR record that match "_presence_tcp.local.". The client then receives replies from all machines that advertise support for link-local messaging. The client can then find out detailed information about each machine by sending SRV and TXT queries to "username@machine-name._presence._tcp.local." for each machine.</p>
+<h2>5.
+       <a name="presence">Exchanging Presence</a>
+</h2>
+  <p class="" style="">When the _presence._tcp service is used, presence is exchanged via the format described in the <a href="#txt">TXT Records</a> section of this document. In particular, presence information is not pushed as in XMPP (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2257462">11</a>]). Instead, clients listen for presence announcements from other local entities. Recommended rates for sending updates can be found in <span style="font-weight: bold">draft-cheshire-dnsext-multicastdns</span>.</p>
+<h2>6.
+       <a name="comms">Exchanging Messages</a>
+</h2>
+  <p class="" style="">In order to exchange Jabber communications, the sender opens a TCP connection on the discovered port and opens a stream to the recipient with no 'to' or 'from' address:</p>
+  <p class="caption">Example 1. Opening a Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The recipient then responds with a stream header as well:</p>
+  <p class="caption">Example 2. Stream Header Response</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The sender then can send messages (or IQs) by specifying 'to' and 'from' addresses using the logical local addresses:  [<a href="#nt-id2257514">12</a>]</p>
+  <p class="caption">Example 3. Sending a Message</p>
+<div class="indent"><pre>
+&lt;message to='hildjj@wolfram' from='stpeter@roundabout'&gt;
+  &lt;body&gt;hey, testing out link-local messaging&lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">To end the chat, close the stream:</p>
+  <p class="caption">Example 4. Ending the Chat</p>
+<div class="indent"><pre>
+&lt;/stream:stream&gt;
+  </pre></div>
+<h2>7.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">The DNS does not allow characters outside of the <span class="ref" style="">US-ASCII</span>  [<a href="#nt-id2257580">13</a>] character set in A, SRV, PTR, or TXT records. This can pose problems when using the DNS in conjunction with XMPP-like systems, since XMPP allows virtually the full range of <span class="ref" style="">Unicode</span>  [<a href="#nt-id2257596">14</a>] characters in usernames and availability status messages. If any non-US-ASCII characters are to be included, they MUST be converted to percent-encoded octets following the rules specified in Section 2.6 of <span class="ref" style="">RFC 4395</span>  [<a href="#nt-id2257612">15</a>].</p>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP networks depend on TLS (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2257649">16</a>]) for channel encryption, SASL (<span class="ref" style="">RFC 2222</span>  [<a href="#nt-id2257672">17</a>]) for authentication, and the Domain Name System (<span class="ref" style="">RFC 1034</span>  [<a href="#nt-id2257695">18</a>]) for validation of server hostnames; these technologies help to ensure the identity of sending entities. By contrast, zero-configuration networking uses dynamic discovery and asserted machine names as the basis of sender identity. Therefore, zero-configuration networking does not result in authenticated identities in the same way that XMPP itself does, nor does it provide for an encrypted channel between local entities. (TLS could be negotiated on the local streams, but is out of scope for this specification.)</p>
+  <p class="" style="">Because of the extremely different nature of a true XMPP network and a localized client "mesh", local entities MUST NOT attempt to inject local traffic onto an XMPP network and an XMPP server MUST reject communications until an entity is properly authenticated. However, a client on a local mesh MAY forward traffic to an XMPP network after having properly authenticated on such a network (e.g., to forward a message received on a local client mesh to a contact on an XMPP network).</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The p2pj port number 5298 is not included in the <span class="ref" style="">IANA Port Numbers Registry</span>  [<a href="#nt-id2257755">19</a>] maintained by the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257779">20</a>]. The author will investigate whether that port number (or some other port number) needs to be registered.</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257817">21</a>].</p>
+<h2>11.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jens Alfke, Marc Krochmal, and Justin Karneges for their input.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251610">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250655">2</a>. DNS-Based Service Discovery &lt;<a href="http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt">http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250703">3</a>. RFC 3927: Dynamic Configuration of IPv4 Link-Local Addresses &lt;<a href="http://www.ietf.org/rfc/rfc3927.txt">http://www.ietf.org/rfc/rfc3927.txt</a>&gt;.</p>
+<p><a name="nt-id2250752">4</a>. Multicast DNS &lt;<a href="http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt">http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256830">5</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2256874">6</a>. RFC 2317: Classless IN-ADDR.ARPA delegation &lt;<a href="http://www.ietf.org/rfc/rfc2317.txt">http://www.ietf.org/rfc/rfc2317.txt</a>&gt;.</p>
+<p><a name="nt-id2256891">7</a>. RFC 1886: DNS Extensions to support IP version 6 &lt;<a href="http://www.ietf.org/rfc/rfc1886.txt">http://www.ietf.org/rfc/rfc1886.txt</a>&gt;.</p>
+<p><a name="nt-id2256926">8</a>. RFC 1464: Using the Domain Name System To Store Arbitrary String Attributes &lt;<a href="http://www.ietf.org/rfc/rfc1464.txt">http://www.ietf.org/rfc/rfc1464.txt</a>&gt;.</p>
+<p><a name="nt-id2257290">9</a>. The client should keep a local cache of icons keyed by hash. If the phsh value is not in the cache, the client should fetch the unknown icon and then cache it. Implementations should also include logic for expiring avatar icons.</p>
+<p><a name="nt-id2257339">10</a>. These values effectively map to mere XMPP presence (the user is online or available) and the XMPP &lt;show/&gt; value of "away".</p>
+<p><a name="nt-id2257462">11</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257514">12</a>. The "JIDs" MUST be of the form "username@machine-name" as discovered via SRV (this is the &lt;Instance&gt; portion of the Service Instance Name).</p>
+<p><a name="nt-id2257580">13</a>. Coded Character Set - 7-bit American Standard Code for Information Interchange (American National Standards Institute X3.4, 1986).</p>
+<p><a name="nt-id2257596">14</a>. The Unicode Standard, Version 3.2.0 (The Unicode Consortium, 2000).</p>
+<p><a name="nt-id2257612">15</a>. RFC 4395: Guidelines and Registration Procedures for New URI Schemes &lt;<a href="http://www.ietf.org/rfc/rfc4395.txt">http://www.ietf.org/rfc/rfc4395.txt</a>&gt;.</p>
+<p><a name="nt-id2257649">16</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2257672">17</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p><a name="nt-id2257695">18</a>. RFC 1034: Domain Names - Concepts and Facilities &lt;<a href="http://www.ietf.org/rfc/rfc1034.txt">http://www.ietf.org/rfc/rfc1034.txt</a>&gt;.</p>
+<p><a name="nt-id2257755">19</a>. IANA registry of port numbers &lt;<a href="http://www.iana.org/assignments/port-numbers">http://www.iana.org/assignments/port-numbers</a>&gt;.</p>
+<p><a name="nt-id2257779">20</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257817">21</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.4 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Corrected PTR format and client discovery process.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-02-23)</h4>
+<div class="indent">
+<p class="" style="">Added more details about DNS setup and stream initiation; specified internationalization considerations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-02-22)</h4>
+<div class="indent">
+<p class="" style="">Corrected information about Service Instance Name format, p2pj port, and presence discovery process.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version; changed title to Link-Local Messaging.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-02-07)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0174-0.5.html
+++ b/content/xep-0174-0.5.html
@@ -1,0 +1,389 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0174: Link-Local Messaging</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Link-Local Messaging">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-14">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0174">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0174: Link-Local Messaging</h1>
+<p>This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0174<br>
+            Version: 0.5<br>
+            Last Updated: 2006-04-14<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 3927, draft-cheshire-dnsext-dns-sd, draft-cheshire-dnsext-multicastdns<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Link-Local%20Messaging%20(JEP-0174)">http://wiki.jabber.org/index.php/Link-Local Messaging (JEP-0174)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#dns">DNS Records</a>
+</dt>
+<dl><dt>3.1.  <a href="#txt">TXT Records</a>
+</dt></dl>
+<dt>4.  <a href="#disco">Discovering Other Users</a>
+</dt>
+<dt>5.  <a href="#presence">Exchanging Presence</a>
+</dt>
+<dt>6.  <a href="#comms">Exchanging Messages</a>
+</dt>
+<dt>7.  <a href="#offline">Going Offline</a>
+</dt>
+<dt>8.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#impl-network">Multiple Network Interfaces</a>
+</dt>
+<dt>8.2.  <a href="#impl-icons">Buddy Icons</a>
+</dt>
+</dl>
+<dt>9.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>10.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>11.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>12.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>13.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">XMPP as defined in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250772">1</a>] does not support direct client-to-client interactions, since it requires authentication with a server: an XMPP client is allowed access to the network only once it has authentication with a server, and the client is not granted access to the network if authentication fails for any reason. If a client attempts to communicate directly with another client, such communication will fail because all XMPP communications are sent through a server and a client cannot inject messages onto the network without first authenticating with a server.</p>
+  <p class="" style="">However, it is possible to establish an XMPP-like communications system on a local network using zero-configuration networking. In this situation, the clients obviate the XMPP requirement for authentication with a server by relying on zero-configuration networking to establish link-local communiation using the _presence._tcp DNS SRV service type. Once discovery has been completed, the clients are then able to exchange messages and other structured data using the XMPP &lt;message/&gt; and &lt;iq/&gt; stanzas. Note well that such communications are restricted to the local network because of how zero-configuration networking works. It is impossible for clients that communicate via link-local addresses to insert messages into an XMPP network, which is why this kind of local "mesh" is most accurately referred to as an XMPP-like system that exists outside the context of existing XMPP networks.</p>
+  <p class="" style="">Such a local "mesh" can be quite valuable in certain circumstances. For instance, participants in a trade show or conference, users of the same WiFi hotspot, or employees on the same local area network can communicate without the need for a pre-configured server. For this reason, support for link-local messaging has been built into Apple's iChat client when operating in Bonjour (formerly Rendezvous) mode. Because it is desirable for other Jabber clients to support such functionality, this document describes how to use zero-configuration networking as the basis for local Jabber communication.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Terminology</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Bonjour</td>
+      <td align="" colspan="" rowspan="">Apple Computer's implementation of zero-configuration networking, formerly known as Rendezvous. See &lt;<a href="http://www.apple.com/macosx/features/bonjour/">http://www.apple.com/macosx/features/bonjour/</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">DNS-SD</td>
+      <td align="" colspan="" rowspan="">A convention for naming and structuring DNS SRV records such that a client can dynamically discover a domain for a service using only standard DNS queries. See <span class="ref" style="">DNS-Based Service Discovery</span>  [<a href="#nt-id2250804">2</a>]. For a full list of registered DNS-SD records, see &lt;<a href="http://www.dns-sd.org/ServiceTypes.html">http://www.dns-sd.org/ServiceTypes.html</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Link-local address</td>
+      <td align="" colspan="" rowspan="">An IPv4 or IPv6 address that is valid for communication with other devices connected to the same physical or logical link. See <span class="ref" style="">RFC 3927</span>  [<a href="#nt-id2250851">3</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Multicast DNS (MDNS)</td>
+      <td align="" colspan="" rowspan="">A technology that provides the ability to perform DNS-like operations on a local link in the absence of any conventional unicast DNS server. See <span class="ref" style="">Multicast DNS</span>  [<a href="#nt-id2250896">4</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Zero-configuration networking</td>
+      <td align="" colspan="" rowspan="">A set of technologies that enable the use of the Internet Protocol for local communications. See &lt;<a href="http://www.zeroconf.org/">http://www.zeroconf.org/</a>&gt;.</td> 
+    </tr>
+  </table>
+<h2>3.
+       <a name="dns">DNS Records</a>
+</h2>
+  <p class="" style="">In order to advertise its availability for link-local messaging, a client MUST publish four different kinds of DNS records:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">An address ("A") record of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+machine-name.local. A ip-address
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">An "SRV" record (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2257101">5</a>]) of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp &lt;ttl&gt; IN SRV &lt;priority&gt; &lt;weight&gt; port-number username@machine-name.local. 
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">A "PTR" record (see <span class="ref" style="">RFC 2317</span>  [<a href="#nt-id2257144">6</a>] and <span class="ref" style="">RFC 1886</span>  [<a href="#nt-id2257163">7</a>]) of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp.local. port-number IN PTR username@machine-name._presence._tcp.local.
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Various "TXT" records (see <span class="ref" style="">RFC 1464</span>  [<a href="#nt-id2257195">8</a>]) of the following form (see the <a href="#txt">TXT Records</a> section of this document for an explanation of these fields):</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;owner&gt; IN &lt;ttl&gt; TXT "1st=user-first-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "email=user-email-address"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "jid=user-jabber-id"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "last=user-last-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "msg=freeform-availability-status"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "phsh=sha1-hash-of-avatar"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "port.p2pj=5298"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "status=avail-or-dnd"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "txtvers=1"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "vc=CU!"
+      </pre></div>
+    </li>
+  </ol>
+  <p class="" style="">The "machine-name" is the name of the computer, the "username" is the system username of the principal currently logged into the computer, the "port" may be any unassigned port number, and the "ip-address" is the physical address of the computer on the local network.</p>
+  <p class="" style="">So, for example, if the machine name is "roundabout", the username is "stpeter", the chosen port is "5526", the IP address is "10.2.1.187", and the personal information is that associated with the author of this document, the DNS records would be as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+roundabout.local. A 10.2.1.187
+
+_presence._tcp IN SRV 5526 stpeter@roundabout.local. 
+
+_presence._tcp.local. 5526 IN PTR stpeter@roundabout._presence._tcp.local.
+
+psa IN TXT "1st=Peter"
+psa IN TXT "email=stpeter@jabber.org"
+psa IN TXT "jid=stpeter@jabber.org"
+psa IN TXT "last=Saint-Andre"
+psa IN TXT "msg=on the phone"
+psa IN TXT "phsh=a3839614e1a382bcfebbcf20464f519e81770813"
+psa IN TXT "port.p2pj=5298"
+psa IN TXT "status=dnd"
+psa IN TXT "txtvers=1"
+psa IN TXT "vc=CU!"
+  </pre></div>
+  <p class="" style="">The IPv4 and IPv6 addresses associated with a machine may vary depending on the local network to which the machine is connected. For example, on an Ethernet connection the physical address might be "10.2.1.187" but when the machine is connected to a wireless network, its physical address might change to "10.10.1.179".</p>
+  <p class="" style="">In the unlikely event that the "presence name" (username@machine-name) asserted by a client is already taken by another entity on the network, the client MUST choose a different presence name, which SHOULD be formed by adding the digit "1" to the end of the username string, adding the digit "2" if the resulting presence name is already taken, and incrementing the digit until a unique presence name is constructed.</p> 
+  <div class="indent">
+<h3>3.1 <a name="txt">TXT Records</a>
+</h3>
+  <p class="" style="">DNS-SD enables service definitions to include various TXT keys that specify parameters to be used in the context of the service type. The TXT keys defined for the _presence._tcp service are as follows:</p>
+  <p class="caption">Table 2: TXT Records</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">1st</td>
+      <td align="" colspan="" rowspan="">The first name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">email</td>
+      <td align="" colspan="" rowspan="">The email address of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jid</td>
+      <td align="" colspan="" rowspan="">The Jabber ID of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">last</td>
+      <td align="" colspan="" rowspan="">The last name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">msg</td>
+      <td align="" colspan="" rowspan="">Natural-language text describing the user's state. This is equivalent to the XMPP &lt;status/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">phsh</td>
+      <td align="" colspan="" rowspan="">The SHA-1 hash of the user's avatar icon or photo.  [<a href="#nt-id2257435">9</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">port.p2pj</td>
+      <td align="" colspan="" rowspan="">The (hardcoded) port for peer-to-peer Jabber communications. Clients MUST use the port discovered via SRV lookups and MUST ignore the value of this TXT field.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">status</td>
+      <td align="" colspan="" rowspan="">The presence availability of the user. Allowable values are "avail", "away", and "dnd".  [<a href="#nt-id2257487">10</a>]</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">txtvers</td>
+      <td align="" colspan="" rowspan="">The version of the TXT fields supported by the client. This document describes txtvers "1".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">vc</td>
+      <td align="" colspan="" rowspan="">A flag advertising the user's ability to engage in audio or video conferencing. If the user is able to engage in audio conferencing, the string MUST include the "A" character. If the user is able to engage in video conferencing, the string MUST include the "V" character. If the user is able to engage in conferencing with more than one participant, the string MUST include the "C" character. If the user is not currently engaged in an auudio or video conference, the string MUST include the "!" character. The order of characters in the string is immaterial.</td>
+    </tr>
+  </table>
+</div>
+<h2>4.
+       <a name="disco">Discovering Other Users</a>
+</h2>
+  <p class="" style="">In order to discover other users, a client sends out an MDNS request for PTR record that match "_presence_tcp.local.". The client then receives replies from all machines that advertise support for link-local messaging.  [<a href="#nt-id2257562">11</a>] The client MAY then find out detailed information about each machine by sending SRV and TXT queries to "username@machine-name._presence._tcp.local." for each machine (however, to preserve bandwidth, the client SHOULD NOT send these queries unless it is about to initiate communications with the other user, and it MUST cancel the queries after it has received a response). Note: The presence name to be used for display in a link-local "roster" MUST be obtained from the SRV record, not the PTR record; the client MAY display a name or nickname derived from the TXT records if available.</p>
+<h2>5.
+       <a name="presence">Exchanging Presence</a>
+</h2>
+  <p class="" style="">When the _presence._tcp service is used, presence is exchanged via the format described in the <a href="#txt">TXT Records</a> section of this document. In particular, presence information is not pushed as in XMPP (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2257623">12</a>]). Instead, clients listen for presence announcements from other local entities. Recommended rates for sending updates can be found in <span style="font-weight: bold">draft-cheshire-dnsext-multicastdns</span>.</p>
+<h2>6.
+       <a name="comms">Exchanging Messages</a>
+</h2>
+  <p class="" style="">In order to exchange Jabber communications, the sender opens a TCP connection at the IP address and port discovered via the SRV lookup for a local entity and opens a stream to the recipient with no 'to' or 'from' address:</p>
+  <p class="caption">Example 1. Opening a Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The recipient then responds with a stream header as well:</p>
+  <p class="caption">Example 2. Stream Header Response</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The sender then can send messages (or IQs) by specifying 'to' and 'from' addresses using the logical local addresses:  [<a href="#nt-id2257684">13</a>]</p>
+  <p class="caption">Example 3. Sending a Message</p>
+<div class="indent"><pre>
+&lt;message to='hildjj@wolfram' from='stpeter@roundabout'&gt;
+  &lt;body&gt;hey, testing out link-local messaging&lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">To end the chat, close the stream:</p>
+  <p class="caption">Example 4. Ending the Chat</p>
+<div class="indent"><pre>
+&lt;/stream:stream&gt;
+  </pre></div>
+<h2>7.
+       <a name="offline">Going Offline</a>
+</h2>
+  <p class="" style="">In order to go offline, a client MUST send a Multicast DNS "Goodbye" packet for the user's PTR record. As a result, all other entities on the local network will receive a Multicast DNS "Remove" event, at which point they MUST cancel any outstanding TXT, SRV, or NULL record queries for the offline user.</p>
+<h2>8.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="impl-network">Multiple Network Interfaces</a>
+</h3>
+    <p class="" style="">Devices that use link-local messaging may have multiple network interfaces. As a result, it is possible to discover the same entity multiple times. Even if a client discovers the same presence name on multiple network interfaces, it MUST show only one entity in the local roster. In addition, because local IP addresses can be dynamically re-assigned, the client SHOULD NOT store the IP address to be used for communications when it discovers that address in the initial DNS lookup phase; instead, SHOULD delay sending the Multicast DNS query until the client is ready to communicate with the other entity.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="impl-icons">Buddy Icons</a>
+</h3>
+    <p class="" style="">If an entity has an associated icon (e.g., a user avatar or photo), its client SHOULD publish the raw binary data for that image via a DNS NULL record of the following form:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp.local. IN NULL raw-binary-data-here
+    </pre></div>
+    <p class="" style="">Note: In accordance with <span class="ref" style="">RFC 1035</span>  [<a href="#nt-id2257814">14</a>], the data MUST be 65535 octets or less.</p>
+    <p class="" style="">After retrieving the "phsh" value from a Buddy's TXT record, a client SHOULD search its local picture database to learn the last recorded picture hash value for an entity and then compares it to the "phsh" value in the TXT record. If the values are equal, the client SHOULD uses the local copy of the icon. If the picture hash values are not equal, the client SHOULD issue a Multicast DNS NULL record query to retrieve the new icon. After retrieving the NULL record, the client SHOULD replace the old "phsh" value in the picture database with the new "phsh" value and save the icon to disk. If the client needs to send a Multicast DNS query in order to retrieve the icon, it MUST cancel the NULL record query immediately after receiving a response containing the new picture data.</p>
+    <p class="" style="">If a user changes their picture, the user's client MUST update the NULL record with the contents of the new picture, calculate a new picture hash, and then update the "phsh" value in the TXT record with the new hash value. Since all users logged into local presence are monitoring for TXT record changes, they will see that the "phsh" value was changed; if they wish to view the new icon, their clients SHOULD issue a new Multicast DNS query to retrieve the updated picture.</p>
+  </div>
+<h2>9.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">The DNS does not allow characters outside of the <span class="ref" style="">US-ASCII</span>  [<a href="#nt-id2257888">15</a>] character set in A, SRV, PTR, or TXT records. This can pose problems when using the DNS in conjunction with XMPP-like systems, since XMPP allows virtually the full range of <span class="ref" style="">Unicode</span>  [<a href="#nt-id2257911">16</a>] characters in usernames and availability status messages. If any non-US-ASCII characters are to be included, they MUST be converted to percent-encoded octets following the rules specified in Section 2.6 of <span class="ref" style="">RFC 4395</span>  [<a href="#nt-id2257928">17</a>].</p>
+<h2>10.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP networks depend on TLS (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2257964">18</a>]) for channel encryption, SASL (<span class="ref" style="">RFC 2222</span>  [<a href="#nt-id2257986">19</a>]) for authentication, and the Domain Name System (<span class="ref" style="">RFC 1034</span>  [<a href="#nt-id2258009">20</a>]) for validation of server hostnames; these technologies help to ensure the identity of sending entities. By contrast, zero-configuration networking uses dynamic discovery and asserted machine names as the basis of sender identity. Therefore, zero-configuration networking does not result in authenticated identities in the same way that XMPP itself does, nor does it provide for an encrypted channel between local entities. (TLS could be negotiated on the local streams, but is out of scope for this specification.)</p>
+  <p class="" style="">Because of the extremely different nature of a true XMPP network and a localized client "mesh", local entities MUST NOT attempt to inject local traffic onto an XMPP network and an XMPP server MUST reject communications until an entity is properly authenticated. However, a client on a local mesh MAY forward traffic to an XMPP network after having properly authenticated on such a network (e.g., to forward a message received on a local client mesh to a contact on an XMPP network).</p>
+  <p class="" style="">The TXT records advertised as part of this protocol MAY result in exposure of user information (such as full name, email address, and Jabber ID). A client MUST enable a user to disable publication of this personal information.</p>
+<h2>11.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The p2pj port number 5298 is not included in the <span class="ref" style="">IANA Port Numbers Registry</span>  [<a href="#nt-id2258072">21</a>] maintained by the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258101">22</a>]. The author will investigate whether that port number (or some other port number) needs to be registered.</p>
+<h2>12.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258140">23</a>].</p>
+<h2>13.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jens Alfke, Marc Krochmal, and Justin Karneges for their input.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250772">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250804">2</a>. DNS-Based Service Discovery &lt;<a href="http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt">http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250851">3</a>. RFC 3927: Dynamic Configuration of IPv4 Link-Local Addresses &lt;<a href="http://www.ietf.org/rfc/rfc3927.txt">http://www.ietf.org/rfc/rfc3927.txt</a>&gt;.</p>
+<p><a name="nt-id2250896">4</a>. Multicast DNS &lt;<a href="http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt">http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2257101">5</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2257144">6</a>. RFC 2317: Classless IN-ADDR.ARPA delegation &lt;<a href="http://www.ietf.org/rfc/rfc2317.txt">http://www.ietf.org/rfc/rfc2317.txt</a>&gt;.</p>
+<p><a name="nt-id2257163">7</a>. RFC 1886: DNS Extensions to support IP version 6 &lt;<a href="http://www.ietf.org/rfc/rfc1886.txt">http://www.ietf.org/rfc/rfc1886.txt</a>&gt;.</p>
+<p><a name="nt-id2257195">8</a>. RFC 1464: Using the Domain Name System To Store Arbitrary String Attributes &lt;<a href="http://www.ietf.org/rfc/rfc1464.txt">http://www.ietf.org/rfc/rfc1464.txt</a>&gt;.</p>
+<p><a name="nt-id2257435">9</a>. The client should keep a local cache of icons keyed by hash. If the phsh value is not in the cache, the client should fetch the unknown icon and then cache it. Implementations should also include logic for expiring avatar icons.</p>
+<p><a name="nt-id2257487">10</a>. These values map to mere XMPP presence (the user is available) and the XMPP &lt;show/&gt; values of "away" and "dnd".</p>
+<p><a name="nt-id2257562">11</a>. The replies will include a record corresponding the client itself; the client MUST filter out this result.</p>
+<p><a name="nt-id2257623">12</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257684">13</a>. The "JIDs" MUST be of the form "username@machine-name" as discovered via SRV (this is the &lt;Instance&gt; portion of the Service Instance Name).</p>
+<p><a name="nt-id2257814">14</a>. RFC 1035: Domain Names - Implementation and Specification &lt;<a href="http://www.ietf.org/rfc/rfc1035.txt">http://www.ietf.org/rfc/rfc1035.txt</a>&gt;.</p>
+<p><a name="nt-id2257888">15</a>. Coded Character Set - 7-bit American Standard Code for Information Interchange (American National Standards Institute X3.4, 1986).</p>
+<p><a name="nt-id2257911">16</a>. The Unicode Standard, Version 3.2.0 (The Unicode Consortium, 2000).</p>
+<p><a name="nt-id2257928">17</a>. RFC 4395: Guidelines and Registration Procedures for New URI Schemes &lt;<a href="http://www.ietf.org/rfc/rfc4395.txt">http://www.ietf.org/rfc/rfc4395.txt</a>&gt;.</p>
+<p><a name="nt-id2257964">18</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2257986">19</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p><a name="nt-id2258009">20</a>. RFC 1034: Domain Names - Concepts and Facilities &lt;<a href="http://www.ietf.org/rfc/rfc1034.txt">http://www.ietf.org/rfc/rfc1034.txt</a>&gt;.</p>
+<p><a name="nt-id2258072">21</a>. IANA registry of port numbers &lt;<a href="http://www.iana.org/assignments/port-numbers">http://www.iana.org/assignments/port-numbers</a>&gt;.</p>
+<p><a name="nt-id2258101">22</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258140">23</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.5 (2006-04-14)</h4>
+<div class="indent">
+<p class="" style="">Specified presence name conflict resolution procedure, offline procedure, use of DNS NULL record for icons, and handling of multiple network interfaces.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Corrected PTR format and client discovery process.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-02-23)</h4>
+<div class="indent">
+<p class="" style="">Added more details about DNS setup and stream initiation; specified internationalization considerations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-02-22)</h4>
+<div class="indent">
+<p class="" style="">Corrected information about Service Instance Name format, p2pj port, and presence discovery process.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version; changed title to Link-Local Messaging.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-02-07)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0174-0.6.html
+++ b/content/xep-0174-0.6.html
@@ -1,0 +1,394 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0174: Link-Local Messaging</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Link-Local Messaging">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-06-05">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0174">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0174: Link-Local Messaging</h1>
+<p>This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0174<br>
+            Version: 0.6<br>
+            Last Updated: 2006-06-05<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, RFC 3927, draft-cheshire-dnsext-dns-sd, draft-cheshire-dnsext-multicastdns<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Link-Local%20Messaging%20(JEP-0174)">http://wiki.jabber.org/index.php/Link-Local Messaging (JEP-0174)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#dns">DNS Records</a>
+</dt>
+<dl><dt>3.1.  <a href="#txt">TXT Records</a>
+</dt></dl>
+<dt>4.  <a href="#disco">Discovering Other Users</a>
+</dt>
+<dt>5.  <a href="#presence">Exchanging Presence</a>
+</dt>
+<dt>6.  <a href="#comms">Exchanging Messages</a>
+</dt>
+<dt>7.  <a href="#offline">Going Offline</a>
+</dt>
+<dt>8.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#impl-network">Multiple Network Interfaces</a>
+</dt>
+<dt>8.2.  <a href="#impl-icons">Buddy Icons</a>
+</dt>
+</dl>
+<dt>9.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>10.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>11.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>12.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>13.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">XMPP as defined in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250708">1</a>] does not support direct client-to-client interactions, since it requires authentication with a server: an XMPP client is allowed access to the network only once it has authentication with a server, and the client is not granted access to the network if authentication fails for any reason. If a client attempts to communicate directly with another client, such communication will fail because all XMPP communications are sent through a server and a client cannot inject messages onto the network without first authenticating with a server.</p>
+  <p class="" style="">However, it is possible to establish an XMPP-like communications system on a local network using zero-configuration networking. In this situation, the clients obviate the XMPP requirement for authentication with a server by relying on zero-configuration networking to establish link-local communiation using the _presence._tcp DNS SRV service type. Once discovery has been completed, the clients are then able to exchange messages and other structured data using the XMPP &lt;message/&gt; and &lt;iq/&gt; stanzas. Note well that such communications are restricted to the local network because of how zero-configuration networking works. It is impossible for clients that communicate via link-local addresses to insert messages into an XMPP network, which is why this kind of local "mesh" is most accurately referred to as an XMPP-like system that exists outside the context of existing XMPP networks.</p>
+  <p class="" style="">Such a local "mesh" can be quite valuable in certain circumstances. For instance, participants in a trade show or conference, users of the same WiFi hotspot, or employees on the same local area network can communicate without the need for a pre-configured server. For this reason, support for link-local messaging has been built into Apple's iChat client when operating in Bonjour (formerly Rendezvous) mode. Because it is desirable for other Jabber clients to support such functionality, this document describes how to use zero-configuration networking as the basis for local Jabber communication.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Terminology</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Bonjour</td>
+      <td align="" colspan="" rowspan="">Apple Computer's implementation of zero-configuration networking, formerly known as Rendezvous. See &lt;<a href="http://www.apple.com/macosx/features/bonjour/">http://www.apple.com/macosx/features/bonjour/</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">DNS-SD</td>
+      <td align="" colspan="" rowspan="">A convention for naming and structuring DNS SRV records such that a client can dynamically discover a domain for a service using only standard DNS queries. See <span class="ref" style="">DNS-Based Service Discovery</span>  [<a href="#nt-id2250749">2</a>]. For a full list of registered DNS-SD records, see &lt;<a href="http://www.dns-sd.org/ServiceTypes.html">http://www.dns-sd.org/ServiceTypes.html</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Link-local address</td>
+      <td align="" colspan="" rowspan="">An IPv4 or IPv6 address that is valid for communication with other devices connected to the same physical or logical link. See <span class="ref" style="">RFC 3927</span>  [<a href="#nt-id2250839">3</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Multicast DNS (mDNS)</td>
+      <td align="" colspan="" rowspan="">A technology that provides the ability to perform DNS-like operations on a local link in the absence of any conventional unicast DNS server. See <span class="ref" style="">Multicast DNS</span>  [<a href="#nt-id2250816">4</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Zero-configuration networking</td>
+      <td align="" colspan="" rowspan="">A set of technologies that enable the use of the Internet Protocol for local communications. See &lt;<a href="http://www.zeroconf.org/">http://www.zeroconf.org/</a>&gt;.</td> 
+    </tr>
+  </table>
+<h2>3.
+       <a name="dns">DNS Records</a>
+</h2>
+  <p class="" style="">In order to advertise its availability for link-local messaging, a client MUST publish four different kinds of DNS records:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">An address ("A") record of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+machine-name.local. A ip-address
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">An "SRV" record (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2257217">5</a>]) of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp &lt;ttl&gt; IN SRV &lt;priority&gt; &lt;weight&gt; port-number username@machine-name.local. 
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">A "PTR" record (see <span class="ref" style="">RFC 2317</span>  [<a href="#nt-id2257261">6</a>] and <span class="ref" style="">RFC 1886</span>  [<a href="#nt-id2257280">7</a>]) of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp.local. port-number IN PTR username@machine-name._presence._tcp.local.
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Optionally, various "TXT" records (see <span class="ref" style="">RFC 1464</span>  [<a href="#nt-id2257311">8</a>]) of the following form, as further described in to the <a href="#txt">TXT Records</a> section of this document):</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;owner&gt; IN &lt;ttl&gt; TXT "1st=user-first-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "email=user-email-address"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "jid=user-jabber-id"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "last=user-last-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "msg=freeform-availability-status"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "phsh=sha1-hash-of-avatar"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "port.p2pj=5298"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "status=avail-or-dnd"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "txtvers=1"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "vc=CU!"
+      </pre></div>
+    </li>
+  </ol>
+  <p class="" style="">The "machine-name" is the name of the computer, the "username" is the system username of the principal currently logged into the computer, the "port" may be any unassigned port number, and the "ip-address" is the physical address of the computer on the local network.</p>
+  <p class="" style="">So, for example, if the machine name is "roundabout", the username is "stpeter", the chosen port is "5526", the IP address is "10.2.1.187", and the personal information is that associated with the author of this document, the DNS records would be as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+roundabout.local. A 10.2.1.187
+
+_presence._tcp IN SRV 5526 stpeter@roundabout.local. 
+
+_presence._tcp.local. 5526 IN PTR stpeter@roundabout._presence._tcp.local.
+
+psa IN TXT "1st=Peter"
+psa IN TXT "email=stpeter@jabber.org"
+psa IN TXT "jid=stpeter@jabber.org"
+psa IN TXT "last=Saint-Andre"
+psa IN TXT "msg=on the phone"
+psa IN TXT "phsh=a3839614e1a382bcfebbcf20464f519e81770813"
+psa IN TXT "port.p2pj=5298"
+psa IN TXT "status=dnd"
+psa IN TXT "txtvers=1"
+psa IN TXT "vc=CU!"
+  </pre></div>
+  <p class="" style="">The IPv4 and IPv6 addresses associated with a machine may vary depending on the local network to which the machine is connected. For example, on an Ethernet connection the physical address might be "10.2.1.187" but when the machine is connected to a wireless network, its physical address might change to "10.10.1.179".</p>
+  <p class="" style="">In the unlikely event that the "presence name" (username@machine-name) asserted by a client is already taken by another entity on the network, the client MUST choose a different presence name, which SHOULD be formed by adding the digit "1" to the end of the username string, adding the digit "2" if the resulting presence name is already taken, and incrementing the digit until a unique presence name is constructed.</p> 
+  <div class="indent">
+<h3>3.1 <a name="txt">TXT Records</a>
+</h3>
+  <p class="" style="">DNS-SD enables service definitions to include various TXT keys that specify parameters to be used in the context of the service type. The TXT keys defined for the _presence._tcp service are as follows:</p>
+  <p class="caption">Table 2: TXT Records</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">1st</td>
+      <td align="" colspan="" rowspan="">The first name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">email</td>
+      <td align="" colspan="" rowspan="">The email address of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jid</td>
+      <td align="" colspan="" rowspan="">The Jabber ID of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">last</td>
+      <td align="" colspan="" rowspan="">The last name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">msg</td>
+      <td align="" colspan="" rowspan="">Natural-language text describing the user's state. This is equivalent to the XMPP &lt;status/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">phsh</td>
+      <td align="" colspan="" rowspan="">The SHA-1 hash of the user's avatar icon or photo.  [<a href="#nt-id2257558">9</a>] This SHOULD be requested using mDNS in unicast mode by sending a DNS query to the mDNS multicast address (224.0.0.251 or its IPv6 equivalent FF02::FB).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">port.p2pj</td>
+      <td align="" colspan="" rowspan="">The (hardcoded) port for peer-to-peer Jabber communications. Clients MUST use the port discovered via SRV lookups and MUST ignore the value of this TXT field, which is included only for backwards-compatibility with some older, existing implementations.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">status</td>
+      <td align="" colspan="" rowspan="">The presence availability of the user. Allowable values are "avail", "away", and "dnd", which map to mere XMPP presence (the user is available) and the XMPP &lt;show/&gt; values of "away" and "dnd", respectively.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">txtvers</td>
+      <td align="" colspan="" rowspan="">The version of the TXT fields supported by the client. This document describes txtvers "1".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">vc</td>
+      <td align="" colspan="" rowspan="">A flag advertising the user's ability to engage in audio or video conferencing. If the user is able to engage in audio conferencing, the string MUST include the "A" character. If the user is able to engage in video conferencing, the string MUST include the "V" character. If the user is able to engage in conferencing with more than one participant, the string MUST include the "C" character. If the user is not currently engaged in an auudio or video conference, the string MUST include the "!" character. The order of characters in the string is immaterial.</td>
+    </tr>
+  </table>
+  <p class="" style="">It is OPTIONAL to include any of these TXT keys, since link-local messaging can be used by non-human entities (e.g., devices) and these keys relate to human users. However, for use by humans, certain keys are of greater interest than others, e.g. the "msg" and "status" keys. See also the <a href="#security">Security Considerations</a> section of this document regarding the inclusion of information that may have an impact on personal privacy (e.g., the "1st", "last", "email", and "jid" keys).</p>
+</div>
+<h2>4.
+       <a name="disco">Discovering Other Users</a>
+</h2>
+  <p class="" style="">In order to discover other users, a client sends an mDNS request for PTR records that match "_presence_tcp.local.". The client then receives replies from all machines that advertise support for link-local messaging.  [<a href="#nt-id2257707">10</a>] The client MAY then find out detailed information about each machine by sending SRV and TXT queries to "username@machine-name._presence._tcp.local." for each machine (however, to preserve bandwidth, the client SHOULD NOT send these queries unless it is about to initiate communications with the other user, and it MUST cancel the queries after it has received a response). Note: The presence name to be used for display in a link-local "roster" MUST be obtained from the &lt;Instance&gt; portion of the received PTR record for each user; the client MAY display a name or nickname derived from the TXT records if available.</p>
+<h2>5.
+       <a name="presence">Exchanging Presence</a>
+</h2>
+  <p class="" style="">When the _presence._tcp service is used, presence is exchanged via the format described in the <a href="#txt">TXT Records</a> section of this document. In particular, presence information is not pushed as in XMPP (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250467">11</a>]). Instead, clients listen for presence announcements from other local entities. Recommended rates for sending updates can be found in <span style="font-weight: bold">draft-cheshire-dnsext-multicastdns</span>.</p>
+<h2>6.
+       <a name="comms">Exchanging Messages</a>
+</h2>
+  <p class="" style="">In order to exchange Jabber communications, the sender opens a TCP connection at the IP address and port discovered via the SRV lookup for a local entity and opens a stream to the recipient with no 'to' or 'from' address:</p>
+  <p class="caption">Example 1. Opening a Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The recipient then responds with a stream header as well:</p>
+  <p class="caption">Example 2. Stream Header Response</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The sender then can send messages (or IQs) by specifying 'to' and 'from' addresses using the logical local addresses:  [<a href="#nt-id2250527">12</a>]</p>
+  <p class="caption">Example 3. Sending a Message</p>
+<div class="indent"><pre>
+&lt;message to='hildjj@wolfram' from='stpeter@roundabout'&gt;
+  &lt;body&gt;hey, testing out link-local messaging&lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">To end the chat, close the stream:</p>
+  <p class="caption">Example 4. Ending the Chat</p>
+<div class="indent"><pre>
+&lt;/stream:stream&gt;
+  </pre></div>
+<h2>7.
+       <a name="offline">Going Offline</a>
+</h2>
+  <p class="" style="">In order to go offline, a client MUST send a Multicast DNS "Goodbye" packet for the user's PTR record. As a result, all other entities on the local network will receive a Multicast DNS "Remove" event, at which point they MUST cancel any outstanding TXT, SRV, or NULL record queries for the offline user.</p>
+<h2>8.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="impl-network">Multiple Network Interfaces</a>
+</h3>
+    <p class="" style="">Devices that use link-local messaging may have multiple network interfaces. As a result, it is possible to discover the same entity multiple times. Even if a client discovers the same presence name on multiple network interfaces, it MUST show only one entity in the local roster. In addition, because local IP addresses can be dynamically re-assigned, the client SHOULD NOT store the IP address to be used for communications when it discovers that address in the initial DNS lookup phase; instead, SHOULD delay sending the Multicast DNS query until the client is ready to communicate with the other entity.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="impl-icons">Buddy Icons</a>
+</h3>
+    <p class="" style="">If an entity has an associated icon (e.g., a user avatar or photo), its client SHOULD publish the raw binary data for that image via a DNS NULL record of the following form:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp.local. IN NULL raw-binary-data-here
+    </pre></div>
+    <p class="" style="">Note: In accordance with <span class="ref" style="">RFC 1035</span>  [<a href="#nt-id2258102">13</a>], the data MUST be 65535 octets or less.</p>
+    <p class="" style="">After retrieving the "phsh" value from a Buddy's TXT record, a client SHOULD search its local picture database to learn the last recorded picture hash value for an entity and then compares it to the "phsh" value in the TXT record. If the values are equal, the client SHOULD uses the local copy of the icon. If the picture hash values are not equal, the client SHOULD issue a Multicast DNS NULL record query to retrieve the new icon. After retrieving the NULL record, the client SHOULD replace the old "phsh" value in the picture database with the new "phsh" value and save the icon to disk. If the client needs to send a Multicast DNS query in order to retrieve the icon, it MUST cancel the NULL record query immediately after receiving a response containing the new picture data.</p>
+    <p class="" style="">If a user changes their picture, the user's client MUST update the NULL record with the contents of the new picture, calculate a new picture hash, and then update the "phsh" value in the TXT record with the new hash value. Since all users logged into local presence are monitoring for TXT record changes, they will see that the "phsh" value was changed; if they wish to view the new icon, their clients SHOULD issue a new Multicast DNS query to retrieve the updated picture.</p>
+  </div>
+<h2>9.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style="">While the DNS does not allow characters outside of the <span class="ref" style="">US-ASCII</span>  [<a href="#nt-id2258177">14</a>] character set in domain names, <span style="font-weight: bold">draft-cheshire-dnsext-dns-sd</span> recommends support for UTF-8-encoded Unicode characters in the &lt;Instance&gt; portion of Service Instance Names included in PTR records (see Section 4.1 of <span style="font-weight: bold">draft-cheshire-dnsext-dns-sd</span>), which in link-local messaging is the "username@machine-name" portion of the PTR record. This document also adheres to that recommendation.</p>
+  <p class="" style="">However, the DNS does not allow characters outside the US-ASCII character set in DNS A, SRV, or TXT records. This can pose problems when using the DNS in conjunction with XMPP-like systems, since XMPP allows virtually the full range of <span class="ref" style="">Unicode</span>  [<a href="#nt-id2258260">15</a>] characters in usernames (the SRV "Service" name) and availability status messages (the TXT "msg" name). If any non-US-ASCII characters are to be included in such records, they MUST be converted to percent-encoded octets following the rules specified in Section 2.6 of <span class="ref" style="">RFC 4395</span>  [<a href="#nt-id2258224">16</a>].</p>
+<h2>10.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP networks depend on TLS (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2258280">17</a>]) for channel encryption, SASL (<span class="ref" style="">RFC 2222</span>  [<a href="#nt-id2258302">18</a>]) for authentication, and the Domain Name System (<span class="ref" style="">RFC 1034</span>  [<a href="#nt-id2258324">19</a>]) for validation of server hostnames; these technologies help to ensure the identity of sending entities. By contrast, zero-configuration networking uses dynamic discovery and asserted machine names as the basis of sender identity. Therefore, zero-configuration networking does not result in authenticated identities in the same way that XMPP itself does, nor does it provide for an encrypted channel between local entities. (TLS could be negotiated on the local streams, but is out of scope for this specification.)</p>
+  <p class="" style="">Because of fundamental differences between a true XMPP network and a localized XMPP client "mesh", local entities MUST NOT attempt to inject local traffic onto an XMPP network and an XMPP server MUST reject communications until an entity is properly authenticated. However, a client on a local mesh MAY forward traffic to an XMPP network after having properly authenticated on such a network (e.g., to forward a message received on a local client mesh to a contact on an XMPP network).</p>
+  <p class="" style="">The TXT records optionally advertised as part of this protocol MAY result in exposure of privacy-sensitive information about a human user (such as full name, email address, and Jabber ID). A client MUST allow a user to disable publication of this personal information (e.g., via client configuration).</p>
+<h2>11.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The p2pj port number 5298 is not included in the <span class="ref" style="">IANA Port Numbers Registry</span>  [<a href="#nt-id2258390">20</a>] maintained by the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258415">21</a>]. The author will investigate whether that port number (or some other port number) needs to be registered.</p>
+<h2>12.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258457">22</a>].</p>
+<h2>13.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Jens Alfke, Marc Krochmal, and Justin Karneges for their input.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250708">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250749">2</a>. DNS-Based Service Discovery &lt;<a href="http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt">http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250839">3</a>. RFC 3927: Dynamic Configuration of IPv4 Link-Local Addresses &lt;<a href="http://www.ietf.org/rfc/rfc3927.txt">http://www.ietf.org/rfc/rfc3927.txt</a>&gt;.</p>
+<p><a name="nt-id2250816">4</a>. Multicast DNS &lt;<a href="http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt">http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2257217">5</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2257261">6</a>. RFC 2317: Classless IN-ADDR.ARPA delegation &lt;<a href="http://www.ietf.org/rfc/rfc2317.txt">http://www.ietf.org/rfc/rfc2317.txt</a>&gt;.</p>
+<p><a name="nt-id2257280">7</a>. RFC 1886: DNS Extensions to support IP version 6 &lt;<a href="http://www.ietf.org/rfc/rfc1886.txt">http://www.ietf.org/rfc/rfc1886.txt</a>&gt;.</p>
+<p><a name="nt-id2257311">8</a>. RFC 1464: Using the Domain Name System To Store Arbitrary String Attributes &lt;<a href="http://www.ietf.org/rfc/rfc1464.txt">http://www.ietf.org/rfc/rfc1464.txt</a>&gt;.</p>
+<p><a name="nt-id2257558">9</a>. The client should keep a local cache of icons keyed by hash. If the phsh value is not in the cache, the client should fetch the unknown icon and then cache it. Implementations should also include logic for expiring avatar icons.</p>
+<p><a name="nt-id2257707">10</a>. The replies will include a record corresponding the client itself; the client MUST filter out this result.</p>
+<p><a name="nt-id2250467">11</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250527">12</a>. The "JIDs" MUST be of the form "username@machine-name" as discovered via SRV (this is the &lt;Instance&gt; portion of the Service Instance Name).</p>
+<p><a name="nt-id2258102">13</a>. RFC 1035: Domain Names - Implementation and Specification &lt;<a href="http://www.ietf.org/rfc/rfc1035.txt">http://www.ietf.org/rfc/rfc1035.txt</a>&gt;.</p>
+<p><a name="nt-id2258177">14</a>. Coded Character Set - 7-bit American Standard Code for Information Interchange (American National Standards Institute X3.4, 1986).</p>
+<p><a name="nt-id2258260">15</a>. The Unicode Standard, Version 3.2.0 (The Unicode Consortium, 2000).</p>
+<p><a name="nt-id2258224">16</a>. RFC 4395: Guidelines and Registration Procedures for New URI Schemes &lt;<a href="http://www.ietf.org/rfc/rfc4395.txt">http://www.ietf.org/rfc/rfc4395.txt</a>&gt;.</p>
+<p><a name="nt-id2258280">17</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2258302">18</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p><a name="nt-id2258324">19</a>. RFC 1034: Domain Names - Concepts and Facilities &lt;<a href="http://www.ietf.org/rfc/rfc1034.txt">http://www.ietf.org/rfc/rfc1034.txt</a>&gt;.</p>
+<p><a name="nt-id2258390">20</a>. IANA registry of port numbers &lt;<a href="http://www.iana.org/assignments/port-numbers">http://www.iana.org/assignments/port-numbers</a>&gt;.</p>
+<p><a name="nt-id2258415">21</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258457">22</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.6 (2006-06-05)</h4>
+<div class="indent">
+<p class="" style="">Clarified internationalization considerations and use of mDNS in unicast mode for avatar retrieval.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-04-14)</h4>
+<div class="indent">
+<p class="" style="">Specified presence name conflict resolution procedure, offline procedure, use of DNS NULL record for icons, and handling of multiple network interfaces.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Corrected PTR format and client discovery process.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-02-23)</h4>
+<div class="indent">
+<p class="" style="">Added more details about DNS setup and stream initiation; specified internationalization considerations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-02-22)</h4>
+<div class="indent">
+<p class="" style="">Corrected information about Service Instance Name format, p2pj port, and presence discovery process.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version; changed title to Link-Local Messaging.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-02-07)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0174-0.7.html
+++ b/content/xep-0174-0.7.html
@@ -1,0 +1,397 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0174: Link-Local Messaging</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Link-Local Messaging">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-06-06">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0174">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0174: Link-Local Messaging</h1>
+<p>This document describes how to establish XMPP-like communications over local networks using zero-configuration networking.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0174<br>
+            Version: 0.7<br>
+            Last Updated: 2006-06-06<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, XMPP IM, RFC 3927, draft-cheshire-dnsext-dns-sd, draft-cheshire-dnsext-multicastdns<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Link-Local%20Messaging%20(JEP-0174)">http://wiki.jabber.org/index.php/Link-Local Messaging (JEP-0174)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#glossary">Glossary</a>
+</dt>
+<dt>3.  <a href="#dns">DNS Records</a>
+</dt>
+<dl><dt>3.1.  <a href="#txt">TXT Records</a>
+</dt></dl>
+<dt>4.  <a href="#disco">Discovering Other Users</a>
+</dt>
+<dt>5.  <a href="#presence">Exchanging Presence</a>
+</dt>
+<dt>6.  <a href="#comms">Exchanging Messages</a>
+</dt>
+<dt>7.  <a href="#offline">Going Offline</a>
+</dt>
+<dt>8.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#impl-network">Multiple Network Interfaces</a>
+</dt>
+<dt>8.2.  <a href="#impl-icons">Buddy Icons</a>
+</dt>
+</dl>
+<dt>9.  <a href="#i18n">Internationalization Considerations</a>
+</dt>
+<dt>10.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>11.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>12.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>13.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">XMPP as defined in <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250734">1</a>] does not support direct client-to-client interactions, since it requires authentication with a server: an XMPP client is allowed access to the network only once it has authentication with a server, and the client is not granted access to the network if authentication fails for any reason. If a client attempts to communicate directly with another client, such communication will fail because all XMPP communications are sent through a server and a client cannot inject messages onto the network without first authenticating with a server.</p>
+  <p class="" style="">However, it is possible to establish an XMPP-like communications system on a local network using zero-configuration networking. In this situation, the clients obviate the XMPP requirement for authentication with a server by relying on zero-configuration networking to establish link-local communiation using the _presence._tcp DNS SRV service type. Once discovery has been completed, the clients are then able to exchange messages and other structured data using the XMPP &lt;message/&gt; and &lt;iq/&gt; stanzas. Note well that such communications are restricted to the local network because of how zero-configuration networking works. It is impossible for clients that communicate via link-local addresses to insert messages into an XMPP network, which is why this kind of local "mesh" is most accurately referred to as an XMPP-like system that exists outside the context of existing XMPP networks.</p>
+  <p class="" style="">Such a local "mesh" can be quite valuable in certain circumstances. For instance, participants in a trade show or conference, users of the same WiFi hotspot, or employees on the same local area network can communicate without the need for a pre-configured server. For this reason, support for link-local messaging has been built into Apple's iChat client when operating in Bonjour (formerly Rendezvous) mode. Because it is desirable for other Jabber clients to support such functionality, this document describes how to use zero-configuration networking as the basis for local Jabber communication.</p>
+<h2>2.
+       <a name="glossary">Glossary</a>
+</h2>
+  <p class="caption">Table 1: Terminology</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Term</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Bonjour</td>
+      <td align="" colspan="" rowspan="">Apple Computer's implementation of zero-configuration networking, formerly known as Rendezvous. See &lt;<a href="http://www.apple.com/macosx/features/bonjour/">http://www.apple.com/macosx/features/bonjour/</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">DNS-SD</td>
+      <td align="" colspan="" rowspan="">A convention for naming and structuring DNS SRV records such that a client can dynamically discover a domain for a service using only standard DNS queries. See <span class="ref" style="">DNS-Based Service Discovery</span>  [<a href="#nt-id2250814">2</a>]. For a full list of registered DNS-SD records, see &lt;<a href="http://www.dns-sd.org/ServiceTypes.html">http://www.dns-sd.org/ServiceTypes.html</a>&gt;.</td> 
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Link-local address</td>
+      <td align="" colspan="" rowspan="">An IPv4 or IPv6 address that is valid for communication with other devices connected to the same physical or logical link. See <span class="ref" style="">RFC 3927</span>  [<a href="#nt-id2250870">3</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Multicast DNS (mDNS)</td>
+      <td align="" colspan="" rowspan="">A technology that provides the ability to perform DNS-like operations on a local link in the absence of any conventional unicast DNS server. See <span class="ref" style="">Multicast DNS</span>  [<a href="#nt-id2257158">4</a>].</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">Zero-configuration networking</td>
+      <td align="" colspan="" rowspan="">A set of technologies that enable the use of the Internet Protocol for local communications. See &lt;<a href="http://www.zeroconf.org/">http://www.zeroconf.org/</a>&gt;.</td> 
+    </tr>
+  </table>
+<h2>3.
+       <a name="dns">DNS Records</a>
+</h2>
+  <p class="" style="">In order to advertise its availability for link-local messaging, a client MUST publish four different kinds of DNS records:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">An address ("A") record of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+machine-name.local. A ip-address
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">An "SRV" record (see <span class="ref" style="">RFC 2782</span>  [<a href="#nt-id2257297">5</a>]) of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp &lt;ttl&gt; IN SRV &lt;priority&gt; &lt;weight&gt; port-number username@machine-name.local. 
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">A "PTR" record (see <span class="ref" style="">RFC 2317</span>  [<a href="#nt-id2257266">6</a>] and <span class="ref" style="">RFC 1886</span>  [<a href="#nt-id2257320">7</a>]) of the following form:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp.local. port-number IN PTR username@machine-name._presence._tcp.local.
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Optionally, various "TXT" records (see <span class="ref" style="">RFC 1464</span>  [<a href="#nt-id2257354">8</a>]) of the following form, as further described in to the <a href="#txt">TXT Records</a> section of this document):</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;owner&gt; IN &lt;ttl&gt; TXT "1st=user-first-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "email=user-email-address"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "jid=user-jabber-id"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "last=user-last-name"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "msg=freeform-availability-status"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "phsh=sha1-hash-of-avatar"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "port.p2pj=5298"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "status=avail-or-dnd"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "txtvers=1"
+&lt;owner&gt; IN &lt;ttl&gt; TXT "vc=CU!"
+      </pre></div>
+    </li>
+  </ol>
+  <p class="" style="">The "machine-name" is the name of the computer, the "username" is the system username of the principal currently logged into the computer, the "port" may be any unassigned port number, and the "ip-address" is the physical address of the computer on the local network.</p>
+  <p class="" style="">So, for example, if the machine name is "roundabout", the username is "stpeter", the chosen port is "5526", the IP address is "10.2.1.187", and the personal information is that associated with the author of this document, the DNS records would be as follows:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+roundabout.local. A 10.2.1.187
+
+_presence._tcp IN SRV 5526 stpeter@roundabout.local. 
+
+_presence._tcp.local. 5526 IN PTR stpeter@roundabout._presence._tcp.local.
+
+psa IN TXT "1st=Peter"
+psa IN TXT "email=stpeter@jabber.org"
+psa IN TXT "jid=stpeter@jabber.org"
+psa IN TXT "last=Saint-Andre"
+psa IN TXT "msg=on the phone"
+psa IN TXT "phsh=a3839614e1a382bcfebbcf20464f519e81770813"
+psa IN TXT "port.p2pj=5298"
+psa IN TXT "status=dnd"
+psa IN TXT "txtvers=1"
+psa IN TXT "vc=CU!"
+  </pre></div>
+  <p class="" style="">The IPv4 and IPv6 addresses associated with a machine may vary depending on the local network to which the machine is connected. For example, on an Ethernet connection the physical address might be "10.2.1.187" but when the machine is connected to a wireless network, its physical address might change to "10.10.1.179".</p>
+  <p class="" style="">In the unlikely event that the "presence name" (username@machine-name) asserted by a client is already taken by another entity on the network, the client MUST choose a different presence name, which SHOULD be formed by adding the digit "1" to the end of the username string, adding the digit "2" if the resulting presence name is already taken, and incrementing the digit until a unique presence name is constructed.</p> 
+  <div class="indent">
+<h3>3.1 <a name="txt">TXT Records</a>
+</h3>
+  <p class="" style="">DNS-SD enables service definitions to include various TXT keys that specify parameters to be used in the context of the service type. The TXT keys defined for the _presence._tcp service are as follows:</p>
+  <p class="caption">Table 2: TXT Records</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Name</th>
+      <th colspan="" rowspan="">Description</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">1st</td>
+      <td align="" colspan="" rowspan="">The first name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">email</td>
+      <td align="" colspan="" rowspan="">The email address of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">jid</td>
+      <td align="" colspan="" rowspan="">The Jabber ID of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">last</td>
+      <td align="" colspan="" rowspan="">The last name of the user.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">msg</td>
+      <td align="" colspan="" rowspan="">Natural-language text describing the user's state. This is equivalent to the XMPP &lt;status/&gt; element.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">phsh</td>
+      <td align="" colspan="" rowspan="">The SHA-1 hash of the user's avatar icon or photo.  [<a href="#nt-id2257596">9</a>] This SHOULD be requested using mDNS in unicast mode by sending a DNS query to the mDNS multicast address (224.0.0.251 or its IPv6 equivalent FF02::FB).</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">port.p2pj</td>
+      <td align="" colspan="" rowspan="">The (hardcoded) port for peer-to-peer Jabber communications. Clients MUST use the port discovered via SRV lookups and MUST ignore the value of this TXT field, which is included only for backwards-compatibility with some older, existing implementations.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">status</td>
+      <td align="" colspan="" rowspan="">The presence availability of the user. Allowable values are "avail", "away", and "dnd", which map to mere XMPP presence (the user is available) and the XMPP &lt;show/&gt; values of "away" and "dnd", respectively.</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">txtvers</td>
+      <td align="" colspan="" rowspan="">The version of the TXT fields supported by the client. This document describes txtvers "1".</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">vc</td>
+      <td align="" colspan="" rowspan="">A flag advertising the user's ability to engage in audio or video conferencing. If the user is able to engage in audio conferencing, the string MUST include the "A" character. If the user is able to engage in video conferencing, the string MUST include the "V" character. If the user is able to engage in conferencing with more than one participant, the string MUST include the "C" character. If the user is not currently engaged in an auudio or video conference, the string MUST include the "!" character. The order of characters in the string is immaterial.</td>
+    </tr>
+  </table>
+  <p class="" style="">It is OPTIONAL to include any of these TXT keys, since link-local messaging can be used by non-human entities (e.g., devices) and these keys relate to human users. However, for use by humans, certain keys are of greater interest than others, e.g. the "msg" and "status" keys. See also the <a href="#security">Security Considerations</a> section of this document regarding the inclusion of information that may have an impact on personal privacy (e.g., the "1st", "last", "email", and "jid" keys).</p>
+</div>
+<h2>4.
+       <a name="disco">Discovering Other Users</a>
+</h2>
+  <p class="" style="">In order to discover other users, a client sends an mDNS request for PTR records that match "_presence_tcp.local.". The client then receives replies from all machines that advertise support for link-local messaging.  [<a href="#nt-id2257757">10</a>] The client MAY then find out detailed information about each machine by sending SRV and TXT queries to "username@machine-name._presence._tcp.local." for each machine (however, to preserve bandwidth, the client SHOULD NOT send these queries unless it is about to initiate communications with the other user, and it MUST cancel the queries after it has received a response). Note: The presence name to be used for display in a link-local "roster" MUST be obtained from the &lt;Instance&gt; portion of the received PTR record for each user; the client MAY display a name or nickname derived from the TXT records if available.</p>
+<h2>5.
+       <a name="presence">Exchanging Presence</a>
+</h2>
+  <p class="" style="">When the _presence._tcp service is used, presence is exchanged via the format described in the <a href="#txt">TXT Records</a> section of this document. In particular, presence information is not pushed as in XMPP (see <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2257823">11</a>]). Instead, clients listen for presence announcements from other local entities. Recommended rates for sending updates can be found in <span style="font-weight: bold">draft-cheshire-dnsext-multicastdns</span>.</p>
+<h2>6.
+       <a name="comms">Exchanging Messages</a>
+</h2>
+  <p class="" style="">In order to exchange Jabber communications, the sender opens a TCP connection at the IP address and port discovered via the SRV lookup for a local entity and opens a stream to the recipient with no 'to' or 'from' address:</p>
+  <p class="caption">Example 1. Opening a Stream</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The recipient then responds with a stream header as well:</p>
+  <p class="caption">Example 2. Stream Header Response</p>
+<div class="indent"><pre>
+&lt;stream:stream xmlns='jabber:client' xmlns:stream='http://etherx.jabber.org/streams'&gt;
+  </pre></div>
+  <p class="" style="">The sender then can send messages (or IQs) by specifying 'to' and 'from' addresses using the logical local addresses:  [<a href="#nt-id2257881">12</a>]</p>
+  <p class="caption">Example 3. Sending a Message</p>
+<div class="indent"><pre>
+&lt;message to='hildjj@wolfram' from='stpeter@roundabout'&gt;
+  &lt;body&gt;hey, testing out link-local messaging&lt;/body&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">To end the chat, close the stream:</p>
+  <p class="caption">Example 4. Ending the Chat</p>
+<div class="indent"><pre>
+&lt;/stream:stream&gt;
+  </pre></div>
+<h2>7.
+       <a name="offline">Going Offline</a>
+</h2>
+  <p class="" style="">In order to go offline, a client MUST send a Multicast DNS "Goodbye" packet for the user's PTR record. As a result, all other entities on the local network will receive a Multicast DNS "Remove" event, at which point they MUST cancel any outstanding TXT, SRV, or NULL record queries for the offline user.</p>
+<h2>8.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="impl-network">Multiple Network Interfaces</a>
+</h3>
+    <p class="" style="">Devices that use link-local messaging may have multiple network interfaces. As a result, it is possible to discover the same entity multiple times. Even if a client discovers the same presence name on multiple network interfaces, it MUST show only one entity in the local roster. In addition, because local IP addresses can be dynamically re-assigned, the client SHOULD NOT store the IP address to be used for communications when it discovers that address in the initial DNS lookup phase; instead, SHOULD delay sending the Multicast DNS query until the client is ready to communicate with the other entity.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="impl-icons">Buddy Icons</a>
+</h3>
+    <p class="" style="">If an entity has an associated icon (e.g., a user avatar or photo), its client SHOULD publish the raw binary data for that image via a DNS NULL record of the following form:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+_presence._tcp.local. IN NULL raw-binary-data-here
+    </pre></div>
+    <p class="" style="">Note: In accordance with <span class="ref" style="">RFC 1035</span>  [<a href="#nt-id2258015">13</a>], the data MUST be 65535 octets or less.</p>
+    <p class="" style="">After retrieving the "phsh" value from a Buddy's TXT record, a client SHOULD search its local picture database to learn the last recorded picture hash value for an entity and then compares it to the "phsh" value in the TXT record. If the values are equal, the client SHOULD uses the local copy of the icon. If the picture hash values are not equal, the client SHOULD issue a Multicast DNS NULL record query to retrieve the new icon. After retrieving the NULL record, the client SHOULD replace the old "phsh" value in the picture database with the new "phsh" value and save the icon to disk. If the client needs to send a Multicast DNS query in order to retrieve the icon, it MUST cancel the NULL record query immediately after receiving a response containing the new picture data.</p>
+    <p class="" style="">If a user changes their picture, the user's client MUST update the NULL record with the contents of the new picture, calculate a new picture hash, and then update the "phsh" value in the TXT record with the new hash value. Since all users logged into local presence are monitoring for TXT record changes, they will see that the "phsh" value was changed; if they wish to view the new icon, their clients SHOULD issue a new Multicast DNS query to retrieve the updated picture.</p>
+  </div>
+<h2>9.
+       <a name="i18n">Internationalization Considerations</a>
+</h2>
+  <p class="" style=""><span style="font-weight: bold">RFC 1035</span> does not allow characters outside the <span class="ref" style="">US-ASCII</span>  [<a href="#nt-id2258091">14</a>] character range in DNS A records. Therefore the "machine-name" portion of an A record as used for link-local messaging MUST NOT contain characters outside the US-ASCII character range.</p>
+  <p class="" style="">Although <span style="font-weight: bold">RFC 2317</span> and <span style="font-weight: bold">RFC 2782</span> do not allow characters outside the US-ASCII character range in PTR and SRV records respectively, Section 4.1 of <span style="font-weight: bold">draft-cheshire-dnsext-dns-sd</span> recommends support for UTF-8-encoded Unicode characters in the &lt;Instance&gt; portion of Service Instance Names, which in link-local messaging is the "username@machine-name" portion of the PTR or SRV record. This document adheres to the recommendation in <span style="font-weight: bold">draft-cheshire-dnsext-dns-sd</span>. However, as mentioned above, the "machine-name" portion of the &lt;Instance&gt; portion MUST NOT contain characters outside the US-ASCII range.</p>
+  <p class="" style="">Although <span style="font-weight: bold">RFC 1464</span> does not allow characters outside the US-ASCII character range in TXT records, Section 6.5 of <span style="font-weight: bold">draft-cheshire-dnsext-dns-sd</span> mentions support for UTF-8-encoded Unicode characters in text record values (e.g., values of the TXT "msg" name). This document adheres to the recommendation in <span style="font-weight: bold">draft-cheshire-dnsext-dns-sd</span>.</p>
+<h2>10.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">XMPP networks depend on TLS (<span class="ref" style="">RFC 2246</span>  [<a href="#nt-id2258196">15</a>]) for channel encryption, SASL (<span class="ref" style="">RFC 2222</span>  [<a href="#nt-id2258218">16</a>]) for authentication, and the Domain Name System (<span class="ref" style="">RFC 1034</span>  [<a href="#nt-id2258239">17</a>]) for validation of server hostnames; these technologies help to ensure the identity of sending entities. By contrast, zero-configuration networking uses dynamic discovery and asserted machine names as the basis of sender identity. Therefore, zero-configuration networking does not result in authenticated identities in the same way that XMPP itself does, nor does it provide for an encrypted channel between local entities. (TLS could be negotiated on the local streams, but is out of scope for this specification.)</p>
+  <p class="" style="">Because of fundamental differences between a true XMPP network and a localized XMPP client "mesh", local entities MUST NOT attempt to inject local traffic onto an XMPP network and an XMPP server MUST reject communications until an entity is properly authenticated. However, a client on a local mesh MAY forward traffic to an XMPP network after having properly authenticated on such a network (e.g., to forward a message received on a local client mesh to a contact on an XMPP network).</p>
+  <p class="" style="">The TXT records optionally advertised as part of this protocol MAY result in exposure of privacy-sensitive information about a human user (such as full name, email address, and Jabber ID). A client MUST allow a user to disable publication of this personal information (e.g., via client configuration).</p>
+<h2>11.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">The p2pj port number 5298 is not included in the <span class="ref" style="">IANA Port Numbers Registry</span>  [<a href="#nt-id2258306">18</a>] maintained by the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2258331">19</a>]. The author will investigate whether that port number (or some other port number) needs to be registered.</p>
+<h2>12.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This document requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2258371">20</a>].</p>
+<h2>13.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Justin Karneges, Jens Alfke, and Marc Krochmal for their input.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250734">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250814">2</a>. DNS-Based Service Discovery &lt;<a href="http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt">http://files.dns-sd.org/draft-cheshire-dnsext-dns-sd.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250870">3</a>. RFC 3927: Dynamic Configuration of IPv4 Link-Local Addresses &lt;<a href="http://www.ietf.org/rfc/rfc3927.txt">http://www.ietf.org/rfc/rfc3927.txt</a>&gt;.</p>
+<p><a name="nt-id2257158">4</a>. Multicast DNS &lt;<a href="http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt">http://files.multicastdns.org/draft-cheshire-dnsext-multicastdns.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2257297">5</a>. RFC 2782: A DNS RR for specifying the location of services (DNS SRV) &lt;<a href="http://www.ietf.org/rfc/rfc2782.txt">http://www.ietf.org/rfc/rfc2782.txt</a>&gt;.</p>
+<p><a name="nt-id2257266">6</a>. RFC 2317: Classless IN-ADDR.ARPA delegation &lt;<a href="http://www.ietf.org/rfc/rfc2317.txt">http://www.ietf.org/rfc/rfc2317.txt</a>&gt;.</p>
+<p><a name="nt-id2257320">7</a>. RFC 1886: DNS Extensions to support IP version 6 &lt;<a href="http://www.ietf.org/rfc/rfc1886.txt">http://www.ietf.org/rfc/rfc1886.txt</a>&gt;.</p>
+<p><a name="nt-id2257354">8</a>. RFC 1464: Using the Domain Name System To Store Arbitrary String Attributes &lt;<a href="http://www.ietf.org/rfc/rfc1464.txt">http://www.ietf.org/rfc/rfc1464.txt</a>&gt;.</p>
+<p><a name="nt-id2257596">9</a>. The client should keep a local cache of icons keyed by hash. If the phsh value is not in the cache, the client should fetch the unknown icon and then cache it. Implementations should also include logic for expiring avatar icons.</p>
+<p><a name="nt-id2257757">10</a>. The replies will include a record corresponding the client itself; the client MUST filter out this result.</p>
+<p><a name="nt-id2257823">11</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2257881">12</a>. The "JIDs" MUST be of the form "username@machine-name" as discovered via SRV (this is the &lt;Instance&gt; portion of the Service Instance Name).</p>
+<p><a name="nt-id2258015">13</a>. RFC 1035: Domain Names - Implementation and Specification &lt;<a href="http://www.ietf.org/rfc/rfc1035.txt">http://www.ietf.org/rfc/rfc1035.txt</a>&gt;.</p>
+<p><a name="nt-id2258091">14</a>. Coded Character Set - 7-bit American Standard Code for Information Interchange (American National Standards Institute X3.4, 1986).</p>
+<p><a name="nt-id2258196">15</a>. RFC 2246: The TLS Protocol Version 1.0 &lt;<a href="http://www.ietf.org/rfc/rfc2246.txt">http://www.ietf.org/rfc/rfc2246.txt</a>&gt;.</p>
+<p><a name="nt-id2258218">16</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p><a name="nt-id2258239">17</a>. RFC 1034: Domain Names - Concepts and Facilities &lt;<a href="http://www.ietf.org/rfc/rfc1034.txt">http://www.ietf.org/rfc/rfc1034.txt</a>&gt;.</p>
+<p><a name="nt-id2258306">18</a>. IANA registry of port numbers &lt;<a href="http://www.iana.org/assignments/port-numbers">http://www.iana.org/assignments/port-numbers</a>&gt;.</p>
+<p><a name="nt-id2258331">19</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2258371">20</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.7 (2006-06-06)</h4>
+<div class="indent">
+<p class="" style="">Further clarified internationalization considerations.</p> (psa)
+    </div>
+<h4>Version 0.6 (2006-06-05)</h4>
+<div class="indent">
+<p class="" style="">Clarified internationalization considerations and use of mDNS in unicast mode for avatar retrieval.</p> (psa)
+    </div>
+<h4>Version 0.5 (2006-04-14)</h4>
+<div class="indent">
+<p class="" style="">Specified presence name conflict resolution procedure, offline procedure, use of DNS NULL record for icons, and handling of multiple network interfaces.</p> (psa)
+    </div>
+<h4>Version 0.4 (2006-03-16)</h4>
+<div class="indent">
+<p class="" style="">Corrected PTR format and client discovery process.</p> (psa)
+    </div>
+<h4>Version 0.3 (2006-02-23)</h4>
+<div class="indent">
+<p class="" style="">Added more details about DNS setup and stream initiation; specified internationalization considerations.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-02-22)</h4>
+<div class="indent">
+<p class="" style="">Corrected information about Service Instance Name format, p2pj port, and presence discovery process.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version; changed title to Link-Local Messaging.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-02-07)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0175-0.1.html
+++ b/content/xep-0175-0.1.html
@@ -1,0 +1,226 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0175: Best Practices for Use of SASL ANONYMOUS</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Best Practices for Use of SASL ANONYMOUS">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies best practices for use of the SASL ANONYMOUS mechanism in the context of client authentication with an XMPP server.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-02-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0175">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0175: Best Practices for Use of SASL ANONYMOUS</h1>
+<p>This document specifies best practices for use of the SASL ANONYMOUS mechanism in the context of client authentication with an XMPP server.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Proposed">Proposed</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Informational">Informational</a><br>
+            Number: 0175<br>
+            Version: 0.1<br>
+            Last Updated: 2006-02-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Best%20Practices%20for%20Use%20of%20SASL%20ANONYMOUS%20(JEP-0175)">http://wiki.jabber.org/index.php/Best Practices for Use of SASL ANONYMOUS (JEP-0175)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#rec">Recommendation</a>
+</dt>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This document describes a protocol or best practice that is intended for addition to the specification that will supersede either <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251035">1</a>] or <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2252033">2</a>] within the Internet Standards Process. This document is provided only for the purpose of open community discussion of the potential modification and will be obsoleted as soon as the relevant RFC is published.</span></p>
+  <p class="" style=""><span style="font-weight: bold">RFC 3920</span> allows the use of any SASL mechanism (see <span class="ref" style="">RFC 4422</span>  [<a href="#nt-id2252053">3</a>]) in XMPP authentication, including the SASL ANONYMOUS mechanism (see <span class="ref" style="">RFC 4505</span>  [<a href="#nt-id2252071">4</a>]). This document specifies a recommended protocol flow for such use.</p>
+  <p class="" style="">Note: This document is provided for discussion purposes in order to clarify the usage of SASL ANONYMOUS in XMPP systems. It is not meant to supersede the text in <span style="font-weight: bold">RFC 3920</span>, <span style="font-weight: bold">RFC 4422</span>, or <span style="font-weight: bold">RFC 4505</span>. However, the recommendations in this document may be folded into <span style="font-weight: bold">rfc3920bis</span> when that document is written.</p>
+<h2>2.
+       <a name="rec">Recommendation</a>
+</h2>
+  <p class="" style=""><span style="font-weight: bold">RFC 3920</span> specifies that after an XMPP client authenticates with an XMPP server, it must bind a resource to the XML stream so that XML stanzas can be routed to the client. In essence there are three resource binding scenarios:</p>
+  <ol start="" type="">
+    <li>The client specifies a desired resource identifier and the server accepts it.</li>
+    <li>The client specifies a desired resource identifier but the server does not accept it, instead overruling the client and assigning a resource identifier.</li>
+    <li>The client asks the server to assign a resource identifier and the server does so.</li>
+  </ol>
+  <p class="" style="">No matter which scenario is enacted, at the end of the process the server informs the client of its full JID (&lt;node@domain.tld/resource&gt;). In particular, it might be helpful for an XMPP server to assign a full JID to the client (i.e., not just the resource identifier) if it authenticates with SASL ANONYMOUS, and to ensure that the "bare JID" portion (&lt;node@domain.tld&gt;) is unique in the context of the domain served by the server.</p>
+  <p class="" style="">The RECOMMENDED protocol flow following TLS negotiation (refer to <span style="font-weight: bold">RFC 3920</span>) is as follows:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">Client initiates stream to server.</p>
+      <p class="caption">Example 1. Stream initiation</p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        to='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server replies with stream header.</p>
+      <p class="caption">Example 2. Stream header reply</p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        id='c2s_234' 
+        from='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server advertises stream features.</p>
+      <p class="caption">Example 3. Stream features advertisement</p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    &lt;mechanism&gt;DIGEST-MD5&lt;mechanism&gt;
+    &lt;mechanism&gt;ANONYMOUS&lt;mechanism&gt;
+  &lt;/mechanisms&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client requests SASL ANONYMOUS mechanism.</p>
+      <p class="caption">Example 4. Requesting SASL ANONYMOUS</p>
+<div class="indent"><pre>
+&lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='ANONYMOUS'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server sends &lt;success/&gt;.</p>
+      <p class="caption">Example 5. Sending success</p>
+<div class="indent"><pre>
+&lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client opens new stream.</p>
+      <p class="caption">Example 6. Initiating a new stream</p>
+<div class="indent"><pre>
+&lt;stream:stream
+        xmlns:stream='http://etherx.jabber.org/streams'
+        xmlns='jabber:client'
+        to='example.com'
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server tells client that resource binding is required.</p>
+      <p class="caption">Example 7. Stream header reply with features</p>
+<div class="indent"><pre>
+&lt;stream:stream
+        xmlns:stream='http://etherx.jabber.org/streams'
+        xmlns='jabber:client'
+        id='c2s_345'
+        from='example.com'
+        version='1.0'&gt;
+&lt;stream:features&gt;
+  &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'/&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client requests that server create a resource for it.</p>
+      <p class="caption">Example 8. Requesting resource creation</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='bind_1'&gt;
+  &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'/&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server replies with full JID.</p>
+      <p class="caption">Example 9. Server informs client of full JID</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='bind_1'&gt;
+  &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;jid&gt;somenode@example.com/someresource&lt;/jid&gt;
+  &lt;/bind&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </li>
+  </ol>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations or concerns above and beyond those discussed in <span style="font-weight: bold">RFC 3920</span>.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259693">5</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259736">6</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251035">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2252033">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2252053">3</a>. RFC 4422: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc4422.txt">http://www.ietf.org/rfc/rfc4422.txt</a>&gt;.</p>
+<p><a name="nt-id2252071">4</a>. RFC 4505: The SASL ANONYMOUS Mechanism &lt;<a href="http://www.ietf.org/rfc/rfc4505.txt">http://www.ietf.org/rfc/rfc4505.txt</a>&gt;.</p>
+<p><a name="nt-id2259693">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259736">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version; modified flow to remove unecessary challenge.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-01-24)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0176-0.1.html
+++ b/content/xep-0176-0.1.html
@@ -1,0 +1,487 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0176: Jingle RTP-ICE Transport</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle RTP-ICE Transport">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines a Jingle transport method that results in sending data using the Real-time Transport Protocol (RTP) where the negotiation essentially follows the Interactive Connectivity Establishment (ICE) methodology.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0176">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0176: Jingle RTP-ICE Transport</h1>
+<p>This document defines a Jingle transport method that results in sending data using the Real-time Transport Protocol (RTP) where the negotiation essentially follows the Interactive Connectivity Establishment (ICE) methodology.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0176<br>
+            Version: 0.1<br>
+            Last Updated: 2006-03-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rtp-ice<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20RTP-ICE%20Transport%20(JEP-0176)">http://wiki.jabber.org/index.php/Jingle RTP-ICE Transport (JEP-0176)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol Description</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#protocol-initiate">Transport Initiation</a>
+</dt>
+<dt>3.2.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>3.3.  <a href="#protocol-negotiate">Negotiation</a>
+</dt>
+<dl>
+<dt>3.3.1.  <a href="#protocol-negotiate-candidate">Syntax of Candidate Element</a>
+</dt>
+<dt>3.3.2.  <a href="#protocol-negotiate-flow">Negotiation Flow</a>
+</dt>
+</dl>
+<dt>3.4.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>3.5.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>3.6.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dl><dt>4.1.  <a href="#security-e2e">End-to-End Data Encryption</a>
+</dt></dl>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>6.2.  <a href="#registrar-transports">Jingle Transport Methods</a>
+</dt>
+</dl>
+<dt>7.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2251598">1</a>] defines a framework for negotiating and managing out-of-band multimedia sessions over XMPP. In order to provide a flexible framework, the base Jingle specification defines neither data transport methods nor media (session) types, leaving that up to separate specifications. The current document defines a transport method for establishing and managing Real-time Transport Protocol (RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2251549">2</a>]) streams between XMPP entities, similar to the Interactive Connectivity Establishment (ICE) methodology currently being developed within the IETF (see <span class="ref" style="">Interactive Connectivity Establishment (ICE)</span>  [<a href="#nt-id2251572">3</a>]).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle transport method defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to establish and manage multimedia RTP streams between two XMPP entities, even if they are behind Network Address Translators (NATs) or firewalls.</li>
+    <li>Make it relatively easy to implement support in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol Description</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="protocol-initiate">Transport Initiation</a>
+</h3>
+    <p class="" style="">In order for the initiating entity in a Jingle exchange to start the negotiation, it MUST send a Jingle "session-initiate" stanza as described in <span style="font-weight: bold">JEP-0166</span>. This stanza MUST include at least one transport method. If the initiating entity wishes to negotiate the RTP-ICE transport, it MUST include an empty &lt;transport/&gt; child element qualified by the 'http://jabber.org/protocol/jingle/transport/rtp-ice' namespace.</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='session-initiate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">As described in <span style="font-weight: bold">JEP-0166</span>, to provisionally accept the session initiation request, the target entity returns an IQ-result:</p>
+    <p class="caption">Example 2. Target Entity Provisionally Accepts the Session Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="protocol-negotiate">Negotiation</a>
+</h3>
+    <p class="" style="">As soon as the target entity provisionally accepts the session initiation request, the next phase of the session flow begins: negotiation of connectivity by exchanging XML-formatted candidate transports for the channel. The process for this negotiation is largely the same in Jingle as it is in <span style="font-weight: bold">Interactive Connectivity Establishment (ICE)</span>. The main exception is that Jingle takes advantage of the request-response semantics of the XMPP &lt;iq/&gt; stanza type by sending each candidate transport in a separate IQ exchange. The candidate syntax and negotiation flow described below.</p>
+    <p class="" style="">Note: Earlier versions of <span style="font-weight: bold">JEP-0166</span> (from which this document has been split) contained the concept of a "default candidate"; that functionality is now described in <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2250795">4</a>].</p>
+    <div class="indent">
+<h3>3.3.1 <a name="protocol-negotiate-candidate">Syntax of Candidate Element</a>
+</h3>
+      <p class="" style="">In contrast to <span style="font-weight: bold">ICE</span>, in Jingle candidates are encoded into XML rather than into SDP. In addition, in Jingle a candidate is a single XML element (rather than the candidate pairs recommended in <span style="font-weight: bold">ICE</span>) to save bandwidth.</p>
+      <p class="" style="">The following is an example of the candidate format:</p>
+      <p class="caption">Example 3. Initiating Entity Sends a Candidate Transport</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice1'
+                 protocol='udp'
+                 preference='1.0'
+                 username='/38UHtocC941jdS4' 
+                 password='pcd+Z/WmsthSFIcz'
+                 type='local'
+                 network='0'
+                 generation='0' 
+                 ip='10.1.1.104' 
+                 port='13540'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The attributes of the &lt;candidate/&gt; element are as follows:</p>
+      <ul>
+        <li>The 'channel' attribute identifies a channel within the context of the specified session type; possible values might include 'myrtpvoice' (for Real-time Transfer Protocol) and 'myrtcpvoice' (for Real-Time Control Protocol).</li>
+        <li>The allowable values for the 'protocol' attribute are "udp", "tcp", and "ssltcp" as described below.</li>
+        <li>The 'username', 'password', and 'preference' attributes directly map to the same entities in <span style="font-weight: bold">ICE</span>.</li>
+        <li>The 'type' attribute is used for diagnostics; the allowable values are "local", "stun" (see <span class="ref" style="">RFC 3489</span>  [<a href="#nt-id2250907">5</a>]), and "relay".</li>
+        <li>The 'network' attribute is also used for diagnostics; it is an index, starting at 0, referencing which network this candidate is on for a given peer (useful if the calling hardware has more than one Network Interface Card or NIC).</li>
+        <li>The 'generation' attribute is an index, starting at 0, that enables the parties to keep track of updates to the candidate throughout the life of the session (see below).</li>
+        <li>The 'ip' attribute specifies the Internet Protocol (IP) address for the candidate transport mechanism; this may be either an IPv4 address or an IPv6 address.</li>
+        <li>The 'port' attribute specifies the port at the candidate IP address.</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>3.3.2 <a name="protocol-negotiate-flow">Negotiation Flow</a>
+</h3>
+      <p class="" style="">The first step in negotiating connectivity is for each client to immediately begin sending candidate transport methods to the other client. These candidates SHOULD be gathered by following the procedure specified in Section 7.1 of <span style="font-weight: bold">ICE</span> and prioritied by following the procedure specified in Section 7.2 of <span style="font-weight: bold">ICE</span>. Each candidate MUST be sent in a &lt;jingle/&gt; element with an action of "transport-info".</p>
+      <p class="" style="">If the target entity successfully receives the candidate, it returns an IQ-result (if not, for example because the candidate data is improperly formatted, it returns an error).</p>
+      <p class="" style="">Note well that the target entity is only indicating receipt of the candidate, not telling the initiating entity that the candidate will be used.</p>
+      <p class="" style="">The initiating entity keeps sending candidates, one after the other (without stopping to receive an acknowledgement of receipt from the target entity for each candidate) until it has exhausted its supply of possible or desirable candidate transports:  [<a href="#nt-id2256830">6</a>] For each candidate, the target entity acknowledges receipt.</p>
+      <p class="" style="">At the same time (i.e., immediately after provisionally accepting the session, not waiting for the initiating entity to begin or finish sending candidates), the target entity also begins sending candidates that may work for it. As above, the initiating entity acknowledges receipt of the candidates.</p>
+      <p class="" style="">As the initiating entity and target entity receive candidates, they probe the various candidate transports for connectivity. In performing these connectivity checks, client SHOULD follow the procedure specified in Section 7.6 of <span style="font-weight: bold">ICE</span>.</p>
+      <p class="caption">Example 4. Initiating Entity Sends a Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice1'
+                 protocol='udp'
+                 preference='1.0'
+                 username='/38UHtocC941jdS4' 
+                 password='pcd+Z/WmsthSFIcz'
+                 type='local'
+                 network='0'
+                 generation='0' 
+                 ip='10.1.1.104' 
+                 port='13540'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 5. Initiating Entity Sends a Second Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info2' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice2'
+                 protocol='udp'
+                 preference='0.8'
+                 type='stun'
+                 username='ld6Hi+PfVtnmU8cf'
+                 password='gzoufy3aMXBRtiWs'
+                 network='1'
+                 generation='0' 
+                 ip='1.2.3.4' 
+                 port='6459'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 6. Initiating Entity Sends a Third Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info3' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice3'
+                 protocol='udp'
+                 preference='0.1'
+                 type='relay'
+                 username='XKqUmqiftjPUYAbF'
+                 password='G4116MkgTzb8+1N/'
+                 network='2'
+                 generation='0' 
+                 ip='5.6.7.8' 
+                 port='9823'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">For each candidate received, the other party MUST acknowledge receipt or return an error:</p>
+      <p class="caption">Example 7. Receiving Entity Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info1' type='result'/&gt;
+
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info2' type='result'/&gt;
+
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info3' type='result'/&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If, based on STUN connectivity checks, either entity determines that it will be able to establish a connection, it sends a &lt;jingle/&gt; element with an action of 'transport-accept' to the initiating entity, specifying the acceptable candidate:</p>
+    <p class="caption">Example 8. Juliet Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='transport-accept' 
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice3'
+                 protocol='udp'
+                 preference='0.1'
+                 type='relay'
+                 username='XKqUmqiftjPUYAbF'
+                 password='G4116MkgTzb8+1N/'
+                 network='2'
+                 generation='0' 
+                 ip='5.6.7.8' 
+                 port='9823'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the transport-accept stanza SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity. If provided, all future commmunications SHOULD be sent to the JID provided in the 'responder' attribute.</p> 
+    <p class="" style="">The initiating entity then acknowledges the target entity's acceptance:</p>
+    <p class="caption">Example 9. Romeo Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending media over the negotiated connection.</p>
+    <p class="" style="">In the event that the target entity cannot find a suitable candidate transport, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session, either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 10. Juliet Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='term1' 
+    to='romeo@montague.net/orchard' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity then acknowledges termination of the session:</p>
+    <p class="caption">Example 11. Romeo Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further communication for the session type MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'redirect' or 'terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 12. Juliet Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">The syntax and semantics informational message payloads specific to the Raw UDP transport method will be defined in a future version of this specification.</p>
+  </div>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="security-e2e">End-to-End Data Encryption</a>
+</h3>
+    <p class="" style="">In order to secure the end-to-end data stream, implementations SHOULD use native RTP encryption methods, such as <span class="ref" style="">ZRTP</span>  [<a href="#nt-id2257191">7</a>] or <span class="ref" style="">RTP Over DTLS</span>  [<a href="#nt-id2257219">8</a>].</p>
+  </div>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257261">9</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257306">10</a>] shall include 'http://jabber.org/protocol/jingle/transport/rtp-ice' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="registrar-transports">Jingle Transport Methods</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include "http://jabber.org/protocol/jingle/transport/rtp-ice" in its registry of Jingle transport methods. The registry submission is as follows:</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;rtp-ice&lt;/name&gt;
+  &lt;desc&gt;
+    A method for negotiation of RTP streams with built-in NAT and firewall traversal, 
+    similar to the IETF's Interactive Connectivity Establishment (ICE) methodology.
+  &lt;/desc&gt;
+  &lt;doc&gt;JEP-0176&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>7.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/transports/rtp-ice'
+    xmlns='http://jabber.org/protocol/jingle/transports/rtp-ice'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='transport'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='candidate' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='candidate'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='generation' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='ip' type='IPaddress' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='network' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='password' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='port' type='xs:unsignedShort' use='required'/&gt;
+          &lt;xs:attribute name='preference' type='xs:decimal' use='required'/&gt;
+          &lt;xs:attribute name='username' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='IPaddress'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:pattern value='((1?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]).){3}(1?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251598">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2251549">2</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2251572">3</a>. Interactive Connectivity Establishment (ICE): A Methodology for Network Address Translator (NAT) Traversal for Offer/Answer Protocols &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-06.txt">http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-06.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250795">4</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2250907">5</a>. RFC 3489: STUN - Simple Traversal of User Datagram Protocol (UDP) Through Network Address Translators (NATs) &lt;<a href="http://www.ietf.org/rfc/rfc3489.txt">http://www.ietf.org/rfc/rfc3489.txt</a>&gt;.</p>
+<p><a name="nt-id2256830">6</a>. Because certain candidates may be more "expensive" in terms of bandwidth or processing power, the initiator may not want to advertise their existence unless necessary.</p>
+<p><a name="nt-id2257191">7</a>. ZRTP: Extensions to RTP for Diffie-Hellman Key Agreement for SRTP &lt;<a href="http://www.ietf.org/internet-drafts/draft-zimmermann-avt-zrtp-01.txt">http://www.ietf.org/internet-drafts/draft-zimmermann-avt-zrtp-01.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2257219">8</a>. Real-Time Transport Protocol (RTP) over Datagram Transport Layer Security (DTLS) &lt;<a href="http://scm.sipfoundry.org/rep/ietf-drafts/ekr/draft-tschofenig-avt-rtp-dtls-00.txt">http://scm.sipfoundry.org/rep/ietf-drafts/ekr/draft-tschofenig-avt-rtp-dtls-00.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2257261">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257306">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-03-01)</h4>
+<div class="indent">Initial JEP version (split from JEP-0166). (psa/jb)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0176-0.2.html
+++ b/content/xep-0176-0.2.html
@@ -1,0 +1,511 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0176: Jingle RTP-ICE Transport</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle RTP-ICE Transport">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines a Jingle transport method that results in sending data using the Real-time Transport Protocol (RTP) where the negotiation essentially follows the Interactive Connectivity Establishment (ICE) methodology.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-24">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0176">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0176: Jingle RTP-ICE Transport</h1>
+<p>This document defines a Jingle transport method that results in sending data using the Real-time Transport Protocol (RTP) where the negotiation essentially follows the Interactive Connectivity Establishment (ICE) methodology.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0176<br>
+            Version: 0.2<br>
+            Last Updated: 2006-03-24<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: rtp-ice<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20RTP-ICE%20Transport%20(JEP-0176)">http://wiki.jabber.org/index.php/Jingle RTP-ICE Transport (JEP-0176)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol Description</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#protocol-initiate">Transport Initiation</a>
+</dt>
+<dt>3.2.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>3.3.  <a href="#protocol-negotiate">Negotiation</a>
+</dt>
+<dl>
+<dt>3.3.1.  <a href="#protocol-negotiate-candidate">Syntax of Candidate Element</a>
+</dt>
+<dt>3.3.2.  <a href="#protocol-negotiate-flow">Negotiation Flow</a>
+</dt>
+</dl>
+<dt>3.4.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>3.5.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>3.6.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>4.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>4.1.  <a href="#impl-dtmf">DTMF</a>
+</dt></dl>
+<dt>5.  <a href="#deploy">Deployment Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl><dt>6.1.  <a href="#security-e2e">End-to-End Data Encryption</a>
+</dt></dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-transports">Jingle Transport Methods</a>
+</dt>
+</dl>
+<dt>9.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2251570">1</a>] defines a framework for negotiating and managing out-of-band multimedia sessions over XMPP. In order to provide a flexible framework, the base Jingle specification defines neither data transport methods nor media (session) types, leaving that up to separate specifications. The current document defines a transport method for establishing and managing Real-time Transport Protocol (RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2251606">2</a>]) streams between XMPP entities, similar to the Interactive Connectivity Establishment (ICE) methodology currently being developed within the IETF (see <span class="ref" style="">Interactive Connectivity Establishment (ICE)</span>  [<a href="#nt-id2250632">3</a>]).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle transport method defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to establish and manage multimedia RTP streams between two XMPP entities, even if they are behind Network Address Translators (NATs) or firewalls.</li>
+    <li>Make it relatively easy to implement support in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol Description</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="protocol-initiate">Transport Initiation</a>
+</h3>
+    <p class="" style="">In order for the initiating entity in a Jingle exchange to start the negotiation, it MUST send a Jingle "session-initiate" stanza as described in <span style="font-weight: bold">JEP-0166</span>. This stanza MUST include at least one transport method. If the initiating entity wishes to negotiate the RTP-ICE transport, it MUST include an empty &lt;transport/&gt; child element qualified by the 'http://jabber.org/protocol/jingle/transport/rtp-ice' namespace.</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='session-initiate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">As described in <span style="font-weight: bold">JEP-0166</span>, to provisionally accept the session initiation request, the target entity returns an IQ-result:</p>
+    <p class="caption">Example 2. Target Entity Provisionally Accepts the Session Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="protocol-negotiate">Negotiation</a>
+</h3>
+    <p class="" style="">As soon as the target entity provisionally accepts the session initiation request, the next phase of the session flow begins: negotiation of connectivity by exchanging XML-formatted candidate transports for the channel. The process for this negotiation is largely the same in Jingle as it is in <span style="font-weight: bold">Interactive Connectivity Establishment (ICE)</span>. The main exception is that Jingle takes advantage of the request-response semantics of the XMPP &lt;iq/&gt; stanza type by sending each candidate transport in a separate IQ exchange. The candidate syntax and negotiation flow described below.</p>
+    <p class="" style="">Note: Earlier versions of <span style="font-weight: bold">JEP-0166</span> (from which this document has been split) contained the concept of a "default candidate"; that functionality is now described in <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2250790">4</a>].</p>
+    <div class="indent">
+<h3>3.3.1 <a name="protocol-negotiate-candidate">Syntax of Candidate Element</a>
+</h3>
+      <p class="" style="">In contrast to <span style="font-weight: bold">ICE</span>, in Jingle candidates are encoded into XML rather than into SDP. In addition, in Jingle a candidate is a single XML element (rather than the candidate pairs recommended in <span style="font-weight: bold">ICE</span>) to save bandwidth.</p>
+      <p class="" style="">The following is an example of the candidate format:</p>
+      <p class="caption">Example 3. Initiating Entity Sends a Candidate Transport</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice1'
+                 protocol='udp'
+                 preference='1.0'
+                 username='/38UHtocC941jdS4' 
+                 password='pcd+Z/WmsthSFIcz'
+                 type='local'
+                 network='0'
+                 generation='0' 
+                 ip='10.1.1.104' 
+                 port='13540'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The attributes of the &lt;candidate/&gt; element are as follows:</p>
+      <ul>
+        <li>The 'channel' attribute identifies a channel within the context of the specified session type; possible values might include 'myrtpvoice' (for Real-time Transfer Protocol) and 'myrtcpvoice' (for Real-Time Control Protocol).</li>
+        <li>The allowable values for the 'protocol' attribute are "udp", "tcp", and "ssltcp" as described below.</li>
+        <li>The 'username', 'password', and 'preference' attributes directly map to the same entities in <span style="font-weight: bold">ICE</span>.</li>
+        <li>The 'type' attribute is used for diagnostics; the allowable values are "local", "stun" (see <span class="ref" style="">RFC 3489</span>  [<a href="#nt-id2256854">5</a>]), and "relay".</li>
+        <li>The 'network' attribute is also used for diagnostics; it is an index, starting at 0, referencing which network this candidate is on for a given peer (useful if the calling hardware has more than one Network Interface Card or NIC).</li>
+        <li>The 'generation' attribute is an index, starting at 0, that enables the parties to keep track of updates to the candidate throughout the life of the session (see below).</li>
+        <li>The 'ip' attribute specifies the Internet Protocol (IP) address for the candidate transport mechanism; this may be either an IPv4 address or an IPv6 address.</li>
+        <li>The 'port' attribute specifies the port at the candidate IP address.</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>3.3.2 <a name="protocol-negotiate-flow">Negotiation Flow</a>
+</h3>
+      <p class="" style="">The first step in negotiating connectivity is for each client to immediately begin sending candidate transport methods to the other client. These candidates SHOULD be gathered by following the procedure specified in Section 7.1 of <span style="font-weight: bold">ICE</span> and prioritied by following the procedure specified in Section 7.2 of <span style="font-weight: bold">ICE</span>. Each candidate MUST be sent in a &lt;jingle/&gt; element with an action of "transport-info".</p>
+      <p class="" style="">If the target entity successfully receives the candidate, it returns an IQ-result (if not, for example because the candidate data is improperly formatted, it returns an error).</p>
+      <p class="" style="">Note well that the target entity is only indicating receipt of the candidate, not telling the initiating entity that the candidate will be used.</p>
+      <p class="" style="">The initiating entity keeps sending candidates, one after the other (without stopping to receive an acknowledgement of receipt from the target entity for each candidate) until it has exhausted its supply of possible or desirable candidate transports:  [<a href="#nt-id2256942">6</a>] For each candidate, the target entity acknowledges receipt.</p>
+      <p class="" style="">At the same time (i.e., immediately after provisionally accepting the session, not waiting for the initiating entity to begin or finish sending candidates), the target entity also begins sending candidates that may work for it. As above, the initiating entity acknowledges receipt of the candidates.</p>
+      <p class="" style="">As the initiating entity and target entity receive candidates, they probe the various candidate transports for connectivity. In performing these connectivity checks, client SHOULD follow the procedure specified in Section 7.6 of <span style="font-weight: bold">ICE</span>.</p>
+      <p class="caption">Example 4. Initiating Entity Sends a Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice1'
+                 protocol='udp'
+                 preference='1.0'
+                 username='/38UHtocC941jdS4' 
+                 password='pcd+Z/WmsthSFIcz'
+                 type='local'
+                 network='0'
+                 generation='0' 
+                 ip='10.1.1.104' 
+                 port='13540'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 5. Initiating Entity Sends a Second Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info2' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice2'
+                 protocol='udp'
+                 preference='0.8'
+                 type='stun'
+                 username='ld6Hi+PfVtnmU8cf'
+                 password='gzoufy3aMXBRtiWs'
+                 network='1'
+                 generation='0' 
+                 ip='1.2.3.4' 
+                 port='6459'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 6. Initiating Entity Sends a Third Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info3' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice3'
+                 protocol='udp'
+                 preference='0.1'
+                 type='relay'
+                 username='XKqUmqiftjPUYAbF'
+                 password='G4116MkgTzb8+1N/'
+                 network='2'
+                 generation='0' 
+                 ip='5.6.7.8' 
+                 port='9823'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">For each candidate received, the other party MUST acknowledge receipt or return an error:</p>
+      <p class="caption">Example 7. Receiving Entity Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info1' type='result'/&gt;
+
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info2' type='result'/&gt;
+
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info3' type='result'/&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If, based on STUN connectivity checks, either entity determines that it will be able to establish a connection, it sends a &lt;jingle/&gt; element with an action of 'transport-accept' to the initiating entity, specifying the acceptable candidate:</p>
+    <p class="caption">Example 8. Juliet Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='transport-accept' 
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/rtp-ice'&gt;
+      &lt;candidate name='myrtpvoice3'
+                 protocol='udp'
+                 preference='0.1'
+                 type='relay'
+                 username='XKqUmqiftjPUYAbF'
+                 password='G4116MkgTzb8+1N/'
+                 network='2'
+                 generation='0' 
+                 ip='5.6.7.8' 
+                 port='9823'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the transport-accept stanza SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity. If provided, all future commmunications SHOULD be sent to the JID provided in the 'responder' attribute.</p> 
+    <p class="" style="">The initiating entity then acknowledges the target entity's acceptance:</p>
+    <p class="caption">Example 9. Romeo Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending media over the negotiated connection.</p>
+    <p class="" style="">In the event that the target entity cannot find a suitable candidate transport, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session, either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 10. Juliet Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='term1' 
+    to='romeo@montague.net/orchard' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity then acknowledges termination of the session:</p>
+    <p class="caption">Example 11. Romeo Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further communication for the session type MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'redirect' or 'terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 12. Juliet Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">The syntax and semantics informational message payloads specific to the Raw UDP transport method will be defined in a future version of this specification.</p>
+  </div>
+<h2>4.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="impl-dtmf">DTMF</a>
+</h3>
+    <p class="" style="">If it is necessary to send Dual Tone Multi-Frequency (DTMF) tones, it is RECOMMENDED to use the RTP-native methods specified in <span class="ref" style="">RFC 2833</span>  [<a href="#nt-id2257441">7</a>]. The XML format specified <span class="ref" style="">Jingle DTMF </span>  [<a href="#nt-id2257467">8</a>] MAY be used only as a fallback.</p>
+  </div>
+<h2>5.
+       <a name="deploy">Deployment Notes</a>
+</h2>
+  <p class="" style="">This specification applies exclusively to Jabber/XMPP clients and places no additional requirements on Jabber/XMPP servers. However, service administrators may wish to deploy a STUN server and/or data relay service in order to ease the client-to-client negotiation process.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="security-e2e">End-to-End Data Encryption</a>
+</h3>
+    <p class="" style="">In order to secure the end-to-end data stream, implementations SHOULD use native RTP encryption methods, such as <span class="ref" style="">ZRTP</span>  [<a href="#nt-id2257534">9</a>] or <span class="ref" style="">RTP Over DTLS</span>  [<a href="#nt-id2257558">10</a>].</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257596">11</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257642">12</a>] shall include 'http://jabber.org/protocol/jingle/transport/rtp-ice' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-transports">Jingle Transport Methods</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include "http://jabber.org/protocol/jingle/transport/rtp-ice" in its registry of Jingle transport methods. The registry submission is as follows:</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;rtp-ice&lt;/name&gt;
+  &lt;desc&gt;
+    A method for negotiation of RTP streams with built-in NAT and firewall traversal, 
+    similar to the IETF's Interactive Connectivity Establishment (ICE) methodology.
+  &lt;/desc&gt;
+  &lt;doc&gt;JEP-0176&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/transports/rtp-ice'
+    xmlns='http://jabber.org/protocol/jingle/transports/rtp-ice'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='transport'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='candidate' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='candidate'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='generation' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='ip' type='IPaddress' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='network' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='password' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='port' type='xs:unsignedShort' use='required'/&gt;
+          &lt;xs:attribute name='preference' type='xs:decimal' use='required'/&gt;
+          &lt;xs:attribute name='username' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='IPaddress'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:pattern value='((1?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]).){3}(1?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251570">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2251606">2</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2250632">3</a>. Interactive Connectivity Establishment (ICE): A Methodology for Network Address Translator (NAT) Traversal for Offer/Answer Protocols &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-07.txt">http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-07.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250790">4</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2256854">5</a>. RFC 3489: STUN - Simple Traversal of User Datagram Protocol (UDP) Through Network Address Translators (NATs) &lt;<a href="http://www.ietf.org/rfc/rfc3489.txt">http://www.ietf.org/rfc/rfc3489.txt</a>&gt;.</p>
+<p><a name="nt-id2256942">6</a>. Because certain candidates may be more "expensive" in terms of bandwidth or processing power, the initiator may not want to advertise their existence unless necessary.</p>
+<p><a name="nt-id2257441">7</a>. RFC 2833: RTP Payload for DTMF Digits, Telephony Tones and Telephony Signals &lt;<a href="http://www.ietf.org/rfc/rfc2833.txt">http://www.ietf.org/rfc/rfc2833.txt</a>&gt;.</p>
+<p><a name="nt-id2257467">8</a>. JEP-0181: Jingle DTMF &lt;<a href="http://www.jabber.org/jeps/jep-0181.html">http://www.jabber.org/jeps/jep-0181.html</a>&gt;.</p>
+<p><a name="nt-id2257534">9</a>. ZRTP: Extensions to RTP for Diffie-Hellman Key Agreement for SRTP &lt;<a href="http://www.ietf.org/internet-drafts/draft-zimmermann-avt-zrtp-01.txt">http://www.ietf.org/internet-drafts/draft-zimmermann-avt-zrtp-01.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2257558">10</a>. Real-Time Transport Protocol (RTP) over Datagram Transport Layer Security (DTLS) &lt;<a href="http://scm.sipfoundry.org/rep/ietf-drafts/ekr/draft-tschofenig-avt-rtp-dtls-00.txt">http://scm.sipfoundry.org/rep/ietf-drafts/ekr/draft-tschofenig-avt-rtp-dtls-00.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2257596">11</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257642">12</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-03-24)</h4>
+<div class="indent">
+<p class="" style="">Recommended use of RTP-native methods for DTMF.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-03-01)</h4>
+<div class="indent">Initial JEP version (split from JEP-0166). (psa/jb)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0176-0.3.html
+++ b/content/xep-0176-0.3.html
@@ -1,0 +1,516 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0176: Jingle ICE Transport</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle ICE Transport">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Creator" content="Sean Egan">
+<meta name="DC.Description" content="This document defines a Jingle transport method that results in sending data between two entities using Interactive Connectivity Establishment (ICE) methodology.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0176">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0176: Jingle ICE Transport</h1>
+<p>This document defines a Jingle transport method that results in sending data between two entities using Interactive Connectivity Establishment (ICE) methodology.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0176<br>
+            Version: 0.3<br>
+            Last Updated: 2006-07-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: ice<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20ICE%20Transport%20(JEP-0176)">http://wiki.jabber.org/index.php/Jingle ICE Transport (JEP-0176)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+<h3>Sean Egan</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:seanegan@google.com">seanegan@google.com</a><br>
+        JID: 
+        <a href="xmpp:seanegan@google.com">seanegan@google.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol Description</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#protocol-initiate">Transport Initiation</a>
+</dt>
+<dt>3.2.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>3.3.  <a href="#protocol-negotiate">Negotiation</a>
+</dt>
+<dl>
+<dt>3.3.1.  <a href="#protocol-negotiate-candidate">Syntax of Candidate Element</a>
+</dt>
+<dt>3.3.2.  <a href="#protocol-negotiate-flow">Negotiation Flow</a>
+</dt>
+</dl>
+<dt>3.4.  <a href="#protocol-acceptance">Acceptance</a>
+</dt>
+<dt>3.5.  <a href="#protocol-terminate">Termination</a>
+</dt>
+<dt>3.6.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>4.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>4.1.  <a href="#impl-dtmf">DTMF</a>
+</dt></dl>
+<dt>5.  <a href="#deploy">Deployment Notes</a>
+</dt>
+<dt>6.  <a href="#security">Security Considerations</a>
+</dt>
+<dl><dt>6.1.  <a href="#security-e2e">End-to-End Data Encryption</a>
+</dt></dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>8.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>8.2.  <a href="#registrar-transports">Jingle Transport Methods</a>
+</dt>
+</dl>
+<dt>9.  <a href="#schema">XML Schemas</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This specification is out of sync with the IETF's Interactive Connectivity Establishment (ICE) document, which is a work in progress. It will be brought into synchronization after publication of version 10 of the ICE specification.</span></p>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2250770">1</a>] defines a framework for negotiating and managing out-of-band data sessions over XMPP. In order to provide a flexible framework, the base Jingle specification defines neither data transport methods nor content (session) types, leaving that up to separate specifications. The current document defines a transport method for establishing and managing data connections between XMPP entities, using the Interactive Connectivity Establishment (ICE) methodology currently being developed within the IETF (see <span class="ref" style="">Interactive Connectivity Establishment (ICE)</span>  [<a href="#nt-id2250936">2</a>]).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle transport method defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to establish and manage out-of-band connections between two XMPP entities, even if they are behind Network Address Translators (NATs) or firewalls.</li>
+    <li>Make it relatively easy to implement support in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol Description</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="protocol-initiate">Transport Initiation</a>
+</h3>
+    <p class="" style="">In order for the initiating entity in a Jingle exchange to start the negotiation, it MUST send a Jingle "session-initiate" stanza as described in <span style="font-weight: bold">JEP-0166</span>. This stanza MUST include at least one transport method. If the initiating entity wishes to negotiate the ICE transport, it MUST include an empty &lt;transport/&gt; child element qualified by the 'http://jabber.org/protocol/jingle/transport/ice' namespace.</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='session-initiate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'/&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">As described in <span style="font-weight: bold">JEP-0166</span>, to provisionally accept the session initiation request, the target entity returns an IQ-result:</p>
+    <p class="caption">Example 2. Target Entity Provisionally Accepts the Session Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="protocol-negotiate">Negotiation</a>
+</h3>
+    <p class="" style="">As soon as the target entity provisionally accepts the session initiation request, the next phase of the session flow begins: negotiation of connectivity by exchanging XML-formatted candidate transports for the channel. The process for this negotiation is largely the same in Jingle as it is in <span style="font-weight: bold">Interactive Connectivity Establishment (ICE)</span>. The main exception is that Jingle takes advantage of the request-response semantics of the XMPP &lt;iq/&gt; stanza type by sending each candidate transport in a separate IQ exchange. The candidate syntax and negotiation flow described below.</p>
+    <p class="" style="">Note: Earlier versions of <span style="font-weight: bold">JEP-0166</span> (from which this document has been split) contained the concept of a "default candidate"; that functionality is now described in <span class="ref" style="">Jingle Raw UDP Transport Method </span>  [<a href="#nt-id2250861">3</a>].</p>
+    <div class="indent">
+<h3>3.3.1 <a name="protocol-negotiate-candidate">Syntax of Candidate Element</a>
+</h3>
+      <p class="" style="">In contrast to <span style="font-weight: bold">ICE</span>, in Jingle candidates are encoded into XML rather than into SDP. In addition, in Jingle a candidate is a single XML element (rather than the candidate pairs recommended in <span style="font-weight: bold">ICE</span>).</p>
+      <p class="" style="">The following is an example of the candidate format:</p>
+      <p class="caption">Example 3. Initiating Entity Sends a Candidate Transport</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info'
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+      &lt;candidate name='myrtpvoice1'
+                 protocol='udp'
+                 preference='1.0'
+                 username='/38UHtocC941jdS4' 
+                 password='pcd+Z/WmsthSFIcz'
+                 type='local'
+                 network='0'
+                 generation='0' 
+                 ip='10.1.1.104' 
+                 port='13540'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">The attributes of the &lt;candidate/&gt; element are as follows:</p>
+      <ul>
+        <li>The 'channel' attribute identifies a channel within the context of the specified session type; possible values might include 'myrtpvoice' (for Real-time Transfer Protocol) and 'myrtcpvoice' (for Real-Time Control Protocol).</li>
+        <li>The allowable values for the 'protocol' attribute are: "udp" (when standard <span style="font-weight: bold">ICE</span> is used); "tcp", "tcp-act", and "tcp-pass" (when <span class="ref" style="">TCP Candidates with Interactive Connectivity Establishment (ICE)</span>  [<a href="#nt-id2259722">4</a>] is used); and "ssltcp" (definition to follow).</li>
+        <li>The 'username', 'password', and 'preference' attributes directly map to the same entities in <span style="font-weight: bold">ICE</span>.</li>
+        <li>The 'type' attribute is used for diagnostics; the allowable values are "local", "stun" (see <span class="ref" style="">RFC 3489</span>  [<a href="#nt-id2259758">5</a>]), and "relay".</li>
+        <li>The 'network' attribute is also used for diagnostics; it is an index, starting at 0, referencing which network this candidate is on for a given peer (useful if the calling hardware has more than one Network Interface Card or NIC).</li>
+        <li>The 'generation' attribute is an index, starting at 0, that enables the parties to keep track of updates to the candidate throughout the life of the session (see below).</li>
+        <li>The 'ip' attribute specifies the Internet Protocol (IP) address for the candidate transport mechanism; this may be either an IPv4 address or an IPv6 address.</li>
+        <li>The 'port' attribute specifies the port at the candidate IP address.</li>
+      </ul>
+    </div>
+    <div class="indent">
+<h3>3.3.2 <a name="protocol-negotiate-flow">Negotiation Flow</a>
+</h3>
+      <p class="" style="">The first step in negotiating connectivity is for each client to immediately begin sending candidate transport methods to the other client. These candidates SHOULD be gathered by following the procedure specified in Section 7.1 of <span style="font-weight: bold">ICE</span> and prioritied by following the procedure specified in Section 7.2 of <span style="font-weight: bold">ICE</span>. Each candidate MUST be sent in a &lt;jingle/&gt; element with an action of "transport-info".</p>
+      <p class="" style="">If the target entity successfully receives the candidate, it returns an IQ-result (if not, for example because the candidate data is improperly formatted, it returns an error).</p>
+      <p class="" style="">Note well that the target entity is only indicating receipt of the candidate, not telling the initiating entity that the candidate will be used.</p>
+      <p class="" style="">The initiating entity keeps sending candidates, one after the other (without stopping to receive an acknowledgement of receipt from the target entity for each candidate) until it has exhausted its supply of possible or desirable candidate transports:  [<a href="#nt-id2259823">6</a>] For each candidate, the target entity acknowledges receipt.</p>
+      <p class="" style="">At the same time (i.e., immediately after provisionally accepting the session, not waiting for the initiating entity to begin or finish sending candidates), the target entity also begins sending candidates that may work for it. As above, the initiating entity acknowledges receipt of the candidates.</p>
+      <p class="" style="">As the initiating entity and target entity receive candidates, they probe the various candidate transports for connectivity. In performing these connectivity checks, client SHOULD follow the procedure specified in Section 7.6 of <span style="font-weight: bold">ICE</span>.</p>
+      <p class="caption">Example 4. Initiating Entity Sends a Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+      &lt;candidate name='myrtpvoice1'
+                 protocol='udp'
+                 preference='1.0'
+                 username='/38UHtocC941jdS4' 
+                 password='pcd+Z/WmsthSFIcz'
+                 type='local'
+                 network='0'
+                 generation='0' 
+                 ip='10.1.1.104' 
+                 port='13540'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 5. Initiating Entity Sends a Second Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info2' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+      &lt;candidate name='myrtpvoice2'
+                 protocol='udp'
+                 preference='0.8'
+                 type='stun'
+                 username='ld6Hi+PfVtnmU8cf'
+                 password='gzoufy3aMXBRtiWs'
+                 network='1'
+                 generation='0' 
+                 ip='1.2.3.4' 
+                 port='6459'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="caption">Example 6. Initiating Entity Sends a Third Candidate</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='info3' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-info' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+      &lt;candidate name='myrtpvoice3'
+                 protocol='udp'
+                 preference='0.1'
+                 type='relay'
+                 username='XKqUmqiftjPUYAbF'
+                 password='G4116MkgTzb8+1N/'
+                 network='2'
+                 generation='0' 
+                 ip='5.6.7.8' 
+                 port='9823'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+      </pre></div>
+      <p class="" style="">For each candidate received, the other party MUST acknowledge receipt or return an error:</p>
+      <p class="caption">Example 7. Receiving Entity Acknowledges Receipt</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info1' type='result'/&gt;
+
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info2' type='result'/&gt;
+
+&lt;iq from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='info3' type='result'/&gt;
+      </pre></div>
+    </div>
+  </div>
+  <div class="indent">
+<h3>3.4 <a name="protocol-acceptance">Acceptance</a>
+</h3>
+    <p class="" style="">If, based on STUN connectivity checks, either entity determines that it will be able to establish a connection, it sends a &lt;jingle/&gt; element with an action of 'transport-accept' to the initiating entity, specifying the acceptable candidate:</p>
+    <p class="caption">Example 8. Juliet Definitively Accepts the Call</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='accept1'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='transport-accept' 
+          initiator='romeo@montague.net/orchard'
+          responder='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/ice'&gt;
+      &lt;candidate name='myrtpvoice3'
+                 protocol='udp'
+                 preference='0.1'
+                 type='relay'
+                 username='XKqUmqiftjPUYAbF'
+                 password='G4116MkgTzb8+1N/'
+                 network='2'
+                 generation='0' 
+                 ip='5.6.7.8' 
+                 port='9823'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The &lt;jingle/&gt; element in the transport-accept stanza SHOULD possess a 'responder' attribute that explicitly specifies the full JID of the responding entity. If provided, all future commmunications SHOULD be sent to the JID provided in the 'responder' attribute.</p> 
+    <p class="" style="">The initiating entity then acknowledges the target entity's acceptance:</p>
+    <p class="caption">Example 9. Romeo Acknowledges Definitive Acceptance</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='accept1'/&gt;
+    </pre></div>
+    <p class="" style="">Now the initiating entity and target entity can begin sending data over the negotiated connection.</p>
+    <p class="" style="">In the event that the target entity cannot find a suitable candidate transport, it SHOULD terminate the session as described below.</p>
+  </div>
+  <div class="indent">
+<h3>3.5 <a name="protocol-terminate">Termination</a>
+</h3>
+    <p class="" style="">In order to gracefully end the session, either the target entity or the initiating entity MUST a send a "terminate" action to the other party:</p>
+    <p class="caption">Example 10. Juliet Terminates the Session</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='term1' 
+    to='romeo@montague.net/orchard' 
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='terminate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">The initiating entity then acknowledges termination of the session:</p>
+    <p class="caption">Example 11. Romeo Acknowledges Termination</p>
+<div class="indent"><pre>
+&lt;iq type='result' to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='term1'/&gt;
+    </pre></div>
+    <p class="" style="">Unfortunately, not all sessions end gracefully. The following events MUST be considered session-ending events, and any further communication for the session type MUST be completed through negotiation of a new session:</p>
+    <ul>
+      <li>Receipt of a 'redirect' or 'terminate' action from the other party.</li>
+      <li>Receipt of &lt;presence type='unavailable'/&gt; from the other party.</li>
+    </ul>
+    <p class="" style="">In particular, one party MUST consider the session to be in the ENDED state if it receives presence of type "unavailable" from the other party:</p>
+    <p class="caption">Example 12. Juliet Goes Offline</p>
+<div class="indent"><pre>
+&lt;presence from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' type='unavailable'/&gt;
+    </pre></div>
+    <p class="" style="">Naturally, in this case there is nothing for the initiating entity to acknowledge.</p>
+  </div>
+  <div class="indent">
+<h3>3.6 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">The syntax and semantics informational message payloads specific to the ICE transport method will be defined in a future version of this specification.</p>
+  </div>
+<h2>4.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="impl-dtmf">DTMF</a>
+</h3>
+    <p class="" style="">If it is necessary to send Dual Tone Multi-Frequency (DTMF) tones, it is REQUIRED to use the XML format specified <span class="ref" style="">Jingle DTMF </span>  [<a href="#nt-id2260345">7</a>].</p>
+  </div>
+<h2>5.
+       <a name="deploy">Deployment Notes</a>
+</h2>
+  <p class="" style="">This specification applies exclusively to Jabber/XMPP clients and places no additional requirements on Jabber/XMPP servers. However, service administrators may wish to deploy a STUN server and/or data relay service in order to ease the client-to-client negotiation process.</p>
+<h2>6.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="security-e2e">End-to-End Data Encryption</a>
+</h3>
+    <p class="" style="">In order to secure the end-to-end data stream, implementations SHOULD use encryption methods appropriate to the transport method in use.</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260436">8</a>].</p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>8.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260479">9</a>] shall include 'http://jabber.org/protocol/jingle/transport/ice' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>8.2 <a name="registrar-transports">Jingle Transport Methods</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include "http://jabber.org/protocol/jingle/transport/ice" in its registry of Jingle transport methods. The registry submission is as follows:</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;ice&lt;/name&gt;
+  &lt;desc&gt;
+    A method for negotiation of out-of-band connections with built-in NAT and firewall traversal, 
+    similar to the IETF's Interactive Connectivity Establishment (ICE) methodology.
+  &lt;/desc&gt;
+  &lt;doc&gt;JEP-0176&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>9.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/transports/ice'
+    xmlns='http://jabber.org/protocol/jingle/transports/ice'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='transport'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:choice&gt;
+        &lt;xs:sequence&gt;
+          &lt;xs:element ref='candidate' minOccurs='0' maxOccurs='1'/&gt;
+        &lt;/xs:sequence&gt;
+      &lt;/xs:choice&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='candidate'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='generation' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='ip' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='network' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='password' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='port' type='xs:unsignedShort' use='required'/&gt;
+          &lt;xs:attribute name='preference' type='xs:decimal' use='required'/&gt;
+          &lt;xs:attribute name='username' type='xs:string' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250770">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2250936">2</a>. Interactive Connectivity Establishment (ICE): A Methodology for Network Address Translator (NAT) Traversal for Offer/Answer Protocols &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-09.txt">http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-09.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250861">3</a>. JEP-0177: Jingle Raw UDP Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0177.html">http://www.jabber.org/jeps/jep-0177.html</a>&gt;.</p>
+<p><a name="nt-id2259722">4</a>. TCP Candidates with Interactive Connectivity Establishment (ICE) &lt;<a href="http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-tcp-00.txt">http://www.ietf.org/internet-drafts/draft-ietf-mmusic-ice-tcp-00.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2259758">5</a>. RFC 3489: STUN - Simple Traversal of User Datagram Protocol (UDP) Through Network Address Translators (NATs) &lt;<a href="http://www.ietf.org/rfc/rfc3489.txt">http://www.ietf.org/rfc/rfc3489.txt</a>&gt;.</p>
+<p><a name="nt-id2259823">6</a>. Because certain candidates may be more "expensive" in terms of bandwidth or processing power, the initiator may not want to advertise their existence unless necessary.</p>
+<p><a name="nt-id2260345">7</a>. JEP-0181: Jingle DTMF &lt;<a href="http://www.jabber.org/jeps/jep-0181.html">http://www.jabber.org/jeps/jep-0181.html</a>&gt;.</p>
+<p><a name="nt-id2260436">8</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260479">9</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Specified that DTMF must use in-band signalling (JEP-0181).</p> (se/psa)
+    </div>
+<h4>Version 0.2 (2006-03-24)</h4>
+<div class="indent">
+<p class="" style="">Recommended use of RTP-native methods for DTMF.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-03-01)</h4>
+<div class="indent">Initial JEP version (split from JEP-0166). (psa/jb)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0177-0.1.html
+++ b/content/xep-0177-0.1.html
@@ -1,0 +1,283 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0177: Jingle Raw UDP Transport</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle Raw UDP Transport">
+<meta name="DC.Creator" content="Joe Beda">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Scott Ludwig">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document defines a Jingle transport method that results in sending data using the Real-time Transport Protocol (RTP) over a raw User Datagram Protocol (UDP) connection.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-01">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0177">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0177: Jingle Raw UDP Transport</h1>
+<p>This document defines a Jingle transport method that results in sending data using the Real-time Transport Protocol (RTP) over a raw User Datagram Protocol (UDP) connection.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0177<br>
+            Version: 0.1<br>
+            Last Updated: 2006-03-01<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: raw-udp<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20Raw%20UDP%20Transport%20(JEP-0177)">http://wiki.jabber.org/index.php/Jingle Raw UDP Transport (JEP-0177)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Joe Beda</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jbeda@google.com">jbeda@google.com</a><br>
+        JID: 
+        <a href="xmpp:jbeda@google.com">jbeda@google.com</a></p>
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Scott Ludwig</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:scottlu@google.com">scottlu@google.com</a><br>
+        JID: 
+        <a href="xmpp:scottlu@google.com">scottlu@google.com</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol Description</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#protocol-initiate">Transport Initiation</a>
+</dt>
+<dt>3.2.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>3.3.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dl><dt>4.1.  <a href="#security-e2e">End-to-End Data Encryption</a>
+</dt></dl>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>6.2.  <a href="#registrar-transports">Jingle Transport Methods</a>
+</dt>
+</dl>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2251556">1</a>] defines a framework for negotiating and managing out-of-band multimedia sessions over XMPP. In order to provide a flexible framework, the base Jingle specification defines neither data transport methods nor media (session) types, leaving that up to separate specifications. The current document defines a transport method for establishing and managing Real-time Transport Protocol (RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2251586">2</a>]) streams between XMPP entities using a raw User Datagram Protocol (UDP) connection (see <span class="ref" style="">RFC 768</span>  [<a href="#nt-id2251609">3</a>]).</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle transport method defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Make it possible to establish and manage multimedia RTP streams between two XMPP entities over the IP address and port that the initiator considers most likely to succeed.</li>
+    <li>Make it relatively easy to implement support in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol Description</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="protocol-initiate">Transport Initiation</a>
+</h3>
+    <p class="" style="">In order for the initiating entity in a Jingle exchange to start the negotiation, it MUST send a Jingle "session-initiate" stanza as described in <span style="font-weight: bold">JEP-0166</span>. This stanza MUST include at least one transport methods. If the initiating entity wishes to negotiate the Raw UDP transport, it MUST include an empty &lt;transport/&gt; child element qualified by the 'http://jabber.org/protocol/jingle/transport/raw-udp' namespace.</p>
+    <p class="" style="">This &lt;transport/&gt; element MUST include one and only one &lt;candidate/&gt; element per channel, whose 'ip' and 'port' attributes specify the IP address and port number of the candidate that the initiator has reason to believe will be most likely to succeed for that channel. (Note: In older versions of JEP-0166, this was referrred to as the "default candidate".) This is not necessarily the initiator's preferred address for communication, but instead is the "address most likely to succeed", i.e., the address that is assumed to be reachable by the vast majority of target entities. To determine reachability, the client needs classify ahead of time the permissiveness of the firewall or network address translator (NAT) it is behind, if any. If the NAT is symmetric (not permissive), the candidate SHOULD specify a relay address. Otherwise it SHOULD be an address derived via prior discovery using <span class="ref" style="">RFC 3489</span>  [<a href="#nt-id2250710">4</a>], which will be an address on the outside of the firewall or NAT.</p>
+    <p class="caption">Example 1. Initiation Example</p>
+<div class="indent"><pre>
+&lt;iq to='juliet@capulet.com/balcony' from='romeo@montague.net/orchard' id='jingle1' type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='session-initiate' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;description ...&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+      &lt;candidate name='myvoicedata' ip='10.1.1.104' port='13540' generation='0'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">Note: The 'name' attribute specifies the name of the channel and the 'generation' attribute provides a tracking mechanism for determining which version of this candidate is in force (this is useful if the candidate is redefined mid-stream, for example if the port is changed).</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">As described in <span style="font-weight: bold">JEP-0166</span>, to provisionally accept the session initiation request, the target entity returns an IQ-result:</p>
+    <p class="caption">Example 2. Target Entity Provisionally Accepts the Session Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">To accept the Raw UDP transport method, the target entity MUST send a &lt;jingle/&gt; element with an action of 'transport-accept', specifying the transport method desired.</p>
+    <p class="caption">Example 3. Target Entity Accepts the Raw UDP Transport Method</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle2'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle' 
+          action='transport-accept' 
+          initiator='romeo@montague.net/orchard'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/raw-udp'&gt;
+      &lt;candidate ip='10.1.1.104' port='13540'/&gt;
+    &lt;/transport&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="protocol-info">Informational Messages</a>
+</h3>
+    <p class="" style="">The syntax and semantics informational message payloads specific to the Raw UDP transport method will be defined in a future version of this specification.</p>
+  </div>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <div class="indent">
+<h3>4.1 <a name="security-e2e">End-to-End Data Encryption</a>
+</h3>
+    <p class="" style="">In order to secure the end-to-end data stream, implementations SHOULD use native RTP encryption methods, such as <span class="ref" style="">ZRTP</span>  [<a href="#nt-id2250892">5</a>] or <span class="ref" style="">RTP Over DTLS</span>  [<a href="#nt-id2250871">6</a>].</p>
+  </div>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2256774">7</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>6.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2256822">8</a>] shall include 'http://jabber.org/protocol/jingle/transport/raw-udp' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="registrar-transports">Jingle Transport Methods</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include "http://jabber.org/protocol/jingle/transport/raw-udp" in its registry of Jingle transport methods. The registry submission is as follows:</p>
+    <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;raw-udp&lt;/name&gt;
+  &lt;desc&gt;A method for exchanging RTP streams over a raw UDP connection.&lt;/desc&gt;
+  &lt;doc&gt;JEP-0176&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/transports/raw-udp'
+    xmlns='http://jabber.org/protocol/jingle/transports/raw-udp'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='transport'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='candidate' minOccurs='0' maxOccurs='1'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='candidate'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='generation' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='ip' type='IPaddress' use='required'/&gt;
+          &lt;xs:attribute name='port' type='xs:unsignedShort' use='required'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='IPaddress'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:pattern value='((1?[0-9]?[0-9]|2[0-4][0-9]|25[0-5]).){3}(1?[0-9]?[0-9]|2[0-4][0-9]|25[0-5])'/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251556">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2251586">2</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2251609">3</a>. RFC 768: User Datagram Protocol &lt;<a href="http://www.ietf.org/rfc/rfc0768.txt">http://www.ietf.org/rfc/rfc0768.txt</a>&gt;.</p>
+<p><a name="nt-id2250710">4</a>. RFC 3489: STUN - Simple Traversal of User Datagram Protocol (UDP) Through Network Address Translators (NATs) &lt;<a href="http://www.ietf.org/rfc/rfc3489.txt">http://www.ietf.org/rfc/rfc3489.txt</a>&gt;.</p>
+<p><a name="nt-id2250892">5</a>. ZRTP: Extensions to RTP for Diffie-Hellman Key Agreement for SRTP &lt;<a href="http://www.ietf.org/internet-drafts/draft-zimmermann-avt-zrtp-01.txt">http://www.ietf.org/internet-drafts/draft-zimmermann-avt-zrtp-01.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2250871">6</a>. Real-Time Transport Protocol (RTP) over Datagram Transport Layer Security (DTLS) &lt;<a href="http://scm.sipfoundry.org/rep/ietf-drafts/ekr/draft-tschofenig-avt-rtp-dtls-00.txt">http://scm.sipfoundry.org/rep/ietf-drafts/ekr/draft-tschofenig-avt-rtp-dtls-00.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2256774">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2256822">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-03-01)</h4>
+<div class="indent">Initial JEP version (split from JEP-0166). (psa/jb)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0178-0.1.html
+++ b/content/xep-0178-0.1.html
@@ -1,0 +1,462 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0178: Best Practices for Use of SASL EXTERNAL</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Best Practices for Use of SASL EXTERNAL">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Description" content="This document specifies best practices for use of the SASL EXTERNAL mechanism within XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0178">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0178: Best Practices for Use of SASL EXTERNAL</h1>
+<p>This document specifies best practices for use of the SASL EXTERNAL mechanism within XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0178<br>
+            Version: 0.1<br>
+            Last Updated: 2006-03-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Best%20Practices%20for%20Use%20of%20SASL%20EXTERNAL%20(JEP-0178)">http://wiki.jabber.org/index.php/Best Practices for Use of SASL EXTERNAL (JEP-0178)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Peter Millard</h3>
+<p class="indent">
+        See <a href="#authornote">Author Note</a><br></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#c2s">Client-to-Server Recommendation</a>
+</dt>
+<dt>3.  <a href="#s2s">Server-to-Server Recommendation</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#authornote">Author Note</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251649">1</a>] allows the use of any SASL mechanism (see <span class="ref" style="">RFC 2222</span>  [<a href="#nt-id2251673">2</a>]) in XMPP authentication, including the SASL EXTERNAL mechanism. This document specifies a recommended protocol flow for such use.</p>
+  <p class="" style="">Note: This document is provided for discussion purposes in order to clarify the usage of SASL EXTERNAL in XMPP systems. It is not meant to supersede the text in <span style="font-weight: bold">RFC 3920</span> or <span style="font-weight: bold">RFC 2222</span>. However, the recommendations in this document may be folded into <span style="font-weight: bold">rfc3920bis</span> when that document is written.</p>
+<h2>2.
+       <a name="c2s">Client-to-Server Recommendation</a>
+</h2>
+  <p class="" style="">The RECOMMENDED protocol flow for client-to-server use of SASL EXTERNAL is as follows:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">Client initiates stream to server.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        to='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        id='c2s_234' 
+        from='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server advertises TLS stream feature.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+    &lt;required/&gt;
+  &lt;/starttls&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client sends STARTTLS command to server.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server informs client to proceed.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client presents certificate.</p>
+    </li>
+    <li>
+      <p class="" style="">Server validates certificate.</p>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">If certification authority is not recognized or certificate has been revoked, server closes client's TCP connection.</p>
+        </li>
+        <li>
+          <p class="" style="">Else server completes successful TLS negotiation and client initiates a new stream header to server.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        to='example.com' 
+        version='1.0'&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">Server replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        id='c2s_345' 
+        from='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server advertises SASL mechanisms. Because client presented a certificate, server advertises SASL EXTERNAL mechanism.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    &lt;mechanism&gt;DIGEST-MD5&lt;mechanism&gt;
+    &lt;mechanism&gt;EXTERNAL&lt;mechanism&gt;
+    &lt;mechanism&gt;ANONYMOUS&lt;mechanism&gt;
+  &lt;/mechanisms&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Because client presented a certificate, client SHOULD consider EXTERNAL to be its preferred SASL mechanism. The client SHOULD NOT include an authorization identity (i.e., XML character data for the &lt;auth/&gt; element) since client-to-server authorization in XMPP is handled during resource binding.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='EXTERNAL'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server sends &lt;success/&gt;.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client opens new stream.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream
+        xmlns:stream='http://etherx.jabber.org/streams'
+        xmlns='jabber:client'
+        to='example.com'
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream
+        xmlns:stream='http://etherx.jabber.org/streams'
+        xmlns='jabber:client'
+        id='c2s_345'
+        from='example.com'
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server tells client that resource binding is required.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'/&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client binds a resource (or requests that server create a resource for it).</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq type='set' id='bind_1'&gt;
+  &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;resource&gt;someresource&lt;/resource&gt;
+  &lt;/bind&gt;
+&lt;/iq&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server determines the authorized JID of the user.  [<a href="#nt-id2257172">3</a>]</p>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">If the certificate presented by the client contains only one valid XMPP address  [<a href="#nt-id2257194">4</a>] that corresponds to a registered account on the server, the server SHOULD use that address as the user's authorized JID for the purpose of resource binding, add the requested resource (or create a resource if no resource was requested), and return the result as the user's authorized full JID (&lt;node@domain.tld/resource&gt;) for purposes of resource binding.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq type='result' id='bind_1'&gt;
+  &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;jid&gt;somenode@example.com/someresource&lt;/jid&gt;
+  &lt;/bind&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">If the certificate contains more than one valid XMPP address that corresponds to a registered account on the server (e.g., because the server offers virtual hosting), the server SHOULD use the JID whose hostname matches the 'to' address of the stream header sent by the client to the server, add the requested resource (or create a resource if no resource was requested), and return the result as the user's authorized full JID (&lt;node@domain.tld/resource&gt;) for purposes of resource binding.</p>
+        </li>
+        <li>
+          <p class="" style="">If the certificate does not contain a valid XMPP address that corresponds to a registered account on the server, the server MAY attempt to determine if there is a registered account associated with the user, for example by performing an LDAP lookup based on the Common Name in the certificate; if such a JID mapping is successful, the server SHOULD use that mapped JID as the user's authorized JID, add the requested resource (or create a resource if no resource was requested), and return the result as the user's authorized full JID (&lt;node@domain.tld/resource&gt;) for purposes of resource binding. </p>
+        </li>
+        <li>
+          <p class="" style="">If the user cannot be associated with an account registered on the server, the server MUST return a resource binding error, which SHOULD be &lt;not-authorized/&gt;.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;iq type='error' id='bind_1'&gt;
+  &lt;bind xmlns='urn:ietf:params:xml:ns:xmpp-bind'&gt;
+    &lt;jid&gt;someresource&lt;/jid&gt;
+  &lt;/bind&gt;
+  &lt;error type='cancel'&gt;
+    &lt;not-authorized xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </li>
+  </ol>
+<h2>3.
+       <a name="s2s">Server-to-Server Recommendation</a>
+</h2>
+  <p class="" style="">The RECOMMENDED protocol flow for server-to-server use of SASL EXTERNAL is as follows:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">Server1 initiates stream to server2.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:server' 
+        from='conference.example.org' 
+        to='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server2 replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:server' 
+        id='s2s_234' 
+        from='example.com' 
+        to='conference.example.org'
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server2 advertises TLS stream feature.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+    &lt;required/&gt;
+  &lt;/starttls&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server1 sends STARTTLS command to Server2.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server2 informs Server1 to proceed.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server1 presents certificate.</p>
+    </li>
+    <li>
+      <p class="" style="">Server2 validates certificate.</p>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">If certificate has been revoked, Server2 closes Server1's TCP connection.</p>
+        </li>
+        <li>
+          <p class="" style="">Else Server2 completes successful TLS negotiation and Server1 initiates a new stream header to Server2.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:server' 
+        from='conference.example.org'
+        to='example.com' 
+        version='1.0'&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">Server2 replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:server' 
+        id='s2s_345' 
+        from='example.com' 
+        to='conference.example.org'
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server2 advertises SASL mechanisms. Because Server1 presented a certificate, Server2 advertises SASL EXTERNAL mechanism.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    &lt;mechanism&gt;EXTERNAL&lt;mechanism&gt;
+  &lt;/mechanisms&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Because Server1 presented a certificate, Server1 SHOULD consider EXTERNAL to be its preferred SASL mechanism. Server1 SHOULD include an authorization identity (base64-encoded according as described in RFC 3920) as the XML character data of the &lt;auth/&gt; element, which SHOULD be the same as the 'from' address on the stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='EXTERNAL'&gt;Y29uZmVyZW5jZS5leGFtcGxlLm9yZwo=&lt;/auth&gt;
+      </pre></div>
+      <p class="" style="">(In this case, the authorization identity is "conference.example.org".)</p>
+    </li>
+    <li>
+      <p class="" style="">Server2 determines if hostname is valid.</p>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">If the authorization identity provided by Server1 matches one of the valid XMPP addresses in the certificate or one of the Common Names in the certificates, Server2 SHOULD return success.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Else server MUST return a &lt;not-authorized/&gt; failure and close the stream.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;failure xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+  &lt;not-authorized/&gt;
+&lt;/failure&gt;
+&lt;/stream:stream&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </li>
+  </ol>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations or concerns above and beyond those discussed in <span style="font-weight: bold">RFC 3920</span>.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257777">5</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257823">6</a>].</p>
+<h2>7.
+       <a name="authornote">Author Note</a>
+</h2>
+  <p class="" style="">Peter Millard, a co-author of this specification through version 0.1, died on April 26, 2006.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251649">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251673">2</a>. RFC 2222: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc2222.txt">http://www.ietf.org/rfc/rfc2222.txt</a>&gt;.</p>
+<p><a name="nt-id2257172">3</a>. Although TLS and SASL EXTERNAL result in an authenticated user, the server now needs to determine which JID the user is authorized to use.</p>
+<p><a name="nt-id2257194">4</a>. A valid XMPP address is a JID encapsulated as a subjectAltName with an ASN.1 Object Identifier of "id-on-xmppAddr" (which is equivalent to the dotted display format of "1.3.6.1.5.5.7.8.5").</p>
+<p><a name="nt-id2257777">5</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257823">6</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-02-10)</h4>
+<div class="indent">
+<p class="" style="">Specified inclusion of authorization identity for server-to-server.</p> (psa/pgm)
+    </div>
+<h4>Version 0.0.2 (2006-02-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified distinction between authentication and authorization.</p> (psa/pgm)
+    </div>
+<h4>Version 0.0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/pgm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0178-0.2.html
+++ b/content/xep-0178-0.2.html
@@ -1,0 +1,429 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0178: Best Practices for Use of SASL EXTERNAL</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Best Practices for Use of SASL EXTERNAL">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Peter Millard">
+<meta name="DC.Description" content="This document specifies best practices for use of the SASL EXTERNAL mechanism within XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0178">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0178: Best Practices for Use of SASL EXTERNAL</h1>
+<p>This document specifies best practices for use of the SASL EXTERNAL mechanism within XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Informational">Informational</a><br>
+            Number: 0178<br>
+            Version: 0.2<br>
+            Last Updated: 2006-03-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Best%20Practices%20for%20Use%20of%20SASL%20EXTERNAL%20(JEP-0178)">http://wiki.jabber.org/index.php/Best Practices for Use of SASL EXTERNAL (JEP-0178)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Peter Millard</h3>
+<p class="indent">
+        See <a href="#authornote">Author Note</a><br></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#c2s">Client-to-Server Recommendation</a>
+</dt>
+<dt>3.  <a href="#s2s">Server-to-Server Recommendation</a>
+</dt>
+<dt>4.  <a href="#other">Use of SASL EXTERNAL Without Certificates</a>
+</dt>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>8.  <a href="#authornote">Author Note</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span style="font-style: italic">Note: This document describes a protocol or best practice that is intended for addition to the specification that will supersede either <span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2250762">1</a>] or <span class="ref" style="">RFC 3921</span>  [<a href="#nt-id2250924">2</a>] within the Internet Standards Process. This document is provided only for the purpose of open community discussion of the potential modification and will be obsoleted as soon as the relevant RFC is published.</span></p>
+  <p class="" style=""><span style="font-weight: bold">RFC 3920</span> allows the use of any SASL mechanism (see <span class="ref" style="">RFC 4422</span>  [<a href="#nt-id2250941">3</a>]) in XMPP authentication, including the SASL EXTERNAL mechanism. This document specifies a recommended protocol flow for such use.</p>
+  <p class="" style="">Note: This document is provided for discussion purposes in order to clarify the usage of SASL EXTERNAL in XMPP systems. It is not meant to supersede the text in <span style="font-weight: bold">RFC 3920</span> or <span style="font-weight: bold">RFC 4422</span>. However, it is intended that the recommendations in this document will be folded into <span style="font-weight: bold">rfc3920bis</span>.</p>
+<h2>2.
+       <a name="c2s">Client-to-Server Recommendation</a>
+</h2>
+  <p class="" style="">The RECOMMENDED protocol flow for client-to-server use of SASL EXTERNAL with end-user certificates is as follows:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">Client initiates stream to server.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        to='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        id='c2s_234' 
+        from='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server advertises TLS stream feature.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+    &lt;required/&gt;
+  &lt;/starttls&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client sends STARTTLS command to server.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server informs client to proceed.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Client presents certificate.</p>
+    </li>
+    <li>
+      <p class="" style="">Server validates certificate.</p>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">If certification authority is not recognized or certificate has been revoked, server closes client's TCP connection.</p>
+        </li>
+        <li>
+          <p class="" style="">Else server completes successful TLS negotiation and client initiates a new stream header to server.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        to='example.com' 
+        version='1.0'&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">Server replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:client' 
+        id='c2s_345' 
+        from='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server advertises SASL mechanisms. Because client presented a certificate, server advertises SASL EXTERNAL mechanism.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    &lt;mechanism&gt;DIGEST-MD5&lt;mechanism&gt;
+    &lt;mechanism&gt;EXTERNAL&lt;mechanism&gt;
+    &lt;mechanism&gt;ANONYMOUS&lt;mechanism&gt;
+  &lt;/mechanisms&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Because client presented a certificate, client SHOULD consider EXTERNAL to be its preferred SASL mechanism. The client SHOULD NOT include an authorization identity (i.e., XML character data for the &lt;auth/&gt; element) since client-to-server authorization in XMPP is handled during resource binding.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='EXTERNAL'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server determines whether to allow authenticatation of user.</p>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">If the certificate presented by the client contains only one valid XMPP address  [<a href="#nt-id2259642">4</a>] that corresponds to a registered account on the server, the server SHOULD allow authentication of that JID.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">If the certificate contains more than one valid XMPP address that corresponds to a registered account on the server (e.g., because the server offers virtual hosting), the server SHOULD allow authentication of the JID whose hostname matches the 'to' address of the stream header sent by the client to the server.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">If the certificate does not contain a valid XMPP address that corresponds to a registered account on the server, the server MAY attempt to determine if there is a registered account associated with the user, for example by performing an LDAP lookup based on the Common Name in the certificate; if such a JID mapping is successful, the server SHOULD allow authentication of that mapped JID.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">If the user cannot be associated with an account registered on the server, the server MUST return a SASL failure of &lt;not-authorized/&gt; and close the stream.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;failure xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+  &lt;not-authorized/&gt;
+&lt;/failure&gt;
+&lt;/stream:stream&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">If SASL authentication succeeded, client opens new stream, then client and server proceed with resource binding as described in <span style="font-weight: bold">RFC 3920</span>.</p>
+    </li>
+  </ol>
+<h2>3.
+       <a name="s2s">Server-to-Server Recommendation</a>
+</h2>
+  <p class="" style="">The RECOMMENDED protocol flow for server-to-server use of SASL EXTERNAL with server (domain) certificates is as follows:</p>
+  <ol start="" type="">
+    <li>
+      <p class="" style="">Server1 initiates stream to server2.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:server' 
+        from='conference.example.org' 
+        to='example.com' 
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server2 replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:server' 
+        id='s2s_234' 
+        from='example.com' 
+        to='conference.example.org'
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server2 advertises TLS stream feature.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+    &lt;required/&gt;
+  &lt;/starttls&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server1 sends STARTTLS command to Server2.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;starttls xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server2 informs Server1 to proceed.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;proceed xmlns='urn:ietf:params:xml:ns:xmpp-tls'/&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server1 presents certificate.</p>
+    </li>
+    <li>
+      <p class="" style="">Server2 validates certificate.</p>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">If certificate has been revoked, Server2 closes Server1's TCP connection.</p>
+        </li>
+        <li>
+          <p class="" style="">Else Server2 completes successful TLS negotiation and Server1 initiates a new stream header to Server2.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:server' 
+        from='conference.example.org'
+        to='example.com' 
+        version='1.0'&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </li>
+    <li>
+      <p class="" style="">Server2 replies with stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream 
+        xmlns:stream='http://etherx.jabber.org/streams' 
+        xmlns='jabber:server' 
+        id='s2s_345' 
+        from='example.com' 
+        to='conference.example.org'
+        version='1.0'&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Server2 advertises SASL mechanisms. Because Server1 presented a certificate, Server2 advertises SASL EXTERNAL mechanism.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:features&gt;
+  &lt;mechanisms xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+    &lt;mechanism&gt;EXTERNAL&lt;mechanism&gt;
+  &lt;/mechanisms&gt;
+&lt;/stream:features&gt;
+      </pre></div>
+    </li>
+    <li>
+      <p class="" style="">Because Server1 presented a certificate, Server1 SHOULD consider EXTERNAL to be its preferred SASL mechanism. Server1 SHOULD include an authorization identity (base64-encoded according as described in RFC 3920) as the XML character data of the &lt;auth/&gt; element, which SHOULD be the same as the 'from' address on the stream header.</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;auth xmlns='urn:ietf:params:xml:ns:xmpp-sasl' mechanism='EXTERNAL'&gt;Y29uZmVyZW5jZS5leGFtcGxlLm9yZwo=&lt;/auth&gt;
+      </pre></div>
+      <p class="" style="">(In this case, the authorization identity is "conference.example.org".)</p>
+    </li>
+    <li>
+      <p class="" style="">Server2 determines if hostname is valid.</p>
+      <ol start="" type="">
+        <li>
+          <p class="" style="">If the authorization identity provided by Server1 matches one of the valid XMPP addresses in the certificate or one of the Common Names in the certificates, Server2 SHOULD return success.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;success xmlns='urn:ietf:params:xml:ns:xmpp-sasl'/&gt;
+          </pre></div>
+        </li>
+        <li>
+          <p class="" style="">Else server MUST return a &lt;not-authorized/&gt; failure and close the stream.</p>
+          <p class="caption"></p>
+<div class="indent"><pre>
+&lt;failure xmlns='urn:ietf:params:xml:ns:xmpp-sasl'&gt;
+  &lt;not-authorized/&gt;
+&lt;/failure&gt;
+&lt;/stream:stream&gt;
+          </pre></div>
+        </li>
+      </ol>
+    </li>
+  </ol>
+<h2>4.
+       <a name="other">Use of SASL EXTERNAL Without Certificates</a>
+</h2>
+  <p class="" style="">The SASL EXTERNAL mechanism can be used outside the context of X.509 certificates, for example Intern Protocol Security (IPSec) as specified in <span class="ref" style="">RFC 4301</span>  [<a href="#nt-id2260084">5</a>]. A future version of this specification may document best practices for use of SASL EXTERNAL outside the context of the X.509 infrastructure.</p>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations or concerns above and beyond those discussed in <span style="font-weight: bold">RFC 3920</span>.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2260142">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260185">7</a>].</p>
+<h2>8.
+       <a name="authornote">Author Note</a>
+</h2>
+  <p class="" style="">Peter Millard, co-author of the initial version of this specification, died on April 26, 2006. The remaining author appreciates his assistance in defining the best practices described herein.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2250762">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250924">2</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250941">3</a>. RFC 4422: Simple Authentication and Security Layer (SASL) &lt;<a href="http://www.ietf.org/rfc/rfc4422.txt">http://www.ietf.org/rfc/rfc4422.txt</a>&gt;.</p>
+<p><a name="nt-id2259642">4</a>. A valid XMPP address is a JID encapsulated as a subjectAltName with an ASN.1 Object Identifier of "id-on-xmppAddr" (which is equivalent to the dotted display format of "1.3.6.1.5.5.7.8.5").</p>
+<p><a name="nt-id2260084">5</a>. RFC 4301: Security Architecture for the Internet Protocol &lt;<a href="http://www.ietf.org/rfc/rfc4301.txt">http://www.ietf.org/rfc/rfc4301.txt</a>&gt;.</p>
+<p><a name="nt-id2260142">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260185">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Corrected client-server failure case to place error in SASL flow rather than binding flow; added note about non-X.509 usages.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.3 (2006-02-10)</h4>
+<div class="indent">
+<p class="" style="">Specified inclusion of authorization identity for server-to-server.</p> (psa/pgm)
+    </div>
+<h4>Version 0.0.2 (2006-02-10)</h4>
+<div class="indent">
+<p class="" style="">Clarified distinction between authentication and authorization.</p> (psa/pgm)
+    </div>
+<h4>Version 0.0.1 (2006-02-09)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/pgm)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0179-0.1.html
+++ b/content/xep-0179-0.1.html
@@ -1,0 +1,275 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0179: Jingle IAX Transport Method</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle IAX Transport Method">
+<meta name="DC.Creator" content="Antonio F. Cano">
+<meta name="DC.Description" content="This document defines a Jingle transport method that results in using the Inter-Asterisk eXchange protocol (IAX) for the final communication.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-09">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0179">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="">
+</head>
+<body>
+<h1>JEP-0179: Jingle IAX Transport Method</h1>
+<p>This document defines a Jingle transport method that results in using the Inter-Asterisk eXchange protocol (IAX) for the final communication.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0179<br>
+            Version: 0.1<br>
+            Last Updated: 2006-03-09<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle-iax<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20IAX%20Transport%20Method%20(JEP-0179)">http://wiki.jabber.org/index.php/Jingle IAX Transport Method (JEP-0179)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Antonio F. Cano</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:antoniofcano@grupoikusnet.com">antoniofcano@grupoikusnet.com</a><br>
+        JID: 
+        <a href="xmpp:antoniofcano@jabber.org">antoniofcano@jabber.org</a></p>
+</div>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#protocol">Protocol Description</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#protocol-initiate">Transport Initiation</a>
+</dt>
+<dt>3.2.  <a href="#protocol-response">Target Entity Response</a>
+</dt>
+<dt>3.3.  <a href="#protocol-info">Informational Messages</a>
+</dt>
+</dl>
+<dt>4.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#registrar-ns">Caller Identification</a>
+</dt>
+<dt>4.2.  <a href="#registrar-ns">Asterisk PBX</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>7.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>7.2.  <a href="#registrar-transport">Jingle IAX Transport Description</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2251686">1</a>]  defines a framework for negotiating and managing out-of-band multimedia sessions over XMPP. In order to provide a flexible framework, the base Jingle specification defines neither data transport methods nor media (session) types, leaving that up to separate specifications. The current document defines a transport method for establishing and managing <span class="ref" style="">IAX</span>  [<a href="#nt-id2251643">2</a>] sessions between XMPP entities.</p>
+  <p class="" style="">IAX is a peer-to-peer media and signaling protocol, where the endpoints maintain state machines. With respect to media, sequencing and timing information is included into IAX frames, without the use of Real-Time Transport Protocol (RTP) for the media.  [<a href="#nt-id2251656">3</a>] The IAX protocol handles the signaling and, when the call is accepted by both peers, the media passes between the two hosts. With this approach, IAX doesn't suffer from NAT traversal problems associated with others protocols like SIP or other related protocols.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle transport description defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable negotiation of parameters necessary for take in contact both IAX peers.</li>
+    <li>Make it relatively easy to implement support in standard Jabber/XMPP clients.</li>
+    <li>Where communication with non-XMPP entities is needed, push as much complexity as possible onto server-side gateways between the XMPP network and the non-XMPP network.</li>
+  </ol>
+<h2>3.
+       <a name="protocol">Protocol Description</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="protocol-initiate">Transport Initiation</a>
+</h3>
+    <p class="" style="">In order for the initiating entity in a Jingle exchange to start the negotiation, it MUST send a Jingle "session-initiate" stanza as described in <span style="font-weight: bold">JEP-0166</span>. This stanza MUST include at least one transport method. If the initiating entity wishes to negotiate the IAX transport, it MUST include an empty &lt;transport/&gt; child element qualified by the 'http://jabber.org/protocol/jingle/transport/iax' namespace.</p>
+
+   <p class="caption">Example 1. Initiation Example, sended by Romeo</p>
+<div class="indent"><pre>
+    &lt;iq to='juliet@capulet.com/balcony'
+      from='romeo@montague.net/orchard'
+      id='jingle1'
+      type='set'&gt;
+      &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+            action='session-initiate'
+            initiator='romeo@montague.net/orchard'
+            sid='a73sjjvkla37jfea'&gt;
+        &lt;description ...&gt; 
+        &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/iax' version='2'/&gt;
+    &lt;/jingle&gt;
+    &lt;/iq&gt;
+  </pre></div>
+
+ </div>
+
+  <div class="indent">
+<h3>3.2 <a name="protocol-response">Target Entity Response</a>
+</h3>
+    <p class="" style="">As described in <span style="font-weight: bold">JEP-0166</span>, to provisionally accept the session initiation request, the target entity returns an IQ-result:</p>
+    <p class="caption">Example 2. Target Entity Provisionally Accepts the Session Request</p>
+<div class="indent"><pre>
+&lt;iq type='result' from='juliet@capulet.com/balcony' to='romeo@montague.net/orchard' id='jingle1'/&gt;
+    </pre></div>
+    <p class="" style="">To accept the IAX  transport method, the target entity MUST send a &lt;jingle/&gt; element with an action of 'transport-accept', specifying the transport method desired.</p>
+    <p class="" style="">This &lt;transport/&gt; element MUST include two  &lt;candidate/&gt; element per channel, whose 'ip' and 'port' attributes specify the IP address and port number of the candidate that the initiator has reason to believe will be most likely to succeed for that channel. The two candidates are the local and remote one. NAT type doesn't matter because the IAX protocol by itself addresses the problem of NAT traversal. We differentiate the two candidates with name attribute.</p>
+    <p class="" style="">The transport attributes are:</p>
+    <ol start="" type="">
+      <li>Version -- this is the protocol version we want to use by (currently 1 or 2, perhaps other versions in the future). This information is provided as an attribute of the transport.</li>
+      <li>User -- the user needed to log into the Asterisk PBX. This is OPTIONAL.</li>
+      <li>Password -- the password needed to log the User into the Asterisk PBX. This is OPTIONAL.</li>
+      <li>Secure -- describes the encryption method, this is OPTIONAL because at the moment there is one implementation of AES128 in Asterisk but not in the protocol, this could change in the future.</li>
+    </ol>
+    <p class="" style="">User and Password are OPTIONAL and needed in the case we want to call an extension that is behind an Asterisk PBX. The Asterisk PBX has to be properly configured to accept this kind of call.</p>
+    <p class="" style="">When we get the answer, it is time to see if the media that we want to start is supported by both peers. If so the IAX session is initialized by the protocol stack.</p>
+    <p class="" style="">The candidate attributes are:</p>
+    <ol start="" type="">
+      <li>Name -- the name of the candidate MUST be local, public or vpn.</li>
+      <li>IP -- the IP where the candidate is located.</li>
+      <li>Port -- the port where the candidate is listening.</li>
+    </ol>
+    <p class="" style="">To discover this public IP address we need a third party and SHOULD make discovery via <span class="ref" style="">RFC 3489</span>  [<a href="#nt-id2250862">4</a>], which will be an address on the outside of the firewall or NAT.</p>
+    <p class="caption">Example 3. Target Entity Accepts the IAX Transport Method</p>
+<div class="indent"><pre>
+    &lt;iq to='romeo@montague.net/orchard'
+        from='juliet@capulet.com/balcony'
+        id='jingle1'
+        type='result'&gt;
+      &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+            action='transport-accept'
+            initiator='juliet@capulet.com/balcony'
+            sid='a73sjjvkla37jfea'&gt;
+        &lt;transport xmlns='http://jabber.org/protocol/jingle/transport/iax' 
+                   version='2' 
+                   secure='aes128' 
+                   user='some-Asterisk-Username' 
+                   password='some-Asterisk-Password'&gt;
+          &lt;candidate name='local' ip='some-Local-IP-address-here' port='some-Local-Port-here'/&gt;
+          &lt;candidate name='public' ip='some-Remote-IP-address-here' port='some-Remote-Port-here'/&gt;
+        &lt;/transport&gt;
+    &lt;/jingle&gt;
+    &lt;/iq&gt;
+  </pre></div>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="protocol-info">Informational Messages</a>
+</h3>
+     <p class="" style="">The syntax and semantics informational message payloads specific to the IAX  transport method will be defined in a future version of this specification.</p>
+  </div> 
+<h2>4.
+       <a name="impl">Implementation Notes</a>
+</h2>
+    <p class="" style="">Port is returned by the IAX library stack initialization process. By default the port is 4569 UDP but if we have more than one IAX entity in the same box this port could be different.</p>
+    <p class="" style="">For IAX library implementations it is RECOMMENDED to use IAXclient  [<a href="#nt-id2250391">5</a>], because is an easy to use library, stable (used in most of IAX implementations) and multiplatform.</p>
+    <div class="indent">
+<h3>4.1 <a name="registrar-ns">Caller Identification</a>
+</h3>
+       <p class="" style="">Once the Jingle negotiation has been completed and the IAX stack has control, the initiating entity has to set his callerID information (cidname to Jingle and cidnum to JabberID) before dialing to a contact. If the initator's client has to show the contact's information, this comes from the initiator attribute of the returned IQ.</p>
+    </div>
+    <div class="indent">
+<h3>4.2 <a name="registrar-ns">Asterisk PBX</a>
+</h3>
+       <p class="" style="">IAX is a native protocol of the Asterisk PBX. When using the IAX protocol we could easily connect with an Asterisk PBX. There are two scenarios:</p>
+       <ol start="" type="">
+         <li><p class="" style="">We want to reach an internal extension directly (or go to PSTN line through Asterisk). in that case we need a user and password with rights into the PBX and setup into the Jabber client (the Jabber client will act like a softphone). This information has to be given for the final user to the entity. The idea in this scenario isn't so clear because if the jabber client acts like a softphone and we need to call an extension, we coudl just dial the extension without using Jingle.</p></li>
+         <li><p class="" style="">The Asterisk PBX accept incoming calls from IAX. In that case just call the Asterisk like other peer and the Asterisk MUST be properly configured for accepting the 'anonymous' (not an internal user of the PBX) incoming call.</p></li> 
+      </ol>
+      <p class="" style="">In both cases, the Asterisk PBX has to be logged into the Jabber network and implement the Jingle extension like a channel (Asterisk terminology).</p>
+    </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257110">6</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257161">7</a>] shall include 'http://jabber.org/protocol/jingle/transport/iax' and 'http://jabber.org/protocol/jingle/info/iax' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>7.2 <a name="registrar-transport">Jingle IAX Transport Description</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the name "iax" in its registry of Jingle transport descriptions. The registration is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;transport&gt;
+  &lt;name&gt;iax&lt;/name&gt;
+  &lt;desc&gt;Jingle IAX sessions.&lt;/desc&gt;
+  &lt;doc&gt;XXXX&lt;/doc&gt;
+&lt;/transport&gt;
+    </pre></div>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251686">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2251643">2</a>. IAX: Inter-Asterisk eXchange Version 2 &lt;<a href="http://www.ietf.org/internet-drafts/draft-guy-iax-01.txt">http://www.ietf.org/internet-drafts/draft-ietf-guy-iax-01.txt</a>&gt;. Work in progress.</p>
+<p><a name="nt-id2251656">3</a>. IAX is a binary protocol; this design choice was made for bandwidth efficiency.</p>
+<p><a name="nt-id2250862">4</a>. RFC 3489: STUN - Simple Traversal of User Datagram Protocol (UDP) Through Network Address Translators (NATs) &lt;<a href="http://www.ietf.org/rfc/rfc3489.txt">http://www.ietf.org/rfc/rfc3489.txt</a>&gt;.</p>
+<p><a name="nt-id2250391">5</a>. See &lt;<a href="http://iaxclient.sourceforge.net/">http://iaxclient.sourceforge.net/</a>&gt;.</p>
+<p><a name="nt-id2257110">6</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257161">7</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-03-09)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.4 (2006-03-02)</h4>
+<div class="indent">
+<p class="" style="">Synced with last revision of Jingle and Raw UDP transport. Review some descriptions and modify some names like location for candidate</p> (afc)
+    </div>
+<h4>Version 0.0.3 (2006-02-26)</h4>
+<div class="indent">
+<p class="" style="">Modify the initiate proccess, Rome tell to Juliet the transport to use and she answer with the transport information needed to be contacted. Added to transport the remoteTransport an localTransport data.</p> (afc)
+    </div>
+<h4>Version 0.0.2 (2006-02-24)</h4>
+<div class="indent">
+<p class="" style="">Some fixes and take care of Asterisk PBX entity.</p> (afc)
+    </div>
+<h4>Version 0.0.1 (2006-02-23)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (afc)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0180-0.1.html
+++ b/content/xep-0180-0.1.html
@@ -1,0 +1,331 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0180: Jingle Video Media Description Format</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle Video Media Description Format">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Milton Chen">
+<meta name="DC.Description" content="This document defines a media description format for Jingle video sessions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-23">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0180">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0180: Jingle Video Media Description Format</h1>
+<p>This document defines a media description format for Jingle video sessions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0180<br>
+            Version: 0.1<br>
+            Last Updated: 2006-03-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle-video<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20Video%20Media%20Description%20Format%20(JEP-0180)">http://wiki.jabber.org/index.php/Jingle Video Media Description Format (JEP-0180)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Milton Chen</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:Milton.Chen@vseelab.com">Milton.Chen@vseelab.com</a><br></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#format">Media Description Format</a>
+</dt>
+<dt>4.  <a href="#sdp">Mapping to Session Description Protocol</a>
+</dt>
+<dt>5.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>6.  <a href="#info">Informational Messages</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>7.1.  <a href="#impl-codecs">Codecs</a>
+</dt></dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-media">Jingle Media Description Formats</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-media">Media Description Format</a>
+</dt>
+<dt>11.2.  <a href="#schema-info">Informational Messages</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2251538">1</a>] can be used to initiate and negotiate a wide range of peer-to-peer sessions. One session type of interest is video exchange. This document specifies a format for describing Jingle video sessions.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle media description format defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable negotiation of parameters necessary for video exchange.</li>
+    <li>Map these parameters to Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2251595">2</a>]) to enable interoperability.</li>
+    <li>Define informational messages related to video exchange chat.</li>
+  </ol>
+<h2>3.
+       <a name="format">Media Description Format</a>
+</h2>
+  <p class="" style="">A Jingle video session is described by one or more encodings contained within a wrapper &lt;description/&gt; element. In the language of <span style="font-weight: bold">RFC 2327</span> these encodings are payload-types; therefore, each &lt;payload-type/&gt; element specifies an encoding that can be used for the video stream. Such encodings are often used in the context of the Real-time Transfer Protocol (RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2250630">3</a>]) but may be used in other contexts as well. The most common encodings for the Audio/Video Profile (AVP) of RTP are listed in <span class="ref" style="">RFC 3551</span>  [<a href="#nt-id2250653">4</a>] (these "static" types are reserved from payload ID 0 through payload ID 96), although other encodings are allowed (these "dynamic" types use payload IDs 97 to 127) in accordance with the dynamic assignment rules described in Section 3 of <span style="font-weight: bold">RFC 3551</span>. The 'id' attribute is REQUIRED and the 'name' attribute is RECOMMENDED. The encodings SHOULD be provided in order of preference.</p>
+  <p class="caption">Example 1. Video Description Format</p>
+<div class="indent"><pre>
+    &lt;description xmlns='http://jabber.org/protocol/jingle/media/video'&gt;
+      &lt;payload-type id='18' name='G729'/&gt;
+      &lt;payload-type id='97' name='IPCMWB'/&gt;
+      &lt;payload-type id='98' name='L16' transparent='true'/&gt;
+      &lt;payload-type id='13' name='CN'/&gt;
+    &lt;/description&gt;
+  </pre></div>
+  <p class="" style="">The &lt;description/&gt; element is intended to be a child of a &lt;jingle/&gt; element as specified in <span style="font-weight: bold">JEP-0166</span>.</p>
+  <p class="" style="">The defined attributes of the &lt;description/&gt; element are as follows:</p>
+  <p class="caption">Table 1: Video Description Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Attribute</th>
+      <th colspan="" rowspan="">Description</th>
+      <th colspan="" rowspan="">Datatype/Units</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">channels</td>
+      <td align="" colspan="" rowspan="">The number of channels (e.g., 2 for stereoscopic video)</td>
+      <td align="" colspan="" rowspan="">positiveInteger (defaults to 1)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">height</td>
+      <td align="" colspan="" rowspan="">The vertical extent of the displayed video, in pixels</td>
+      <td align="" colspan="" rowspan="">positiveInteger</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">layer</td>
+      <td align="" colspan="" rowspan="">The relationship of a layer to the "bottom" of the stack, where 0 = bottom (the first layer)</td>
+      <td align="" colspan="" rowspan="">nonNegativeInteger</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">transparent</td>
+      <td align="" colspan="" rowspan="">Whether or not a layer is transparent</td>
+      <td align="" colspan="" rowspan="">boolean</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">width</td>
+      <td align="" colspan="" rowspan="">The horizontal extent of the displayed video, in pixels</td>
+      <td align="" colspan="" rowspan="">positiveInteger</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x</td>
+      <td align="" colspan="" rowspan="">The horizontal starting point of a tile, in pixels from the origin point</td>
+      <td align="" colspan="" rowspan="">positiveInteger</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">y</td>
+      <td align="" colspan="" rowspan="">The vertical starting point of a tile, in pixels from the origin point</td>
+      <td align="" colspan="" rowspan="">positiveInteger</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="sdp">Mapping to Session Description Protocol</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>5.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">If an entity supports the Jingle video media description format, it MUST advertise that fact by returning a feature of "http://jabber.org/protocol/jingle/media/video" in response to <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2256927">5</a>] information requests.</p>
+  <p class="caption">Example 2. Service Discovery Information Request</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    id='disco1'
+    to='juliet@capulet.com/balcony' 
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 3. Service Discovery Information Response</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='disco1'
+    to='romeo@montague.net/orchard' 
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/jingle'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle/media/video'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="info">Informational Messages</a>
+</h2>
+  <p class="" style="">Informational messages may be sent by either party within the context of Jingle to communicate the status of a Jingle video session, device, or principal. The informational message MUST be an IQ-set containing a &lt;jingle/&gt; element of type "media-info", where the informational message is a payload  element qualified by the 'http://jabber.org/protocol/jingle/info/video' namespace. No payload elements have yet been defined, but will be specified in a future version of this document.</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-codecs">Codecs</a>
+</h3>
+    <p class="" style="">Support for the Theora codec  [<a href="#nt-id2256997">6</a>] is RECOMMENDED.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The description of a format for video sessions introduces no known security vulnerabilities.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257061">7</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257113">8</a>] shall include 'http://jabber.org/protocol/jingle/media/video' and 'http://jabber.org/protocol/jingle/info/video' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-media">Jingle Media Description Formats</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the name "video" in its registry of Jingle media description formats. The registration is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;media&gt;
+  &lt;name&gt;video&lt;/name&gt;
+  &lt;desc&gt;Jingle sessions that support video exchanges&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/media&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-media">Media Description Format</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/media/video'
+    xmlns='http://jabber.org/protocol/jingle/media/video'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='description'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='payload-type' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='payload-type'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='channels' type='xs:integer' use='optional' default='1'/&gt;
+          &lt;xs:attribute name='height' type='xs:nonNegativeInteger' use='optional'/&gt;
+          &lt;xs:attribute name='id' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='layer' type='xs:nonNegativeInteger' use='optional'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='rate' type='xs:short' use='optional'/&gt;
+          &lt;xs:attribute name='transparent' type='xs:boolean' use='optional'/&gt;
+          &lt;xs:attribute name='width' type='xs:nonNegativeInteger' use='optional'/&gt;
+          &lt;xs:attribute name='x' type='xs:integer' use='optional'/&gt;
+          &lt;xs:attribute name='y' type='xs:integer' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-info">Informational Messages</a>
+</h3>
+    <p class="" style="">To follow.</p>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251538">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2251595">2</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2250630">3</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2250653">4</a>. RFC 3551: RTP Profile for Audio and Video Conferences with Minimal Control &lt;<a href="http://www.ietf.org/rfc/rfc3551.txt">http://www.ietf.org/rfc/rfc3551.txt</a>&gt;.</p>
+<p><a name="nt-id2256927">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2256997">6</a>. See &lt;<a href="http://www.theora.org/">http://www.theora.org/</a>&gt;.</p>
+<p><a name="nt-id2257061">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257113">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-03-23)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0180-0.2.html
+++ b/content/xep-0180-0.2.html
@@ -1,0 +1,337 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0180: Jingle Video Content Description Format</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle Video Content Description Format">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Milton Chen">
+<meta name="DC.Description" content="This document defines a content description format for Jingle video sessions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-12">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0180">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0180: Jingle Video Content Description Format</h1>
+<p>This document defines a content description format for Jingle video sessions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0180<br>
+            Version: 0.2<br>
+            Last Updated: 2006-07-12<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle-video<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20Video%20Content%20Description%20Format%20(JEP-0180)">http://wiki.jabber.org/index.php/Jingle Video Content Description Format (JEP-0180)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Milton Chen</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:Milton.Chen@vseelab.com">Milton.Chen@vseelab.com</a><br></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#format">Content Description Format</a>
+</dt>
+<dt>4.  <a href="#sdp">Mapping to Session Description Protocol</a>
+</dt>
+<dt>5.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>6.  <a href="#info">Informational Messages</a>
+</dt>
+<dt>7.  <a href="#impl">Implementation Notes</a>
+</dt>
+<dl><dt>7.1.  <a href="#impl-codecs">Codecs</a>
+</dt></dl>
+<dt>8.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>9.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>10.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>10.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+<dt>10.2.  <a href="#registrar-content">Jingle Content Description Formats</a>
+</dt>
+</dl>
+<dt>11.  <a href="#schema">XML Schemas</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#schema-content">Content Description Format</a>
+</dt>
+<dt>11.2.  <a href="#schema-info">Informational Messages</a>
+</dt>
+</dl>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">Jingle</span>  [<a href="#nt-id2251745">1</a>] can be used to initiate and negotiate a wide range of peer-to-peer sessions. One session type of interest is video exchange. This document specifies a format for describing Jingle video sessions.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">The Jingle content description format defined herein is designed to meet the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable negotiation of parameters necessary for video exchange.</li>
+    <li>Map these parameters to Session Description Protocol (SDP; see <span class="ref" style="">RFC 2327</span>  [<a href="#nt-id2250758">2</a>]) to enable interoperability.</li>
+    <li>Define informational messages related to video exchange chat.</li>
+  </ol>
+<h2>3.
+       <a name="format">Content Description Format</a>
+</h2>
+  <p class="" style="">A Jingle video session is described by one or more encodings contained within a wrapper &lt;description/&gt; element. In the language of <span style="font-weight: bold">RFC 2327</span> these encodings are payload-types; therefore, each &lt;payload-type/&gt; element specifies an encoding that can be used for the video stream. Such encodings are often used in the context of the Real-time Transfer Protocol (RTP; see <span class="ref" style="">RFC 3550</span>  [<a href="#nt-id2250934">3</a>]) but may be used in other contexts as well. The most common encodings for the Audio/Video Profile (AVP) of RTP are listed in <span class="ref" style="">RFC 3551</span>  [<a href="#nt-id2250956">4</a>] (these "static" types are reserved from payload ID 0 through payload ID 96), although other encodings are allowed (these "dynamic" types use payload IDs 97 to 127) in accordance with the dynamic assignment rules described in Section 3 of <span style="font-weight: bold">RFC 3551</span>. The 'id' attribute is REQUIRED and the 'name' attribute is RECOMMENDED. The encodings SHOULD be provided in order of preference.</p>
+  <p class="caption">Example 1. Video Description Format</p>
+<div class="indent"><pre>
+    &lt;description xmlns='http://jabber.org/protocol/jingle/content/video'&gt;
+      &lt;payload-type id='18' name='G729'/&gt;
+      &lt;payload-type id='97' name='IPCMWB'/&gt;
+      &lt;payload-type id='98' name='L16' transparent='true'/&gt;
+      &lt;payload-type id='13' name='CN'/&gt;
+    &lt;/description&gt;
+  </pre></div>
+  <p class="" style="">The &lt;description/&gt; element is intended to be a child of a &lt;jingle/&gt; element as specified in <span style="font-weight: bold">JEP-0166</span>.</p>
+  <p class="" style="">The defined attributes of the &lt;description/&gt; element are as follows:</p>
+  <p class="caption">Table 1: Video Description Attributes</p>
+<table border="1" cellpadding="3" cellspacing="0">
+    <tr class="body">
+      <th colspan="" rowspan="">Attribute</th>
+      <th colspan="" rowspan="">Description</th>
+      <th colspan="" rowspan="">Datatype/Units</th>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">channels</td>
+      <td align="" colspan="" rowspan="">The number of channels (e.g., 2 for stereoscopic video)</td>
+      <td align="" colspan="" rowspan="">positiveInteger (defaults to 1)</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">height</td>
+      <td align="" colspan="" rowspan="">The vertical extent of the displayed video, in pixels</td>
+      <td align="" colspan="" rowspan="">positiveInteger</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">layer</td>
+      <td align="" colspan="" rowspan="">The relationship of a layer to the "bottom" of the stack, where 0 = bottom (the first layer)</td>
+      <td align="" colspan="" rowspan="">nonNegativeInteger</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">transparent</td>
+      <td align="" colspan="" rowspan="">Whether or not a layer is transparent</td>
+      <td align="" colspan="" rowspan="">boolean</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">width</td>
+      <td align="" colspan="" rowspan="">The horizontal extent of the displayed video, in pixels</td>
+      <td align="" colspan="" rowspan="">positiveInteger</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">x</td>
+      <td align="" colspan="" rowspan="">The horizontal starting point of a tile, in pixels from the origin point</td>
+      <td align="" colspan="" rowspan="">positiveInteger</td>
+    </tr>
+    <tr class="body">
+      <td align="" colspan="" rowspan="">y</td>
+      <td align="" colspan="" rowspan="">The vertical starting point of a tile, in pixels from the origin point</td>
+      <td align="" colspan="" rowspan="">positiveInteger</td>
+    </tr>
+  </table>
+<h2>4.
+       <a name="sdp">Mapping to Session Description Protocol</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>5.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">If an entity supports the Jingle video content description format, it MUST advertise that fact by returning a feature of "http://jabber.org/protocol/jingle/content/video" in response to <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259594">5</a>] information requests.</p>
+  <p class="caption">Example 2. Service Discovery Information Request</p>
+<div class="indent"><pre>
+&lt;iq from='romeo@montague.net/orchard' 
+    id='disco1'
+    to='juliet@capulet.com/balcony' 
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 3. Service Discovery Information Response</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' 
+    id='disco1'
+    to='romeo@montague.net/orchard' 
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/jingle'/&gt;
+    &lt;feature var='http://jabber.org/protocol/jingle/content/video'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>6.
+       <a name="info">Informational Messages</a>
+</h2>
+  <p class="" style="">Informational messages may be sent by either party within the context of Jingle to communicate the status of a Jingle video session, device, or principal. The informational message MUST be an IQ-set containing a &lt;jingle/&gt; element of type "content-info", where the informational message is a payload  element qualified by the 'http://jabber.org/protocol/jingle/info/video' namespace. No payload elements have yet been defined, but will be specified in a future version of this document.</p>
+<h2>7.
+       <a name="impl">Implementation Notes</a>
+</h2>
+  <div class="indent">
+<h3>7.1 <a name="impl-codecs">Codecs</a>
+</h3>
+    <p class="" style="">Support for the Theora codec  [<a href="#nt-id2259662">6</a>] is RECOMMENDED.</p>
+  </div>
+<h2>8.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The description of a format for video sessions introduces no known security vulnerabilities.</p>
+<h2>9.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259726">7</a>].</p>
+<h2>10.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>10.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259779">8</a>] shall include 'http://jabber.org/protocol/jingle/content/video' and 'http://jabber.org/protocol/jingle/info/video' in its registry of protocol namespaces.</p>
+  </div>
+  <div class="indent">
+<h3>10.2 <a name="registrar-content">Jingle Content Description Formats</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall include the name "video" in its registry of Jingle content description formats. The registration is as follows:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;content&gt;
+  &lt;name&gt;video&lt;/name&gt;
+  &lt;desc&gt;Jingle sessions that support video exchanges&lt;/desc&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/content&gt;
+    </pre></div>
+  </div>
+<h2>11.
+       <a name="schema">XML Schemas</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="schema-content">Content Description Format</a>
+</h3>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/content/video'
+    xmlns='http://jabber.org/protocol/jingle/content/video'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='description'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='payload-type' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='payload-type'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='channels' type='xs:integer' use='optional' default='1'/&gt;
+          &lt;xs:attribute name='height' type='xs:nonNegativeInteger' use='optional'/&gt;
+          &lt;xs:attribute name='id' type='xs:unsignedByte' use='required'/&gt;
+          &lt;xs:attribute name='layer' type='xs:nonNegativeInteger' use='optional'/&gt;
+          &lt;xs:attribute name='name' type='xs:string' use='optional'/&gt;
+          &lt;xs:attribute name='rate' type='xs:short' use='optional'/&gt;
+          &lt;xs:attribute name='transparent' type='xs:boolean' use='optional'/&gt;
+          &lt;xs:attribute name='width' type='xs:nonNegativeInteger' use='optional'/&gt;
+          &lt;xs:attribute name='x' type='xs:integer' use='optional'/&gt;
+          &lt;xs:attribute name='y' type='xs:integer' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="schema-info">Informational Messages</a>
+</h3>
+    <p class="" style="">To follow.</p>
+  </div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251745">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2250758">2</a>. RFC 2327: SDP: Session Description Protocol &lt;<a href="http://www.ietf.org/rfc/rfc2327.txt">http://www.ietf.org/rfc/rfc2327.txt</a>&gt;.</p>
+<p><a name="nt-id2250934">3</a>. RFC 3550: RTP: A Transport Protocol for Real-Time Applications &lt;<a href="http://www.ietf.org/rfc/rfc3550.txt">http://www.ietf.org/rfc/rfc3550.txt</a>&gt;.</p>
+<p><a name="nt-id2250956">4</a>. RFC 3551: RTP Profile for Audio and Video Conferences with Minimal Control &lt;<a href="http://www.ietf.org/rfc/rfc3551.txt">http://www.ietf.org/rfc/rfc3551.txt</a>&gt;.</p>
+<p><a name="nt-id2259594">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259662">6</a>. See &lt;<a href="http://www.theora.org/">http://www.theora.org/</a>&gt;.</p>
+<p><a name="nt-id2259726">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259779">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-07-12)</h4>
+<div class="indent">
+<p class="" style="">Updated to use content type instead of media type.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-03-23)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa/mc)
+    </div>
+<h4>Version 0.0.1 (2006-03-20)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa/mc)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0181-0.1.html
+++ b/content/xep-0181-0.1.html
@@ -1,0 +1,196 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0181: Jingle DTMF</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle DTMF">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies an XML format for encapsulating DTMF data in informational messages sent within the context of Jingle audio interactions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-23">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0181">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0181: Jingle DTMF</h1>
+<p>This document specifies an XML format for encapsulating DTMF data in informational messages sent within the context of Jingle audio interactions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0181<br>
+            Version: 0.1<br>
+            Last Updated: 2006-03-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle-dtmf<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20DTMF%20(JEP-0181)">http://wiki.jabber.org/index.php/Jingle DTMF (JEP-0181)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#format">Format</a>
+</dt>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>5.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>6.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Traditional telephony systems use Dual Tone Multi-Frequency (DTMF) for dialing and to issue commands such as those used in Interactive Voice Response (IVR) applications. Internet telephony systems also use DTMF tones for interoperability with the public switched telephone network (PSTN). XMPP clients that use <span class="ref" style="">Jingle</span>  [<a href="#nt-id2251524">1</a>] for voice chat (see <span class="ref" style="">Jingle Audio Media Description Format</span>  [<a href="#nt-id2251549">2</a>]) SHOULD use the native DTMF format for the relevant transport method, for example <span class="ref" style="">RFC 2833</span>  [<a href="#nt-id2251572">3</a>] for <span class="ref" style="">Jingle RTP-ICE Transport Method</span>  [<a href="#nt-id2251594">4</a>] and the native IAX format for <span class="ref" style="">Jingle IAX Transport Method </span>  [<a href="#nt-id2251615">5</a>]. This document specifies an XML format for use as a fallback when transport-native DTMF formats are not available.</p>
+<h2>2.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">The format for the XML DTMF format is as follows:</p>
+  <p class="caption">Example 1. Basic DTMF Format</p>
+<div class="indent"><pre>
+&lt;dtmf xmlns='http://jabber.org/protocol/info/dtmf'&gt;
+  &lt;tone code='integer' duration='integer'/&gt;
+  &lt;tone ... /&gt;
+&lt;/dtmf&gt;
+  </pre></div>
+  <p class="" style="">The &lt;dtmf/&gt; element MUST contain at least one &lt;tone/&gt; element and MAY contain more than one &lt;tone/&gt; element.</p>
+  <p class="" style="">The &lt;tone/&gt; element MUST possess a 'code' attribute that specifies the tone(s) to be generated and MAY possess a 'duration' attribute that specifies the duration of each tone in milliseconds.</p>
+  <p class="" style="">The value of the 'code' attribute MUST be one or more instances of the following characters: 1, 2, 3, 4, 5, 6, 7, 8, 9, *, 0, or #.  [<a href="#nt-id2250671">6</a>]</p>
+  <p class="" style="">The value of the 'duration' attribute MUST be a positive integer; the integer MUST be greater than 50 (in accordance with <span style="font-weight: bold">ANSI T1.401-1988</span>), SHOULD be at least 70, and SHOULD NOT be significantly more than 120.</p>
+  <p class="" style="">The &lt;dtmf&gt; element SHOULD be sent as the payload of a Jingle media-info message as illustrated in the following example.</p>
+  <p class="caption">Example 2. Entity Sends DTMF Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='ivr.shakespeare.lit'
+    id='dtmf1'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='media-info'
+          initiator='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;dtmf xmlns='http://jabber.org/protocol/jingle/info/dtmf'&gt;
+      &lt;tone code='76636'/&gt;
+    &lt;/dtmf&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This document introduces no known security vulnerabilities.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250770">7</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250818">8</a>] shall include 'http://jabber.org/protocol/jingle/info/dtmf' in its registry of protocol namespaces.</p>
+  </div>
+<h2>6.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/info/dtmf'
+    xmlns='http://jabber.org/protocol/jingle/info/dtmf'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='dtmf'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='tone' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='tone'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='code' type='xs:string' use='required'/&gt;
+          &lt;xs:attribute name='duration' type='xs:positiveInteger' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251524">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2251549">2</a>. JEP-0167: Jingle Audio Media Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2251572">3</a>. RFC 2833: RTP Payload for DTMF Digits, Telephony Tones and Telephony Signals &lt;<a href="http://www.ietf.org/rfc/rfc2833.txt">http://www.ietf.org/rfc/rfc2833.txt</a>&gt;.</p>
+<p><a name="nt-id2251594">4</a>. JEP-0176: Jingle RTP-ICE Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0176.html">http://www.jabber.org/jeps/jep-0176.html</a>&gt;.</p>
+<p><a name="nt-id2251615">5</a>. JEP-0179: Jingle IAX Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0179.html">http://www.jabber.org/jeps/jep-0179.html</a>&gt;.</p>
+<p><a name="nt-id2250671">6</a>. Although the characters A, B, C, and D were originally defined as part of DTMF, they were never deployed to consumers and were used only for control purposes at private branch exchanges (PBXs) and central office operator stations; therefore they MUST NOT be sent.</p>
+<p><a name="nt-id2250770">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2250818">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-03-23)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-03-21)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0181-0.2.html
+++ b/content/xep-0181-0.2.html
@@ -1,0 +1,208 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0181: Jingle DTMF</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Jingle DTMF">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies an XML format for encapsulating DTMF data in informational messages sent within the context of Jingle audio interactions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-06-29">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0181">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0181: Jingle DTMF</h1>
+<p>This document specifies an XML format for encapsulating DTMF data in informational messages sent within the context of Jingle audio interactions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0181<br>
+            Version: 0.2<br>
+            Last Updated: 2006-06-29<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, JEP-0166<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: jingle-dtmf<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Jingle%20DTMF%20(JEP-0181)">http://wiki.jabber.org/index.php/Jingle DTMF (JEP-0181)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#format">Format</a>
+</dt>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>5.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl><dt>5.1.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt></dl>
+<dt>6.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">Traditional telephony systems use Dual Tone Multi-Frequency (DTMF) for dialing and to issue commands such as those used in Interactive Voice Response (IVR) applications. Internet telephony systems also use DTMF tones for interoperability with the public switched telephone network (PSTN). XMPP clients that use <span class="ref" style="">Jingle</span>  [<a href="#nt-id2251691">1</a>] for voice chat (see <span class="ref" style="">Jingle Audio Media Description Format</span>  [<a href="#nt-id2251749">2</a>]) SHOULD use the native DTMF format for the relevant transport method, for example <span class="ref" style="">RFC 2833</span>  [<a href="#nt-id2251718">3</a>] for <span class="ref" style="">Jingle RTP-ICE Transport Method</span>  [<a href="#nt-id2250751">4</a>] and the native IAX format for <span class="ref" style="">Jingle IAX Transport Method </span>  [<a href="#nt-id2250774">5</a>]. This document specifies an XML format for use as a fallback when transport-native DTMF formats are not available.</p>
+<h2>2.
+       <a name="format">Format</a>
+</h2>
+  <p class="" style="">The format for the XML DTMF format is as follows:</p>
+  <p class="caption">Example 1. Basic DTMF Format</p>
+<div class="indent"><pre>
+&lt;dtmf xmlns='http://jabber.org/protocol/info/dtmf'&gt;
+  &lt;tone code='integer' duration='integer'/&gt;
+  &lt;tone ... /&gt;
+&lt;/dtmf&gt;
+  </pre></div>
+  <p class="" style="">The &lt;dtmf/&gt; element MUST contain at least one &lt;tone/&gt; element and MAY contain more than one &lt;tone/&gt; element.</p>
+  <p class="" style="">The &lt;tone/&gt; element MUST possess a 'code' attribute that specifies the tone(s) to be generated and MAY possess a 'duration' attribute that specifies the duration of each tone in milliseconds.</p>
+  <p class="" style="">The value of the 'code' attribute SHOULD be one or more instances of the following characters: 0, 1, 2, 3, 4, 5, 6, 7, 8, 9, #, and *  -- however, the characters A, B, C, and D MAY be sent as well.  [<a href="#nt-id2250831">6</a>]</p>
+  <p class="" style="">The value of the 'duration' attribute MUST be a positive integer; the integer MUST be greater than 50 (in accordance with <span style="font-weight: bold">ANSI T1.401-1988</span>), SHOULD be at least 70, and SHOULD NOT be significantly more than 120.</p>
+  <p class="" style="">The &lt;dtmf&gt; element SHOULD be sent as the payload of a Jingle media-info message as illustrated in the following example.</p>
+  <p class="caption">Example 2. Entity Sends DTMF Message</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony'
+    to='ivr.shakespeare.lit'
+    id='dtmf1'
+    type='set'&gt;
+  &lt;jingle xmlns='http://jabber.org/protocol/jingle'
+          action='media-info'
+          initiator='juliet@capulet.com/balcony'
+          sid='a73sjjvkla37jfea'&gt;
+    &lt;dtmf xmlns='http://jabber.org/protocol/jingle/info/dtmf'&gt;
+      &lt;tone code='76636'/&gt;
+    &lt;/dtmf&gt;
+  &lt;/jingle&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This document introduces no known security vulnerabilities.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250931">7</a>].</p>
+<h2>5.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>5.1 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250980">8</a>] shall include 'http://jabber.org/protocol/jingle/info/dtmf' in its registry of protocol namespaces.</p>
+  </div>
+<h2>6.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/jingle/info/dtmf'
+    xmlns='http://jabber.org/protocol/jingle/info/dtmf'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:element name='dtmf'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='tone' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='tone'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:simpleContent&gt;
+        &lt;xs:extension base='empty'&gt;
+          &lt;xs:attribute name='code' type='DTMFString' use='required'/&gt;
+          &lt;xs:attribute name='duration' type='xs:positiveInteger' use='optional'/&gt;
+        &lt;/xs:extension&gt;
+      &lt;/xs:simpleContent&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:simpleType name="DTMFString"&gt;
+    &lt;xs:restriction base="xs:string"&gt;
+      &lt;xs:pattern value="(#|\*|0|1|2|3|4|5|6|7|8|9|A|B|C|D)*" /&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+  &lt;xs:simpleType name='empty'&gt;
+    &lt;xs:restriction base='xs:string'&gt;
+      &lt;xs:enumeration value=''/&gt;
+    &lt;/xs:restriction&gt;
+  &lt;/xs:simpleType&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251691">1</a>. JEP-0166: Jingle &lt;<a href="http://www.jabber.org/jeps/jep-0166.html">http://www.jabber.org/jeps/jep-0166.html</a>&gt;.</p>
+<p><a name="nt-id2251749">2</a>. JEP-0167: Jingle Audio Media Description Format &lt;<a href="http://www.jabber.org/jeps/jep-0167.html">http://www.jabber.org/jeps/jep-0167.html</a>&gt;.</p>
+<p><a name="nt-id2251718">3</a>. RFC 2833: RTP Payload for DTMF Digits, Telephony Tones and Telephony Signals &lt;<a href="http://www.ietf.org/rfc/rfc2833.txt">http://www.ietf.org/rfc/rfc2833.txt</a>&gt;.</p>
+<p><a name="nt-id2250751">4</a>. JEP-0176: Jingle RTP-ICE Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0176.html">http://www.jabber.org/jeps/jep-0176.html</a>&gt;.</p>
+<p><a name="nt-id2250774">5</a>. JEP-0179: Jingle IAX Transport Method &lt;<a href="http://www.jabber.org/jeps/jep-0179.html">http://www.jabber.org/jeps/jep-0179.html</a>&gt;.</p>
+<p><a name="nt-id2250831">6</a>. Although A, B, C, and D were originally defined as part of DTMF, they were never deployed to telephony consumers and were used only for control purposes at private branch exchanges (PBXs) and central office operator stations; however, they are used in certain non-telephony applications of DTMF, such as ham radio.</p>
+<p><a name="nt-id2250931">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2250980">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-06-29)</h4>
+<div class="indent">
+<p class="" style="">Allowed characters A, B, C, and D; updated schema.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-03-23)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-03-21)</h4>
+<div class="indent">First draft. (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0182-0.1.html
+++ b/content/xep-0182-0.1.html
@@ -1,0 +1,138 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0182: Application-Specific Error Conditions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Application-Specific Error Conditions">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a registry of application-specific error conditions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-03-23">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0182">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0182: Application-Specific Error Conditions</h1>
+<p>This document defines a registry of application-specific error conditions.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This Procedural JEP proposes that the process or activity defined herein shall be followed by the Jabber Software Foundation (JSF). However, this process or activity has not yet been approved by the Jabber Council and/or the JSF Board of Directors and is therefore not currently in force.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Procedural<br>
+            Number: 0182<br>
+            Version: 0.1<br>
+            Last Updated: 2006-03-23<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Application-Specific%20Error%20Conditions%20(JEP-0182)">http://wiki.jabber.org/index.php/Application-Specific Error Conditions (JEP-0182)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#registrar-conditions">Application-Specific Error Conditions Registry</a>
+</dt>
+<dl><dt>2.1.1.  <a href="#registrar-conditions-process">Registration Process</a>
+</dt></dl>
+<dt>2.2.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251523">1</a>] specifies that an XMPP error stanza may include a child element qualified by an XML namespace other than 'urn:ietf:params:xml:ns:xmpp-stanzas'. This enables any XMPP protocol extension to define its own application-specific error conditions. Although this introduces a great deal of flexibility, it may also introduce confusion regarding possible conditions. Therefore, this document defines a registry of application-specific error conditions, to be maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2251553">2</a>]. In addition, this document registers a namespace of 'http://jabber.org/protocol/errors' as a fallback namespace for defining generalized error conditions that are not specific to a particular protocol (e.g., &lt;stanza-too-big/&gt; as a particular form of the &lt;not-acceptable/&gt; condition).</p> 
+<h2>2.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="registrar-conditions">Application-Specific Error Conditions Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of application-specific error conditions.</p>
+    <div class="indent">
+<h3>2.1.1 <a name="registrar-conditions-process">Registration Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;ns&gt;the XML namespace that qualifies the condition&lt;/ns&gt;
+  &lt;element&gt;the XML element of the error condition&lt;/element&gt;
+  &lt;desc&gt;a natural-language description of the error condition&lt;/desc&gt;
+  &lt;doc&gt;the document in which the condition is specified&lt;/doc&gt;
+&lt;/condition&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one condition at a time, each contained in a separate &lt;condition/&gt; element.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250650">3</a>] shall include 'http://jabber.org/protocol/errors' in its registry of protocol namespaces.</p>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This document introduces no known security vulnerabilities.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250897">4</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251523">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251553">2</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250650">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250897">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-03-23)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-03-21)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0182-0.2.html
+++ b/content/xep-0182-0.2.html
@@ -1,0 +1,143 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0182: Application-Specific Error Conditions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Application-Specific Error Conditions">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document defines a registry of application-specific error conditions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-28">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0182">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0182: Application-Specific Error Conditions</h1>
+<p>This document defines a registry of application-specific error conditions.</p>
+<p><hr></p>
+<p style="color:red">NOTICE: This JEP is currently within Last Call or under consideration by the Jabber Council for advancement to the next stage in the JSF standards process. For further details, visit &lt;<a href="http://www.jabber.org/council/queue.shtml">http://www.jabber.org/council/queue.shtml</a>&gt;.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Proposed<br>
+            Type: Procedural<br>
+            Number: 0182<br>
+            Version: 0.2<br>
+            Last Updated: 2006-04-28<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: N/A<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Application-Specific%20Error%20Conditions%20(JEP-0182)">http://wiki.jabber.org/index.php/Application-Specific Error Conditions (JEP-0182)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>2.1.  <a href="#registrar-conditions">Application-Specific Error Conditions Registry</a>
+</dt>
+<dl><dt>2.1.1.  <a href="#registrar-conditions-process">Registration Process</a>
+</dt></dl>
+<dt>2.2.  <a href="#registrar-ns">Protocol Namespaces</a>
+</dt>
+</dl>
+<dt>3.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>4.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251725">1</a>] specifies that an XMPP error stanza may include a child element qualified by an XML namespace other than 'urn:ietf:params:xml:ns:xmpp-stanzas'. This enables any XMPP protocol extension to define its own application-specific error conditions. Although this introduces a great deal of flexibility, it may also introduce confusion regarding possible conditions. Therefore, this document defines a registry of application-specific error conditions, to be maintained by the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2251759">2</a>]. In addition, this document registers a namespace of 'http://jabber.org/protocol/errors' as a fallback namespace for defining generalized error conditions that are not specific to a particular protocol (e.g., &lt;stanza-too-big/&gt; as a particular form of the &lt;not-acceptable/&gt; condition).</p> 
+<h2>2.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>2.1 <a name="registrar-conditions">Application-Specific Error Conditions Registry</a>
+</h3>
+    <p class="" style="">The Jabber Registrar shall create a registry of application-specific error conditions.</p>
+    <p class="" style="">All application-specific error conditions that are defined in Jabber Enhancement Proposals MUST be included in this registry. Application-specific error conditions that are defined outside of the JEP process MAY be included in this registry, but it is not required for them to be so registered.</p>
+    <div class="indent">
+<h3>2.1.1 <a name="registrar-conditions-process">Registration Process</a>
+</h3>
+      <p class="" style="">In order to submit new values to this registry, the registrant must define an XML fragment of the following form and either include it in the relevant Jabber Enhancement Proposal or send it to the email address &lt;registrar@jabber.org&gt;:</p>
+      <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;ns&gt;the XML namespace that qualifies the condition&lt;/ns&gt;
+  &lt;element&gt;the XML element of the error condition&lt;/element&gt;
+  &lt;desc&gt;a natural-language description of the error condition&lt;/desc&gt;
+  &lt;doc&gt;the document in which the condition is specified&lt;/doc&gt;
+&lt;/condition&gt;
+      </pre></div>
+      <p class="" style="">The registrant may register more than one condition at a time, each contained in a separate &lt;condition/&gt; element.</p>
+    </div>
+  </div>
+  <div class="indent">
+<h3>2.2 <a name="registrar-ns">Protocol Namespaces</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2250829">3</a>] shall include 'http://jabber.org/protocol/errors' in its registry of protocol namespaces.</p>
+  </div>
+<h2>3.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This document introduces no known security vulnerabilities.</p>
+<h2>4.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250904">4</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251725">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251759">2</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250829">3</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2250904">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-04-28)</h4>
+<div class="indent">
+<p class="" style="">Added note about scope of registry.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-03-23)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-03-21)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0184-0.1.html
+++ b/content/xep-0184-0.1.html
@@ -1,0 +1,619 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0184: Message Receipts</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Message Receipts">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Creator" content="Joe Hildebrand">
+<meta name="DC.Description" content="This document specifies a protocol for XMPP message receipts.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0184">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0184: Message Receipts</h1>
+<p>This document specifies a protocol for XMPP message receipts.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0184<br>
+            Version: 0.1<br>
+            Last Updated: 2006-04-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: amp-receipts<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Message%20Receipts%20(JEP-0184)">http://wiki.jabber.org/index.php/Message Receipts (JEP-0184)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+<h3>Joe Hildebrand</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:jhildebrand@jabber.com">jhildebrand@jabber.com</a><br>
+        JID: 
+        <a href="xmpp:hildjj@jabber.org">hildjj@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#reqs">Requirements</a>
+</dt>
+<dt>3.  <a href="#scenarios">Scenarios</a>
+</dt>
+<dt>4.  <a href="#format">Protocol Format</a>
+</dt>
+<dt>5.  <a href="#rules">Business Rules</a>
+</dt>
+<dt>6.  <a href="#flow">Protocol Flows</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#flow-happy">Happy Path</a>
+</dt>
+<dt>6.2.  <a href="#flow-messagenotreceived">Message Not Received</a>
+</dt>
+<dt>6.3.  <a href="#flow-receiptnotreceived">Receipt Not Received</a>
+</dt>
+<dt>6.4.  <a href="#flow-senderoffline">Sender Goes Offline</a>
+</dt>
+<dt>6.5.  <a href="#flow-recipientoffline">Recipient Goes Offline</a>
+</dt>
+</dl>
+<dt>7.  <a href="#disco">Service Discovery</a>
+</dt>
+<dt>8.  <a href="#neg">Negotiation</a>
+</dt>
+<dt>9.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>10.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>11.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dl>
+<dt>11.1.  <a href="#registrar-conditions">Rule Conditions Registry</a>
+</dt>
+<dt>11.2.  <a href="#registrar-formtype">Field Standardization</a>
+</dt>
+</dl>
+<dt>12.  <a href="#ack">Acknowledgements</a>
+</dt>
+<dt>13.  <a href="#issues">Open Issues</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">While <span class="ref" style="">Advanced Message Processing</span>  [<a href="#nt-id2251770">1</a>] provides message acknowledgements at the server level, it does not extend that model all the way to the client. However, sometimes client-level acknowledgements are needed, for example to provide "receipts". This document defines a mechanism for XMPP message receipts.</p>
+<h2>2.
+       <a name="reqs">Requirements</a>
+</h2>
+  <p class="" style="">This document addresses the following requirements:</p>
+  <ol start="" type="">
+    <li>Enable a sender to request notification that an XMPP message stanza has been received.</li>
+    <li>Enable a recipient to provide message receipts if desired.</li>
+  </ol>
+  <p class="" style="">Note: This document explicitly does not define a protocol for "guaranteed delivery", since that term (like "security") means different things to different people. Instead, we define a more focused protocol that addresses the need for message receipts, thus solving one problem that falls under the heading of "guaranteed delivery".</p>
+<h2>3.
+       <a name="scenarios">Scenarios</a>
+</h2>
+  <p class="" style="">In general there are five possible scenarios (where "S" stands for sender and "R" stands for recipient):</p>
+  <p class="caption">Example 1. Scenario 1: Happy Path</p>
+<div class="indent"><pre>
+S                                       R
+|                                       |
+| ------------------------------------&gt; |
+|    send message                       |
+|                                       |
+| &lt;------------------------------------ |
+|                      send receipt     |
+|                                       |
+  </pre></div>
+  <p class="" style="">In Scenario 1, the use case ends successfully with message delivery, receipt delivery, and no retries.</p>
+  <p class="caption">Example 2. Scenario 2: Message Not Received</p>
+<div class="indent"><pre>
+S                                       R
+|                                       |
+| -----------------------------x        |
+|    send message                       |
+|                                       |
+| [trigger timeout]                     |
+|                                       |
+| ------------------------------------&gt; |
+|    re-send message                    |
+|                                       |
+| &lt;------------------------------------ |
+|                      send receipt     |
+|                                       |
+  </pre></div>
+  <p class="" style="">In Scenario 2, the use case ends successfully with message delivery failure, message retry, and receipt delivery.</p>
+  <p class="caption">Example 3. Scenario 3: Receipt Not Received</p>
+<div class="indent"><pre>
+S                                       R
+|                                       |
+| ------------------------------------&gt; |
+|    send message                       |
+|                                       |
+|      x------------------------------- |
+|                      send receipt     |
+|                                       |
+| [trigger timeout]                     |
+|                                       |
+| ------------------------------------&gt; |
+|    re-send message                    |
+|                                       |
+| &lt;------------------------------------ |
+|                      send receipt     |
+|                                       |
+  </pre></div>
+  <p class="" style="">In Scenario 3, the use case ends successfully with message delivery, receipt delivery failure, message retry, and receipt delivery.</p>
+  <p class="caption">Example 4. Scenario 4: Message Sent, Sender Goes Offline</p>
+<div class="indent"><pre>
+S                                       R
+|                                       |
+| ------------------------------------&gt; |
+|    send message                       |
+|                                       |
+| ------------------------------------&gt; |
+|    send presence unavailable          |
+|                                       |
+  </pre></div>
+  <p class="" style="">In Scenario 4, the use case ends unsuccessfully with message delivery and the sender generating presence unavailable (because the sender has gone offline, the recipient has no one to send the receipt to).</p>
+  <p class="caption">Example 5. Scenario 5: Message Sent, Recipient Goes Offline</p>
+<div class="indent"><pre>
+S                                       R
+|                                       |
+| ------------------------------------&gt; |
+|    send message                       |
+|                                       |
+| &lt;------------------------------------ |
+|    send presence unavailable          |
+|                                       |
+  </pre></div>
+  <p class="" style="">In Scenario 5, the use case ends unsuccessfully with message delivery and the recipient generating presence unavailable (because the recipient has gone offline before sending a receipt, the sender cannot be sure that the message has been received).</p>
+<h2>4.
+       <a name="format">Protocol Format</a>
+</h2>
+  <p class="" style="">In order to make it possible for senders to request, and for recipients to generate, message receipts, we define a new <span style="font-weight: bold">Advanced Message Processing</span> rule: "receipt". In accordance with <span style="font-weight: bold">JEP-0079</span>, we provide the following information about the receipt rule:</p>
+  <ul>
+    <li>The namespace shall be "http://jabber.org/protocol/amp?condition=receipt".</li>
+    <li>The condition applies only to final receipt by the intended recipient; therefore, the per-hop flag does not apply.</li>
+    <li>The only defined value of the receipt rule is "received".</li>
+    <li>This condition is met if a message processing application (client) controlled by the intended recipient has received and processed the message; the term "processed" is understood to include presentation to a human user if appropriate  [<a href="#nt-id2250802">2</a>] or any other application-specific client-side processing, including generation of an error response if the application determines that the message contents cannot be handled.</li>
+    <li>Although any defined action may be triggered, the only action needed in order to support message receipts is the "notify" action.</li>
+  </ul>
+  <p class="" style="">The following is an example of a message that includes a request for return receipt.</p>
+  <p class="caption">Example 6. A message with receipt requested</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">If the recipient supports Advanced Message Processing and the "receipt" rule, it MUST generate a receipt:</p>
+  <p class="caption">Example 7. A message receipt</p>
+<div class="indent"><pre>
+&lt;message
+    from='kingrichard@royalty.england.lit/throne'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' status='notify'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+  </pre></div>
+<h2>5.
+       <a name="rules">Business Rules</a>
+</h2>
+  <p class="" style="">The general business rules specified for Advanced Message Processing in <span style="font-weight: bold">JEP-0079</span> apply to any rule; in addition, the following business rules apply specifically to the receipt rule:</p>
+  <ol start="" type="">
+    <li><p class="" style="">A sender SHOULD NOT include a request for message receipts unless it knows (via <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2259180">4</a>] or <span class="ref" style="">Entity Capabilities</span>  [<a href="#nt-id2259202">5</a>]) that the intended recipient supports the protocol described herein or unless the use of message receipts is negotiated via <span class="ref" style="">Chat Session Negotiation</span>  [<a href="#nt-id2259224">6</a>].</p></li>
+    <li><p class="" style="">The sender (i.e., the message generating application controlled by the sender) MUST initiate a timeout upon sending each message, which timeout SHOULD be 30 seconds. If the sender does not receive a message receipt (or failure event) within its timeout period, it MUST re-send the message with an identical value of the XMPP 'id' attribute.</p></li>
+    <li><p class="" style="">The sender MUST NOT send a large number of retries. How many retries are appropriate depends on how important the message is perceived to be. In any case, a sender SHOULD NOT send more than five retries.</p></li>
+    <li><p class="" style="">The recipient (i.e., the message processing application controlled by the intended recipient that receives a given message) MUST initiate a timeout upon sending each message receipt, which timeout SHOULD be 60 seconds. If the recipient does not receive a re-sent message within its timeout period, it SHOULD stop waiting for a re-sent message and discard memory of that message ID.</p></li>
+    <li><p class="" style="">The recipient MUST NOT include a request for message receipts in its acknowledgements. If the sender receives a request for message receipts in an acknowledgement, it MUST NOT acknowledge the acknowledement.</p></li>
+    <li><p class="" style="">The recipient SHOULD send the message receipt once it has processed the message, which may include presenting it to a human user (e.g., visually or aurally). The receiving application SHOULD NOT require a human user to positively affirm that he or she has read and understood the message before sending the receipt, since this is unnecessarily intrusive in the context of instant messaging.</p></li>
+  </ol>
+<h2>6.
+       <a name="flow">Protocol Flows</a>
+</h2>
+  <p class="" style="">This document covers one use case: sending messages with return receipt requested, for which succcess is defined as the sender receiving a message receipt. As described above, there are five possible scenarios. These are described in more detail in the following sections.</p>
+  <div class="indent">
+<h3>6.1 <a name="flow-happy">Happy Path</a>
+</h3>
+    <p class="" style="">In the "happy path", the sender sends the message and the recipient returns a receipt within the sender's timeout period.</p>
+    <p class="caption">Example 8. A message with receipt requested</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 9. A message receipt</p>
+<div class="indent"><pre>
+&lt;message
+    from='kingrichard@royalty.england.lit/throne'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' status='notify'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="flow-messagenotreceived">Message Not Received</a>
+</h3>
+    <p class="" style="">In this scenario the sender sends the message but it is not received for whatever reason; therefore the sender resends the message after the timeout period expires, the resent message is received, and the recipient returns a receipt within the sender's (second) timeout period.</p>
+    <p class="caption">Example 10. A message with receipt requested</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The message is not received and the sender does not receive a receipt within the sender's timeout period; therefore the sender resends the message.</p>
+    <p class="caption">Example 11. A message with receipt requested</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">Now the message is received and the recipient returns a receipt.</p>
+    <p class="caption">Example 12. A message receipt</p>
+<div class="indent"><pre>
+&lt;message
+    from='kingrichard@royalty.england.lit/throne'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' status='notify'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="flow-receiptnotreceived">Receipt Not Received</a>
+</h3>
+    <p class="" style="">In this scenario the sender sends the message and it not received, but the message receipt is not received for whatever reason; therefore the sender resends the message after the timeout period expires, the resent message is received, and the recipient returns a receipt within the sender's (second) timeout period.</p>
+    <p class="caption">Example 13. A message with receipt requested</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The message is received and the recipient returns a receipt.</p>
+    <p class="caption">Example 14. A message receipt</p>
+<div class="indent"><pre>
+&lt;message
+    from='kingrichard@royalty.england.lit/throne'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' status='notify'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The message receipt is not received by the sender within the sender's timeout period; therefore the sender resends the message.</p>
+    <p class="caption">Example 15. A message with receipt requested</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="" style="">The resent message is received and the recipient returns a receipt, which is received by the sender within the sender's (second) timeout period.</p>
+    <p class="caption">Example 16. A message receipt</p>
+<div class="indent"><pre>
+&lt;message
+    from='kingrichard@royalty.england.lit/throne'
+    id='richard2-4.1.247'
+    to='northumberland@shakespeare.lit'&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp' status='notify'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="flow-senderoffline">Sender Goes Offline</a>
+</h3>
+    <p class="" style="">In this scenario the sender sends the message but immediately goes offline. Therefore the recipient MUST NOT send a receipt.</p>
+    <p class="caption">Example 17. A message with receipt requested</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 18. Sender goes offline</p>
+<div class="indent"><pre>
+&lt;presence
+    from='northumberland@shakespeare.lit/westminster'
+    to='kingrichard@royalty.england.lit/throne'
+    type='unavailable'&gt;
+    </pre></div>
+    <p class="" style="">The use case ends unsuccessfully, since the sender did not receive a receipt.</p>
+  </div>
+  <div class="indent">
+<h3>6.5 <a name="flow-recipientoffline">Recipient Goes Offline</a>
+</h3>
+    <p class="" style="">In this scenario the sender sends the message but receives unavailable presence from the recipient before receiving a receipt within the timeout period.</p>
+    <p class="caption">Example 19. A message with receipt requested</p>
+<div class="indent"><pre>
+&lt;message
+    from='northumberland@shakespeare.lit'
+    id='richard2-4.1.247'
+    to='kingrichard@royalty.england.lit'&gt;
+  &lt;body&gt;My lord, dispatch; read o'er these articles.&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule condition='receipt' action='notify' value='received'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 20. Recipient goes offline</p>
+<div class="indent"><pre>
+&lt;presence
+    from='kingrichard@royalty.england.lit/throne'
+    to='northumberland@shakespeare.lit/westminster'
+    type='unavailable'&gt;
+    </pre></div>
+    <p class="" style="">The use case ends unsuccessfully, since the sender did not receive a receipt.</p>
+  </div>
+<h2>7.
+       <a name="disco">Service Discovery</a>
+</h2>
+  <p class="" style="">If a sender wishes to request message receipts, it SHOULD first discover whether the intended recipient supports message receipts. Support can be discovered indirectly via <span style="font-weight: bold">Entity Capabilities</span> or directly via <span style="font-weight: bold">Service Discovery</span>.</p>
+  <p class="" style="">If an entity supports Advanced Message Processing, it MUST report that by including a service discovery feature of "http://jabber.org/protocol/amp" as described in <span style="font-weight: bold">JEP-0079</span>:</p>
+  <p class="caption">Example 21. Initial Service Discovery information request</p>
+<div class="indent"><pre>
+&lt;iq from='northumberland@shakespeare.lit/westminster'
+    to='kingrichard@royalty.england.lit/throne'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 22. Service Discovery information response</p>
+<div class="indent"><pre>
+&lt;iq from='kingrichard@royalty.england.lit/throne'
+    to='northumberland@shakespeare.lit/westminster'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">An entity that supports Advanced Message Processing SHOULD also maintain a service discovery node named "http://jabber.org/protocol/amp", at which it advertises the individual actions and conditions it supports. If an entity supports message receipts, it SHOULD respond to service discovery information requests sent to that node with a reply that includes 'http://jabber.org/protocol/amp?condition=receipt' condition:</p>
+  <p class="caption">Example 23. Request for information about individual actions and conditions</p>
+<div class="indent"><pre>
+&lt;iq from='northumberland@shakespeare.lit/westminster'
+    to='kingrichard@royalty.england.lit/throne'
+    type='get'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/amp'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 24. Response for individual actions and conditions</p>
+<div class="indent"><pre>
+&lt;iq from='kingrichard@royalty.england.lit/throne'
+    to='northumberland@shakespeare.lit/westminster'
+    type='result'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'
+         node='http://jabber.org/protocol/amp'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/amp?condition=receipt'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>8.
+       <a name="neg">Negotiation</a>
+</h2>
+  <p class="" style="">Two entities MAY negotiate the use of message receipts for a given session using <span style="font-weight: bold">Chat Session Negotiation</span>. The parameter to be negotiated is named "http://jabber.org/protocol/amp?condition=receipt". Its use is illustrated in the following examples.</p>
+  <p class="caption">Example 25. User requests chat session</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='northumberland@shakespeare.lit/westminster'
+         to='kingrichard@royalty.england.lit'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='form'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field label='Accept this chat?'
+             type='boolean' 
+             var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+        &lt;required/&gt;
+      &lt;/field&gt;
+      &lt;field label='Enable Message Receipts?'
+             type='boolean' 
+             var='http://jabber.org/protocol/amp?condition=receipt'&gt;
+        &lt;value&gt;0&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+    <p class="caption">Example 26. Contact accepts offer and specifies parameters</p>
+<div class="indent"><pre>
+&lt;message type='normal'
+         from='kingrichard@royalty.england.lit/throne'
+         to='northumberland@shakespeare.lit/westminster'
+         id='init1'&gt;
+  &lt;thread&gt;ffd7076498744578d10edabfe7f4a866&lt;/thread&gt;
+  &lt;feature xmlns='http://jabber.org/protocol/feature-neg'&gt;
+    &lt;x xmlns='jabber:x:data' type='submit'&gt;
+      &lt;field var='FORM_TYPE' type='hidden'&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='accept'&gt;
+        &lt;value&gt;true&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var='http://jabber.org/protocol/amp?condition=receipt'&gt;
+        &lt;value&gt;1&lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/feature&gt;
+&lt;/message&gt;
+    </pre></div>
+<h2>9.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">To follow.</p>
+<h2>10.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250474">7</a>] is necessary as a result of this JEP.</p>
+<h2>11.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <div class="indent">
+<h3>11.1 <a name="registrar-conditions">Rule Conditions Registry</a>
+</h3>
+    <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2260010">8</a>] maintains a registry of Advanced Message Processing &lt;rule/&gt; conditions (see &lt;<a href="http://www.jabber.org/registrar/amp-actions.html">http://www.jabber.org/registrar/amp-actions.html</a>&gt;). The Registrar shall add the following condition to the registry:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;condition&gt;
+  &lt;name&gt;receipt&lt;/name&gt;
+  &lt;ns&gt;http://jabber.org/protocol/amp?condition=receipt&lt;/ns&gt;
+  &lt;per-hop&gt;false&lt;/per-hop&gt;
+  &lt;value&gt;received&lt;/value&gt;
+  &lt;processing&gt;
+    The condition is met if a message processing application (client)
+    controlled by the intended recipient has received and processed
+    the message, including presentation to a human user if appropriate.
+  &lt;/processing&gt;
+  &lt;doc&gt;JEP-xxxx&lt;/doc&gt;
+&lt;/condition&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>11.2 <a name="registrar-formtype">Field Standardization</a>
+</h3>
+    <p class="" style=""><span class="ref" style="">Field Standardization for Data Forms</span>  [<a href="#nt-id2260074">9</a>] defines a process for standardizing the fields used within Data Forms qualified by a particular namespace and the Jabber Registrar maintains a registry of such fields (see &lt;<a href="http://www.jabber.org/registrar/formtypes.html">http://www.jabber.org/registrar/formtypes.html</a>&gt;). The Registrar shall add the following field for use in Chat Session Negotiation forms:</p>
+    <p class="caption">Registry Submission</p>
+<div class="indent"><pre>
+&lt;form_type&gt;
+  &lt;name&gt;http://jabber.org/protocol/chatneg&lt;/name&gt;
+  &lt;field
+      var='http://jabber.org/protocol/amp?condition=receipt'
+      type='boolean'
+      label='Whether to enable Message Receipts per JEP-0184'/&gt;
+&lt;/form_type&gt;
+      </pre></div>
+  </div>
+<h2>12.
+       <a name="ack">Acknowledgements</a>
+</h2>
+  <p class="" style="">Thanks to Joe Kemp for his input.</p>
+<h2>13.
+       <a name="issues">Open Issues</a>
+</h2>
+  <ul>
+    <li>What if unavailable presence is not received in Scenario 4 or Scenario 5?</li>
+  </ul>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251770">1</a>. JEP-0079: Advanced Message Processing &lt;<a href="http://www.jabber.org/jeps/jep-0079.html">http://www.jabber.org/jeps/jep-0079.html</a>&gt;.</p>
+<p><a name="nt-id2250802">2</a>. Therefore this specification does not distinguish between delivery and presentation, as was done in <span class="ref" style="">Message Events</span>  [<a href="#nt-id2250827">3</a>].</p>
+<p><a name="nt-id2250827">3</a>. JEP-0022: Message Events &lt;<a href="http://www.jabber.org/jeps/jep-0022.html">http://www.jabber.org/jeps/jep-0022.html</a>&gt;.</p>
+<p><a name="nt-id2259180">4</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2259202">5</a>. JEP-0115: Entity Capabilities &lt;<a href="http://www.jabber.org/jeps/jep-0115.html">http://www.jabber.org/jeps/jep-0115.html</a>&gt;.</p>
+<p><a name="nt-id2259224">6</a>. JEP-0155: Chat Session Negotiation &lt;<a href="http://www.jabber.org/jeps/jep-0155.html">http://www.jabber.org/jeps/jep-0155.html</a>&gt;.</p>
+<p><a name="nt-id2250474">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2260010">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+<p><a name="nt-id2260074">9</a>. JEP-0068: Field Data Standardization for Data Forms &lt;<a href="http://www.jabber.org/jeps/jep-0068.html">http://www.jabber.org/jeps/jep-0068.html</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-04-11)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-04-07)</h4>
+<div class="indent">
+<p class="" style="">Added text and examples for service discovery; added text and examples for chat session negotiation; added recommendations regarding message processing, retries, etc.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-03-27)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0185-0.1.html
+++ b/content/xep-0185-0.1.html
@@ -1,0 +1,335 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0185: Dialback Key Generation and Validation</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Dialback Key Generation and Validation">
+<meta name="DC.Creator" content="Philipp Hancke">
+<meta name="DC.Description" content="This document explains how to generate and validate dialback keys">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-04-11">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0185">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0185: Dialback Key Generation and Validation</h1>
+<p>This document explains how to generate and validate dialback keys</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Informational JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the best practice or protocol profile described herein is encouraged in exploratory implementations, although production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Informational<br>
+            Number: 0185<br>
+            Version: 0.1<br>
+            Last Updated: 2006-04-11<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>Dependencies: XMPP Core<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: Not yet assigned<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Dialback%20Key%20Generation%20and%20Validation%20(JEP-0185)">http://wiki.jabber.org/index.php/Dialback Key Generation and Validation (JEP-0185)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Philipp Hancke</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:fippo@goodadvice.pages.de">fippo@goodadvice.pages.de</a><br>
+        JID: 
+        <a href="xmpp:fippo@goodadvice.pages.de">fippo@goodadvice.pages.de</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#sect-id2251696">Dialback explained</a>
+</dt>
+<dt>3.  <a href="#sect-id2250689">Key Generation and Validation</a>
+</dt>
+<dt>4.  <a href="#sect-id2250808">Attacks against key generation methods</a>
+</dt>
+<dl>
+<dt>4.1.  <a href="#sect-id2250872">Hostname of Originating Server not considered</a>
+</dt>
+<dt>4.2.  <a href="#sect-id2259169">stream id not considered</a>
+</dt>
+<dt>4.3.  <a href="#sect-id2259230">Hostname of the Receiving Server not considered</a>
+</dt>
+<dt>4.4.  <a href="#sect-id2259286">shared secret is not considered</a>
+</dt>
+</dl>
+<dt>5.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>6.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>7.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style=""><span class="ref" style="">RFC 3920</span>  [<a href="#nt-id2251685">1</a>] does not specify how to generate the keys used in the dialback protocol, and why each of the variables used in key generation is crucial for security. This document is provided for discussion purposes and aims at clarifying the key generation and its validation mechanism and to show common attacks on weak mechanisms. It is not meant to supercede the text in <span style="font-weight: bold">RFC 3920</span>.</p>
+<h2>2.
+       <a name="sect-id2251696">Dialback explained</a>
+</h2>
+  <p class="" style="">The Originating Server, which generates the dialback key, and the Authorative Server, which validates the dialback key, may reside on different hosts or be running in separate processes. The method used in key generation and validation should not require interactive communication between Originating Server, Authorative Server and optionally a third party like a database.</p>
+  <p class="" style="">Based on</p>
+  <ul>
+    <li>the hostname of Originating Server,</li>
+    <li>the hostname of Receiving Server,</li>
+    <li>the stream ID,</li>
+    <li>a secret known by the Authorative Server's network,</li>
+  </ul>
+  <p class="" style="">RFC 3920 leaves it to the implementation how the key is generated.</p>
+  <p class="" style="">The last item, a shared secret known to Originating Server and Authorative Server is static and can be set up in a configuration option for each host or process. If there is no configured secret, a random one MUST be generated when starting the server.</p>
+  <p class="" style="">To protect this secret's confidentiality, a hash algorithm SHOULD be used in the key generation method. The choice which algorithm to use is left to the implementation, but usage of the SHA1 algorithm described in <span class="ref" style="">RFC 3174</span>  [<a href="#nt-id2250629">2</a>] is recommended.</p>
+  <p class="" style="">The input to the hash algorithm is a string concatenation of all factors mentioned above. The order in which those are concatenated or any character separators inserted during concatenation is up to the implementation. To avoid problems of encoding, a hexadecimal representation of the digest algorithm output SHOULD be used.</p>
+  <p class="" style="">The examples in this document will use the SHA1 algorithm and separate the factors by a colon, similar to <span class="ref" style="">RFC 2831</span>  [<a href="#nt-id2250676">3</a>]:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+key = HEX( H({ ID, ":", hostname of Receiving Server, ":", 
+	       hostname of Originating or Authorative server, ":", secret} ) )
+  </pre></div>
+  <p class="" style="">The secret used in the examples is "thesecret"</p>
+<h2>3.
+       <a name="sect-id2250689">Key Generation and Validation</a>
+</h2>
+  <p class="" style="">This document closely follows the description of the dialback protocol in RFC 3920, but omits steps that are not important for the generation and validation of the dialback keys. For ease of comparison the numbering of the steps is the same as in section 8.3 of RFC 3920.</p>
+  <p class="" style="">3. Receiving Server sends a stream header back to the Originating Server, including a unique ID for this interaction:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;stream:stream
+  xmlns:stream='http://etherx.jabber.org/streams'
+  xmlns='jabber:server'
+  xmlns:db='jabber:server:dialback'
+  to='example.com'
+  from='example.org'
+  id='457F9224A0'&gt;
+    </pre></div>
+  <p class="" style="">The Originating Server now generates a dialback key to be sent to the Receiving Server:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+key = SHA1({ ID, ':', receiving server, ':', originating server, ':', secret })
+    = SHA1({ '457F9224A0', ':', 'example.com', ':', 
+	     'example.org', ':', 'thesecret' })
+    = SHA1('457F9224A0:example.com:example.org:thesecret')
+    = 'f19f09ad8a0d7c4778eff54ee5727c2d660ceeb2'
+  </pre></div>
+  <p class="" style="">4. The Originating Server sends the generated dialback key to the Receiving Server:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;db:result
+  to='example.com'
+  from='example.org'&gt;
+    f19f09ad8a0d7c4778eff54ee5727c2d660ceeb2
+&lt;/db:result&gt;
+    </pre></div>
+  <p class="" style="">8. The Receiving Server sends the Authorative Server a request for verification of the key:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;db:verify
+  to='example.org'
+  from='example.com'
+  id='457F9224A0'&gt;
+    f19f09ad8a0d7c4778eff54ee5727c2d660ceeb2
+&lt;/db:verify&gt;
+    </pre></div>
+  <p class="" style="">The Authorative Server calculates the valid key for this verify request, using data supplied in the packet and the secret shared with the Originating Server.</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+key = SHA1({ ID, ':', Receiving Server, ':', Authorative Server, ':', secret })
+    = SHA1({ '457F9224A0', ':', 'example.com', ':', 
+	     'example.org', ':', 'thesecret' })
+    = SHA1('457F9224A0:example.com:example.org:thesecret')
+    = 'f19f09ad8a0d7c4778eff54ee5727c2d660ceeb2'
+    </pre></div>
+    <p class="" style="">9. The Authorative Server compares this value to the key contained in the verification requests and informs the Originating Server of the result, in our example a success:</p>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;db:verify
+  from='example.org'
+  to='example.com'
+  id='457F9224A0'
+  type='valid'/&gt;
+    </pre></div>
+<h2>4.
+       <a name="sect-id2250808">Attacks against key generation methods</a>
+</h2>
+  <p class="" style="">This section contains attack scenarios that illustrate why each of the factors used in key generation is important.</p>
+  <p class="" style="">An attacker will assume the role of the Originating server and try to send a dialback key that the Authorative Server acknowlegdes as valid. If this is successful, the attacker is allowed to send packets for the hostname of the Authorative Server.</p>
+  <p class="" style="">In each subsection, the example hash method ignores one of the variables,</p>
+  <ul>
+    <li>hostname of Originating Server,</li>
+    <li>stream ID,</li>
+    <li>hostname of Receiving Server,</li>
+    <li>or shared secret</li>
+  </ul>
+  <p class="" style="">by using an empty string instead, and it is shown how an attacker might exploit this behavior to get a valid result from the Authorative Server.</p>
+  <div class="indent">
+<h3>4.1 <a name="sect-id2250872">Hostname of Originating Server not considered</a>
+</h3>
+    <p class="" style="">This subsection demonstrates what can happen if the key generation method ignores the hostname of the Originating Server, e.g. for the hash function</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+key = SHA1({ ID, ':', hostname of receiving server, ':', empty string, ':', secret })
+    </pre></div>
+    <p class="" style="">The dialback keys generated for the originating domains 'example.org' and 'example.net' are the same, which might disclose that the secret used to generate the keys for these domains is equal. An attacker can not exploit this any further.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;db:verify
+  to='example.org'
+  from='example.com'
+  id='4a4a6813131'&gt; 
+    d46bd18b327a65b609eda23419310719597a7838
+&lt;/db:verify&gt;
+    </pre></div>
+    <p class="" style="">This key is generated using the empty string instead of the originating domain name:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+SHA1('4a4a6813131:example.com::thesecret') = 
+	    'd46bd18b327a65b609eda23419310719597a7838'
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.2 <a name="sect-id2259169">stream id not considered</a>
+</h3>
+    <p class="" style="">This subsection demonstrates a replay attack that is possible if the key generation method ignores the stream id, e.g. for the hash function</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+key = SHA1({ empty string, ':', hostname of receiving server, ':', 
+	   hostname of originating server, ':', secret })
+    </pre></div>
+    <p class="" style="">If the attacker is able to obtain a single valid dialback key exchanged between the two domains, this key can be used to validate any stream.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;db:verify
+  to='example.org'
+  from='example.com'
+  id='434afab75131f'&gt;
+    f9864ed156570ee8b505fad8d5d17374d513371b
+&lt;/db:verify&gt;
+    </pre></div>
+    <p class="" style="">This key is generated using the empty string instead of the id:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+SHA1(':example.com:example.org:thesecret') = 
+	    'f9864ed156570ee8b505fad8d5d17374d513371b'
+    </pre></div> 
+    <p class="" style="">This key is also valid for</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;db:verify
+  to='example.org'
+  from='example.com'
+  id='anyidyouwant'&gt;
+    f9864ed156570ee8b505fad8d5d17374d513371b
+&lt;/db:verify&gt;
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.3 <a name="sect-id2259230">Hostname of the Receiving Server not considered</a>
+</h3>
+    <p class="" style="">This subsection demonstrates against a key generation method that ignores the hostname of the receiving server, e.g. for the hash function</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+key = SHA1({ ID, ':', empty string, ':', 
+	hostname of originating server, ':', secret })
+    </pre></div>
+    <p class="" style="">The attacker can use a dialback key and stream ID we have sent a domain under his control.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;db:verify
+  to='example.org'
+  from='example.com'
+  id='abag32325bg1'&gt;
+    67cdeb22c9300b52a9ec466f7878adc2d318fd8a
+&lt;/db:verify&gt;
+    </pre></div>
+    <p class="" style="">This key is generated using the empty string instead of the receiving domain:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+SHA1('abag32325bg1::example.org:thesecret') = 
+	    '67cdeb22c9300b52a9ec466f7878adc2d318fd8a'
+    </pre></div>
+  </div>
+  <div class="indent">
+<h3>4.4 <a name="sect-id2259286">shared secret is not considered</a>
+</h3>
+    <p class="" style="">If the key generation method does not take into account a shared secret in the Authorative Servers network or if this secret is disclosed and the key generation method is known, an attacker can generate valid dialback keys.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+key = SHA1({ ID, ':', hostname of receiving server, ':', 
+	hostname of originating server, ':', empty string})</pre></div>
+    <p class="" style="">In both cases the attacker is able to generate an arbitrary number of dialback keys.</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+&lt;db:verify
+  to='example.org'
+  from='example.com'
+  id='aqtqrq13'&gt;
+    1f44ba7a2eca0e7f9908e18d239ed5c2ad9fe9c1
+&lt;/db:verify&gt;
+    </pre></div>
+    <p class="" style="">This key is generated for the empty string instead of the secret:</p>
+    <p class="caption"></p>
+<div class="indent"><pre>
+SHA1('aqtqrq13:example.com:example.org:') = 
+	    '1f44ba7a2eca0e7f9908e18d239ed5c2ad9fe9c1'
+    </pre></div>
+  </div>
+<h2>5.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">This JEP introduces no security considerations or concerns above and beyond those discussed in <span style="font-weight: bold">RFC3920</span>, but describes what might happen if the security considerations are ignored.</p>
+<h2>6.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259400">4</a>].</p>
+<h2>7.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259443">5</a>].</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251685">1</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250629">2</a>. RFC 3174: US Secure Hash Algorithm 1 (SHA1) &lt;<a href="http://www.ietf.org/rfc/rfc3174.txt">http://www.ietf.org/rfc/rfc3174.txt</a>&gt;.</p>
+<p><a name="nt-id2250676">3</a>. RFC 2831: Using Digest Authentication as a SASL Mechanism &lt;<a href="http://www.ietf.org/rfc/rfc2831.txt">http://www.ietf.org/rfc/rfc2831.txt</a>&gt;.</p>
+<p><a name="nt-id2259400">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259443">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-04-11)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-03-30)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (ph)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0186-0.1.html
+++ b/content/xep-0186-0.1.html
@@ -1,0 +1,215 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0186: Invisible Command</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Invisible Command">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies an XMPP-compatible protocol for user invisibility.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-05-30">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0186">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0186: Invisible Command</h1>
+<p>This document specifies an XMPP-compatible protocol for user invisibility.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: Experimental<br>
+            Type: Standards Track<br>
+            Number: 0186<br>
+            Version: 0.1<br>
+            Last Updated: 2006-05-30<br>
+            JIG: Standards JIG<br>
+                Approving Body: Jabber Council<br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: invisibility<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Invisible%20Command%20(JEP-0186)">http://wiki.jabber.org/index.php/Invisible Command (JEP-0186)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The keywords "MUST", "MUST NOT", "REQUIRED", "SHALL", "SHALL NOT", "SHOULD", "SHOULD NOT", "RECOMMENDED", "NOT RECOMMENDED", "MAY", and "OPTIONAL" in this document are to be interpreted as described in RFC 2119.</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#proto">Introduction</a>
+</dt>
+<dt>2.  <a href="#proto">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>3.2.  <a href="#invisible">User Becomes Invisible</a>
+</dt>
+<dt>3.3.  <a href="#visible">User Becomes Visible</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2257213">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2257234">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2257248">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="proto">Introduction</a>
+</h2>
+  <p class="" style="">Jabber instant messaging technologies have long supported the ability for IM users to be online but appear invisible. The existing protocols for doing so are:</p>
+  <ul>
+    <li><p class="" style=""><span class="ref" style="">Invisible Presence</span>  [<a href="#nt-id2251622">1</a>] -- this protocol is not compatible with <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251645">2</a>] and <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2251668">3</a>], and it does not provide reliable documentation of the protocol in use since many server implementations support presence of type "invisible" but not presence of type "visible".</p></li>
+    <li><p class="" style=""><span class="ref" style="">Invisibility</span>  [<a href="#nt-id2250687">4</a>] -- this protocol is in many ways a mis-use of privacy lists for the temporary purpose of appearing invisible rather than the intended purpose of permanently blocking communications.</p></li>
+  </ul>
+  <p class="" style="">Therefore, this document defines an IQ-based protocol that enables an IM user to "go invisible" and "go visible" at will.</p>
+<h2>2.
+       <a name="proto">Requirements</a>
+</h2>
+  <p class="" style="">The requirements for invisible mode are straightforward:</p>
+  <ol start="" type="">
+    <li>A user should be able to become visible or invisible at any time.</li>
+    <li>When in invisible mode, a user should be able to send directed presence to particular contacts.</li>
+  </ol>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco">Discovering Support</a>
+</h3>
+    <p class="" style="">In order for a client to discover whether its server supports the protocol defined herein, it MUST send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250772">5</a>] information request to the server:</p>
+    <p class="caption">Example 1. Service discovery request</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' to='tolkien.lit' type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server supports the protocol defined herein, it MUST return a feature of "http://jabber.org/protocol/invisibility":</p>
+    <p class="caption">Example 2. Service discovery response</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' to='tolkien.lit' type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/invisibility'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A client SHOULD complete this service discovery process before sending initial presence to its server.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="invisible">User Becomes Invisible</a>
+</h3>
+    <p class="" style="">In order for a client to go invisible, it shall send an IQ-set with no 'to' address (thus handled by the user's server) containing an &lt;invisible/&gt; element qualified by the 'http://jabber.org/protocol/invisibility' namespace:</p>
+    <p class="caption">Example 3. Invisible command</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='inv1'&gt;
+  &lt;invisible xmlns='http://jabber.org/protocol/invisibility'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can successfully process the invisibility command, it MUST return an IQ-result:</p>
+    <p class="caption">Example 4. Invisible command is successful</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='inv1'/&gt;
+    </pre></div>
+    <p class="" style="">(Standard XMPP stanza errors apply; see <span style="font-weight: bold">RFC 3920</span> and <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2250886">6</a>].)</p>
+    <p class="" style="">If the client enters invisible mode after having previously sent undirected presence with no 'type' attribute (e.g., after sending initial presence), the server MUST send &lt;presence type='unavailable'/&gt; presence from the client's resource to all contacts who would receive unavailable presence if the client sent &lt;presence type='unavailable'/&gt;.</p>
+    <p class="" style="">While the client is in invisible mode, the server:</p>
+    <ol start="" type="">
+      <li><p class="" style="">MUST NOT broadcast presence notifications as a result of receiving any subsequent undirected presence notifications from the client.</p></li>
+      <li><p class="" style="">MUST deliver any directed presence stanzas generated by the client.  [<a href="#nt-id2250942">7</a>]</p></li>
+      <li><p class="" style="">MUST deliver any outbound &lt;message/&gt; and &lt;iq/&gt; stanzas generated by the client.</p></li>
+      <li><p class="" style="">MUST deliver any inbound &lt;message/&gt; and &lt;iq/&gt; stanzas whose 'to' address is the resource of the client.  [<a href="#nt-id2250958">8</a>]</p></li>
+      <li><p class="" style="">SHOULD deliver inbound &lt;message/&gt; stanzas whose 'to' address is the bare JID of the user (subject to standard XMPP stanza handling rules).</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="visible">User Becomes Visible</a>
+</h3>
+    <p class="" style="">In order for a client to become visible again, it shall send an IQ-set with no 'to' address (thus handled by the user's server) containing a &lt;visible/&gt; element qualified by the 'http://jabber.org/protocol/invisibility' namespace:</p>
+    <p class="caption">Example 5. Visible command</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='vis1'&gt;
+  &lt;visible xmlns='http://jabber.org/protocol/invisibility'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can successfully process the visibility command, it MUST return an IQ-result:</p>
+    <p class="caption">Example 6. Visible command is successful</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='vis1'/&gt;
+    </pre></div>
+    <p class="" style="">When the client becomes visible, the server MUST treat that state as equivalent to an active session before receiving initial presence from the client. It is the responsibility of the client to send an undirected presence notification to the server, which the server MUST broadcast to all entities who would normally receive presence broadcasts from the client (as well as any other entities to which the client sent directed presence while invisible).</p>
+  </div>
+<h2>4.
+       <a name="sect-id2257213">Security Considerations</a>
+</h2>
+  <p class="" style="">It is possible to leak presence while in invisible mode (for example, by sending a message to a contact). A client SHOULD warn a user before allowing the user to generate any outbound traffic and MUST NOT respond to IQ requests received from entities with which it has not initiated communications while in invisible mode (e.g., by sending directed presence).</p>
+<h2>5.
+       <a name="sect-id2257234">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2257269">9</a>] is required as a result of this JEP.</p>
+<h2>6.
+       <a name="sect-id2257248">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2257312">10</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251622">1</a>. JEP-0018: Invisible Presence &lt;<a href="http://www.jabber.org/jeps/jep-0018.html">http://www.jabber.org/jeps/jep-0018.html</a>&gt;.</p>
+<p><a name="nt-id2251645">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2251668">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250687">4</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p><a name="nt-id2250772">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2250886">6</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2250942">7</a>. If after sending directed presence the client then sends &lt;presence type='unavailable'/&gt;, the server MUST deliver that unavailable presence only to the entities to which the client sent directed presence after going invisible.</p>
+<p><a name="nt-id2250958">8</a>. If a client responds to such messages or IQs, it may leak presence. A client SHOULD warn the user before allowing the user to respond to such messages and MUST NOT automatically respond to IQs unless the user is in an existing conversation with the sender, has sent IQs to the sender, or has sent directed presence to the sender.</p>
+<p><a name="nt-id2257269">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2257312">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-05-30)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-05-15)</h4>
+<div class="indent">
+<p class="" style="">Recommended delivery of messages sent to bare JID.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-05-11)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0186-0.2.html
+++ b/content/xep-0186-0.2.html
@@ -1,0 +1,222 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0186: Invisible Command</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Invisible Command">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies an XMPP-compatible protocol for user invisibility.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-07">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0186">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0186: Invisible Command</h1>
+<p>This document specifies an XMPP-compatible protocol for user invisibility.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0186<br>
+            Version: 0.2<br>
+            Last Updated: 2006-07-07<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: invisibility<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Invisible%20Command%20(JEP-0186)">http://wiki.jabber.org/index.php/Invisible Command (JEP-0186)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#proto">Introduction</a>
+</dt>
+<dt>2.  <a href="#proto">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>3.2.  <a href="#invisible">User Becomes Invisible</a>
+</dt>
+<dt>3.3.  <a href="#visible">User Becomes Visible</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2259542">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2259564">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2259586">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="proto">Introduction</a>
+</h2>
+  <p class="" style="">Jabber instant messaging technologies have long supported the ability for IM users to be online but appear invisible. The existing protocols for doing so are:</p>
+  <ul>
+    <li><p class="" style=""><span class="ref" style="">Invisible Presence</span>  [<a href="#nt-id2251711">1</a>] -- this protocol is not compatible with <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2251734">2</a>] and <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250761">3</a>], and it does not provide reliable documentation of the protocol in use since many server implementations support presence of type "invisible" but not presence of type "visible".</p></li>
+    <li><p class="" style=""><span class="ref" style="">Invisibility</span>  [<a href="#nt-id2250790">4</a>] -- this protocol is in many ways a mis-use of privacy lists for the temporary purpose of appearing invisible rather than the intended purpose of permanently blocking communications.</p></li>
+  </ul>
+  <p class="" style="">In order to provide a standards-compliant protocol that can be used in the long term, this document defines an IQ-based protocol that enables an IM user to "go invisible" and "go visible" at will within the context of a given session.</p>
+<h2>2.
+       <a name="proto">Requirements</a>
+</h2>
+  <p class="" style="">The requirements for invisible mode are straightforward:</p>
+  <ol start="" type="">
+    <li>A user should be able to become visible or invisible at any time within an XMPP session.</li>
+    <li>Invisible mode is active only for the current session; if the user ends that session and starts another session, the invisibility mode set for the previous session does not carry over to the new session.</li>
+    <li>When in invisible mode, a user should be able to send directed presence to particular contacts.</li>
+  </ol>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco">Discovering Support</a>
+</h3>
+    <p class="" style="">In order for a client to discover whether its server supports the protocol defined herein, it MUST send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250887">5</a>] information request to the server:</p>
+    <p class="caption">Example 1. Service discovery request</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' to='tolkien.lit' type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server supports the protocol defined herein, it MUST return a feature of "http://jabber.org/protocol/invisibility":</p>
+    <p class="caption">Example 2. Service discovery response</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' to='tolkien.lit' type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/invisibility'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A client SHOULD complete this service discovery process before sending initial presence to its server.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="invisible">User Becomes Invisible</a>
+</h3>
+    <p class="" style="">In order for a client to go invisible, it shall send an IQ-set with no 'to' address (thus handled by the user's server) containing an &lt;invisible/&gt; element qualified by the 'http://jabber.org/protocol/invisibility' namespace:</p>
+    <p class="caption">Example 3. Invisible command</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='inv1'&gt;
+  &lt;invisible xmlns='http://jabber.org/protocol/invisibility'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can successfully process the invisibility command, it MUST return an IQ-result:</p>
+    <p class="caption">Example 4. Invisible command is successful</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='inv1'/&gt;
+    </pre></div>
+    <p class="" style="">(Standard XMPP stanza errors apply; see <span style="font-weight: bold">RFC 3920</span> and <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2251032">6</a>].)</p>
+    <p class="" style="">If the client enters invisible mode after having previously sent undirected presence with no 'type' attribute (e.g., after sending initial presence), the server MUST send &lt;presence type='unavailable'/&gt; presence from the client's resource to all contacts who would receive unavailable presence if the client sent &lt;presence type='unavailable'/&gt;.</p>
+    <p class="" style="">While the client is in invisible mode, the server:</p>
+    <ol start="" type="">
+      <li><p class="" style="">MUST NOT broadcast presence notifications as a result of receiving any subsequent undirected presence notifications from the client.</p></li>
+      <li><p class="" style="">MUST deliver any directed presence stanzas generated by the client.  [<a href="#nt-id2259432">7</a>]</p></li>
+      <li><p class="" style="">MUST deliver any outbound &lt;message/&gt; and &lt;iq/&gt; stanzas generated by the client.</p></li>
+      <li><p class="" style="">MUST deliver any inbound &lt;message/&gt; and &lt;iq/&gt; stanzas whose 'to' address is the resource of the client.  [<a href="#nt-id2259629">8</a>]</p></li>
+      <li><p class="" style="">SHOULD deliver inbound &lt;message/&gt; stanzas whose 'to' address is the bare JID of the user (subject to standard XMPP stanza handling rules).</p></li>
+    </ol>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="visible">User Becomes Visible</a>
+</h3>
+    <p class="" style="">In order for a client to become visible again, it shall send an IQ-set with no 'to' address (thus handled by the user's server) containing a &lt;visible/&gt; element qualified by the 'http://jabber.org/protocol/invisibility' namespace:</p>
+    <p class="caption">Example 5. Visible command</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='vis1'&gt;
+  &lt;visible xmlns='http://jabber.org/protocol/invisibility'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can successfully process the visibility command, it MUST return an IQ-result:</p>
+    <p class="caption">Example 6. Visible command is successful</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='vis1'/&gt;
+    </pre></div>
+    <p class="" style="">When the client becomes visible, the server MUST treat that state as equivalent to an active session before receiving initial presence from the client. It is the responsibility of the client to send an undirected presence notification to the server, which the server MUST broadcast to all entities who would normally receive presence broadcasts from the client (as well as any other entities to which the client sent directed presence while invisible).</p>
+  </div>
+<h2>4.
+       <a name="sect-id2259542">Security Considerations</a>
+</h2>
+  <p class="" style="">It is possible to leak presence while in invisible mode (for example, by sending a message to a contact). A client SHOULD warn a user before allowing the user to generate any outbound traffic and MUST NOT respond to IQ requests received from entities with which it has not initiated communications while in invisible mode (e.g., by sending directed presence).</p>
+<h2>5.
+       <a name="sect-id2259564">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259597">9</a>] is required as a result of this JEP.</p>
+<h2>6.
+       <a name="sect-id2259586">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259643">10</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251711">1</a>. JEP-0018: Invisible Presence &lt;<a href="http://www.jabber.org/jeps/jep-0018.html">http://www.jabber.org/jeps/jep-0018.html</a>&gt;.</p>
+<p><a name="nt-id2251734">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250761">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250790">4</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p><a name="nt-id2250887">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251032">6</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2259432">7</a>. If after sending directed presence the client then sends &lt;presence type='unavailable'/&gt;, the server MUST deliver that unavailable presence only to the entities to which the client sent directed presence after going invisible.</p>
+<p><a name="nt-id2259629">8</a>. If a client responds to such messages or IQs, it may leak presence. A client SHOULD warn the user before allowing the user to respond to such messages and MUST NOT automatically respond to IQs unless the user is in an existing conversation with the sender, has sent IQs to the sender, or has sent directed presence to the sender.</p>
+<p><a name="nt-id2259597">9</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259643">10</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.2 (2006-07-07)</h4>
+<div class="indent">
+<p class="" style="">Clarified that invisibility mode does not carry across sessions.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-05-30)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-05-15)</h4>
+<div class="indent">
+<p class="" style="">Recommended delivery of messages sent to bare JID.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-05-11)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0186-0.3.html
+++ b/content/xep-0186-0.3.html
@@ -1,0 +1,226 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0186: Invisible Command</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Invisible Command">
+<meta name="DC.Creator" content="Peter Saint-Andre">
+<meta name="DC.Description" content="This document specifies an XMPP-compatible protocol for user invisibility.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-08-02">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0186">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0186: Invisible Command</h1>
+<p>This document specifies an XMPP-compatible protocol for user invisibility.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0186<br>
+            Version: 0.3<br>
+            Last Updated: 2006-08-02<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>
+                Dependencies: None<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: invisibility<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Invisible%20Command%20(JEP-0186)">http://wiki.jabber.org/index.php/Invisible Command (JEP-0186)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Peter Saint-Andre</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:stpeter@jabber.org">stpeter@jabber.org</a><br>
+        JID: 
+        <a href="xmpp:stpeter@jabber.org">stpeter@jabber.org</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#proto">Introduction</a>
+</dt>
+<dt>2.  <a href="#proto">Requirements</a>
+</dt>
+<dt>3.  <a href="#usecases">Use Cases</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#disco">Discovering Support</a>
+</dt>
+<dt>3.2.  <a href="#invisible">User Becomes Invisible</a>
+</dt>
+<dt>3.3.  <a href="#visible">User Becomes Visible</a>
+</dt>
+</dl>
+<dt>4.  <a href="#sect-id2259753">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#sect-id2259775">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#sect-id2259800">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="proto">Introduction</a>
+</h2>
+  <p class="" style="">Jabber instant messaging technologies have long supported the ability for IM users to be online but appear invisible. The existing protocols for doing so are:</p>
+  <ul>
+    <li><p class="" style=""><span class="ref" style="">Invisible Presence</span>  [<a href="#nt-id2252085">1</a>] -- this protocol is not compatible with <span class="ref" style="">XMPP Core</span>  [<a href="#nt-id2250754">2</a>] and <span class="ref" style="">XMPP IM</span>  [<a href="#nt-id2250777">3</a>], and it does not provide reliable documentation of the protocol in use since many server implementations support presence of type "invisible" but not presence of type "visible".</p></li>
+    <li><p class="" style=""><span class="ref" style="">Invisibility</span>  [<a href="#nt-id2250806">4</a>] -- this protocol is in many ways a mis-use of privacy lists for the temporary purpose of appearing invisible rather than the intended purpose of permanently blocking communications.</p></li>
+  </ul>
+  <p class="" style="">In order to provide a standards-compliant protocol that can be used in the long term, this document defines an IQ-based protocol that enables an IM user to "go invisible" and "go visible" at will within the context of a given session.</p>
+<h2>2.
+       <a name="proto">Requirements</a>
+</h2>
+  <p class="" style="">The requirements for invisible mode are straightforward:</p>
+  <ol start="1" type="">
+    <li>A user should be able to become visible or invisible at any time within an XMPP session.</li>
+    <li>Invisible mode is active only for the current session; if the user ends that session and starts another session, the invisibility set for the previous session does not carry over to the new session.</li>
+    <li>When in invisible mode, a user should be able to send directed presence to particular contacts.</li>
+  </ol>
+<h2>3.
+       <a name="usecases">Use Cases</a>
+</h2>
+  <div class="indent">
+<h3>3.1 <a name="disco">Discovering Support</a>
+</h3>
+    <p class="" style="">In order for a client to discover whether its server supports the protocol defined herein, it MUST send a <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2250905">5</a>] information request to the server:</p>
+    <p class="caption">Example 1. Service discovery request</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' to='tolkien.lit' type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server supports the protocol defined herein, it MUST return a feature of "http://jabber.org/protocol/invisibility":</p>
+    <p class="caption">Example 2. Service discovery response</p>
+<div class="indent"><pre>
+&lt;iq from='bilbo@tolkien.lit/shire' to='tolkien.lit' type='get' id='disco1'&gt;
+  &lt;query xmlns='http://jabber.org/protocol/disco#info'&gt;
+    ...
+    &lt;feature var='http://jabber.org/protocol/invisibility'/&gt;
+    ...
+  &lt;/query&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">A client SHOULD complete this service discovery process before sending initial presence to its server.</p>
+  </div>
+  <div class="indent">
+<h3>3.2 <a name="invisible">User Becomes Invisible</a>
+</h3>
+    <p class="" style="">In order for a client to go invisible, it shall send an IQ-set with no 'to' address (thus handled by the user's server) containing an &lt;invisible/&gt; element qualified by the 'http://jabber.org/protocol/invisibility' namespace:</p>
+    <p class="caption">Example 3. Invisible command</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='inv1'&gt;
+  &lt;invisible xmlns='http://jabber.org/protocol/invisibility'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can successfully process the invisibility command, it MUST return an IQ-result:</p>
+    <p class="caption">Example 4. Invisible command is successful</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='inv1'/&gt;
+    </pre></div>
+    <p class="" style="">(Standard XMPP stanza errors apply; see <span style="font-weight: bold">RFC 3920</span> and <span class="ref" style="">Error Condition Mappings</span>  [<a href="#nt-id2251016">6</a>].)</p>
+    <p class="" style="">If the client enters invisible mode after having previously sent undirected presence with no 'type' attribute (e.g., after sending initial presence), the server MUST send &lt;presence type='unavailable'/&gt; presence from the client's resource to all contacts who would receive unavailable presence if the client sent &lt;presence type='unavailable'/&gt;.</p>
+    <p class="" style="">While the client is in invisible mode, the server:</p>
+    <ol start="1" type="">
+      <li><p class="" style="">MUST NOT broadcast presence notifications as a result of receiving any subsequent undirected presence notifications from the client.</p></li>
+      <li><p class="" style="">MUST deliver directed presence stanzas generated by the client.</p></li>
+      <li><p class="" style="">MUST deliver inbound &lt;presence/&gt; stanzas.</p></li>
+      <li><p class="" style="">SHOULD deliver inbound &lt;message/&gt; stanzas whose 'to' address is the bare JID of the user (subject to standard XMPP stanza handling rules).</p></li>
+      <li><p class="" style="">MUST deliver inbound &lt;message/&gt; and &lt;iq/&gt; stanzas whose 'to' address is the resource of the client.</p></li>
+      <li><p class="" style="">MUST deliver outbound &lt;message/&gt; and &lt;iq/&gt; stanzas generated by the client (for an important note regarding presence leaks, see the <a href="#security">Security Considerations</a> section of this document).</p></li>
+    </ol>
+    <p class="" style="">If after sending directed presence the client then sends &lt;presence type='unavailable'/&gt;, the server MUST deliver that unavailable presence only to the entities to which the client sent directed presence after going invisible.</p>
+  </div>
+  <div class="indent">
+<h3>3.3 <a name="visible">User Becomes Visible</a>
+</h3>
+    <p class="" style="">In order for a client to become visible again, it shall send an IQ-set with no 'to' address (thus handled by the user's server) containing a &lt;visible/&gt; element qualified by the 'http://jabber.org/protocol/invisibility' namespace:</p>
+    <p class="caption">Example 5. Visible command</p>
+<div class="indent"><pre>
+&lt;iq type='set' id='vis1'&gt;
+  &lt;visible xmlns='http://jabber.org/protocol/invisibility'/&gt;
+&lt;/iq&gt;
+    </pre></div>
+    <p class="" style="">If the server can successfully process the visibility command, it MUST return an IQ-result:</p>
+    <p class="caption">Example 6. Visible command is successful</p>
+<div class="indent"><pre>
+&lt;iq type='result' id='vis1'/&gt;
+    </pre></div>
+    <p class="" style="">When the client becomes visible, the server MUST treat that state as equivalent to an active session before receiving initial presence from the client. It is the responsibility of the client to send an undirected presence notification to the server, which the server MUST broadcast to all entities who would normally receive presence broadcasts from the client (as well as any other entities to which the client sent directed presence while invisible).</p>
+  </div>
+<h2>4.
+       <a name="sect-id2259753">Security Considerations</a>
+</h2>
+  <p class="" style="">It is possible to leak presence while in invisible mode (for example, by sending a message, IQ, or presence stanza to a contact). A client SHOULD warn a user before allowing the client to generate any outbound traffic and MUST NOT respond to IQ requests received from entities with which it has not initiated communications while in invisible mode (e.g., by sending messages, IQs, or directed presence).</p>
+<h2>5.
+       <a name="sect-id2259775">IANA Considerations</a>
+</h2>
+  <p class="" style="">No interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2259811">7</a>] is required as a result of this JEP.</p>
+<h2>6.
+       <a name="sect-id2259800">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">No namespaces or parameters need to be registered with the <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259852">8</a>] as a result of this JEP.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2252085">1</a>. JEP-0018: Invisible Presence &lt;<a href="http://www.jabber.org/jeps/jep-0018.html">http://www.jabber.org/jeps/jep-0018.html</a>&gt;.</p>
+<p><a name="nt-id2250754">2</a>. RFC 3920: Extensible Messaging and Presence Protocol (XMPP): Core &lt;<a href="http://www.ietf.org/rfc/rfc3920.txt">http://www.ietf.org/rfc/rfc3920.txt</a>&gt;.</p>
+<p><a name="nt-id2250777">3</a>. RFC 3921: Extensible Messaging and Presence Protocol (XMPP): Instant Messaging and Presence &lt;<a href="http://www.ietf.org/rfc/rfc3921.txt">http://www.ietf.org/rfc/rfc3921.txt</a>&gt;.</p>
+<p><a name="nt-id2250806">4</a>. JEP-0126: Invisibility &lt;<a href="http://www.jabber.org/jeps/jep-0126.html">http://www.jabber.org/jeps/jep-0126.html</a>&gt;.</p>
+<p><a name="nt-id2250905">5</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2251016">6</a>. JEP-0086: Error Condition Mappings &lt;<a href="http://www.jabber.org/jeps/jep-0086.html">http://www.jabber.org/jeps/jep-0086.html</a>&gt;.</p>
+<p><a name="nt-id2259811">7</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259852">8</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.3 (2006-08-02)</h4>
+<div class="indent">
+<p class="" style="">Added inbound presence rule to server handling section.</p> (psa)
+    </div>
+<h4>Version 0.2 (2006-07-07)</h4>
+<div class="indent">
+<p class="" style="">Clarified that invisibility mode does not carry across sessions.</p> (psa)
+    </div>
+<h4>Version 0.1 (2006-05-30)</h4>
+<div class="indent">
+<p class="" style="">Initial JEP version.</p> (psa)
+    </div>
+<h4>Version 0.0.2 (2006-05-15)</h4>
+<div class="indent">
+<p class="" style="">Recommended delivery of messages sent to bare JID.</p> (psa)
+    </div>
+<h4>Version 0.0.1 (2006-05-11)</h4>
+<div class="indent">
+<p class="" style="">First draft.</p> (psa)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0187-0.1.html
+++ b/content/xep-0187-0.1.html
@@ -1,0 +1,500 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0187: Offline Encrypted Sessions</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Offline Encrypted Sessions">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This document specifies an end-to-end encryption protocol for offline XMPP communication sessions.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0187">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0187: Offline Encrypted Sessions</h1>
+<p>This document specifies an end-to-end encryption protocol for offline XMPP communication sessions.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0187<br>
+            Version: 0.1<br>
+            Last Updated: 2006-07-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, RFC 2104, RFC 2409, RFC 3526, RFC 3548, xml-c14n, JEP-0004, JEP-0020, JEP-0068, JEP-0079, JEP-0116, JEP-0155, JEP-0163<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: offlineesession<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Offline%20Encrypted%20Sessions%20(JEP-0187)">http://wiki.jabber.org/index.php/Offline Encrypted Sessions (JEP-0187)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<p class="indent">Given that this JEP normatively references IETF technologies, discussion on the JSF-IETF list may also be appropriate (see &lt;<a href="http://mail.jabber.org/mailman/listinfo/jsf-ietf">http://mail.jabber.org/mailman/listinfo/jsf-ietf</a>&gt; for details).</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#personae">Dramatis Personae</a>
+</dt>
+<dt>3.  <a href="#init">Offline ESession Negotiation</a>
+</dt>
+<dl>
+<dt>3.1.  <a href="#init-offline-publish">Publishing Offline ESession Options</a>
+</dt>
+<dt>3.2.  <a href="#init-offline-request">Requesting Offline ESession Options</a>
+</dt>
+<dt>3.3.  <a href="#init-offline-start">Starting an Offline ESession</a>
+</dt>
+<dt>3.4.  <a href="#init-offline-accept">Accepting Offline ESessions</a>
+</dt>
+</dl>
+<dt>4.  <a href="#exchange">Exchanging Stanzas</a>
+</dt>
+<dt>5.  <a href="#terminate">ESession Termination</a>
+</dt>
+<dt>6.  <a href="#sec">Security Considerations</a>
+</dt>
+<dl>
+<dt>6.1.  <a href="#sec-replay">Replay Attacks</a>
+</dt>
+<dt>6.2.  <a href="#sec-expire">Options Expiry Time</a>
+</dt>
+<dt>6.3.  <a href="#sec-identity">Identity Exposure</a>
+</dt>
+<dt>6.4.  <a href="#sec-conclusion">Conclusion</a>
+</dt>
+</dl>
+<dt>7.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>8.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">The convenience of sending stanzas to other entities that are offline ("offline messages") is an important and popular feature of most XMPP implementations (see <span class="ref" style="">Best Practices for Handling Offline Messages</span>  [<a href="#nt-id2251046">1</a>]). Without offline messages delivery would have to wait until both entities managed to be online at the same time. So many urgent messages could not be delivered in time. For example, the sender might want to send an urgent message before jumping on a flight.</p>
+  <p class="" style="">End-to-end encryption is another desirable feature for any communication technology. Unfortunately it is not possible to make offline encryption quite so secure as online encryption. However, offline encryption has a long history and is certainly preferable to having no encryption at all.  [<a href="#nt-id2251062">2</a>] Unfortunately, for reasons described in <span class="ref" style="">Cryptographic Design of Encrypted Sessions</span>  [<a href="#nt-id2251092">3</a>], the existing proposals (including <span class="ref" style="">Current Jabber OpenPGP Usage</span>  [<a href="#nt-id2251115">4</a>] and <span class="ref" style="">RFC 3923</span>  [<a href="#nt-id2251138">5</a>]) have not been widely implemented and deployed. This document describes a different approach to offline end-to-end encryption for use by entities that communicate using XMPP. It builds on the existing online <span class="ref" style="">Encrypted Sessions</span>  [<a href="#nt-id2259725">6</a>] protocol. As a result it offers important advantages over the existing "Object Encryption" proposals:</p>
+  <ul>
+    <li>Perfect Forward Secrecy  [<a href="#nt-id2251072">7</a>]</li>
+    <li>Other security features described in <span style="font-weight: bold">Cryptographic Design of Encrypted Sessions</span>
+</li>
+    <li>Most of the code can be borrowed from implementations of <span style="font-weight: bold">Encrypted Sessions</span>
+</li>
+  </ul>
+  <p class="" style="">The requirements and the consequent cryptographic design that underpin this protocol are described in <span style="font-weight: bold">Cryptographic Design of Encrypted Sessions</span>. The basic concept is that of an encrypted session which acts as a secure tunnel between the online endpoint and the offline endpoint. The offline endpoint completes its part of the tunnel "negotiation" by publishing its preferences before it goes offline (see <a href="#sec">Security Considerations</a>). Once the tunnel is established by the online endpoint, the content of each one-to-one XML stanza sent by the online endpoint is encrypted and then transmitted within a "wrapper" stanza.</p>
+<h2>2.
+       <a name="personae">Dramatis Personae</a>
+</h2>
+  <p class="" style="">This JEP introduces two characters to help the reader follow the necessary exchanges:</p>
+  <ol start="1" type="">
+    <li>"Bob" is the name of the online participant in the offline ESession. Within the scope of this JEP, his fully-qualified JID is: &lt;bob@example.com/laptop&gt;.</li>
+    <li>"Alice" is the name of the offline participant in the offline ESession started by Bob. Within the scope of this JEP, we stipulate that her fully-qualified JID is: &lt;alice@example.org/pda&gt;.</li>
+  </ol>
+  <p class="" style="">While Bob and Alice are introduced as "end users", they are simply meant to be examples of Jabber entities. Any directly addressable Jabber entity may participate in an offline ESession.</p>
+<h2>3.
+       <a name="init">Offline ESession Negotiation</a>
+</h2>
+  <p class="" style="">The approach to establishing a secure session with an entity that is offline is in essence a special case of 3-message negotiation employed for online ESessions (see <span style="font-weight: bold">Encrypted Sessions</span>).</p>
+  <p class="" style="">Alice MAY publish a set of offline ESession options just before she goes offline. If Bob subscribes to Alice's presence and wishes to establish an online ESession with her, but he finds that she is offline, then if she published her offline ESession options before going offline, he may use the protocol described below to perform the initial Diffie-Hellman key exchange, establish an offline ESession and send encrypted stanzas to her while she is offline. Note: Bob MUST NOT initiate a new ESession with Alice if he already has an ESession established with her.</p>
+  <p class="" style="">Note: Alice MAY also publish <span style="font-style: italic">another</span> similar set of relatively long-lived  [<a href="#nt-id2259874">8</a>] offline ESession options that any entity MAY use for the same purpose.</p>
+
+    <div class="indent">
+<h3>3.1 <a name="init-offline-publish">Publishing Offline ESession Options</a>
+</h3>
+      <p class="" style="">In order to publish either set of her offline ESession options Alice MUST create an options data form in exactly the same way as she would create an online ESession request data form (see the ESession Request section in <span style="font-weight: bold">Encrypted Sessions</span>) except she MUST omit The 'accept' and 'pk_hash' fields. Note: The list of stanza types she is willing to decrypt MUST NOT include the value 'iq'.</p>
+      <p class="" style="">Alice MUST append to the content of the form an 'expires' field containing the UTC time (see <span class="ref" style="">Jabber Date and Time Profiles</span>  [<a href="#nt-id2259939">9</a>]) that she decides her offline ESession options will expire (see <a href="#sec-expire">Options Expiry Time</a> Security Considerations).</p>
+      <p class="" style="">Alice MUST store her value of N<span class="sub" style="">A</span> (her ESession ID), all her values of x (one for each MODP group) and the time she decides her offline ESession options will expire in a secure way, so that she can retrieve them when she comes back online (idealy even if that is using a different client and/or a different machine).</p>
+      <p class="" style="">If Alice would not be able to decrypt stanzas if she came back online using a different client and/or a different machine then she SHOULD also encapsulate the resource of her client in a 'match_resource' field and append it to her options data form. In this case, the list of stanza types she is willing to decrypt MUST include only 'message'.</p>
+      <p class="" style="">Alice MUST also append to the content of the form the list of the fingerprints (PKIDs) of all her public signature-verification keys that she can sign for in a 'pkids' field, and the corresponding list of signatures (see <a href="#sign">Signature Generation</a>) of the <span style="font-style: italic">content</span> of the data form (excluding the 'signs' field).</p>
+      <p class="" style="">Alice MUST publish the ESession options data form through her own server using <span class="ref" style="">Personal Eventing via Pubsub</span>  [<a href="#nt-id2260036">10</a>].</p>
+      <p class="" style="">If the pubkey PEP node does not exist already then Alice MUST create it first. In this case, Alice SHOULD specify the "Presence" access model for the set of options for presence subscribers (or the "Open" model for the set for other entities), unless she wants greater control over trivial access to her identity (see <a href="#sec-identity">Identity Exposure</a> Security Considerations). Alice SHOULD specify that the options will never be pushed to subscribers (even when she publishes new options) - especially if she specifies the "Whitelist" access model.</p>
+  <p class="caption">Example 1. Alice Creates PEP Node for ESession Options for Presence Subscribers</p>
+<div class="indent"><pre>
+&lt;iq from='alice@example.org/pda' type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/esession#subscription'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#deliver_notifications'&gt;
+          &lt;option&gt;&lt;value&gt;0&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#send_last_published_item'&gt;
+          &lt;option&gt;&lt;value&gt;never&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;presence&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 2. Alice Creates PEP Node for ESession Options for All Entities</p>
+<div class="indent"><pre>
+&lt;iq from='alice@example.org/pda' type='set' id='create2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/esession'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#deliver_notifications'&gt;
+          &lt;option&gt;&lt;value&gt;0&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#send_last_published_item'&gt;
+          &lt;option&gt;&lt;value&gt;never&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;open&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Once the publishing node has been created, Alice can update her options for subscribers to her presence whenever she goes offline:</p>
+  <p class="caption">Example 3. Alice Publishes Her ESession Options for Her Presence Subscribers</p>
+<div class="indent"><pre>
+&lt;iq from='alice@example.org/pda' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/esession#subscription'&gt;
+      &lt;item&gt;
+        &lt;x type='form' xmlns='jabber:x:data'&gt;
+          &lt;field type="hidden" var="FORM_TYPE"&gt;
+            &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field type="boolean" var="logging"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field type="boolean" var="secure"&gt;
+            &lt;value&gt;0&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="modp"&gt;
+            &lt;option&gt;&lt;value&gt;5&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;14&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;2&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="crypt_algs"&gt;
+            &lt;option&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;twofish256-ctr&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;aes128-ctr&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="hash_algs"&gt;
+            &lt;option&gt;&lt;value&gt;whirlpool&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="sign_algs"&gt;
+            &lt;option&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;dsa&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="compress"&gt;
+            &lt;option&gt;&lt;value&gt;none&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-multi" var="stanzas"&gt;
+            &lt;option&gt;&lt;value&gt;message&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="list-single" var="ver"&gt;
+            &lt;option&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/option&gt;
+            &lt;option&gt;&lt;value&gt;1.2&lt;/value&gt;&lt;/option&gt;
+          &lt;/field&gt;
+          &lt;field type="text-single" var="rekey_freq"&gt;
+            &lt;value&gt;1&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="expires"&gt;
+            &lt;value&gt;2006-06-09T02:56:15Z&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="my_nonce"&gt;
+            &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="keys"&gt;
+            &lt;value&gt; ** Base64 encoded value of e5 ** &lt;/value&gt;
+            &lt;value&gt; ** Base64 encoded value of e14 ** &lt;/value&gt;
+            &lt;value&gt; ** Base64 encoded value of e2 ** &lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="match_resource"&gt;
+            &lt;value&gt;pda&lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="pkids"&gt;
+            &lt;value&gt; ** PKID ** &lt;/value&gt;
+            &lt;value&gt; ** PKID ** &lt;/value&gt;
+          &lt;/field&gt;
+          &lt;field var="signs"&gt;
+            &lt;value&gt; ** signature of form ** &lt;/value&gt;
+            &lt;value&gt; ** signature of form ** &lt;/value&gt;
+          &lt;/field&gt;
+        &lt;/x&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">At the risk of divulging her presence, Alice MAY also update her options for all entities:</p>
+  <p class="caption">Example 4. Alice Publishes Her ESession Options for All Entities</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='pub2'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/esession'&gt;
+      ...
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.2 <a name="init-offline-request">Requesting Offline ESession Options</a>
+</h3>
+      <p class="" style="">If Bob believes Alice is offline he SHOULD request her ESession options and, if he does not have a local copy of any of her public keys specified therein, her long-term public signature-verification keys (see <span class="ref" style="">Public Key Publishing</span>  [<a href="#nt-id2250542">11</a>]) from her server using <span style="font-weight: bold">Personal Eventing via Pubsub</span>.  [<a href="#nt-id2250532">12</a>]</p>
+      <p class="" style="">If Bob is subscribing to Alice's presence he MUST request her ESession Options exclusively for subscribers.</p>
+      <p class="caption">Example 5. Bob asks Alice's Server for her ESession Options (Subscribers)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='es4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='http://jabber.org/protocol/esession#subscription'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If Bob is not subscribing to Alice's presence (or if Alice has no ESession options exclusively for subscribers) he MUST use the following request instead.</p>
+      <p class="caption">Example 6. Bob asks Alice's Server for her ESession Options (All Entities)</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    from='bob@example.com/laptop'
+    to='alice@example.org'
+    id='es4'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='http://jabber.org/protocol/esession'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+      <p class="" style="">If, after receiving Alice's public keys and ESession options, Bob is unable to verify any of Alice's signatures of her offline options data form (see <a href="#sign">Signature Verification</a>) then he MUST proceed no further, since he cannot be sure who will be able to decrypt his stanzas.</p>
+      <p class="" style="">If Bob cannot acquire Alice's ESession options, or he does not support one or more of the options in each Alice's ESession fields, or if the 'expires' field indicates that Alice's options have expired, then he MUST NOT send encrypted stanzas to her while she is offline.</p>
+    </div>
+
+    <div class="indent">
+<h3>3.3 <a name="init-offline-start">Starting an Offline ESession</a>
+</h3>
+      <p class="" style="">Bob MUST now continue as if Alice had requested an online ESession, performing the steps described in three of the sections of <span style="font-weight: bold">Encrypted Sessions</span>:</p>
+      <ol start="1" type="">
+        <li><p class="" style=""><span style="font-weight: bold">Diffie-Hellman Preparation (Bob)</span> Note: If the value of e he selected is not valid, Bob SHOULD terminate the ESession <span style="font-style: italic">without</span> sending an error.</p></li>
+        <li><p class="" style=""><span style="font-weight: bold">Generating Session Keys</span></p></li>
+        <li><p class="" style=""><span style="font-weight: bold">Hiding Identity</span> Note: Since Bob did not receive a 'pk_hash' field, he MUST assume its value is false. Bob SHOULD NOT include a 'pk_hash' field in form<span class="sub" style="">B</span> since Alice has already proved her identity.</p></li>
+      </ol>
+      <p class="" style="">As with 3-message ESession negotiation, Bob should encapsulate the Base64 encoded values of ID<span class="sub" style="">B</span> and M<span class="sub" style="">B</span> in data form fields ('identity' and 'mac'), and append the new fields to form<span class="sub" style="">B</span>.</p>
+      <p class="" style="">Bob MAY also send encrypted content (see the Exchanging Stanzas section of <span style="font-weight: bold">Encrypted Sessions</span>) in the same stanza. Note: If he also includes a &lt;terminate/&gt; element (see the ESession Termination section of <span style="font-weight: bold">Encrypted Sessions</span>) within the &lt;encrypted/&gt; element then the ESession is terminated immediately. This special case, where a single stanza is encrypted and sent in isolation, is equivalent to object encryption (or object signing if no encryption is specified) and offers several significant advantages over non-session approaches - including perfect forward secrecy.</p>
+      <p class="" style="">If Alice included a 'match_resource' field in her ESession options, then Bob MUST address all the stanzas he sends within the offline ESession to the specified resource and use the <span style="font-weight: bold">Advanced Message Processing</span> protocol to ensure that they are not delivered to any other resource.</p>
+      <p class="" style="">After sending form<span class="sub" style="">B</span> to Alice, Bob can assume that the ESession negotiation is complete.</p>
+      <p class="caption">Example 7. Bob Establishes an ESession Without Negotiation</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop' to='alice@example.org/pda' type='chat'&gt;
+  &lt;init xmlns='http://jabber.org/protocol/esession#init'&gt;
+    &lt;x type='submit' xmlns='jabber:x:data'&gt;
+      &lt;field var="FORM_TYPE"&gt;
+        &lt;value&gt;http://jabber.org/protocol/chatneg&lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="logging"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="secure"&gt;&lt;value&gt;0&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="modp"&gt;&lt;value&gt;5&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="crypt_algs"&gt;&lt;value&gt;aes256-ctr&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="hash_algs"&gt;&lt;value&gt;sha256&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="sign_algs"&gt;&lt;value&gt;rsa&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="compress"&gt;&lt;value&gt;none&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="stanzas"&gt;&lt;value&gt;message&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="ver"&gt;&lt;value&gt;1.3&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="rekey_freq"&gt;&lt;value&gt;50&lt;/value&gt;&lt;/field&gt;
+      &lt;field var="my_nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="keys"&gt;
+        &lt;value&gt; ** Base64 encoded value of d ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="nonce"&gt;
+        &lt;value&gt; ** Base64 encoded ESession ID ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="counter"&gt;
+        &lt;value&gt; ** Base64 encoded block counter ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="identity"&gt;
+        &lt;value&gt; ** Encrypted identity ** &lt;/value&gt;
+      &lt;/field&gt;
+      &lt;field var="mac"&gt;
+        &lt;value&gt; ** Integrity of identity ** &lt;/value&gt;
+      &lt;/field&gt;
+    &lt;/x&gt;
+  &lt;/init&gt;
+  &lt;encrypted xmlns='http://jabber.org/protocol/esession'&gt;
+    &lt;data&gt; ** Base64 encoded m_final ** &lt;/data&gt;
+    &lt;mac&gt; ** Base64 encoded a_mac ** &lt;/mac&gt;
+  &lt;/encrypted&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='??????' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+&lt;/message&gt;
+    </pre></div>
+    </div>
+    <div class="indent">
+<h3>3.4 <a name="init-offline-accept">Accepting Offline ESessions</a>
+</h3>
+      <p class="" style="">When Alice comes online she MUST perform the following steps:</p>
+      <ol start="" type="">
+        <li>
+<p class="" style="">Ensure she is no longer publishing offline ESession options exclusively for entities that are subscribing to her presence.</p>
+            <p class="caption">Example 8. Alice Stops Publishing Her ESession Options</p>
+<div class="indent"><pre>
+&lt;iq type='set' from='alice@example.org/pda' id='es5'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/esession#subscription'&gt;
+      &lt;item/&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+        </li>
+        <li><p class="" style="">Retrieve any values of N<span class="sub" style="">A</span>, x (one for each MODP group for each N<span class="sub" style="">A</span>) and her offline ESession options expiry time that she stored before going offline, and destroy in a secure way any persistently stored copies that correspond to ESession options exclusively for subscribers.</p></li>
+      </ol>
+      <p class="" style="">If the current time is after her offline ESession options expiry time then she MUST discard all stanzas from offline ESessions without decrypting them. Otherwise, when Alice receives an offline ESession request stanza from Bob then she MUST perform the following steps:</p>
+      <ol start="" type="">
+        <li><p class="" style="">Select her value of x that corresponds to the 'nonce' and 'modp' fields she received from Bob.  [<a href="#nt-id2260781">14</a>]</p></li>
+        <li><p class="" style="">Confirm that she has not already received a key exchange stanza from Bob with the same value of d or N<span class="sub" style="">B</span> ('my_nonce' field) since she published her ESession options (see the Replay Attacks subsection of the Security Considerations section of <span style="font-weight: bold">Encrypted Sessions</span>). If the options were for subscribers, that means since she came online.</p></li>
+        <li>
+<p class="" style="">Alice MUST now continue as if Bob had responded to her online ESession request, performing the steps described in two of the sections of <span style="font-weight: bold">Encrypted Sessions</span>:</p>
+        <ul>
+          <li><p class="" style=""><span style="font-weight: bold">Diffie-Hellman Preparation (Alice)</span> Note: If she is not prepared to support any of the ESession options specified by Bob, or if the value of d she selected is not valid, then Alice SHOULD terminate the ESession <span style="font-style: italic">without</span> sending an error.</p></li>
+          <li><p class="" style=""><span style="font-weight: bold">Verifying Bob's Identity</span> Note: Since Alice did not send a 'pk_hash' field to Bob, she MUST assume its value is false. If the value of M<span class="sub" style="">B</span> she calculated does not match the one she received, or if she cannot confirm that pubKey<span class="sub" style="">B</span> really is Bob's public key, or if she cannot confirm that sign<span class="sub" style="">B</span> is the signature of the HMAC result, then Alice SHOULD terminate the ESession <span style="font-style: italic">without</span> sending an error.</p></li>
+        </ul>
+</li>
+      </ol>
+    </div>
+<h2>4.
+       <a name="exchange">Exchanging Stanzas</a>
+</h2>
+  <p class="" style="">Alice MUST NOT send encrypted content within an offline ESession started by Bob. If Bob is conducting an offline ESession with Alice when she is online (e.g., if he is not subscribing to her presence), then if Alice wants to send a stanza to Bob, she MUST terminate the offline ESession and start a new online ESession first.</p>
+  <p class="" style="">For Offline ESessions, Bob SHOULD include a 'Created' SHIM header in the encrypted content. Assuming she trusts Bob, Alice SHOULD trust this header and ignore the unencrypted <span class="ref" style="">Delayed Delivery</span>  [<a href="#nt-id2260958">15</a>] element inserted by her server.</p>
+  <p class="caption">Example 9. Unencrypted Stanza</p>
+<div class="indent"><pre>
+&lt;message from='bob@example.com/laptop'
+         to='alice@example.org/pda'
+         type='chat'&gt;
+  &lt;body&gt;Hello, Alice!&lt;/body&gt;
+  &lt;amp xmlns='http://jabber.org/protocol/amp'&gt;
+    &lt;rule action='error' condition='match-resource' value='exact'/&gt;
+  &lt;/amp&gt;
+  &lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+    &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+  &lt;/headers&gt;
+  &lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+&lt;/message&gt;
+</pre></div>
+  <p class="caption">Example 10. XML Content to be Encrypted</p>
+<div class="indent"><pre>
+&lt;body&gt;Hello, Alice!&lt;/body&gt;
+&lt;headers xmlns='http://jabber.org/protocol/shim'&gt;
+  &lt;header name='Created'&gt;2005-02-10T03:01:52Z&lt;/header&gt;
+&lt;/headers&gt;
+&lt;active xmlns='http://jabber.org/protocol/chatstates'/&gt;
+  </pre></div>
+<h2>5.
+       <a name="terminate">ESession Termination</a>
+</h2>
+  <p class="" style="">If Bob notices that Alice comes online during his offline ESession with her then he MUST terminate the ESession immediately. If required he may then negotiate a new (more secure) online ESession.</p>
+  <p class="" style="">When Alice receives the offline ESession termination stanza from Bob, she SHOULD NOT send a termination stanza back to him.</p>
+<h2>6.
+       <a name="sec">Security Considerations</a>
+</h2>
+  <p class="" style="">For more security considerations refer to the Security Considerations section of <span style="font-weight: bold">Encrypted Sessions</span></p>
+  <div class="indent">
+<h3>6.1 <a name="sec-replay">Replay Attacks</a>
+</h3>
+    <p class="" style="">Since Alice supplies the same set of values of e for all offline ESessions, to prevent complete offline ESessions being replayed to her, she MUST take care to securely store <span style="font-style: italic">new</span> values (or destroy existing values) of N<span class="sub" style="">A</span> and x for subscribers whenever she goes offline (see <a href="#init-publish">Publishing ESession Options</a>). Also, when Alice comes online again, she MUST remember all the values of d he receives in offline ESession negotiation stanzas, and reject any offline ESessions that specify a value of d she has already received (see <a href="#init-accept">Accepting an Offline ESession</a>).</p>
+    <p class="" style="">Note: If Alice publishes ESession options for non-subscribers, and if she does not update them whenever she comes online then, until she updates the options, she MUST save all the values of d she receives to secure persistent storage (along with the values of N<span class="sub" style="">A</span> and x).</p>
+  </div>
+  <div class="indent">
+<h3>6.2 <a name="sec-expire">Options Expiry Time</a>
+</h3>
+    <p class="" style="">If Alice's offline private Diffie-Hellman keys are compromised, and the attacker also controls communications between Bob and Alice's server, then the attacker could prevent Bob discovering if she comes online, and resend her compromised ESession options to Bob whenever he asks for them. This would allow the attacker to decrypt all messages sent to Alice before her offline ESession options expire. Alice would probably never receive the messages sent to her after she comes back online. If an attack is discovered before the compromised ESession options expire then Alice SHOULD change her long-term signing key. Alice SHOULD mitigate this attack by choosing an expiry time for her ESession options that is not too long after she expects to be online again.</p>
+  </div>
+  <div class="indent">
+<h3>6.3 <a name="sec-identity">Identity Exposure</a>
+</h3>
+    <p class="" style="">Offline ESession options include public keys. By publishing her public keys Alice associates her identity with her JID. Although the public keys are public information, it may be critically important for Alice to keep her identity secret from all but a few specified people. Implementors MUST take great care to ensure the identity of Alice is never divulged to anyone except her (PEP) server and the entities who have been permitted by Alice to access her offline ESession options. However, even then, Alice will not be able to protect her identity being exposed by passive attacks!</p>
+  </div>
+  <div class="indent">
+<h3>6.4 <a name="sec-conclusion">Conclusion</a>
+</h3>
+    <p class="" style="">Alice MAY decide not to support offline ESessions since they are less secure than online ESessions. In addition to the issues above, the Perfect Forward Secrecy window of vulnerability is longer. More seriously, Alice MUST store her private Diffie-Hellman keys, x<span class="sub" style="">1</span>...x<span class="sub" style="">Z</span>, to local disk or to a server (perhaps symmetrically encrypted with a password). It is <span style="font-style: italic">really</span> hard to securely erase something from a disk. However, if Alice does not support Offline ESessions then, while she is offline, Bob, or Aunt Tillie, will probably send her completely unprotected messages!</p>
+  </div>
+<h2>7.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2261239">16</a>]. </p>
+<h2>8.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2261279">17</a>] shall add 'http://jabber.org/protocol/esession#subscription' to its registry of protocol namespaces.</p>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251046">1</a>. JEP-0160: Best Practices for Handling Offline Messages &lt;<a href="http://www.jabber.org/jeps/jep-0160.html">http://www.jabber.org/jeps/jep-0160.html</a>&gt;.</p>
+<p><a name="nt-id2251062">2</a>. This protocol does not stop paranoid users avoiding sending offline messages.</p>
+<p><a name="nt-id2251092">3</a>. JEP-0188: Cryptographic Design of Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0188.html">http://www.jabber.org/jeps/jep-0188.html</a>&gt;.</p>
+<p><a name="nt-id2251115">4</a>. JEP-0027: Current Jabber OpenPGP Usage &lt;<a href="http://www.jabber.org/jeps/jep-0027.html">http://www.jabber.org/jeps/jep-0027.html</a>&gt;.</p>
+<p><a name="nt-id2251138">5</a>. RFC 3923: End-to-End Signing and Object Encryption for the Extensible Messaging and Presence Protocol (XMPP) &lt;<a href="http://www.ietf.org/rfc/rfc3923.txt">http://www.ietf.org/rfc/rfc3923.txt</a>&gt;.</p>
+<p><a name="nt-id2259725">6</a>. JEP-0116: Encrypted Sessions &lt;<a href="http://www.jabber.org/jeps/jep-0116.html">http://www.jabber.org/jeps/jep-0116.html</a>&gt;.</p>
+<p><a name="nt-id2251072">7</a>. Long-lived keys are typically used for a few years, whereas Offline ESession decryption keys typically exist for just a few hours. So the Perfect Forward Secrecy feature significantly enhances the security of Offline ESessions.</p>
+<p><a name="nt-id2259874">8</a>. The more often Alice changes her published ESession options, the shorter the Perfect Forward Secrecy window of vulnerability. However, whenever she changes them she divulges her presence to all the entities that are monitoring them.</p>
+<p><a name="nt-id2259939">9</a>. JEP-0082: Jabber Date and Time Profiles &lt;<a href="http://www.jabber.org/jeps/jep-0082.html">http://www.jabber.org/jeps/jep-0082.html</a>&gt;.</p>
+<p><a name="nt-id2260036">10</a>. JEP-0163: Personal Eventing via Pubsub &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2250542">11</a>. JEP-0189: Public Key Publishing &lt;<a href="http://www.jabber.org/jeps/jep-0189.html">http://www.jabber.org/jeps/jep-0189.html</a>&gt;.</p>
+<p><a name="nt-id2250532">12</a>. There is no need for Bob to discover Alice's support for the Offline ESessions protocol via <span class="ref" style="">Service Discovery</span>  [<a href="#nt-id2260388">13</a>].</p>
+<p><a name="nt-id2260388">13</a>. JEP-0030: Service Discovery &lt;<a href="http://www.jabber.org/jeps/jep-0030.html">http://www.jabber.org/jeps/jep-0030.html</a>&gt;.</p>
+<p><a name="nt-id2260781">14</a>. Alice may not be able to find the specified value of x if, for example, she went offline using a different client and/or a different machine without publishing a 'match_resource' field. In this case Alice cannot decrypt the offline ESession!</p>
+<p><a name="nt-id2260958">15</a>. JEP-0091: Delayed Delivery &lt;<a href="http://www.jabber.org/jeps/jep-0091.html">http://www.jabber.org/jeps/jep-0091.html</a>&gt;.</p>
+<p><a name="nt-id2261239">16</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2261279">17</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-07-18)</h4>
+<div class="indent">Initial version (extracted from JEP-0116 version 0.9). (ip)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>

--- a/content/xep-0189-0.1.html
+++ b/content/xep-0189-0.1.html
@@ -1,0 +1,331 @@
+<html>
+<head>
+<meta http-equiv="Content-Type" content="text/html; charset=UTF-8">
+<title>JEP-0189: Public Key Publishing</title>
+<link rel="stylesheet" type="text/css" href="jep.css">
+<link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
+<meta name="DC.Title" content="Public Key Publishing">
+<meta name="DC.Creator" content="Ian Paterson">
+<meta name="DC.Description" content="This document specifies how an entity may publish its public keys over XMPP.">
+<meta name="DC.Publisher" content="Jabber Software Foundation">
+<meta name="DC.Contributor" content="JEP Editor">
+<meta name="DC.Date" content="2006-07-18">
+<meta name="DC.Type" content="Jabber Enhancement Proposal">
+<meta name="DC.Format" content="XHTML">
+<meta name="DC.Identifier" content="JEP-0189">
+<meta name="DC.Language" content="en">
+<meta name="DC.Rights" content="This Jabber Enhancement Proposal is copyright 1999 - 2006 by the Jabber Software Foundation (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;http://www.jabber.org/jsf/ipr-policy.shtml&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;http://creativecommons.org/licenses/by/2.5/&gt;).">
+</head>
+<body>
+<h1>JEP-0189: Public Key Publishing</h1>
+<p>This document specifies how an entity may publish its public keys over XMPP.</p>
+<p><hr></p>
+<p style="color:red">WARNING: This Standards-Track JEP is Experimental. Publication as a Jabber Enhancement Proposal does not imply approval of this proposal by the Jabber Software Foundation. Implementation of the protocol described herein is encouraged in exploratory implementations, but production systems should not deploy implementations of this protocol until it advances to a status of Draft.</p>
+<p><hr></p>
+<h2>JEP Information</h2>
+<p class="indent">
+            Status: 
+            <a href="http://www.jabber.org/jeps/jep-0001.html#states-Experimental">Experimental</a><br>
+            Type:
+            <a href="http://www.jabber.org/jeps/jep-0001.html#types-Standards%20Track">Standards Track</a><br>
+            Number: 0189<br>
+            Version: 0.1<br>
+            Last Updated: 2006-07-18<br>
+            JIG: Standards JIG<br>
+                Approving Body: <a href="http://www.jabber.org/council/">Jabber Council</a><br>Dependencies: XMPP Core, JEP-0060, JEP-0163<br>
+                Supersedes: None<br>
+                Superseded By: None<br>
+            Short Name: pubkey<br>
+        Schema: &lt;<a href="http://jabber.org/protocol/pubkey/pubkey.xsd">http://jabber.org/protocol/pubkey/pubkey.xsd</a>&gt;<br>
+              Wiki Page: &lt;<a href="http://wiki.jabber.org/index.php/Public%20Key%20Publishing%20(JEP-0189)">http://wiki.jabber.org/index.php/Public Key Publishing (JEP-0189)</a>&gt;
+            </p>
+<h2>Author Information</h2>
+<div class="indent">
+<h3>Ian Paterson</h3>
+<p class="indent">
+        Email:
+        <a href="mailto:ian.paterson@clientside.co.uk">ian.paterson@clientside.co.uk</a><br>
+        JID: 
+        <a href="xmpp:ian@zoofy.com">ian@zoofy.com</a></p>
+</div>
+<h2>Legal Notice</h2>
+<p class="indent">This Jabber Enhancement Proposal is copyright 1999 - 2006 by the <a href="http://www.jabber.org/jsf/">Jabber Software Foundation</a> (JSF) and is in full conformance with the JSF's Intellectual Property Rights Policy &lt;<a href="http://www.jabber.org/jsf/ipr-policy.shtml">http://www.jabber.org/jsf/ipr-policy.shtml</a>&gt;. This material may be distributed only subject to the terms and conditions set forth in the Creative Commons Attribution License (&lt;<a href="http://creativecommons.org/licenses/by/2.5/">http://creativecommons.org/licenses/by/2.5/</a>&gt;).</p>
+<h2>Discussion Venue</h2>
+<p class="indent">The preferred venue for discussion of this document is the Standards-JIG discussion list: &lt;<a href="http://mail.jabber.org/mailman/listinfo/standards-jig">http://mail.jabber.org/mailman/listinfo/standards-jig</a>&gt;.</p>
+<h2>Relation to XMPP</h2>
+<p class="indent">The Extensible Messaging and Presence Protocol (XMPP) is defined in the XMPP Core (RFC 3920) and XMPP IM (RFC 3921) specifications contributed by the Jabber Software Foundation to the Internet Standards Process, which is managed by the Internet Engineering Task Force in accordance with RFC 2026. Any protocol defined in this JEP has been developed outside the Internet Standards Process and is to be understood as an extension to XMPP rather than as an evolution, development, or modification of XMPP itself.</p>
+<h2>Conformance Terms</h2>
+<p class="indent">The following keywords as used in this document are to be interpreted as described in RFC 2119: "MUST", "SHALL", "REQUIRED"; "MUST NOT", "SHALL NOT"; "SHOULD", "RECOMMENDED"; "SHOULD NOT", "NOT RECOMMENDED"; "MAY", "OPTIONAL".</p>
+<p><hr></p>
+<h2>Table of Contents</h2>
+<div class="indent"><dl>
+<dt>1.  <a href="#intro">Introduction</a>
+</dt>
+<dt>2.  <a href="#usecases-pubsub">Public Key Publication and Retrieval via PEP</a>
+</dt>
+<dt>3.  <a href="#usecases-request">Requesting Public Keys Directly From Another Entity</a>
+</dt>
+<dt>4.  <a href="#security">Security Considerations</a>
+</dt>
+<dt>5.  <a href="#iana">IANA Considerations</a>
+</dt>
+<dt>6.  <a href="#registrar">Jabber Registrar Considerations</a>
+</dt>
+<dt>7.  <a href="#schema">XML Schema</a>
+</dt>
+<dt><a href="#notes">Notes</a></dt>
+<dt><a href="#revs">Revision History</a></dt>
+</dl></div>
+<p><hr></p>
+<h2>1.
+       <a name="intro">Introduction</a>
+</h2>
+  <p class="" style="">This JEP defines different methods an entity may use for publishing its long-term public keys:</p>
+  <ul>
+    <li>Publishing public keys to a set of subscribers.</li>
+    <li>Querying another entity for its public keys.</li>
+  </ul>
+  <p class="" style="">An entity MAY have multiple keys with different formats, signatures, algorithms, strengths and expiry dates. Each client used by a user may use different keys.</p>
+<h2>2.
+       <a name="usecases-pubsub">Public Key Publication and Retrieval via PEP</a>
+</h2>
+  <p class="" style="">An entity SHOULD use <span class="ref" style="">Personal Eventing via Pubsub</span>  [<a href="#nt-id2251680">1</a>] to publish all its long-term public keys via its own server.</p>
+  <p class="" style="">If the pubkey PEP node does not exist already then the entity MUST create it first. In this case, the entity SHOULD specify that the keys will only be pushed to subscribers whenever new keys are published (i.e. not when subscribers become newly available or when a new subscription is created). If the user wants to control access to his/her identity (see <a href="#security">Security Considerations</a>) then the entity MUST also specify an appropriate access model other than "Open".</p>
+  <p class="caption">Example 1. Entity Creates Public Keys Publishing Node</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='create1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;create node='http://jabber.org/protocol/pubkey'/&gt;
+    &lt;configure&gt;
+      &lt;x xmlns='jabber:x:data' type='form'&gt;
+        &lt;field var='FORM_TYPE' type='hidden'&gt;
+          &lt;value&gt;http://jabber.org/protocol/pubsub#node_config&lt;/value&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#send_last_published_item'&gt;
+          &lt;option&gt;&lt;value&gt;never&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#access_model'&gt;
+          &lt;option&gt;&lt;value&gt;roster&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+        &lt;field var='pubsub#roster_groups_allowed'&gt;
+          &lt;option&gt;&lt;value&gt;friends&lt;/value&gt;&lt;/option&gt;
+        &lt;/field&gt;
+      &lt;/x&gt;
+    &lt;/configure&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">Once the publishing node has been created, the entity can update the keys at any time. Note: Any change to the list of keys requires all keys to be republished. So clients SHOULD take care to request (see third example below) and then include all keys for the JID that were published previously by other clients (unless the keys have expired).  [<a href="#nt-id2251720">2</a>]</p>
+  <p class="caption">Example 2. Entity Publishes Keys to its Server</p>
+<div class="indent"><pre>
+&lt;iq from='juliet@capulet.com/balcony' type='set' id='pub1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;publish node='http://jabber.org/protocol/pubkey'&gt;
+      &lt;item&gt;
+        &lt;pubkeys xmlns='http://jabber.org/protocol/pubkey'&gt;
+          &lt;pubkey type='x509v3-sign-rsa'&gt;
+            &lt;key&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/key&gt;
+            &lt;key&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='pgp-sign-dss'&gt;
+            &lt;key&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='ssh-rsa'&gt;
+            &lt;key&gt; ** Base64 encoded unsigned RSA public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='ssh-dss'&gt;
+            &lt;key&gt; ** Base64 encoded unsigned DSS public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+        &lt;/pubkeys&gt;
+      &lt;/item&gt;
+    &lt;/publish&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 3. Subscriber Receives Event with Keys</p>
+<div class="indent"><pre>
+&lt;message to='romeo@montague.net/garden' from='juliet@capulet.com' type='headline'&gt;
+  &lt;event xmlns='http://jabber.org/protocol/pubsub#event'&gt;
+    &lt;items node='http://jabber.org/protocol/pubkey'&gt;
+      &lt;item&gt;
+        &lt;pubkeys xmlns='http://jabber.org/protocol/pubkey'&gt;
+          &lt;pubkey type='x509v3-sign-rsa'&gt;
+            &lt;key&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/key&gt;
+            &lt;key&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='pgp-sign-dss'&gt;
+            &lt;key&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='ssh-rsa'&gt;
+            &lt;key&gt; ** Base64 encoded unsigned RSA public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='ssh-dss'&gt;
+            &lt;key&gt; ** Base64 encoded unsigned DSS public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+        &lt;/pubkeys&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/event&gt;
+  &lt;addresses xmlns='http://jabber.org/protocol/address'&gt;
+    &lt;address type='replyto' jid='juliet@capulet.com/balcony'/&gt;
+  &lt;/addresses&gt;
+&lt;/message&gt;
+  </pre></div>
+  <p class="" style="">Note: The stanza containing the event notification (see example above) MAY also include 'replyto' data (as specified by the <span class="ref" style="">Extended Stanza Addressing</span>  [<a href="#nt-id2250817">3</a>] protocol) to provide an explicit association between the published data and the resource that published it.</p>
+  <p class="caption">Example 4. Subscriber Requests Keys from Account</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    to='juliet@capulet.com'
+    from='romeo@montague.net/garden'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='http://jabber.org/protocol/pubkey'/&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="caption">Example 5. Entity's Server Returns Keys to Subscriber</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    to='romeo@montague.net/garden'
+    from='juliet@capulet.com'
+    id='items1'&gt;
+  &lt;pubsub xmlns='http://jabber.org/protocol/pubsub'&gt;
+    &lt;items node='http://jabber.org/protocol/pubkey'&gt;
+      &lt;item&gt;
+        &lt;pubkeys xmlns='http://jabber.org/protocol/pubkey'&gt;
+          &lt;pubkey type='x509v3-sign-rsa'&gt;
+            &lt;key&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/key&gt;
+            &lt;key&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='pgp-sign-dss'&gt;
+            &lt;key&gt; ** Base64 encoded OpenPGP certificate containing DSS public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='ssh-rsa'&gt;
+            &lt;key&gt; ** Base64 encoded unsigned RSA public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+          &lt;pubkey type='ssh-dss'&gt;
+            &lt;key&gt; ** Base64 encoded unsigned DSS public key ** &lt;/key&gt;
+          &lt;/pubkey&gt;
+        &lt;/pubkeys&gt;
+      &lt;/item&gt;
+    &lt;/items&gt;
+  &lt;/pubsub&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>3.
+       <a name="usecases-request">Requesting Public Keys Directly From Another Entity</a>
+</h2>
+  <p class="" style="">If an entity wishes to request the public keys of another entity and it cannot access the keys via <span style="font-weight: bold">Personal Eventing via Pubsub</span>, then the entity MAY send an IQ to the other entity:</p>
+  <p class="caption">Example 6. Location request</p>
+<div class="indent"><pre>
+&lt;iq type='get'
+    id='keys1'
+    to='juliet@capulet.com/balcony'
+    from='romeo@montague.net/garden'&gt;
+  &lt;pubkey xmlns='http://jabber.org/protocol/pubkey'/&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">The other entity MUST make a careful access control decision before returning only those public keys for which it holds the corresponding private key (not necessarily the full list of keys being published via <span style="font-weight: bold">Personal Eventing via Pubsub</span>):</p>
+  <p class="caption">Example 7. Successful public keys response</p>
+<div class="indent"><pre>
+&lt;iq type='result'
+    id='keys1'
+    to='romeo@montague.net/garden'
+    from='juliet@capulet.com/balcony'&gt;
+    &lt;pubkeys xmlns='http://jabber.org/protocol/pubkey'&gt;
+      &lt;pubkey type='x509v3-sign-rsa'&gt;
+        &lt;key&gt; ** Base64 encoded x509 certificate containing RSA public key ** &lt;/key&gt;
+      &lt;/pubkey&gt;
+      &lt;pubkey type='ssh-rsa'&gt;
+        &lt;key&gt; ** Base64 encoded unsigned RSA public key ** &lt;/key&gt;
+      &lt;/pubkey&gt;
+    &lt;/pubkeys&gt;
+&lt;/iq&gt;
+  </pre></div>
+  <p class="" style="">If the receiving entity decides not to return the public keys, it MUST return an IQ error, which SHOULD be &lt;service-unavailable/&gt; (to avoid divulging presence to unauthorized entities), but MAY be some other appropriate error, such as &lt;forbidden/&gt; or &lt;not-allowed/&gt;:</p>
+  <p class="caption">Example 8. Access to public keys denied</p>
+<div class="indent"><pre>
+&lt;iq type='error'
+    id='keys1'
+    to='romeo@montague.net/garden'
+    from='juliet@capulet.com/balcony'&gt;
+  &lt;pubkey xmlns='http://jabber.org/protocol/pubkey'/&gt;
+  &lt;error code='503' type='cancel'&gt;
+    &lt;service-unavailable xmlns='urn:ietf:params:xml:ns:xmpp-stanzas'/&gt;
+  &lt;/error&gt;
+&lt;/iq&gt;
+  </pre></div>
+<h2>4.
+       <a name="security">Security Considerations</a>
+</h2>
+  <p class="" style="">The reliable association between a user or entity and its public keys is beyond the scope of this JEP. However, it is RECOMMENDED that each client maintains its own secure library of the public keys (or the "fingerprints" of the keys) it associates with other users (not necessarily JIDs).</p>
+  <p class="" style="">Whenever public keys are published an identity is typically associated with a JID. Although the public keys are public information, it may be critically important for the user of the JID to keep his identity secret from all but a few specified people. Implementors MUST take great care to ensure the identity of the user of a JID is never divulged to anyone except the entities who have been permitted by the user to access the public key.</p>
+<h2>5.
+       <a name="iana">IANA Considerations</a>
+</h2>
+  <p class="" style="">This JEP requires no interaction with the <span class="ref" style="">Internet Assigned Numbers Authority (IANA)</span>  [<a href="#nt-id2250998">4</a>].</p>
+<h2>6.
+       <a name="registrar">Jabber Registrar Considerations</a>
+</h2>
+  <p class="" style="">The <span class="ref" style="">Jabber Registrar</span>  [<a href="#nt-id2259551">5</a>] shall add 'http://jabber.org/protocol/pubkey' to its registry of protocol namespaces.</p>
+<h2>7.
+       <a name="schema">XML Schema</a>
+</h2>
+  <p class="caption"></p>
+<div class="indent"><pre>
+&lt;?xml version='1.0' encoding='UTF-8'?&gt;
+
+&lt;xs:schema
+    xmlns:xs='http://www.w3.org/2001/XMLSchema'
+    targetNamespace='http://jabber.org/protocol/pubkey'
+    xmlns='http://jabber.org/protocol/pubkey'
+    elementFormDefault='qualified'&gt;
+
+  &lt;xs:annotation&gt;
+    &lt;xs:documentation&gt;
+      The protocol documented by this schema is defined in
+      JEP-0189: http://www.jabber.org/jeps/jep-0189.html
+    &lt;/xs:documentation&gt;
+  &lt;/xs:annotation&gt;
+
+  &lt;xs:element name='pubkeys'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='pubkey' minOccurs='0' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='pubkey'&gt;
+    &lt;xs:complexType&gt;
+      &lt;xs:sequence&gt;
+        &lt;xs:element ref='key' minOccurs='1' maxOccurs='unbounded'/&gt;
+      &lt;/xs:sequence&gt;
+      &lt;xs:attribute name='type' type='xs:string' use='required'&gt;
+    &lt;/xs:complexType&gt;
+  &lt;/xs:element&gt;
+
+  &lt;xs:element name='key' type='xs:string'/&gt;
+
+&lt;/xs:schema&gt;
+  </pre></div>
+<p><hr></p>
+<a name="notes"></a><h2>Notes</h2>
+<div class="indent">
+<p><a name="nt-id2251680">1</a>. JEP-0163: Personal Eventing via Pubsub &lt;<a href="http://www.jabber.org/jeps/jep-0163.html">http://www.jabber.org/jeps/jep-0163.html</a>&gt;.</p>
+<p><a name="nt-id2251720">2</a>. The keys are long-term so they will only be republished infrequently.</p>
+<p><a name="nt-id2250817">3</a>. JEP-0033: Extended Stanza Addressing &lt;<a href="http://www.jabber.org/jeps/jep-0033.html">http://www.jabber.org/jeps/jep-0033.html</a>&gt;.</p>
+<p><a name="nt-id2250998">4</a>. The Internet Assigned Numbers Authority (IANA) is the central coordinator for the assignment of unique parameter values for Internet protocols, such as port numbers and URI schemes. For further information, see &lt;<a href="http://www.iana.org/">http://www.iana.org/</a>&gt;.</p>
+<p><a name="nt-id2259551">5</a>. The Jabber Registrar maintains a list of reserved Jabber protocol namespaces as well as registries of parameters used in the context of protocols approved by the Jabber Software Foundation. For further information, see &lt;<a href="http://www.jabber.org/registrar/">http://www.jabber.org/registrar/</a>&gt;.</p>
+</div>
+<p><hr></p>
+<a name="revs"></a><h2>Revision History</h2>
+<div class="indent">
+<h4>Version 0.1 (2006-07-18)</h4>
+<div class="indent">Initial version. (ip)
+    </div>
+</div>
+<p><hr></p>
+<p>END</p>
+</body>
+</html>


### PR DESCRIPTION
Templating has caused links to archives specifications to use `xep` in the file identifier, even for archived versions were JEPs.

These links cause 404 errors (as no archived 'xep' exist, although an archived 'jep' does exist).

This PR duplicates all `jep` files to `xep` files (apart from 4 files, that already had a `xep` equivalent) to help ensure that archived versions can be found.

The solution isn't great, but doesn't depend on:
- adjusting incorrect links, some of which won't be under our control
- modifying webserver configuration, which has proven to be a lenghty process

Furthermore, this is a one-off: there won't be any _new_ 'JEP' versions, as the rename from JEP to XEP happened ages ago.

As such, this is a pragmatic, low-effort approach. It does introduce duplication, but that should be an acceptable price to pay.

fixes #6